### PR TITLE
Write a reference the way the module reading it reaches the type

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -16,6 +16,7 @@ import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
@@ -1418,11 +1419,17 @@ public interface Ast {
         /**
          * A name that has been resolved has both answers or neither.
          *
+         * <p>Both, or neither: a name the parser read is unanswered on both counts, and a name
+         * resolution answered is answered on both. Nothing in between is a state — the pair comes
+         * from one pass, which has both or has not run.
+         *
          * <p>Refused rather than allowed to stand, because what a name reaches is asked of a table
          * and a table answers a key it has not got with silence. A rewrite that carried the
          * denotation across and dropped the reach name would leave a reference that resolves to a
          * declaration and reaches nothing, and the first reader of it would read the spelling
-         * instead — which is what this pair was separated out to stop.
+         * instead — which is what this pair was separated out to stop. The other half is the same
+         * defect facing the other way: a reach name beside no denotation is a key nothing says the
+         * meaning of, and {@link ReachName#of} is where one would have to come from.
          *
          * <p>The region is the expression's and the name's is {@code written}'s, and they part
          * company only where the author wrapped the name in something the tree does not keep:
@@ -1431,9 +1438,10 @@ public interface Ast {
          * name is written somewhere this expression is not, which no source can produce.
          */
         public Var {
-            if (denotes != null && reachedAs == null) {
-                throw new IllegalArgumentException("`" + written.canonical() + "` denotes " + denotes
-                        + " and says nothing about how this module reaches it");
+            if ((denotes == null) != (reachedAs == null)) {
+                throw new IllegalArgumentException("`" + written.canonical() + "` denotes "
+                        + denotes + " and is reached as " + reachedAs
+                        + "; a name has both answers or neither");
             }
             if (written.region() != null && region == null) {
                 throw new IllegalArgumentException("`" + written.canonical()
@@ -1662,7 +1670,16 @@ public interface Ast {
          */
         public Apply(String fn, ValueName denotes, ReachName reachedAs, List<Expr> args,
                      ConstructionOrigin origin, SourcePos pos, Region region) {
-            this(Var.respelled(fn, denotes, reachedAs, pos, null), args, origin, pos, region);
+            this(Var.respelled(fn, Objects.requireNonNull(denotes, unanswered(fn, "denotes")),
+                            Objects.requireNonNull(reachedAs, unanswered(fn, "is reached as")),
+                            pos, null),
+                    args, origin, pos, region);
+        }
+
+        /** Why a pass may not apply a name it has not answered for. */
+        private static String unanswered(String fn, String half) {
+            return "a pass applying `" + fn + "` says what it means: nothing here " + half
+                    + " it, and the spelling would be resolved again wherever this is read";
         }
 
         /** Whether what this applies is a name. A reader that wants the name itself matches on

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -11,6 +11,7 @@ import souther.compiler.types.CoverageOrigin;
 import souther.compiler.types.ReachName;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.TypeReachName;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
@@ -184,9 +185,21 @@ public interface Ast {
         }
 
         /** A name a pass synthesized, already knowing what it denotes. It is written nowhere;
-         * {@code pos} is what a complaint about it points at. */
+         * {@code pos} is what a complaint about it points at. The spelling is the declaration's own,
+         * which is what a reference internal to a module reaches it by. */
         public static Name resolved(TypeName denotes, SourcePos pos) {
             return new Name(WrittenName.synthetic(denotes.name(), pos), denotes);
+        }
+
+        /**
+         * The same, spelled as the module this is being written into reaches it.
+         *
+         * <p>For a pass whose output a person reads back: the declaration's own name is not what
+         * every module writes, so a name synthesized with it quotes a spelling the reader cannot
+         * write. What it denotes is the same either way.
+         */
+        public static Name reached(TypeReachName.Written type, SourcePos pos) {
+            return new Name(WrittenName.synthetic(type.rendered(), pos), type.denotes());
         }
 
         /** The bare name this reaches its declaration by, whatever the source spelled. */
@@ -1520,17 +1533,24 @@ public interface Ast {
         }
 
         /**
-         * The name of the declaration this reference reaches, or the name written where nothing has
-         * been resolved. The reading counterpart of {@link Apply#reaches()}: {@link #name()} is the
-         * name the source writes, which an import may have let go without its qualifier.
+         * The name of the declaration this reference reaches — what a table keyed by a declaration's
+         * name is looked up with. The reading counterpart of {@link Apply#reaches()}:
+         * {@link #name()} is the name the source writes, which an import may have let go without its
+         * qualifier.
          *
-         * <p>The spelling is answered only for a tree resolution never saw — one a pass built for
-         * itself, which {@code FixtureTemplate} does and the example reader asks this of. It is not
-         * what a rewrite that dropped the reach name would get: a name that denotes something and
-         * says nothing about how it is reached cannot be built at all (see the constructor).
+         * <p>Never the spelling. A name that reached a reader without being resolved has no answer
+         * to this, and it says so rather than handing back the characters — which is the same rule
+         * {@link #bare()} is under, and for the same reason: an import lets a name be written
+         * without its qualifier, so the spelling misses in the very table this is asked for, and a
+         * table answers a key it has not got with silence. Every pass that writes a reference of its
+         * own says what it means (ADR-0067), so there is no tree downstream of resolution for the
+         * fallback to have been for.
          */
         public String reaches() {
-            return reachedAs == null ? name() : reachedAs.rendered();
+            if (reachedAs == null) {
+                throw new IllegalStateException("`" + name() + "` was never resolved");
+            }
+            return reachedAs.rendered();
         }
 
         /**
@@ -1619,7 +1639,8 @@ public interface Ast {
         }
 
         /**
-         * Applying a name a pass chose, at the form it stands in.
+         * Applying a name a pass chose, at the form it stands in, saying what that name means and
+         * how the body being written into reaches it.
          *
          * <p>{@code fn} is a spelling and not an occurrence — a library name a rewrite reached for,
          * a fixture's constructor, a value rendered back out of what was computed — so the applied
@@ -1628,18 +1649,17 @@ public interface Ast {
          * occurrence is; building one from a spelling and a position measures the spelling at the
          * anchor, and the two are the same number only until they are not.
          *
+         * <p>The denotation and the reach name are taken and not optional. A pass writing an
+         * application either has them or is writing a name it has not resolved, and the second is
+         * what ADR-0067 rules out: the spelling would be read back downstream by whatever the
+         * reading module happens to mean by it. Only the parser leaves a callee unanswered, and it
+         * builds the {@link Var} for itself.
+         *
          * <p>{@code region} is the application's and is not handed to the callee. What the callee
          * covers is its own — a rewrite that puts another name in a call leaves the arguments where
          * they are, so a report about what is applied would otherwise underline them too. A caller
          * that has the callee's extent builds the {@link Var} itself and passes it.
          */
-        public Apply(String fn, List<Expr> args, SourcePos pos, Region region) {
-            this(Var.respelled(fn, null, null, pos, null), args, ConstructionOrigin.own(), pos,
-                    region);
-        }
-
-        /** The same, for a pass that already knows what the name means and how the body it is
-         * writing into reaches it. */
         public Apply(String fn, ValueName denotes, ReachName reachedAs, List<Expr> args,
                      ConstructionOrigin origin, SourcePos pos, Region region) {
             this(Var.respelled(fn, denotes, reachedAs, pos, null), args, origin, pos, region);

--- a/souther-compiler/src/main/java/souther/compiler/ast/StructuralCost.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/StructuralCost.java
@@ -156,11 +156,13 @@ public final class StructuralCost {
             if (node == null) {
                 continue;
             }
+            // Asked of the name only where something is being substituted for it. What a name
+            // reaches is an answer resolution gives, and the tree this is measured on before that
+            // has none — a definition is counted as written the moment it is parsed, and nothing is
+            // substituted into it there.
             if (node instanceof Ast.Var name) {
-                Ast.Expr body = Path.holds(step.path(), name.reaches())
-                        ? null
-                        : reaches.substitutedAt(name);
-                if (body != null) {
+                Ast.Expr body = reaches.substitutedAt(name);
+                if (body != null && !Path.holds(step.path(), name.reaches())) {
                     todo.add(new Step(body, step.above(), name,
                             new Path(name.reaches(), step.path())));
                     continue;

--- a/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.TypeReachName;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -154,6 +155,45 @@ public final class Symbols {
         }
         TypeName candidate = new TypeName(target, written.substring(dot + 1));
         return contains(candidate) && exposes(target, candidate.name()) ? candidate : null;
+    }
+
+    /**
+     * How this module writes {@code type} — the other direction of {@link #resolve}, and the one
+     * thing a writer of surface text cannot work out from the type itself.
+     *
+     * <p>Bare only where the bare spelling means this very declaration. Asked as "is the name in
+     * scope" instead, a module that declares an {@code Amount} of its own and reaches another
+     * module's under an alias would write the imported one bare, and the reference would name the
+     * declaration it is not — silently, since both spellings resolve.
+     *
+     * <p>An alias is chosen by name where a module has more than one, so that two runs of the same
+     * compilation write one reference. Nothing here picks the alias for being better than the
+     * others; it picks it for being the same one every time.
+     *
+     * <p>A qualified name reaches only what its module exposes, so a type another module keeps to
+     * itself has no name here at all. That happens without anything being wrong with the model: a
+     * sum is reached through its module and its cases through the sum, so a case a module does not
+     * expose is a value a reader takes and cannot write. It is answered as
+     * {@link TypeReachName.Unnameable} rather than as the qualified spelling, which would resolve to
+     * nothing wherever it was put.
+     */
+    public TypeReachName reach(TypeName type) {
+        if (type.isPrimitive() || TypeName.RUNTIME.equals(type.module())
+                || type.equals(scope.get(type.name()))) {
+            return new TypeReachName.Bare(type);
+        }
+        if (!exposes(type.module(), type.name())) {
+            return new TypeReachName.Unnameable(type);
+        }
+        String alias = null;
+        for (Map.Entry<String, String> each : aliases.entrySet()) {
+            if (each.getValue().equals(type.module())
+                    && (alias == null || each.getKey().compareTo(alias) < 0)) {
+                alias = each.getKey();
+            }
+        }
+        return alias != null ? new TypeReachName.ViaAlias(alias, type)
+                : new TypeReachName.ViaModule(type);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
@@ -158,8 +158,20 @@ public final class Symbols {
     }
 
     /**
-     * How this module writes {@code type} — the other direction of {@link #resolve}, and the one
-     * thing a writer of surface text cannot work out from the type itself.
+     * How this module writes {@code type} — the one thing a writer of surface text cannot work out
+     * from the type itself.
+     *
+     * <p>A section of {@link #resolve} rather than its inverse. Several spellings reach one
+     * declaration — {@code Amount}, {@code up.Amount} and {@code lib.Amount} may all be it — so
+     * there is no inverse to have; this picks one of them, and what it picks resolves back to the
+     * type it was asked about. That is the whole of the contract, and it is what a generated row
+     * being writable means.
+     *
+     * <p>Read back by whichever reader reads the position the name is written at, which for the
+     * language's own vocabulary is not this one: a primitive and the runtime's error cases are
+     * {@link #resolveCase}'s to answer, and {@code resolve} says nothing about them. They are
+     * written as themselves wherever they are written, so the section holds there through that
+     * reader.
      *
      * <p>Bare only where the bare spelling means this very declaration. Asked as "is the name in
      * scope" instead, a module that declares an {@code Amount} of its own and reaches another
@@ -170,13 +182,12 @@ public final class Symbols {
      * compilation write one reference. Nothing here picks the alias for being better than the
      * others; it picks it for being the same one every time.
      *
-     * <p>The inverse of {@link #resolve} and held to it: what this answers resolves back to the
-     * type it was asked about. So a bare name is answered only where the bare name means this type
-     * <em>here</em>, and that is one question for every kind of type. A primitive's spelling is
-     * reserved (E1502), so nothing can be standing on it. The runtime namespace's own data is not
-     * reserved and is the lowest rung of a module's scope — a module declaring a {@code
-     * RoundingMode} of its own takes the spelling, and the language's one has no other, so it is
-     * unnameable there rather than bare (ADR-0087).
+     * <p>So a bare name is answered only where the bare name means this type <em>here</em>, and
+     * that is one question for every kind of type. A primitive's spelling is reserved (E1502), so
+     * nothing can be standing on it. The runtime namespace's own data is not reserved and is the
+     * lowest rung of a module's scope — a module declaring a {@code RoundingMode} of its own takes
+     * the spelling, and the language's one has no other, so it is unnameable there rather than bare
+     * (ADR-0087).
      *
      * <p>A qualified name reaches only what its module exposes, so a type another module keeps to
      * itself has no name here at all. That happens without anything being wrong with the model: a

--- a/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
@@ -170,6 +170,14 @@ public final class Symbols {
      * compilation write one reference. Nothing here picks the alias for being better than the
      * others; it picks it for being the same one every time.
      *
+     * <p>The inverse of {@link #resolve} and held to it: what this answers resolves back to the
+     * type it was asked about. So a bare name is answered only where the bare name means this type
+     * <em>here</em>, and that is one question for every kind of type. A primitive's spelling is
+     * reserved (E1502), so nothing can be standing on it. The runtime namespace's own data is not
+     * reserved and is the lowest rung of a module's scope — a module declaring a {@code
+     * RoundingMode} of its own takes the spelling, and the language's one has no other, so it is
+     * unnameable there rather than bare (ADR-0087).
+     *
      * <p>A qualified name reaches only what its module exposes, so a type another module keeps to
      * itself has no name here at all. That happens without anything being wrong with the model: a
      * sum is reached through its module and its cases through the sum, so a case a module does not
@@ -178,9 +186,14 @@ public final class Symbols {
      * nothing wherever it was put.
      */
     public TypeReachName reach(TypeName type) {
-        if (type.isPrimitive() || TypeName.RUNTIME.equals(type.module())
-                || type.equals(scope.get(type.name()))) {
+        if (type.isPrimitive() || type.equals(scope.get(type.name()))) {
             return new TypeReachName.Bare(type);
+        }
+        if (TypeName.RUNTIME.equals(type.module())) {
+            // Reached bare, and only while nothing else here is: the runtime namespace is not a
+            // module a qualifier names, so a module declaring the spelling leaves it with no name.
+            return scope.containsKey(type.name()) ? new TypeReachName.Unnameable(type)
+                    : new TypeReachName.Bare(type);
         }
         if (!exposes(type.module(), type.name())) {
             return new TypeReachName.Unnameable(type);

--- a/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
@@ -572,6 +572,25 @@ public final class FixtureReader {
                 neutral.shaped(raw(nd, Type.ref(built), Admission.HELD), Type.ref(built)));
     }
 
+    /**
+     * The type an application constructs, or null where what it applies is not a type.
+     *
+     * <p>Read off what the callee denotes, which resolution settled and every producer of a tree
+     * carries (ADR-0067). Asked of the spelling instead, an import that let a name be written bare
+     * missed the table, a module declaring its own type of the same spelling answered with that one,
+     * and a row generated for an aliased type resolved to nothing at all (issue #696) — all three
+     * silently, since a miss is what a table keyed by names does with a key it has not got.
+     */
+    private static TypeName constructs(Ast.Apply c) {
+        return c.denotes() instanceof ValueName.OfType named ? named.type() : null;
+    }
+
+    /** Whether an application is a newtype's construction written in call form (ADR-0032). */
+    private boolean constructsANewtype(Ast.Apply c) {
+        TypeName built = constructs(c);
+        return built != null && neutral.isNewtype(built);
+    }
+
     private Asserted assertedApply(Ast.Apply c, Type position) {
         Type.Prim written = Type.Prim.named(c.reaches());
         if (written != null && written.temporal()) {
@@ -602,7 +621,7 @@ public final class FixtureReader {
             // what the position holds. Nothing about the position enters.
             return assertedLive(answered(c, helper));
         }
-        if (!neutral.isNewtype(c.written())) {
+        if (!constructsANewtype(c)) {
             String reached = helperKey(c);
             if (reached != null && noMethod(reached)) {
                 throw FixtureException.cannotBeCalled(c.written());
@@ -612,7 +631,7 @@ public final class FixtureReader {
         if (c.args().size() != 1) {
             throw new FixtureException("`" + c.written() + "` takes one argument");
         }
-        return assertedNewtype(symbols.resolve(c.written()), c.args().get(0), c.written());
+        return assertedNewtype(constructs(c), c.args().get(0), c.written());
     }
 
     /**
@@ -953,7 +972,7 @@ public final class FixtureReader {
         if (expected instanceof Ast.NewData nd) {
             return nd.typeName().written();
         }
-        if (expected instanceof Ast.Apply c && neutral.isNewtype(c.written())) {
+        if (expected instanceof Ast.Apply c && constructsANewtype(c)) {
             return c.written();
         }
         return null;   // a literal expected (a primitive output)
@@ -1011,8 +1030,8 @@ public final class FixtureReader {
     private TypeName constructedCase(Ast.Expr e, Set<String> followed, List<TypeName> worn) {
         return switch (e) {
             case Ast.NewData nd -> nd.typeName().denotes();
-            case Ast.Apply c when neutral.isNewtype(c.written()) -> {
-                TypeName named = symbols.resolveCase(c.written());
+            case Ast.Apply c when constructsANewtype(c) -> {
+                TypeName named = constructs(c);
                 yield wears(named, c, worn)
                         ? constructedCase(c.args().get(0), followed, worn.subList(1, worn.size()))
                         : named;
@@ -1566,8 +1585,7 @@ public final class FixtureReader {
             case Ast.NewData nd -> new Stated.Name(nd.typeName().denotes());
             case Ast.Var v -> statedByName(v);
             case Ast.Apply c when appliedHelper(c) != null -> ELSEWHERE;
-            case Ast.Apply c when neutral.isNewtype(c.written()) ->
-                    caseNamed(symbols.resolveCase(c.written()));
+            case Ast.Apply c when constructsANewtype(c) -> caseNamed(constructs(c));
             // `Date("…")` is a temporal, and `Set.fromList([…])` a collection: values under no name.
             case Ast.Apply c when Type.Prim.named(c.reaches()) != null
                     || "Set.fromList".equals(c.reaches()) || "Map.fromList".equals(c.reaches()) ->
@@ -1641,10 +1659,7 @@ public final class FixtureReader {
         return switch (e) {
             case Ast.NewData nd -> Type.ref(nd.typeName().denotes());
             // `AmountN(100)` is the newtype's construction written in call form (ADR-0032).
-            case Ast.Apply c when neutral.isNewtype(c.written()) -> {
-                TypeName named = symbols.resolve(c.written());
-                yield named == null ? null : Type.ref(named);
-            }
+            case Ast.Apply c when constructsANewtype(c) -> Type.ref(constructs(c));
             case Ast.FieldAccess fa -> {
                 Type target = declaredTypeOf(fa.target(), seen, bound);
                 yield target == null ? null : fieldTypeOf(target, fa.field());
@@ -1936,7 +1951,7 @@ public final class FixtureReader {
      * so the two readers of a call cannot come to different answers. */
     private Applied appliedHelper(Ast.Apply c) {
         if ("Set.fromList".equals(c.reaches()) || "Map.fromList".equals(c.reaches())
-                || neutral.isNewtype(c.written())) {
+                || constructsANewtype(c)) {
             return null;
         }
         String reached = helperKey(c);
@@ -2078,7 +2093,7 @@ public final class FixtureReader {
             }
             return CallElaborator.parseTemporal(c.written(), lit.value(), lit.reportedAt());
         }
-        if (!neutral.isNewtype(c.written())) {
+        if (!constructsANewtype(c)) {
             String reached = helperKey(c);
             if (reached != null && noMethod(reached)) {
                 // A function this module cannot run: a helper whose body produces a function, which
@@ -2088,6 +2103,7 @@ public final class FixtureReader {
             }
             throw new FixtureException("`" + c.written() + "` is not a newtype; a fixture cannot call it");
         }
+        TypeName built = constructs(c);
         if (c.args().size() != 1) {
             throw new FixtureException("`" + c.written() + "` takes one argument");
         }
@@ -2099,10 +2115,10 @@ public final class FixtureReader {
         // the argument is shaped against what the newtype wraps, the same way a record fixture
         // shapes a field's value: a `Map` newtype's entry pairs become a map, a `Set` newtype's
         // written list stays a list for its decoder to dedupe
-        return neutral.newtypeAt(expected, c.written(),
+        return neutral.newtypeAt(expected, built,
                 neutral.shaped(raw(c.args().get(0),
-                                neutral.shapeOf(neutral.newtypeBaseType(c.written())), below(admission)),
-                        neutral.shapeOf(neutral.newtypeBaseType(c.written()))));
+                                neutral.shapeOf(neutral.newtypeBaseType(built)), below(admission)),
+                        neutral.shapeOf(neutral.newtypeBaseType(built))));
     }
 
     private Object record(Ast.NewData nd, Type expected, Admission admission) {

--- a/souther-compiler/src/main/java/souther/compiler/examples/NeutralForm.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/NeutralForm.java
@@ -359,10 +359,6 @@ final class NeutralForm {
     }
 
     /** As above, for a construction written as a call, where the name is what the row spelled. */
-    Object newtypeAt(Type position, String written, Object inner) {
-        return newtypeAt(position, symbols.resolve(written), inner);
-    }
-
     /** Whether the position this case is written in reads a bare name: it is typed as an enumeration,
      * or it is untyped here and every sum that lists the case is one. */
     boolean readsABareName(Type expected, TypeName caseName) {
@@ -421,26 +417,15 @@ final class NeutralForm {
         return declaredType == null ? null : declaredType.denotes();
     }
 
-    boolean isNewtype(String name) {
-        return symbols.declaration(name) instanceof Ast.Data d && d.newtype();
-    }
-
-    /** As above, for a name that has already been resolved — an imported value's body names its own
-     * module's types, which the module reading the row need not have imported. */
+    /** Whether {@code name} is a newtype — asked of a name resolution settled, never of a spelling:
+     * an imported value's body names its own module's types, which the module reading the row need
+     * not have imported, and a module of its own may declare something else of that spelling. */
     boolean isNewtype(TypeName name) {
         return name != null && symbols.get(name) instanceof Ast.Data d && d.newtype();
     }
 
     /** The written form of what a newtype wraps, kept whole so a generic base
      * ({@code data 在庫 = Map<商品ID, Int>}) keeps its type arguments. */
-    Ast.TypeRef newtypeBaseType(String name) {
-        return symbols.declaration(name) instanceof Ast.Data d && d.newtype() && d.fields().size() == 1
-                && d.fields().get(0).type() instanceof Ast.TypeRef base
-                ? base
-                : null;
-    }
-
-    /** As above, for a name that has already been resolved. */
     Ast.TypeRef newtypeBaseType(TypeName name) {
         return name != null && symbols.get(name) instanceof Ast.Data d && d.newtype()
                 && d.fields().size() == 1 && d.fields().get(0).type() instanceof Ast.TypeRef base

--- a/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
@@ -8,8 +8,8 @@ import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Place;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.ConstructionOrigin;
-import souther.compiler.types.TypeName;
 import souther.compiler.types.ReachName;
+import souther.compiler.types.TypeReachName;
 import souther.compiler.types.ValueName;
 
 import java.math.BigDecimal;
@@ -31,6 +31,13 @@ import java.util.Map;
  * <p>The tree carries what its names denote, because that is what a fixture is read by. A construction
  * is reached by the type it names, not by the spelling — so the type is put there when the value is
  * made, where it is known, rather than looked up again from the text.
+ *
+ * <p>Every name a value here wears arrives as a {@link TypeReachName}, so that the two forms are
+ * written from one answer. What the tree denotes and what the text spells are the two halves of one
+ * reference, and nothing here decides either: a type declared as {@code Amount} is written
+ * {@code up.Amount} by a module that reached it through an alias, and a generator that spelled the
+ * declaration's own name offered a row nobody could paste while handing the reader a name it
+ * resolved to something else (issue #696).
  */
 public record FixtureTemplate(String text, Ast.Expr value) {
 
@@ -105,12 +112,21 @@ public record FixtureTemplate(String text, Ast.Expr value) {
         return temporal("Instant", iso);
     }
 
-    /** Every temporal is written the same way — the type's name applied to its ISO 8601 text — so the
-     *  four share this rather than repeating it and letting one of them drift. */
+    /**
+     * Every temporal is written the same way — the type's name applied to its ISO 8601 text — so the
+     * four share this rather than repeating it and letting one of them drift.
+     *
+     * <p>A temporal is the language's own vocabulary rather than any module's declaration, so the
+     * name is the library namespace applied, which is what the same call written in a source reaches
+     * ({@link ValueName.Stdlib#namespace}). No module renames it and none has to be asked how it
+     * writes it.
+     */
     private static FixtureTemplate temporal(String type, String iso) {
+        ValueName.Stdlib namespace = ValueName.Stdlib.namespace(type);
         return new FixtureTemplate(type + "(\"" + iso + "\")",
-                new Ast.Apply(type, List.of(new Ast.StringLit(iso, NOWHERE, NO_SOURCE)),
-                        NOWHERE, NO_SOURCE));
+                new Ast.Apply(type, namespace, new ReachName.OfLibrary(namespace),
+                        List.of(new Ast.StringLit(iso, NOWHERE, NO_SOURCE)),
+                        ConstructionOrigin.own(), NOWHERE, NO_SOURCE));
     }
 
     /** The absent optional, which the language names rather than any module. */
@@ -121,11 +137,12 @@ public record FixtureTemplate(String text, Ast.Expr value) {
     }
 
     /** A case that carries nothing: naming it is constructing it. */
-    public static FixtureTemplate unitCase(TypeName type) {
-        return new FixtureTemplate(type.name(),
-                new Ast.Var(WrittenName.synthetic(type.name(), NOWHERE),
-                        new ValueName.OfType(type.name(), type, ConstructionOrigin.own()),
-                        new ReachName.Bare(type.name())));
+    public static FixtureTemplate unitCase(TypeReachName.Written type) {
+        String written = type.rendered();
+        return new FixtureTemplate(written,
+                new Ast.Var(WrittenName.synthetic(written, NOWHERE),
+                        new ValueName.OfType(written, type.denotes(), ConstructionOrigin.own()),
+                        new ReachName.Bare(written)));
     }
 
     /**
@@ -136,12 +153,16 @@ public record FixtureTemplate(String text, Ast.Expr value) {
      * second count reached a row as an {@code Int}, and the decoder turned it down with nothing said
      * about why.
      *
+     * <p>Null where the case at {@code at} is one this module cannot name — a case the module
+     * declaring it does not expose, which a value can be of and no author can write down. Every
+     * other carrier writes a literal, which needs no name from anyone.
+     *
      * <p>Bare. How many names the value wears at the position it is going to is a different question
      * with its own answer ({@link Witnesses#wrapped}), which walks every layer; answered here as
      * well, it was answered one layer deep, and a value of a newtype over a newtype came back
      * missing the name in the middle.
      */
-    public static FixtureTemplate on(Carrier carrier, Place at) {
+    public static FixtureTemplate on(Carrier carrier, Place at, TypeReachName.Naming naming) {
         return switch (carrier) {
             case Carrier.Whole _ -> integer(Count.number(at).at().longValueExact());
             case Carrier.Dense _ -> decimal(Count.number(at).at());
@@ -151,17 +172,28 @@ public record FixtureTemplate(String text, Ast.Expr value) {
             case Carrier.Seconds _ -> dateTime(carrier.written(at));
             // Naming a case builds it, which is what a row writes at such a position — never the
             // place the case takes in its declaration.
-            case Carrier.Ordinal ordinal -> unitCase(ordinal.caseAt(at));
+            case Carrier.Ordinal ordinal ->
+                    naming.of(ordinal.caseAt(at)) instanceof TypeReachName.Written written
+                            ? unitCase(written) : null;
             // A string stands for itself, so what a row carries is the string, escaped the way the
             // language reads one back.
             case Carrier.Text _ -> string(at.key());
         };
     }
 
-    /** A newtype around one value, written in the call form a row writes it in (ADR-0032). */
-    public static FixtureTemplate newtype(TypeName type, FixtureTemplate inner) {
-        return new FixtureTemplate(type.name() + "(" + inner.text() + ")",
-                new Ast.Apply(type.name(), List.of(inner.value()), NOWHERE, NO_SOURCE));
+    /**
+     * A newtype around one value, written in the call form a row writes it in (ADR-0032).
+     *
+     * <p>The construction says where it came from and the name says what it is, which is how the
+     * same call reads when a source wrote it: applying a type is the newtype taking what it wraps,
+     * so the origin is the application's and the name carries none of its own.
+     */
+    public static FixtureTemplate newtype(TypeReachName.Written type, FixtureTemplate inner) {
+        String written = type.rendered();
+        return new FixtureTemplate(written + "(" + inner.text() + ")",
+                new Ast.Apply(written, new ValueName.OfType(written, type.denotes(), null),
+                        new ReachName.Bare(written), List.of(inner.value()),
+                        ConstructionOrigin.own(), NOWHERE, NO_SOURCE));
     }
 
     /** No elements. A list, a set and a map are all written this way in a fixture: what the position
@@ -195,15 +227,15 @@ public record FixtureTemplate(String text, Ast.Expr value) {
     }
 
     /** A record, field by field, in the order the fields were declared. */
-    public static FixtureTemplate record(TypeName type, Map<String, FixtureTemplate> fields) {
+    public static FixtureTemplate record(TypeReachName.Written type, Map<String, FixtureTemplate> fields) {
         List<String> written = new ArrayList<>();
         List<Ast.FieldInit> inits = new ArrayList<>();
         for (Map.Entry<String, FixtureTemplate> field : fields.entrySet()) {
             written.add(field.getKey() + " = " + field.getValue().text());
             inits.add(new Ast.FieldInit(field.getKey(), field.getValue().value(), NOWHERE));
         }
-        return new FixtureTemplate(type.name() + " { " + String.join(", ", written) + " }",
-                new Ast.NewData(Ast.Name.resolved(type, NOWHERE), inits, List.of(),
+        return new FixtureTemplate(type.rendered() + " { " + String.join(", ", written) + " }",
+                new Ast.NewData(Ast.Name.reached(type, NOWHERE), inits, List.of(),
                         ConstructionOrigin.own(), NOWHERE, NO_SOURCE));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -14,6 +14,7 @@ import souther.compiler.observe.Classification;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.TypeReachName;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -429,7 +430,8 @@ public final class Generator {
             declared = at1 < 0 || at1 >= subject.types().size() ? null : subject.types().get(at1);
         }
         return declared == null ? null
-                : Witnesses.wrapped(declared, FixtureTemplate.on(carrier, at), subject.symbols());
+                : Witnesses.wrapped(declared, FixtureTemplate.on(carrier, at, subject.symbols()::reach),
+                        subject.symbols());
     }
 
     /** A row at a line drawn at one count of one position. */
@@ -1279,9 +1281,18 @@ public final class Generator {
             // Under the names the position is written with, which the reading that found the fields
             // took off to find them. A row at a `data SlotN = Slot` carries `SlotN(Slot { ... })`,
             // and a value composed without them is of a type the parameter does not declare.
-            FixtureTemplate record = RepresentativeSource.under(
-                    view.wrappers().stream().map(TypeOps.Layer::named).toList(),
-                    FixtureTemplate.record(product.name(), built));
+            List<TypeReachName.Written> worn = new ArrayList<>();
+            for (TypeOps.Layer layer : view.wrappers()) {
+                if (!(symbols.reach(layer.named()) instanceof TypeReachName.Written written)) {
+                    return null;   // a name this module cannot write leaves no value to write
+                }
+                worn.add(written);
+            }
+            if (!(symbols.reach(product.name()) instanceof TypeReachName.Written written)) {
+                return null;
+            }
+            FixtureTemplate record = RepresentativeSource.under(worn,
+                    FixtureTemplate.record(written, built));
             return recipe == null ? record : recipe.written(record);
         }
         return null;
@@ -1334,8 +1345,11 @@ public final class Generator {
             // written as a literal of another — which is how a date-time's second count reached a
             // row as an `Int`, and the decoder refused it with the report saying only that every
             // value tried had been refused.
-            return new Edge(List.of(Witnesses.wrapped(axis.type(),
-                    FixtureTemplate.on(carrier, at), symbols)), null, at, null);
+            FixtureTemplate standing = Witnesses.wrapped(axis.type(),
+                    FixtureTemplate.on(carrier, at, symbols::reach), symbols);
+            return standing == null
+                    ? Edge.none(UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE)
+                    : new Edge(List.of(standing), null, at, null);
         }
         int size = CountDomain.asCount(at);
         if (size < 0) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
@@ -195,7 +195,9 @@ final class Intervals {
     private static List<FixtureTemplate> standingIn(NumericTerm of, Place inside, Type type,
                                                     Carrier carrier, Symbols symbols) {
         if (of instanceof NumericTerm.ValueOf) {
-            return List.of(Witnesses.wrapped(type, FixtureTemplate.on(carrier, inside), symbols));
+            FixtureTemplate standing = Witnesses.wrapped(type,
+                    FixtureTemplate.on(carrier, inside, symbols::reach), symbols);
+            return standing == null ? List.of() : List.of(standing);
         }
         int size = CountDomain.asCount(inside);
         if (size < 0) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
@@ -8,6 +8,7 @@ import souther.compiler.check.TypeView;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.TypeReachName;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -62,16 +63,30 @@ final class PartitionClasses {
      */
     static List<PartitionClass> of(TypeView view, Symbols symbols) {
         List<TypeName> worn = view.wrappers().stream().map(TypeOps.Layer::named).toList();
+        // The same names twice over, because two different questions are asked of them. Whether an
+        // observed value is under this class is asked of the declarations, and what a row writes it
+        // under is asked of the module doing the writing — one of these is an identity and the other
+        // is a reference, and a module reaching a name through an alias answers them differently.
+        List<TypeReachName.Written> writes = new ArrayList<>();
+        for (TypeName each : worn) {
+            if (!(symbols.reach(each) instanceof TypeReachName.Written written)) {
+                // A name the position wears that nothing here writes. The classes are still the
+                // position's, and no row for any of them can be written down, so each says that
+                // rather than being offered a value spelled with a name that resolves to nothing.
+                return unwritable(view, symbols, worn, each);
+            }
+            writes.add(written);
+        }
         return switch (view.shape()) {
             // A `Bool` is two values. No other primitive has classes to read off its type: what a
             // number's rules leave is a range with edges — everything outside a newtype's invariant
             // is refused at construction (E1903), so there is no class on the other side to cover —
             // and what does divide a number is a threshold, which is read from a body and not here.
             case Shape.Scalar scalar -> scalar.prim() == Type.Prim.BOOL
-                    ? eitherWay(worn) : List.of();
-            case Shape.Sum sum -> caseClasses(Type.ref(sum.name()), worn, symbols);
-            case Shape.Cases cases -> caseClasses(Type.union(cases.members()), worn, symbols);
-            case Shape.Optional optional -> heldOrNot(optional.element(), worn, symbols);
+                    ? eitherWay(worn, writes) : List.of();
+            case Shape.Sum sum -> caseClasses(Type.ref(sum.name()), worn, writes, symbols);
+            case Shape.Cases cases -> caseClasses(Type.union(cases.members()), worn, writes, symbols);
+            case Shape.Optional optional -> heldOrNot(optional.element(), worn, writes, symbols);
             // Shapes whose types state no division of their own. A record is made of positions and a
             // collection holds its values inside something — what that comes to is the structural
             // reading's answer, not this one's — and a unit data has one value, which no class of
@@ -86,28 +101,59 @@ final class PartitionClasses {
         };
     }
 
+    /**
+     * The classes of a position whose values cannot be written here at all, each saying why.
+     *
+     * <p>They are counted like any other: a case a module does not expose is still a case of the
+     * position, and a row already sitting in one still covers it. What is absent is the offer of a
+     * new row, and the reason is the model's — {@code domain} keeps the case to itself — rather than
+     * anything about this generator.
+     */
+    private static List<PartitionClass> unwritable(TypeView view, Symbols symbols,
+                                                   List<TypeName> worn, TypeName unnamed) {
+        String why = notExposed(unnamed);
+        List<PartitionClass> out = new ArrayList<>();
+        // The classes of the same position with no names to write them under. What each is and what
+        // reads a value into it are the position's either way; only the recipes are dropped, and
+        // they are what there is no writing them.
+        for (PartitionClass each : of(new TypeView(view.declared(), List.of(), view.shape()),
+                symbols)) {
+            out.add(PartitionClass.ungeneratable(each.id(), each.label(),
+                    Classifier.under(worn, each.classifier()), why));
+        }
+        return out;
+    }
+
+    /** Why nothing here can write a value of {@code unnamed}: no spelling reaches it. */
+    private static String notExposed(TypeName unnamed) {
+        return "`" + unnamed.module() + "` does not expose `" + unnamed.name()
+                + "`, so nothing here can name it";
+    }
+
     /** The two values of a {@code Bool}, under the names the position writes them under. */
-    private static List<PartitionClass> eitherWay(List<TypeName> worn) {
+    private static List<PartitionClass> eitherWay(List<TypeName> worn,
+                                                  List<TypeReachName.Written> writes) {
         return List.of(
                 PartitionClass.of("true", "true",
                         Classifier.under(worn, Classifier.byShape(v -> isBool(v, true))),
-                        RepresentativeSource.under(worn,
+                        RepresentativeSource.under(writes,
                                 RepresentativeSource.of(FixtureTemplate.bool(true)))),
                 PartitionClass.of("false", "false",
                         Classifier.under(worn, Classifier.byShape(v -> isBool(v, false))),
-                        RepresentativeSource.under(worn,
+                        RepresentativeSource.under(writes,
                                 RepresentativeSource.of(FixtureTemplate.bool(false)))));
     }
 
     /** Whether an optional holds anything, which is the one division its type makes. */
     private static List<PartitionClass> heldOrNot(Type element, List<TypeName> worn,
+                                                  List<TypeReachName.Written> writes,
                                                   Symbols symbols) {
         List<FixtureTemplate> some = Partitions.representativesOf(element, symbols);
         return List.of(
                 PartitionClass.of("None", "None",
                         Classifier.under(worn,
                                 Classifier.byShape(v -> v instanceof ObservedValue.Absent)),
-                        RepresentativeSource.under(worn,
+                        RepresentativeSource.under(writes,
                                 RepresentativeSource.of(FixtureTemplate.none()))),
                 some.isEmpty()
                         ? PartitionClass.ungeneratable("Some", "Some",
@@ -117,16 +163,17 @@ final class PartitionClasses {
                         : PartitionClass.of("Some", "Some",
                                 Classifier.under(worn, Classifier.byShape(
                                         v -> !(v instanceof ObservedValue.Absent))),
-                                RepresentativeSource.under(worn,
+                                RepresentativeSource.under(writes,
                                         RepresentativeSource.of(some))));
     }
 
     /** A sum's cases, each a class, under the names the position writes them under. */
     private static List<PartitionClass> caseClasses(Type sum, List<TypeName> worn,
+                                                    List<TypeReachName.Written> writes,
                                                     Symbols symbols) {
         List<PartitionClass> cases = new ArrayList<>();
         for (TypeName leaf : TypeOps.leafCases(sum, symbols)) {
-            cases.add(caseClass(leaf, worn, symbols));
+            cases.add(caseClass(leaf, worn, writes, symbols));
         }
         return cases;
     }
@@ -137,16 +184,23 @@ final class PartitionClasses {
         return leaf.name();
     }
 
-    private static PartitionClass caseClass(TypeName leaf, List<TypeName> worn, Symbols symbols) {
+    private static PartitionClass caseClass(TypeName leaf, List<TypeName> worn,
+                                            List<TypeReachName.Written> writes, Symbols symbols) {
         Classifier is = Classifier.under(worn, Classifier.byShape(v -> switch (v) {
             case ObservedValue.Unit u -> leaf.equals(u.type());
             case ObservedValue.Constructed c -> leaf.equals(c.type());
             default -> false;
         }));
+        // A case whose module does not expose it: a value of the position all the same, and one no
+        // author here can write down. Said as that, rather than offered under a spelling that
+        // resolves to nothing wherever the row is pasted (issue #696).
+        if (!(symbols.reach(leaf) instanceof TypeReachName.Written names)) {
+            return PartitionClass.ungeneratable(idOfCase(leaf), leaf.name(), is, notExposed(leaf));
+        }
         if (!(symbols.get(leaf) instanceof Ast.Data data)) {
             return PartitionClass.of(idOfCase(leaf), leaf.name(), is,   // naming it builds it
-                    RepresentativeSource.under(worn,
-                            RepresentativeSource.of(FixtureTemplate.unitCase(leaf))));
+                    RepresentativeSource.under(writes,
+                            RepresentativeSource.of(FixtureTemplate.unitCase(names))));
         }
         if (data.newtype()) {
             List<FixtureTemplate> inner = Partitions.insideTheNewtype(leaf, symbols);
@@ -154,8 +208,8 @@ final class PartitionClasses {
                     ? PartitionClass.ungeneratable(idOfCase(leaf), leaf.name(), is,
                             "nothing here composed a value of what `" + leaf.name() + "` wraps")
                     : PartitionClass.of(idOfCase(leaf), leaf.name(), is,
-                            RepresentativeSource.under(worn, RepresentativeSource.under(
-                                    List.of(leaf), RepresentativeSource.of(inner))));
+                            RepresentativeSource.under(writes, RepresentativeSource.under(
+                                    List.of(names), RepresentativeSource.of(inner))));
         }
         // A record case is written field by field, which is the generator's composition. So the class
         // names the constructor and the generator does the composing — the same walk every other
@@ -163,7 +217,7 @@ final class PartitionClasses {
         // way: what is composed is an `Approved`, and what the row writes is `DecisionN(Approved
         // { id = 1 })`.
         return PartitionClass.of(idOfCase(leaf), leaf.name(), is,
-                RepresentativeSource.under(worn, new RepresentativeSource.Composed(leaf)));
+                RepresentativeSource.under(writes, new RepresentativeSource.Composed(leaf)));
     }
 
     private static boolean isBool(ObservedValue v, boolean expected) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -23,6 +23,7 @@ import souther.compiler.numeric.Place;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.TypeReachName;
 import souther.compiler.types.ValueName;
 
 import java.math.BigDecimal;
@@ -389,9 +390,9 @@ public final class Partitions {
         List<PartitionClass> classes = new ArrayList<>();
         for (Place value : values) {
             String written = carrier.written(value);
-            classes.add(PartitionClass.of(term + "/= " + written, "= " + written,
+            classes.add(classAt(term + "/= " + written, "= " + written,
                     holding(term, carrier, at -> at.sameAs(value)),
-                    RepresentativeSource.of(standing(type, carrier, value, symbols))));
+                    standing(type, carrier, value, symbols)));
         }
         Place other = carrier.somethingOtherThan(values, within);
         String label = "/= " + String.join(", ",
@@ -401,15 +402,25 @@ public final class Partitions {
                         holding(term, carrier, at -> values.stream().noneMatch(at::sameAs)),
                         "nothing here composed a value of this position other than the ones"
                                 + " singled out")
-                : PartitionClass.of(term + "/" + label, label,
+                : classAt(term + "/" + label, label,
                         holding(term, carrier, at -> values.stream().noneMatch(at::sameAs)),
-                        RepresentativeSource.of(standing(type, carrier, other, symbols))));
+                        standing(type, carrier, other, symbols)));
         return List.copyOf(classes);
+    }
+
+    /** A class over the one value that stands for it, or one nothing produces where there is no
+     *  such value — which is what a position wearing a name this module cannot write leaves. */
+    private static PartitionClass classAt(String id, String label, Classifier is,
+                                          FixtureTemplate standing) {
+        return standing == null
+                ? PartitionClass.ungeneratable(id, label, is,
+                        "nothing here can write a value of this position")
+                : PartitionClass.of(id, label, is, RepresentativeSource.of(standing));
     }
 
     /** A count written at a position, wearing every name that position declares. */
     private static FixtureTemplate standing(Type type, Carrier carrier, Place at, Symbols symbols) {
-        return Witnesses.wrapped(type, FixtureTemplate.on(carrier, at), symbols);
+        return Witnesses.wrapped(type, FixtureTemplate.on(carrier, at, symbols::reach), symbols);
     }
 
     /** A classifier that reads the term's count out of a row and answers about it. */
@@ -781,7 +792,9 @@ public final class Partitions {
         if (type == Type.INT || type == Type.DECIMAL) {
             Carrier carrier = type == Type.DECIMAL ? Carrier.DENSE : Carrier.WHOLE;
             Place at = inside(within, carrier);
-            return at == null ? List.of() : List.of(FixtureTemplate.on(carrier, at));
+            FixtureTemplate standing = at == null ? null
+                    : FixtureTemplate.on(carrier, at, symbols::reach);
+            return standing == null ? List.of() : List.of(standing);
         }
         if (type == Type.STRING) {
             return List.of(FixtureTemplate.string("x"));
@@ -833,10 +846,15 @@ public final class Partitions {
         // A newtype the model only bounds has no classes — everything outside the bound is refused at
         // construction — but it does have values, and the edge of the bound is one that builds.
         if (type instanceof Type.Ref ref && symbols.get(ref.name()) instanceof Ast.Data data) {
-            return data.newtype()
+            if (!data.newtype()) {
+                return composed(ref.name(), symbols, expanding);
+            }
+            // A newtype nothing here names has no value anything here can write: the name goes on
+            // the value as it is written, and there is none to put on.
+            return symbols.reach(ref.name()) instanceof TypeReachName.Written written
                     ? insideTheNewtype(ref.name(), symbols, within, expanding).stream()
-                            .map(t -> FixtureTemplate.newtype(ref.name(), t)).toList()
-                    : composed(ref.name(), symbols, expanding);
+                            .map(t -> FixtureTemplate.newtype(written, t)).toList()
+                    : List.of();
         }
         return List.of();
     }
@@ -910,7 +928,8 @@ public final class Partitions {
                 left = FieldDomains.of(record, data, symbols, settled);
             }
         }
-        return List.of(FixtureTemplate.record(record, chosen));
+        return symbols.reach(record) instanceof TypeReachName.Written written
+                ? List.of(FixtureTemplate.record(written, chosen)) : List.of();
     }
 
     /** How many of whatever counts a value the rules on it require it to hold, read where the rules
@@ -1119,8 +1138,10 @@ public final class Partitions {
         DeclaredBounds.Bounds own = DeclaredBounds.of(new Type.Ref(newtype), symbols);
         NumericDomain.Bounds bounds = TypeBounds.admissible(own, within);
         Place held = bounds == null || bounds.isEmpty() ? null : inside(bounds, own.carrier());
-        if (held != null) {
-            candidates.add(FixtureTemplate.on(own.carrier(), held));
+        FixtureTemplate at = held == null ? null
+                : FixtureTemplate.on(own.carrier(), held, symbols::reach);
+        if (at != null) {
+            candidates.add(at);
         }
         if (base == Type.STRING && symbols.get(newtype) instanceof Ast.Data data) {
             for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(data, symbols)) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/RepresentativeSource.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/RepresentativeSource.java
@@ -1,6 +1,7 @@
 package souther.compiler.partition;
 
 import souther.compiler.types.TypeName;
+import souther.compiler.types.TypeReachName;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -75,7 +76,7 @@ public sealed interface RepresentativeSource {
          * value under, outermost first — a fact about the position rather than about the
          * constructor.
          */
-        record Compose(TypeName through, List<TypeName> worn) implements Evaluation {
+        record Compose(TypeName through, List<TypeReachName.Written> worn) implements Evaluation {
 
             public Compose {
                 worn = List.copyOf(worn);
@@ -154,7 +155,7 @@ public sealed interface RepresentativeSource {
      * and a class of {@code data DecisionN = Decision} composes an {@code Approved} and hands back
      * {@code DecisionN(Approved { id = 1 })}, by one rule.
      */
-    record Projected(RepresentativeSource inner, List<TypeName> wrappers)
+    record Projected(RepresentativeSource inner, List<TypeReachName.Written> wrappers)
             implements RepresentativeSource {
 
         public Projected {
@@ -169,7 +170,7 @@ public sealed interface RepresentativeSource {
                 // The names go on outside whatever the inner recipe already wears, which is the
                 // order they were read off the position in.
                 case Evaluation.Compose compose -> {
-                    List<TypeName> both = new ArrayList<>(wrappers);
+                    List<TypeReachName.Written> both = new ArrayList<>(wrappers);
                     both.addAll(compose.worn());
                     yield new Evaluation.Compose(compose.through(), both);
                 }
@@ -199,7 +200,7 @@ public sealed interface RepresentativeSource {
 
     /** {@code inner}, written under {@code wrappers} — or {@code inner} itself where the position
      *  wears no name, so that a recipe carries no projection over nothing. */
-    static RepresentativeSource under(List<TypeName> wrappers, RepresentativeSource inner) {
+    static RepresentativeSource under(List<TypeReachName.Written> wrappers, RepresentativeSource inner) {
         return wrappers.isEmpty() ? inner : new Projected(inner, wrappers);
     }
 
@@ -210,7 +211,7 @@ public sealed interface RepresentativeSource {
      * later is written as are the same operation, and two spellings of it are two chances to
      * disagree about which name goes outside.
      */
-    static FixtureTemplate under(List<TypeName> worn, FixtureTemplate value) {
+    static FixtureTemplate under(List<TypeReachName.Written> worn, FixtureTemplate value) {
         FixtureTemplate at = value;
         // Innermost last: the names were read off the position outermost first, so they go back on
         // in the order that leaves the outermost outside.

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -7,6 +7,7 @@ import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.TypeReachName;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -397,19 +398,26 @@ final class Witnesses {
             return null;
         }
         return wrapped(type, FixtureTemplate.on(
-                carrier == Type.DECIMAL ? Carrier.DENSE : Carrier.WHOLE, at), symbols);
+                carrier == Type.DECIMAL ? Carrier.DENSE : Carrier.WHOLE, at, symbols::reach), symbols);
     }
 
-    /** The value under every name the position wears, which is how it is written where the position
-     * declares a newtype rather than what the newtype carries. */
+    /**
+     * The value under every name the position wears, which is how it is written where the position
+     * declares a newtype rather than what the newtype carries.
+     *
+     * <p>Null where {@code bare} is, and where a name the position wears is one this module cannot
+     * write: a value goes under the names as it is written, so a name there is nothing here reaches
+     * leaves no way of writing the value at all.
+     */
     static FixtureTemplate wrapped(Type type, FixtureTemplate bare, Symbols symbols) {
-        if (!(type instanceof Type.Ref ref) || !(symbols.get(ref.name()) instanceof Ast.Data data)
-                || !data.newtype()) {
+        if (bare == null || !(type instanceof Type.Ref ref)
+                || !(symbols.get(ref.name()) instanceof Ast.Data data) || !data.newtype()) {
             return bare;
         }
         TypeName name = ref.name();
-        return FixtureTemplate.newtype(name,
-                wrapped(TypeOps.newtypeInner(name, symbols), bare, symbols));
+        FixtureTemplate inner = wrapped(TypeOps.newtypeInner(name, symbols), bare, symbols);
+        return inner != null && symbols.reach(name) instanceof TypeReachName.Written written
+                ? FixtureTemplate.newtype(written, inner) : null;
     }
 
     private Witnesses() {}

--- a/souther-compiler/src/main/java/souther/compiler/types/ReachName.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/ReachName.java
@@ -92,13 +92,21 @@ public sealed interface ReachName {
      * is what decides the answer for a helper: the module's own is reached bare and another's under
      * the module that declares it, and neither the declaration nor the spelling says which case this
      * is on its own.
+     *
+     * <p>A name that denotes nothing is {@link ValueName.Unresolved}, which is an answer and is
+     * reached by its spelling like anything else. No denotation at all is not a third kind of name:
+     * it is a caller that has not resolved one yet, and answering it with the spelling would put a
+     * reference into the tree that reaches whatever the spelling happens to mean downstream.
      */
     static ReachName of(ValueName denotes, String written, String self) {
         if (self == null) {
             throw new IllegalArgumentException("which module is reading decides this: " + written);
         }
+        if (denotes == null) {
+            throw new IllegalArgumentException("`" + written
+                    + "` has not been resolved, so nothing here says how it is reached");
+        }
         return switch (denotes) {
-            case null -> new Bare(written);
             case ValueName.Helper helper -> helper.module().equals(self)
                     ? new Bare(helper.name()) : new OfModule(helper.module(), helper.name());
             case ValueName.Stdlib library -> new OfLibrary(library);

--- a/souther-compiler/src/main/java/souther/compiler/types/TypeReachName.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/TypeReachName.java
@@ -34,7 +34,7 @@ public sealed interface TypeReachName {
     sealed interface Written extends TypeReachName {
 
         /** The reference as this module writes it — what goes into anything an author reads back,
-         * and what {@code Symbols.resolve} answers {@link #denotes()} for. */
+         * and what the reader of the position it is written at answers {@link #denotes()} for. */
         String rendered();
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/types/TypeReachName.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/TypeReachName.java
@@ -1,0 +1,131 @@
+package souther.compiler.types;
+
+/**
+ * How a module writes a declared type — the answer {@link ReachName} gives for the value namespace.
+ *
+ * <p>Not the type's identity. Which module declares a type is a fact about the declaration and is
+ * {@link TypeName}'s to say; this is a fact about a reference to it from somewhere, and neither can
+ * be derived from the other. One {@code lib.Amount} is written {@code Amount} in a module that
+ * imported it, {@code up.Amount} in one that aliased {@code lib} as {@code up}, and
+ * {@code lib.Amount} in one that did neither — three references, one declaration.
+ *
+ * <p>Held together with what it denotes, and not as a string. A caller with only the rendering has
+ * the half that cannot be looked anything up with, and a caller with only the name has the half that
+ * cannot be written into anything a person reads; a pass that carried one of them alone is the
+ * defect this exists to remove, since the two are recovered from each other by resolving a spelling
+ * — which is the rediscovery {@link ReachName} was separated out to stop.
+ *
+ * <p>Having a spelling at all is one of the answers. A module reaches a sum through its declaring
+ * module and the cases that sum lists through the sum, so a case its module does not expose is a
+ * value of a position here that nothing here can name. That is a state of the reference and is held
+ * as one: only {@link Written} has a {@link Written#rendered()}, so a caller that would write the
+ * name has to say what it does where there is none, rather than being handed a spelling that
+ * resolves to nothing wherever it is put.
+ *
+ * <p>The interface is sealed and the switches over it carry no {@code default}, so a shape added
+ * here is a compile error at every place that reads one.
+ */
+public sealed interface TypeReachName {
+
+    /** The declaration this reference reaches. */
+    TypeName denotes();
+
+    /** A reference this module can write. */
+    sealed interface Written extends TypeReachName {
+
+        /** The reference as this module writes it — what goes into anything an author reads back,
+         * and what {@code Symbols.resolve} answers {@link #denotes()} for. */
+        String rendered();
+    }
+
+    /**
+     * A type written as its bare name: one the module declares itself, or one an import brought in
+     * under that spelling.
+     *
+     * <p>Bare only where the bare spelling means <em>this</em> declaration. A module that declares
+     * an {@code Amount} of its own and imports another module's under an alias writes the imported
+     * one qualified, and a reference that took the bare spelling because the name was in scope would
+     * name the wrong declaration and compile.
+     */
+    record Bare(TypeName denotes) implements Written {
+
+        @Override
+        public String rendered() {
+            return denotes.name();
+        }
+
+        @Override
+        public String toString() {
+            return rendered();
+        }
+    }
+
+    /** A type reached under an {@code import ... as} alias, which names a module and is not one. */
+    record ViaAlias(String alias, TypeName denotes) implements Written {
+
+        public ViaAlias {
+            if (alias == null) {
+                throw new IllegalArgumentException("an alias is what this is reached under: "
+                        + denotes);
+            }
+        }
+
+        @Override
+        public String rendered() {
+            return alias + "." + denotes.name();
+        }
+
+        @Override
+        public String toString() {
+            return rendered();
+        }
+    }
+
+    /** A type reached under the name of the module that declares it — what is left where the module
+     * neither declares it, imports it, nor aliases the module it comes from. */
+    record ViaModule(TypeName denotes) implements Written {
+
+        @Override
+        public String rendered() {
+            return denotes.qualified();
+        }
+
+        @Override
+        public String toString() {
+            return rendered();
+        }
+    }
+
+    /**
+     * Nothing here names it: the module that declares it does not expose it, so no spelling reaches
+     * it from here — not the bare name, and not the qualified one either.
+     *
+     * <p>A value of it can still stand at a position here. A sum is reached through its module and
+     * its cases through the sum, so a behavior takes a value of a case it cannot name and a decoder
+     * builds one; what cannot happen is a person writing that value down, which is what a generated
+     * row is for.
+     */
+    record Unnameable(TypeName denotes) implements TypeReachName {
+
+        @Override
+        public String toString() {
+            return "no name for " + denotes + " here";
+        }
+    }
+
+    /**
+     * Whatever answers this for a module — {@code Symbols}, which holds what the module's bare names
+     * mean and which modules its aliases name.
+     *
+     * <p>Taken as an argument by anything that writes a reference it did not read, so that the
+     * question is asked of the module rather than answered from the declaration's own spelling. A
+     * writer that could reach for {@link TypeName#name()} instead is a writer that answers it wrong
+     * wherever the bare spelling is not this module's word for the type.
+     */
+    @FunctionalInterface
+    interface Naming {
+
+        /** How the module this belongs to writes {@code type}. */
+        TypeReachName of(TypeName type);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/ACaseIsBuiltAtItsPositionWithoutBeingNamedHereTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACaseIsBuiltAtItsPositionWithoutBeingNamedHereTest.java
@@ -27,6 +27,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * reads. Asked of the leaf's own spelling, the answer is what the reading module has under that
  * spelling — nothing here — and the value went out with no discriminator on it and was refused for
  * the key it was missing (issue #683).
+ *
+ * <p>Being a case of the position is not being writable at it. {@code domain} exposes the sum and
+ * not its cases, so no spelling here reaches {@code 事業主都合}'s leaves — not the bare name, and not
+ * the qualified one either. The class is still a class and a row already sitting in it still covers
+ * it; what cannot be offered is a new row, and the reason belongs to the model rather than to this
+ * generator. Offered anyway, the row was a name out of scope wherever it was pasted (issue #696).
  */
 class ACaseIsBuiltAtItsPositionWithoutBeingNamedHereTest {
 
@@ -70,14 +76,17 @@ class ACaseIsBuiltAtItsPositionWithoutBeingNamedHereTest {
     }
 
     @Test
-    void aLeafThisModuleDoesNotNameIsStillBuiltAtThePositionThatListsIt() {
+    void aLeafThisModuleCanNameGetsARowAndTheOthersGetTheirReason() {
         Generator.GenerationResult filled = filled();
 
-        assertEquals(List.of(), filled.unresolved(),
-                "every case of the position has a value, including the ones spelled nowhere here");
-        assertEquals(List.of("BusinessClosure", "Dismissal", "Resignation { note = \"x\" }"),
+        assertEquals(List.of("Resignation { note = \"x\" }"),
                 filled.rows().stream()
                         .map(r -> String.join(", ", r.inputs().stream().map(i -> i.text()).toList()))
                         .toList());
+        assertEquals(List.of(
+                        "`domain` does not expose `BusinessClosure`, so nothing here can name it",
+                        "`domain` does not expose `Dismissal`, so nothing here can name it"),
+                filled.unresolved().stream().map(u -> u.said().orElseThrow()).toList(),
+                "each case of the position that has no name here says so");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompilePostfixApplicationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePostfixApplicationTest.java
@@ -307,7 +307,11 @@ class CompilePostfixApplicationTest {
     @Test
     void anApplicationSaysWhetherItAppliesAName() {
         SourcePos at = new SourcePos(1, 1);
-        Ast.Apply named = new Ast.Apply("List.map", java.util.List.of(), at, null);
+        souther.compiler.types.ValueName.Stdlib map =
+                new souther.compiler.types.ValueName.Stdlib("List", "map");
+        Ast.Apply named = new Ast.Apply("List.map", map,
+                new ReachName.OfLibrary(map), java.util.List.of(),
+                souther.compiler.types.ConstructionOrigin.own(), at, null);
         Ast.Apply nameless = new Ast.Apply(new Ast.Block(java.util.List.of(),
                 new Ast.IntLit(1, at, null), at, null), java.util.List.of(),
                 souther.compiler.types.ConstructionOrigin.own(), at, null);

--- a/souther-compiler/src/test/java/souther/compiler/ast/ANameAnsweredHalfwayIsRefusedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ast/ANameAnsweredHalfwayIsRefusedTest.java
@@ -27,14 +27,19 @@ class ANameAnsweredHalfwayIsRefusedTest {
 
     private static final ValueName.Helper DECLARED = new ValueName.Helper("demo", "spin");
 
-    /** A name the parser read: nothing has been answered about it yet, and that is a state. */
+    /**
+     * A name the parser read: nothing has been answered about it yet, and that is a state. It says
+     * what it is written as, and refuses both questions that are about a declaration rather than
+     * about the characters — the answer either wants is the one that is missing, and handing back
+     * the spelling is what a table keyed by declarations misses on.
+     */
     @Test
-    void aNameNothingHasAnsweredYetIsFine() {
+    void aNameNothingHasAnsweredYetSaysOnlyWhatItIsWrittenAs() {
         Ast.Var written = new Ast.Var("spin", POS);
 
         assertEquals("spin", written.name());
-        assertEquals("spin", written.reaches(),
-                "nothing resolved it, so what it reaches is what it is written as");
+        assertThrows(IllegalStateException.class, written::bare);
+        assertThrows(IllegalStateException.class, written::reaches);
     }
 
     /** What it denotes without how it is reached is not a state a rewrite may leave behind. */
@@ -44,15 +49,6 @@ class ANameAnsweredHalfwayIsRefusedTest {
                 () -> new Ast.Var(WrittenName.of("spin", POS), DECLARED, null));
 
         assertEquals(true, refused.getMessage().contains("spin"), refused.getMessage());
-    }
-
-    /** And a reader asking what a name is declared as, of one nothing answered, is told so rather
-     * than handed the spelling — the answer it wanted is the one that is missing. */
-    @Test
-    void theDeclaredNameOfSomethingNothingAnsweredIsRefused() {
-        Ast.Var written = new Ast.Var("spin", POS);
-
-        assertThrows(IllegalStateException.class, written::bare);
     }
 
     /** Answered, it says both. */

--- a/souther-compiler/src/test/java/souther/compiler/ast/ANameAnsweredHalfwayIsRefusedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ast/ANameAnsweredHalfwayIsRefusedTest.java
@@ -1,10 +1,13 @@
 package souther.compiler.ast;
 
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.ReachName;
 import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -42,13 +45,45 @@ class ANameAnsweredHalfwayIsRefusedTest {
         assertThrows(IllegalStateException.class, written::reaches);
     }
 
-    /** What it denotes without how it is reached is not a state a rewrite may leave behind. */
+    /**
+     * Half an answer is not a state a rewrite may leave behind, whichever half it is. One way round
+     * leaves a reference that resolves to a declaration and reaches nothing; the other leaves a key
+     * with nothing saying what it means, and there is nowhere for it to have come from —
+     * {@link ReachName#of} takes the denotation to work one out.
+     */
     @Test
-    void aNameThatDenotesSomethingAndReachesNothingCannotBeBuilt() {
-        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+    void aNameAnsweredOnOneCountOnlyCannotBeBuilt() {
+        IllegalArgumentException noReach = assertThrows(IllegalArgumentException.class,
                 () -> new Ast.Var(WrittenName.of("spin", POS), DECLARED, null));
+        IllegalArgumentException noDenotation = assertThrows(IllegalArgumentException.class,
+                () -> new Ast.Var(WrittenName.of("spin", POS), null,
+                        new ReachName.OfModule("demo", "spin")));
 
-        assertEquals(true, refused.getMessage().contains("spin"), refused.getMessage());
+        assertEquals(true, noReach.getMessage().contains("spin"), noReach.getMessage());
+        assertEquals(true, noDenotation.getMessage().contains("spin"), noDenotation.getMessage());
+    }
+
+    /**
+     * And a pass applying a name says what it means. The application a pass writes takes both
+     * answers and takes them as answers: the constructor that took a spelling alone is gone, and
+     * this is the one that replaced it, so a caller with nothing to say cannot say it here either.
+     *
+     * <p>Refused at the application rather than left to {@link Ast.Var}, which admits the pair
+     * being absent — that is the parser's state, and the parser builds its own callee. A pass has
+     * resolution behind it or is writing a name for someone downstream to resolve, which is what
+     * ADR-0067 rules out.
+     */
+    @Test
+    void anApplicationAPassWritesCannotLeaveItsNameUnanswered() {
+        assertThrows(NullPointerException.class,
+                () -> new Ast.Apply("spin", null, new ReachName.OfModule("demo", "spin"),
+                        List.of(), ConstructionOrigin.own(), POS, null));
+        assertThrows(NullPointerException.class,
+                () -> new Ast.Apply("spin", DECLARED, null,
+                        List.of(), ConstructionOrigin.own(), POS, null));
+        assertThrows(NullPointerException.class,
+                () -> new Ast.Apply("spin", null, null,
+                        List.of(), ConstructionOrigin.own(), POS, null));
     }
 
     /** Answered, it says both. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AReachedNameResolvesBackToWhatItWasAskedAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AReachedNameResolvesBackToWhatItWasAskedAboutTest.java
@@ -1,0 +1,144 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Shapes;
+import souther.compiler.types.TypeName;
+import souther.compiler.types.TypeReachName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * {@code Symbols.reach} is the inverse of {@code Symbols.resolve}, and is held to it.
+ *
+ * <p>The two are one relation read in two directions: {@code resolve} takes what a module wrote and
+ * answers the declaration, {@code reach} takes the declaration and answers what this module writes.
+ * A pair that does not compose is a reference the compiler produced and the compiler will not read
+ * — which is the whole of what a generated row being writable means.
+ *
+ * <p>Held over every declaration a module can meet rather than over cases picked out here. A
+ * spelling that happens to round-trip for the type it was written for says nothing about the one
+ * beside it: the answers differ by whether the bare name is taken, by which module declares it, and
+ * by whether that module exposes it, and none of those is visible in a name.
+ */
+class AReachedNameResolvesBackToWhatItWasAskedAboutTest {
+
+    private static final String LIB = """
+            module lib exposing ( Shown, Sum, One, Two )
+
+            data Shown = Int
+            data Hidden = String
+
+            data One
+            data Two
+            data Sum = One | Two
+            """;
+
+    /** Every way of reaching another module at once, beside a declaration of its own. */
+    private static final String APP = """
+            module app exposing ( Own, In, f )
+
+            import lib as up
+            import lib ( Shown )
+
+            data Own = { n: Int }
+            data RoundingMode = { tag: String }
+
+            data In = { n: Int }
+
+            behavior f : (i: In) -> Own constructs Own
+            let f (i) = Own { n = i.n }
+            """;
+
+    private static Symbols scopeOf(String module, String... sources) {
+        Compilation compilation = Compilation.ofSources(List.of(sources), ModulePath.EMPTY);
+        compilation.answerEverything();
+        return compilation.db().ask(new Shapes.Scope(module)).value();
+    }
+
+    /** Every declaration this compilation has, which is what a position here may turn out to be. */
+    private static List<TypeName> everyDeclaration() {
+        List<TypeName> named = new ArrayList<>();
+        for (String each : List.of("Shown", "Hidden", "One", "Two", "Sum")) {
+            named.add(new TypeName("lib", each));
+        }
+        for (String each : List.of("Own", "RoundingMode", "In")) {
+            named.add(new TypeName("app", each));
+        }
+        named.add(TypeName.runtime("RoundingMode"));
+        return named;
+    }
+
+    /** What {@code reach} answers resolves back to the type it was asked about. */
+    @Test
+    void whatIsWrittenForATypeResolvesToThatType() {
+        Symbols symbols = scopeOf("app", LIB, APP);
+
+        List<String> broken = new ArrayList<>();
+        for (TypeName type : everyDeclaration()) {
+            if (symbols.reach(type) instanceof TypeReachName.Written written) {
+                if (!type.equals(symbols.resolve(written.rendered()))) {
+                    broken.add(written.rendered() + " is written for " + type + " and resolves to "
+                            + symbols.resolve(written.rendered()));
+                }
+            }
+        }
+
+        assertEquals(List.of(), broken);
+    }
+
+    /** And what it says has no name here has none — no spelling this module can write reaches it. */
+    @Test
+    void whatHasNoNameHereIsNotReachedByAnySpellingThisModuleWrites() {
+        Symbols symbols = scopeOf("app", LIB, APP);
+
+        List<TypeName> unnameable = new ArrayList<>();
+        for (TypeName type : everyDeclaration()) {
+            if (symbols.reach(type) instanceof TypeReachName.Unnameable u) {
+                unnameable.add(u.denotes());
+            }
+        }
+
+        assertEquals(List.of(new TypeName("lib", "Hidden"), TypeName.runtime("RoundingMode")),
+                unnameable, "one its module keeps to itself, one this module took the spelling of");
+        for (TypeName type : unnameable) {
+            for (String spelling : List.of(type.name(), type.qualified(),
+                    "up." + type.name(), "lib." + type.name())) {
+                assertFalse(type.equals(symbols.resolve(spelling)),
+                        "`" + spelling + "` reaches " + type + " after all");
+            }
+        }
+    }
+
+    /**
+     * The case the law is about, on its own: a module that declares the spelling the language's own
+     * data has takes it, and the language's has no other (ADR-0087). Answered bare, the reference
+     * would resolve to this module's declaration — a different type, and one that compiles.
+     */
+    @Test
+    void aRuntimeBackedTypeThisModuleTookTheSpellingOfHasNoNameHere() {
+        TypeName language = TypeName.runtime("RoundingMode");
+
+        assertInstanceOf(TypeReachName.Unnameable.class, scopeOf("app", LIB, APP).reach(language));
+        assertEquals(new TypeName("app", "RoundingMode"),
+                scopeOf("app", LIB, APP).resolve("RoundingMode"));
+    }
+
+    /** And where nothing here took it, it is written as itself. */
+    @Test
+    void aRuntimeBackedTypeNothingHereShadowsIsWrittenBare() {
+        Symbols symbols = scopeOf("lib", LIB, APP);
+        TypeName language = TypeName.runtime("RoundingMode");
+
+        assertEquals("RoundingMode", assertInstanceOf(TypeReachName.Written.class,
+                symbols.reach(language)).rendered());
+        assertEquals(language, symbols.resolve("RoundingMode"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AReachedNameResolvesBackToWhatItWasAskedAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AReachedNameResolvesBackToWhatItWasAskedAboutTest.java
@@ -16,12 +16,19 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
- * {@code Symbols.reach} is the inverse of {@code Symbols.resolve}, and is held to it.
+ * What {@code Symbols.reach} writes for a type resolves back to that type.
  *
- * <p>The two are one relation read in two directions: {@code resolve} takes what a module wrote and
- * answers the declaration, {@code reach} takes the declaration and answers what this module writes.
- * A pair that does not compose is a reference the compiler produced and the compiler will not read
- * — which is the whole of what a generated row being writable means.
+ * <p>A section of {@code Symbols.resolve} and not its inverse. {@code Amount}, {@code up.Amount}
+ * and {@code lib.Amount} may all reach one declaration, so there is no inverse to have; {@code
+ * reach} picks one of them, and the one it picks is read back as the type it was asked about. A
+ * pair that does not compose is a reference the compiler produced and the compiler will not read,
+ * which is the whole of what a generated row being writable means.
+ *
+ * <p>Read back by whichever reader reads the position the name is written at. For a declaration
+ * that is {@code resolve}; for the language's own vocabulary — a primitive, the runtime's error
+ * cases — {@code resolve} answers nothing at all and {@code resolveCase} is the reader. Both are
+ * held below, so where the section stops being about {@code resolve} is written down rather than
+ * left out of the list.
  *
  * <p>Held over every declaration a module can meet rather than over cases picked out here. A
  * spelling that happens to round-trip for the type it was written for says nothing about the one
@@ -140,5 +147,31 @@ class AReachedNameResolvesBackToWhatItWasAskedAboutTest {
         assertEquals("RoundingMode", assertInstanceOf(TypeReachName.Written.class,
                 symbols.reach(language)).rendered());
         assertEquals(language, symbols.resolve("RoundingMode"));
+    }
+
+    /**
+     * The language's own vocabulary is written as itself, and read back by the reader that reads a
+     * case rather than by {@code resolve}, which says nothing about either of them.
+     *
+     * <p>Here rather than left out of {@link #everyDeclaration()}: a section is a section on a
+     * domain, and a domain nothing states is one a later reader assumes is everything. These reach
+     * a position — a primitive heads a union a behavior answers with, and the runtime's failures
+     * are its cases — so a writer meets them and has to be told what they are written as.
+     */
+    @Test
+    void theLanguagesOwnVocabularyIsWrittenAsItselfAndReadBackAsACase() {
+        Symbols symbols = scopeOf("app", LIB, APP);
+
+        for (TypeName vocabulary : List.of(TypeName.primitive("Int"),
+                TypeName.runtime("DivisionByZero"))) {
+            TypeReachName.Written written = assertInstanceOf(TypeReachName.Written.class,
+                    symbols.reach(vocabulary), vocabulary.toString());
+
+            assertEquals(vocabulary.name(), written.rendered());
+            assertEquals(vocabulary, symbols.resolveCase(written.rendered()),
+                    "the reader of the position a case name stands at");
+            assertEquals(null, symbols.resolve(written.rendered()),
+                    "and not this one, which answers for declarations");
+        }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/CallElaboratorNoCalleeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/CallElaboratorNoCalleeTest.java
@@ -114,9 +114,10 @@ class CallElaboratorNoCalleeTest {
     /**
      * And an application of something that is not a name, which is where the absent denotation
      * actually comes from: {@code Ast.Apply#denotes} answers for the name it applies, and there is
-     * none. Written as a name with no answer instead, this pinned a node the AST refuses to build —
-     * a pass applying a name says what it means (ADR-0067), so the only unanswered callee left is
-     * one that is not a name at all.
+     * none. Written as a name with no answer instead, this pinned a node the constructor a pass
+     * writes an application with no longer builds — a pass applying a name says what it means
+     * (ADR-0067). The shape itself is still writable, since the parser has to hold a tree
+     * resolution has not seen; what is gone is a pass reaching for it.
      */
     @Test
     void anApplicationOfSomethingThatIsNotANameIsAnInternalError() {

--- a/souther-compiler/src/test/java/souther/compiler/check/CallElaboratorNoCalleeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/CallElaboratorNoCalleeTest.java
@@ -111,8 +111,20 @@ class CallElaboratorNoCalleeTest {
         }
     }
 
+    /**
+     * And an application of something that is not a name, which is where the absent denotation
+     * actually comes from: {@code Ast.Apply#denotes} answers for the name it applies, and there is
+     * none. Written as a name with no answer instead, this pinned a node the AST refuses to build —
+     * a pass applying a name says what it means (ADR-0067), so the only unanswered callee left is
+     * one that is not a name at all.
+     */
     @Test
-    void anUnresolvedCallIsAnInternalError() {
-        assertInstanceOf(IllegalStateException.class, answerFor(null));
+    void anApplicationOfSomethingThatIsNotANameIsAnInternalError() {
+        Ast.Expr block = new Ast.Block(List.of(), new Ast.IntLit(1, AT, null), AT, null);
+        RuntimeException e = CallElaborator.noCallee(new Ast.Apply(block,
+                List.of(new Ast.IntLit(1, AT, null)), ConstructionOrigin.own(), AT, null));
+
+        assertInstanceOf(IllegalStateException.class, e);
+        assertTrue(e.getMessage().contains("7:3"), () -> "says where: " + e.getMessage());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/ConstEvalMatchBudgetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ConstEvalMatchBudgetTest.java
@@ -2,6 +2,9 @@ package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.ConstructionOrigin;
+import souther.compiler.types.ReachName;
+import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,8 +25,11 @@ class ConstEvalMatchBudgetTest {
     private static final SourcePos POS = new SourcePos(1, 1);
 
     private static Optional<Object> fold(String pattern, String subject) {
-        return ConstEval.eval(new Ast.Apply("String.matches",
-                List.of(new Ast.StringLit(pattern, POS, null), new Ast.StringLit(subject, POS, null)), POS, null));
+        ValueName.Stdlib matches = new ValueName.Stdlib("String", "matches");
+        return ConstEval.eval(new Ast.Apply("String.matches", matches,
+                new ReachName.OfLibrary(matches),
+                List.of(new Ast.StringLit(pattern, POS, null), new Ast.StringLit(subject, POS, null)),
+                ConstructionOrigin.own(), POS, null));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/partition/AGeneratedFixtureSaysWhatItsNamesDenoteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AGeneratedFixtureSaysWhatItsNamesDenoteTest.java
@@ -1,0 +1,121 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Every name in a fixture this generator builds says what it denotes.
+ *
+ * <p>ADR-0067 says a pass that synthesizes a node states what its name means rather than writing a
+ * spelling for someone else to resolve. This is the pass that did not: a fixture's constructions
+ * carried the spelling alone, so the reader of them had to ask what it meant in whatever module it
+ * happened to be read in, and got the wrong declaration where the module had one of that name and
+ * none where it did not (issue #696).
+ *
+ * <p>Held over the whole tree of every row of a model reaching another module's declarations three
+ * ways at once — bare, through an alias, and applied. The reader's own tests would pass on a tree
+ * with the answer missing, because a reader can always fall back to the spelling; this is the
+ * proposition that there is nothing to fall back from, and it belongs to the side that writes.
+ */
+class AGeneratedFixtureSaysWhatItsNamesDenoteTest {
+
+    private static final String LIB = """
+            module lib exposing ( Amount, Kind, Domestic, Overseas, When )
+
+            data Amount = Int
+            data When = Date
+
+            data Domestic
+            data Overseas
+            data Kind = Domestic | Overseas
+            """;
+
+    private static final String APP = """
+            module app exposing ( Req, Ok, No, Verdict, f )
+
+            import lib as up
+
+            data Req = { amount: up.Amount, kind: up.Kind, at: up.When, note: String? }
+
+            data Ok
+            data No
+            data Verdict = Ok | No
+
+            behavior f : (r: Req) -> Verdict
+                constructs Ok, No
+            let f (r) = { guard r.amount.value < 500 else Ok
+                No }
+            """;
+
+    /** Every expression of every row the model is offered, at every depth. */
+    private static List<Ast.Expr> everyNodeOfEveryRow() {
+        Compilation compilation = Compilation.ofSources(List.of(LIB, APP), ModulePath.EMPTY);
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        Adequacy.Filling filling =
+                compilation.db().ask(new Adequacy.Generated("app")).value().get("f");
+
+        List<Ast.Expr> nodes = new ArrayList<>();
+        java.util.stream.Stream
+                .concat(filling.boundaries().rows().stream(), filling.pairs().rows().stream())
+                .forEach(row -> row.inputs().forEach(input -> collect(input.value(), nodes)));
+        return nodes;
+    }
+
+    private static void collect(Ast.Expr e, List<Ast.Expr> into) {
+        if (e == null) {
+            return;
+        }
+        into.add(e);
+        Ast.forEachChild(e, child -> collect(child, into));
+    }
+
+    /** The names, each with what it denotes — and nothing carrying a spelling and no answer. */
+    @Test
+    void everyNameInARowCarriesWhatItDenotes() {
+        List<Ast.Expr> nodes = everyNodeOfEveryRow();
+        assertFalse(nodes.isEmpty(), "the model under test produces rows");
+
+        List<String> unanswered = new ArrayList<>();
+        for (Ast.Expr node : nodes) {
+            if (node instanceof Ast.Var name && name.denotes() == null) {
+                unanswered.add(name.name());
+            }
+            if (node instanceof Ast.NewData nd && nd.typeName().denotes() == null) {
+                unanswered.add(nd.typeName().written());
+            }
+        }
+
+        assertEquals(List.of(), unanswered);
+    }
+
+    /**
+     * And each of them answers what it reaches, which is the question every table in the compiler is
+     * asked with. A name that denotes something and reaches nothing cannot be built at all, so this
+     * is the pair being present rather than a second reading of the first.
+     */
+    @Test
+    void everyNameInARowAnswersWhatItReaches() {
+        List<String> reached = new ArrayList<>();
+        for (Ast.Expr node : everyNodeOfEveryRow()) {
+            if (node instanceof Ast.Var name) {
+                reached.add(name.reaches());
+            }
+        }
+
+        assertEquals(List.of("Date", "None", "up.Amount", "up.Domestic", "up.Overseas", "up.When"),
+                reached.stream().distinct().sorted().toList(),
+                "the module's declarations through its alias, the language's own vocabulary as"
+                        + " itself, and nothing under a declaration's own spelling");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AGeneratedRowIsWrittenTheWayTheModuleReachesItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AGeneratedRowIsWrittenTheWayTheModuleReachesItTest.java
@@ -1,0 +1,193 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A generated row names a type as the module it is offered to reaches it.
+ *
+ * <p>A row is text somebody pastes into their own module, so the names in it are that module's
+ * references and not the declarations' own spellings. One {@code lib.Amount} is {@code Amount} where
+ * an import brought it in, {@code up.Amount} where an alias reaches it, and {@code lib.Amount} where
+ * neither does — and the generator, which holds the declaration, is the one place that cannot see
+ * which (issue #696).
+ *
+ * <p>Held against the compiler rather than against a spelling written out here. Whether the row is a
+ * row is whether it compiles where it is offered, so the row this produces is pasted back into the
+ * module it was produced for and the module is compiled again. A test comparing the text with an
+ * expected string agrees with whatever the generator does, including writing a name nothing resolves.
+ */
+class AGeneratedRowIsWrittenTheWayTheModuleReachesItTest {
+
+    private static final String LIB = """
+            module lib exposing ( Amount, Kind, Domestic, Overseas )
+
+            data Amount = Int
+
+            data Domestic
+            data Overseas
+            data Kind = Domestic | Overseas
+            """;
+
+    /** A boundary at an imported newtype, drawn by a guard, and a case beside it. */
+    private static String app(String imports, String amount, String kind) {
+        return """
+                module app exposing ( Req, Ok, No, Verdict, f )
+
+                %s
+
+                data Req = { amount: %s, kind: %s }
+
+                data Ok
+                data No
+                data Verdict = Ok | No
+
+                behavior f : (r: Req) -> Verdict
+                    constructs Ok, No
+                let f (r) = { guard r.amount.value < 500 else Ok
+                    No }
+                """.formatted(imports, amount, kind);
+    }
+
+    private static Compilation compiled(String source) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(LIB, source), ModulePath.EMPTY);
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    /**
+     * The distinct rows this module is offered, boundaries and pairs alike, as the text of the one
+     * input each carries.
+     *
+     * <p>Distinct, and in the order they were offered. How many rows a boundary and a pair each ask
+     * for is the generator's own arithmetic and is held where that is what is under test; what is
+     * under test here is the names in them, and a row repeated says nothing more about a name than
+     * the first one did.
+     */
+    private static List<String> rowsFor(String source) {
+        Map<String, Adequacy.Filling> filling =
+                compiled(source).db().ask(new Adequacy.Generated("app")).value();
+        Adequacy.Filling f = filling.get("f");
+        return java.util.stream.Stream
+                .concat(f.boundaries().rows().stream(), f.pairs().rows().stream())
+                .map(r -> String.join(", ", r.inputs().stream().map(FixtureTemplate::text).toList()))
+                .distinct().toList();
+    }
+
+    /** An import that brought the names in: they are written as they are declared. */
+    @Test
+    void aTypeAnImportBroughtInIsWrittenBare() {
+        List<String> rows = rowsFor(app("import lib ( Amount, Kind, Domestic, Overseas )",
+                "Amount", "Kind"));
+
+        assertEquals(List.of(
+                        "Req { amount = Amount(500), kind = Domestic }",
+                        "Req { amount = Amount(499), kind = Domestic }",
+                        "Req { amount = Amount(499), kind = Overseas }",
+                        "Req { amount = Amount(500), kind = Overseas }"),
+                rows);
+    }
+
+    /**
+     * The same model reaching the same declarations through an alias. Nothing about the types
+     * changed and every name in every row did.
+     */
+    @Test
+    void aTypeReachedThroughAnAliasIsWrittenThroughIt() {
+        List<String> rows = rowsFor(app("import lib as up", "up.Amount", "up.Kind"));
+
+        assertEquals(List.of(
+                        "Req { amount = up.Amount(500), kind = up.Domestic }",
+                        "Req { amount = up.Amount(499), kind = up.Domestic }",
+                        "Req { amount = up.Amount(499), kind = up.Overseas }",
+                        "Req { amount = up.Amount(500), kind = up.Overseas }"),
+                rows);
+    }
+
+    /**
+     * And where the module declares an {@code Amount} of its own beside the one it reaches through
+     * the alias, which is the case a bare spelling answers wrong rather than not at all: both names
+     * resolve, and only one of them is the type at the position.
+     */
+    @Test
+    void aTypeIsNotWrittenBareWhereTheBareNameIsAnotherDeclaration() {
+        List<String> rows = rowsFor(app("import lib as up\n\n                data Amount = String",
+                "up.Amount", "up.Kind"));
+
+        assertEquals(List.of(
+                        "Req { amount = up.Amount(500), kind = up.Domestic }",
+                        "Req { amount = up.Amount(499), kind = up.Domestic }",
+                        "Req { amount = up.Amount(499), kind = up.Overseas }",
+                        "Req { amount = up.Amount(500), kind = up.Overseas }"),
+                rows);
+    }
+
+    /**
+     * A type the import list left out is written under the module that declares it — beside a case
+     * from the same module the same import did bring in, so the two forms stand in one row.
+     */
+    @Test
+    void aTypeAnImportLeftOutIsWrittenUnderItsModule() {
+        String source = app("import lib ( Kind, Domestic, Overseas )", "lib.Amount", "Kind");
+        List<String> rows = rowsFor(source);
+
+        assertEquals(List.of(
+                        "Req { amount = lib.Amount(500), kind = Domestic }",
+                        "Req { amount = lib.Amount(499), kind = Domestic }",
+                        "Req { amount = lib.Amount(499), kind = Overseas }",
+                        "Req { amount = lib.Amount(500), kind = Overseas }"),
+                rows);
+        assertEquals(List.of(), outOfScope(source, rows.get(0)),
+                "and the qualified form compiles where it is offered");
+    }
+
+    /**
+     * And the row compiles where it is offered, which is the whole of what a row being a row means.
+     *
+     * <p>Pasted back into the module it was written for. Beside it, the row this used to offer —
+     * the same values under the declarations' own spellings — so that the check is one this model
+     * can fail: the names are the only difference between the two, and one of them is out of scope
+     * in the module both are pasted into.
+     */
+    @Test
+    void aRowCompilesInTheModuleItIsOfferedToAndTheDeclarationsOwnSpellingDoesNot() {
+        String source = app("import lib as up", "up.Amount", "up.Kind");
+        String offered = rowsFor(source).get(0);
+        String declared = offered.replace("up.", "");
+
+        assertEquals(List.of(), outOfScope(source, offered),
+                "the row the generator offers names nothing this module cannot reach");
+        assertEquals(List.of("E1023", "E1023"), outOfScope(source, declared),
+                "and the declarations' own spellings are two names that are not in scope here");
+    }
+
+    /**
+     * The names-not-in-scope diagnostics a compile of {@code source} with {@code row} pasted into it
+     * reports. Only those: whether the value the row expects is the one the behavior answers with is
+     * a different question, and a row that names everything it needs may still disagree.
+     */
+    private static List<String> outOfScope(String source, String row) {
+        return codesFor(source, row).stream().filter(each -> each.equals("E1023")).toList();
+    }
+
+    /** Every diagnostic a compile of {@code source} with {@code row} pasted into it reports. */
+    private static List<String> codesFor(String source, String row) {
+        Compilation pasted = compiled(source + """
+
+                example f
+                    | "boundary" : (%s) -> No
+                """.formatted(row));
+        return pasted.diagnostics().values().stream().flatMap(List::stream)
+                .map(d -> d.diagnostic().code()).toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AGeneratedRowIsWrittenTheWayTheModuleReachesItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AGeneratedRowIsWrittenTheWayTheModuleReachesItTest.java
@@ -147,17 +147,23 @@ class AGeneratedRowIsWrittenTheWayTheModuleReachesItTest {
                         "Req { amount = lib.Amount(499), kind = Overseas }",
                         "Req { amount = lib.Amount(500), kind = Overseas }"),
                 rows);
-        assertEquals(List.of(), outOfScope(source, rows.get(0)),
+        assertEquals(List.of("E1905"), addedByPasting(source, rows.get(0)),
                 "and the qualified form compiles where it is offered");
     }
 
     /**
      * And the row compiles where it is offered, which is the whole of what a row being a row means.
      *
-     * <p>Pasted back into the module it was written for. Beside it, the row this used to offer —
-     * the same values under the declarations' own spellings — so that the check is one this model
-     * can fail: the names are the only difference between the two, and one of them is out of scope
-     * in the module both are pasted into.
+     * <p>Pasted back into the module it was written for, and held to every diagnostic the compile
+     * reports rather than to the absence of one of them: a row that named nothing out of scope
+     * could still be a syntax error or a value of the wrong type, and a check written as "no
+     * E1023" would call that a row. What is left is E1905, the expectation this pastes in being
+     * deliberately not the one the behavior answers with — the row was read, which is the point.
+     *
+     * <p>Beside it, the row this used to offer — the same values under the declarations' own
+     * spellings — so the check is one this model can fail. The names are the only difference
+     * between the two, and one of them is two names out of scope in the module both are pasted
+     * into.
      */
     @Test
     void aRowCompilesInTheModuleItIsOfferedToAndTheDeclarationsOwnSpellingDoesNot() {
@@ -165,29 +171,39 @@ class AGeneratedRowIsWrittenTheWayTheModuleReachesItTest {
         String offered = rowsFor(source).get(0);
         String declared = offered.replace("up.", "");
 
-        assertEquals(List.of(), outOfScope(source, offered),
-                "the row the generator offers names nothing this module cannot reach");
-        assertEquals(List.of("E1023", "E1023"), outOfScope(source, declared),
+        assertEquals(List.of("E1905"), addedByPasting(source, offered),
+                "the row was read, and only the expectation pasted beside it disagrees");
+        assertEquals(List.of("E1023", "E1023"), addedByPasting(source, declared),
                 "and the declarations' own spellings are two names that are not in scope here");
     }
 
     /**
-     * The names-not-in-scope diagnostics a compile of {@code source} with {@code row} pasted into it
-     * reports. Only those: whether the value the row expects is the one the behavior answers with is
-     * a different question, and a row that names everything it needs may still disagree.
+     * What pasting {@code row} into {@code source} adds to what that model already reported.
+     *
+     * <p>The difference and not the whole, because a model can have something to say without the
+     * row — one of these leaves an import it does not use — and what is under test is the row. Held
+     * as everything the compile added rather than as the absence of one code: a row that named
+     * nothing out of scope could still be a syntax error or a value of the wrong type, and a check
+     * written as "no E1023" would call that a row.
      */
-    private static List<String> outOfScope(String source, String row) {
-        return codesFor(source, row).stream().filter(each -> each.equals("E1023")).toList();
-    }
-
-    /** Every diagnostic a compile of {@code source} with {@code row} pasted into it reports. */
-    private static List<String> codesFor(String source, String row) {
-        Compilation pasted = compiled(source + """
+    private static List<String> addedByPasting(String source, String row) {
+        List<String> before = new java.util.ArrayList<>(codesFor(source));
+        List<String> added = new java.util.ArrayList<>();
+        for (String each : codesFor(source + """
 
                 example f
                     | "boundary" : (%s) -> No
-                """.formatted(row));
-        return pasted.diagnostics().values().stream().flatMap(List::stream)
+                """.formatted(row))) {
+            if (!before.remove(each)) {
+                added.add(each);
+            }
+        }
+        return added;
+    }
+
+    /** Every diagnostic a compile of {@code source} reports. */
+    private static List<String> codesFor(String source) {
+        return compiled(source).diagnostics().values().stream().flatMap(List::stream)
                 .map(d -> d.diagnostic().code()).toList();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANameGoesBackOnTheWayItCameOffTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANameGoesBackOnTheWayItCameOffTest.java
@@ -64,6 +64,11 @@ class ANameGoesBackOnTheWayItCameOffTest {
         return symbols.own(name);
     }
 
+    /** The same name as this module writes it, which is what a row is written with. */
+    private souther.compiler.types.TypeReachName.Written reached(String name) {
+        return (souther.compiler.types.TypeReachName.Written) symbols.reach(named(name));
+    }
+
     private PartitionClass classOf(String type, String id) {
         return PartitionClasses.of(Type.ref(named(type)), symbols).stream()
                 .filter(each -> each.id().equals(id)).findFirst().orElseThrow();
@@ -104,9 +109,9 @@ class ANameGoesBackOnTheWayItCameOffTest {
                 classOf("DecisionNN", "Approved").representatives().evaluate());
 
         assertEquals(named("Approved"), compose.through());
-        assertEquals(List.of(named("DecisionNN"), named("DecisionN")), compose.worn());
+        assertEquals(List.of(reached("DecisionNN"), reached("DecisionN")), compose.worn());
         assertEquals("DecisionNN(DecisionN(Approved { id = 1 }))",
-                compose.written(FixtureTemplate.record(named("Approved"),
+                compose.written(FixtureTemplate.record(reached("Approved"),
                         Map.of("id", FixtureTemplate.integer(1)))).text());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnOrdinalIsNeverWhatAnEnumerationIsWrittenAsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnOrdinalIsNeverWhatAnEnumerationIsWrittenAsTest.java
@@ -126,7 +126,8 @@ class AnOrdinalIsNeverWhatAnEnumerationIsWrittenAsTest {
     /** A row writes the case, which is what naming it builds. */
     @Test
     void aRowAtAnOrdinalCarriesTheCaseAndNotItsPlace() {
-        FixtureTemplate written = FixtureTemplate.on(carrier(), Count.of(1));
+        FixtureTemplate written = FixtureTemplate.on(carrier(), Count.of(1),
+                souther.compiler.types.TypeReachName.Bare::new);
 
         assertEquals("Qualified", written.text());
         assertInstanceOf(souther.compiler.ast.Ast.Var.class, written.value(),


### PR DESCRIPTION
Reported as #696: a compiler-generated `Ast.Apply` drops the resolved callee identity, so
`FixtureReader` resolves the source spelling again. The identity is half of it. The
generator writes two forms of one value — the text a row carries and the tree a decoder
builds — and it wrote both from the declaration's own name, which is not what any module
necessarily calls the type.

## The defect, measured

`lib` declares a newtype; `app` takes it at a boundary. The only difference between the
runs is how `app` reaches it.

| how `app` reaches it | `symbols.resolve("Amount")` | before | after |
| --- | --- | --- | --- |
| `import lib as up` | `null` | no row: every candidate refused | `up.Amount(500)` |
| `import lib ( Amount )` | `lib.Amount` | `Amount(500)` | unchanged |
| alias, plus `data Amount = String` of its own | `app.Amount` | no row; read as the wrong type | `up.Amount(500)` |

The text half fails on its own. An imported unit case carried its identity already, so the
candidate built and the row was offered — `Req { kind = Domestic }`, pasted into a module
that cannot write `Domestic`. Fixing only the tree moves the newtype case onto the same
footing rather than off it.

## What is in it

`types/TypeReachName` — `Bare` / `ViaAlias` / `ViaModule`, and `Unnameable` for a type no
spelling here reaches. `rendered()` lives on `Written` alone, so a caller has to say what
it does where there is no name. `Symbols.reach` decides it once, and asks whether the bare
spelling means *this* declaration rather than whether the name is in scope.

`FixtureTemplate` writes text and tree from that one answer. `FixtureReader`'s seven
readers ask what the callee denotes. Three shapes that let a synthesized node stay silent
are removed: `Ast.Apply(String fn, …)`, `Var.reaches()`'s fall back to the spelling, and
`ReachName.of`'s `null -> Bare(written)`. ADR-0067 stated the rule and nothing held it.

A case whose module does not expose it has no spelling here at all — E1611 holds a
signature to exposed types, and a sum's cases come through the sum. Those classes are
still counted and each says why no row can be offered for it, instead of being offered a
name that resolves to nothing wherever the row is pasted. `ACaseIsBuiltAtItsPosition…Test`
was pinning one of those rows as expected output.

## Effect on souther-examples

Both jars over all fourteen modules:

- generated rows 953 → 1100
- `every value tried … was refused` 499 → 84
- no module lost a row (crm 377 → 499, realworld 74 → 97, hr 404 → 406)

## Tests

`AGeneratedRowIsWrittenTheWayTheModuleReachesItTest` pastes the offered row back into the
module it was offered to and compiles it, beside the same row under the declarations' own
names — which is two names out of scope, so the check is one the model can fail.
`AGeneratedFixtureSaysWhatItsNamesDenoteTest` holds the tree invariant on the side that
writes: a reader can always fall back to a spelling, so a reader's tests would pass
without it. `ANameAnsweredHalfwayIsRefusedTest` loses a test that had become half of
another one.

All modules green (souther-compiler 4276).

## Not closed by this

#700 — the same class, one layer over: four readers identify a live value's declaration by
resolving its class's *simple* name, so a module reaching the type through an alias
observes none of its own cases. Nothing upstream has to change for it; the value carries
its class and the readers throw it away.

`Type.show` renders a type's bare name and qualifies only when two shown types collide. It
is diagnostic presentation rather than a reference something is pasted back as, so it is
left alone here.

Refs #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)
