### PR TITLE
Close name resolution to the pass that reads a module

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -361,7 +361,7 @@ public final class DataChecker {
                                 .hint(new BehaviorMessage.ASumsCasesAreDeclaredWithIt(c.written())).say(new BehaviorMessage.ACaseIsDeclaredInAnotherModule(c.written(), sum.name(), c.denotes().module())).build());
             }
         }
-        List<String> cycle = sumCycle(symbols.own(sum.name()), symbols, new LinkedHashSet<>());
+        List<String> cycle = sumCycle(symbols.own(sum), symbols, new LinkedHashSet<>());
         if (cycle != null) {
             throw CompileException.of(Diagnostic
                             .at(sum.pos()).say(new BehaviorMessage.ASumContainsItself(sum.name(), String.join(" | ", cycle))).build());
@@ -369,7 +369,7 @@ public final class DataChecker {
         sum.decoder().ifPresent(disc -> {
             // a derived codec dispatches over the leaves, so a nested sum's cases count too (§sum-data,
             // §sum-discrimination)
-            Set<TypeName> dispatchable = TypeOps.leafCases(Type.ref(symbols.own(sum.name())), symbols);
+            Set<TypeName> dispatchable = TypeOps.leafCases(Type.ref(symbols.own(sum)), symbols);
             for (Ast.Variant v : disc.variants()) {
                 Ast.Def caseDef = symbols.get(v.caseType().denotes());
                 if (!dispatchable.contains(v.caseType().denotes())) {
@@ -394,14 +394,14 @@ public final class DataChecker {
             // declaring a field of that name and the tag want one key. Refused here rather than
             // written over where it is encoded, which would lose the value with nothing said.
             TypeName carrying = TypeOps.memberCarryingField(
-                    Type.ref(symbols.own(sum.name())), enc.key(), symbols);
+                    Type.ref(symbols.own(sum)), enc.key(), symbols);
             if (carrying != null) {
                 throw CompileException.of(Diagnostic
                                 .at(sum.pos())
                                 .hint(new DataMessage.TheTagAndTheFieldWantOneKey(enc.key())).say(new DataMessage.ACaseDeclaresTheDiscriminatorField(carrying.name(), enc.key(), sum.name())).build());
             }
             Set<TypeName> covered = new HashSet<>();
-            Set<TypeName> encodable = TypeOps.leafCases(Type.ref(symbols.own(sum.name())), symbols);
+            Set<TypeName> encodable = TypeOps.leafCases(Type.ref(symbols.own(sum)), symbols);
             for (Ast.EncVariant v : enc.variants()) {
                 if (!encodable.contains(v.caseType().denotes())) {
                     throw CompileException.of(Diagnostic.at(v.pos())
@@ -520,7 +520,7 @@ public final class DataChecker {
     }
 
     private static Scope fieldScope(CheckContext ctx) {
-        return fieldScope(ctx.symbols().own(ctx.data().name()), ctx.data(), ctx.symbols());
+        return fieldScope(ctx.symbols().own(ctx.data()), ctx.data(), ctx.symbols());
     }
 
     /**
@@ -589,7 +589,7 @@ public final class DataChecker {
 
     private static void checkConstruct(Ast.Construct c, CheckContext ctx, Map<String, Type> fields,
                                        Scope env) {
-        if (!c.typeName().denotes().equals(ctx.symbols().own(ctx.data().name()))) {
+        if (!c.typeName().denotes().equals(ctx.symbols().own(ctx.data()))) {
             throw CompileException.of(Diagnostic.at(c.pos())
                     .say(new CodecMessage.TheDecoderBuildsAnotherType(ctx.data().name(),
                             c.typeName().written()))
@@ -713,7 +713,7 @@ public final class DataChecker {
     }
 
     private static void checkEncoder(Ast.EncoderDef enc, CheckContext ctx) {
-        Scope env = Scope.NONE.with(enc.self(), Type.ref(ctx.symbols().own(ctx.data().name())));
+        Scope env = Scope.NONE.with(enc.self(), Type.ref(ctx.symbols().own(ctx.data())));
         checkRawExpr(enc.result(), env, ctx);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -366,7 +366,7 @@ public final class Resolve {
         Ast.TypeRef denoted = resolved.denoting(typeOf(resolved));
         // A reference with no name is a tuple or a container shape, which names no declaration.
         if (denoted.name() != null && denoted.pos() != null) {
-            TypeName names = symbols.resolve(denoted.name());
+            TypeName names = symbols.resolve(denoted.written());
             if (names != null) {
                 denotations.add(new Denotation(denoted.written(), names));
             }
@@ -377,7 +377,7 @@ public final class Resolve {
     // --- definitions ---
 
     private Ast.Def def(Ast.Def def) {
-        owner = new BindingOwner.OfData(symbols.own(def.name()));
+        owner = new BindingOwner.OfData(symbols.own(def));
         return switch (def) {
             case Ast.UnitData u -> u;
             // an invariant reads the fields of the data it belongs to, which are what bind its
@@ -403,7 +403,7 @@ public final class Resolve {
                 out.add(c);
                 continue;
             }
-            TypeName denoted = symbols.resolve(c.written());
+            TypeName denoted = symbols.resolve(c.name());
             if (denoted == null) {
                 throw CompileException.of(Diagnostic
                                 .at(s.pos()).say(new BehaviorMessage.UnknownCaseInASum(c.written(), s.name())).build());
@@ -430,7 +430,7 @@ public final class Resolve {
      * declaring declaration's, so this is where an editor is answered from either way.
      */
     private void declareFields(Ast.Data d) {
-        Map<String, BindingId> bindings = TypeOps.fieldBindings(symbols.own(d.name()), d, symbols);
+        Map<String, BindingId> bindings = TypeOps.fieldBindings(symbols.own(d), d, symbols);
         for (Ast.Field field : d.fields()) {
             BindingId binding = bindings.get(field.name());
             if (binding != null) {
@@ -444,7 +444,7 @@ public final class Resolve {
         // which binding each field is is answered in one place, so the pass that emits this
         // invariant reaches the same ones without working them out again
         for (Map.Entry<String, BindingId> f
-                : TypeOps.fieldBindings(symbols.own(d.name()), d, symbols).entrySet()) {
+                : TypeOps.fieldBindings(symbols.own(d), d, symbols).entrySet()) {
             bound = bound.and(f.getKey(), new ValueName.Local(f.getKey(), f.getValue()));
         }
         return bound;
@@ -740,7 +740,8 @@ public final class Resolve {
      * construction of a unit data and records where it came from; applied, it is a newtype taking
      * what it wraps, and the application is what says that.
      */
-    private ValueName lookup(String written, boolean applied, Bindings bound) {
+    private ValueName lookup(WrittenName name, boolean applied, Bindings bound) {
+        String written = name.canonical();
         // a binding in force wins over everything else: a body may bind a name a module declares,
         // and the binding is what the name means there
         ValueName.Local binding = bound.binderOf(written);
@@ -770,7 +771,7 @@ public final class Resolve {
             }
             return null;
         }
-        TypeName type = symbols.resolve(written);
+        TypeName type = symbols.resolve(name);
         if (type != null && !type.isUnresolved()) {
             return new ValueName.OfType(written, type, applied ? null : ConstructionOrigin.own());
         }
@@ -832,7 +833,7 @@ public final class Resolve {
             return null;
         }
         WrittenName written = dottedName(fa);
-        ValueName denotes = lookup(written.canonical(), applied, bound);
+        ValueName denotes = lookup(written, applied, bound);
         if (denotes != null) {
             ValueName resolved = answered(written, denotes);
             return new Ast.Var(written, resolved,
@@ -894,7 +895,7 @@ public final class Resolve {
 
     /** What a name used as a value denotes, and the report for one that denotes nothing. */
     private ValueName valueName(WrittenName written, Bindings bound) {
-        ValueName denotes = lookup(written.canonical(), false, bound);
+        ValueName denotes = lookup(written, false, bound);
         return denotes != null ? denotes
                 : nothing(written.canonical(), unknownIdentifier(written, bound));
     }
@@ -907,7 +908,7 @@ public final class Resolve {
      * position it was written in is a fact about the source rather than about the name.
      */
     private ValueName calledName(Ast.Apply call, Bindings bound) {
-        ValueName denotes = lookup(call.written(), true, bound);
+        ValueName denotes = lookup(call.name(), true, bound);
         return denotes != null ? denotes
                 : nothing(call.written(), unknownIdentifier(call.name(), bound));
     }
@@ -1029,7 +1030,7 @@ public final class Resolve {
         if (n.denotes() != null) {
             return n;
         }
-        TypeName denoted = symbols.resolve(n.written());
+        TypeName denoted = symbols.resolve(n.name());
         if (denoted == null) {
             return answered(n.denoting(nothingDenotes(n)));
         }
@@ -1051,7 +1052,7 @@ public final class Resolve {
         if (n.denotes() != null) {
             return n;
         }
-        TypeName denoted = symbols.resolveCase(n.written());
+        TypeName denoted = symbols.resolveCase(n.name());
         if (denoted == null) {
             denoted = TypeName.optionCase(n.written());
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -430,7 +430,7 @@ public final class Resolve {
      * declaring declaration's, so this is where an editor is answered from either way.
      */
     private void declareFields(Ast.Data d) {
-        Map<String, BindingId> bindings = TypeOps.fieldBindings(symbols.own(d), d, symbols);
+        Map<String, BindingId> bindings = TypeOps.fieldBindingsWhileResolving(symbols.own(d), d, symbols);
         for (Ast.Field field : d.fields()) {
             BindingId binding = bindings.get(field.name());
             if (binding != null) {
@@ -444,7 +444,7 @@ public final class Resolve {
         // which binding each field is is answered in one place, so the pass that emits this
         // invariant reaches the same ones without working them out again
         for (Map.Entry<String, BindingId> f
-                : TypeOps.fieldBindings(symbols.own(d), d, symbols).entrySet()) {
+                : TypeOps.fieldBindingsWhileResolving(symbols.own(d), d, symbols).entrySet()) {
             bound = bound.and(f.getKey(), new ValueName.Local(f.getKey(), f.getValue()));
         }
         return bound;

--- a/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.ast.WrittenName;
 import souther.compiler.types.TypeName;
 
 import java.util.ArrayList;
@@ -81,9 +82,35 @@ public final class Symbols {
         return module;
     }
 
-    /** A name in the module being compiled. The caller vouches that it is declared here. */
-    public TypeName own(String name) {
-        return new TypeName(module, name);
+    /**
+     * The type a declaration of the module being compiled is.
+     *
+     * <p>Asked with the declaration and not with a name. A spelling says nothing about which module
+     * declares what it spells, so stamping this module onto one answers for a declaration here
+     * whatever the spelling came from — a name read off a class, a name another module wrote. A
+     * caller holding the declaration is a caller that has it from this module's own tree.
+     */
+    public TypeName own(Ast.Def def) {
+        TypeName named = new TypeName(module, def.name());
+        // Held to, and not taken on trust. A declaration is an argument like any other, so a caller
+        // holding one of another module's can hand it over and be answered about a type of this one
+        // — which is the reading a `constructs` entry naming an imported type got, silently, for as
+        // long as the answer was worked out from a spelling.
+        // Held to a name this module declares. Asked only where this module's declarations are
+        // known: a module in an import cycle is compiled with nothing registered for it, and
+        // refusing there would replace the report about the cycle with one about a declaration that
+        // is fine.
+        //
+        // Not held to being the declaration registered under that name. A module that declares a
+        // name twice registers one of them, and the pass that reports it walks both. So a
+        // declaration another module wrote under a name this one also writes is admitted here, and
+        // nothing this holds can tell the two apart — which declaration a definition is stays
+        // something worked out from a name until a declaration carries its own.
+        if (get(named) == null && !declaredIn(module).isEmpty()) {
+            throw new IllegalArgumentException(
+                    "`" + def.name() + "` is not declared in `" + module + "`");
+        }
+        return named;
     }
 
     /** The definition of {@code name}, or null when no module declares it. The runtime namespace
@@ -106,24 +133,17 @@ public final class Symbols {
         return registry.declaration(name) != null;
     }
 
-    /** The definition the written name {@code written} denotes here, or null when nothing does. The
-     * name must have been written in the module being compiled. */
-    public Ast.Def declaration(String written) {
-        TypeName name = resolve(written);
-        return name == null ? null : get(name);
-    }
-
     /**
      * What a written case name denotes. Beside the data cases a module declares or imports, an arm may
      * name a case of a primitive-headed union: the primitive itself ({@code Int} in {@code Int |
      * DivisionByZero}), or one of the error cases the runtime declares rather than any module. Null
      * when it is none of those.
      */
-    public TypeName resolveCase(String written) {
-        return switch (written) {
+    TypeName resolveCase(WrittenName written) {
+        return switch (written.canonical()) {
             case "Int", "String", "Bool", "Decimal", "Date", "Time", "DateTime", "Instant", "Raw" ->
-                    TypeName.primitive(written);
-            case "DivisionByZero", "NotANumber", "NotADate", "NotATime" -> TypeName.runtime(written);
+                    TypeName.primitive(written.canonical());
+            case "DivisionByZero", "NotANumber", "NotADate", "NotATime" -> TypeName.runtime(written.canonical());
             default -> resolve(written);
         };
     }
@@ -140,7 +160,13 @@ public final class Symbols {
      * <p>"Here" is the whole story: a name is resolved in the module that wrote it, by that module's
      * own {@link Resolve} pass, so this never has to answer for a spelling written somewhere else.
      */
-    public TypeName resolve(String written) {
+    TypeName resolve(WrittenName written) {
+        return resolveSpelling(written.canonical());
+    }
+
+    /** As above, of the spelling itself. Private: a spelling reaches this only from a name of this
+     *  module's own text, which is what a {@link WrittenName} is and a bare string is not. */
+    private TypeName resolveSpelling(String written) {
         int dot = written.lastIndexOf('.');
         if (dot < 0) {
             TypeName name = scope.get(written);

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeCardinality.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeCardinality.java
@@ -207,7 +207,7 @@ public final class TypeCardinality {
         Map<TypeName, Ast.Def> declared = new LinkedHashMap<>();
         List<TypeName> left = new ArrayList<>();
         for (Ast.Def def : module.defs()) {
-            left.add(symbols.own(def.name()));
+            left.add(symbols.own(def));
         }
         while (!left.isEmpty()) {
             TypeName name = left.remove(left.size() - 1);

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -910,8 +910,12 @@ public final class TypeOps {
             out.putIfAbsent(field.name(), new BindingId(owner, ordinal++));
         }
         for (Ast.Name include : data.includes()) {
+            // Resolve asks this while it is resolving, so an include here may be a name nothing
+            // has answered for yet. Reading the spelling is the pass doing its own work and not
+            // a second reading of an answer already given — which is why it is asked of the name
+            // and only where there is no denotation to read.
             TypeName source = include.denotes() != null
-                    ? include.denotes() : symbols.resolve(include.written());
+                    ? include.denotes() : symbols.resolve(include.name());
             if (source != null && seen.add(source)
                     && symbols.get(source) instanceof Ast.Data included) {
                 walkFields(included, source, symbols, seen, out);
@@ -1558,7 +1562,7 @@ public final class TypeOps {
                 if (ref.name().startsWith("'")) {
                     yield Type.var(ref.name());   // a type variable, admitted only in the core
                 }
-                TypeName resolved = symbols.resolve(ref.name());
+                TypeName resolved = symbols.resolve(ref.written());
                 if (resolved != null) {
                     yield resolved.isUnresolved() ? Type.ERRONEOUS : Type.ref(resolved);
                 }
@@ -1566,7 +1570,7 @@ public final class TypeOps {
                 // that way; a declaration reads it the same, which is what lets `Int |
                 // DivisionByZero` be written rather than only met. Asked after the module's own
                 // declarations, so a name a model declares keeps its meaning.
-                TypeName asCase = symbols.resolveCase(ref.name());
+                TypeName asCase = symbols.resolveCase(ref.written());
                 if (asCase != null && !asCase.isUnresolved()) {
                     yield Type.ref(asCase);
                 }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -882,7 +882,24 @@ public final class TypeOps {
     public static Map<String, BindingId> fieldBindings(TypeName declared, Ast.Data data,
                                                        Symbols symbols) {
         Map<String, BindingId> bindings = new LinkedHashMap<>();
-        walkFields(data, declared, symbols, new LinkedHashSet<>(), bindings);
+        walkFields(data, declared, symbols, new LinkedHashSet<>(), bindings, false);
+        return bindings;
+    }
+
+    /**
+     * As above, asked by {@link Resolve} while it is resolving.
+     *
+     * <p>The one caller for which an include may still be a name nothing has answered for. Reading
+     * the spelling there is the pass doing its own work, and it is a separate way in so that it
+     * cannot be reached by a reader after the pass: one that met an unanswered include and repaired
+     * it from characters would be answering for whatever the reading module has under them, and
+     * would hide the producer that left the name unanswered — which is the whole of what this
+     * change is about.
+     */
+    static Map<String, BindingId> fieldBindingsWhileResolving(TypeName declared, Ast.Data data,
+                                                              Symbols symbols) {
+        Map<String, BindingId> bindings = new LinkedHashMap<>();
+        walkFields(data, declared, symbols, new LinkedHashSet<>(), bindings, true);
         return bindings;
     }
 
@@ -903,22 +920,29 @@ public final class TypeOps {
      * says nothing more.
      */
     private static void walkFields(Ast.Data data, TypeName declared, Symbols symbols,
-                                   Set<TypeName> seen, Map<String, BindingId> out) {
+                                   Set<TypeName> seen, Map<String, BindingId> out,
+                                   boolean resolving) {
         BindingOwner owner = new BindingOwner.OfFields(declared);
         int ordinal = 0;
         for (Ast.Field field : data.fields()) {
             out.putIfAbsent(field.name(), new BindingId(owner, ordinal++));
         }
         for (Ast.Name include : data.includes()) {
-            // Resolve asks this while it is resolving, so an include here may be a name nothing
-            // has answered for yet. Reading the spelling is the pass doing its own work and not
-            // a second reading of an answer already given — which is why it is asked of the name
-            // and only where there is no denotation to read.
-            TypeName source = include.denotes() != null
-                    ? include.denotes() : symbols.resolve(include.name());
+            TypeName source = include.denotes();
+            if (source == null) {
+                if (!resolving) {
+                    // Resolve answers every name it reads, an unknown one included, so a tree it
+                    // wrote has none of these. One here is a tree some other producer built, and
+                    // reading the spelling to carry on would answer for whatever this module has
+                    // under it and leave the producer unmentioned.
+                    throw new IllegalStateException("the include `" + include.written()
+                            + "` of `" + declared + "` denotes nothing");
+                }
+                source = symbols.resolve(include.name());
+            }
             if (source != null && seen.add(source)
                     && symbols.get(source) instanceof Ast.Data included) {
-                walkFields(included, source, symbols, seen, out);
+                walkFields(included, source, symbols, seen, out, resolving);
             }
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/UninhabitableTypes.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UninhabitableTypes.java
@@ -59,7 +59,7 @@ public final class UninhabitableTypes {
                                                              TypeCardinality.Cardinalities solved) {
         Map<TypeName, Integer> declaredAt = new LinkedHashMap<>();
         for (Ast.Def def : module.defs()) {
-            declaredAt.put(symbols.own(def.name()), declaredAt.size());
+            declaredAt.put(symbols.own(def), declaredAt.size());
         }
         Set<TypeName> none = solved.withNoValue();
         if (none.isEmpty()) {

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -305,22 +305,22 @@ public final class Backend {
                 // when the behavior declares it in `constructs` — that declaration is the authority
                 // to build it (spec §asymmetric-interop), and unlike a unit it cannot be told apart from a decoded
                 // pass-through output (会員) by shape alone.
-                List<String> unitCases = new ArrayList<>();
+                List<TypeName> unitCases = new ArrayList<>();
                 for (Ast.TypeTerm term : spec.ret().cases()) {
                     if (term instanceof Ast.TypeRef t && t.denotes() instanceof Type.Ref r
                             && b.symbols.get(r.name()) instanceof Ast.UnitData) {
-                        unitCases.add(r.name().name());
+                        unitCases.add(r.name());
                     }
                 }
-                List<Ast.Data> dataConstructs = new ArrayList<>();
+                List<TypeName> dataConstructs = new ArrayList<>();
                 Set<TypeName> seenConstruct = new HashSet<>();
                 if (spec.constructs() != null) {
                     for (Ast.Name tn : spec.constructs()) {
                         // a field-bearing data or newtype; de-duplicated so a repeated `constructs`
                         // entry does not emit the factory method twice (a duplicate-method class file)
-                        if (b.symbols.get(tn.denotes()) instanceof Ast.Data data
+                        if (b.symbols.get(tn.denotes()) instanceof Ast.Data
                                 && seenConstruct.add(tn.denotes())) {
-                            dataConstructs.add(data);
+                            dataConstructs.add(tn.denotes());
                         }
                     }
                 }
@@ -708,7 +708,7 @@ public final class Backend {
      * rather than {@code Object}. If either side is a list/option/map (no single reference class), the
      * signature is omitted and the raw interface stands.
      */
-    private byte[] generateRequiredBase(String name, List<String> unitCases, List<Ast.Data> dataConstructs,
+    private byte[] generateRequiredBase(String name, List<TypeName> unitCases, List<TypeName> dataConstructs,
                                         List<Type> paramTypes, Type retType) {
         ClassDesc cdR = cdBehavior(name);
         // Injected-vs-unary is orthogonal to composition: one input is the unary Behavior<In,Out> (so
@@ -731,19 +731,19 @@ public final class Backend {
                 code.invokespecial(CD_Object, "<init>", MTD_void);
                 code.return_();
             });
-            for (String caseName : unitCases) {
+            for (TypeName caseName : unitCases) {
                 emitUnitFactory(cb, caseName);
             }
-            for (Ast.Data data : dataConstructs) {   // a field-bearing data or a newtype
-                emitDataFactory(cb, data);
+            for (TypeName construct : dataConstructs) {   // a field-bearing data or a newtype
+                emitDataFactory(cb, construct);
             }
         });
     }
 
     /** A no-arg factory for a unit case: the type has exactly one value, so it hands that out. */
-    private void emitUnitFactory(ClassBuilder cb, String typeName) {
-        ClassDesc caseCd = cd(typeName);
-        cb.withMethodBody(typeName, MethodTypeDesc.of(caseCd),
+    private void emitUnitFactory(ClassBuilder cb, TypeName typeName) {
+        ClassDesc caseCd = ctx.cd(typeName);
+        cb.withMethodBody(typeName.name(), MethodTypeDesc.of(caseCd),
                 ClassFile.ACC_PROTECTED | ClassFile.ACC_FINAL, code -> {
                     loadSharedInstance(code, caseCd);
                     code.areturn();
@@ -753,8 +753,11 @@ public final class Backend {
     /** A factory taking the data's fields (in declaration order) and building it through
      * {@code __construct}, so the invariant is checked and a violation aborts (spec §algebraic-types) — the same
      * path an in-domain construction takes, not a decode of an external representation. */
-    private void emitDataFactory(ClassBuilder cb, Ast.Data data) {
-        ClassDesc cdType = cd(data.name());
+    private void emitDataFactory(ClassBuilder cb, TypeName construct) {
+        // The type as the `constructs` clause resolved it: an entry there may name a type another
+        // module declares, and the class of one is that module's.
+        Ast.Data data = (Ast.Data) symbols.get(construct);
+        ClassDesc cdType = ctx.cd(construct);
         Map<String, Type> fields = ctx.fieldTypes(data);
         ClassDesc[] fieldDs = fieldDescs(fields, ctx);
         String sig = factorySignature(fields, cdType);
@@ -994,7 +997,7 @@ public final class Backend {
      * the union, which writes the discriminator no member writes on itself.
      */
     private byte[] generateBehaviorResult(String resultName, List<TypeName> members) {
-        ClassDesc cdR = cd(resultName);
+        ClassDesc cdR = generated(resultName);
         List<ClassDesc> caseCds = new ArrayList<>();
         for (TypeName member : members) {
             caseCds.add(ctx.resultMemberClass(member));
@@ -1011,8 +1014,8 @@ public final class Backend {
         return ctx.successType(ret);
     }
 
-    private ClassDesc cd(String typeName) {
-        return ctx.cd(typeName);
+    private ClassDesc generated(String simpleName) {
+        return ctx.generated(simpleName);
     }
 
     /** The class a behavior is emitted under (spec §jvm-behavior). Anything that has to name that class from

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
@@ -60,7 +60,8 @@ final class CodecGen {
     /** The three boundary input sources a decoder can read from (spec §external-representation, §codec-generation). */
     enum Src { NEUTRAL, JSON, JOOQ }
 
-    private ClassDesc cd(String typeName) { return ctx.cd(typeName); }
+    private ClassDesc generated(String simpleName) { return ctx.generated(simpleName); }
+    private ClassDesc cd(Ast.Def def) { return ctx.cd(def); }
     private ClassDesc cd(TypeName typeName) { return ctx.cd(typeName); }
     private Map<String, Type> fieldTypes(Ast.Data data) { return ctx.fieldTypes(data); }
     private ClassDesc[] fieldDescs(Map<String, Type> fields) { return JvmTypes.fieldDescs(fields, ctx); }
@@ -226,7 +227,7 @@ final class CodecGen {
     }
 
     byte[] generateSumEncoder(Ast.SumData sum, Ast.SumEncoder enc) {
-        ClassDesc cdEnc = cd(sum.name() + "$Enc");
+        ClassDesc cdEnc = generated(sum.name() + "$Enc");
         return build(cdEnc, cb -> {
             cb.withFlags(ClassFile.ACC_FINAL | ClassFile.ACC_SUPER);
             cb.withInterfaceSymbols(CD_REncoder);
@@ -258,7 +259,7 @@ final class CodecGen {
     }
 
     byte[] generateSumDecoder(Ast.SumData sum, Ast.Discriminate disc, Src src) {
-        ClassDesc cdDec = cd(sum.name() + srcSuffix(src));
+        ClassDesc cdDec = generated(sum.name() + srcSuffix(src));
         return build(cdDec, cb -> {
             cb.withFlags(ClassFile.ACC_FINAL | ClassFile.ACC_SUPER);
             cb.withInterfaceSymbols(CD_RDecoder);
@@ -316,7 +317,7 @@ final class CodecGen {
      * the value's path, the way a newtype's invariant does, rather than being read as some other case.
      */
     byte[] generateEnumSumDecoder(Ast.SumData sum, Src src) {
-        ClassDesc cdDec = cd(sum.name() + srcSuffix(src));
+        ClassDesc cdDec = generated(sum.name() + srcSuffix(src));
         List<TypeName> cases = TypeOps.leafCases(sum, symbols);
         return build(cdDec, cb -> {
             cb.withFlags(ClassFile.ACC_FINAL | ClassFile.ACC_SUPER);
@@ -376,7 +377,7 @@ final class CodecGen {
 
     /** Encodes an enumeration to its case's name — the same string its decoder reads. */
     byte[] generateEnumSumEncoder(Ast.SumData sum) {
-        ClassDesc cdEnc = cd(sum.name() + "$Enc");
+        ClassDesc cdEnc = generated(sum.name() + "$Enc");
         return build(cdEnc, cb -> {
             cb.withFlags(ClassFile.ACC_FINAL | ClassFile.ACC_SUPER);
             cb.withInterfaceSymbols(CD_REncoder);
@@ -384,7 +385,7 @@ final class CodecGen {
             emitSharedInstance(cb, cdEnc);
             cb.withMethodBody("encode", MTD_Rencode, ClassFile.ACC_PUBLIC, code -> {
                 code.aload(1);
-                code.invokestatic(cd(sum.name()), TAG_METHOD, MTD_tag, true);
+                code.invokestatic(cd(sum), TAG_METHOD, MTD_tag, true);
                 code.areturn();
             });
         });
@@ -423,10 +424,10 @@ final class CodecGen {
 
     void emitFactory(ClassBuilder cb, String name, ClassDesc returnIface, Ast.Data data,
                              String suffix) {
-        ClassDesc impl = cd(data.name() + suffix);
-        ClassDesc self = cd(data.name());
+        ClassDesc impl = generated(data.name() + suffix);
+        ClassDesc self = cd(data);
         MethodSignature sig = name.equals("decoder")
-                ? decoderSig(self, isMapInput(data.name()))
+                ? decoderSig(self, isMapInput(data))
                 : encoderSig(self, encoderOutput(data));
         emitCodecFactory(cb, name, returnIface, impl, sig);
     }
@@ -501,16 +502,15 @@ final class CodecGen {
     }
 
     /** Emits a source's decoder factory ({@code jsonDecoder()} / {@code recordDecoder()}). */
-    void emitSourceFactory(ClassBuilder cb, String typeName, Src src, boolean mapInput) {
-        emitCodecFactory(cb, srcFactory(src), CD_RDecoder, cd(typeName + srcSuffix(src)),
-                decoderSigFor(src, cd(typeName), mapInput));
+    void emitSourceFactory(ClassBuilder cb, Ast.Def def, Src src, boolean mapInput) {
+        emitCodecFactory(cb, srcFactory(src), CD_RDecoder, generated(def.name() + srcSuffix(src)),
+                decoderSigFor(src, cd(def), mapInput));
     }
 
     /** jOOQ rows are flat: a type is Record-decodable iff it is an object (or a sum of objects/units)
      * whose every field is a scalar column — a primitive, a newtype, or an optional of those; no
      * nested object, list, map, or sum. */
-    boolean recordCompatible(String typeName) {
-        Ast.Def def = symbols.declaration(typeName);
+    boolean recordCompatible(Ast.Def def) {
         if (def instanceof Ast.SumData sum) {
             if (TypeOps.isUnitOnlySum(sum, symbols)) {
                 return false;   // an enumeration is a bare column, not a whole row (issue #161)
@@ -555,7 +555,7 @@ final class CodecGen {
 
     byte[] generateDecoderClass(ClassDesc cdName, Ast.Data data, Ast.DecoderDef dec,
                                         Map<String, Type> fields, Src src) {
-        ClassDesc cdDec = cd(data.name() + srcSuffix(src));
+        ClassDesc cdDec = generated(data.name() + srcSuffix(src));
         decoderClass = cdDec;
         Invariants invariants = invariantsOf(data, fields);
         return build(cdDec, cb -> {
@@ -825,8 +825,8 @@ final class CodecGen {
 
     /** True when the type's decoder reads from a {@code Map} (object/sum), false for a bare
      * value (newtype/unit). Used to bridge nested field-value decoders with {@code nested()}. */
-    boolean isMapInput(String typeName) {
-        return isMapInputOf(symbols.declaration(typeName));
+    boolean isMapInput(Ast.Def def) {
+        return isMapInputOf(def);
     }
 
     boolean isMapInput(Ast.Name typeName) {
@@ -1396,7 +1396,7 @@ final class CodecGen {
      * clause declared {@code i}th as a plain boolean, emitted beside the whole-invariant check
      * compile-time construction checking uses (ADR-0032). */
     private DynamicCallSiteDesc invariantPredicateCallSite(ClassDesc cdName, Type base, int clause) {
-        ClassDesc cdCtfe = cd(typeName(cdName) + "$Ctfe");
+        ClassDesc cdCtfe = generated(typeName(cdName) + "$Ctfe");
         MethodTypeDesc check = MethodTypeDesc.of(ConstantDescs.CD_boolean, JvmTypes.jvmType(base, ctx));
         // A Predicate's argument is a reference, so the instantiated type takes the decoded value's
         // boxed form and the metafactory unboxes it into `check`'s primitive parameter.
@@ -1565,7 +1565,7 @@ final class CodecGen {
     }
 
     byte[] generateEncoderClass(ClassDesc cdName, Ast.Data data, Ast.EncoderDef enc) {
-        ClassDesc cdEnc = cd(data.name() + "$Enc");
+        ClassDesc cdEnc = generated(data.name() + "$Enc");
         return build(cdEnc, cb -> {
             cb.withFlags(ClassFile.ACC_FINAL | ClassFile.ACC_SUPER);
             cb.withInterfaceSymbols(CD_REncoder);
@@ -1575,9 +1575,9 @@ final class CodecGen {
                 BodyGen gen = new BodyGen(ctx, code, data, cdName, 2);
                 code.aload(1);
                 code.checkcast(cdName);
-                int selfSlot = gen.slot(Type.ref(symbols.own(data.name())));
+                int selfSlot = gen.slot(Type.ref(symbols.own(data)));
                 code.astore(selfSlot);
-                gen.bind(enc.self(), selfSlot, Type.ref(symbols.own(data.name())));
+                gen.bind(enc.self(), selfSlot, Type.ref(symbols.own(data)));
                 emitRawExpr(code, gen, enc.result());
                 code.areturn();
             });
@@ -1875,7 +1875,7 @@ final class CodecGen {
      * only what wraps it here.
      */
     byte[] generateResultUnionEncoder(String resultName, List<TypeName> members) {
-        ClassDesc cdEnc = cd(resultName + "$Enc");
+        ClassDesc cdEnc = generated(resultName + "$Enc");
         boolean enumeration = isEnumeration(members);
         return build(cdEnc, cb -> {
             cb.withFlags(ClassFile.ACC_FINAL | ClassFile.ACC_SUPER);
@@ -1993,8 +1993,8 @@ final class CodecGen {
 
     /** The static {@code encoder()} factory on the union's sealed interface. */
     void emitResultUnionEncoderFactory(ClassBuilder cb, String resultName, List<TypeName> members) {
-        emitCodecFactory(cb, "encoder", CD_REncoder, cd(resultName + "$Enc"),
-                encoderSig(cd(resultName), isEnumeration(members) ? CD_String : CD_Map));
+        emitCodecFactory(cb, "encoder", CD_REncoder, generated(resultName + "$Enc"),
+                encoderSig(generated(resultName), isEnumeration(members) ? CD_String : CD_Map));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodegenContext.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodegenContext.java
@@ -316,16 +316,20 @@ final class CodegenContext {
     }
 
     /**
-     * The class of a name as the source (or a derived codec) wrote it. It is resolved the same way
-     * the checker resolved it, so an imported type lands in its own package. A name nothing declares
-     * is one this backend made up — a generated {@code $Enc}/{@code Result} class — and belongs to
-     * the module being generated.
+     * The class of a name this backend made up, in the module being generated — a {@code $Enc}, a
+     * {@code $Dec}, a {@code $Ctfe}. Nothing declares these, so there is nothing to look up and no
+     * other module they could belong to.
+     *
+     * <p>Not for a type. Which module declares a type is what its {@link TypeName} says, and reading
+     * it back off a spelling here answers for whatever this module has under that spelling.
      */
-    ClassDesc cd(String typeName) {
-        return typeDescs.computeIfAbsent(typeName, n -> {
-            TypeName resolved = symbols.resolve(n);
-            return ClassDesc.of(resolved != null ? resolved.qualified() : pkg + "." + n);
-        });
+    ClassDesc generated(String simpleName) {
+        return typeDescs.computeIfAbsent(simpleName, n -> ClassDesc.of(pkg + "." + n));
+    }
+
+    /** The class of a declaration of the module being generated. */
+    ClassDesc cd(Ast.Def def) {
+        return cd(symbols.own(def));
     }
 
     ClassDesc cdBehavior(String name) {
@@ -484,7 +488,7 @@ final class CodegenContext {
     ClassDesc[] caseInterfaces(String name) {
         List<ClassDesc> ifaces = new ArrayList<>();
         for (String sum : caseToSums.getOrDefault(name, List.of())) {
-            ifaces.add(cd(sum));
+            ifaces.add(generated(sum));
         }
         return ifaces.toArray(new ClassDesc[0]);
     }

--- a/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
@@ -55,7 +55,8 @@ final class ValueClassGen {
         this.codec = codec;
     }
 
-    private ClassDesc cd(String typeName) { return ctx.cd(typeName); }
+    private ClassDesc generated(String simpleName) { return ctx.generated(simpleName); }
+    private ClassDesc cd(Ast.Def def) { return ctx.cd(def); }
     private ClassDesc cd(TypeName typeName) { return ctx.cd(typeName); }
     private ClassDesc[] caseInterfaces(String name) { return ctx.caseInterfaces(name); }
     private Map<String, Type> fieldTypes(Ast.Data data) { return ctx.fieldTypes(data); }
@@ -64,7 +65,7 @@ final class ValueClassGen {
     private ClassDesc[] fieldDescs(Map<String, Type> fields) { return JvmTypes.fieldDescs(fields, ctx); }
 
     void generateData(Ast.Data data, Map<String, byte[]> out) {
-        ClassDesc cdName = cd(data.name());
+        ClassDesc cdName = cd(data);
         Map<String, Type> fields = fieldTypes(data);
 
         out.put(pkg + "." + data.name(), build(cdName, cb -> {
@@ -94,10 +95,10 @@ final class ValueClassGen {
             emitConstructMethod(cb, cdName, data, fields);
             emitAccessors(cb, cdName, fields);
             data.decoder().ifPresent(d -> {
-                boolean mapInput = codec.isMapInput(data.name());
+                boolean mapInput = codec.isMapInput(data);
                 codec.emitFactory(cb, "decoder", CD_RDecoder, data, "$Dec");
-                codec.emitSourceFactory(cb, data.name(), CodecGen.Src.JSON, mapInput);
-                if (codec.recordCompatible(data.name())) codec.emitSourceFactory(cb, data.name(), CodecGen.Src.JOOQ, mapInput);
+                codec.emitSourceFactory(cb, data, CodecGen.Src.JSON, mapInput);
+                if (codec.recordCompatible(data)) codec.emitSourceFactory(cb, data, CodecGen.Src.JOOQ, mapInput);
             });
             data.encoder().ifPresent(e -> codec.emitFactory(cb, "encoder", CD_REncoder, data, "$Enc"));
         }));
@@ -107,7 +108,7 @@ final class ValueClassGen {
                     codec.generateDecoderClass(cdName, data, dec, fields, CodecGen.Src.NEUTRAL));
             out.put(pkg + "." + data.name() + "$DecJson",
                     codec.generateDecoderClass(cdName, data, dec, fields, CodecGen.Src.JSON));
-            if (codec.recordCompatible(data.name())) {
+            if (codec.recordCompatible(data)) {
                 out.put(pkg + "." + data.name() + "$DecRecord",
                         codec.generateDecoderClass(cdName, data, dec, fields, CodecGen.Src.JOOQ));
             }
@@ -136,8 +137,8 @@ final class ValueClassGen {
      * rather than as the whole invariant (issue #83, spec §decoder-error).
      */
     private void emitCtfeCheck(Ast.Data data, Map<String, Type> fields, Map<String, byte[]> out) {
-        ClassDesc cdName = cd(data.name());
-        ClassDesc cdCtfe = cd(data.name() + "$Ctfe");
+        ClassDesc cdName = cd(data);
+        ClassDesc cdCtfe = generated(data.name() + "$Ctfe");
         List<Ast.InvariantClause> clauses = TypeOps.effectiveInvariants(data, symbols);
         out.put(pkg + "." + data.name() + "$Ctfe", build(cdCtfe, cb -> {
             cb.withFlags(ClassFile.ACC_PUBLIC | ClassFile.ACC_FINAL | ClassFile.ACC_SUPER);
@@ -161,7 +162,7 @@ final class ValueClassGen {
                     BodyGen gen = new BodyGen(ctx, code, data, cdName, 0);
                     int slot = 0;
                     Map<String, BindingId> bound =
-                            TypeOps.fieldBindings(symbols.own(data.name()), data, symbols);
+                            TypeOps.fieldBindings(symbols.own(data), data, symbols);
                     for (Map.Entry<String, Type> f : fields.entrySet()) {
                         gen.bind(bound.get(f.getKey()), f.getKey(), slot, f.getValue());
                         slot += width(f.getValue());
@@ -180,7 +181,7 @@ final class ValueClassGen {
     }
 
     void generateSum(Ast.SumData sum, Map<String, byte[]> out) {
-        ClassDesc cdX = cd(sum.name());
+        ClassDesc cdX = cd(sum);
         List<ClassDesc> caseCds = new ArrayList<>();
         for (Ast.Name caseName : sum.cases()) {
             caseCds.add(cd(caseName.denotes()));
@@ -211,13 +212,13 @@ final class ValueClassGen {
                 emitOrderMethods(cb, cdX, cases);
             }
             sum.decoder().ifPresent(disc -> {
-                codec.emitCodecFactory(cb, "decoder", CD_RDecoder, cd(sum.name() + "$Dec"),
+                codec.emitCodecFactory(cb, "decoder", CD_RDecoder, generated(sum.name() + "$Dec"),
                         CodecGen.decoderSig(cdX, !enumeration));
-                codec.emitSourceFactory(cb, sum.name(), CodecGen.Src.JSON, !enumeration);
-                if (codec.recordCompatible(sum.name())) codec.emitSourceFactory(cb, sum.name(), CodecGen.Src.JOOQ, true);
+                codec.emitSourceFactory(cb, sum, CodecGen.Src.JSON, !enumeration);
+                if (codec.recordCompatible(sum)) codec.emitSourceFactory(cb, sum, CodecGen.Src.JOOQ, true);
             });
             sum.encoder().ifPresent(enc ->
-                    codec.emitCodecFactory(cb, "encoder", CD_REncoder, cd(sum.name() + "$Enc"),
+                    codec.emitCodecFactory(cb, "encoder", CD_REncoder, generated(sum.name() + "$Enc"),
                             CodecGen.encoderSig(cdX, enumeration ? CD_String : CD_Map)));
         }));
         sum.decoder().ifPresent(disc -> {
@@ -227,7 +228,7 @@ final class ValueClassGen {
             out.put(pkg + "." + sum.name() + "$DecJson", enumeration
                     ? codec.generateEnumSumDecoder(sum, CodecGen.Src.JSON)
                     : codec.generateSumDecoder(sum, disc, CodecGen.Src.JSON));
-            if (codec.recordCompatible(sum.name())) {
+            if (codec.recordCompatible(sum)) {
                 out.put(pkg + "." + sum.name() + "$DecRecord", codec.generateSumDecoder(sum, disc, CodecGen.Src.JOOQ));
             }
         });
@@ -311,7 +312,7 @@ final class ValueClassGen {
         Map<String, Type> held = Map.of("value", MatchElaborator.caseBindType(member));
         List<ClassDesc> ifaces = new ArrayList<>();
         for (String union : unions) {
-            ifaces.add(cd(union));
+            ifaces.add(generated(union));
         }
         return build(cdB, cb -> {
             cb.withFlags(ClassFile.ACC_PUBLIC | ClassFile.ACC_FINAL | ClassFile.ACC_SUPER);
@@ -331,9 +332,9 @@ final class ValueClassGen {
     }
 
     void generateUnit(Ast.UnitData unit, Map<String, byte[]> out) {
-        ClassDesc cdU = cd(unit.name());
-        ClassDesc cdDec = cd(unit.name() + "$Dec");
-        ClassDesc cdEnc = cd(unit.name() + "$Enc");
+        ClassDesc cdU = cd(unit);
+        ClassDesc cdDec = generated(unit.name() + "$Dec");
+        ClassDesc cdEnc = generated(unit.name() + "$Enc");
         out.put(pkg + "." + unit.name(), build(cdU, cb -> {
             cb.withFlags(pub(unit.name()) | ClassFile.ACC_FINAL | ClassFile.ACC_SUPER);
             // a unit is a field-less data, so it is a record with no components: `case 承認済み()`
@@ -357,15 +358,15 @@ final class ValueClassGen {
             // A unit ignores its input, so it decodes from every source. Generate all three so
             // unit cases of a JSON/record sum have a matching decoder to dispatch to.
             codec.emitCodecFactory(cb, "decoder", CD_RDecoder, cdDec, CodecGen.decoderSig(cdU, false));
-            codec.emitCodecFactory(cb, "jsonDecoder", CD_RDecoder, cd(unit.name() + "$DecJson"),
+            codec.emitCodecFactory(cb, "jsonDecoder", CD_RDecoder, generated(unit.name() + "$DecJson"),
                     CodecGen.decoderSigFor(CodecGen.Src.JSON, cdU, false));
-            codec.emitCodecFactory(cb, "recordDecoder", CD_RDecoder, cd(unit.name() + "$DecRecord"),
+            codec.emitCodecFactory(cb, "recordDecoder", CD_RDecoder, generated(unit.name() + "$DecRecord"),
                     CodecGen.decoderSigFor(CodecGen.Src.JOOQ, cdU, false));
             codec.emitCodecFactory(cb, "encoder", CD_REncoder, cdEnc, CodecGen.encoderSig(cdU, CD_Map));
         }));
         out.put(pkg + "." + unit.name() + "$Dec", codec.generateUnitDecoder(cdU, cdDec));
-        out.put(pkg + "." + unit.name() + "$DecJson", codec.generateUnitDecoder(cdU, cd(unit.name() + "$DecJson")));
-        out.put(pkg + "." + unit.name() + "$DecRecord", codec.generateUnitDecoder(cdU, cd(unit.name() + "$DecRecord")));
+        out.put(pkg + "." + unit.name() + "$DecJson", codec.generateUnitDecoder(cdU, generated(unit.name() + "$DecJson")));
+        out.put(pkg + "." + unit.name() + "$DecRecord", codec.generateUnitDecoder(cdU, generated(unit.name() + "$DecRecord")));
         out.put(pkg + "." + unit.name() + "$Enc", codec.generateUnitEncoder(cdEnc));
     }
 
@@ -655,7 +656,7 @@ final class ValueClassGen {
                         BodyGen gen = new BodyGen(ctx, code, data, cdName, 0);
                         int slot = 0;
                         Map<String, BindingId> bound =
-                                TypeOps.fieldBindings(symbols.own(data.name()), data, symbols);
+                                TypeOps.fieldBindings(symbols.own(data), data, symbols);
                         for (Map.Entry<String, Type> f : fields.entrySet()) {
                             gen.bind(bound.get(f.getKey()), f.getKey(), slot, f.getValue());
                             slot += width(f.getValue());

--- a/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
+++ b/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
@@ -74,7 +74,7 @@ public final class Deriver {
         }
         // the decoder and the encoder each read the value under a name of their own, so each owns
         // the bindings it writes rather than sharing the declaration's
-        BindingOwner declared = new BindingOwner.OfData(symbols.own(d.name()));
+        BindingOwner declared = new BindingOwner.OfData(symbols.own(d));
         Optional<Ast.DecoderDef> decoder = d.decoder().isPresent()
                 ? d.decoder()
                 : Optional.of(deriveDecoder(d, shapes, symbols,
@@ -94,7 +94,7 @@ public final class Deriver {
     private static Ast.DecoderDef deriveDecoder(Ast.Data d, Map<String, CodecShape> shapes,
                                                Symbols symbols, Ast.Binders binders) {
         SourcePos pos = d.pos();
-        Ast.Name self = Ast.Name.resolved(symbols.own(d.name()), pos);
+        Ast.Name self = Ast.Name.resolved(symbols.own(d), pos);
         // only an explicit newtype `data X = Y` is bare; a braced record is always an object, even
         // with one field (spec §newtype).
         Map.Entry<String, CodecShape> single = bareField(d, shapes);

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -706,8 +706,9 @@ public final class ExampleVerifier {
             state.failed(FailurePhase.INVOCATION);
             return;
         } catch (AbortException ae) {
+            TypeName only = fixtures.caseOnly(row.expected());
             String stated = asserted != null ? fixtures.shown(asserted)
-                    : fixtures.caseOnly(row.expected());
+                    : only == null ? null : only.name();
             out.add(mismatch(fixtures, row, stated == null ? "the expected value" : stated,
                     "aborted: " + ae.getMessage(), null));
             state.failed(FailurePhase.INVOCATION);
@@ -718,13 +719,15 @@ public final class ExampleVerifier {
             return;
         }
         result = projected(result, sig.outputType());
-        state.resultArm = symbols.resolve(NeutralForm.simpleName(result));
+        // The case the run answered with is the one the value is. Its class names the module that
+        // declares it, and what this module means by that class's spelling is a different question.
+        state.resultArm = fixtures.typeOf(result);
         state.stage = Stage.COMPARED;
-        String arm = fixtures.caseOnly(row.expected());
+        TypeName arm = fixtures.caseOnly(row.expected());
         if (arm != null) {
             // A bare case name asserts the arm and nothing under it, so there is no value to compare.
-            if (!NeutralForm.simpleName(result).equals(arm)) {
-                out.add(mismatch(fixtures, row, arm, fixtures.describeActual(result), null));
+            if (!arm.equals(state.resultArm)) {
+                out.add(mismatch(fixtures, row, arm.name(), fixtures.describeActual(result), null));
                 state.failed(FailurePhase.COMPARISON);
                 return;
             }

--- a/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
@@ -341,9 +341,9 @@ public final class FixtureReader {
      * <p>The case's own name, not the spelling: what came out carries the name its type was declared
      * under, so a row spelling that type qualified asserts the same case.
      */
-    String caseOnly(Ast.Expr expected) {
+    TypeName caseOnly(Ast.Expr expected) {
         return expected instanceof Ast.Var v && v.denotes() instanceof ValueName.OfType named
-                ? named.type().name() : null;
+                ? named.type() : null;
     }
 
     // --- what a row asserts ---------------------------------------------------------------------
@@ -602,7 +602,7 @@ public final class FixtureReader {
             // what the position holds. Nothing about the position enters.
             return assertedLive(answered(c, helper));
         }
-        if (!neutral.isNewtype(c.written())) {
+        if (!neutral.isNewtype(appliedType(c))) {
             String reached = helperKey(c);
             if (reached != null && noMethod(reached)) {
                 throw FixtureException.cannotBeCalled(c.written());
@@ -612,7 +612,7 @@ public final class FixtureReader {
         if (c.args().size() != 1) {
             throw new FixtureException("`" + c.written() + "` takes one argument");
         }
-        return assertedNewtype(symbols.resolve(c.written()), c.args().get(0), c.written());
+        return assertedNewtype(appliedType(c), c.args().get(0), c.written());
     }
 
     /**
@@ -899,7 +899,7 @@ public final class FixtureReader {
         // The type the value is, and not this module's reading of its spelling: a helper a fixture
         // applies may be one another module published, and what it answered with is that module's
         // type however this module spells the same name.
-        TypeName type = answeredType(live);
+        TypeName type = typeOf(live);
         if (type != null && symbols.get(type) instanceof Ast.Data data) {
             Map<String, Asserted> fields = new LinkedHashMap<>();
             if (data.newtype()) {
@@ -953,7 +953,7 @@ public final class FixtureReader {
         if (expected instanceof Ast.NewData nd) {
             return nd.typeName().written();
         }
-        if (expected instanceof Ast.Apply c && neutral.isNewtype(c.written())) {
+        if (expected instanceof Ast.Apply c && neutral.isNewtype(appliedType(c))) {
             return c.written();
         }
         return null;   // a literal expected (a primitive output)
@@ -1011,8 +1011,8 @@ public final class FixtureReader {
     private TypeName constructedCase(Ast.Expr e, Set<String> followed, List<TypeName> worn) {
         return switch (e) {
             case Ast.NewData nd -> nd.typeName().denotes();
-            case Ast.Apply c when neutral.isNewtype(c.written()) -> {
-                TypeName named = symbols.resolveCase(c.written());
+            case Ast.Apply c when neutral.isNewtype(appliedType(c)) -> {
+                TypeName named = appliedType(c);
                 yield wears(named, c, worn)
                         ? constructedCase(c.args().get(0), followed, worn.subList(1, worn.size()))
                         : named;
@@ -1056,7 +1056,7 @@ public final class FixtureReader {
         if (result instanceof Iterable<?> || result instanceof Map<?, ?>) {
             return showAny(result);
         }
-        Object encoded = encodedOrNull(result, name);
+        Object encoded = encodedOrNull(result, typeOf(result));
         if (encoded != null) {
             return show(name, encoded);
         }
@@ -1086,7 +1086,7 @@ public final class FixtureReader {
             return elements.isEmpty() ? "[]" : "[ " + String.join(", ", elements) + " ]";
         }
         String name = NeutralForm.simpleName(v);
-        Object encoded = encodedOrNull(v, name);
+        Object encoded = encodedOrNull(v, typeOf(v));
         return encoded != null ? show(name, encoded) : name;
     }
 
@@ -1104,16 +1104,11 @@ public final class FixtureReader {
         return m.invoke(null);
     }
 
-    /** {@code result} through its class's derived {@code encoder()}, or null when it has none. */
-    private Object encodedOrNull(Object result, String name) {
-        TypeName type = symbols.resolve(name);
-        return encoded(result, type != null ? type.qualified() : module.name() + "." + name);
-    }
-
-    /** As above, for a type already resolved — a fixture says which case it constructs, and that answer
-     * names the class whether or not the reader spells the type the way its module does. */
+    /** {@code result} through the derived {@code encoder()} of the type it is, or null where the type
+     * is not one a module declares and so has no derived codec to reach. The type names the class
+     * whether or not the reader spells it the way its module does. */
     private Object encodedOrNull(Object result, TypeName type) {
-        return encoded(result, type.qualified());
+        return type == null ? null : encoded(result, type.qualified());
     }
 
     private Object encoded(Object result, String className) {
@@ -1351,7 +1346,7 @@ public final class FixtureReader {
                 // and a fixture is not elaborated, so a value's Java surface would otherwise be
                 // reachable as though it were the data's — `.isEmpty` on a `String` is a method
                 // here and a field nowhere.
-                TypeName answered = answeredType(value);
+                TypeName answered = typeOf(value);
                 if (answered == null || fieldTypeOf(Type.ref(answered), fa.field()) == null) {
                     throw new FixtureException("`" + written + "` answered with a value that"
                             + " declares no field `" + fa.field() + "`");
@@ -1566,8 +1561,8 @@ public final class FixtureReader {
             case Ast.NewData nd -> new Stated.Name(nd.typeName().denotes());
             case Ast.Var v -> statedByName(v);
             case Ast.Apply c when appliedHelper(c) != null -> ELSEWHERE;
-            case Ast.Apply c when neutral.isNewtype(c.written()) ->
-                    caseNamed(symbols.resolveCase(c.written()));
+            case Ast.Apply c when neutral.isNewtype(appliedType(c)) ->
+                    caseNamed(appliedType(c));
             // `Date("…")` is a temporal, and `Set.fromList([…])` a collection: values under no name.
             case Ast.Apply c when Type.Prim.named(c.reaches()) != null
                     || "Set.fromList".equals(c.reaches()) || "Map.fromList".equals(c.reaches()) ->
@@ -1581,24 +1576,23 @@ public final class FixtureReader {
         };
     }
 
+    /** Which declaration a live value is — {@link NeutralForm#typeOf}, which every reader of a run
+     *  asks, and {@link #represents} is the same discipline the other way about. */
+    TypeName typeOf(Object value) {
+        return neutral.typeOf(value);
+    }
+
     /**
-     * The data a live value is, read off the class it was generated as. A binary name is a
-     * {@link TypeName}'s qualified form, so this answers the type the value is.
+     * Which declaration an application constructs, where it constructs one — a newtype written in
+     * call form, and null for anything else applied.
      *
-     * <p>Not its simple name resolved here. A helper a fixture applies may be one another module
-     * published, and resolving the spelling in this module's scope would answer for a type this
-     * module happens to declare under the same name rather than for the one the value is — the
-     * same reason {@link #represents} compares a class against a candidate's qualified form
-     * instead of resolving what came out.
+     * <p>What the application already denotes, and not what its spelling means read again here.
+     * {@link Ast.Apply#written()} is what a report quotes: an import lets a name be written without
+     * its qualifier, so a spelling is not a key any table can be asked with.
      */
-    private TypeName answeredType(Object value) {
-        String binary = value.getClass().getName();
-        int dot = binary.lastIndexOf('.');
-        if (dot < 0) {
-            return null;
-        }
-        TypeName named = new TypeName(binary.substring(0, dot), binary.substring(dot + 1));
-        return symbols.contains(named) ? named : null;
+    private static TypeName appliedType(Ast.Apply c) {
+        return c.function() instanceof Ast.Var v && v.denotes() instanceof ValueName.OfType named
+                ? named.type() : null;
     }
 
     /**
@@ -1641,8 +1635,8 @@ public final class FixtureReader {
         return switch (e) {
             case Ast.NewData nd -> Type.ref(nd.typeName().denotes());
             // `AmountN(100)` is the newtype's construction written in call form (ADR-0032).
-            case Ast.Apply c when neutral.isNewtype(c.written()) -> {
-                TypeName named = symbols.resolve(c.written());
+            case Ast.Apply c when neutral.isNewtype(appliedType(c)) -> {
+                TypeName named = appliedType(c);
                 yield named == null ? null : Type.ref(named);
             }
             case Ast.FieldAccess fa -> {
@@ -1936,7 +1930,7 @@ public final class FixtureReader {
      * so the two readers of a call cannot come to different answers. */
     private Applied appliedHelper(Ast.Apply c) {
         if ("Set.fromList".equals(c.reaches()) || "Map.fromList".equals(c.reaches())
-                || neutral.isNewtype(c.written())) {
+                || neutral.isNewtype(appliedType(c))) {
             return null;
         }
         String reached = helperKey(c);
@@ -2078,7 +2072,7 @@ public final class FixtureReader {
             }
             return CallElaborator.parseTemporal(c.written(), lit.value(), lit.reportedAt());
         }
-        if (!neutral.isNewtype(c.written())) {
+        if (!neutral.isNewtype(appliedType(c))) {
             String reached = helperKey(c);
             if (reached != null && noMethod(reached)) {
                 // A function this module cannot run: a helper whose body produces a function, which
@@ -2099,10 +2093,10 @@ public final class FixtureReader {
         // the argument is shaped against what the newtype wraps, the same way a record fixture
         // shapes a field's value: a `Map` newtype's entry pairs become a map, a `Set` newtype's
         // written list stays a list for its decoder to dedupe
-        return neutral.newtypeAt(expected, c.written(),
+        return neutral.newtypeAt(expected, appliedType(c),
                 neutral.shaped(raw(c.args().get(0),
-                                neutral.shapeOf(neutral.newtypeBaseType(c.written())), below(admission)),
-                        neutral.shapeOf(neutral.newtypeBaseType(c.written()))));
+                                neutral.shapeOf(neutral.newtypeBaseType(appliedType(c))), below(admission)),
+                        neutral.shapeOf(neutral.newtypeBaseType(appliedType(c)))));
     }
 
     private Object record(Ast.NewData nd, Type expected, Admission admission) {

--- a/souther-compiler/src/main/java/souther/compiler/examples/NeutralForm.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/NeutralForm.java
@@ -25,8 +25,11 @@ import java.util.Set;
  * a map's entries — are the same rules whichever direction arrives at them, so they are here rather
  * than restated on one side and read from the other.
  *
- * <p>Nothing here knows about the JVM classes an example runs against ({@link HelperInvoker} does) or
- * about diagnostics: a form that cannot be reached is a {@link FixtureException}, which the row reports.
+ * <p>Running an example is {@link HelperInvoker}'s, and diagnostics are the row's: a form that cannot
+ * be reached is a {@link FixtureException}, which the row reports. What is here is the one reading of
+ * the classes a run answers with — {@link #typeOf} for which declaration a value is and
+ * {@link #simpleName} for what a report quotes — because a live value's type is a question every
+ * reader of a run asks and only one answer to it is right.
  */
 final class NeutralForm {
 
@@ -95,7 +98,7 @@ final class NeutralForm {
         if (name.equals("Option$Some")) {
             return of(field(live, "value", helper), opened, helper);
         }
-        TypeName caseName = symbols.resolve(name);
+        TypeName caseName = typeOf(live);
         if (caseName == null) {
             throw new FixtureException("`" + helper + "` returned a " + name
                     + ", which is not a type this example can read");
@@ -358,11 +361,6 @@ final class NeutralForm {
                 : type instanceof Type.SetOf s ? s.element() : null;
     }
 
-    /** As above, for a construction written as a call, where the name is what the row spelled. */
-    Object newtypeAt(Type position, String written, Object inner) {
-        return newtypeAt(position, symbols.resolve(written), inner);
-    }
-
     /** Whether the position this case is written in reads a bare name: it is typed as an enumeration,
      * or it is untyped here and every sum that lists the case is one. */
     boolean readsABareName(Type expected, TypeName caseName) {
@@ -421,26 +419,14 @@ final class NeutralForm {
         return declaredType == null ? null : declaredType.denotes();
     }
 
-    boolean isNewtype(String name) {
-        return symbols.declaration(name) instanceof Ast.Data d && d.newtype();
-    }
-
-    /** As above, for a name that has already been resolved — an imported value's body names its own
-     * module's types, which the module reading the row need not have imported. */
+    /** Whether a name is a newtype's. Asked of what a reference denotes: an imported value's body
+     * names its own module's types, which the module reading the row need not have imported. */
     boolean isNewtype(TypeName name) {
         return name != null && symbols.get(name) instanceof Ast.Data d && d.newtype();
     }
 
     /** The written form of what a newtype wraps, kept whole so a generic base
      * ({@code data 在庫 = Map<商品ID, Int>}) keeps its type arguments. */
-    Ast.TypeRef newtypeBaseType(String name) {
-        return symbols.declaration(name) instanceof Ast.Data d && d.newtype() && d.fields().size() == 1
-                && d.fields().get(0).type() instanceof Ast.TypeRef base
-                ? base
-                : null;
-    }
-
-    /** As above, for a name that has already been resolved. */
     Ast.TypeRef newtypeBaseType(TypeName name) {
         return name != null && symbols.get(name) instanceof Ast.Data d && d.newtype()
                 && d.fields().size() == 1 && d.fields().get(0).type() instanceof Ast.TypeRef base
@@ -585,7 +571,33 @@ final class NeutralForm {
                 || v instanceof java.time.Instant;
     }
 
-    /** The case name a live value carries: its class's simple name, which is the type's own name. */
+    /**
+     * Which declaration a live value is, read off the class it was generated as. A binary name is a
+     * {@link TypeName}'s qualified form, so the class the run answered with says both the module and
+     * the name, and this answers for the type the value is.
+     *
+     * <p>Not its simple name resolved here. A helper a fixture applies may be one another module
+     * published, and resolving the spelling in this module's scope answers for whatever this module
+     * has under it: nothing, where the type is reached through an alias and no bare name of this
+     * module spells it, and the wrong declaration where this module spells something else the same.
+     * The class carries the module, and dropping it is what makes those two answers possible.
+     */
+    TypeName typeOf(Object live) {
+        if (live == null) {
+            return null;
+        }
+        String binary = live.getClass().getName();
+        int dot = binary.lastIndexOf('.');
+        if (dot < 0) {
+            return null;
+        }
+        TypeName named = new TypeName(binary.substring(0, dot), binary.substring(dot + 1));
+        return symbols.contains(named) ? named : null;
+    }
+
+    /** What a report quotes a live value's class as. Its own name, and not the type's identity —
+     *  {@link #typeOf} is that, and the two are separate answers because a report about a value of a
+     *  type this module cannot name still has to say what it was. */
     static String simpleName(Object o) {
         if (o == null) {
             return "null";

--- a/souther-compiler/src/main/java/souther/compiler/examples/ObservedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ObservedValues.java
@@ -116,7 +116,7 @@ final class ObservedValues {
                     ? new ObservedValue.Unknown("an optional's value could not be read")
                     : walk(inner, depth);
         }
-        TypeName type = symbols.resolve(name);
+        TypeName type = neutral.typeOf(live);
         if (type == null) {
             return new ObservedValue.Unknown("`" + name + "` is not a type this module can name");
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
@@ -158,10 +158,20 @@ public record FixtureTemplate(String text, Ast.Expr value) {
         };
     }
 
-    /** A newtype around one value, written in the call form a row writes it in (ADR-0032). */
+    /**
+     * A newtype around one value, written in the call form a row writes it in (ADR-0032).
+     *
+     * <p>Applied with what it constructs, as a case naming itself is. Nothing resolves a tree built
+     * here, so a spelling left on its own is a spelling nothing will ever settle, and the reader
+     * would have to work out which declaration it means from the characters — which answers for
+     * whatever the reading module has under them.
+     */
     public static FixtureTemplate newtype(TypeName type, FixtureTemplate inner) {
         return new FixtureTemplate(type.name() + "(" + inner.text() + ")",
-                new Ast.Apply(type.name(), List.of(inner.value()), NOWHERE, NO_SOURCE));
+                new Ast.Apply(type.name(),
+                        new ValueName.OfType(type.name(), type, ConstructionOrigin.own()),
+                        new ReachName.Bare(type.name()), List.of(inner.value()),
+                        ConstructionOrigin.own(), NOWHERE, NO_SOURCE));
     }
 
     /** No elements. A list, a set and a map are all written this way in a fixture: what the position

--- a/souther-compiler/src/test/java/souther/compiler/AnAnsweredCaseIsReadOffTheValueAndNotResolvedHereTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnAnsweredCaseIsReadOffTheValueAndNotResolvedHereTest.java
@@ -1,0 +1,95 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.meta.ModulePath;
+import souther.compiler.observe.RowOutcome;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Output;
+import souther.compiler.types.TypeName;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Which case a behavior answered with is read off the value, and the value carries its module.
+ *
+ * <p>A row's answer arrives as a live value of the class it was generated as, and that class names
+ * the module that declares it. Asking instead what this module means by the class's simple name
+ * answers for whatever this module has under that spelling: nothing, where the type is reached
+ * through an alias, and the wrong declaration where the reading module spells something else the
+ * same.
+ *
+ * <p>Two modules, because that is where the two ways of asking come apart, and the same model twice
+ * — once reached by an alias and once by a bare import — because the answer must not depend on how
+ * the reading module spells what it imports. Both rows hold in both, so a difference here is a
+ * difference in what was recorded about rows that passed.
+ */
+class AnAnsweredCaseIsReadOffTheValueAndNotResolvedHereTest {
+
+    private static final String LIB = """
+            module lib exposing ( Yes, No, Answer )
+
+            data Yes
+            data No
+            data Answer = Yes | No
+            """;
+
+    /** Reaches the type through an alias, so no bare name of this module spells it. */
+    private static final String THROUGH_AN_ALIAS = """
+            module viaalias exposing ( In, f )
+
+            import lib as up
+
+            data In = { n: Int }
+
+            behavior f : (i: In) -> up.Answer constructs up.Yes, up.No
+            let f (i) = if i.n > 0 then up.Yes else up.No
+
+            example f
+                | "yes" : (In { n = 1 }) -> up.Yes
+                | "no"  : (In { n = 0 }) -> up.No
+            """;
+
+    /** The same model, spelled bare: the control that says the alias is the only difference. */
+    private static final String SPELLED_BARE = """
+            module viabare exposing ( In, g )
+
+            import lib ( Answer, Yes, No )
+
+            data In = { n: Int }
+
+            behavior g : (i: In) -> Answer constructs Yes, No
+            let g (i) = if i.n > 0 then Yes else No
+
+            example g
+                | "yes" : (In { n = 1 }) -> Yes
+                | "no"  : (In { n = 0 }) -> No
+            """;
+
+    private static List<TypeName> armsAnsweredIn(String module, String source) {
+        Compilation compilation = Compilation.ofSources(List.of(LIB, source), ModulePath.EMPTY);
+        compilation.answerEverything();
+        String sourceId = compilation.exampleSourcesOf(module).get(0);
+        List<RowOutcome> rows = compilation.db()
+                .ask(new Output.Examples(module, sourceId, Output.CoverageMode.NONE))
+                .value().rows();
+        assertEquals(2, rows.size(), rows.toString());
+        return rows.stream().map(RowOutcome::resultArm).toList();
+    }
+
+    @Test
+    void aModuleReachingTheTypeThroughAnAliasObservesTheCasesItsRowsAnswerWith() {
+        assertEquals(List.of(new TypeName("lib", "Yes"), new TypeName("lib", "No")),
+                armsAnsweredIn("viaalias", THROUGH_AN_ALIAS),
+                "the case a row answered with is the one the value is, whatever this module calls it");
+    }
+
+    @Test
+    void spellingTheImportBareAnswersTheSame() {
+        assertEquals(armsAnsweredIn("viabare", SPELLED_BARE),
+                armsAnsweredIn("viaalias", THROUGH_AN_ALIAS),
+                "how the reading module reaches the type is not part of what its rows observed");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/AnAnsweredCaseIsReadOffTheValueAndNotResolvedHereTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnAnsweredCaseIsReadOffTheValueAndNotResolvedHereTest.java
@@ -68,6 +68,27 @@ class AnAnsweredCaseIsReadOffTheValueAndNotResolvedHereTest {
                 | "no"  : (In { n = 0 }) -> No
             """;
 
+    /**
+     * Reaches the type through an alias and declares something else of the spelling its cases carry.
+     * The lookup that missed above answers here — with this module's declaration, which the rows
+     * never mention and no value of theirs is.
+     */
+    private static final String SPELLS_ITS_OWN = """
+            module shadows exposing ( In, Yes, h )
+
+            import lib as up
+
+            data In = { n: Int }
+            data Yes = { irrelevant: String }
+
+            behavior h : (i: In) -> up.Answer constructs up.Yes, up.No
+            let h (i) = if i.n > 0 then up.Yes else up.No
+
+            example h
+                | "yes" : (In { n = 1 }) -> up.Yes
+                | "no"  : (In { n = 0 }) -> up.No
+            """;
+
     private static List<TypeName> armsAnsweredIn(String module, String source) {
         Compilation compilation = Compilation.ofSources(List.of(LIB, source), ModulePath.EMPTY);
         compilation.answerEverything();
@@ -84,6 +105,19 @@ class AnAnsweredCaseIsReadOffTheValueAndNotResolvedHereTest {
         assertEquals(List.of(new TypeName("lib", "Yes"), new TypeName("lib", "No")),
                 armsAnsweredIn("viaalias", THROUGH_AN_ALIAS),
                 "the case a row answered with is the one the value is, whatever this module calls it");
+    }
+
+    /**
+     * The stronger of the two. A miss says the reading failed and can be seen; an answer of the
+     * wrong declaration is a reading that succeeded and means something else, and nothing in the
+     * report says which of the two `Yes` a row confirmed.
+     */
+    @Test
+    void aModuleThatSpellsSomethingElseTheSameObservesTheCasesItsRowsAnswerWith() {
+        assertEquals(List.of(new TypeName("lib", "Yes"), new TypeName("lib", "No")),
+                armsAnsweredIn("shadows", SPELLS_ITS_OWN),
+                "the case a row answered with is the one the value is, and this module's `Yes` is"
+                        + " not a value any of these rows produced");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/NoPublicWayToTurnASpellingIntoATypeIdentityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/NoPublicWayToTurnASpellingIntoATypeIdentityTest.java
@@ -1,0 +1,122 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Resolve;
+import souther.compiler.check.Symbols;
+import souther.compiler.frontend.CstFrontend;
+import souther.compiler.types.TypeName;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A spelling means something in the module that wrote it, and only the pass that reads that module
+ * turns one into the type it denotes. Everything after holds the type.
+ *
+ * <p>This is checked against the shape of the API rather than against an answer, because the rule was
+ * already written down three times — on {@code Symbols}, on {@code Resolve}, on
+ * {@code Ast.Apply.written()} — and was broken all the same. A sentence is kept by whoever reads it;
+ * a signature is kept by everyone. What a reader outside can reach is the whole of what it can do
+ * wrong, so that is what is measured here.
+ */
+class NoPublicWayToTurnASpellingIntoATypeIdentityTest {
+
+    private static final String LIB = """
+            module lib exposing ( Amount )
+
+            data Amount = Int
+            """;
+
+    private static final String APP = """
+            module app
+
+            data Note = { text: String }
+            """;
+
+    /**
+     * No public method takes a spelling and answers with an identity. A caller outside the pass has
+     * a type or it has nothing, and the way to get one is to be handed it.
+     */
+    @Test
+    void nothingPublicOnSymbolsTakesAStringAndAnswersWithADeclarationOrItsName() {
+        List<String> answering = new ArrayList<>();
+        for (Method m : Symbols.class.getDeclaredMethods()) {
+            if (!Modifier.isPublic(m.getModifiers())) {
+                continue;
+            }
+            boolean identity = m.getReturnType() == TypeName.class
+                    || Ast.Def.class.isAssignableFrom(m.getReturnType());
+            boolean fromASpelling = List.of(m.getParameterTypes()).contains(String.class);
+            if (identity && fromASpelling) {
+                answering.add(m.getName());
+            }
+        }
+        assertEquals(List.of(), answering,
+                "a spelling reaches a declaration only through the pass that resolves it");
+    }
+
+    /** And the pass's own way in is not reachable from outside it. */
+    @Test
+    void resolutionIsNotPartOfTheSurface() {
+        for (Method m : Symbols.class.getDeclaredMethods()) {
+            if (m.getName().equals("resolve") || m.getName().equals("resolveCase")) {
+                assertFalse(Modifier.isPublic(m.getModifiers()),
+                        m.getName() + " is the pass's own reading and belongs to it");
+            }
+        }
+    }
+
+    /**
+     * The one entry that answers with an identity of this module holds what it is handed to being
+     * one. Its name says the declaration is this module's, and a declaration is an argument like any
+     * other, so a caller can hand over another module's — which is how a {@code constructs} entry
+     * naming an imported type was answered about a class of the module that names it.
+     *
+     * <p>Held to the name being declared here, which is as far as this can be held: a declaration
+     * another module wrote under a name this one also writes is not told apart from one of this
+     * module's, because nothing a declaration carries says which module wrote it.
+     */
+    @Test
+    void aDeclarationOfAnotherModuleIsNotOneOfThisModulesOwn() {
+        Symbols app = symbolsOf(APP);
+        Ast.Def foreign = declarationOf(LIB, "Amount");
+
+        IllegalArgumentException refused =
+                assertThrows(IllegalArgumentException.class, () -> app.own(foreign));
+        assertTrue(refused.getMessage().contains("not declared in"), refused.getMessage());
+    }
+
+    /** And the same question about this module's own declaration is answered. */
+    @Test
+    void aDeclarationOfThisModuleIsAnsweredWithItsName() {
+        assertEquals(new TypeName("app", "Note"),
+                symbolsOf(APP).own(declarationOf(APP, "Note")));
+    }
+
+    private static Symbols symbolsOf(String source) {
+        return Symbols.of(resolved(source));
+    }
+
+    private static Ast.Module resolved(String source) {
+        Ast.Module parsed = CstFrontend.parse(source);
+        return Resolve.module(parsed, Symbols.of(parsed));
+    }
+
+    private static Ast.Def declarationOf(String source, String name) {
+        for (Ast.Def def : resolved(source).defs()) {
+            if (def.name().equals(name)) {
+                return def;
+            }
+        }
+        throw new IllegalStateException("the fixture declares `" + name + "`");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/NoPublicWayToTurnASpellingIntoATypeIdentityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/NoPublicWayToTurnASpellingIntoATypeIdentityTest.java
@@ -86,7 +86,7 @@ class NoPublicWayToTurnASpellingIntoATypeIdentityTest {
      * module's, because nothing a declaration carries says which module wrote it.
      */
     @Test
-    void aDeclarationOfAnotherModuleIsNotOneOfThisModulesOwn() {
+    void aDeclarationWhoseNameThisModuleDoesNotDeclareIsRefused() {
         Symbols app = symbolsOf(APP);
         Ast.Def foreign = declarationOf(LIB, "Amount");
 

--- a/souther-compiler/src/test/java/souther/compiler/check/ABoundaryMapKeyIsClassifiedByOneRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ABoundaryMapKeyIsClassifiedByOneRuleTest.java
@@ -4,6 +4,7 @@ import souther.compiler.ast.Ast;
 import souther.compiler.frontend.CstFrontend;
 import souther.compiler.types.MapKeyRepresentation;
 import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
 
 import org.junit.jupiter.api.Test;
 
@@ -72,14 +73,14 @@ class ABoundaryMapKeyIsClassifiedByOneRuleTest {
     }
 
     private Type named(String name) {
-        return Type.ref(symbols.own(name));
+        return Type.ref(new TypeName(symbols.module(), name));
     }
 
     /** What a named key must classify as: the outermost name, whatever it wraps. Reaching for the
      *  base's representation would name a type whose codec is not the one the map's keys go
      *  through. */
     private void assertNamedKey(String name) {
-        assertEquals(new MapKeyRepresentation.NamedKey(symbols.own(name)), classify(named(name)));
+        assertEquals(new MapKeyRepresentation.NamedKey(new TypeName(symbols.module(), name)), classify(named(name)));
     }
 
     // --- the leaves ---------------------------------------------------------------------------

--- a/souther-compiler/src/test/java/souther/compiler/check/AGrantedNameIsReadAsGrantedWhereverItIsReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AGrantedNameIsReadAsGrantedWhereverItIsReachedTest.java
@@ -50,10 +50,10 @@ class AGrantedNameIsReadAsGrantedWhereverItIsReachedTest {
         Symbols symbols = compilation.symbols("demo");
         TypeCardinality.Cardinalities solved =
                 TypeCardinality.solve(compilation.module("demo"), symbols);
-        assertEquals(Cardinality.NO_VALUE, solved.of(symbols.own(reader)),
+        assertEquals(Cardinality.NO_VALUE, solved.of(new TypeName(symbols.module(), reader)),
                 "`" + reader + "` has no value while nothing is granted");
-        assertFalse(solved.granting(Set.of(symbols.own(granted)))
-                        .get(symbols.own(reader)).none(),
+        assertFalse(solved.granting(Set.of(new TypeName(symbols.module(), granted)))
+                        .get(new TypeName(symbols.module(), reader)).none(),
                 "`" + reader + "` reaches `" + granted + "` and was granted it has values");
     }
 
@@ -134,7 +134,7 @@ class AGrantedNameIsReadAsGrantedWhereverItIsReachedTest {
         Symbols symbols = compilation.symbols("demo");
         assertEquals(Cardinality.NO_VALUE,
                 TypeCardinality.solve(compilation.module("demo"), symbols)
-                        .granting(Set.of(symbols.own("Granted"))).get(symbols.own("Bad")),
+                        .granting(Set.of(new TypeName(symbols.module(), "Granted"))).get(new TypeName(symbols.module(), "Bad")),
                 "and what it wraps was not granted anything");
     }
 
@@ -169,7 +169,7 @@ class AGrantedNameIsReadAsGrantedWhereverItIsReachedTest {
                 TypeCardinality.solve(compilation.module("demo"), symbols);
 
         assertEquals(List.of(Cardinality.NO_VALUE, Cardinality.NO_VALUE),
-                List.of(solved.of(symbols.own("A")), solved.of(symbols.own("B"))),
+                List.of(solved.of(new TypeName(symbols.module(), "A")), solved.of(new TypeName(symbols.module(), "B"))),
                 "neither of them can be built");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/HowManyValuesAPositionHasIsNotHowMuchItHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/HowManyValuesAPositionHasIsNotHowMuchItHoldsTest.java
@@ -38,7 +38,7 @@ class HowManyValuesAPositionHasIsNotHowMuchItHoldsTest {
                         .map(each -> each.diagnostic().code().toString()).toList(),
                 "the model this reads has to be one somebody could write");
         Symbols symbols = compilation.symbols("demo");
-        return OccurrenceValues.of(symbols.own(name), data(compilation, name), symbols)
+        return OccurrenceValues.of(new TypeName(symbols.module(), name), data(compilation, name), symbols)
                 .wholeValuesAt(path);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest.java
@@ -3,6 +3,7 @@ package souther.compiler.check;
 import souther.compiler.ast.Ast;
 import souther.compiler.frontend.CstFrontend;
 import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
 
 import java.util.List;
 
@@ -50,7 +51,7 @@ class OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest {
     }
 
     private TypeView view(String name) {
-        return TypeView.of(Type.ref(symbols.own(name)), symbols);
+        return TypeView.of(Type.ref(new TypeName(symbols.module(), name)), symbols);
     }
 
     private TypeView view(Type type) {
@@ -62,7 +63,7 @@ class OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest {
     /** The reading issue #631 is about. What the position is, is what the name wraps. */
     @Test
     void aNewtypeOverASumIsThatSum() {
-        assertEquals(new Shape.Sum(symbols.own("Stage")), view("StageN").shape());
+        assertEquals(new Shape.Sum(new TypeName(symbols.module(), "Stage")), view("StageN").shape());
     }
 
     @Test
@@ -74,7 +75,7 @@ class OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest {
     @Test
     void aNewtypeOverARecordIsThatRecord() {
         Shape.Product product = assertInstanceOf(Shape.Product.class, view("SlotN").shape());
-        assertEquals(symbols.own("Slot"), product.name());
+        assertEquals(new TypeName(symbols.module(), "Slot"), product.name());
         assertEquals(java.util.Set.of("hour", "room"), product.fields().keySet());
     }
 
@@ -118,7 +119,7 @@ class OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest {
 
     @Test
     void theDeclaredTypeIsWhatTheSignatureWrote() {
-        assertEquals(Type.ref(symbols.own("StageN")), view("StageN").declared());
+        assertEquals(Type.ref(new TypeName(symbols.module(), "StageN")), view("StageN").declared());
     }
 
     // --- the shapes a position can have ---------------------------------------------------------
@@ -126,8 +127,8 @@ class OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest {
     @Test
     void eachTypeConstructorReadsAsItsOwnShape() {
         assertEquals(new Shape.Scalar(Type.Prim.STRING), view(Type.STRING).shape());
-        assertEquals(new Shape.Unit(symbols.own("Won")), view("Won").shape());
-        assertEquals(new Shape.Sum(symbols.own("Stage")), view("Stage").shape());
+        assertEquals(new Shape.Unit(new TypeName(symbols.module(), "Won")), view("Won").shape());
+        assertEquals(new Shape.Sum(new TypeName(symbols.module(), "Stage")), view("Stage").shape());
         assertEquals(new Shape.Sequence(Shape.Sequence.Kind.LIST, Type.INT),
                 view(Type.list(Type.INT)).shape());
         assertEquals(new Shape.Sequence(Shape.Sequence.Kind.SET, Type.INT),
@@ -152,13 +153,13 @@ class OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest {
         assertEquals(new Shape.Bottom(), view(Type.NOTHING).shape());
         assertEquals(new Shape.Erroneous(), view(Type.ERRONEOUS).shape());
         assertEquals(new Shape.Undecided(), view(Type.var("'a")).shape());
-        assertEquals(new Shape.Unresolved(symbols.own("Cyclic")), view("Cyclic").shape());
+        assertEquals(new Shape.Unresolved(new TypeName(symbols.module(), "Cyclic")), view("Cyclic").shape());
     }
 
     @Test
     void aUnionNobodyNamedIsItsMembers() {
-        Type union = Type.union(java.util.Set.of(symbols.own("Won"), symbols.own("Qualified")));
-        assertEquals(new Shape.Cases(java.util.Set.of(symbols.own("Won"), symbols.own("Qualified"))),
+        Type union = Type.union(java.util.Set.of(new TypeName(symbols.module(), "Won"), new TypeName(symbols.module(), "Qualified")));
+        assertEquals(new Shape.Cases(java.util.Set.of(new TypeName(symbols.module(), "Won"), new TypeName(symbols.module(), "Qualified"))),
                 view(union).shape());
     }
 
@@ -166,6 +167,6 @@ class OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest {
      *  name resolved to nothing usable rather than standing in for a value. */
     @Test
     void aNewtypeReachingItselfIsUnresolvedRatherThanAShape() {
-        assertEquals(new Shape.Unresolved(symbols.own("Cyclic")), view("Cyclic").shape());
+        assertEquals(new Shape.Unresolved(new TypeName(symbols.module(), "Cyclic")), view("Cyclic").shape());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/UnsupportedInformationNeverShrinksTheModelSetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/UnsupportedInformationNeverShrinksTheModelSetTest.java
@@ -39,14 +39,14 @@ class UnsupportedInformationNeverShrinksTheModelSetTest {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         Symbols symbols = compilation.symbols("demo");
-        return FieldDomains.of(symbols.own(name), data(compilation, name), symbols);
+        return FieldDomains.of(new TypeName(symbols.module(), name), data(compilation, name), symbols);
     }
 
     private static OccurrenceCounts countsOf(String source, String name) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         Symbols symbols = compilation.symbols("demo");
-        return OccurrenceCounts.of(symbols.own(name), data(compilation, name), symbols);
+        return OccurrenceCounts.of(new TypeName(symbols.module(), name), data(compilation, name), symbols);
     }
 
     /** Two clauses that cannot both hold, both of them read. */

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatOneDeclarationComesToUnderWhatIsKnownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatOneDeclarationComesToUnderWhatIsKnownTest.java
@@ -40,11 +40,11 @@ class WhatOneDeclarationComesToUnderWhatIsKnownTest {
         Symbols symbols = compilation.symbols("demo");
         Map<TypeName, Cardinality> solution = new HashMap<>();
         for (int each = 0; each < assumed.length; each += 2) {
-            solution.put(symbols.own((String) assumed[each]), (Cardinality) assumed[each + 1]);
+            solution.put(new TypeName(symbols.module(), (String) assumed[each]), (Cardinality) assumed[each + 1]);
         }
         for (Ast.Def def : compilation.module("demo").defs()) {
             if (def.name().equals(name)) {
-                return CardinalityTransfer.upperOf(symbols.own(name), def, symbols, solution, _ -> false);
+                return CardinalityTransfer.upperOf(new TypeName(symbols.module(), name), def, symbols, solution, _ -> false);
             }
         }
         throw new IllegalArgumentException("no such declaration: " + name);

--- a/souther-compiler/src/test/java/souther/compiler/examples/AValueWearsTheEnvelopeThePositionReadsItThroughTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AValueWearsTheEnvelopeThePositionReadsItThroughTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.check.Symbols;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
 
 import java.util.Map;
 
@@ -76,7 +77,7 @@ class AValueWearsTheEnvelopeThePositionReadsItThroughTest {
     }
 
     private Type at(String type) {
-        return Type.ref(symbols.own(type));
+        return Type.ref(new TypeName(symbols.module(), type));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACaseComposedForOneReaderIsComposedForEveryReaderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACaseComposedForOneReaderIsComposedForEveryReaderTest.java
@@ -6,6 +6,7 @@ import souther.compiler.check.Resolve;
 import souther.compiler.check.Symbols;
 import souther.compiler.frontend.CstFrontend;
 import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
 
 import java.util.List;
 import java.util.Set;
@@ -55,7 +56,7 @@ class ACaseComposedForOneReaderIsComposedForEveryReaderTest {
     }
 
     private Type named(String name) {
-        return Type.ref(symbols.own(name));
+        return Type.ref(new TypeName(symbols.module(), name));
     }
 
     private Type sum() {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ADeclaredCaseIsNotYetAClassThePositionHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ADeclaredCaseIsNotYetAClassThePositionHoldsTest.java
@@ -10,6 +10,7 @@ import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.PartitionEvidence;
 import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
 
 import java.util.List;
 
@@ -60,7 +61,7 @@ class ADeclaredCaseIsNotYetAClassThePositionHoldsTest {
     @Test
     void theTypeDeclaresEveryCaseWhateverItsRulesSay() {
         assertEquals(List.of("Prospecting", "Qualified", "Won"),
-                PartitionClasses.of(Type.ref(symbols.own("StageI")), symbols).stream()
+                PartitionClasses.of(Type.ref(new TypeName(symbols.module(), "StageI")), symbols).stream()
                         .map(PartitionClass::id).toList());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ALeafIsNotAnAbsenceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ALeafIsNotAnAbsenceTest.java
@@ -6,6 +6,7 @@ import souther.compiler.check.Shape;
 import souther.compiler.check.Symbols;
 import souther.compiler.frontend.CstFrontend;
 import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
 
 import org.junit.jupiter.api.Test;
 
@@ -46,7 +47,7 @@ class ALeafIsNotAnAbsenceTest {
     }
 
     private Type named(String name) {
-        return Type.ref(symbols.own(name));
+        return Type.ref(new TypeName(symbols.module(), name));
     }
 
     // --- a leaf says one thing ------------------------------------------------------------------

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANameGoesBackOnTheWayItCameOffTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANameGoesBackOnTheWayItCameOffTest.java
@@ -61,7 +61,7 @@ class ANameGoesBackOnTheWayItCameOffTest {
     }
 
     private TypeName named(String name) {
-        return symbols.own(name);
+        return new TypeName(symbols.module(), name);
     }
 
     private PartitionClass classOf(String type, String id) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionAPartitionIsDerivedFromIsProvedToBeOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionAPartitionIsDerivedFromIsProvedToBeOneTest.java
@@ -8,6 +8,7 @@ import souther.compiler.check.Symbols;
 import souther.compiler.diag.CompileException;
 import souther.compiler.frontend.CstFrontend;
 import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
 
 import org.junit.jupiter.api.Test;
 
@@ -58,7 +59,7 @@ class APositionAPartitionIsDerivedFromIsProvedToBeOneTest {
     }
 
     private Type named(String name) {
-        return Type.ref(symbols.own(name));
+        return Type.ref(new TypeName(symbols.module(), name));
     }
 
     // --- what a partition may be derived from ---------------------------------------------------
@@ -101,7 +102,7 @@ class APositionAPartitionIsDerivedFromIsProvedToBeOneTest {
     @Test
     void aShapeNoPositionCanHaveIsThisCompilerDisagreeingWithItself() {
         List<Type> unreachable = List.of(
-                Type.union(java.util.Set.of(symbols.own("Prospecting"), symbols.own("Won"))),
+                Type.union(java.util.Set.of(new TypeName(symbols.module(), "Prospecting"), new TypeName(symbols.module(), "Won"))),
                 Type.tuple(List.of(Type.INT, Type.STRING)),
                 Type.fn(List.of(Type.INT), Type.INT),
                 Type.NEVER,

--- a/souther-compiler/src/test/java/souther/compiler/partition/LocalEvidenceIsAskedOfBothProducersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/LocalEvidenceIsAskedOfBothProducersTest.java
@@ -8,6 +8,7 @@ import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeView;
 import souther.compiler.frontend.CstFrontend;
 import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
 
 import java.util.List;
 
@@ -60,7 +61,7 @@ class LocalEvidenceIsAskedOfBothProducersTest {
 
     private LocalInspection inspect(String type) {
         return LocalInspection.inspect(
-                PartitionInput.of(TypeView.of(Type.ref(symbols.own(type)), symbols)),
+                PartitionInput.of(TypeView.of(Type.ref(new TypeName(symbols.module(), type)), symbols)),
                 TermPath.of("x"), symbols, null);
     }
 


### PR DESCRIPTION
`ExampleVerifier` recorded which case a row's behavior answered with by resolving the runtime
class's simple name in the reading module's scope. A module reaching the type through an alias
has no bare name for it, so the lookup missed and two rows that pass were reported as confirming
no case at all; a module declaring something else of that spelling got that instead, with nothing
said. Four readers asked it that way and a fifth, private one asked it correctly.

The fix is not those five call sites. `Symbols` already said "Only source text goes in", `Resolve`
already said "There is no spelling left to compare", and `Ast.Apply.written()` already said
"**Never a lookup key**". The rule was written down three times and broken anyway, because a
spelling and an identity are the same Java type and every composition compiles.

## What changed

`resolve` and `resolveCase` take a `WrittenName` and are not visible outside `check`.
`declaration(String)` had no caller inside the pass and is deleted. Post-`Resolve` consumers —
`examples`, the backend, `Deriver` — hold what a name denotes or hold nothing.

`TypeOps.fieldBindings` read an include's denotation and repaired a missing one from the
spelling. `Resolve` needs that, asking while it is resolving; its other callers are all after the
pass, where the branch would have covered a producer that left an include unanswered. It is two
entries now: `fieldBindings` refuses an include that denotes nothing, and
`fieldBindingsWhileResolving` is the pass's own and only the pass can reach it.

`own(String)` is `own(Ast.Def)`. It vouched, on the caller's word, that a spelling is declared
here. The word was wrong: a `constructs` entry naming an imported type was answered with a class
of the module that names it, and javac refused the generated base as soon as the declaration had
to be handed over. `unitCases` and `dataConstructs` dropped a `TypeName` to its simple name for
the same round trip and now carry it.

`CodegenContext.cd(String)` answered two questions — the class of a declaration and the class of
something this backend made up — and fabricated a package for whatever failed to resolve. They
are `cd(TypeName)` / `cd(Ast.Def)` and `generated(String)`, and the second looks nothing up.

Five pairs of methods had the correct implementation sitting beside the wrong one as an overload
(`isNewtype`, `isMapInput`, `encodedOrNull`, `newtypeBaseType`, `newtypeAt`), with the caller's
choice deciding correctness. The spelling-keyed half of each is gone. #696 landed the same
reading of an application while this was open; its `constructs(c)` is kept and the duplicate
written here is removed.

## The generator, not the readers

Moving `examples` onto carried identity dropped 55 generation tests. `FixtureTemplate` held a
`TypeName` and built its application from the name alone, so every reader was working the
declaration out from characters and correcting for what the producer had thrown away. Giving the
application what it constructs brought all 55 back — one line.

## What is not closed

`own` refuses a declaration whose name this module does not declare, which is the reading that
was wrong. A declaration another module wrote under a name this one also writes is not told apart
from one of this module's: a module that declares a name twice registers one of them and the pass
reporting that walks both, so "not the one registered" is a state `own` has to admit. That closes
when a declaration carries its own identity (#703). The comment, the test name and this paragraph
say the same thing.

## Checks

`NoPublicWayToTurnASpellingIntoATypeIdentityTest` fixes the property rather than an answer: no
public method of `Symbols` takes a `String` and answers with a `TypeName` or an `Ast.Def`,
resolution is not on the surface, and `own` refuses a declaration whose name this module does not
declare. An implementation-shaped test is worth it here because the failure was a sentence three
files kept and nothing enforced.

Both failure modes of the issue are held, with the bare-import spelling beside them as a control.
Reading the case off the value the way this module names spellings gives `[null, null]` for the
aliased module and `[shadows.Yes, null]` for the one that spells something else the same, so
neither test passes for the wrong reason — the second is the stronger, being a lookup that
succeeded and meant something else.

All tests pass (compiler 4289, lsp 202, syntax 333, fmt 113, runtime 98).

Refs #700. Follow-ups: #702 (one owner for the names the backend gives the classes it generates),
#703 (unresolved and resolved trees as separate types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)