### PR TITLE
Own a failure where it happened, so a mistake in one definition is not one in the next

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
@@ -32,15 +32,28 @@ public final class NewtypeDesugar {
     public static Ast.Module rewrite(Ast.Module m, Symbols symbols) {
         List<Ast.FnDef> fns = new ArrayList<>();
         for (Ast.FnDef fn : m.fns()) {
-            Ast.FnBody body = switch (fn.body()) {
-                case Ast.FnBody.Written w -> new Ast.FnBody.Written(go(w.expr(), symbols));
-                case Ast.FnBody.Intrinsic i -> i;
-            };
-            fns.add(fn.withBody(body));
+            fns.add(rewriteOf(fn, symbols));
         }
         return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(),
                 m.defs(), m.behaviors(), fns, m.takenOn(), m.examples(), m.fakes(),
                 m.exampleFileTarget(), m.pos());
+    }
+
+    /**
+     * One definition's body, with each newtype construction written in it rewritten to the
+     * construction it is.
+     *
+     * <p>A definition at a time, because an application that wraps no single value is wrong in the
+     * body that wrote it and in no other. Rewriting them together answers for a whole module, and
+     * one such application would leave every other definition without the form the check and the
+     * backend read.
+     */
+    public static Ast.FnDef rewriteOf(Ast.FnDef fn, Symbols symbols) {
+        Ast.FnBody body = switch (fn.body()) {
+            case Ast.FnBody.Written w -> new Ast.FnBody.Written(go(w.expr(), symbols));
+            case Ast.FnBody.Intrinsic i -> i;
+        };
+        return fn.withBody(body);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
@@ -52,17 +52,29 @@ public final class NewtypeDesugar {
     public static Ast.Module rewriteInvariants(Ast.Module m, Symbols symbols) {
         List<Ast.Def> defs = new ArrayList<>();
         for (Ast.Def def : m.defs()) {
-            if (def instanceof Ast.Data d && !d.invariants().isEmpty()) {
-                defs.add(new Ast.Data(d.written(), d.newtype(), d.includes(), d.fields(),
-                        Ast.mapClauses(d.invariants(), inv -> go(inv, symbols)),
-                        d.decoder(), d.encoder(), d.pos()));
-            } else {
-                defs.add(def);
-            }
+            defs.add(rewriteInvariantsOf(def, symbols));
         }
         return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(),
                 defs, m.behaviors(), m.fns(), m.takenOn(), m.examples(), m.fakes(),
                 m.exampleFileTarget(), m.pos());
+    }
+
+    /**
+     * One declaration's invariants, with each newtype construction written in them rewritten to the
+     * construction it is.
+     *
+     * <p>A declaration at a time, because what is wrong with one clause is wrong with the
+     * declaration that wrote it and with nothing else. Rewriting them together would answer for a
+     * whole module, and one bad application would leave every other declaration without the form
+     * every later stage reads.
+     */
+    public static Ast.Def rewriteInvariantsOf(Ast.Def def, Symbols symbols) {
+        if (def instanceof Ast.Data d && !d.invariants().isEmpty()) {
+            return new Ast.Data(d.written(), d.newtype(), d.includes(), d.fields(),
+                    Ast.mapClauses(d.invariants(), inv -> go(inv, symbols)),
+                    d.decoder(), d.encoder(), d.pos());
+        }
+        return def;
     }
 
     private static Ast.Expr go(Ast.Expr e, Symbols symbols) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -53,6 +53,17 @@ public final class Resolve {
     private final List<ValueUse> values0 = new ArrayList<>();
     /** Every name it could not answer, as the error it would once have thrown. */
     private final List<CompileException> unresolved = new ArrayList<>();
+    /**
+     * How many names it did not answer, which is not the same as how many it reported.
+     *
+     * <p>A name is left unanswered and said nothing about where the reason is somewhere else and
+     * already reported there — a module this compilation has and cannot use exports names that
+     * stand in an importer's scope as identities nothing declares, so the importer is not told a
+     * second time about a file that is fine. That is the same absence as a misspelling and only the
+     * report differs, so whether a declaration's names came out is counted here rather than read off
+     * what was reported while it was being read.
+     */
+    private int unanswered;
     /** What each binding this pass gave an identity to is called, and where that is written. */
     private final Map<BindingId, BoundName> binders = new LinkedHashMap<>();
     /** How many bindings each definition has been given, so the next one gets the next number. */
@@ -262,7 +273,8 @@ public final class Resolve {
         // the one beside it wrote, and the names met while it was being read are its own.
         Map<String, OfDeclaration> declarations = new LinkedHashMap<>();
         for (Ast.Def def : m.defs()) {
-            int unansweredBefore = r.unresolved.size();
+            int reportedBefore = r.unresolved.size();
+            int unansweredBefore = r.unanswered;
             int denotedBefore = r.denotations.size();
             Ast.Def resolved = r.def(def);
             defs.add(resolved);
@@ -270,8 +282,14 @@ public final class Resolve {
             for (Denotation d : r.denotations.subList(denotedBefore, r.denotations.size())) {
                 reaches.add(d.denotes());
             }
-            declarations.put(resolved.name(),
-                    new OfDeclaration(r.unresolved.size() == unansweredBefore, Set.copyOf(reaches)));
+            // The first of a name is what the module declares and the second is reported and left
+            // out, which `TypeChecker.declared` settles and every stage reads from there. Whether a
+            // declaration came out is about the same one: read off the second, it answers about a
+            // declaration nothing else is holding, and the one the module has is told it has no
+            // meaning because of a mistake in the copy below it.
+            declarations.putIfAbsent(resolved.name(),
+                    new OfDeclaration(r.unresolved.size() == reportedBefore
+                            && r.unanswered == unansweredBefore, Set.copyOf(reaches)));
         }
         List<Ast.BehaviorDef> behaviors = new ArrayList<>();
         for (Ast.BehaviorDef b : m.behaviors()) {
@@ -406,7 +424,9 @@ public final class Resolve {
         // A reference with no name is a tuple or a container shape, which names no declaration.
         if (denoted.name() != null && denoted.pos() != null) {
             TypeName names = symbols.resolve(denoted.written());
-            if (names != null) {
+            if (names != null && names.isUnresolved()) {
+                unanswered++;
+            } else if (names != null) {
                 denotations.add(new Denotation(denoted.written(), names));
             }
         }
@@ -966,7 +986,11 @@ public final class Resolve {
      * there under a spelling nothing binds.
      */
     private ValueName answered(WrittenName written, ValueName denotes) {
-        if (written.pos() == null || denotes instanceof ValueName.Unresolved) {
+        if (denotes instanceof ValueName.Unresolved) {
+            unanswered++;
+            return denotes;
+        }
+        if (written.pos() == null) {
             return denotes;
         }
         values0.add(new ValueUse(written, denotes));
@@ -1132,7 +1156,9 @@ public final class Resolve {
      * synthesized by an earlier pass rather than written, so there is nothing to point at, and a
      * name nothing answered is an absence rather than a declaration to record. */
     private Ast.Name answered(Ast.Name n) {
-        if (n.pos() != null && !n.denotes().isUnresolved()) {
+        if (n.denotes().isUnresolved()) {
+            unanswered++;
+        } else if (n.pos() != null) {
             denotations.add(new Denotation(n.name(), n.denotes()));
         }
         return n;

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -171,12 +171,14 @@ public final class Resolve {
     }
 
     /**
-     * A resolved module, every name the pass answered in it, and the names it could not answer.
+     * What the pass worked out about the names a module writes, and nothing else.
      *
-     * <p>A name that denotes nothing does not end the pass. It denotes {@link TypeName#unresolved},
-     * which becomes {@link souther.compiler.types.Type#ERRONEOUS}, and the rest of the module is
-     * resolved as if the mistake were not there — so an author is told about every unknown name at
-     * once instead of one per compile, and an editor can still say what the names around it mean.
+     * <p>Every entry is an answer it reached. A name it could not answer is in none of them, so a
+     * reader asking about one is told there is nothing there rather than handed a declaration that
+     * was never written — the identity the traversal carries past a mistake stands for the absence
+     * and is not an identity anything declares. This is what a reader outside the compiler is
+     * offered, which is why it is a partial record rather than a total one: an incomplete module has
+     * incomplete answers about it, and the answers it does have are as good as any other module's.
      *
      * <p>{@code binders} says what each binding is called and where the author wrote that name. A
      * binding is not its position — a pass that expands a helper stamps the call site over the
@@ -191,8 +193,20 @@ public final class Resolve {
      * something else, so a reader answered with one of these would be answered about a name that is
      * not there, at a width that is not its.
      */
-    public record Resolved(Ast.Module module, List<Denotation> denotations, List<ValueUse> values,
-                           List<CompileException> unresolved, Map<BindingId, BoundName> binders) {}
+    public record ResolutionIndex(List<Denotation> types, List<ValueUse> values,
+                                  Map<BindingId, BoundName> binders) {}
+
+    /**
+     * A resolved module, what the pass worked out about the names in it, and the names it could not
+     * answer.
+     *
+     * <p>A name that denotes nothing does not end the pass. It denotes {@link TypeName#unresolved},
+     * which becomes {@link souther.compiler.types.Type#ERRONEOUS}, and the rest of the module is
+     * resolved as if the mistake were not there — so an author is told about every unknown name at
+     * once instead of one per compile, and an editor can still say what the names around it mean.
+     */
+    public record Resolved(Ast.Module module, ResolutionIndex index,
+                           List<CompileException> unresolved) {}
 
     /** What a binding is called, and the occurrence of that name the author wrote. */
     public record BoundName(WrittenName written) {
@@ -279,8 +293,9 @@ public final class Resolve {
                 new Ast.Module(m.name(), m.exposing(), exposedOutputs, m.imports(), defs,
                         behaviors, fns, m.takenOn(), examples, fakes, m.exampleFileTarget(),
                         m.pos()),
-                List.copyOf(r.denotations), List.copyOf(r.values0), List.copyOf(r.unresolved),
-                Map.copyOf(r.binders));
+                new ResolutionIndex(List.copyOf(r.denotations), List.copyOf(r.values0),
+                        Map.copyOf(r.binders)),
+                List.copyOf(r.unresolved));
     }
 
     private Ast.FnDef fn(Ast.FnDef f) {
@@ -919,9 +934,14 @@ public final class Resolve {
      * wraps — is a use of that type as much as one written in a field's type is, and is recorded as
      * one too. Otherwise renaming the type would rewrite every other mention of it and leave these,
      * which is a rename that stops the workspace compiling.
+     *
+     * <p>A name nothing answered to is recorded nowhere. What this collects is what the pass worked
+     * out, and it did not work that one out: the name it carries stands for the absence so that the
+     * traversal can go on past it, and a reader handed that name back would be told a binding is
+     * there under a spelling nothing binds.
      */
     private ValueName answered(WrittenName written, ValueName denotes) {
-        if (written.pos() == null) {
+        if (written.pos() == null || denotes instanceof ValueName.Unresolved) {
             return denotes;
         }
         values0.add(new ValueUse(written, denotes));
@@ -1084,9 +1104,10 @@ public final class Resolve {
     }
 
     /** Records what a name was answered with, and hands it back. A name with no position was
-     * synthesized by an earlier pass rather than written, so there is nothing to point at. */
+     * synthesized by an earlier pass rather than written, so there is nothing to point at, and a
+     * name nothing answered is an absence rather than a declaration to record. */
     private Ast.Name answered(Ast.Name n) {
-        if (n.pos() != null) {
+        if (n.pos() != null && !n.denotes().isUnresolved()) {
             denotations.add(new Denotation(n.name(), n.denotes()));
         }
         return n;

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -20,8 +20,10 @@ import souther.compiler.Reserved;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Says once, for a whole module, what every written type name denotes.
@@ -206,7 +208,18 @@ public final class Resolve {
      * once instead of one per compile, and an editor can still say what the names around it mean.
      */
     public record Resolved(Ast.Module module, ResolutionIndex index,
-                           List<CompileException> unresolved) {}
+                           List<CompileException> unresolved,
+                           Map<String, OfDeclaration> declarations) {}
+
+    /**
+     * What resolving one declaration came to.
+     *
+     * <p>{@code answered} is whether every name written in it was answered — the names met while it
+     * was being read, and no others, so a mistake in the declaration beside it is not one of these.
+     * {@code reaches} is what those names turned out to denote, which is what says whether this
+     * declaration stands on one that has no meaning.
+     */
+    public record OfDeclaration(boolean answered, Set<TypeName> reaches) {}
 
     /** What a binding is called, and the occurrence of that name the author wrote. */
     public record BoundName(WrittenName written) {
@@ -245,8 +258,20 @@ public final class Resolve {
     public static Resolved resolving(Ast.Module m, Symbols symbols, Values values) {
         Resolve r = new Resolve(symbols, values);
         List<Ast.Def> defs = new ArrayList<>();
+        // Which names were answered is settled per declaration: what one of them writes is nothing
+        // the one beside it wrote, and the names met while it was being read are its own.
+        Map<String, OfDeclaration> declarations = new LinkedHashMap<>();
         for (Ast.Def def : m.defs()) {
-            defs.add(r.def(def));
+            int unansweredBefore = r.unresolved.size();
+            int denotedBefore = r.denotations.size();
+            Ast.Def resolved = r.def(def);
+            defs.add(resolved);
+            Set<TypeName> reaches = new LinkedHashSet<>();
+            for (Denotation d : r.denotations.subList(denotedBefore, r.denotations.size())) {
+                reaches.add(d.denotes());
+            }
+            declarations.put(resolved.name(),
+                    new OfDeclaration(r.unresolved.size() == unansweredBefore, Set.copyOf(reaches)));
         }
         List<Ast.BehaviorDef> behaviors = new ArrayList<>();
         for (Ast.BehaviorDef b : m.behaviors()) {
@@ -295,7 +320,7 @@ public final class Resolve {
                         m.pos()),
                 new ResolutionIndex(List.copyOf(r.denotations), List.copyOf(r.values0),
                         Map.copyOf(r.binders)),
-                List.copyOf(r.unresolved));
+                List.copyOf(r.unresolved), Map.copyOf(declarations));
     }
 
     private Ast.FnDef fn(Ast.FnDef f) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -51,19 +51,21 @@ public final class Resolve {
     private final List<Denotation> denotations = new ArrayList<>();
     /** The same, for the names used as values. */
     private final List<ValueUse> values0 = new ArrayList<>();
-    /** Every name it could not answer, as the error it would once have thrown. */
+    /** What it has to say about the names it could not answer, as the errors it would once have
+     * thrown. Not every one of them is in here: some are already reported elsewhere. */
     private final List<CompileException> unresolved = new ArrayList<>();
     /**
-     * How many names it did not answer, which is not the same as how many it reported.
+     * How many names it could not answer, by every route there is.
      *
-     * <p>A name is left unanswered and said nothing about where the reason is somewhere else and
-     * already reported there — a module this compilation has and cannot use exports names that
-     * stand in an importer's scope as identities nothing declares, so the importer is not told a
-     * second time about a file that is fine. That is the same absence as a misspelling and only the
-     * report differs, so whether a declaration's names came out is counted here rather than read off
-     * what was reported while it was being read.
+     * <p>Counted apart from what was said about them, because they are two things. A name is left
+     * unanswered and said nothing about where the reason is somewhere else and already reported
+     * there — a module this compilation has and cannot use has its exported names put in an
+     * importer's scope as identities nothing declares, so the importer is not told a second time
+     * about a file that is fine. That is the same absence as a misspelling; only the report differs.
+     * Whether a declaration's names came out is this, and never how many diagnostics were added
+     * while it was being read.
      */
-    private int unanswered;
+    private int failed;
     /** What each binding this pass gave an identity to is called, and where that is written. */
     private final Map<BindingId, BoundName> binders = new LinkedHashMap<>();
     /** How many bindings each definition has been given, so the next one gets the next number. */
@@ -273,8 +275,7 @@ public final class Resolve {
         // the one beside it wrote, and the names met while it was being read are its own.
         Map<String, OfDeclaration> declarations = new LinkedHashMap<>();
         for (Ast.Def def : m.defs()) {
-            int reportedBefore = r.unresolved.size();
-            int unansweredBefore = r.unanswered;
+            int failedBefore = r.failed;
             int denotedBefore = r.denotations.size();
             Ast.Def resolved = r.def(def);
             defs.add(resolved);
@@ -288,8 +289,7 @@ public final class Resolve {
             // declaration nothing else is holding, and the one the module has is told it has no
             // meaning because of a mistake in the copy below it.
             declarations.putIfAbsent(resolved.name(),
-                    new OfDeclaration(r.unresolved.size() == reportedBefore
-                            && r.unanswered == unansweredBefore, Set.copyOf(reaches)));
+                    new OfDeclaration(r.failed == failedBefore, Set.copyOf(reaches)));
         }
         List<Ast.BehaviorDef> behaviors = new ArrayList<>();
         for (Ast.BehaviorDef b : m.behaviors()) {
@@ -425,7 +425,7 @@ public final class Resolve {
         if (denoted.name() != null && denoted.pos() != null) {
             TypeName names = symbols.resolve(denoted.written());
             if (names != null && names.isUnresolved()) {
-                unanswered++;
+                failed++;
             } else if (names != null) {
                 denotations.add(new Denotation(denoted.written(), names));
             }
@@ -987,7 +987,7 @@ public final class Resolve {
      */
     private ValueName answered(WrittenName written, ValueName denotes) {
         if (denotes instanceof ValueName.Unresolved) {
-            unanswered++;
+            failed++;
             return denotes;
         }
         if (written.pos() == null) {
@@ -1141,6 +1141,7 @@ public final class Resolve {
         try {
             return TypeOps.denoted(ref, symbols);
         } catch (CompileException e) {
+            failed++;
             unresolved.add(e);
             return Type.ERRONEOUS;
         }
@@ -1157,7 +1158,7 @@ public final class Resolve {
      * name nothing answered is an absence rather than a declaration to record. */
     private Ast.Name answered(Ast.Name n) {
         if (n.denotes().isUnresolved()) {
-            unanswered++;
+            failed++;
         } else if (n.pos() != null) {
             denotations.add(new Denotation(n.name(), n.denotes()));
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -85,14 +85,14 @@ public final class TypeChecker {
                                        Ast.Module lowered, Map<String, ReqSig> reqSigs,
                                        Map<String, ReqSig> calleeSigs,
                                        Map<String, Type> recursiveHelperFns,
-                                       Map<String, Ast.FnDef> imported, Set<String> unbuilt) {
+                                       Map<String, Ast.FnDef> imported, Set<String> settled) {
         Elaborated elaborated = new Elaborated();
         List<Unanswerable> abandoned = new ArrayList<>();
         List<CompileException> errors = new ArrayList<>();
         boolean stopped = false;
         try {
             checkRecovering(module, symbols, sigs, importedInjected, lowered, calleeSigs, errors,
-                    elaborated, abandoned, reqSigs, recursiveHelperFns, imported, unbuilt);
+                    elaborated, abandoned, reqSigs, recursiveHelperFns, imported, settled);
         } catch (Unanswerable e) {
             abandoned.add(e);
             stopped = true;
@@ -189,7 +189,7 @@ public final class TypeChecker {
                                         Map<String, ReqSig> reqSigs,
                                         Map<String, Type> recursiveHelperFns,
                                         Map<String, Ast.FnDef> publishedToHere,
-                                        Set<String> unbuilt) {
+                                        Set<String> settled) {
         // Both components, because what reads this walks both: a helper is checked whether the module
         // declared it or took it on to emit, and one missing here is a helper checked against a body
         // it does not have.
@@ -228,7 +228,7 @@ public final class TypeChecker {
         // clauses says so about both. Within one clause the first construction is the answer: naming
         // every one of them tells the author nothing the first does not.
         for (Ast.Def def : module.defs()) {
-            if (unbuilt.contains(def.name())) {
+            if (!settled.contains(def.name())) {
                 continue;
             }
             if (def instanceof Ast.Data data) {
@@ -242,13 +242,14 @@ public final class TypeChecker {
                 }
             }
         }
-        // A declaration whose meaning was not settled is not checked. What such a check would find
-        // is the mistake that stopped it being settled, said again from further down — that the
-        // type it is made of has no decoder, or no fields, or no value — against a line the author
-        // has no reason to look at. It is not that it was reported: the declaration has nothing to
-        // check, because what it is made of is not there.
+        // Only a declaration whose meaning was settled is checked, and `settled` is what says which
+        // those are. What a check over one of the others would find is the mistake that stopped it
+        // being settled, said again from further down — that the type it is made of has no decoder,
+        // or no fields, or no value — against a line the author has no reason to look at. The caller
+        // holds the declarations that have a meaning and hands them over; there is nothing here that
+        // asks why one of the others has none.
         for (Ast.Def def : module.defs()) {
-            if (unbuilt.contains(def.name())) {
+            if (!settled.contains(def.name())) {
                 continue;
             }
             collect(errors, abandoned, () -> {

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -85,14 +85,14 @@ public final class TypeChecker {
                                        Ast.Module lowered, Map<String, ReqSig> reqSigs,
                                        Map<String, ReqSig> calleeSigs,
                                        Map<String, Type> recursiveHelperFns,
-                                       Map<String, Ast.FnDef> imported) {
+                                       Map<String, Ast.FnDef> imported, Set<String> unbuilt) {
         Elaborated elaborated = new Elaborated();
         List<Unanswerable> abandoned = new ArrayList<>();
         List<CompileException> errors = new ArrayList<>();
         boolean stopped = false;
         try {
             checkRecovering(module, symbols, sigs, importedInjected, lowered, calleeSigs, errors,
-                    elaborated, abandoned, reqSigs, recursiveHelperFns, imported);
+                    elaborated, abandoned, reqSigs, recursiveHelperFns, imported, unbuilt);
         } catch (Unanswerable e) {
             abandoned.add(e);
             stopped = true;
@@ -188,7 +188,8 @@ public final class TypeChecker {
                                         Elaborated elaborated, List<Unanswerable> abandoned,
                                         Map<String, ReqSig> reqSigs,
                                         Map<String, Type> recursiveHelperFns,
-                                        Map<String, Ast.FnDef> publishedToHere) {
+                                        Map<String, Ast.FnDef> publishedToHere,
+                                        Set<String> unbuilt) {
         // Both components, because what reads this walks both: a helper is checked whether the module
         // declared it or took it on to emit, and one missing here is a helper checked against a body
         // it does not have.
@@ -227,6 +228,9 @@ public final class TypeChecker {
         // clauses says so about both. Within one clause the first construction is the answer: naming
         // every one of them tells the author nothing the first does not.
         for (Ast.Def def : module.defs()) {
+            if (unbuilt.contains(def.name())) {
+                continue;
+            }
             if (def instanceof Ast.Data data) {
                 for (Ast.InvariantClause clause : data.invariants()) {
                     collect(errors, abandoned, () -> {
@@ -238,7 +242,15 @@ public final class TypeChecker {
                 }
             }
         }
+        // A declaration whose meaning was not settled is not checked. What such a check would find
+        // is the mistake that stopped it being settled, said again from further down — that the
+        // type it is made of has no decoder, or no fields, or no value — against a line the author
+        // has no reason to look at. It is not that it was reported: the declaration has nothing to
+        // check, because what it is made of is not there.
         for (Ast.Def def : module.defs()) {
+            if (unbuilt.contains(def.name())) {
+                continue;
+            }
             collect(errors, abandoned, () -> {
                 switch (def) {
                     case Ast.Data data ->

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -1153,12 +1153,21 @@ public final class Bodies {
             }
             TypeChecker.Reported reported;
             try {
-                Answer<Set<String>> unbuilt = db.ask(new Names.Unbuilt(name));
+                // The declarations that have a meaning to check, asked for one at a time. What has
+                // none is not here and nothing here asks why: a reader of a declaration knows there
+                // is one or there is not, and the reasons belong to the pass that settles them.
+                Set<String> settled = new LinkedHashSet<>();
+                for (Ast.Def def : lowering.value().settled().defs()) {
+                    if (db.ask(new Names.Definition(
+                            new TypeName(name, def.name()))).present()) {
+                        settled.add(def.name());
+                    }
+                }
                 reported = TypeChecker.checkModule(lowering.value().settled(), scope.value(),
                         signatures.present() ? signatures.value() : null,
                         injected.value(), lowering.value().lowered(),
                         reqSigs.value(), calleeSigs.value(), sigs.value(), published.value(),
-                        unbuilt.present() ? unbuilt.value() : Set.of());
+                        settled);
             } catch (CompileException e) {
                 return Answer.absent(e);
             }

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -1153,10 +1153,12 @@ public final class Bodies {
             }
             TypeChecker.Reported reported;
             try {
+                Answer<Set<String>> unbuilt = db.ask(new Names.Unbuilt(name));
                 reported = TypeChecker.checkModule(lowering.value().settled(), scope.value(),
                         signatures.present() ? signatures.value() : null,
                         injected.value(), lowering.value().lowered(),
-                        reqSigs.value(), calleeSigs.value(), sigs.value(), published.value());
+                        reqSigs.value(), calleeSigs.value(), sigs.value(), published.value(),
+                        unbuilt.present() ? unbuilt.value() : Set.of());
             } catch (CompileException e) {
                 return Answer.absent(e);
             }

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -690,6 +690,115 @@ public final class Names {
     }
 
     /**
+     * One declaration as its meaning was settled, or absent where it was not settled.
+     *
+     * <p>The unit a name is answered for is the declaration. A definition is here when every name
+     * written in it was answered and every declaration it reaches has one of these too; otherwise
+     * there is nothing to hand a later pass, and it is not built rather than built around what is
+     * missing.
+     */
+    public record Definition(TypeName named) implements Key<Ast.Def> {
+        @Override
+        public String module() {
+            return named.module();
+        }
+
+        @Override
+        public Answer<Ast.Def> compute(Db db) {
+            Answer<Resolve.Resolved> resolution = db.ask(new Resolution(named.module()));
+            Answer<Set<String>> unbuilt = db.ask(new Unbuilt(named.module()));
+            if (!resolution.present() || !unbuilt.present()
+                    || unbuilt.value().contains(named.name())) {
+                return Answer.absent();
+            }
+            for (Ast.Def def : resolution.value().module().defs()) {
+                if (def.name().equals(named.name())) {
+                    return Answer.of(def);
+                }
+            }
+            return Answer.absent();
+        }
+    }
+
+    /**
+     * The declarations of a module that have no meaning to give.
+     *
+     * <p>Two ways in, and both are about what a declaration is made of rather than about what was
+     * reported. A name written in it was not answered, so what it is made of is not there; or what
+     * it reaches is one of these, so what that is made of is not there either. A module that will
+     * not be emitted for some other reason has declarations that mean what they say, and they are
+     * not in here.
+     *
+     * <p>Asked of a whole module at once because the reaching is a relation among its own
+     * declarations, and following it one declaration at a time would ask a question of itself where
+     * two of them are made of each other. Across modules there is no such loop to close: an import
+     * cycle is settled before this, so a module's declarations reach another's and stop.
+     */
+    public record Unbuilt(String name) implements Key<Set<String>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Set<String>> compute(Db db) {
+            if (cyclic(db, name)) {
+                return Answer.absent();
+            }
+            Answer<Resolve.Resolved> resolution = db.ask(new Resolution(name));
+            if (!resolution.present()) {
+                return Answer.absent();
+            }
+            Map<String, Resolve.OfDeclaration> declarations = resolution.value().declarations();
+            Set<String> unbuilt = new LinkedHashSet<>();
+            Map<String, Set<String>> elsewhere = new LinkedHashMap<>();
+            for (Map.Entry<String, Resolve.OfDeclaration> declared : declarations.entrySet()) {
+                if (!declared.getValue().answered()) {
+                    unbuilt.add(declared.getKey());
+                    continue;
+                }
+                for (TypeName reached : declared.getValue().reaches()) {
+                    if (reached.module().equals(name)) {
+                        continue;
+                    }
+                    Set<String> there = elsewhere.computeIfAbsent(reached.module(),
+                            m -> unbuiltIn(db, m));
+                    if (there.contains(reached.name())) {
+                        unbuilt.add(declared.getKey());
+                        break;
+                    }
+                }
+            }
+            // What reaches one of these has nothing to stand on either, and so has what reaches
+            // that. Held to the declarations of this module, which is where the relation is.
+            boolean more = true;
+            while (more) {
+                more = false;
+                for (Map.Entry<String, Resolve.OfDeclaration> declared : declarations.entrySet()) {
+                    if (unbuilt.contains(declared.getKey())) {
+                        continue;
+                    }
+                    for (TypeName reached : declared.getValue().reaches()) {
+                        if (reached.module().equals(name) && unbuilt.contains(reached.name())) {
+                            unbuilt.add(declared.getKey());
+                            more = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            return Answer.of(Set.copyOf(unbuilt));
+        }
+
+        /** What another module could not build, or nothing where it could not be read — what is
+         * wrong there is reported there, and a name reaching into it is answered by its absence. */
+        private static Set<String> unbuiltIn(Db db, String module) {
+            Answer<Set<String>> there = db.ask(new Unbuilt(module));
+            return there.present() ? there.value() : Set.of();
+        }
+    }
+
+    /**
      * Whether everything the compiler worked out about a module's names came out.
      *
      * <p>One question, asked in one place, so that whether a module may be emitted does not become a

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -733,8 +733,13 @@ public final class Names {
      * declarations, and following it one declaration at a time would ask a question of itself where
      * two of them are made of each other. Across modules there is no such loop to close: an import
      * cycle is settled before this, so a module's declarations reach another's and stop.
+     *
+     * <p>Not part of what a reader outside this file asks. Whether a declaration has a meaning is
+     * {@link Definition}'s to answer and is answered by handing one over or not; a reader that could
+     * ask which ones have none would be a reader deciding for itself what to do about it, which is
+     * how the question of what a name means came to be answered in several places at once.
      */
-    public record Unbuilt(String name) implements Key<Set<String>> {
+    record Unbuilt(String name) implements Key<Set<String>> {
         @Override
         public String module() {
             return name;

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -669,6 +669,27 @@ public final class Names {
     }
 
     /**
+     * What resolution worked out about the names a module writes.
+     *
+     * <p>This is what a reader outside the compiler is answered from, and it is asked for on its
+     * own so that such a reader never holds the tree. The two are not the same artifact and do not
+     * come and go together: a module the compiler will not build on is still a module an editor has
+     * to say things about, and every name that did resolve in it is a name it can be told about.
+     */
+    public record Facts(String name) implements Key<Resolve.ResolutionIndex> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Resolve.ResolutionIndex> compute(Db db) {
+            Answer<Resolve.Resolved> resolution = db.ask(new Resolution(name));
+            return resolution.present() ? Answer.of(resolution.value().index()) : Answer.absent();
+        }
+    }
+
+    /**
      * Whether everything the compiler worked out about a module's names came out.
      *
      * <p>One question, asked in one place, so that whether a module may be emitted does not become a
@@ -861,19 +882,16 @@ public final class Names {
     /** Every name {@code module} writes, paired with what it denotes, or null when the module could
      * not be read. */
     private static Set<Use> usesIn(Db db, String module) {
-        Answer<Resolve.Resolved> resolution = db.ask(new Resolution(module));
+        Answer<Resolve.ResolutionIndex> facts = db.ask(new Facts(module));
         Ast.Module bound = db.ask(new Bound(module)).value();
-        if (!resolution.present() || bound == null) {
+        if (!facts.present() || bound == null) {
             return null;
         }
         Set<Use> used = new HashSet<>();
-        for (Resolve.Denotation d : resolution.value().denotations()) {
-            if (!d.denotes().isUnresolved()) {
-                used.add(new Use(d.written().canonical(), d.denotes().module(),
-                        d.denotes().name()));
-            }
+        for (Resolve.Denotation d : facts.value().types()) {
+            used.add(new Use(d.written().canonical(), d.denotes().module(), d.denotes().name()));
         }
-        for (Resolve.ValueUse v : resolution.value().values()) {
+        for (Resolve.ValueUse v : facts.value().values()) {
             switch (v.denotes()) {
                 case ValueName.Behavior b ->
                         used.add(new Use(v.written().canonical(), b.module(), b.name()));
@@ -984,12 +1002,12 @@ public final class Names {
             if (name == null) {
                 return Answer.absent();
             }
-            Answer<Resolve.Resolved> resolution = db.ask(new Resolution(name));
-            if (!resolution.present()) {
+            Answer<Resolve.ResolutionIndex> facts = db.ask(new Facts(name));
+            if (!facts.present()) {
                 return Answer.absent();
             }
             Resolve.Denotation innermost = null;
-            for (Resolve.Denotation d : resolution.value().denotations()) {
+            for (Resolve.Denotation d : facts.value().types()) {
                 if (!spans(d.written(), at)) {
                     continue;
                 }
@@ -1044,12 +1062,12 @@ public final class Names {
 
         @Override
         public Answer<List<Resolve.Denotation>> compute(Db db) {
-            Answer<Resolve.Resolved> resolution = db.ask(new Resolution(name));
-            if (!resolution.present()) {
+            Answer<Resolve.ResolutionIndex> facts = db.ask(new Facts(name));
+            if (!facts.present()) {
                 return Answer.of(List.of());
             }
             List<Resolve.Denotation> uses = new ArrayList<>();
-            for (Resolve.Denotation d : resolution.value().denotations()) {
+            for (Resolve.Denotation d : facts.value().types()) {
                 if (denoted.equals(d.denotes())) {
                     uses.add(d);
                 }
@@ -1077,11 +1095,11 @@ public final class Names {
             if (name == null) {
                 return Answer.absent();
             }
-            Answer<Resolve.Resolved> resolution = db.ask(new Resolution(name));
-            if (!resolution.present()) {
+            Answer<Resolve.ResolutionIndex> facts = db.ask(new Facts(name));
+            if (!facts.present()) {
                 return Answer.absent();
             }
-            for (Resolve.ValueUse use : resolution.value().values()) {
+            for (Resolve.ValueUse use : facts.value().values()) {
                 if (spans(use.written(), at)) {
                     return Answer.of(use);
                 }
@@ -1105,12 +1123,12 @@ public final class Names {
 
         @Override
         public Answer<List<Resolve.ValueUse>> compute(Db db) {
-            Answer<Resolve.Resolved> resolution = db.ask(new Resolution(name));
-            if (!resolution.present()) {
+            Answer<Resolve.ResolutionIndex> facts = db.ask(new Facts(name));
+            if (!facts.present()) {
                 return Answer.of(List.of());
             }
             List<Resolve.ValueUse> uses = new ArrayList<>();
-            for (Resolve.ValueUse use : resolution.value().values()) {
+            for (Resolve.ValueUse use : facts.value().values()) {
                 if (denoted.equals(use.denotes())) {
                     uses.add(use);
                 }
@@ -1140,11 +1158,11 @@ public final class Names {
             if (name == null) {
                 return Answer.absent();
             }
-            Answer<Resolve.Resolved> resolution = db.ask(new Resolution(name));
-            if (!resolution.present()) {
+            Answer<Resolve.ResolutionIndex> facts = db.ask(new Facts(name));
+            if (!facts.present()) {
                 return Answer.absent();
             }
-            Map<BindingId, Resolve.BoundName> binders = resolution.value().binders();
+            Map<BindingId, Resolve.BoundName> binders = facts.value().binders();
             for (Map.Entry<BindingId, Resolve.BoundName> bound : binders.entrySet()) {
                 Resolve.BoundName written = bound.getValue();
                 if (answerable(bound.getKey(), binders)
@@ -1206,12 +1224,12 @@ public final class Names {
             // a binding is not a position, so where it was written is asked of the pass that
             // answered it rather than read off the name
             if (denoted instanceof ValueName.Local local) {
-                Answer<Resolve.Resolved> resolution =
-                        db.ask(new Resolution(local.id().owner().module()));
-                if (!resolution.present()) {
+                Answer<Resolve.ResolutionIndex> facts =
+                        db.ask(new Facts(local.id().owner().module()));
+                if (!facts.present()) {
                     return Answer.absent();
                 }
-                Resolve.BoundName binder = resolution.value().binders().get(local.id());
+                Resolve.BoundName binder = facts.value().binders().get(local.id());
                 return binder == null ? Answer.absent() : Answer.of(List.of(binder.written()));
             }
             String in = module();

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -269,18 +269,78 @@ public final class Shapes {
         @Override
         public Answer<Ast.Module> compute(Db db) {
             Answer<Ast.Module> derived = db.ask(new Derived(name));
-            if (!derived.present()) {
+            Answer<Map<String, Ast.FnDef>> fns = db.ask(new DesugaredFns(name));
+            if (!derived.present() || !fns.present()) {
                 return Answer.absent();
             }
+            List<Ast.FnDef> out = new ArrayList<>();
+            for (Ast.FnDef fn : derived.value().fns()) {
+                Ast.FnDef came = fns.value().get(fn.name());
+                if (came == null) {
+                    return Answer.absent();
+                }
+                out.add(came);
+            }
+            Ast.Module m = derived.value();
+            return Answer.of(new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(),
+                    m.defs(), m.behaviors(), out, m.takenOn(), m.examples(), m.fakes(),
+                    m.exampleFileTarget(), m.pos()));
+        }
+    }
+
+    /**
+     * A module's definitions by name, each with the newtype constructions written in its body
+     * rewritten to the constructions they are, and only the ones that came out.
+     *
+     * <p>A definition at a time, and every one of them worked out whether or not the one before it
+     * came out. What it reads about the declarations it names is asked for a declaration at a time
+     * too, so a declaration that did not come out leaves the definitions that do not name it with
+     * their answers.
+     */
+    public record DesugaredFns(String name) implements Key<Map<String, Ast.FnDef>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, Ast.FnDef>> compute(Db db) {
+            Answer<Ast.Module> settling = db.ask(new Settling(name));
             Answer<Symbols> scope = Names.symbols(db, name, Names.Stage.DERIVED);
-            if (!scope.present()) {
+            if (!settling.present() || !scope.present()) {
                 return Answer.absent();
             }
-            try {
-                return Answer.of(NewtypeDesugar.rewrite(derived.value(), scope.value()));
-            } catch (CompileException e) {
-                return Answer.absent(e);
+            Map<String, Ast.FnDef> out = new LinkedHashMap<>();
+            List<Report> reports = new ArrayList<>();
+            for (Ast.FnDef fn : settling.value().fns()) {
+                try {
+                    out.put(fn.name(), NewtypeDesugar.rewriteOf(fn, scope.value()));
+                } catch (CompileException e) {
+                    reports.addAll(Report.of(e));
+                }
             }
+            return Answer.of(Map.copyOf(out), reports);
+        }
+    }
+
+    /**
+     * One definition with the newtype constructions in its body rewritten — its own question, so a
+     * reader depends on the definition it named and not on everything defined beside it.
+     */
+    public record DesugaredFn(String module, String fn) implements Key<Ast.FnDef> {
+        @Override
+        public String module() {
+            return module;
+        }
+
+        @Override
+        public Answer<Ast.FnDef> compute(Db db) {
+            Answer<Map<String, Ast.FnDef>> fns = db.ask(new DesugaredFns(module));
+            if (!fns.present()) {
+                return Answer.absent();
+            }
+            Ast.FnDef came = fns.value().get(fn);
+            return came == null ? Answer.absent() : Answer.of(came);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -38,7 +38,12 @@ public final class Shapes {
 
     /**
      * A module with its codecs derived and the invariants of every type it spreads settled into the
-     * spreading declaration.
+     * spreading declaration — the form each declaration is read from, before what one of them wrote
+     * is normalized.
+     *
+     * <p>Not what a later stage reads. This is how {@link DerivedDeclarations} works its answers
+     * out, and a mistake reached here is a mistake in the module rather than in any one
+     * declaration: the derive and the settling read every declaration to answer about each.
      *
      * <p>The two go together because settling reads the spread source through the same symbols the
      * derive produced: an invariant that arrives by spread is part of the declaration from here on,
@@ -49,7 +54,7 @@ public final class Shapes {
      * bodies — and it is the imported module's bodies it reaches, never this one's: what a module
      * imports is read off its resolved form, so nothing here is asked through itself.
      */
-    public record Derived(String name) implements Key<Ast.Module> {
+    record Settling(String name) implements Key<Ast.Module> {
         @Override
         public String module() {
             return name;
@@ -75,15 +80,8 @@ public final class Shapes {
             try {
                 Ast.Module declared = onlyWhatItDeclares(resolved.value());
                 Ast.Module derived = Deriver.derive(declared, scope.value());
-                // The invariants are whole here — spread in, imports substituted, helpers expanded —
-                // and this is where a newtype construction written `金額(500)` becomes the
-                // construction it is. A construction reaching an invariant through a helper is
-                // written in that helper's body, which this module has not desugared yet, so
-                // normalizing here rather than with the bodies is what leaves one spelling for every
-                // check over an invariant to read.
-                return Answer.of(NewtypeDesugar.rewriteInvariants(
-                        HelperInvariants.withSettledInvariants(derived, scope.value(), published),
-                        scope.value()));
+                return Answer.of(
+                        HelperInvariants.withSettledInvariants(derived, scope.value(), published));
             } catch (CompileException e) {
                 return Answer.absent(e);
             }
@@ -180,7 +178,20 @@ public final class Shapes {
         }
     }
 
-    /** A derived module's declarations by name — what every later stage resolves a type against. */
+    /**
+     * A module's declarations by name, each in the form every later stage resolves a type against,
+     * and only the ones that came out.
+     *
+     * <p>This is where a newtype construction written {@code 金額(500)} becomes the construction it
+     * is. A construction reaching an invariant through a helper is written in that helper's body,
+     * which this module has not desugared yet, so normalizing here rather than with the bodies is
+     * what leaves one spelling for every check over an invariant to read.
+     *
+     * <p>A declaration at a time, so what is wrong with one clause is wrong with the declaration
+     * that wrote it. Every declaration is worked out whether or not the one before it came out —
+     * stopping at the first would leave the declarations after it without an answer, and each of
+     * them owns what it has to say.
+     */
     public record DerivedDeclarations(String name) implements Key<Map<String, Ast.Def>> {
         @Override
         public String module() {
@@ -189,8 +200,58 @@ public final class Shapes {
 
         @Override
         public Answer<Map<String, Ast.Def>> compute(Db db) {
-            Answer<Ast.Module> m = db.ask(new Derived(name));
-            return m.present() ? Answer.of(Names.defsOf(m.value())) : Answer.absent();
+            Answer<Ast.Module> settling = db.ask(new Settling(name));
+            Answer<Symbols> scope = Names.symbols(db, name, Names.Stage.RESOLVED);
+            if (!settling.present() || !scope.present()) {
+                return Answer.absent();
+            }
+            Map<String, Ast.Def> out = new LinkedHashMap<>();
+            List<Report> reports = new ArrayList<>();
+            for (Ast.Def def : settling.value().defs()) {
+                try {
+                    out.put(def.name(), NewtypeDesugar.rewriteInvariantsOf(def, scope.value()));
+                } catch (CompileException e) {
+                    reports.addAll(Report.of(e));
+                }
+            }
+            return Answer.of(Map.copyOf(out), reports);
+        }
+    }
+
+    /**
+     * The module every later stage reads, where every declaration in it came out.
+     *
+     * <p>An assembly and not a stage of its own: each declaration is answered on its own and says
+     * what it has to say there, and this is the conjunction of those answers. One that did not come
+     * out leaves no module to hand over — a module missing a declaration it writes would be read as
+     * one that does not declare it, which is a different thing to say and not a true one — while the
+     * declarations beside it keep the answers they have.
+     */
+    public record Derived(String name) implements Key<Ast.Module> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Ast.Module> compute(Db db) {
+            Answer<Ast.Module> settling = db.ask(new Settling(name));
+            Answer<Map<String, Ast.Def>> declarations = db.ask(new DerivedDeclarations(name));
+            if (!settling.present() || !declarations.present()) {
+                return Answer.absent();
+            }
+            List<Ast.Def> defs = new ArrayList<>();
+            for (Ast.Def def : settling.value().defs()) {
+                Ast.Def came = declarations.value().get(def.name());
+                if (came == null) {
+                    return Answer.absent();
+                }
+                defs.add(came);
+            }
+            Ast.Module m = settling.value();
+            return Answer.of(new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(),
+                    defs, m.behaviors(), m.fns(), m.takenOn(), m.examples(), m.fakes(),
+                    m.exampleFileTarget(), m.pos()));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -157,9 +157,10 @@ public final class Shapes {
      * One declaration with its codecs derived and its spreads settled — what every later stage
      * resolves a type to.
      *
-     * <p>Its own question, so a reader depends on the declaration it named and not on everything
-     * declared beside it. A module still derives its declarations together; that is how the answer
-     * is worked out, not what the answer is about, and moving that apart changes nothing here.
+     * <p>Its own question, so its failure is the named declaration's and not the ones beside it: a
+     * clause that cannot be read costs the declaration that wrote it this answer and costs the rest
+     * nothing. A module still derives its declarations together, and this is read through that, so
+     * what it depends on is still the module — what it is about is the one declaration.
      */
     public record DerivedDef(TypeName named) implements Key<Ast.Def> {
         @Override
@@ -324,8 +325,10 @@ public final class Shapes {
     }
 
     /**
-     * One definition with the newtype constructions in its body rewritten — its own question, so a
-     * reader depends on the definition it named and not on everything defined beside it.
+     * One definition with the newtype constructions in its body rewritten — its own question, so
+     * its failure is the named definition's and not the ones beside it. It is read through
+     * {@link DesugaredFns}, which works every definition out, so what it depends on is still the
+     * module; what it is about is the one definition.
      */
     public record DesugaredFn(String module, String fn) implements Key<Ast.FnDef> {
         @Override

--- a/souther-compiler/src/test/java/souther/compiler/query/ADeclarationThatDoesNotComeOutDoesNotTakeItsSiblingsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ADeclarationThatDoesNotComeOutDoesNotTakeItsSiblingsTest.java
@@ -1,0 +1,78 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.diag.Located;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.types.TypeName;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a declaration comes to is answered for that declaration.
+ *
+ * <p>{@link Shapes.DerivedDef} says of itself that a reader depends on the declaration it named and
+ * not on everything declared beside it. The work behind it was a module at a time all the same, and
+ * one clause that could not be read took the answer away from every declaration in the file — a
+ * reader asking about a type written above the mistake, and reaching nothing to do with it, was told
+ * there is no such type.
+ *
+ * <p>So the failure is owned where it happened. The declaration that wrote the clause has no
+ * answer; the ones beside it have theirs. The module is assembled from all of them and is there only
+ * when each one is, which is a different question and is asked once.
+ */
+class ADeclarationThatDoesNotComeOutDoesNotTakeItsSiblingsTest {
+
+    /** `Bad` applies a newtype to two values, which is not something a newtype wraps. */
+    private static final String SOURCE = """
+            module m.a exposing ( Amount, Bad, Note )
+
+            data Amount = Int
+
+            data Bad = Int
+                invariant ok = Amount(value, value) > 0
+
+            data Note = { text: String }
+            """;
+
+    private static Compilation compiled() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("a.sou", SOURCE);
+        return Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+    }
+
+    private static boolean derived(Compilation c, String declared) {
+        return c.db().ask(new Shapes.DerivedDef(new TypeName("m.a", declared))).present();
+    }
+
+    @Test
+    void theDeclarationWithTheMistakeHasNoAnswerAndTheOthersHaveTheirs() {
+        Compilation c = compiled();
+
+        assertFalse(derived(c, "Bad"), "the clause it wrote cannot be read");
+        assertTrue(derived(c, "Amount"), "which is nothing to do with what `Amount` is");
+        assertTrue(derived(c, "Note"), "nor with what `Note` is");
+    }
+
+    /** And the module, which is every one of them, is not there. */
+    @Test
+    void theModuleIsNotAssembledWhileOneOfItsDeclarationsIsMissing() {
+        assertFalse(compiled().db().ask(new Shapes.Derived("m.a")).present());
+    }
+
+    /** The mistake is said once, where it is written. */
+    @Test
+    void theOneMistakeIsSaidOnce() {
+        List<String> said = Located.diagnosticsOf(compiled().diagnostics()).get("a.sou").stream()
+                .map(d -> d.code() + " " + d.said()).toList();
+
+        assertEquals(1, said.size(), said.toString());
+        assertTrue(said.get(0).startsWith("E1802"), said.toString());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ADeclarationWrittenTwiceIsAnsweredForByTheOneTheModuleHasTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ADeclarationWrittenTwiceIsAnsweredForByTheOneTheModuleHasTest.java
@@ -1,0 +1,47 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.types.TypeName;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Where a name is written twice, whether the declaration came out is asked of the one the module
+ * has.
+ *
+ * <p>A name written twice is one declaration and one mistake: the first is what the module
+ * declares and the second is reported and left out, which is settled once and read from there by
+ * every stage. Whether a declaration came out has to be settled for the same one — read off the
+ * second, it answers about a declaration nothing else in the compiler is holding, and the module
+ * that does declare a perfectly good `A` is told it has no meaning.
+ */
+class ADeclarationWrittenTwiceIsAnsweredForByTheOneTheModuleHasTest {
+
+    private static Compilation compiled(String source) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("a.sou", source);
+        return Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+    }
+
+    private static boolean has(Compilation c, String declared) {
+        return c.db().ask(new Names.Definition(new TypeName("m.a", declared))).present();
+    }
+
+    /** The second `A` names nothing; the first, which is the one the module has, is made of `Int`. */
+    @Test
+    void theDeclarationTheModuleHasKeepsItsMeaningWhateverTheRejectedOneIsMadeOf() {
+        Compilation c = compiled("""
+                module m.a exposing ( A )
+
+                data A = { value: Int }
+                data A = { value: Nowhere }
+                """);
+
+        assertTrue(has(c, "A"), "what `m.a` declares as `A` is made of `Int`");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ADefinitionReachingOneThatWasNotBuiltIsNotBuiltTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ADefinitionReachingOneThatWasNotBuiltIsNotBuiltTest.java
@@ -1,13 +1,16 @@
 package souther.compiler.query;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.diag.Located;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.types.TypeName;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -66,6 +69,26 @@ class ADefinitionReachingOneThatWasNotBuiltIsNotBuiltTest {
 
         assertFalse(has(c, "Late"), "`Nowhere` was not answered");
         assertFalse(has(c, "Early"), "which the declaration above it is made of");
+    }
+
+    /**
+     * And nothing is said about one of these a second time. The author has one mistake and is told
+     * about it once; a report against the declaration that merely reaches it sends them to a line
+     * that is correct — here, that `Order` has no decoder, which is not a second mistake but the
+     * first one said again from further downstream.
+     */
+    @Test
+    void theOneMistakeIsReportedOnceAndNotAgainstWhatReachesIt() {
+        Compilation c = compiled("""
+                module m.a exposing ( Order, Line )
+
+                data Order = { total: Nowhere }
+                data Line = { order: Order }
+                """);
+        List<String> said = Located.diagnosticsOf(c.diagnostics()).get("a.sou").stream()
+                .map(d -> d.code() + " " + d.said()).toList();
+
+        assertEquals(1, said.size(), "the unknown name, and nothing about `Line`: " + said);
     }
 
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/ADefinitionReachingOneThatWasNotBuiltIsNotBuiltTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ADefinitionReachingOneThatWasNotBuiltIsNotBuiltTest.java
@@ -1,0 +1,71 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.types.TypeName;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A definition exists where its meaning was settled, and the unit that is settled is the
+ * declaration.
+ *
+ * <p>Two ways there is none. A name written in it was not answered, so what it is made of is not
+ * there; or what it reaches has no meaning, so what it is made of is not there either. The second
+ * is not "a diagnostic was reported upstream" and not "the module will not be emitted" — either of
+ * those would put the question of what a name means back in the hands of a later check. It is that
+ * the declaration this one reaches did not come out, which is a fact about the declaration and is
+ * settled where the declaration is.
+ *
+ * <p>The declaration beside them is untouched. Taking a whole module away over one unknown name
+ * would take away every answer the compiler had about the rest of it, and an author fixing a
+ * misspelt type would be told about the next mistake only after the compile that follows.
+ */
+class ADefinitionReachingOneThatWasNotBuiltIsNotBuiltTest {
+
+    private static Compilation compiled(String source) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("a.sou", source);
+        return Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+    }
+
+    private static boolean has(Compilation c, String declared) {
+        return c.db().ask(new Names.Definition(new TypeName("m.a", declared))).present();
+    }
+
+    /** `Line` reaches `Order`, which names nothing. */
+    @Test
+    void aDeclarationReachingAnUnbuiltOneIsNotBuiltAndTheIndependentOneIs() {
+        Compilation c = compiled("""
+                module m.a exposing ( Order, Line, Note )
+
+                data Order = { total: Nowhere }
+                data Line = { order: Order }
+                data Note = { text: String }
+                """);
+
+        assertFalse(has(c, "Order"), "`Nowhere` was not answered");
+        assertFalse(has(c, "Line"), "what `Line` is made of has no meaning, so neither has `Line`");
+        assertTrue(has(c, "Note"), "and a declaration reaching neither is untouched");
+    }
+
+    /** The same where what is reached is written after what reaches it. */
+    @Test
+    void whereTheUnbuiltDeclarationIsWrittenLaterItStillTakesTheOneThatReachesIt() {
+        Compilation c = compiled("""
+                module m.a exposing ( Early, Late )
+
+                data Early = { o: Late }
+                data Late = { x: Nowhere }
+                """);
+
+        assertFalse(has(c, "Late"), "`Nowhere` was not answered");
+        assertFalse(has(c, "Early"), "which the declaration above it is made of");
+    }
+
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ADefinitionThatDoesNotDesugarDoesNotTakeItsSiblingsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ADefinitionThatDoesNotDesugarDoesNotTakeItsSiblingsTest.java
@@ -1,0 +1,57 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.meta.ModulePath;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a definition's body comes to is answered for that definition.
+ *
+ * <p>The same proposition as {@link ADeclarationThatDoesNotComeOutDoesNotTakeItsSiblingsTest}, one
+ * stage down and about a different unit: a declaration is what the stage above answers for, and a
+ * definition is what this one answers for. An application that wraps no single value is wrong in the
+ * body that wrote it, and the definition beside it is written about something else.
+ */
+class ADefinitionThatDoesNotDesugarDoesNotTakeItsSiblingsTest {
+
+    /** `f` applies a newtype to two values; `g` is written about nothing to do with it. */
+    private static final String SOURCE = """
+            module m.a exposing ( Amount, f, g )
+
+            data Amount = Int
+
+            behavior f : (n: Int) -> Int
+            let f (n) = Amount(n, n).value
+
+            behavior g : (n: Int) -> Int
+            let g (n) = n
+            """;
+
+    private static Compilation compiled() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("a.sou", SOURCE);
+        return Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+    }
+
+    @Test
+    void theDefinitionWithTheMistakeHasNoAnswerAndTheOneBesideItHasOne() {
+        Compilation c = compiled();
+
+        assertFalse(c.db().ask(new Shapes.DesugaredFn("m.a", "f")).present(),
+                "what `f` wrote is not an application of a newtype");
+        assertTrue(c.db().ask(new Shapes.DesugaredFn("m.a", "g")).present(),
+                "which is nothing to do with what `g` is");
+    }
+
+    /** And the module, which is every one of them, is not there. */
+    @Test
+    void theModuleIsNotAssembledWhileOneOfItsDefinitionsIsMissing() {
+        assertFalse(compiled().db().ask(new Shapes.Desugared("m.a")).present());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ANameLeftUnansweredCountsWhetherOrNotItWasReportedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ANameLeftUnansweredCountsWhetherOrNotItWasReportedTest.java
@@ -1,0 +1,64 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.types.TypeName;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A declaration has a meaning where its names were answered, and not where they merely went
+ * unreported.
+ *
+ * <p>Some names are left unanswered on purpose and said nothing about. A module this compilation
+ * has and cannot use is one: what is wrong with it is reported on its own source, and a name it was
+ * to have exported stands in the importer's scope as an identity nothing declares, so the importer
+ * is not told a second time about a file that is fine.
+ *
+ * <p>That is an absence, and it is the same absence as a misspelling — it is only the report that
+ * differs. Reading "was anything reported while this declaration was being read" as "were its names
+ * answered" makes the two come apart, and the declaration made of a name nothing answered is handed
+ * to the stages below as one that has a meaning.
+ */
+class ANameLeftUnansweredCountsWhetherOrNotItWasReportedTest {
+
+    /** Takes a name the compiler ships, which no source may — so the module is here and unusable. */
+    private static final String RESERVED = """
+            module souther.evil exposing ( X )
+
+            data X = Int
+            """;
+
+    private static final String IMPORTER = """
+            module app.main exposing ( A, Note )
+
+            import souther.evil ( X )
+
+            data A = { x: X }
+            data Note = { text: String }
+            """;
+
+    private static Compilation compiled() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("evil.sou", RESERVED);
+        byId.put("main.sou", IMPORTER);
+        return Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+    }
+
+    private static boolean has(Compilation c, String declared) {
+        return c.db().ask(new Names.Definition(new TypeName("app.main", declared))).present();
+    }
+
+    @Test
+    void aDeclarationMadeOfANameNothingAnsweredHasNoMeaningEvenWhereNothingWasSaid() {
+        Compilation c = compiled();
+
+        assertFalse(has(c, "A"), "`X` was not answered, whatever was or was not reported about it");
+        assertTrue(has(c, "Note"), "and a declaration reaching neither is untouched");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/AnEditorIsNotToldAnIdentityNothingResolvedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnEditorIsNotToldAnIdentityNothingResolvedTest.java
@@ -1,0 +1,100 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.types.TypeName;
+import souther.compiler.types.ValueName;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * A name nothing answered is a name the editor has no answer for.
+ *
+ * <p>What resolution worked out is what an editor is told, and a name that denotes nothing is not
+ * something it worked out. Standing an identity in for the absence — a {@code TypeName} of a
+ * declaration nobody wrote, a {@code ValueName} nothing binds — makes the reader's question come
+ * back answered, so go-to-definition, find-references and rename each act on a declaration that is
+ * not there. Absence is the answer, and a reader that has none falls back to what it can say
+ * honestly.
+ *
+ * <p>Each absence is asserted beside a name written in the same form that did resolve, and both in
+ * one test. Held apart, the absence would be the answer a compilation that recorded nothing at all
+ * gives — a reader with no facts to consult says nothing either — and the proposition here is the
+ * other one: the facts are there, they say what the pass worked out, and they say nothing about
+ * what it did not.
+ */
+class AnEditorIsNotToldAnIdentityNothingResolvedTest {
+
+    private static final String ID = "m.sou";
+
+    /** `D` is written at column 15 and `Nowhere` at column 21. */
+    private static final String TYPES = """
+            module m
+
+            data D = { v: Int }
+            data E = { v: D, w: Nowhere }
+            """;
+
+    /** `A` is written at column 16 and `Nowhere` at column 19. */
+    private static final String CONSTRUCTS = """
+            module m exposing ( A, f )
+
+            data A = { n: Int }
+
+            behavior f : (n: Int) -> A
+                constructs A, Nowhere
+            let f (n) = A { n = n }
+            """;
+
+    /** The binder `n` is at column 8 and `nowhere` at column 13. */
+    private static final String VALUES = """
+            module m exposing ( f )
+
+            behavior f : (n: Int) -> Int
+            let f (n) = nowhere
+            """;
+
+    private static Object under(String source, Key<?> key) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put(ID, source);
+        return Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY).db().ask(key).value();
+    }
+
+    private static TypeName typeAt(int line, int column) {
+        return (TypeName) under(TYPES, new Names.TypeAt(new SourcePos(line, column, ID)));
+    }
+
+    private static ValueName valueAt(int line, int column) {
+        return (ValueName) under(VALUES, new Names.ValueAt(new SourcePos(line, column, ID)));
+    }
+
+    /** Both names are written in one field list, so what separates them is what they name. */
+    @Test
+    void aFieldTypeIsAnsweredAndOneNamingNothingIsNot() {
+        assertEquals(new TypeName("m", "D"), typeAt(4, 15));
+        assertNull(typeAt(4, 21), "no declaration is named `Nowhere`, so the field's type is none");
+    }
+
+    /** Both names are written in one {@code constructs} clause. */
+    @Test
+    void aClauseEntryIsAnsweredAndOneNamingNothingIsNot() {
+        assertEquals(new TypeName("m", "A"),
+                (TypeName) under(CONSTRUCTS, new Names.TypeAt(new SourcePos(6, 16, ID))));
+        assertNull((TypeName) under(CONSTRUCTS, new Names.TypeAt(new SourcePos(6, 19, ID))),
+                "no declaration is named `Nowhere`, so the clause names none");
+    }
+
+    /** Both names are written in one definition, one as its binder and one in its body. */
+    @Test
+    void aBinderIsAnsweredAndANameNothingBindsIsNot() {
+        assertInstanceOf(ValueName.Local.class, valueAt(4, 8));
+        assertNull(valueAt(4, 13), "nothing binds `nowhere`, so the cursor is on no value");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
@@ -389,7 +389,7 @@ class ResolvedValueNamesTest {
         Map<String, String> byId = new LinkedHashMap<>();
         byId.put("a.sou", source);
         Compilation c = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
-        for (Resolve.ValueUse use : c.db().ask(new Names.Resolution("m.a")).value().values()) {
+        for (Resolve.ValueUse use : c.db().ask(new Names.Facts("m.a")).value().values()) {
             if (use.written().canonical().equals(written)
                     && use.denotes() instanceof ValueName.Local local) {
                 return c.db().ask(new Names.ValueDeclaredAt(local)).value();

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -993,7 +993,7 @@ public final class Analyzer {
      */
     private boolean resolves(Compilation compilation, String uri) {
         String module = compilation.moduleOf(uri);
-        return module != null && compilation.db().ask(new Names.Resolution(module)).present();
+        return module != null && compilation.db().ask(new Names.Facts(module)).present();
     }
 
     /** Where a type is declared, as the compiler answers it. */


### PR DESCRIPTION
`Resolve` states an invariant its consumers keep for themselves, and #464, #696 and #700 were
consumers keeping it wrong. Measuring that turned up a second thing of the same shape, in a place
the issue does not mention: what a pass could not do to one definition was recorded as the absence
of the whole module, and every stage below read that absence as a fact about every definition in
the file.

Three of them, each measured:

- `data Order = { total: Nowhere }` beside `data Line = { order: Order }` reported the unknown name
  and then, from further down, that `Order` has no decoder — one mistake, two reports, the second
  against a line the author has no reason to look at.
- One invariant writing `Amount(value, value)` left `Note`, which has nothing to do with it, with no
  derived form for anything downstream to read.
- One body writing the same thing left the module undesugared, so nothing was checked and a
  behavior written about something else lost the type error the compiler had found in it.

## What changed

**What resolution worked out is its own artifact.** `Resolve.ResolutionIndex` holds the type
occurrences, the value occurrences and the binders, and it is partial: an occurrence the pass
answered is in it, one it did not is in none of them. It used to record the identity the traversal
carries past a mistake — a cursor on `Nowhere` was answered with a declaration called
`souther.unresolved.Nowhere`, and one on a name nothing binds with a binding of that spelling, so
go-to-definition, find-references and rename each acted on a declaration that is not there.
`Names.Facts` is where it is asked for, and every reader outside the compiler asks that rather than
the type that carries the module.

**Whether a declaration came out is settled per declaration.** `Names.Unbuilt` settles the two ways
one has no meaning — a name in it was not answered, or what it reaches has none — and neither is
"something was reported upstream" nor "the module will not be emitted", either of which would put
what a name means back in the hands of a later check. `Names.Definition` hands over the ones that
came out. The check over a declaration is handed those and asks nothing about the others.

**A stage answers for the unit it is about.** Deriving, settling and normalizing ran over a module
inside one `try`; normalizing is now a declaration at a time and desugaring a definition at a time,
each owning what it has to say. `Shapes.Derived` and `Shapes.Desugared` are assemblies of those
answers: every one asked for, and a module handed over when each is there.

## What this is not

Removing the failed declaration from the module was tried first, and is what the third commit
records. Read as a module that does not declare it, `exposing ( Order )` became an export of an
imported name and said so, and the definitions beside it lost the answers the compiler had about
them. What a module declares is a question about what is written in it; whether a declaration came
out is another question, and the two are asked of different things throughout.

## Not in scope

The middle of the pipeline — `Prepared` through `CheckedBehavior` — still funnels through a complete
module, so a definition that does not desugar still costs its siblings their check. Moving it needs a
behavior-local environment built from what each behavior reaches, which is one indivisible change
across eleven queries and rests on six equivalences that have to be measured rather than assumed:
`HelperInliner.recursiveHelpers()` mixes the graph's answer with `takenOnRecursive`, which is read
off every body in the module, so handing that band the definitions that came out would silently
change which helpers are recursive. The sentinels themselves — `TypeName.unresolved`,
`ValueName.Unresolved`, `Names.Nameless` — are removed once nothing reads them.

Refs #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)