### PR TITLE
Read a case's discriminator off the type at the position it stands in

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
@@ -1322,15 +1322,24 @@ public final class FixtureReader {
                         : denotes instanceof ValueName.Helper ? valueBody(v.name()) : null;
                 // A name standing for no value is not one a field can be taken off; the ordinary
                 // reading below says what it is instead of this one guessing.
-                yield body == null ? new Projected.Declared(declaredTypeOf(v, new HashSet<>()),
-                                raw(v, null, below))
+                // Read at the type the name is declared with, which is the position it stands at:
+                // the same type this hands on as the evidence of what was projected. Reading it at
+                // no position would leave the form to be worked out from the case rather than from
+                // where the value is (issue #683).
+                yield body == null ? projectedAtItsDeclaredType(v, below)
                         : expanding(denotes, () -> projectTarget(body, admission));
             }
             case Ast.Apply c when appliedHelper(c) instanceof Applied helper ->
                     new Projected.Live(answered(c, helper), c.written());
-            default -> new Projected.Declared(declaredTypeOf(e, new HashSet<>()),
-                    raw(e, null, below));
+            default -> projectedAtItsDeclaredType(e, below);
         };
+    }
+
+    /** What a projection takes a field off, read at the type it is declared with — the one type the
+     *  evidence it carries is stated in, so the value and the type it is read at come from one place. */
+    private Projected projectedAtItsDeclaredType(Ast.Expr e, Admission below) {
+        Type declared = declaredTypeOf(e, new HashSet<>());
+        return new Projected.Declared(declared, raw(e, declared, below));
     }
 
     /** One step of a chain: evidence in, evidence out. */
@@ -1794,7 +1803,6 @@ public final class FixtureReader {
      * stands in. */
     private Object unitInput(TypeName caseName, Type expected) {
         {
-            String name = caseName.name();
             // A fixture is built in the neutral form the boundary reads, so a case of an enumeration
             // is written the way that sum travels: its name, bare (issue #161). The same unit data may
             // be a case of an enumeration and of a sum that has a field-bearing case, and those travel
@@ -1804,7 +1812,8 @@ public final class FixtureReader {
                 return caseName.name();
             }
             Map<String, Object> unit = new LinkedHashMap<>();
-            neutral.tagged(name, unit);   // a unit case of a sum still needs the tag its decoder reads
+            // a unit case read through a sum still needs the tag that sum's decoder reads
+            neutral.tagged(expected, caseName, unit);
             return unit;
         }
     }
@@ -2103,7 +2112,7 @@ public final class FixtureReader {
         TypeName built = nd.typeName().denotes();
         if (neutral.isNewtype(built) && nd.spreads().isEmpty() && nd.inits().size() == 1
                 && nd.inits().get(0).name().equals("value")) {
-            return neutral.newtypeAt(expected, built, nd.typeName().written(),
+            return neutral.newtypeAt(expected, built,
                     neutral.shaped(raw(nd.inits().get(0).value(),
                                     neutral.shapeOf(neutral.newtypeBaseType(built)), below(admission)),
                             neutral.shapeOf(neutral.newtypeBaseType(built))));
@@ -2161,7 +2170,7 @@ public final class FixtureReader {
             }
             map.put(fi.name(), v);
         }
-        neutral.tagged(nd.typeName().denotes(), map);
+        neutral.tagged(expected, nd.typeName().denotes(), map);
         return map;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/examples/NeutralForm.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/NeutralForm.java
@@ -106,12 +106,12 @@ final class NeutralForm {
                 return caseName.name();
             }
             Map<String, Object> unit = new LinkedHashMap<>();
-            tagged(caseName, unit);
+            tagged(position, caseName, unit);
             return unit;
         }
         if (data.newtype()) {
             Type base = shapeOf(newtypeBaseType(caseName));
-            return newtypeAt(position, caseName, name,
+            return newtypeAt(position, caseName,
                     shaped(of(field(live, "value", helper), base, helper), base));
         }
         Map<String, Ast.TypeRef> declared = fieldTypes(caseName);
@@ -124,7 +124,7 @@ final class NeutralForm {
                 out.put(f.getKey(), value);
             }
         }
-        tagged(caseName, out);
+        tagged(position, caseName, out);
         return out;
     }
 
@@ -144,29 +144,22 @@ final class NeutralForm {
     // --- the form itself, read by both directions -------------------------------------------------
 
     /**
-     * A newtype case read through its sum decodes from the adjacent form that sum's decoder reads —
-     * the inner value under {@code value}, next to the discriminator (spec §sum-discrimination) — while a fixture
-     * names the case the way the domain constructs it,
-     * {@code アクティベート済み(メールアドレス("a@example.com"))}. Wrap it here, as a product case's
-     * field map and a unit case's name are wrapped; a newtype no sum lists is its bare inner value,
-     * unchanged.
-     */
-    private Object adjacentlyTagged(String caseName, Object inner) {
-        Map<String, Object> tagged = new LinkedHashMap<>();
-        tagged(caseName, tagged);
-        if (tagged.isEmpty()) {
-            return inner;   // not a case of any sum: the newtype's own form is its inner value
-        }
-        tagged.put("value", inner);
-        return tagged;
-    }
-
-    /**
-     * Writes the discriminator a sum's decoder reads, when the data is a case of one.
-     * A fixture names the case it means — `予算枠 = 未定予算`, or a whole `プロジェクト依頼 { … }` where
-     * the parameter is the sum `依頼` — the same way the domain writes a construction, while the
-     * decoder that reads it wants a tag on a key. Where the case is read as itself rather than
-     * through its sum, the tag is a field the decoder does not look at.
+     * Writes the discriminator the type declared at this position reads the case under, where it
+     * reads it through a sum at all.
+     *
+     * <p>What is written is decided by the type the position declares (spec §encode-law): a case's own
+     * decoder reads no discriminator and its sum's reads one, so `承認 { id = 1 }` is `{"id":1}` where
+     * `承認` is what is declared and `{"id":1,"type":"承認"}` where `承認 | 却下` is. A fixture names the
+     * case it means — `予算枠 = 未定予算`, or a whole `プロジェクト依頼 { … }` where the parameter is the
+     * sum `依頼` — the same way the domain writes a construction, and the sum it is read through is
+     * what puts the tag on a key beside it.
+     *
+     * <p>The key and the tag are the sum's own, read off the decoder {@link souther.compiler.derive.Deriver}
+     * derived for it and {@code CodecGen} emits — not decided again here. A derived decoder dispatches
+     * over the leaves of the sums it names (spec §sum-discrimination), so a case reached through a
+     * nested sum is listed by the position's own decoder and there is nothing to walk. Issue #683 was
+     * this being answered by searching every visible sum for one that lists the case, which is a
+     * question about the case rather than about the position it stands at.
      *
      * <p>A field the fixture wrote itself is never replaced. A case whose own field is named like its
      * sum's discriminator is already ambiguous at the boundary — the case encoder and the sum encoder
@@ -174,14 +167,42 @@ final class NeutralForm {
      * decoding something the author did not write. Leaving the written value in place makes the row
      * fail on the tag it cannot match, which is the honest outcome.
      */
-    void tagged(String written, Map<String, Object> map) {
-        TypeName caseName = symbols.resolve(written);
-        if (caseName != null) {
-            tagged(caseName, map);
+    void tagged(Type declaredType, TypeName caseName, Map<String, Object> map) {
+        if (caseName == null) {
+            return;
+        }
+        if (declaredType == null) {
+            taggedWithoutADeclaredType(caseName, map);
+            return;
+        }
+        // Anything but a sum reads the case as itself: its own type, and — since a union is written
+        // only as a behavior's own answer, where it arrives with no declared type below — nothing else.
+        if (!(open(declaredType) instanceof Type.Ref ref)
+                || !(symbols.get(ref.name()) instanceof Ast.SumData sum)
+                || sum.decoder().isEmpty()) {
+            return;
+        }
+        Ast.Discriminate reads = sum.decoder().get();
+        for (Ast.Variant variant : reads.variants()) {
+            if (caseName.equals(variant.caseType().denotes())) {
+                map.putIfAbsent(reads.key(), variant.tag());
+                return;
+            }
         }
     }
 
-    void tagged(TypeName caseName, Map<String, Object> map) {
+    /**
+     * The same, where the position has no declared type to read the case through: an answer of
+     * several types, which admission and not a decoder decides ({@code FixtureReader}), and a value
+     * written where nothing says what it stands at.
+     *
+     * <p>Nothing here can be asked of the position, so the sums that list the case answer instead.
+     * That is right for as long as they agree, and today they cannot disagree: every discriminator is
+     * derived — keyed {@code "type"} and tagged with the case's own name — and a sum's cases are
+     * declared in its own module, so one case has one tag however many sums list it (issue #683
+     * measured this). A written discriminator would end the agreement and this fallback with it.
+     */
+    private void taggedWithoutADeclaredType(TypeName caseName, Map<String, Object> map) {
         for (Ast.Def def : symbols.visible()) {
             if (!(def instanceof Ast.SumData sum) || sum.decoder().isEmpty()) {
                 continue;
@@ -236,34 +257,28 @@ final class NeutralForm {
         return v;
     }
 
-    /** Whether the position names this type itself rather than a sum that lists it. Read as itself, a
-     *  newtype's form is its inner value — what its own decoder reads — and what some other
-     *  declaration does with the type does not reach here. */
-    private boolean readsAsItself(Type position, TypeName caseName) {
-        return open(position) instanceof Type.Ref r && caseName.equals(r.name());
-    }
-
     /**
      * A newtype's neutral form at the position it is written in: its inner value, wearing the envelope
      * only where the position reads it through a sum that lists it.
      *
+     * <p>A newtype case read through its sum decodes from the adjacent form that sum's decoder reads —
+     * the inner value under {@code value}, next to the discriminator (spec §sum-discrimination) — while
+     * a fixture names the case the way the domain constructs it,
+     * {@code アクティベート済み(メールアドレス("a@example.com"))}.
+     *
      * <p>The {@code "value"} envelope is not part of a newtype's representation — it is what
-     * membership adds, which is why a standalone newtype is bare (spec §sum-discrimination). So the position decides
-     * it, the way it decides whether a unit case travels as a bare name, and what some other
-     * declaration does with the type does not reach a fixture written at the type itself.
-     */
-    /**
-     * As below, for a case already resolved. A name spelled here would have to be one
+     * membership adds, which is why a standalone newtype is bare (spec §sum-discrimination). So the
+     * position decides it, the way it decides whether a unit case travels as a bare name, and what
+     * some other declaration does with the type does not reach a fixture written at the type itself.
+     *
+     * <p>Takes a case already resolved: a name spelled here would have to be one
      * {@link Symbols#resolve} answers to, which an imported type's declared name is not.
      */
     Object newtypeAt(Type position, TypeName caseName, Object inner) {
-        if (readsAsItself(position, caseName)) {
-            return inner;
-        }
         Map<String, Object> envelope = new LinkedHashMap<>();
-        tagged(caseName, envelope);
+        tagged(position, caseName, envelope);
         if (envelope.isEmpty()) {
-            return inner;   // not a case of any sum: the newtype's own form is its inner value
+            return inner;   // read as itself: the newtype's own form is its inner value
         }
         envelope.put("value", inner);
         return envelope;
@@ -329,7 +344,7 @@ final class NeutralForm {
                     return written;
                 }
                 Map<String, Object> unit = new LinkedHashMap<>();
-                tagged(caseName, unit);
+                tagged(to, caseName, unit);
                 return unit;
             }
         }
@@ -343,13 +358,9 @@ final class NeutralForm {
                 : type instanceof Type.SetOf s ? s.element() : null;
     }
 
-    Object newtypeAt(Type position, TypeName caseName, String written, Object inner) {
-        return readsAsItself(position, caseName) ? inner : adjacentlyTagged(written, inner);
-    }
-
     /** As above, for a construction written as a call, where the name is what the row spelled. */
     Object newtypeAt(Type position, String written, Object inner) {
-        return newtypeAt(position, symbols.resolve(written), written, inner);
+        return newtypeAt(position, symbols.resolve(written), inner);
     }
 
     /** Whether the position this case is written in reads a bare name: it is typed as an enumeration,

--- a/souther-compiler/src/test/java/souther/compiler/ACaseIsBuiltAtItsPositionWithoutBeingNamedHereTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACaseIsBuiltAtItsPositionWithoutBeingNamedHereTest.java
@@ -1,0 +1,83 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.meta.ModulePath;
+import souther.compiler.partition.Generator;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * A value is built in the form the position reads it, and the position is a type — not a name this
+ * module happens to have.
+ *
+ * <p>A derived decoder dispatches over the leaves of the sums it names (spec §sum-discrimination), so
+ * a behavior taking `離職事由` is filled with values of leaves the module never writes: it matches on
+ * `事業主都合`, and which kind of employer cause it was is a question its own rules do not ask. The
+ * leaf is a case of the position all the same, and a fixture for it is a fixture of that position.
+ *
+ * <p>Held across two modules because that is the only place the two ways of asking come apart. Asked
+ * of the position's declared type, the leaf is listed by its decoder and carries the tag that decoder
+ * reads. Asked of the leaf's own spelling, the answer is what the reading module has under that
+ * spelling — nothing here — and the value went out with no discriminator on it and was refused for
+ * the key it was missing (issue #683).
+ */
+class ACaseIsBuiltAtItsPositionWithoutBeingNamedHereTest {
+
+    private static final String DOMAIN = """
+            module domain exposing (Reason, EmployerCause, Resignation)
+
+            data BusinessClosure
+            data Dismissal
+            data EmployerCause = BusinessClosure | Dismissal
+
+            data Resignation = { note: String }
+
+            data Reason = EmployerCause | Resignation
+            """;
+
+    /** Names `EmployerCause` and never its cases: the rule here is about the group. */
+    private static final String CONSUMER = """
+            module consumer
+
+            import domain (Reason, EmployerCause, Resignation)
+
+            data Verdict = { text: String }
+
+            behavior judge : (reason: Reason) -> Verdict
+                constructs Verdict
+
+            let judge (reason) =
+                match reason with
+                    | EmployerCause -> Verdict { text = "employer" }
+                    | Resignation   -> Verdict { text = "resigned" }
+            """;
+
+    private static Generator.GenerationResult filled() {
+        Compilation compilation = Compilation.ofSources(List.of(DOMAIN, CONSUMER), ModulePath.EMPTY);
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        Map<String, Adequacy.Filling> all = compilation.db()
+                .ask(new Adequacy.Generated("consumer")).value();
+        assertNotNull(all, "the model under test compiles");
+        return all.get("judge").pairs();
+    }
+
+    @Test
+    void aLeafThisModuleDoesNotNameIsStillBuiltAtThePositionThatListsIt() {
+        Generator.GenerationResult filled = filled();
+
+        assertEquals(List.of(), filled.unresolved(),
+                "every case of the position has a value, including the ones spelled nowhere here");
+        assertEquals(List.of("BusinessClosure", "Dismissal", "Resignation { note = \"x\" }"),
+                filled.rows().stream()
+                        .map(r -> String.join(", ", r.inputs().stream().map(i -> i.text()).toList()))
+                        .toList());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/examples/AValueWearsTheEnvelopeThePositionReadsItThroughTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AValueWearsTheEnvelopeThePositionReadsItThroughTest.java
@@ -39,6 +39,9 @@ class AValueWearsTheEnvelopeThePositionReadsItThroughTest {
             data Yen = Int
             data Paid = Yen
             data Settlement = Paid | Draft
+
+            data Withdrawn = { id: Int }
+            data Appeal = Decision | Withdrawn
             """;
 
     private final Compilation compilation = compiled();
@@ -87,12 +90,25 @@ class AValueWearsTheEnvelopeThePositionReadsItThroughTest {
                 neutral.of(approved(), at("Decision"), "h"));
     }
 
-    /** Two sums may list one case, and each position reads it through its own decoder. What they
-     *  read it under agrees for as long as every discriminator is derived (issue #683). */
+    /**
+     * Two sums may list one case. That they read it under the same key and tag is a fact about
+     * derivation and not about either position: every discriminator is derived, keyed {@code "type"}
+     * and tagged with the case's own name, so there is nothing here for a position to disagree about
+     * yet. Held so that #698 — a written discriminator — has to come past it.
+     */
     @Test
-    void eachSumThatListsTheCaseReadsItThroughItsOwnDecoder() throws Exception {
+    void twoDerivedSumsThatListOneCaseCurrentlyAgreeOnItsDiscriminator() throws Exception {
         assertEquals(neutral.of(approved(), at("Decision"), "h"),
                 neutral.of(approved(), at("Outcome"), "h"));
+    }
+
+    /** A derived decoder dispatches over the leaves of the sums it names, so a case reached through
+     *  a nested sum is listed by the outer position's own decoder and is read there without walking
+     *  to the sum that names it directly. */
+    @Test
+    void aCaseReachedThroughANestedSumIsReadAtTheOuterPosition() throws Exception {
+        assertEquals(Map.of("id", 1L, "type", "Approved"),
+                neutral.of(approved(), at("Appeal"), "h"));
     }
 
     /** A unit case travels as its bare name where the position is an enumeration, and wears the tag

--- a/souther-compiler/src/test/java/souther/compiler/examples/AValueWearsTheEnvelopeThePositionReadsItThroughTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AValueWearsTheEnvelopeThePositionReadsItThroughTest.java
@@ -1,0 +1,132 @@
+package souther.compiler.examples;
+
+import net.unit8.raoh.Ok;
+import net.unit8.raoh.Path;
+import net.unit8.raoh.decode.Decoder;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Symbols;
+import souther.compiler.query.Compilation;
+import souther.compiler.types.Type;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The envelope a value wears is the one the position reads it through, not one its case is owed
+ * wherever it stands. A case's own Encoder writes no discriminator and its sum's writes one
+ * (spec §encode-law), so the same {@code Approved} is {@code {"id":1}} where {@code Approved} is
+ * declared and {@code {"id":1,"type":"Approved"}} where {@code Approved | Rejected} is.
+ */
+class AValueWearsTheEnvelopeThePositionReadsItThroughTest {
+
+    private static final String MODULE = """
+            module demo
+
+            data Approved = { id: Int }
+            data Rejected = { id: Int }
+            data Decision = Approved | Rejected
+            data Outcome = Approved | Rejected
+
+            data Draft
+            data Filed
+            data Stage = Draft | Filed
+            data Note = { text: String }
+            data Step = Draft | Note
+
+            data Yen = Int
+            data Paid = Yen
+            data Settlement = Paid | Draft
+            """;
+
+    private final Compilation compilation = compiled();
+    private final Symbols symbols = compilation.symbols("demo");
+    private final NeutralForm neutral = new NeutralForm(symbols);
+
+    private static Compilation compiled() {
+        Compilation c = Compilation.ofSource(MODULE, "Main");
+        c.answerEverything();
+        return c;
+    }
+
+    /** A value of {@code type}, as a helper would have answered with one: through its own decoder,
+     *  which is the one place a case is built here without going through a sum. */
+    @SuppressWarnings("unchecked")
+    private Object value(String type, Object written) throws Exception {
+        Decoder<Object, ?> decoder = (Decoder<Object, ?>) compilation.loader()
+                .loadClass("demo." + type).getMethod("decoder").invoke(null);
+        return ((Ok<?>) decoder.decode(written, Path.ROOT)).value();
+    }
+
+    private Object approved() throws Exception {
+        return value("Approved", Map.of("id", 1L));
+    }
+
+    private Object unit(String type) throws Exception {
+        return value(type, Map.of());
+    }
+
+    private Object paid() throws Exception {
+        return value("Paid", 500L);
+    }
+
+    private Type at(String type) {
+        return Type.ref(symbols.own(type));
+    }
+
+    @Test
+    void aCaseAtItsOwnPositionCarriesNoDiscriminator() throws Exception {
+        assertEquals(Map.of("id", 1L), neutral.of(approved(), at("Approved"), "h"));
+    }
+
+    @Test
+    void aCaseAtASumThatListsItCarriesTheTagThatSumsDecoderReads() throws Exception {
+        assertEquals(Map.of("id", 1L, "type", "Approved"),
+                neutral.of(approved(), at("Decision"), "h"));
+    }
+
+    /** Two sums may list one case, and each position reads it through its own decoder. What they
+     *  read it under agrees for as long as every discriminator is derived (issue #683). */
+    @Test
+    void eachSumThatListsTheCaseReadsItThroughItsOwnDecoder() throws Exception {
+        assertEquals(neutral.of(approved(), at("Decision"), "h"),
+                neutral.of(approved(), at("Outcome"), "h"));
+    }
+
+    /** A unit case travels as its bare name where the position is an enumeration, and wears the tag
+     *  where the position is a sum that has a field-bearing case as well. */
+    @Test
+    void aUnitCaseIsANameAtAnEnumerationAndATagAtASumThatIsNotOne() throws Exception {
+        assertEquals("Draft", neutral.of(unit("Draft"), at("Stage"), "h"));
+        assertEquals(Map.of("type", "Draft"), neutral.of(unit("Draft"), at("Step"), "h"));
+    }
+
+    /** At its own type a unit case is read by its own decoder, which ignores what it is handed. */
+    @Test
+    void aUnitCaseAtItsOwnPositionCarriesNoDiscriminator() throws Exception {
+        assertEquals(Map.of(), neutral.of(unit("Draft"), at("Draft"), "h"));
+    }
+
+    /** A newtype's form is its inner value where the position reads it as itself, and the inner
+     *  value under `value` beside the tag where the position is a sum that lists it. */
+    @Test
+    void aNewtypeIsBareAtItsOwnPositionAndWrappedAtASumThatListsIt() throws Exception {
+        assertEquals(500L, neutral.of(paid(), at("Paid"), "h"));
+        assertEquals(Map.of("type", "Paid", "value", 500L),
+                neutral.of(paid(), at("Settlement"), "h"));
+    }
+
+    /**
+     * Where the position has no declared type — an answer of several types, which admission and not
+     * a decoder decides — the sums that list the case answer instead. Held here because it is the
+     * one thing the position cannot be asked for, and because it is right only for as long as every
+     * discriminator is derived (issue #683).
+     */
+    @Test
+    void aPositionWithNoDeclaredTypeIsAnsweredByTheSumsThatListTheCase() throws Exception {
+        assertEquals(Map.of("id", 1L, "type", "Approved"), neutral.of(approved(), null, "h"));
+        assertEquals(Map.of("type", "Draft"), neutral.of(unit("Draft"), null, "h"));
+    }
+}


### PR DESCRIPTION
`NeutralForm` decided which discriminator a case carries by walking every visible
declaration for a sum that lists it. That answers a question about the case where the
question is about the position the value stands at.

## What was measured first

The ambiguity #683 reported — two sums naming one case under different keys or tags —
is unreachable. `AstBuilder` builds every sum with an empty decoder and there is no
surface syntax for a written one, so every `Ast.Discriminate` comes from
`Deriver.deriveSum`, which keys it `"type"` and tags each case with its own declared
name. A sum's cases are declared in its own module. `Reason = High | LowRole` beside
`Cause = High | LowRole` compiles, and both codecs read and write
`{"type": "High", ...}`.

## What is fixed

What is written is decided by the type the position declares (spec §encode-law): a
case's own decoder reads no discriminator and its sum's reads one. `tagged` now takes
that type and reads the key and the tag off its own derived decoder —
`Ast.SumData.decoder()`, what `Deriver` decided and `CodecGen` emits — rather than
deciding the form a second time. `readsAsItself` and `adjacentlyTagged` go with it:
at a position that is not a sum listing the case, no envelope is written, which is
what both were saying separately.

Where the position has no declared type the old walk stays, on its own path and named
as the fallback it is. It has one producer: a behavior answering with several types,
where admission and not a decoder picks the case.

## Effect on souther-examples

16 lines of ~20,600 moved. `hr` generates 4 more rows (56 -> 60) and 4
`every value tried was refused at construction` lines are gone: `BusinessClosure` and
`EncouragedResignation`, unit cases `employmentinsurance` does not import by name.
The old path resolved a spelling, got null, left the envelope empty, and the value was
refused with `type: is required`.

## How it is held

Each of a product case, a unit case and a newtype is pinned at its own position and at
a sum that lists it; an enumeration keeps its bare name; the fallback is asserted where
no type is declared.

Both directions are controlled for. Making the typed path write no tag fails 34 tests
across eight classes. Restoring the old walk fails the three that assert what a value's
own position reads. All modules are green.

## Left for later

- #696 — compiler-generated `Ast.Apply` drops the resolved callee identity, which is
  what still forces `FixtureReader` to resolve spellings. Attempted here and reverted:
  the identity is absent on generator-built nodes, so it needs upstream work.
- #697 — whether codec-target selection is duplicated across three type walks.
- #698 — the untyped fallback holds only while every discriminator is derived.

Refs #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)
