### PR TITLE
Ask the ABI where a class is written, and what type a class's name says it is

### DIFF
--- a/souther-cli/src/main/java/souther/cli/Main.java
+++ b/souther-cli/src/main/java/souther/cli/Main.java
@@ -1,5 +1,6 @@
 package souther.cli;
 
+import souther.compiler.jvm.JvmClassName;
 import souther.compiler.Compiler;
 import souther.compiler.Reserved;
 import souther.compiler.cst.CstError;
@@ -1041,7 +1042,7 @@ public final class Main {
     static List<Path> writeClasses(Map<String, byte[]> classes, Path outDir) throws IOException {
         List<Path> written = new ArrayList<>();
         for (Map.Entry<String, byte[]> entry : classes.entrySet()) {
-            Path file = outDir.resolve(entry.getKey().replace('.', '/') + ".class");
+            Path file = outDir.resolve(JvmClassName.classFile(entry.getKey()));
             Files.createDirectories(file.getParent());
             Files.write(file, entry.getValue());
             written.add(file);

--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -1,5 +1,6 @@
 package souther.compiler;
 
+import souther.compiler.jvm.JvmClassName;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.msg.DeclarationMessage;
@@ -528,7 +529,7 @@ public final class Compiler {
     /** Compiles source and writes each generated class under {@code outDir}. */
     public static void compileToDir(String source, Path outDir) throws IOException {
         for (Map.Entry<String, byte[]> entry : compile(source).entrySet()) {
-            Path file = outDir.resolve(entry.getKey().replace('.', '/') + ".class");
+            Path file = outDir.resolve(JvmClassName.classFile(entry.getKey()));
             Files.createDirectories(file.getParent());
             Files.write(file, entry.getValue());
         }

--- a/souther-compiler/src/main/java/souther/compiler/doc/JapiCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/JapiCommand.java
@@ -1,5 +1,6 @@
 package souther.compiler.doc;
 
+import souther.compiler.jvm.JvmClassName;
 import souther.compiler.check.Suggest;
 
 import java.io.IOException;
@@ -228,7 +229,7 @@ public final class JapiCommand {
     private record Found(byte[] bytes, Path entry) {}
 
     private static Found findClass(String binaryName, List<Entry> entries, Skipped skipped) {
-        String resource = binaryName.replace('.', '/') + ".class";
+        String resource = JvmClassName.classFile(binaryName);
         for (Entry entry : entries) {
             Path path = entry.path();
             try {

--- a/souther-compiler/src/main/java/souther/compiler/examples/NeutralForm.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/NeutralForm.java
@@ -1,5 +1,6 @@
 package souther.compiler.examples;
 
+import souther.compiler.jvm.SoutherJvmAbi;
 import souther.compiler.ast.Ast;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
@@ -588,13 +589,8 @@ final class NeutralForm {
         if (live == null) {
             return null;
         }
-        String binary = live.getClass().getName();
-        int dot = binary.lastIndexOf('.');
-        if (dot < 0) {
-            return null;
-        }
-        TypeName named = new TypeName(binary.substring(0, dot), binary.substring(dot + 1));
-        return symbols.contains(named) ? named : null;
+        TypeName named = SoutherJvmAbi.declaredTypeOf(live.getClass().getName());
+        return named != null && symbols.contains(named) ? named : null;
     }
 
     /** What a report quotes a live value's class as. Its own name, and not the type's identity —

--- a/souther-compiler/src/main/java/souther/compiler/examples/NeutralForm.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/NeutralForm.java
@@ -589,8 +589,8 @@ final class NeutralForm {
         if (live == null) {
             return null;
         }
-        TypeName named = SoutherJvmAbi.declaredTypeOf(live.getClass().getName());
-        return named != null && symbols.contains(named) ? named : null;
+        TypeName candidate = SoutherJvmAbi.valueTypeCandidate(live.getClass().getName());
+        return candidate != null && symbols.contains(candidate) ? candidate : null;
     }
 
     /** What a report quotes a live value's class as. Its own name, and not the type's identity —

--- a/souther-compiler/src/main/java/souther/compiler/jvm/JvmClassName.java
+++ b/souther-compiler/src/main/java/souther/compiler/jvm/JvmClassName.java
@@ -40,6 +40,25 @@ public final class JvmClassName {
         return ClassDesc.of(binaryName);
     }
 
+    /**
+     * Where a class of this name is written, and read back: {@code demo/Foo.class}, relative to
+     * whatever holds it — an output directory, a jar, a class path root.
+     *
+     * <p>A path is not an identity and the rule is the JVM's rather than this compiler's, which is
+     * why it is a function of a name here rather than a kind of {@link GeneratedClass}. It is still a
+     * rule with one place to live: written out at each of the four readers that wanted it, a compiler
+     * that ever needs to write a class somewhere else has four places to look and no way to know it
+     * found them all.
+     */
+    public static String classFile(String binaryName) {
+        return binaryName.replace('.', '/') + ".class";
+    }
+
+    /** @see #classFile(String) */
+    public String classFile() {
+        return classFile(binaryName);
+    }
+
     /** Whether {@code c} is the class of this name. The question a reader of a run asks — which is
      *  asked of the name the ABI decided, not of a spelling the reader assembled. */
     public boolean is(Class<?> c) {

--- a/souther-compiler/src/main/java/souther/compiler/jvm/SoutherJvmAbi.java
+++ b/souther-compiler/src/main/java/souther/compiler/jvm/SoutherJvmAbi.java
@@ -1,5 +1,7 @@
 package souther.compiler.jvm;
 
+import souther.compiler.types.TypeName;
+
 /**
  * How a {@link GeneratedClass} is spelled on the JVM. The one place that maps a Souther identity to a
  * physical one, and the one place the suffixes and the capitalization exist.
@@ -38,6 +40,28 @@ public final class SoutherJvmAbi {
             case GeneratedClass.Helpers h -> h.module() + ".$Fns";
             case GeneratedClass.Lambda l -> l.module() + ".$Fn" + l.id();
         });
+    }
+
+    /**
+     * The declared type a class of this binary name would be the value class of, or null where the
+     * name is not one a declaration could have produced.
+     *
+     * <p>The inverse of {@code nameOf(new GeneratedClass.Value(type))}, and the only inverse there
+     * can be: a value class is the one kind whose name is its identity, so it is the one kind that
+     * reads back. Every other kind either adds something to a name or is spelled the same as a kind
+     * that does — {@code demo.Quote} is a data {@code Quote} and it is also the interface of a
+     * behavior {@code quote} — so a name alone does not say which, and asking is the only way.
+     *
+     * <p>An answer is a type this ABI <em>would</em> name that way, not evidence that anything
+     * declared it. A caller that needs the declaration checks its own scope, which is where that
+     * question is answered.
+     */
+    public static TypeName declaredTypeOf(String binaryName) {
+        int dot = binaryName.lastIndexOf('.');
+        if (dot <= 0 || dot == binaryName.length() - 1) {
+            return null;
+        }
+        return new TypeName(binaryName.substring(0, dot), binaryName.substring(dot + 1));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/jvm/SoutherJvmAbi.java
+++ b/souther-compiler/src/main/java/souther/compiler/jvm/SoutherJvmAbi.java
@@ -43,20 +43,23 @@ public final class SoutherJvmAbi {
     }
 
     /**
-     * The declared type a class of this binary name would be the value class of, or null where the
-     * name is not one a declaration could have produced.
+     * The {@link TypeName} whose {@code Value} identity would have this binary name, or null where no
+     * type's would. It says nothing about whether such a type is declared, or about what was really
+     * emitted under the name.
      *
-     * <p>The inverse of {@code nameOf(new GeneratedClass.Value(type))}, and the only inverse there
-     * can be: a value class is the one kind whose name is its identity, so it is the one kind that
-     * reads back. Every other kind either adds something to a name or is spelled the same as a kind
-     * that does — {@code demo.Quote} is a data {@code Quote} and it is also the interface of a
-     * behavior {@code quote} — so a name alone does not say which, and asking is the only way.
+     * <p>The naming rule for a value class run backwards, and the only rule here that can be: a value
+     * class is its type, so the two directions are one rule. Every other kind either adds something
+     * to a name or shares one with a kind that does — {@code demo.Quote} is a data {@code Quote} and
+     * it is also the interface of a behavior {@code quote} — so a name alone does not say which, and
+     * asking is the only way.
      *
-     * <p>An answer is a type this ABI <em>would</em> name that way, not evidence that anything
-     * declared it. A caller that needs the declaration checks its own scope, which is where that
-     * question is answered.
+     * <p>Which is why this answers half a question and is named for its half. Whether a type is
+     * there is a module's scope to answer, and the caller that has one asks it:
+     * {@code candidate != null && symbols.contains(candidate)}. An ABI that answered both would be
+     * claiming a declaration it has no way to see — the same shape as an authority that hands out
+     * half an answer, pointed the other way.
      */
-    public static TypeName declaredTypeOf(String binaryName) {
+    public static TypeName valueTypeCandidate(String binaryName) {
         int dot = binaryName.lastIndexOf('.');
         if (dot <= 0 || dot == binaryName.length() - 1) {
             return null;

--- a/souther-compiler/src/main/java/souther/compiler/meta/ModulePath.java
+++ b/souther-compiler/src/main/java/souther/compiler/meta/ModulePath.java
@@ -1,5 +1,6 @@
 package souther.compiler.meta;
 
+import souther.compiler.jvm.JvmClassName;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -60,7 +61,7 @@ public interface ModulePath {
     record ClassPath(List<Path> entries) implements ModulePath {
         @Override
         public byte[] bytes(String binaryName) {
-            String resource = binaryName.replace('.', '/') + ".class";
+            String resource = JvmClassName.classFile(binaryName);
             for (Path entry : entries) {
                 byte[] bytes = read(entry, resource);
                 if (bytes != null) {

--- a/souther-compiler/src/test/java/souther/compiler/jvm/NoPublicWayToMakeAGeneratedClassNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/jvm/NoPublicWayToMakeAGeneratedClassNameTest.java
@@ -55,16 +55,21 @@ class NoPublicWayToMakeAGeneratedClassNameTest {
         assertEquals(List.of(GeneratedClass.class), List.of(nameOf.getParameterTypes()));
     }
 
-    /** And a name it hands back cannot be taken apart into the pieces it was built from — those are
-     *  what a caller finishes by hand, and finishing by hand is the defect. */
+    /**
+     * And a name it hands back cannot be taken apart into the pieces it was built from — those are
+     * what a caller finishes by hand, and finishing by hand is the defect.
+     *
+     * <p>A whole answer to another question is not a piece of one: where a class of this name is
+     * written is complete on its own, and a caller holding it has nothing left to finish.
+     */
     @Test
     void andANameHandsBackNoPieceOfItself() {
         for (Method m : JvmClassName.class.getMethods()) {
             if (m.getDeclaringClass() != JvmClassName.class) {
                 continue;
             }
-            assertTrue(List.of("binaryName", "classDesc", "is", "equals", "hashCode", "toString")
-                            .contains(m.getName()),
+            assertTrue(List.of("binaryName", "classDesc", "classFile", "is",
+                            "equals", "hashCode", "toString").contains(m.getName()),
                     "a public member of a name that is not the whole name: " + m.getName());
         }
     }

--- a/souther-compiler/src/test/java/souther/compiler/jvm/SoutherJvmAbiTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/jvm/SoutherJvmAbiTest.java
@@ -110,26 +110,28 @@ class SoutherJvmAbiTest {
     }
 
     /**
-     * The one kind that reads back out of a name, and what it does not claim.
+     * The one naming rule that runs backwards, and the half of the question it answers.
      *
-     * <p>A value class is its type, so the two directions are the same rule and it is written once.
-     * The answer is a type this ABI would name that way — {@code demo.Quote} reads as the data
-     * {@code Quote} whether or not anything declared it, and whether or not what is really there is
-     * the interface of a behavior {@code quote}. That is the whole of what a name can say.
+     * <p>A value class is its type, so the two directions are one rule and it is written once. What
+     * comes back is the type whose value class <em>would</em> be spelled that way — nothing more.
+     * Whether such a type is declared is a scope's answer, and so is what was really emitted under
+     * the name: {@code shop.FindOrder$Impl} is not a declaration any source could write, and
+     * {@code souther.Int} is a primitive, which reaches codegen as a boxed class and never as a value
+     * class of its own. Both read back here all the same, because reading back is all this does.
      */
     @Test
-    void andAValueClassReadsBackAsTheTypeItIs() {
+    void andAValueClassNameSaysWhichTypeItWouldBe() {
         for (TypeName type : List.of(ORDER, new TypeName("在庫", "金額"),
                 new TypeName("a.b.c", "Deep"), TypeName.primitive("Int"))) {
-            assertEquals(type, SoutherJvmAbi.declaredTypeOf(
+            assertEquals(type, SoutherJvmAbi.valueTypeCandidate(
                     SoutherJvmAbi.nameOf(new GeneratedClass.Value(type)).binaryName()));
         }
         assertEquals(new TypeName("shop", "FindOrder$Impl"),
-                SoutherJvmAbi.declaredTypeOf("shop.FindOrder$Impl"),
-                "it answers for the name, not for what was emitted under it");
-        assertEquals(null, SoutherJvmAbi.declaredTypeOf("Loose"), "a name with no module names no type");
-        assertEquals(null, SoutherJvmAbi.declaredTypeOf(".Foo"));
-        assertEquals(null, SoutherJvmAbi.declaredTypeOf("demo."));
+                SoutherJvmAbi.valueTypeCandidate("shop.FindOrder$Impl"),
+                "a candidate for the name, and no claim about what is under it");
+        assertEquals(null, SoutherJvmAbi.valueTypeCandidate("Loose"), "a name with no module names no type");
+        assertEquals(null, SoutherJvmAbi.valueTypeCandidate(".Foo"));
+        assertEquals(null, SoutherJvmAbi.valueTypeCandidate("demo."));
     }
 
     /** And every decoder does, which is the one branch that is a value rather than a kind. */

--- a/souther-compiler/src/test/java/souther/compiler/jvm/SoutherJvmAbiTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/jvm/SoutherJvmAbiTest.java
@@ -97,6 +97,41 @@ class SoutherJvmAbiTest {
         assertEquals(kinds.size(), stated.size());
     }
 
+    /** Where a class of a given name is written, which is the JVM's rule and is stated here for the
+     *  same reason the rest is: four readers wanted it and each wrote it out. */
+    @Test
+    void andAClassOfThatNameIsWrittenWhereTheAbiSaysItIs() {
+        assertEquals("shop/Order.class", JvmClassName.classFile("shop.Order"));
+        assertEquals("shop/FindOrder$Impl.class",
+                SoutherJvmAbi.nameOf(new GeneratedClass.BehaviorImpl("shop", "findOrder")).classFile());
+        assertEquals("在庫/引き当てる$Impl.class",
+                SoutherJvmAbi.nameOf(new GeneratedClass.BehaviorImpl("在庫", "引き当てる")).classFile());
+        assertEquals("Loose.class", JvmClassName.classFile("Loose"));
+    }
+
+    /**
+     * The one kind that reads back out of a name, and what it does not claim.
+     *
+     * <p>A value class is its type, so the two directions are the same rule and it is written once.
+     * The answer is a type this ABI would name that way — {@code demo.Quote} reads as the data
+     * {@code Quote} whether or not anything declared it, and whether or not what is really there is
+     * the interface of a behavior {@code quote}. That is the whole of what a name can say.
+     */
+    @Test
+    void andAValueClassReadsBackAsTheTypeItIs() {
+        for (TypeName type : List.of(ORDER, new TypeName("在庫", "金額"),
+                new TypeName("a.b.c", "Deep"), TypeName.primitive("Int"))) {
+            assertEquals(type, SoutherJvmAbi.declaredTypeOf(
+                    SoutherJvmAbi.nameOf(new GeneratedClass.Value(type)).binaryName()));
+        }
+        assertEquals(new TypeName("shop", "FindOrder$Impl"),
+                SoutherJvmAbi.declaredTypeOf("shop.FindOrder$Impl"),
+                "it answers for the name, not for what was emitted under it");
+        assertEquals(null, SoutherJvmAbi.declaredTypeOf("Loose"), "a name with no module names no type");
+        assertEquals(null, SoutherJvmAbi.declaredTypeOf(".Foo"));
+        assertEquals(null, SoutherJvmAbi.declaredTypeOf("demo."));
+    }
+
     /** And every decoder does, which is the one branch that is a value rather than a kind. */
     @Test
     void andEveryDecoderHasARow() {


### PR DESCRIPTION
The second half of #702: the repository swept for the shape the naming work was about — a consumer
rebuilding a semantic identity out of primitives — and the two that came back fixed.

## What was swept

Every place in main that joins on `.`, splits on it, walks back from `lastIndexOf('.')`, turns a name
into a path, or compares an assembled string. Each was read for the three questions: who is the
authority for this identity, does it answer completely, and is the consumer re-deriving something.

## What came back

**A value class read back out of a runtime class name.** `NeutralForm.typeOf` split a binary name at
the last dot to rebuild a `TypeName`. That is the inverse of `nameOf(Value(type))`, written in the
package the last two defects of this kind were found in. It is now `SoutherJvmAbi.declaredTypeOf`,
and it is the only inverse there can be: a value class is its type, so the two directions are one
rule. Every other kind either adds something to a name or shares one with a kind that does —
`demo.Quote` is a data `Quote` and it is also the interface of a behavior `quote` — so a name alone
does not say which. It answers for the name and claims nothing about what was declared, which is what
the caller's own scope answers and still does.

**Where a class of a given name is written**, stated at four readers: the two that write a
compilation out, the one that reads a module off the class path, and the one that reads a jar. The
rule is the JVM's rather than this compiler's, so it is a function of a name rather than a kind of
generated class — but it is still a rule, and a compiler that ever writes a class somewhere else now
has one place to look.

Both are stated in the contract test beside the spellings, including what the inverse does not claim.

## What was left, and why

`SoutherProcessor` asks a `Filer`, whose API takes a package and a file name rather than a path, so
the same rule appears there in the shape that API forces. Expressing it through the new one would be
more restatement rather than less.

The joins in `check` and `query` that walk back from a dot are about a name as a module's source
wrote it — `A.member` — which is the resolution question, not this one. It has its own owner and its
own issues behind it.

`HelperNames.qualified` is the shape done right already: one authority, a complete answer, and both
consumers ask.

The three derivations that produce a `.sou` name — a bundled module's resource, the standard
library's, and the `SourceFile` attribute — are three questions that happen to end in the same four
characters, not one identity stated three times.

## `ModuleName`

Not now, on the evidence. The sweep found nothing a module-name value type would have prevented: what
was wrong was deriving other things from a module name, not confusing a module name with another
string. Held open rather than decided against — it would be worth revisiting if a defect of that
second kind ever shows up.

All 4302 compiler tests pass, along with the other modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)