### PR TITLE
Make the pass boundary a type, so a consumer cannot ask whether a name has been resolved

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -175,21 +175,29 @@ public interface Ast {
      * one name too, so neither says what the author typed. A report asks {@link WrittenName#quoted()}
      * and underlines {@link WrittenName#region()}.
      */
-    record Name(WrittenName name, TypeName denotes) implements Ast {
+    sealed interface Name extends Ast permits Name.Written, Name.Denoting, Name.Unanswered {
+
+        /** The name, and the occurrence of it that was read. */
+        WrittenName name();
 
         /** A name as the parser read it, before the resolve pass has said what it denotes. Only the
          * parser writes one: every other producer knows what it means and says so. The spelling is
          * the source's, not one a caller canonicalized on the way in — {@link WrittenName} is what
          * canonicalizes, so the name and the characters it was written with stay one value. */
-        public static Name written(String spelling, SourcePos pos) {
-            return new Name(WrittenName.of(spelling, pos), null);
+        static Name written(String spelling, SourcePos pos) {
+            return new Written(WrittenName.of(spelling, pos));
+        }
+
+        /** The same, off an occurrence the parser has already read. */
+        static Name written(WrittenName name) {
+            return new Written(name);
         }
 
         /** A name a pass synthesized, already knowing what it denotes. It is written nowhere;
          * {@code pos} is what a complaint about it points at. The spelling is the declaration's own,
          * which is what a reference internal to a module reaches it by. */
-        public static Name resolved(TypeName denotes, SourcePos pos) {
-            return new Name(WrittenName.synthetic(denotes.name(), pos), denotes);
+        static Name resolved(TypeName denotes, SourcePos pos) {
+            return new Denoting(WrittenName.synthetic(denotes.name(), pos), denotes);
         }
 
         /**
@@ -199,28 +207,98 @@ public interface Ast {
          * every module writes, so a name synthesized with it quotes a spelling the reader cannot
          * write. What it denotes is the same either way.
          */
-        public static Name reached(TypeReachName.Written type, SourcePos pos) {
-            return new Name(WrittenName.synthetic(type.rendered(), pos), type.denotes());
+        static Name reached(TypeReachName.Written type, SourcePos pos) {
+            return new Denoting(WrittenName.synthetic(type.rendered(), pos), type.denotes());
         }
 
         /** The bare name this reaches its declaration by, whatever the source spelled. */
-        public String written() {
-            return name.canonical();
+        default String written() {
+            return name().canonical();
         }
 
         /** Where the name is written, or where a synthesized one is anchored. */
-        public SourcePos pos() {
-            return name.pos();
+        default SourcePos pos() {
+            return name().pos();
+        }
+
+        /**
+         * The declaration this names, for a reader that is asking which one it is.
+         *
+         * <p>A name still {@link Written} here is a pass reading it before resolution answered it,
+         * and an {@link Unanswered} one is a name resolution read and found nothing for — whose
+         * declaration {@code Names.Unbuilt} settles, so nothing downstream of that is handed one.
+         * Either is a fault in the compiler rather than in the source, so both are refused. This is
+         * the one place that says so.
+         */
+        default TypeName denotes() {
+            if (this instanceof Denoting denoting) {
+                return denoting.type();
+            }
+            throw new IllegalStateException("`" + written() + "` at " + pos()
+                    + (this instanceof Unanswered
+                            ? " denotes nothing and was read as though it did"
+                            : " was read as a declaration before it was resolved"));
         }
 
         /** The same name, resolved to what it denotes. */
-        public Name denoting(TypeName resolved) {
-            return new Name(name, resolved);
+        default Name denoting(TypeName resolved) {
+            return new Denoting(name(), resolved);
         }
 
-        @Override
-        public String toString() {
-            return written();
+        /** The same name, read and found to name nothing. */
+        default Name unanswered() {
+            return new Unanswered(name());
+        }
+
+        /** A name as the parser read it. */
+        record Written(WrittenName name) implements Name {
+
+            @Override
+            public String toString() {
+                return written();
+            }
+        }
+
+        /**
+         * A name resolution answered, and the declaration it names.
+         *
+         * <p>The declaration is one that is there. A name nothing declares is {@link Unanswered},
+         * which is a different type — so "this has been resolved" and "this names something" are
+         * not two readings of one value, which is what a stand-in identity made them.
+         */
+        record Denoting(WrittenName name, TypeName type) implements Name {
+
+            public Denoting {
+                if (type == null) {
+                    throw new IllegalArgumentException("a name that denotes names a declaration: "
+                            + name);
+                }
+                if (type.isUnresolved()) {
+                    throw new IllegalArgumentException("`" + name.canonical()
+                            + "` denotes nothing, and a name that denotes nothing is Unanswered");
+                }
+            }
+
+            @Override
+            public String toString() {
+                return written();
+            }
+        }
+
+        /**
+         * A name resolution read and found no declaration for.
+         *
+         * <p>Reported where it is written, and the declaration it is in has no meaning to work out
+         * — which {@code Names.Unbuilt} is what settles, so the rest of the module goes on being
+         * answered. Not {@link Written}: that one is a name nothing has looked at yet, and the two
+         * were one value for as long as a missing identity stood for both.
+         */
+        record Unanswered(WrittenName name) implements Name {
+
+            @Override
+            public String toString() {
+                return written();
+            }
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -726,46 +726,46 @@ public interface Ast {
      * reuses {@code tupleElems} to carry its key type (a single element) while {@code name} is
      * {@code "Map"} and {@code arg} is the value type (ADR-0040).
      *
-     * <p>{@code denotes} is the type the reference stands for, decided once by {@code Resolve}
-     * (issue #177). Every reference the pass let through carries one, so nothing downstream resolves
-     * a written type a second time — nor has to know which module the reference was written in, which
-     * is what a second resolution needed to get right.
+     * <p>The two forms are the two states a reference is in, as {@link Binder}'s are. The parser
+     * writes {@link Written}, which is the spelling and the shape around it; {@code Resolve} answers
+     * it with {@link Denoting}, which carries the type it stands for. There is no third state and no
+     * absent type: a reference that stands for a type and one that has not been read are different
+     * types, so nothing downstream tests for a missing one.
+     *
+     * <p>The type is decided once (issue #177), which is what keeps a later reader from resolving a
+     * written type a second time — and from having to know which module the reference was written
+     * in, which is what a second resolution needed to get right.
      */
-    record TypeRef(WrittenName written, TypeTerm arg, List<TypeTerm> tupleElems, Type denotes,
-                   SourcePos anchor) implements TypeTerm {
+    sealed interface TypeRef extends TypeTerm permits TypeRef.Written, TypeRef.Denoting {
+
+        /** The name as it is spelled, or null where the reference names none — a tuple, or a type a
+         * pass settled and left no surface for. */
+        WrittenName written();
+
+        /** The single type argument, as {@code List<T>} has. */
+        TypeTerm arg();
+
+        /** A tuple's elements, or the single key type a {@code Map} carries (ADR-0040). */
+        List<TypeTerm> tupleElems();
+
+        /** Where a reference with no name to start at begins. */
+        SourcePos anchor();
 
         /** A reference the source wrote, read off the characters that spell it. */
-        public TypeRef(WrittenName written, TypeTerm arg, List<TypeTerm> tupleElems) {
-            this(written, arg, tupleElems, null, null);
+        static TypeRef written(WrittenName written, TypeTerm arg, List<TypeTerm> tupleElems) {
+            return new Written(written, arg, tupleElems, null);
         }
 
-        /** A reference a pass wrote, named but written nowhere — {@code T?} becoming
-         * {@code Option<T>}, a {@code Map} carrying its key. */
-        public TypeRef(String name, TypeTerm arg, List<TypeTerm> tupleElems, SourcePos pos) {
-            this(name == null ? null : WrittenName.synthetic(name, pos), arg, tupleElems, null, pos);
+        /** A reference a pass wrote before resolution runs, named but written nowhere — {@code T?}
+         * becoming {@code Option<T>}, a {@code Map} carrying its key. */
+        static TypeRef written(String name, TypeTerm arg, List<TypeTerm> tupleElems, SourcePos pos) {
+            return new Written(name == null ? null : WrittenName.synthetic(name, pos), arg,
+                    tupleElems, pos);
         }
 
-        /** An ordinary (non-tuple) reference a pass wrote. */
-        public TypeRef(String name, TypeTerm arg, SourcePos pos) {
-            this(name, arg, null, pos);
-        }
-
-        /** The name this reference stands for, or null where it names none — a tuple, or a type a
-         * pass settled and left no surface for. */
-        public String name() {
-            return written == null ? null : written.canonical();
-        }
-
-        /** Where the reference starts. A named one starts where its name does; {@code anchor} is
-         * for the ones that have no name to start at, which is why it is not asked otherwise: two
-         * places for one reference is two places that can disagree. */
-        public SourcePos pos() {
-            return written == null ? anchor : written.pos();
-        }
-
-        /** The same reference, resolved. */
-        public TypeRef denoting(Type type) {
-            return new TypeRef(written, arg, tupleElems, type, anchor);
+        /** An ordinary (non-tuple) reference a pass wrote before resolution runs. */
+        static TypeRef written(String name, TypeTerm arg, SourcePos pos) {
+            return written(name, arg, null, pos);
         }
 
         /**
@@ -774,14 +774,73 @@ public interface Ast {
          * decided, and there is no source it stands for. Everything downstream of {@code Resolve}
          * reads {@link #denotes()}, so a reference with a decided type is as good as a written one.
          */
-        public static TypeRef of(Type type, SourcePos pos) {
-            return new TypeRef((WrittenName) null, null, null, type, pos);
+        static TypeRef of(Type type, SourcePos pos) {
+            return new Denoting(null, null, null, type, pos);
+        }
+
+        /** The name this reference stands for, or null where it names none. */
+        default String name() {
+            return written() == null ? null : written().canonical();
+        }
+
+        /** Where the reference starts. A named one starts where its name does; {@code anchor} is
+         * for the ones that have no name to start at, which is why it is not asked otherwise: two
+         * places for one reference is two places that can disagree. */
+        default SourcePos pos() {
+            return written() == null ? anchor() : written().pos();
         }
 
         /** A tuple type is the nameless form; a named ref that also carries {@code tupleElems}
          *  (a {@code Map} carrying its key) is not a tuple. */
-        public boolean isTuple() {
-            return written == null && tupleElems != null;
+        default boolean isTuple() {
+            return written() == null && tupleElems() != null;
+        }
+
+        /**
+         * The type this stands for, for a reader that is asking what it is.
+         *
+         * <p>A reference still {@link Written} here is a pass reading a type it was handed before
+         * resolution answered it, which is a fault in the compiler rather than in the source, so it
+         * is refused outright. This is the one place that says so.
+         */
+        default Type denotes() {
+            if (this instanceof Denoting denoting) {
+                return denoting.type();
+            }
+            throw new IllegalStateException("`" + name() + "` at " + pos()
+                    + " was read as a type before it was resolved");
+        }
+
+        /** The same reference, resolved. */
+        default TypeRef denoting(Type type) {
+            return new Denoting(written(), arg(), tupleElems(), type, anchor());
+        }
+
+        /** A reference as the parser read it. */
+        record Written(WrittenName written, TypeTerm arg, List<TypeTerm> tupleElems,
+                       SourcePos anchor) implements TypeRef {
+
+            @Override
+            public String toString() {
+                return name() == null ? "(tuple)" : name();
+            }
+        }
+
+        /** A reference resolution answered, and the type it stands for. */
+        record Denoting(WrittenName written, TypeTerm arg, List<TypeTerm> tupleElems, Type type,
+                        SourcePos anchor) implements TypeRef {
+
+            public Denoting {
+                if (type == null) {
+                    throw new IllegalArgumentException(
+                            "a reference that denotes is a type: " + written);
+                }
+            }
+
+            @Override
+            public String toString() {
+                return name() == null ? String.valueOf(type) : name();
+            }
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -168,9 +168,11 @@ public interface Ast {
      * runs; every name-bearing position in this tree carries one of these, so no later pass decides
      * for itself what a spelling means or whether a qualified one is allowed here (issue #177).
      *
-     * <p>A check reads {@link #denotes()}, which is set on every name the resolve pass let through —
-     * a name that denotes nothing is reported there and the compile stops, so nothing downstream sees
-     * an unresolved one. {@link #written()} is the name, and is not what a report quotes: a bare and
+     * <p>A check reads {@link #denotes()}, which every name the pass answered carries. A name
+     * nothing declares is reported where it is written and is {@link Unanswered} from there on,
+     * which the check over its declaration is what settles ({@code Names.Unbuilt}): the pass does
+     * not stop, so an author is told about every unknown name at once and the definitions beside it
+     * are still checked. {@link #written()} is the name, and is not what a report quotes: a bare and
      * a qualified spelling of one type are one name, and a decomposed and a composed spelling are
      * one name too, so neither says what the author typed. A report asks {@link WrittenName#quoted()}
      * and underlines {@link WrittenName#region()}.
@@ -224,11 +226,12 @@ public interface Ast {
         /**
          * The declaration this names, for a reader that is asking which one it is.
          *
-         * <p>A name still {@link Written} here is a pass reading it before resolution answered it,
-         * and an {@link Unanswered} one is a name resolution read and found nothing for — whose
-         * declaration {@code Names.Unbuilt} settles, so nothing downstream of that is handed one.
-         * Either is a fault in the compiler rather than in the source, so both are refused. This is
-         * the one place that says so.
+         * <p>Refused two ways, and they are not the same thing. A {@link Written} one is a pass
+         * reading it before resolution answered it, which is a fault in this compiler. An
+         * {@link Unanswered} one is a mistake in the source, reported where the name is written —
+         * refused here because there is no declaration to hand back, and a reader that wants to go
+         * on without one asks which of the two it is rather than taking the spelling. This is the
+         * one place that says so.
          */
         default TypeName denotes() {
             if (this instanceof Denoting denoting) {
@@ -1652,19 +1655,44 @@ public interface Ast {
         }
 
         /**
-         * What this name names, for a reader that is asking which declaration it is.
+         * This reference where it names a declaration, and null where resolution read it and found
+         * none.
          *
-         * <p>A {@link Written} one reached a reader without being resolved, which would put this
-         * back to matching spellings. An {@link Unanswered} one denotes nothing, which is an answer
-         * and not a declaration — a reader that took the spelling instead would answer for whatever
-         * the reading module has under it. Both are refused here, which is the one place that says
-         * so.
+         * <p>What a walk over a body asks. An edge, a substitution, a rewrite is about what a name
+         * stands for; a name nothing declares stands for nothing, so there is no edge to add and
+         * nothing to rewrite, and the mistake was reported where the name is written.
+         *
+         * <p>Which is not what a {@link Written} one is. That is a tree that reached a reader before
+         * resolution answered it — a fault in this compiler — and counting it among the names that
+         * declare nothing would let a pass that failed to answer its own nodes go on quietly, with
+         * every walk below reading the tree as though the author had written an unknown name. So it
+         * is refused, and this is the one place that tells the two apart.
+         */
+        default Denoting answered() {
+            if (this instanceof Denoting denoting) {
+                return denoting;
+            }
+            if (this instanceof Unanswered) {
+                return null;
+            }
+            throw new IllegalStateException("`" + name() + "` at " + pos()
+                    + " was read as a declaration before it was resolved");
+        }
+
+        /**
+         * What this name names, for a reader that is asking which declaration it is and has no
+         * answer to give where there is none.
+         *
+         * <p>{@link #answered()} is for the reader that has: a walk that adds no edge for a name
+         * nothing declares. This one is for a reader that would have to make something up.
          */
         default ValueName denotes() {
-            throw new IllegalStateException("`" + name() + "` at " + pos()
-                    + (this instanceof Unanswered
-                            ? " denotes nothing and was read as though it did"
-                            : " was read as a declaration before it was resolved"));
+            Denoting names = answered();
+            if (names == null) {
+                throw new IllegalStateException("`" + name() + "` at " + pos()
+                        + " denotes nothing and was read as though it did");
+            }
+            return names.denotes();
         }
 
         /**
@@ -1673,8 +1701,12 @@ public interface Ast {
          * the name the source writes, which an import may have let go without its qualifier.
          */
         default ReachName reachedAs() {
-            throw new IllegalStateException("`" + name() + "` at " + pos()
-                    + " reaches nothing this module can name");
+            Denoting names = answered();
+            if (names == null) {
+                throw new IllegalStateException("`" + name() + "` at " + pos()
+                        + " reaches nothing this module can name");
+            }
+            return names.reachedAs();
         }
 
         /** As {@link #denotes()}, by the bare name of what it names. */
@@ -1961,6 +1993,17 @@ public interface Ast {
         /** What the name this applies denotes, or null where what it applies is not a name. */
         public ValueName denotes() {
             return function instanceof Var v ? v.denotes() : null;
+        }
+
+        /**
+         * As {@link Var#answered()}, of the name this applies.
+         *
+         * <p>Null the two ways there is no declaration to look up: what is applied is not a name,
+         * or it is one nothing declares. A callee nothing has read yet is refused there, as it is
+         * of a name standing on its own.
+         */
+        public Var.Denoting answered() {
+            return function instanceof Var v ? v.answered() : null;
         }
 
 

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -1546,40 +1546,27 @@ public interface Ast {
      * substitute an expression for a name — the inliner — binds it ahead of the construction and
      * spreads the binding.
      *
-     * <p>A name that denotes nothing was reported where it was written and carries
-     * {@link ValueName.Unresolved}, so a reader downstream never has a spelling to match and never
-     * repeats the report.
+     * <p>The three forms are the three states a name is in, as {@link Name}'s are: read by the
+     * parser and nothing more, answered with what it names, or read by resolution and found to name
+     * nothing — which is an answer, and was reported where the name is written.
      */
-    record Var(WrittenName written, ValueName denotes, ReachName reachedAs,
-               Region region) implements Expr {
+    sealed interface Var extends Expr permits Var.Written, Var.Denoting, Var.Unanswered {
+
+        /** The name, and the occurrence of it that was read. */
+        WrittenName written();
+
+        /** The stretch of source the expression was written over. */
+        @Override
+        Region region();
 
         /**
-         * A name that has been resolved has both answers or neither.
-         *
-         * <p>Both, or neither: a name the parser read is unanswered on both counts, and a name
-         * resolution answered is answered on both. Nothing in between is a state — the pair comes
-         * from one pass, which has both or has not run.
-         *
-         * <p>Refused rather than allowed to stand, because what a name reaches is asked of a table
-         * and a table answers a key it has not got with silence. A rewrite that carried the
-         * denotation across and dropped the reach name would leave a reference that resolves to a
-         * declaration and reaches nothing, and the first reader of it would read the spelling
-         * instead — which is what this pair was separated out to stop. The other half is the same
-         * defect facing the other way: a reach name beside no denotation is a key nothing says the
-         * meaning of, and {@link ReachName#of} is where one would have to come from.
-         *
-         * <p>The region is the expression's and the name's is {@code written}'s, and they part
-         * company only where the author wrapped the name in something the tree does not keep:
+         * The region is the expression's and the name's is {@code written}'s, and they part company
+         * only where the author wrapped the name in something the tree does not keep:
          * {@code (price)} is one expression written over nine characters and one name written over
          * five. So the one has to hold the other. A region that did not would be a claim that the
          * name is written somewhere this expression is not, which no source can produce.
          */
-        public Var {
-            if ((denotes == null) != (reachedAs == null)) {
-                throw new IllegalArgumentException("`" + written.canonical() + "` denotes "
-                        + denotes + " and is reached as " + reachedAs
-                        + "; a name has both answers or neither");
-            }
+        private static void heldBy(WrittenName written, Region region) {
             if (written.region() != null && region == null) {
                 throw new IllegalArgumentException("`" + written.canonical()
                         + "` is written somewhere and the expression it is was written nowhere");
@@ -1592,14 +1579,13 @@ public interface Ast {
 
         /** A name as the parser read it, before resolution has said what it denotes or how this
          * module reaches it. */
-        public Var(String spelling, SourcePos pos) {
-            this(WrittenName.of(spelling, pos), null, null);
+        static Var written(String spelling, SourcePos pos) {
+            return written(WrittenName.of(spelling, pos));
         }
 
-        /** A name standing as an expression over exactly the characters that spell it — every one
-         * but a name the author parenthesized. */
-        public Var(WrittenName written, ValueName denotes, ReachName reachedAs) {
-            this(written, denotes, reachedAs, written.region());
+        /** The same, off an occurrence the parser has already read. */
+        static Var written(WrittenName written) {
+            return new Written(written, written.region());
         }
 
         /**
@@ -1607,11 +1593,18 @@ public interface Ast {
          *
          * <p>The reach name is given rather than worked out here. A pass writing a name into a body
          * either has one in hand — it is rewriting a name that already carried it — or knows which
-         * module's body it is writing into, and neither is something this constructor can see. Worked
+         * module's body it is writing into, and neither is something this factory can see. Worked
          * out from the spelling it would be the very derivation the carried value exists to remove.
          */
-        public Var(String spelling, ValueName denotes, ReachName reachedAs, SourcePos pos) {
-            this(WrittenName.of(spelling, pos), denotes, reachedAs);
+        static Var denoting(String spelling, ValueName denotes, ReachName reachedAs,
+                            SourcePos pos) {
+            return denoting(WrittenName.of(spelling, pos), denotes, reachedAs);
+        }
+
+        /** The same, off an occurrence already read: a name standing as an expression over exactly
+         * the characters that spell it — every one but a name the author parenthesized. */
+        static Var denoting(WrittenName written, ValueName denotes, ReachName reachedAs) {
+            return new Denoting(written, denotes, reachedAs, written.region());
         }
 
         /**
@@ -1623,39 +1616,9 @@ public interface Ast {
          * is written nowhere and only the expression has a place: the region is the one the name it
          * replaced was read over.
          */
-        public static Var respelled(String spelling, ValueName denotes, ReachName reachedAs,
-                                    SourcePos pos, Region region) {
-            return new Var(WrittenName.synthetic(spelling, pos), denotes, reachedAs, region);
-        }
-
-        /** The bare name this reaches its declaration by, whatever the source spelled. */
-        public String name() {
-            return written.canonical();
-        }
-
-        /** Where the name is written. */
-        public SourcePos pos() {
-            return written.pos();
-        }
-
-        /**
-         * The bare name this reaches its declaration by, whatever the source spelled.
-         *
-         * <p>Every name here has been through resolution by the time anything reads it, including
-         * one that denotes nothing — that is an answer too. A name with no answer at all means a
-         * tree reached a reader without being resolved, which would put this back to matching
-         * spellings, so it says so rather than falling back to the spelling.
-         */
-        public String bare() {
-            if (denotes == null) {
-                throw new IllegalStateException("`" + name() + "` was never resolved");
-            }
-            return denotes.name();
-        }
-
-        /** Whether this name denotes nothing — reported where it was written. */
-        public boolean unresolved() {
-            return denotes instanceof ValueName.Unresolved;
+        static Var respelled(String spelling, ValueName denotes, ReachName reachedAs,
+                             SourcePos pos, Region region) {
+            return new Denoting(WrittenName.synthetic(spelling, pos), denotes, reachedAs, region);
         }
 
         /**
@@ -1665,37 +1628,76 @@ public interface Ast {
          * a reader to work out, so it is given the binder it is reading and answers with that
          * binding. There is no way to write one of these without having the binding in hand.
          */
-        public static Var local(Binder binder, SourcePos pos) {
+        static Var local(Binder binder, SourcePos pos) {
             ValueName.Local local = new ValueName.Local(binder.name(), binder.id());
-            return new Var(WrittenName.synthetic(binder.name(), pos), local,
-                    new ReachName.Bare(binder.name()));
+            WrittenName written = WrittenName.synthetic(binder.name(), pos);
+            return new Denoting(written, local, new ReachName.Bare(binder.name()),
+                    written.region());
         }
 
         /** A read of a name a desugaring minted, at the form it is rewriting. Written nowhere: the
          * characters at {@code anchor} spell whatever the author put there, which is not this. */
-        public static Var desugared(String name, SourcePos anchor) {
-            return new Var(WrittenName.synthetic(name, anchor), null, null);
+        static Var desugared(String name, SourcePos anchor) {
+            return written(WrittenName.synthetic(name, anchor));
+        }
+
+        /** The bare name this reaches its declaration by, whatever the source spelled. */
+        default String name() {
+            return written().canonical();
+        }
+
+        /** Where the name is written. */
+        default SourcePos pos() {
+            return written().pos();
         }
 
         /**
-         * The name of the declaration this reference reaches — what a table keyed by a declaration's
-         * name is looked up with. The reading counterpart of {@link Apply#reaches()}:
-         * {@link #name()} is the name the source writes, which an import may have let go without its
-         * qualifier.
+         * What this name names, for a reader that is asking which declaration it is.
          *
-         * <p>Never the spelling. A name that reached a reader without being resolved has no answer
-         * to this, and it says so rather than handing back the characters — which is the same rule
-         * {@link #bare()} is under, and for the same reason: an import lets a name be written
-         * without its qualifier, so the spelling misses in the very table this is asked for, and a
-         * table answers a key it has not got with silence. Every pass that writes a reference of its
-         * own says what it means (ADR-0067), so there is no tree downstream of resolution for the
-         * fallback to have been for.
+         * <p>A {@link Written} one reached a reader without being resolved, which would put this
+         * back to matching spellings. An {@link Unanswered} one denotes nothing, which is an answer
+         * and not a declaration — a reader that took the spelling instead would answer for whatever
+         * the reading module has under it. Both are refused here, which is the one place that says
+         * so.
          */
-        public String reaches() {
-            if (reachedAs == null) {
-                throw new IllegalStateException("`" + name() + "` was never resolved");
-            }
-            return reachedAs.rendered();
+        default ValueName denotes() {
+            throw new IllegalStateException("`" + name() + "` at " + pos()
+                    + (this instanceof Unanswered
+                            ? " denotes nothing and was read as though it did"
+                            : " was read as a declaration before it was resolved"));
+        }
+
+        /**
+         * How this module reaches what the name names — what a table keyed by a declaration's name
+         * is looked up with. The reading counterpart of {@link Apply#reaches()}: {@link #name()} is
+         * the name the source writes, which an import may have let go without its qualifier.
+         */
+        default ReachName reachedAs() {
+            throw new IllegalStateException("`" + name() + "` at " + pos()
+                    + " reaches nothing this module can name");
+        }
+
+        /** As {@link #denotes()}, by the bare name of what it names. */
+        default String bare() {
+            return denotes().name();
+        }
+
+        /**
+         * As {@link #reachedAs()}, rendered.
+         *
+         * <p>Never the spelling. An import lets a name be written without its qualifier, so the
+         * spelling misses in the very table this is asked for, and a table answers a key it has not
+         * got with silence. Every pass that writes a reference of its own says what it means
+         * (ADR-0067), so there is no tree downstream of resolution for a fallback to have been for.
+         */
+        default String reaches() {
+            return reachedAs().rendered();
+        }
+
+        /** Whether this name denotes nothing — read by resolution, and reported where it was
+         * written. */
+        default boolean unresolved() {
+            return this instanceof Unanswered;
         }
 
         /**
@@ -1703,23 +1705,85 @@ public interface Ast {
          *
          * <p>The two answers together, because resolution gives them together and they are the two
          * halves of one question: which declaration this reaches, and under what name it reaches it
-         * from here. Handed over separately, a caller could pair one name's denotation with another's
-         * reach name, and nothing would say so.
+         * from here. Handed over separately, a caller could pair one name's denotation with
+         * another's reach name, and nothing would say so. There is no state between: a name has both
+         * or is one of the two that has neither.
          */
-        public Var denoting(ValueName resolved, ReachName reachedAs) {
-            return new Var(written, resolved, reachedAs, region);
+        default Var denoting(ValueName resolved, ReachName reachedAs) {
+            return new Denoting(written(), resolved, reachedAs, region());
         }
 
         /** The same name denoting {@code resolved}, reached as it already was — for a pass that
          * changes what a name says about where its construction came from and not which declaration
          * it reaches. */
-        public Var denoting(ValueName resolved) {
-            return new Var(written, resolved, reachedAs, region);
+        default Var denoting(ValueName resolved) {
+            return new Denoting(written(), resolved, reachedAs(), region());
         }
 
-        @Override
-        public String toString() {
-            return name();
+        /** The same name, over {@code region} — whichever of the three it is. */
+        default Var over(Region region) {
+            return switch (this) {
+                case Written w -> new Written(w.written(), region);
+                case Denoting d -> new Denoting(d.written(), d.denotes(), d.reachedAs(), region);
+                case Unanswered u -> new Unanswered(u.written(), region);
+            };
+        }
+
+        /** The same name, read and found to name nothing. */
+        default Var unanswered() {
+            return new Unanswered(written(), region());
+        }
+
+        /** A name as the parser read it. */
+        record Written(WrittenName written, Region region) implements Var {
+
+            public Written {
+                heldBy(written, region);
+            }
+
+            @Override
+            public String toString() {
+                return name();
+            }
+        }
+
+        /** A name resolution answered, with the declaration it names and how this module reaches
+         * it. */
+        record Denoting(WrittenName written, ValueName denotes, ReachName reachedAs, Region region)
+                implements Var {
+
+            public Denoting {
+                if (denotes == null || reachedAs == null) {
+                    throw new IllegalArgumentException("`" + written.canonical() + "` denotes "
+                            + denotes + " and is reached as " + reachedAs
+                            + "; a name that is answered is answered on both counts");
+                }
+                heldBy(written, region);
+            }
+
+            @Override
+            public String toString() {
+                return name();
+            }
+        }
+
+        /**
+         * A name resolution read and found nothing for.
+         *
+         * <p>Reported where it is written, or on the import line or the module that could not be
+         * read — whichever could say what is wrong. It carries neither answer, so a reader below has
+         * no spelling to match and no report to repeat.
+         */
+        record Unanswered(WrittenName written, Region region) implements Var {
+
+            public Unanswered {
+                heldBy(written, region);
+            }
+
+            @Override
+            public String toString() {
+                return name();
+            }
         }
     }
 
@@ -1960,7 +2024,7 @@ public interface Ast {
             case DecimalLit x -> new DecimalLit(x.value(), x.pos(), region);
             case StringLit x -> new StringLit(x.value(), x.pos(), region);
             case BoolLit x -> new BoolLit(x.value(), x.pos(), region);
-            case Var x -> new Var(x.written(), x.denotes(), x.reachedAs(), region);
+            case Var x -> x.over(region);
             case Unreachable x -> new Unreachable(x.reason(), x.pos(), region);
             case Neg x -> new Neg(x.operand(), x.pos(), region);
             case FieldAccess x -> new FieldAccess(x.target(), x.name(), x.pos(), region);

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -121,6 +121,10 @@ public final class CallElaborator {
 
     static Core elaborateCall(Ast.Apply call, Scope env, CheckContext ctx,
                                       Type expected) {
+        if (call.function() instanceof Ast.Var.Unanswered) {
+            // reported where the name was written; this definition has no meaning to work out
+            throw new Unanswerable(call.pos());
+        }
         // A call this representation said it keeps standing, asked before anything tries to expand or
         // resolve it: what it names is settled, and the only question left is its signature. Asked of
         // the representation and not of the operation — whether anything downstream has a rule about
@@ -370,8 +374,6 @@ public final class CallElaborator {
             // told apart earlier (E1303), so reaching here is a value position no rewrite covers.
             case ValueName.Builtin b -> CompileException.of(Diagnostic
                             .at(call.appliedAt()).say(new NameMessage.ANameTheLanguageGivesIsNotAFunction(b.name())).build());
-            // thrown out at the top of typeOfCall, before any of the work above
-            case ValueName.Unresolved _ -> unelaborated("an unresolved name", call);
             case null -> unelaborated("nothing", call);
         };
     }
@@ -477,13 +479,13 @@ public final class CallElaborator {
 
     static Type typeOfCall(CallArgs ca, Ast.Apply call, Scope env, CheckContext ctx, Type expected) {
         List<Ast.Expr> args = call.args();
-        if (call.denotes() == null) {
-            throw new IllegalStateException(
-                    "`" + call.written() + "` reached the check unresolved, at " + call.pos());
-        }
-        if (call.denotes() instanceof ValueName.Unresolved) {
+        if (call.function() instanceof Ast.Var.Unanswered) {
             // reported where the name was written; this definition has no meaning to work out
             throw new Unanswerable(call.pos());
+        }
+        if (call.denotes() == null) {
+            throw new IllegalStateException("`" + call.written()
+                    + "` applies something that is not a name, at " + call.pos());
         }
         boolean library = call.denotes() instanceof ValueName.Stdlib;
         Prelude.PreludeEntry entry = library ? Prelude.entry(call.reaches()) : null;

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -63,7 +63,8 @@ public final class DataChecker {
     }
 
     private static void collectConstChecks(Ast.Expr e, Symbols symbols, List<ConstCheck> out) {
-        if (e instanceof Ast.NewData nd && symbols.get(nd.typeName().denotes()) instanceof Ast.Data nt
+        if (e instanceof Ast.NewData nd && !(nd.typeName() instanceof Ast.Name.Unanswered)
+                && symbols.get(nd.typeName().denotes()) instanceof Ast.Data nt
                 && nt.newtype() && isInvariantBearing(nd.typeName().denotes(), symbols)) {
             CallElaborator.newtypeConstantArg(nd).ifPresent(v ->
                     out.add(new ConstCheck(nd.typeName().written(), nd.typeName().denotes(), v, nd.pos())));
@@ -290,6 +291,12 @@ public final class DataChecker {
     static void rejectDuplicateTypes(List<Ast.Name> names, String where, SourcePos pos) {
         Set<TypeName> seen = new HashSet<>();
         for (Ast.Name n : names) {
+            // A name nothing declares denotes no type, so there is no type here for another to be
+            // the same as. It was reported where it is written; calling it a duplicate as well
+            // would be a second report about the one mistake.
+            if (n instanceof Ast.Name.Unanswered) {
+                continue;
+            }
             if (!seen.add(n.denotes())) {
                 throw duplicate(n.written(), where, pos);
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -198,9 +198,12 @@ public final class Elaborator {
             // What the name is was answered when the module's names were resolved; what is left here
             // is its type. A binding is looked up, a unit data is its own value (spec §unit-data), and
             // anything else is not a value — reported below under the name that was written.
+            // A name nothing answered has no meaning to work out, and the definition it is in has
+            // none either: reported where it is written, and abandoned here.
+            case Ast.Var.Unanswered v -> throw new Unanswerable(v.pos());
+            case Ast.Var.Written v -> throw new IllegalStateException(
+                    "`" + v.name() + "` reached the check unresolved, at " + v.pos());
             case Ast.Var v -> switch (v.denotes()) {
-                case null -> throw new IllegalStateException(
-                        "`" + v.name() + "` reached the check unresolved, at " + v.pos());
                 // A binding with no type here is not a naming question: an inference probe types a
                 // body before the binding it asks about has one, and reads the report to find out.
                 case ValueName.Local local when env.typeOf(local.id()) != null ->
@@ -1392,7 +1395,7 @@ public final class Elaborator {
      * an optional is made.
      */
     private static RuntimeException notAValue(Ast.Var v, Scope env) {
-        if (v.denotes() instanceof ValueName.Unresolved) {
+        if (v instanceof Ast.Var.Unanswered) {
             // reported where the name was written; this definition has no meaning to work out
             return new Unanswerable(v.pos());
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -238,7 +238,7 @@ public final class Elaborator {
             case Ast.Binary bin -> BinaryElaborator.elaborateBinary(bin, env, ctx);
             case Ast.NewData nd -> {
                 Ast.Name built = nd.typeName();
-                if (built.denotes().isUnresolved()) {
+                if (built instanceof Ast.Name.Unanswered) {
                     throw new Unanswerable(nd.pos());
                 }
                 if (!(ctx.symbols().get(built.denotes()) instanceof Ast.Data owner)) {

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -432,7 +432,7 @@ public final class HelperInliner {
      * then told it has no method, which is the representation-shaped refusal this removes.
      */
     private static void intrinsicCallsIn(Ast.Expr e, Set<String> out) {
-        if (e instanceof Ast.Apply call && call.function() instanceof Ast.Var.Denoting
+        if (e instanceof Ast.Apply call && call.answered() != null
                 && call.denotes() instanceof ValueName.Stdlib) {
             Prelude.PreludeEntry entry = Prelude.entry(call.reaches());
             if (entry != null && entry.declaration().body() instanceof Ast.FnBody.Intrinsic
@@ -634,7 +634,7 @@ public final class HelperInliner {
      * before inlining, means the step reaches {@code foldFrom} (the one recursive helper) directly
      * rather than through a wrapper that would pass the function on as a value. */
     private static Ast.Apply desugar(Ast.Apply call) {
-        if (!(call.function() instanceof Ast.Var.Denoting)) {
+        if (call.answered() == null) {
             return call;   // it reaches no library name, so there is no sugar to write out
         }
         Prelude.Rewrite rewrite = Prelude.rewriteOf(call.reaches());
@@ -718,7 +718,7 @@ public final class HelperInliner {
      * boundary is read in is what answers for it.
      */
     private Ast.RetType arrivesAs(Ast.Expr arg) {
-        if (!(arg instanceof Ast.Var.Denoting v)) {
+        if (!(arg instanceof Ast.Var v) || v.answered() == null) {
             return null;
         }
         Ast.FnDef is = expands(v.denotes(), v.reaches());
@@ -802,7 +802,7 @@ public final class HelperInliner {
      * Null when the name is not a helper (a builtin, an injected behavior, or unknown).
      */
     private List<Ast.FnParam> declaredParams(Ast.Apply call) {
-        if (!(call.function() instanceof Ast.Var.Denoting)) {
+        if (call.answered() == null) {
             return null;   // it reaches no declaration, so none of them declares anything
         }
         Prelude.Rewrite rewrite = Prelude.rewriteOf(call.reaches());
@@ -871,7 +871,7 @@ public final class HelperInliner {
      * module declares is the lambda — with nothing to tell the two apart by.
      */
     private Ast.FnDef appliedHelper(Ast.Apply call) {
-        if (call.function() instanceof Ast.Var.Unanswered) {
+        if (call.appliesAName() && call.answered() == null) {
             return null;   // it names nothing, so no body stands behind it
         }
         return expands(call.denotes(), call.reaches());
@@ -1016,7 +1016,7 @@ public final class HelperInliner {
     /** The body {@code name} would put here, or null where the name stands for itself — asked as
      *  {@link #valueOf} and {@link #expandCall} ask it, so what is counted is what is spliced. */
     private Ast.Expr substitutedAt(Ast.Var name) {
-        if (!(name instanceof Ast.Var.Denoting)
+        if (name.answered() == null
                 || !(name.denotes() instanceof ValueName.Helper)
                 || graph.recurses(name.reaches())) {
             return null;
@@ -1176,7 +1176,7 @@ public final class HelperInliner {
      * callee's signature is one statement and this call decides its variables once.
      */
     private Ast.Expr expandCall(Ast.Apply rawCall) {
-        if (rawCall.function() instanceof Ast.Var.Unanswered) {
+        if (rawCall.answered() == null && rawCall.appliesAName()) {
             // The callee names nothing, which was reported where it is written. No body stands
             // behind it, no library sugar reaches for it, and no parameter list holds its arguments
             // against anything — so the call stays as it is and only its arguments are expanded.
@@ -1321,7 +1321,7 @@ public final class HelperInliner {
                 given.add(new Ast.Given(instantiated(p.type(), applied), arg,
                         references(helper.writtenBody(), p.binder().id()), arrivesAs(arg)));
                 Ast.FnType declares = declaredFn(p.type(), applied);
-                if (arg instanceof Ast.Var.Denoting fnName) {
+                if (arg instanceof Ast.Var fnName && fnName.answered() != null) {
                     // A name handed to a function parameter is substituted through: what
                     // applies it applies what it stands for. What it stands for is declared
                     // somewhere — a helper's own parameter, a binding, a function an
@@ -1432,7 +1432,7 @@ public final class HelperInliner {
      * {@code ()}, and there is no block taking no parameter to expand it to.
      */
     private OptionalInt declarationArity(Ast.Var v) {
-        if (!(v instanceof Ast.Var.Denoting)) {
+        if (v.answered() == null) {
             return OptionalInt.empty();   // it stands for no declaration to take anything
         }
         int arity = switch (v.denotes()) {
@@ -1478,7 +1478,7 @@ public final class HelperInliner {
             int k = next();
             return inline(etaExpand(v, arity.getAsInt(), i -> "$v" + k + "_" + i));
         }
-        if (!(v instanceof Ast.Var.Denoting) || !(v.denotes() instanceof ValueName.Helper)) {
+        if (v.answered() == null || !(v.denotes() instanceof ValueName.Helper)) {
             return v;
         }
         Ast.FnDef value = table.reached(v.reaches());
@@ -1627,12 +1627,12 @@ public final class HelperInliner {
      * parameter the inliner binds directly (see {@link #inline}).
      */
     private Ast.Apply desugarNamedBlock(Ast.Apply call) {
-        if (!(call.function() instanceof Ast.Var.Denoting)) {
+        if (call.answered() == null) {
             return call;   // it reaches nothing, so it is no named block to desugar
         }
         Integer idx = BLOCK_ARG.get(call.reaches());
         if (idx == null || idx >= call.args().size()
-                || !(call.args().get(idx) instanceof Ast.Var.Denoting v)) {
+                || !(call.args().get(idx) instanceof Ast.Var v) || v.answered() == null) {
             return call;
         }
         Ast.FnDef helper = expands(v.denotes(), v.reaches());
@@ -1982,7 +1982,7 @@ public final class HelperInliner {
      * comes out as far as its spelling is long.
      */
     private Ast.Var renameVar(Ast.Var v, Renaming renaming) {
-        if (!(v instanceof Ast.Var.Denoting)) {
+        if (v.answered() == null) {
             return v;   // it names nothing, so there is nothing to rename it to
         }
         Substituted stands = renaming.substituted(v.denotes());
@@ -2015,7 +2015,7 @@ public final class HelperInliner {
      * no exception.
      */
     private Ast.FnDef valueSpread(Ast.Var spread) {
-        if (!(spread instanceof Ast.Var.Denoting)
+        if (spread.answered() == null
                 || !(spread.denotes() instanceof ValueName.Helper)) {
             return null;
         }
@@ -2038,8 +2038,8 @@ public final class HelperInliner {
      */
     private static boolean references(Ast.Expr e, BindingId binding) {
         ValueName denotes = switch (e) {
-            case Ast.Var.Denoting v -> v.denotes();
-            case Ast.Apply c when c.function() instanceof Ast.Var.Denoting -> c.denotes();
+            case Ast.Var v when v.answered() != null -> v.denotes();
+            case Ast.Apply c when c.answered() != null -> c.denotes();
             default -> null;
         };
         if (denotes instanceof ValueName.Local local && local.id().equals(binding)) {
@@ -2093,15 +2093,16 @@ public final class HelperInliner {
         switch (e) {
             // `List.fold` desugars to `List.foldFrom` before inlining, so a body that folds reaches
             // the recursive `foldFrom` and not the wrapper it wrote.
-            case Ast.Apply call when call.function() instanceof Ast.Var.Denoting callee
+            case Ast.Apply call when call.answered() instanceof Ast.Var.Denoting callee
                     && !(callee.denotes() instanceof ValueName.Local) -> {
                 String fn = "List.fold".equals(call.reaches()) ? "List.foldFrom" : call.reaches();
                 if (table.containsKey(fn)) {
                     out.add(fn);
                 }
             }
-            case Ast.Var.Denoting v when v.denotes() instanceof ValueName.Helper
-                    || v.denotes() instanceof ValueName.Stdlib -> {
+            case Ast.Var v when v.answered() != null
+                    && (v.denotes() instanceof ValueName.Helper
+                            || v.denotes() instanceof ValueName.Stdlib) -> {
                 if (table.containsKey(v.reaches())) {
                     out.add(v.reaches());
                 }
@@ -2123,7 +2124,7 @@ public final class HelperInliner {
         // whatever else bears that name. The call carries what it resolved to, so it is asked rather
         // than matched against the helper table — a parameter named like a helper was reaching the
         // graph as a call to that helper, which made `let f (g: (Int) -> Int) = g(1)` recursive.
-        if (e instanceof Ast.Apply call && call.function() instanceof Ast.Var.Denoting callee
+        if (e instanceof Ast.Apply call && call.answered() instanceof Ast.Var.Denoting callee
                 && !(callee.denotes() instanceof ValueName.Local)) {
             // `List.fold` desugars to `List.foldFrom` before inlining, so a body that folds reaches the
             // recursive `foldFrom` — recursion classification and prelude-injection must see that.

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -775,6 +775,11 @@ public final class HelperInliner {
      * Asked of what the reference denotes, not of how it was spelled. A reference a
      * helper's own settling wrote carries its type and no surface text at all
      * ({@link Ast.TypeRef#of}), so reading the spelling answers no about every one of them.
+     *
+     * <p>The whole reference is in what it denotes: {@code List<'a>} resolves to a type that holds
+     * the variable, so the argument and a tuple's elements are not walked again here. This runs
+     * after resolution, and a reference that has not been read is refused by {@link
+     * Ast.TypeRef#denotes()} rather than answered off its spelling.
      */
     static boolean mentionsTypeVar(Ast.TypeTerm term) {
         if (term instanceof Ast.FnType fn) {
@@ -784,23 +789,7 @@ public final class HelperInliner {
         if (!(term instanceof Ast.TypeRef ref)) {
             return false;
         }
-        if (ref.denotes() != null) {
-            return Type.mentions(ref.denotes(), t -> t instanceof Type.Var);
-        }
-        if (ref.name() != null && ref.name().startsWith("'")) {
-            return true;
-        }
-        if (mentionsTypeVar(ref.arg())) {
-            return true;
-        }
-        if (ref.tupleElems() != null) {
-            for (Ast.TypeTerm e : ref.tupleElems()) {
-                if (mentionsTypeVar(e)) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return Type.mentions(ref.denotes(), t -> t instanceof Type.Var);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -432,7 +432,8 @@ public final class HelperInliner {
      * then told it has no method, which is the representation-shaped refusal this removes.
      */
     private static void intrinsicCallsIn(Ast.Expr e, Set<String> out) {
-        if (e instanceof Ast.Apply call && call.denotes() instanceof ValueName.Stdlib) {
+        if (e instanceof Ast.Apply call && call.function() instanceof Ast.Var.Denoting
+                && call.denotes() instanceof ValueName.Stdlib) {
             Prelude.PreludeEntry entry = Prelude.entry(call.reaches());
             if (entry != null && entry.declaration().body() instanceof Ast.FnBody.Intrinsic
                     && !entry.declaration().params().isEmpty()
@@ -633,6 +634,9 @@ public final class HelperInliner {
      * before inlining, means the step reaches {@code foldFrom} (the one recursive helper) directly
      * rather than through a wrapper that would pass the function on as a value. */
     private static Ast.Apply desugar(Ast.Apply call) {
+        if (!(call.function() instanceof Ast.Var.Denoting)) {
+            return call;   // it reaches no library name, so there is no sugar to write out
+        }
         Prelude.Rewrite rewrite = Prelude.rewriteOf(call.reaches());
         if (rewrite == null || call.args().size() != rewrite.keptArgs()) {
             return call;
@@ -714,7 +718,7 @@ public final class HelperInliner {
      * boundary is read in is what answers for it.
      */
     private Ast.RetType arrivesAs(Ast.Expr arg) {
-        if (!(arg instanceof Ast.Var v)) {
+        if (!(arg instanceof Ast.Var.Denoting v)) {
             return null;
         }
         Ast.FnDef is = expands(v.denotes(), v.reaches());
@@ -798,6 +802,9 @@ public final class HelperInliner {
      * Null when the name is not a helper (a builtin, an injected behavior, or unknown).
      */
     private List<Ast.FnParam> declaredParams(Ast.Apply call) {
+        if (!(call.function() instanceof Ast.Var.Denoting)) {
+            return null;   // it reaches no declaration, so none of them declares anything
+        }
         Prelude.Rewrite rewrite = Prelude.rewriteOf(call.reaches());
         if (rewrite != null && call.args().size() == rewrite.keptArgs()) {
             Ast.FnDef target = table.reached(rewrite.target().qualified());
@@ -864,6 +871,9 @@ public final class HelperInliner {
      * module declares is the lambda — with nothing to tell the two apart by.
      */
     private Ast.FnDef appliedHelper(Ast.Apply call) {
+        if (call.function() instanceof Ast.Var.Unanswered) {
+            return null;   // it names nothing, so no body stands behind it
+        }
         return expands(call.denotes(), call.reaches());
     }
 
@@ -893,8 +903,7 @@ public final class HelperInliner {
             case ValueName.Helper _, ValueName.Stdlib _ -> table.reached(reachedBy);
             // a construction, an injected behavior, `None`, or a name that denotes nothing: each is
             // applied by something other than an expansion, and each is reported where it belongs
-            case ValueName.OfType _, ValueName.Behavior _, ValueName.Builtin _,
-                    ValueName.Unresolved _ -> null;
+            case ValueName.OfType _, ValueName.Behavior _, ValueName.Builtin _ -> null;
         };
     }
 
@@ -1007,7 +1016,9 @@ public final class HelperInliner {
     /** The body {@code name} would put here, or null where the name stands for itself — asked as
      *  {@link #valueOf} and {@link #expandCall} ask it, so what is counted is what is spliced. */
     private Ast.Expr substitutedAt(Ast.Var name) {
-        if (!(name.denotes() instanceof ValueName.Helper) || graph.recurses(name.reaches())) {
+        if (!(name instanceof Ast.Var.Denoting)
+                || !(name.denotes() instanceof ValueName.Helper)
+                || graph.recurses(name.reaches())) {
             return null;
         }
         Ast.FnDef reached = table.reached(name.reaches());
@@ -1165,6 +1176,16 @@ public final class HelperInliner {
      * callee's signature is one statement and this call decides its variables once.
      */
     private Ast.Expr expandCall(Ast.Apply rawCall) {
+        if (rawCall.function() instanceof Ast.Var.Unanswered) {
+            // The callee names nothing, which was reported where it is written. No body stands
+            // behind it, no library sugar reaches for it, and no parameter list holds its arguments
+            // against anything — so the call stays as it is and only its arguments are expanded.
+            List<Ast.Expr> args = new ArrayList<>();
+            for (Ast.Expr a : rawCall.args()) {
+                args.add(inline(a));
+            }
+            return rawCall.withArgs(args);
+        }
         checkFunctionArgumentPlacement(rawCall);
         Ast.Apply call = desugarNamedBlock(desugar(rawCall));
         List<Ast.Expr> args = new ArrayList<>();
@@ -1300,7 +1321,7 @@ public final class HelperInliner {
                 given.add(new Ast.Given(instantiated(p.type(), applied), arg,
                         references(helper.writtenBody(), p.binder().id()), arrivesAs(arg)));
                 Ast.FnType declares = declaredFn(p.type(), applied);
-                if (arg instanceof Ast.Var fnName) {
+                if (arg instanceof Ast.Var.Denoting fnName) {
                     // A name handed to a function parameter is substituted through: what
                     // applies it applies what it stands for. What it stands for is declared
                     // somewhere — a helper's own parameter, a binding, a function an
@@ -1411,6 +1432,9 @@ public final class HelperInliner {
      * {@code ()}, and there is no block taking no parameter to expand it to.
      */
     private OptionalInt declarationArity(Ast.Var v) {
+        if (!(v instanceof Ast.Var.Denoting)) {
+            return OptionalInt.empty();   // it stands for no declaration to take anything
+        }
         int arity = switch (v.denotes()) {
             case ValueName.Stdlib lib -> {
                 Prelude.PreludeEntry entry = Prelude.entry(lib.qualified());
@@ -1428,8 +1452,7 @@ public final class HelperInliner {
             case ValueName.Behavior b -> callableBehaviors.getOrDefault(b.name(), 0);
             // A binding holds whatever it was given; a construction, a checker built-in and a name
             // that denotes nothing stand for no declaration at all.
-            case ValueName.Local _, ValueName.OfType _, ValueName.Builtin _,
-                    ValueName.Unresolved _ -> 0;
+            case ValueName.Local _, ValueName.OfType _, ValueName.Builtin _ -> 0;
             case null -> 0;
         };
         return arity == 0 ? OptionalInt.empty() : OptionalInt.of(arity);
@@ -1455,7 +1478,7 @@ public final class HelperInliner {
             int k = next();
             return inline(etaExpand(v, arity.getAsInt(), i -> "$v" + k + "_" + i));
         }
-        if (!(v.denotes() instanceof ValueName.Helper)) {
+        if (!(v instanceof Ast.Var.Denoting) || !(v.denotes() instanceof ValueName.Helper)) {
             return v;
         }
         Ast.FnDef value = table.reached(v.reaches());
@@ -1604,9 +1627,12 @@ public final class HelperInliner {
      * parameter the inliner binds directly (see {@link #inline}).
      */
     private Ast.Apply desugarNamedBlock(Ast.Apply call) {
+        if (!(call.function() instanceof Ast.Var.Denoting)) {
+            return call;   // it reaches nothing, so it is no named block to desugar
+        }
         Integer idx = BLOCK_ARG.get(call.reaches());
         if (idx == null || idx >= call.args().size()
-                || !(call.args().get(idx) instanceof Ast.Var v)) {
+                || !(call.args().get(idx) instanceof Ast.Var.Denoting v)) {
             return call;
         }
         Ast.FnDef helper = expands(v.denotes(), v.reaches());
@@ -1927,7 +1953,7 @@ public final class HelperInliner {
             case ValueName.Local _ -> true;
             case ValueName.Helper helper -> helper.module().equals(table.module());
             case ValueName.Stdlib _, ValueName.Behavior _, ValueName.OfType _,
-                    ValueName.Builtin _, ValueName.Unresolved _ -> false;
+                    ValueName.Builtin _ -> false;
         };
     }
 
@@ -1956,6 +1982,9 @@ public final class HelperInliner {
      * comes out as far as its spelling is long.
      */
     private Ast.Var renameVar(Ast.Var v, Renaming renaming) {
+        if (!(v instanceof Ast.Var.Denoting)) {
+            return v;   // it names nothing, so there is nothing to rename it to
+        }
         Substituted stands = renaming.substituted(v.denotes());
         if (stands != null) {
             return Ast.Var.respelled(stands.name(), stands.denotes(), stands.reachedAs(),
@@ -1966,7 +1995,7 @@ public final class HelperInliner {
             return Ast.Var.respelled(v.name(), denotes, v.reachedAs(),
                     renaming.at(v.pos()), renaming.over(v.region()));
         }
-        return new Ast.Var(v.written(), denotes, v.reachedAs(), v.region());
+        return new Ast.Var.Denoting(v.written(), denotes, v.reachedAs(), v.region());
     }
 
     private List<Ast.Expr> renameList(List<Ast.Expr> es, Renaming renaming) {
@@ -1986,7 +2015,8 @@ public final class HelperInliner {
      * no exception.
      */
     private Ast.FnDef valueSpread(Ast.Var spread) {
-        if (!(spread.denotes() instanceof ValueName.Helper)) {
+        if (!(spread instanceof Ast.Var.Denoting)
+                || !(spread.denotes() instanceof ValueName.Helper)) {
             return null;
         }
         // by the name it is reached by here, which for another module's value is the qualified one.
@@ -2008,8 +2038,8 @@ public final class HelperInliner {
      */
     private static boolean references(Ast.Expr e, BindingId binding) {
         ValueName denotes = switch (e) {
-            case Ast.Var v -> v.denotes();
-            case Ast.Apply c -> c.denotes();
+            case Ast.Var.Denoting v -> v.denotes();
+            case Ast.Apply c when c.function() instanceof Ast.Var.Denoting -> c.denotes();
             default -> null;
         };
         if (denotes instanceof ValueName.Local local && local.id().equals(binding)) {
@@ -2063,13 +2093,14 @@ public final class HelperInliner {
         switch (e) {
             // `List.fold` desugars to `List.foldFrom` before inlining, so a body that folds reaches
             // the recursive `foldFrom` and not the wrapper it wrote.
-            case Ast.Apply call when !(call.denotes() instanceof ValueName.Local) -> {
+            case Ast.Apply call when call.function() instanceof Ast.Var.Denoting callee
+                    && !(callee.denotes() instanceof ValueName.Local) -> {
                 String fn = "List.fold".equals(call.reaches()) ? "List.foldFrom" : call.reaches();
                 if (table.containsKey(fn)) {
                     out.add(fn);
                 }
             }
-            case Ast.Var v when v.denotes() instanceof ValueName.Helper
+            case Ast.Var.Denoting v when v.denotes() instanceof ValueName.Helper
                     || v.denotes() instanceof ValueName.Stdlib -> {
                 if (table.containsKey(v.reaches())) {
                     out.add(v.reaches());
@@ -2092,7 +2123,8 @@ public final class HelperInliner {
         // whatever else bears that name. The call carries what it resolved to, so it is asked rather
         // than matched against the helper table — a parameter named like a helper was reaching the
         // graph as a call to that helper, which made `let f (g: (Int) -> Int) = g(1)` recursive.
-        if (e instanceof Ast.Apply call && !(call.denotes() instanceof ValueName.Local)) {
+        if (e instanceof Ast.Apply call && call.function() instanceof Ast.Var.Denoting callee
+                && !(callee.denotes() instanceof ValueName.Local)) {
             // `List.fold` desugars to `List.foldFrom` before inlining, so a body that folds reaches the
             // recursive `foldFrom` — recursion classification and prelude-injection must see that.
             String fn = "List.fold".equals(call.reaches()) ? "List.foldFrom" : call.reaches();

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
@@ -152,7 +152,7 @@ public final class HelperNames {
             // The name is this pass's and the place is the callee's: only the spelling changes, so
             // what is underlined for it is the stretch the name it replaced was read over — not the
             // application's, which takes in arguments this pass did not touch.
-            case Ast.Apply call when call.function() instanceof Ast.Var.Denoting
+            case Ast.Apply call when call.answered() != null
                     && foreign(call.denotes(), which) ->
                     new Ast.Apply(
                             Ast.Var.respelled(qualifiedName(call.denotes()), call.denotes(),
@@ -166,7 +166,7 @@ public final class HelperNames {
 
     /** {@code name} written qualified where it denotes a helper {@code which} accepts. */
     private static Ast.Var qualified(Ast.Var name, Predicate<ValueName.Helper> which) {
-        return name instanceof Ast.Var.Denoting && foreign(name.denotes(), which)
+        return name.answered() != null && foreign(name.denotes(), which)
                 ? Ast.Var.respelled(qualifiedName(name.denotes()), name.denotes(),
                         ofModule(name.denotes()), name.pos(), name.region())
                 : name;

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
@@ -152,7 +152,8 @@ public final class HelperNames {
             // The name is this pass's and the place is the callee's: only the spelling changes, so
             // what is underlined for it is the stretch the name it replaced was read over — not the
             // application's, which takes in arguments this pass did not touch.
-            case Ast.Apply call when foreign(call.denotes(), which) ->
+            case Ast.Apply call when call.function() instanceof Ast.Var.Denoting
+                    && foreign(call.denotes(), which) ->
                     new Ast.Apply(
                             Ast.Var.respelled(qualifiedName(call.denotes()), call.denotes(),
                                     ofModule(call.denotes()), call.function().pos(),
@@ -165,7 +166,7 @@ public final class HelperNames {
 
     /** {@code name} written qualified where it denotes a helper {@code which} accepts. */
     private static Ast.Var qualified(Ast.Var name, Predicate<ValueName.Helper> which) {
-        return foreign(name.denotes(), which)
+        return name instanceof Ast.Var.Denoting && foreign(name.denotes(), which)
                 ? Ast.Var.respelled(qualifiedName(name.denotes()), name.denotes(),
                         ofModule(name.denotes()), name.pos(), name.region())
                 : name;

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -339,7 +339,7 @@ final class HelperParams {
      * know which node kinds bind: what the name resolved to already says it.
      */
     private static boolean refersTo(Ast.Expr e, BindingId id) {
-        return e instanceof Ast.Var v && v.denotes() instanceof ValueName.Local local
+        return e instanceof Ast.Var.Denoting v && v.denotes() instanceof ValueName.Local local
                 && local.id().equals(id);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -339,8 +339,8 @@ final class HelperParams {
      * know which node kinds bind: what the name resolved to already says it.
      */
     private static boolean refersTo(Ast.Expr e, BindingId id) {
-        return e instanceof Ast.Var.Denoting v && v.denotes() instanceof ValueName.Local local
-                && local.id().equals(id);
+        return e instanceof Ast.Var v && v.answered() != null
+                && v.denotes() instanceof ValueName.Local local && local.id().equals(id);
     }
 
     /** Whether anything inside {@code e}, or {@code e} itself, satisfies {@code leaf}. */

--- a/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
@@ -85,7 +85,7 @@ public final class MatchElaborator {
         Type branchType = null;
         for (Ast.Case c : m.cases()) {
             for (Ast.Name written : c.caseTypes()) {
-                TypeName caseName = written.denotes();
+                TypeName caseName = names(written);
                 if (!cases.contains(caseName)) {
                     throw notCase(written, what, c, m, cases, ctx.symbols());
                 }
@@ -96,7 +96,7 @@ public final class MatchElaborator {
                 }
             }
             Type bindType = c.caseTypes().size() == 1
-                    ? caseBindType(c.caseTypes().get(0).denotes()) : scrutinee;
+                    ? caseBindType(names(c.caseTypes().get(0))) : scrutinee;
             if (c.unwrapAsserts() != null) {
                 if (c.caseTypes().size() != 1) {
                     throw CompileException.of(Diagnostic.at(c.pos()).say(new MatchMessage.AnOrPatternOpensNothing()).build());
@@ -138,21 +138,22 @@ public final class MatchElaborator {
             }
             Ast.Name arm = c.caseTypes().get(0);
             String caseType = arm.written();
+            TypeName armName = names(arm);
             Type bind;
-            if (TypeName.SOME.equals(arm.denotes())) {
+            if (TypeName.SOME.equals(armName)) {
                 bind = element;
-            } else if (TypeName.NONE.equals(arm.denotes())) {
+            } else if (TypeName.NONE.equals(armName)) {
                 bind = null;
             } else {
                 throw CompileException.of(Diagnostic.at(c.pos()).say(new MatchMessage.NotACaseOfAnOptional(caseType)).build());
             }
             if (c.unwrapAsserts() != null) {
-                if (!TypeName.SOME.equals(arm.denotes())) {
+                if (!TypeName.SOME.equals(armName)) {
                     throw CompileException.of(Diagnostic.at(c.pos()).say(new MatchMessage.TheCaseHasNoValueToOpen(caseType)).build());
                 }
                 checkOptionUnwrapAsserts(c, element, ctx.symbols());
             }
-            if (!covered.add(arm.denotes())) {
+            if (!covered.add(armName)) {
                 throw CompileException.of(Diagnostic.at(c.pos()).say(new MatchMessage.MatchedByMoreThanOneCase(caseType)).build());
             }
             Core body = Elaborator.liftIntoOption(
@@ -177,9 +178,25 @@ public final class MatchElaborator {
     static List<TypeName> denoted(List<Ast.Name> names) {
         List<TypeName> out = new ArrayList<>();
         for (Ast.Name n : names) {
-            out.add(n.denotes());
+            out.add(names(n));
         }
         return out;
+    }
+
+    /**
+     * The case an arm names, or the abandonment of the definition it is written in where nothing
+     * declares it.
+     *
+     * <p>Reported where it is written. What follows from it — that the arm is not a case of what is
+     * matched, that it opens a type other than the one under it, that the match does not cover its
+     * cases — is that one mistake seen from another angle, which is what {@link Unanswerable} is
+     * for.
+     */
+    private static TypeName names(Ast.Name arm) {
+        if (arm instanceof Ast.Name.Unanswered) {
+            throw new Unanswerable(arm.pos());
+        }
+        return arm.denotes();
     }
 
     /** The type a match case binds. A primitive-named case (e.g. {@code Int} in {@code Int |
@@ -219,7 +236,7 @@ public final class MatchElaborator {
         Ast.Name first = layers.get(0);
         // the layer is compared as a type: `Some(billing.金額(v))` opens the same newtype an
         // imported bare `金額` names
-        if (!(element instanceof Type.Ref r) || !r.name().equals(first.denotes())) {
+        if (!(element instanceof Type.Ref r) || !r.name().equals(names(first))) {
             String elementName = element instanceof Type.Ref r2 ? r2.name().name() : Type.show(element);
             throw CompileException.of(Diagnostic.at(c.pos())
                     .say(new MatchMessage.TheNewtypeWrapsAnotherType("Some", elementName,
@@ -236,7 +253,7 @@ public final class MatchElaborator {
                                   boolean firstOpensTheCase) {
         for (int i = 0; i < opened.size(); i++) {
             String name = opened.get(i).written();
-            TypeName layer = opened.get(i).denotes();
+            TypeName layer = names(opened.get(i));
             Type inner = TypeOps.newtypeInner(layer, symbols);
             if (inner == null) {
                 Diagnostic.Builder d = Diagnostic.at(c.pos())
@@ -250,7 +267,7 @@ public final class MatchElaborator {
                 Ast.Name next = opened.get(i + 1);
                 // the layer a pattern claims is compared as a type, so an inner newtype named
                 // through its module opens the same one an imported bare name does
-                if (!(inner instanceof Type.Ref ir) || !ir.name().equals(next.denotes())) {
+                if (!(inner instanceof Type.Ref ir) || !ir.name().equals(names(next))) {
                     String innerName = inner instanceof Type.Ref r ? r.name().name() : Type.show(inner);
                     throw CompileException.of(Diagnostic.at(c.pos())
                             .say(new MatchMessage.TheNewtypeWrapsAnotherType(name, innerName,

--- a/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
@@ -108,7 +108,7 @@ public final class NewtypeDesugar {
                     // `T(v)` is what the author wrote and a construction is what it means, so the
                     // node that replaces the application stands over the same characters.
                     yield new Ast.NewData(
-                            new Ast.Name(call.name(), built),
+                            new Ast.Name.Denoting(call.name(), built),
                             List.of(new Ast.FieldInit("value", args.get(0), call.pos())),
                             List.of(), ConstructionOrigin.own(), call.pos(), call.region());
                 }

--- a/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
@@ -98,7 +98,8 @@ public final class NewtypeDesugar {
                 // were resolved. Asking the type namespace again here would read a binding of the
                 // same spelling as the type it shadows, and rewrite an application of it into a
                 // construction — both of which compile, so the meaning would change in silence.
-                TypeName built = call.denotes() instanceof ValueName.OfType named ? named.type() : null;
+                TypeName built = call.function() instanceof Ast.Var.Denoting
+                        && call.denotes() instanceof ValueName.OfType named ? named.type() : null;
                 if (built != null && symbols.get(built) instanceof Ast.Data nt && nt.newtype()) {
                     if (args.size() != 1) {
                         throw CompileException.of(Diagnostic

--- a/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
@@ -98,7 +98,7 @@ public final class NewtypeDesugar {
                 // were resolved. Asking the type namespace again here would read a binding of the
                 // same spelling as the type it shadows, and rewrite an application of it into a
                 // construction — both of which compile, so the meaning would change in silence.
-                TypeName built = call.function() instanceof Ast.Var.Denoting
+                TypeName built = call.answered() != null
                         && call.denotes() instanceof ValueName.OfType named ? named.type() : null;
                 if (built != null && symbols.get(built) instanceof Ast.Data nt && nt.newtype()) {
                     if (args.size() != 1) {

--- a/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
@@ -151,6 +151,9 @@ final class PartialReachability {
      * not be written where a value goes. A value takes none and is read rather than handed over.
      */
     boolean isPartialFunctionNamed(Ast.Var v) {
+        if (!(v instanceof Ast.Var.Denoting)) {
+            return false;   // it names no helper, partial or otherwise
+        }
         Ast.FnDef declared = declarationOf(v.denotes(), v.reachedAs(), inliner);
         return declared != null && declared.partial() && !declared.params().isEmpty();
     }
@@ -250,13 +253,14 @@ final class PartialReachability {
 
     private static void collectReached(Ast.Expr e, HelperInliner inliner, Set<String> out) {
         switch (e) {
-            case Ast.Apply call -> {
+            // A name nothing answered reaches no declaration, so it makes no edge.
+            case Ast.Apply call when call.function() instanceof Ast.Var.Denoting -> {
                 Ast.FnDef applied = declarationOf(call.denotes(), call.reachedAs(), inliner);
                 if (applied != null) {
                     out.add(keyOf(call.denotes(), call.reachedAs()));
                 }
             }
-            case Ast.Var v -> {
+            case Ast.Var.Denoting v -> {
                 Ast.FnDef read = declarationOf(v.denotes(), v.reachedAs(), inliner);
                 if (read != null && read.params().isEmpty()) {
                     out.add(keyOf(v.denotes(), v.reachedAs()));

--- a/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
@@ -151,7 +151,7 @@ final class PartialReachability {
      * not be written where a value goes. A value takes none and is read rather than handed over.
      */
     boolean isPartialFunctionNamed(Ast.Var v) {
-        if (!(v instanceof Ast.Var.Denoting)) {
+        if (v.answered() == null) {
             return false;   // it names no helper, partial or otherwise
         }
         Ast.FnDef declared = declarationOf(v.denotes(), v.reachedAs(), inliner);
@@ -254,13 +254,13 @@ final class PartialReachability {
     private static void collectReached(Ast.Expr e, HelperInliner inliner, Set<String> out) {
         switch (e) {
             // A name nothing answered reaches no declaration, so it makes no edge.
-            case Ast.Apply call when call.function() instanceof Ast.Var.Denoting -> {
+            case Ast.Apply call when call.answered() != null -> {
                 Ast.FnDef applied = declarationOf(call.denotes(), call.reachedAs(), inliner);
                 if (applied != null) {
                     out.add(keyOf(call.denotes(), call.reachedAs()));
                 }
             }
-            case Ast.Var.Denoting v -> {
+            case Ast.Var v when v.answered() != null -> {
                 Ast.FnDef read = declarationOf(v.denotes(), v.reachedAs(), inliner);
                 if (read != null && read.params().isEmpty()) {
                     out.add(keyOf(v.denotes(), v.reachedAs()));

--- a/souther-compiler/src/main/java/souther/compiler/check/PipelineSigs.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PipelineSigs.java
@@ -104,7 +104,10 @@ public final class PipelineSigs {
                                     Map<String, List<Ast.Var>> pipeStages,
                                     List<Ast.Var> out, Set<String> inProgress, SourcePos pos) {
         for (Ast.Var s : stages) {
-            List<Ast.Var> sub = pipeStages.get(s.bare());
+            // A stage that names nothing was reported where it is written. It is no pipeline to
+            // splice in, and the composition it is part of is abandoned where its signature is
+            // asked for rather than here.
+            List<Ast.Var> sub = s.unresolved() ? null : pipeStages.get(s.bare());
             if (sub == null) {
                 out.add(s);
                 continue;

--- a/souther-compiler/src/main/java/souther/compiler/check/Requirements.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Requirements.java
@@ -124,11 +124,17 @@ public final class Requirements {
             // requires is what it declared, in that order (spec §depends-on, §requirement-propagation).
             case Ast.SpecBehavior spec -> {
                 for (Ast.Var req : spec.dependsOn()) {
-                    add(acc, req.bare(), name);
+                    // Reported where it is written; it names no requirement to propagate.
+                    if (!req.unresolved()) {
+                        add(acc, req.bare(), name);
+                    }
                 }
             }
             case Ast.PipeBehavior pipe -> {
                 for (Ast.Var stage : pipe.stages()) {
+                    if (stage.unresolved()) {
+                        continue;   // it names no behavior, so it carries no requirement in
+                    }
                     String s = stage.bare();
                     if (injected.contains(s)) {
                         // the stage is the dependency: the composition holds it in a field and

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -736,21 +736,26 @@ public final class Resolve {
      * type name is.
      */
     private Ast.Var name(Ast.Var written, Bindings bound) {
-        return written.denotes() != null ? written
-                : reached(written, bound);
+        return written instanceof Ast.Var.Written ? reached(written, bound) : written;
     }
 
     /** An application of a name, with what the name denotes and how this module reaches it answered
      * here — the same pair, from the same place, as a name standing on its own. */
     private Ast.Expr applied(Ast.Apply call, Bindings bound) {
-        ValueName denotes = answered(call.name(), calledName(call, bound));
+        ValueName denotes = calledName(call, bound);
         // Answered rather than rebuilt: what the callee means is settled here and where it is
         // written is not this pass's to decide. Building one from the name would take its extent
         // from the characters that spell it, which is short of what a parenthesized callee covers.
-        Ast.Var name = call.function() instanceof Ast.Var applied
-                ? applied.denoting(denotes, ReachName.of(denotes, call.written(), values.module()))
-                : new Ast.Var(call.name(), denotes,
-                        ReachName.of(denotes, call.written(), values.module()));
+        Ast.Var written = call.function() instanceof Ast.Var applied ? applied
+                : Ast.Var.written(call.name());
+        Ast.Var name;
+        if (denotes == null) {
+            name = written.unanswered();
+        } else {
+            answered(call.name(), denotes);
+            name = written.denoting(denotes,
+                    ReachName.of(denotes, call.written(), values.module()));
+        }
         return new Ast.Apply(name, exprs(call.args(), bound), call.origin(), call.pos(),
                 call.region());
     }
@@ -764,7 +769,11 @@ public final class Resolve {
      * this carries the answer to avoid.
      */
     private Ast.Var reached(Ast.Var v, Bindings bound) {
-        ValueName denotes = answered(v.written(), valueName(v.written(), bound));
+        ValueName denotes = valueName(v.written(), bound);
+        if (denotes == null) {
+            return v.unanswered();
+        }
+        answered(v.written(), denotes);
         return v.denoting(denotes, ReachName.of(denotes, v.name(), values.module()));
     }
 
@@ -892,14 +901,15 @@ public final class Resolve {
      */
     private Ast.Var qualifiedName(Ast.FieldAccess fa, boolean applied, Bindings bound) {
         Ast.Var root = rootName(fa);
-        if (root == null || root.denotes() != null || bound.binderOf(root.name()) != null) {
+        if (root == null || !(root instanceof Ast.Var.Written)
+                || bound.binderOf(root.name()) != null) {
             return null;
         }
         WrittenName written = dottedName(fa);
         ValueName denotes = lookup(written, applied, bound);
         if (denotes != null) {
             ValueName resolved = answered(written, denotes);
-            return new Ast.Var(written, resolved,
+            return Ast.Var.denoting(written, resolved,
                     ReachName.of(resolved, written.canonical(), values.module()));
         }
         return unknownMember(fa, written, applied, bound);
@@ -922,10 +932,8 @@ public final class Resolve {
         if (qualifier == null || !isNamespace(qualifier.canonical())) {
             return null;
         }
-        CompileException why = unknownIdentifier(written, bound);
-        ValueName resolved = answered(written, nothing(written.canonical(), why));
-        return new Ast.Var(written, resolved,
-                ReachName.of(resolved, written.canonical(), values.module()));
+        nothing(unknownIdentifier(written, bound));
+        return new Ast.Var.Unanswered(written, written.region());
     }
 
     /** Whether {@code qualifier} names a namespace a member may be reached through: a
@@ -956,11 +964,10 @@ public final class Resolve {
         };
     }
 
-    /** What a name used as a value denotes, and the report for one that denotes nothing. */
+    /** What a name used as a value denotes, or null where nothing does — reported here. */
     private ValueName valueName(WrittenName written, Bindings bound) {
         ValueName denotes = lookup(written, false, bound);
-        return denotes != null ? denotes
-                : nothing(written.canonical(), unknownIdentifier(written, bound));
+        return denotes != null ? denotes : nothing(unknownIdentifier(written, bound));
     }
 
     /**
@@ -972,8 +979,7 @@ public final class Resolve {
      */
     private ValueName calledName(Ast.Apply call, Bindings bound) {
         ValueName denotes = lookup(call.name(), true, bound);
-        return denotes != null ? denotes
-                : nothing(call.written(), unknownIdentifier(call.name(), bound));
+        return denotes != null ? denotes : nothing(unknownIdentifier(call.name(), bound));
     }
 
     /**
@@ -990,10 +996,6 @@ public final class Resolve {
      * there under a spelling nothing binds.
      */
     private ValueName answered(WrittenName written, ValueName denotes) {
-        if (denotes instanceof ValueName.Unresolved) {
-            failed++;
-            return denotes;
-        }
         if (written.pos() == null) {
             return denotes;
         }
@@ -1004,10 +1006,17 @@ public final class Resolve {
         return denotes;
     }
 
-    /** Records that a name in a body denotes nothing, and gives it the name that says so. */
-    private ValueName nothing(String written, CompileException why) {
+    /**
+     * Records that a name in a body denotes nothing, and answers with nothing.
+     *
+     * <p>The name that carries this is {@link Ast.Var.Unanswered}, built where the reference is:
+     * a stand-in identity handed back here would say a binding is there under a spelling nothing
+     * binds, and every reader below would have to know not to believe it.
+     */
+    private ValueName nothing(CompileException why) {
         unresolved.add(why);
-        return new ValueName.Unresolved(written);
+        failed++;
+        return null;
     }
 
     /** The names a body could have written where it wrote one nothing answers to. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -220,7 +220,7 @@ public final class Resolve {
      * resolved as if the mistake were not there — so an author is told about every unknown name at
      * once instead of one per compile, and an editor can still say what the names around it mean.
      */
-    public record Resolved(Ast.Module module, ResolutionIndex index,
+    public record Resolved(ResolvedModule module, ResolutionIndex index,
                            List<CompileException> unresolved,
                            Map<String, OfDeclaration> declarations) {}
 
@@ -258,7 +258,7 @@ public final class Resolve {
             // the compiler, not something an author can be told about and carry on past.
             throw resolved.unresolved().get(0);
         }
-        return resolved.module();
+        return resolved.module().module();
     }
 
     /** As {@link #module(Ast.Module, Symbols)}, keeping what each name was answered with. */
@@ -333,9 +333,9 @@ public final class Resolve {
             exposedOutputs.put(e.getKey(), r.retType(e.getValue()));
         }
         return new Resolved(
-                new Ast.Module(m.name(), m.exposing(), exposedOutputs, m.imports(), defs,
-                        behaviors, fns, m.takenOn(), examples, fakes, m.exampleFileTarget(),
-                        m.pos()),
+                new ResolvedModule(new Ast.Module(m.name(), m.exposing(), exposedOutputs,
+                        m.imports(), defs, behaviors, fns, m.takenOn(), examples, fakes,
+                        m.exampleFileTarget(), m.pos())),
                 new ResolutionIndex(List.copyOf(r.denotations), List.copyOf(r.values0),
                         Map.copyOf(r.binders)),
                 List.copyOf(r.unresolved), Map.copyOf(declarations));

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -408,7 +408,7 @@ public final class Resolve {
     /** A written type reference, with what it denotes decided here — once, and in the module that
      * wrote it, so no later reader has to know where it was written. */
     private Ast.TypeRef typeRef(Ast.TypeRef ref) {
-        if (ref == null || ref.denotes() != null) {
+        if (ref == null || ref instanceof Ast.TypeRef.Denoting) {
             return ref;
         }
         Ast.TypeTerm arg = typeTerm(ref.arg());
@@ -419,7 +419,7 @@ public final class Resolve {
                 elems.add(typeTerm(e));
             }
         }
-        Ast.TypeRef resolved = new Ast.TypeRef(ref.written(), arg, elems, null, ref.anchor());
+        Ast.TypeRef resolved = new Ast.TypeRef.Written(ref.written(), arg, elems, ref.anchor());
         Ast.TypeRef denoted = resolved.denoting(typeOf(resolved));
         // A reference with no name is a tuple or a container shape, which names no declaration.
         if (denoted.name() != null && denoted.pos() != null) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -35,9 +35,11 @@ import java.util.Set;
  * {@link TypeName} it denotes, and a check that wants to know whether two names are the same type
  * compares what they denote. There is no spelling left to compare.
  *
- * <p>A name that denotes nothing is reported here and denotes {@link TypeName#unresolved} — which
- * becomes {@link souther.compiler.types.Type#ERRONEOUS} — so no later pass sees an unresolved name
- * and none of them needs a null branch. The pass does not stop: the rest of the module is resolved
+ * <p>A name that denotes nothing is reported here and is {@link Ast.Name.Unanswered} from there on
+ * — a state of the name and not a stand-in identity, so nothing below reads it as a declaration and
+ * nothing below has a spelling to fall back to. Where a type reference stands on such a name, what
+ * it denotes is {@link souther.compiler.types.Type#ERRONEOUS}. The pass does not stop: the rest of
+ * the module is resolved
  * as if the mistake were not there, which is what lets an author be told about every unknown name at
  * once and lets an editor still say what the names around one mean. A name a pass synthesized
  * already knowing what it means (a codec {@code Deriver} builds from a field's type) is left as it
@@ -215,10 +217,11 @@ public final class Resolve {
      * A resolved module, what the pass worked out about the names in it, and the names it could not
      * answer.
      *
-     * <p>A name that denotes nothing does not end the pass. It denotes {@link TypeName#unresolved},
-     * which becomes {@link souther.compiler.types.Type#ERRONEOUS}, and the rest of the module is
-     * resolved as if the mistake were not there — so an author is told about every unknown name at
-     * once instead of one per compile, and an editor can still say what the names around it mean.
+     * <p>A name that denotes nothing does not end the pass. It is {@link Ast.Name.Unanswered}, a
+     * type reference standing on one denotes {@link souther.compiler.types.Type#ERRONEOUS}, and the
+     * rest of the module is resolved as if the mistake were not there — so an author is told about
+     * every unknown name at once instead of one per compile, and an editor can still say what the
+     * names around it mean.
      */
     public record Resolved(ResolvedModule module, ResolutionIndex index,
                            List<CompileException> unresolved,

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -458,7 +458,7 @@ public final class Resolve {
     private List<Ast.Name> sumCases(Ast.SumData s) {
         List<Ast.Name> out = new ArrayList<>();
         for (Ast.Name c : s.cases()) {
-            if (c.denotes() != null) {
+            if (!(c instanceof Ast.Name.Written)) {
                 out.add(c);
                 continue;
             }
@@ -466,6 +466,10 @@ public final class Resolve {
             if (denoted == null) {
                 throw CompileException.of(Diagnostic
                                 .at(s.pos()).say(new BehaviorMessage.UnknownCaseInASum(c.written(), s.name())).build());
+            }
+            if (denoted.isUnresolved()) {
+                out.add(answered(c.unanswered()));
+                continue;
             }
             // Recorded like any other written name. A case is a name this module wrote and this pass
             // answered, so leaving it out made it a use nothing could see — an editor asked about it
@@ -1095,14 +1099,14 @@ public final class Resolve {
 
     /** A name that must denote a declared type. */
     private Ast.Name type(Ast.Name n) {
-        if (n.denotes() != null) {
+        if (!(n instanceof Ast.Name.Written)) {
             return n;
         }
         TypeName denoted = symbols.resolve(n.name());
         if (denoted == null) {
-            return answered(n.denoting(nothingDenotes(n)));
+            return answered(nothingDenotes(n));
         }
-        return answered(n.denoting(denoted));
+        return answered(standingFor(n, denoted));
     }
 
     /** The names a {@code match} arm may write: a declared case, a primitive heading a union
@@ -1117,7 +1121,7 @@ public final class Resolve {
     }
 
     private Ast.Name caseName(Ast.Name n) {
-        if (n.denotes() != null) {
+        if (!(n instanceof Ast.Name.Written)) {
             return n;
         }
         TypeName denoted = symbols.resolveCase(n.name());
@@ -1125,9 +1129,9 @@ public final class Resolve {
             denoted = TypeName.optionCase(n.written());
         }
         if (denoted == null) {
-            return answered(n.denoting(nothingDenotes(n)));
+            return answered(nothingDenotes(n));
         }
-        return answered(n.denoting(denoted));
+        return answered(standingFor(n, denoted));
     }
 
     /**
@@ -1147,17 +1151,27 @@ public final class Resolve {
         }
     }
 
-    /** Records that {@code n} denotes nothing, and gives it the name that says so. */
-    private TypeName nothingDenotes(Ast.Name n) {
+    /** Reports that nothing declares {@code n}, and hands back the name that says so. */
+    private Ast.Name nothingDenotes(Ast.Name n) {
         unresolved.add(TypeOps.unknownType(n.name(), symbols));
-        return TypeName.unresolved(n.written());
+        return n.unanswered();
+    }
+
+    /**
+     * {@code n} against what the scope answered with, which is not always a declaration: a name an
+     * import line could not bring in is in scope standing for nothing, so that a use of it takes the
+     * error type rather than being reported as an unknown name at every use. The import line is
+     * where that was reported, so nothing more is said here.
+     */
+    private Ast.Name standingFor(Ast.Name n, TypeName denoted) {
+        return denoted.isUnresolved() ? n.unanswered() : n.denoting(denoted);
     }
 
     /** Records what a name was answered with, and hands it back. A name with no position was
      * synthesized by an earlier pass rather than written, so there is nothing to point at, and a
      * name nothing answered is an absence rather than a declaration to record. */
     private Ast.Name answered(Ast.Name n) {
-        if (n.denotes().isUnresolved()) {
+        if (n instanceof Ast.Name.Unanswered) {
             failed++;
         } else if (n.pos() != null) {
             denotations.add(new Denotation(n.name(), n.denotes()));

--- a/souther-compiler/src/main/java/souther/compiler/check/ResolvedModule.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ResolvedModule.java
@@ -10,12 +10,17 @@ import souther.compiler.ast.Ast;
  * {@link Ast.Var.Unanswered} are for — a name nothing declares was read, was reported where it is
  * written, and is as answered as the pass can make it. What this says is the other one: the pass has
  * been over this tree, so nothing in it is {@link Ast.Name.Written}, {@link Ast.Var.Written} or
- * {@link Ast.TypeRef.Written}, and a reader below has no such state to have a branch for.
+ * {@link Ast.TypeRef.Written}.
  *
  * <p>The three node types say it for themselves at each occurrence; this says it of the whole, which
  * is what a signature can carry. {@code Resolve} states the invariant in prose and every consumer
  * kept it by looking (issues #464, #696, #700); a consumer that is handed one of these cannot ask
  * for a resolution, because it holds nothing to resolve.
+ *
+ * <p>It does not make the unread state unrepresentable at each occurrence. A switch over
+ * {@link Ast.Var} is total over three records whatever module the value came out of, so a reader
+ * still writes an arm for the one that cannot be there and refuses it. What this removes is the
+ * question being asked again at every consumer, not the arm.
  *
  * <p>Minted in this package and nowhere else — the constructor is package-private, and
  * {@link Resolve} is what calls it. A pass that rewrites a resolved tree goes through

--- a/souther-compiler/src/main/java/souther/compiler/check/ResolvedModule.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ResolvedModule.java
@@ -1,0 +1,72 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+
+/**
+ * A module {@code Resolve} has read: one holding no occurrence anything is still to answer.
+ *
+ * <p>Not a module whose names all answer to something. Resolution finishing and every name finding
+ * a declaration are two things, which is what {@link Ast.Name.Unanswered} and
+ * {@link Ast.Var.Unanswered} are for — a name nothing declares was read, was reported where it is
+ * written, and is as answered as the pass can make it. What this says is the other one: the pass has
+ * been over this tree, so nothing in it is {@link Ast.Name.Written}, {@link Ast.Var.Written} or
+ * {@link Ast.TypeRef.Written}, and a reader below has no such state to have a branch for.
+ *
+ * <p>The three node types say it for themselves at each occurrence; this says it of the whole, which
+ * is what a signature can carry. {@code Resolve} states the invariant in prose and every consumer
+ * kept it by looking (issues #464, #696, #700); a consumer that is handed one of these cannot ask
+ * for a resolution, because it holds nothing to resolve.
+ *
+ * <p>Minted in this package and nowhere else — the constructor is package-private, and
+ * {@link Resolve} is what calls it. A pass that rewrites a resolved tree goes through
+ * {@link #with(Ast.Module)}, which is the same claim made again by whoever is making it: the pass
+ * mints its nodes resolved, as {@code Deriver}, {@code NewtypeDesugar}, {@code HelperInliner} and
+ * {@code FixtureTemplate} already do.
+ */
+public final class ResolvedModule {
+
+    private final Ast.Module module;
+
+    ResolvedModule(Ast.Module module) {
+        if (module == null) {
+            throw new IllegalArgumentException("a resolved module is a module");
+        }
+        this.module = module;
+    }
+
+    /** What the module is called. */
+    public String name() {
+        return module.name();
+    }
+
+    /** The tree. */
+    public Ast.Module module() {
+        return module;
+    }
+
+    /**
+     * {@code rewritten} as a resolved module, for a pass that rewrote this one.
+     *
+     * <p>Asked of the module it came from, so the claim is made where a resolved tree already is
+     * rather than anywhere a tree can be built. What a pass writes into one it mints resolved, which
+     * is what every pass after {@code Resolve} already does.
+     */
+    public ResolvedModule with(Ast.Module rewritten) {
+        return new ResolvedModule(rewritten);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof ResolvedModule other && module.equals(other.module);
+    }
+
+    @Override
+    public int hashCode() {
+        return module.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return module.toString();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Scope.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Scope.java
@@ -71,7 +71,7 @@ public record Scope(Map<BindingId, Binding> bindings, Map<String, Type> declared
             case ValueName.Local local -> typeOf(local.id());
             case ValueName.Helper _, ValueName.Stdlib _, ValueName.Behavior _ ->
                     declared.get(reachedBy);
-            case ValueName.OfType _, ValueName.Builtin _, ValueName.Unresolved _ -> null;
+            case ValueName.OfType _, ValueName.Builtin _ -> null;
             case null -> null;
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -60,6 +60,9 @@ public final class SpecChecker {
             switch (b) {
                 case Ast.SpecBehavior spec -> {
                     for (Ast.Var req : spec.dependsOn()) {
+                        if (req.unresolved()) {
+                            continue;   // it names no behavior, so it is no edge of this graph
+                        }
                         if (names.contains(req.bare()) && !out.contains(req.bare())) {
                             out.add(req.bare());
                         }
@@ -75,6 +78,9 @@ public final class SpecChecker {
                 }
                 case Ast.PipeBehavior pipe -> {
                     for (Ast.Var stage : pipe.stages()) {
+                        if (stage.unresolved()) {
+                            continue;   // it names no behavior, so it is no edge of this graph
+                        }
                         if (names.contains(stage.bare()) && !out.contains(stage.bare())) {
                             out.add(stage.bare());
                         }
@@ -652,6 +658,9 @@ public final class SpecChecker {
             List<Ast.Var> stages = PipelineSigs.flattenStages(pipe.stages(), pipeStages,
                     pipe.pos());
             for (int i = 1; i < stages.size(); i++) {
+                if (stages.get(i).unresolved()) {
+                    continue;   // reported where it is written; it declares no arity to hold it to
+                }
                 String stage = stages.get(i).bare();
                 Integer n = arity.get(stage);
                 if (n != null && n != 1) {
@@ -671,7 +680,8 @@ public final class SpecChecker {
     }
 
     private static void collectRequiredCalls(Ast.Expr e, Set<String> requiredNames, List<String> out) {
-        if (e instanceof Ast.Apply call && requiredNames.contains(call.reaches())
+        if (e instanceof Ast.Apply call && call.function() instanceof Ast.Var.Denoting
+                && requiredNames.contains(call.reaches())
                 && !out.contains(call.reaches())) {
             out.add(call.written());
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -680,7 +680,7 @@ public final class SpecChecker {
     }
 
     private static void collectRequiredCalls(Ast.Expr e, Set<String> requiredNames, List<String> out) {
-        if (e instanceof Ast.Apply call && call.function() instanceof Ast.Var.Denoting
+        if (e instanceof Ast.Apply call && call.answered() != null
                 && requiredNames.contains(call.reaches())
                 && !out.contains(call.reaches())) {
             out.add(call.written());

--- a/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
@@ -428,7 +428,8 @@ final class TotalityChecker {
     }
 
     private static void collectOwnCalls(Ast.Expr e, Set<String> own, Set<String> out) {
-        if (e instanceof Ast.Apply call && own.contains(call.reaches())) {
+        if (e instanceof Ast.Apply call && call.function() instanceof Ast.Var.Denoting
+                && own.contains(call.reaches())) {
             out.add(call.written());
         }
         forEachChild(e, c -> collectOwnCalls(c, own, out));

--- a/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
@@ -428,7 +428,7 @@ final class TotalityChecker {
     }
 
     private static void collectOwnCalls(Ast.Expr e, Set<String> own, Set<String> out) {
-        if (e instanceof Ast.Apply call && call.function() instanceof Ast.Var.Denoting
+        if (e instanceof Ast.Apply call && call.answered() != null
                 && own.contains(call.reaches())) {
             out.add(call.written());
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -295,7 +295,11 @@ public final class TypeChecker {
                 DataChecker.rejectDuplicateNames(outputCases, "the behavior output", spec.pos());
                 List<String> required = new ArrayList<>();
                 for (Ast.Var req : spec.dependsOn()) {
-                    required.add(req.bare());
+                    // A name nothing answered is no name for another to be a duplicate of, and it
+                    // was reported where it is written.
+                    if (!req.unresolved()) {
+                        required.add(req.bare());
+                    }
                 }
                 DataChecker.rejectDuplicateNames(required, "`depends on`", spec.pos());
                 DataChecker.rejectDuplicateTypes(spec.constructs(), "`constructs`", spec.pos());

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -402,14 +402,14 @@ public final class TypeOps {
                     }
                 }
                 for (Ast.Name include : d.includes()) {
-                    if (include.denotes() != null && include.denotes().isUnresolved()) {
+                    if (include instanceof Ast.Name.Unanswered) {
                         return true;
                     }
                 }
             }
             if (def instanceof Ast.SumData sum) {
                 for (Ast.Name c : sum.cases()) {
-                    if (c.denotes() != null && c.denotes().isUnresolved()) {
+                    if (c instanceof Ast.Name.Unanswered) {
                         return true;
                     }
                 }
@@ -426,7 +426,7 @@ public final class TypeOps {
                     return true;
                 }
                 for (Ast.Name constructs : spec.constructs()) {
-                    if (constructs.denotes() != null && constructs.denotes().isUnresolved()) {
+                    if (constructs instanceof Ast.Name.Unanswered) {
                         return true;
                     }
                 }
@@ -927,18 +927,23 @@ public final class TypeOps {
             out.putIfAbsent(field.name(), new BindingId(owner, ordinal++));
         }
         for (Ast.Name include : data.includes()) {
-            TypeName source = include.denotes();
-            if (source == null) {
-                if (!resolving) {
-                    // Resolve answers every name it reads, an unknown one included, so a tree it
-                    // wrote has none of these. One here is a tree some other producer built, and
-                    // reading the spelling to carry on would answer for whatever this module has
-                    // under it and leave the producer unmentioned.
-                    throw new IllegalStateException("the include `" + include.written()
-                            + "` of `" + declared + "` denotes nothing");
+            TypeName source = switch (include) {
+                case Ast.Name.Denoting denoting -> denoting.type();
+                // Reported where it is written. A name nothing declares brings in no fields, and
+                // saying so again here would be a second report about the one mistake.
+                case Ast.Name.Unanswered _ -> null;
+                case Ast.Name.Written written -> {
+                    if (!resolving) {
+                        // Resolve answers every name it reads, an unknown one included, so a tree it
+                        // wrote has none of these. One here is a tree some other producer built, and
+                        // reading the spelling to carry on would answer for whatever this module has
+                        // under it and leave the producer unmentioned.
+                        throw new IllegalStateException("the include `" + include.written()
+                                + "` of `" + declared + "` has not been resolved");
+                    }
+                    yield symbols.resolve(written.name());
                 }
-                source = symbols.resolve(include.name());
-            }
+            };
             if (source != null && seen.add(source)
                     && symbols.get(source) instanceof Ast.Data included) {
                 walkFields(included, source, symbols, seen, out, resolving);
@@ -954,6 +959,12 @@ public final class TypeOps {
         // through spreads, holds no such field at all.
         Map<String, String> suppliedBy = new LinkedHashMap<>();
         for (Ast.Name inc : data.includes()) {
+            if (inc instanceof Ast.Name.Unanswered) {
+                // Nothing declares it, which was reported where it is written. It brings in no
+                // fields, and complaining here that it is not a product data would be a second
+                // report about the one mistake.
+                continue;
+            }
             TypeName included = inc.denotes();
             if (!(symbols.get(included) instanceof Ast.Data id)) {
                 throw CompileException.of(Diagnostic.at(inc.name().reportedAt())

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -402,14 +402,14 @@ public final class TypeOps {
                     }
                 }
                 for (Ast.Name include : d.includes()) {
-                    if (include instanceof Ast.Name.Unanswered) {
+                    if (erroneous(include)) {
                         return true;
                     }
                 }
             }
             if (def instanceof Ast.SumData sum) {
                 for (Ast.Name c : sum.cases()) {
-                    if (c instanceof Ast.Name.Unanswered) {
+                    if (erroneous(c)) {
                         return true;
                     }
                 }
@@ -426,7 +426,7 @@ public final class TypeOps {
                     return true;
                 }
                 for (Ast.Name constructs : spec.constructs()) {
-                    if (constructs instanceof Ast.Name.Unanswered) {
+                    if (erroneous(constructs)) {
                         return true;
                     }
                 }
@@ -445,6 +445,24 @@ public final class TypeOps {
             }
         }
         return false;
+    }
+
+    /**
+     * Whether {@code name} is one resolution read and found no declaration for.
+     *
+     * <p>Named as the three states it is one of, so a name nothing has read yet is refused rather
+     * than answered no. A tree reaching here holding one is a pass that did not answer its own
+     * nodes, and calling it "not erroneous" would let that go by while every walk below read the
+     * module as though the author had written it that way.
+     */
+    private static boolean erroneous(Ast.Name name) {
+        return switch (name) {
+            case Ast.Name.Unanswered _ -> true;
+            case Ast.Name.Denoting _ -> false;
+            case Ast.Name.Written written -> throw new IllegalStateException("`"
+                    + written.written() + "` at " + written.pos()
+                    + " was read as a declaration before it was resolved");
+        };
     }
 
     private static boolean erroneous(Ast.RetType ret) {

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
@@ -127,7 +127,7 @@ public final class ValueCycles {
         if (e == null) {
             return;
         }
-        if (e instanceof Ast.Var v && v.denotes() instanceof ValueName.Helper) {
+        if (e instanceof Ast.Var.Denoting v && v.denotes() instanceof ValueName.Helper) {
             Ast.FnDef d = reachable.get(v.reaches());
             if (d != null && d.params().isEmpty()) {
                 out.add(v.reaches());

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
@@ -127,7 +127,8 @@ public final class ValueCycles {
         if (e == null) {
             return;
         }
-        if (e instanceof Ast.Var.Denoting v && v.denotes() instanceof ValueName.Helper) {
+        if (e instanceof Ast.Var v && v.answered() != null
+                && v.denotes() instanceof ValueName.Helper) {
             Ast.FnDef d = reachable.get(v.reaches());
             if (d != null && d.params().isEmpty()) {
                 out.add(v.reaches());

--- a/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
@@ -1952,8 +1952,8 @@ public final class FixtureReader {
     private String helperKey(Ast.Apply c) {
         return switch (c.denotes()) {
             case ValueName.Helper _, ValueName.Stdlib _ -> c.reaches();
-            case ValueName.Local _, ValueName.OfType _, ValueName.Builtin _, ValueName.Behavior _,
-                    ValueName.Unresolved _ -> null;
+            case ValueName.Local _, ValueName.OfType _, ValueName.Builtin _,
+                    ValueName.Behavior _ -> null;
             case null -> null;   // what applying something that is not a name leaves
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -406,7 +406,7 @@ public final class AstBuilder {
                     // one ident past the keyword is the `on` of `depends on`, which lexes as an
                     // ordinary identifier and is no part of the list
                     for (Ast.Name dep : dottedNames(clause, 1)) {
-                        dependsOn.add(new Ast.Var(dep.name(), null, null));
+                        dependsOn.add(Ast.Var.written(dep.name()));
                     }
                 }
             }
@@ -415,7 +415,7 @@ public final class AstBuilder {
         SyntaxNode pipe = n.child(SyntaxKind.PIPE_BEHAVIOR).orElseThrow();
         List<Ast.Var> stages = new ArrayList<>();
         for (SyntaxNode st : childNodes(pipe, SyntaxKind.STAGE)) {
-            stages.add(new Ast.Var(qualifiedNameOf(st), null, null));
+            stages.add(Ast.Var.written(qualifiedNameOf(st)));
         }
         Ast.RetType declaredOut = pipe.child(SyntaxKind.RET_TYPE).map(this::retType).orElse(null);
         return new Ast.PipeBehavior(declared, stages, declaredOut, pos);
@@ -665,7 +665,7 @@ public final class AstBuilder {
     private Ast.Expr expr(SyntaxNode n) {
         return switch (n.kind()) {
             case LITERAL_EXPR -> literal(n);
-            case VAR_EXPR -> new Ast.Var(nameOf(firstIdentToken(n)), null, null);
+            case VAR_EXPR -> Ast.Var.written(nameOf(firstIdentToken(n)));
             case FIELD_ACCESS -> fieldAccess(n);
             case APPLY_EXPR -> apply(n);
             case BINARY_EXPR -> binary(n);
@@ -930,10 +930,10 @@ public final class AstBuilder {
             if (c.kind() == SyntaxKind.SPREAD_MEMBER) {
                 List<SyntaxToken> path = identTokens(c);
                 if (path.size() == 1) {
-                    spreads.add(new Ast.Var(nameOf(path.get(0)), null, null));
+                    spreads.add(Ast.Var.written(nameOf(path.get(0))));
                 } else {
                     String bound = "$s" + (spreadCounter++);
-                    Ast.Expr value = new Ast.Var(nameOf(path.get(0)), null, null);
+                    Ast.Expr value = Ast.Var.written(nameOf(path.get(0)));
                     for (int i = 1; i < path.size(); i++) {
                         value = new Ast.FieldAccess(value, nameOf(path.get(i)),
                                 posOf(path.get(i)),
@@ -949,7 +949,7 @@ public final class AstBuilder {
                 WrittenName field = nameOf(firstIdentToken(c));
                 Optional<SyntaxNode> value = firstExprChildOpt(c);
                 // shorthand `field` means `field = field`, and the one name is both
-                Ast.Expr v = value.isPresent() ? expr(value.get()) : new Ast.Var(field, null, null);
+                Ast.Expr v = value.isPresent() ? expr(value.get()) : Ast.Var.written(field);
                 inits.add(new Ast.FieldInit(field, v));
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -320,7 +320,7 @@ public final class AstBuilder {
             SyntaxNode inner = typeChild(newtype.get());
             Ast.TypeRef innerType = typeRef(inner);
             if (newtype.get().token(SyntaxKind.QUESTION).isPresent()) {
-                innerType = new Ast.TypeRef("Option", innerType, innerType.pos());   // `Y?` → Option<Y>
+                innerType = Ast.TypeRef.written("Option", innerType, innerType.pos());   // `Y?` → Option<Y>
             }
             List<Ast.Field> fields = List.of(new Ast.Field("value", innerType, pos(inner)));
             return new Ast.Data(declared, true, List.of(), fields, clauses,
@@ -374,7 +374,7 @@ public final class AstBuilder {
     private Ast.Field field(SyntaxNode n) {
         Ast.TypeTerm type = typeTerm(typeChild(n));
         if (n.token(SyntaxKind.QUESTION).isPresent()) {
-            type = new Ast.TypeRef("Option", type, type.pos());   // `T?` → Option<T>
+            type = Ast.TypeRef.written("Option", type, type.pos());   // `T?` → Option<T>
         }
         return new Ast.Field(nameOf(firstIdentToken(n)), type);
     }
@@ -521,7 +521,7 @@ public final class AstBuilder {
             // only repeat what the pattern already named
             SourcePos at = pos(pat);
             type = new Ast.RetType(
-                    List.of(new Ast.TypeRef(qualifiedNameOf(pat), null, null)), at);
+                    List.of(Ast.TypeRef.written(qualifiedNameOf(pat), null, null)), at);
             return new Ast.FnParam(bound, type, true);
         }
         return new Ast.FnParam(bound, type, false);
@@ -611,7 +611,7 @@ public final class AstBuilder {
         }
         // `T?` is `Option<T>` for whatever T is: the two spellings are one type, and what may
         // stand in a position is decided by what the position requires of that type, not here
-        return new Ast.TypeRef("Option", cases.get(0), cases.get(0).pos());
+        return Ast.TypeRef.written("Option", cases.get(0), cases.get(0).pos());
     }
 
     private Ast.TypeRef typeRef(SyntaxNode n) {
@@ -625,7 +625,7 @@ public final class AstBuilder {
             if (elems.size() == 1 && elems.get(0) instanceof Ast.TypeRef only) {
                 return only;   // `(T)` reads as grouping
             }
-            return new Ast.TypeRef(null, null, elems, pos(n));
+            return Ast.TypeRef.written(null, null, elems, pos(n));
         }
         Optional<SyntaxToken> typevar = n.token(SyntaxKind.TYPEVAR);
         if (typevar.isPresent()) {
@@ -633,13 +633,13 @@ public final class AstBuilder {
             if (!isReservedNamespace(moduleName)) {
                 throw error(pos(n), new ParseMessage.ATypeVariableIsOnlyAllowedInTheCore(v));
             }
-            return new Ast.TypeRef(v, null, pos(n));   // name begins with `'` → Type.Var
+            return Ast.TypeRef.written(v, null, pos(n));   // name begins with `'` → Type.Var
         }
         WrittenName written = qualifiedNameOf(n);   // `Amount`, `example.billing.Amount`, `B.Amount`
         String name = written.canonical();
         Optional<SyntaxNode> args = n.child(SyntaxKind.TYPE_ARGS);
         if (args.isEmpty()) {
-            return new Ast.TypeRef(written, null, null);
+            return Ast.TypeRef.written(written, null, null);
         }
         List<Ast.TypeTerm> typeArgs = new ArrayList<>();
         for (SyntaxNode c : args.get().childNodes()) {
@@ -648,16 +648,16 @@ public final class AstBuilder {
             }
         }
         if (typeArgs.isEmpty()) {
-            return new Ast.TypeRef(written, null, null);   // the missing argument is reported by name
+            return Ast.TypeRef.written(written, null, null);   // the missing argument is reported by name
         }
         if (name.equals("Map")) {
             // carry the value in `arg` and the key in `tupleElems` (ADR-0040)
             Ast.TypeTerm key = typeArgs.get(0);
             Ast.TypeTerm value = typeArgs.get(typeArgs.size() - 1);
-            return new Ast.TypeRef(written, value, List.of(key));
+            return Ast.TypeRef.written(written, value, List.of(key));
         }
         // List<T> / Set<T> / Option<T>
-        return new Ast.TypeRef(written, typeArgs.get(0), null);
+        return Ast.TypeRef.written(written, typeArgs.get(0), null);
     }
 
     // --- expressions ---

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -291,7 +291,7 @@ public final class AstBuilder {
             for (SyntaxNode member : product.get().childNodes()) {
                 if (member.kind() == SyntaxKind.SPREAD_MEMBER) {
                     SyntaxToken included = identTokens(member).get(0);
-                    includes.add(new Ast.Name(nameOf(included), null));
+                    includes.add(Ast.Name.written(nameOf(included)));
                 } else if (member.kind() == SyntaxKind.FIELD) {
                     fields.add(field(member));
                 }
@@ -311,7 +311,7 @@ public final class AstBuilder {
         if (sum.isPresent()) {
             List<Ast.Name> cases = new ArrayList<>();
             for (SyntaxToken t : identTokens(sum.get())) {
-                cases.add(new Ast.Name(nameOf(t), null));
+                cases.add(Ast.Name.written(nameOf(t)));
             }
             return new Ast.SumData(declared, cases, Optional.empty(), Optional.empty(), pos);
         }
@@ -919,7 +919,7 @@ public final class AstBuilder {
 
     private Ast.Expr newData(SyntaxNode n) {
         SyntaxToken head = identTokens(n).get(0);
-        Ast.Name typeName = new Ast.Name(nameOf(head), null);
+        Ast.Name typeName = Ast.Name.written(nameOf(head));
         List<Ast.FieldInit> inits = new ArrayList<>();
         List<Ast.Var> spreads = new ArrayList<>();
         // a spread naming a field path (`...c.address`) binds that path first, so the construction
@@ -984,7 +984,7 @@ public final class AstBuilder {
             at[0]++;                              // .
             parts.add((SyntaxToken) es.get(at[0]++));
         }
-        return new Ast.Name(joined(parts), null);
+        return Ast.Name.written(joined(parts));
     }
 
     /** The comma-separated names of a {@code constructs}/{@code depends on} clause, each possibly
@@ -1363,7 +1363,7 @@ public final class AstBuilder {
                 Ast.Expr inner = new Ast.FieldAccess(Ast.Var.desugared(whole, pos), "value", pos);
                 Ast.Expr body = bindPattern(patternChild(pat), inner, rest, pos, held);
                 yield Ast.LetIn.opening(whole, value,
-                        new Ast.Name(qualifiedNameOf(pat), null), body, pos, held);
+                        Ast.Name.written(qualifiedNameOf(pat)), body, pos, held);
             }
             case PATTERN_RECORD -> {
                 String whole = "$r" + (patternCounter++);
@@ -1708,7 +1708,7 @@ public final class AstBuilder {
      * binding out of something the author wrote: the token carries both halves, so they cannot be
      * paired wrongly. */
     private Ast.Binder binderOf(SyntaxToken token) {
-        return Ast.Binder.of(new Ast.Name(nameOf(token), null));
+        return Ast.Binder.of(Ast.Name.written(nameOf(token)));
     }
 
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
@@ -132,7 +132,7 @@ public record FixtureTemplate(String text, Ast.Expr value) {
     /** The absent optional, which the language names rather than any module. */
     public static FixtureTemplate none() {
         return new FixtureTemplate("None",
-                new Ast.Var(WrittenName.synthetic("None", NOWHERE),
+                Ast.Var.denoting(WrittenName.synthetic("None", NOWHERE),
                         new ValueName.Builtin("None"), new ReachName.Bare("None")));
     }
 
@@ -140,7 +140,7 @@ public record FixtureTemplate(String text, Ast.Expr value) {
     public static FixtureTemplate unitCase(TypeReachName.Written type) {
         String written = type.rendered();
         return new FixtureTemplate(written,
-                new Ast.Var(WrittenName.synthetic(written, NOWHERE),
+                Ast.Var.denoting(WrittenName.synthetic(written, NOWHERE),
                         new ValueName.OfType(written, type.denotes(), ConstructionOrigin.own()),
                         new ReachName.Bare(written)));
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -1024,7 +1024,10 @@ public final class Bodies {
         }
         Set<String> names = new HashSet<>();
         for (Ast.Var req : spec.value().dependsOn()) {
-            names.add(req.bare());
+            // Reported where it is written; it names no parameter for a body to be held to.
+            if (!req.unresolved()) {
+                names.add(req.bare());
+            }
         }
         return names;
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -2,6 +2,7 @@ package souther.compiler.query;
 
 import souther.compiler.ast.Ast;
 import souther.compiler.check.BehaviorRequirement;
+import souther.compiler.check.ResolvedModule;
 import souther.compiler.check.DataChecker;
 import souther.compiler.check.HelperInliner;
 import souther.compiler.check.HelperGraph;
@@ -566,12 +567,12 @@ public final class Bodies {
             if (Names.cyclic(db, name)) {
                 return Answer.absent();
             }
-            Answer<Ast.Module> resolved = db.ask(new Names.Resolved(name));
+            Answer<ResolvedModule> resolved = db.ask(new Names.Resolved(name));
             if (!resolved.present()) {
                 return Answer.absent();
             }
             Map<String, Ast.FnDef> out = new LinkedHashMap<>();
-            for (Ast.Import imp : resolved.value().imports()) {
+            for (Ast.Import imp : resolved.value().module().imports()) {
                 Answer<Ast.Module> from = db.ask(new Settled(imp.module()));
                 // Closed against the table that module's own bodies are expanded against, which is
                 // everything it can name and not only what it declares: a published body may call a

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -6,6 +6,7 @@ import souther.compiler.ast.WrittenName;
 import souther.compiler.check.HelperInliner;
 import souther.compiler.check.Registry;
 import souther.compiler.check.Resolve;
+import souther.compiler.check.ResolvedModule;
 import souther.compiler.check.Suggest;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeChecker;
@@ -468,8 +469,8 @@ public final class Names {
 
         @Override
         public Answer<Map<String, Ast.Def>> compute(Db db) {
-            Answer<Ast.Module> m = db.ask(new Resolved(name));
-            return m.present() ? Answer.of(defsOf(m.value())) : Answer.absent();
+            Answer<ResolvedModule> m = db.ask(new Resolved(name));
+            return m.present() ? Answer.of(defsOf(m.value().module())) : Answer.absent();
         }
     }
 
@@ -711,7 +712,7 @@ public final class Names {
                     || unbuilt.value().contains(named.name())) {
                 return Answer.absent();
             }
-            for (Ast.Def def : resolution.value().module().defs()) {
+            for (Ast.Def def : resolution.value().module().module().defs()) {
                 if (def.name().equals(named.name())) {
                     return Answer.of(def);
                 }
@@ -1069,14 +1070,14 @@ public final class Names {
     }
 
     /** The resolved module — {@link Resolution} without the record of how it got there. */
-    public record Resolved(String name) implements Key<Ast.Module> {
+    public record Resolved(String name) implements Key<ResolvedModule> {
         @Override
         public String module() {
             return name;
         }
 
         @Override
-        public Answer<Ast.Module> compute(Db db) {
+        public Answer<ResolvedModule> compute(Db db) {
             Answer<Resolve.Resolved> resolution = db.ask(new Resolution(name));
             return resolution.present() ? Answer.of(resolution.value().module()) : Answer.absent();
         }

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -300,7 +300,7 @@ public final class Names {
                 // The module is one this compilation has and could not read. What is wrong with it
                 // is reported on its own source; saying anything here sends the author to a file
                 // that is fine.
-                return reached(ref, new ValueName.Unresolved(written));
+                return ref.unanswered();
             }
             if (!declared.value().contains(bare)) {
                 return nothing(ref, unknown.report(ref, declared.value()));
@@ -316,7 +316,7 @@ public final class Names {
         private Ast.Var bare(Ast.Var ref, String written, Unknown unknown) {
             BehaviorsInScope.Of scope = db.ask(new BehaviorsInScope(m.name())).value();
             if (scope == null) {
-                return reached(ref, new ValueName.Unresolved(written));
+                return ref.unanswered();
             }
             ValueName.Behavior named = scope.byName().get(written);
             if (named != null) {
@@ -325,7 +325,7 @@ public final class Names {
             if (!scope.whole()) {
                 // An import that could not be followed may have been where this name came from.
                 // Whatever is wrong with that module is reported there.
-                return reached(ref, new ValueName.Unresolved(written));
+                return ref.unanswered();
             }
             return nothing(ref, unknown.report(ref, scope.byName().keySet()));
         }
@@ -357,7 +357,7 @@ public final class Names {
         /** Records why a name denotes nothing, and gives it the name that says so. */
         private Ast.Var nothing(Ast.Var ref, Report report) {
             reports.add(report);
-            return reached(ref, new ValueName.Unresolved(ref.name()));
+            return ref.unanswered();
         }
     }
 
@@ -1328,8 +1328,7 @@ public final class Names {
                 case ValueName.Helper h -> h.module();
                 case ValueName.Behavior b -> b.module();
                 case ValueName.Local l -> l.id().owner().module();
-                case ValueName.Stdlib _, ValueName.OfType _,
-                        ValueName.Builtin _, ValueName.Unresolved _ -> null;
+                case ValueName.Stdlib _, ValueName.OfType _, ValueName.Builtin _ -> null;
             };
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -2,6 +2,7 @@ package souther.compiler.query;
 
 import souther.compiler.ast.Ast;
 import souther.compiler.check.ClauseDischarge;
+import souther.compiler.check.ResolvedModule;
 import souther.compiler.check.HelperInliner;
 import souther.compiler.check.HelperInvariants;
 import souther.compiler.check.HelperNames;
@@ -54,17 +55,17 @@ public final class Shapes {
      * bodies — and it is the imported module's bodies it reaches, never this one's: what a module
      * imports is read off its resolved form, so nothing here is asked through itself.
      */
-    record Settling(String name) implements Key<Ast.Module> {
+    record Settling(String name) implements Key<ResolvedModule> {
         @Override
         public String module() {
             return name;
         }
 
         @Override
-        public Answer<Ast.Module> compute(Db db) {
+        public Answer<ResolvedModule> compute(Db db) {
             // The module to expand, which is the resolved one where its values are well founded.
             // Everything below here expands a body of it.
-            Answer<Ast.Module> resolved = db.ask(new Expandable(name));
+            Answer<ResolvedModule> resolved = db.ask(new Expandable(name));
             if (!resolved.present()) {
                 return Answer.absent();
             }
@@ -78,10 +79,10 @@ public final class Shapes {
             // as the unknown name it then is, which is the same answer every other stage gives there.
             Map<String, Ast.FnDef> published = imported.present() ? imported.value() : Map.of();
             try {
-                Ast.Module declared = onlyWhatItDeclares(resolved.value());
+                Ast.Module declared = onlyWhatItDeclares(resolved.value().module());
                 Ast.Module derived = Deriver.derive(declared, scope.value());
-                return Answer.of(
-                        HelperInvariants.withSettledInvariants(derived, scope.value(), published));
+                return Answer.of(resolved.value().with(
+                        HelperInvariants.withSettledInvariants(derived, scope.value(), published)));
             } catch (CompileException e) {
                 return Answer.absent(e);
             }
@@ -130,21 +131,21 @@ public final class Shapes {
      * <p>Read off the resolved module, which is the earliest form that says what each name denotes —
      * and what a name denotes is what decides whether it is an edge at all.
      */
-    public record Expandable(String name) implements Key<Ast.Module> {
+    public record Expandable(String name) implements Key<ResolvedModule> {
         @Override
         public String module() {
             return name;
         }
 
         @Override
-        public Answer<Ast.Module> compute(Db db) {
-            Answer<Ast.Module> resolved = db.ask(new Names.Resolved(name));
+        public Answer<ResolvedModule> compute(Db db) {
+            Answer<ResolvedModule> resolved = db.ask(new Names.Resolved(name));
             if (!resolved.present()) {
                 return Answer.absent();
             }
             Answer<Map<String, Ast.FnDef>> imported = db.ask(new Bodies.ImportedDefinitions(name));
             try {
-                ValueCycles.rejectIn(resolved.value(),
+                ValueCycles.rejectIn(resolved.value().module(),
                         imported.present() ? imported.value() : Map.of());
                 return Answer.of(resolved.value());
             } catch (CompileException e) {
@@ -201,14 +202,14 @@ public final class Shapes {
 
         @Override
         public Answer<Map<String, Ast.Def>> compute(Db db) {
-            Answer<Ast.Module> settling = db.ask(new Settling(name));
+            Answer<ResolvedModule> settling = db.ask(new Settling(name));
             Answer<Symbols> scope = Names.symbols(db, name, Names.Stage.RESOLVED);
             if (!settling.present() || !scope.present()) {
                 return Answer.absent();
             }
             Map<String, Ast.Def> out = new LinkedHashMap<>();
             List<Report> reports = new ArrayList<>();
-            for (Ast.Def def : settling.value().defs()) {
+            for (Ast.Def def : settling.value().module().defs()) {
                 try {
                     out.put(def.name(), NewtypeDesugar.rewriteInvariantsOf(def, scope.value()));
                 } catch (CompileException e) {
@@ -236,20 +237,20 @@ public final class Shapes {
 
         @Override
         public Answer<Ast.Module> compute(Db db) {
-            Answer<Ast.Module> settling = db.ask(new Settling(name));
+            Answer<ResolvedModule> settling = db.ask(new Settling(name));
             Answer<Map<String, Ast.Def>> declarations = db.ask(new DerivedDeclarations(name));
             if (!settling.present() || !declarations.present()) {
                 return Answer.absent();
             }
             List<Ast.Def> defs = new ArrayList<>();
-            for (Ast.Def def : settling.value().defs()) {
+            for (Ast.Def def : settling.value().module().defs()) {
                 Ast.Def came = declarations.value().get(def.name());
                 if (came == null) {
                     return Answer.absent();
                 }
                 defs.add(came);
             }
-            Ast.Module m = settling.value();
+            Ast.Module m = settling.value().module();
             return Answer.of(new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(),
                     defs, m.behaviors(), m.fns(), m.takenOn(), m.examples(), m.fakes(),
                     m.exampleFileTarget(), m.pos()));
@@ -306,14 +307,14 @@ public final class Shapes {
 
         @Override
         public Answer<Map<String, Ast.FnDef>> compute(Db db) {
-            Answer<Ast.Module> settling = db.ask(new Settling(name));
+            Answer<ResolvedModule> settling = db.ask(new Settling(name));
             Answer<Symbols> scope = Names.symbols(db, name, Names.Stage.DERIVED);
             if (!settling.present() || !scope.present()) {
                 return Answer.absent();
             }
             Map<String, Ast.FnDef> out = new LinkedHashMap<>();
             List<Report> reports = new ArrayList<>();
-            for (Ast.FnDef fn : settling.value().fns()) {
+            for (Ast.FnDef fn : settling.value().module().fns()) {
                 try {
                     out.put(fn.name(), NewtypeDesugar.rewriteOf(fn, scope.value()));
                 } catch (CompileException e) {
@@ -435,7 +436,7 @@ public final class Shapes {
 
         @Override
         public Answer<Map<TypeName, List<ClauseDischarge>>> compute(Db db) {
-            Answer<Ast.Module> resolved = db.ask(new Expandable(name));
+            Answer<ResolvedModule> resolved = db.ask(new Expandable(name));
             Answer<Symbols> scope = Names.symbols(db, name, Names.Stage.RESOLVED);
             if (!resolved.present() || !scope.present()) {
                 return Answer.absent();
@@ -445,7 +446,7 @@ public final class Shapes {
             // What the clause says is what the check reads, so an imported bound is substituted here
             // as it is where the invariant is settled. A clause left naming it would be classified as
             // a rule this analysis cannot read, and a construction the bound rejects would compile.
-            Ast.Module declaring = HelperNames.withQualifiedInvariants(resolved.value());
+            Ast.Module declaring = HelperNames.withQualifiedInvariants(resolved.value().module());
             try {
                 Map<TypeName, List<ClauseDischarge>> out = new LinkedHashMap<>();
                 for (Ast.Def def : declaring.defs()) {
@@ -516,7 +517,7 @@ public final class Shapes {
 
         @Override
         public Answer<Map<TypeName, List<Ast.InvariantClause>>> compute(Db db) {
-            Answer<Ast.Module> resolved = db.ask(new Expandable(name));
+            Answer<ResolvedModule> resolved = db.ask(new Expandable(name));
             Answer<Symbols> scope = Names.symbols(db, name, Names.Stage.RESOLVED);
             if (!resolved.present() || !scope.present()) {
                 return Answer.absent();
@@ -525,7 +526,7 @@ public final class Shapes {
             Map<String, Ast.FnDef> published = imported.present() ? imported.value() : Map.of();
             try {
                 return Answer.of(HelperInvariants.invariantsForDischarge(
-                        resolved.value(), scope.value(), published));
+                        resolved.value().module(), scope.value(), published));
             } catch (CompileException e) {
                 return Answer.absent(e);
             }

--- a/souther-compiler/src/main/java/souther/compiler/types/ReachName.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/ReachName.java
@@ -93,10 +93,11 @@ public sealed interface ReachName {
      * the module that declares it, and neither the declaration nor the spelling says which case this
      * is on its own.
      *
-     * <p>A name that denotes nothing is {@link ValueName.Unresolved}, which is an answer and is
-     * reached by its spelling like anything else. No denotation at all is not a third kind of name:
-     * it is a caller that has not resolved one yet, and answering it with the spelling would put a
-     * reference into the tree that reaches whatever the spelling happens to mean downstream.
+     * <p>Asked only of a name that denotes something. One nothing declares is
+     * {@link souther.compiler.ast.Ast.Var.Unanswered}, which reaches nothing and is not asked; it
+     * used to be answered with its own spelling, and a spelling handed back as a reach name is a
+     * reference that reaches whatever the reading module happens to mean by it (ADR-0067). A caller
+     * with no denotation at hand has not resolved one yet, and is refused for the same reason.
      */
     static ReachName of(ValueName denotes, String written, String self) {
         if (self == null) {

--- a/souther-compiler/src/main/java/souther/compiler/types/ReachName.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/ReachName.java
@@ -110,11 +110,10 @@ public sealed interface ReachName {
             case ValueName.Helper helper -> helper.module().equals(self)
                     ? new Bare(helper.name()) : new OfModule(helper.module(), helper.name());
             case ValueName.Stdlib library -> new OfLibrary(library);
-            // Each of these is reached by the name it is written with. A binding is named where it is
-            // bound, a behavior and a type by what this module calls them, and a name that denotes
-            // nothing keeps the spelling so that a report quotes what was written.
-            case ValueName.Local _, ValueName.Behavior _, ValueName.OfType _, ValueName.Builtin _,
-                    ValueName.Unresolved _ -> new Bare(written);
+            // Each of these is reached by the name it is written with: a binding is named where it
+            // is bound, and a behavior and a type by what this module calls them.
+            case ValueName.Local _, ValueName.Behavior _, ValueName.OfType _,
+                    ValueName.Builtin _ -> new Bare(written);
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/types/ValueName.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/ValueName.java
@@ -163,24 +163,4 @@ public sealed interface ValueName {
             return module + "." + name;
         }
     }
-
-    /**
-     * A name nothing denotes, keeping the spelling that was written.
-     *
-     * <p>Why it denotes nothing was reported where it was written, so a reader that meets one says
-     * nothing further: the definition resting on it is abandoned, and the definitions around it are
-     * checked as they would be without it. This is what {@link TypeName#unresolved} is for a type.
-     */
-    record Unresolved(String written) implements ValueName {
-
-        @Override
-        public String name() {
-            return written;
-        }
-
-        @Override
-        public String toString() {
-            return written;
-        }
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompilePostfixApplicationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePostfixApplicationTest.java
@@ -336,7 +336,8 @@ class CompilePostfixApplicationTest {
         SourcePos at = new SourcePos(1, 1);
         BindingId id = new BindingId(new BindingOwner.OfValue("demo", "go"), 0);
         Ast.Apply lowered = new Ast.Apply(
-                new Ast.Var("$fn0", new ValueName.Local("$fn0", id), new ReachName.Bare("$fn0"), at),
+                Ast.Var.denoting("$fn0", new ValueName.Local("$fn0", id),
+                        new ReachName.Bare("$fn0"), at),
                 java.util.List.of(), souther.compiler.types.ConstructionOrigin.own(), "d.count", at, null);
 
         assertEquals("d.count", lowered.written(), "a report quotes what the author wrote");

--- a/souther-compiler/src/test/java/souther/compiler/ast/ANameAnsweredHalfwayIsRefusedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ast/ANameAnsweredHalfwayIsRefusedTest.java
@@ -38,7 +38,7 @@ class ANameAnsweredHalfwayIsRefusedTest {
      */
     @Test
     void aNameNothingHasAnsweredYetSaysOnlyWhatItIsWrittenAs() {
-        Ast.Var written = new Ast.Var("spin", POS);
+        Ast.Var written = Ast.Var.written("spin", POS);
 
         assertEquals("spin", written.name());
         assertThrows(IllegalStateException.class, written::bare);
@@ -54,9 +54,9 @@ class ANameAnsweredHalfwayIsRefusedTest {
     @Test
     void aNameAnsweredOnOneCountOnlyCannotBeBuilt() {
         IllegalArgumentException noReach = assertThrows(IllegalArgumentException.class,
-                () -> new Ast.Var(WrittenName.of("spin", POS), DECLARED, null));
+                () -> Ast.Var.denoting(WrittenName.of("spin", POS), DECLARED, null));
         IllegalArgumentException noDenotation = assertThrows(IllegalArgumentException.class,
-                () -> new Ast.Var(WrittenName.of("spin", POS), null,
+                () -> Ast.Var.denoting(WrittenName.of("spin", POS), null,
                         new ReachName.OfModule("demo", "spin")));
 
         assertEquals(true, noReach.getMessage().contains("spin"), noReach.getMessage());
@@ -89,7 +89,7 @@ class ANameAnsweredHalfwayIsRefusedTest {
     /** Answered, it says both. */
     @Test
     void aResolvedNameSaysWhatItDenotesAndHowItIsReached() {
-        Ast.Var resolved = new Ast.Var(WrittenName.of("spin", POS), DECLARED,
+        Ast.Var resolved = Ast.Var.denoting(WrittenName.of("spin", POS), DECLARED,
                 new ReachName.OfModule("demo", "spin"));
 
         assertEquals("spin", resolved.bare());

--- a/souther-compiler/src/test/java/souther/compiler/ast/ANameNothingDeclaresIsNotAResolvedNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ast/ANameNothingDeclaresIsNotAResolvedNameTest.java
@@ -1,0 +1,75 @@
+package souther.compiler.ast;
+
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.TypeName;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The three states a type name is in, and the one that used to stand for two of them.
+ *
+ * <p>Resolution answers a name or finds nothing declares it, and before it runs neither has
+ * happened. Those are three things. They were two — a name carried the declaration it denotes, and
+ * a name nothing declared carried a stand-in identity under a module called {@code unresolved}, so
+ * "has this been resolved" and "does this name something" were one question read off one value.
+ *
+ * <p>A reader downstream of the pass got a name that answered the first and lied about the second.
+ * What it did with the lie was its own business: {@code TypeOps.fieldTypes} looked the stand-in up,
+ * found no declaration and reported that the spread was not a product data; {@code MatchElaborator}
+ * compared it against {@code Some} and {@code None} and reported that the arm was not a case of an
+ * optional. Both are the unknown name reported a second time, in words that send the author
+ * somewhere else.
+ */
+class ANameNothingDeclaresIsNotAResolvedNameTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    private static final TypeName DECLARED = new TypeName("demo", "Invoice");
+
+    /** Before the pass runs, a name is what it is written as and nothing else. */
+    @Test
+    void aNameNothingHasReadYetRefusesTheQuestion() {
+        Ast.Name written = Ast.Name.written("Invoice", POS);
+
+        assertEquals("Invoice", written.written());
+        IllegalStateException e = assertThrows(IllegalStateException.class, written::denotes);
+        assertTrue(e.getMessage().contains("before it was resolved"), e.getMessage());
+    }
+
+    /**
+     * Read and found nothing, it refuses the same question — and says the other thing, because what
+     * a reader does next differs. One of these is a fault in the compiler; the other is a mistake in
+     * the source that was reported where it is written.
+     */
+    @Test
+    void aNameNothingDeclaresRefusesItToo() {
+        Ast.Name unanswered = Ast.Name.written("Invoice", POS).unanswered();
+
+        assertEquals("Invoice", unanswered.written());
+        IllegalStateException e = assertThrows(IllegalStateException.class, unanswered::denotes);
+        assertTrue(e.getMessage().contains("denotes nothing"), e.getMessage());
+    }
+
+    /**
+     * And a resolved name holds a declaration that is there. The stand-in cannot be put in one, so
+     * there is no value that says it has been resolved and names nothing — which is the state every
+     * reader below the pass was left to notice for itself.
+     */
+    @Test
+    void aResolvedNameCannotCarryAStandIn() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> Ast.Name.written("Invoice", POS).denoting(TypeName.unresolved("Invoice")));
+
+        assertTrue(e.getMessage().contains("Unanswered"), e.getMessage());
+    }
+
+    /** Answered, it says which declaration. */
+    @Test
+    void aResolvedNameSaysWhatItDenotes() {
+        assertEquals(DECLARED, Ast.Name.written("Invoice", POS).denoting(DECLARED).denotes());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/ast/ANameUsedAsAValueHasThreeStatesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ast/ANameUsedAsAValueHasThreeStatesTest.java
@@ -1,0 +1,100 @@
+package souther.compiler.ast;
+
+import souther.compiler.diag.Region;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.ReachName;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * As {@link Ast.Name} for a type, so for a name used as a value: read by nobody, answered, or read
+ * and found to name nothing.
+ *
+ * <p>The third was a denotation like any other — {@code ValueName.Unresolved}, carrying the spelling
+ * — so a reader below the pass held a name that said it had been resolved and named nothing. Every
+ * walk over a body had to know that: the switch over what a name denotes carried an arm for it that
+ * answered null, 0 or false, and a walk that forgot the arm would not have compiled but a walk that
+ * wrote it wrongly would.
+ *
+ * <p>It is a state of the reference now, not a kind of denotation, so a walk asks which of the three
+ * it has and the one that names nothing has neither answer to give.
+ */
+class ANameUsedAsAValueHasThreeStatesTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    private static final ValueName DECLARED = new ValueName.Helper("demo", "spin");
+
+    private static final ReachName REACHED = new ReachName.OfModule("demo", "spin");
+
+    /** Before the pass runs, a name is what it is written as and nothing else. */
+    @Test
+    void aNameNothingHasReadYetRefusesBothAnswers() {
+        Ast.Var written = Ast.Var.written("spin", POS);
+
+        assertEquals("spin", written.name());
+        assertFalse(written.unresolved(), "nothing has looked at it, so nothing found it wanting");
+        assertTrue(assertThrows(IllegalStateException.class, written::bare)
+                .getMessage().contains("before it was resolved"));
+        assertThrows(IllegalStateException.class, written::reaches);
+    }
+
+    /**
+     * Read and found nothing, it refuses both too — and says so as the other thing, because what a
+     * reader does about it differs. A {@link Ast.Var.Written} one is a fault in this compiler; this
+     * one is a mistake in the source, reported where it is written, and the definition holding it is
+     * abandoned rather than diagnosed a second time.
+     */
+    @Test
+    void aNameNothingAnswersToRefusesThemAsTheOtherThing() {
+        Ast.Var nothing = Ast.Var.written("spin", POS).unanswered();
+
+        assertEquals("spin", nothing.name());
+        assertTrue(nothing.unresolved());
+        assertTrue(assertThrows(IllegalStateException.class, nothing::bare)
+                .getMessage().contains("denotes nothing"));
+        assertThrows(IllegalStateException.class, nothing::reaches);
+    }
+
+    /**
+     * And an answered one is answered on both counts. Half of it is not a state a rewrite may leave
+     * behind: one way round leaves a reference that resolves to a declaration and reaches nothing,
+     * the other a key with nothing saying what it means.
+     */
+    @Test
+    void anAnsweredNameIsAnsweredOnBothCounts() {
+        Ast.Var answered = Ast.Var.denoting(WrittenName.of("spin", POS), DECLARED, REACHED);
+
+        assertEquals("spin", answered.bare());
+        assertEquals("demo.spin", answered.reaches());
+        assertFalse(answered.unresolved());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> Ast.Var.denoting(WrittenName.of("spin", POS), DECLARED, null));
+        assertThrows(IllegalArgumentException.class,
+                () -> Ast.Var.denoting(WrittenName.of("spin", POS), null, REACHED));
+    }
+
+    /**
+     * Every state keeps its own kind when the expression it is gets a new extent — a name the
+     * author parenthesized is written over five characters and is an expression over nine.
+     */
+    @Test
+    void anExtentDoesNotChangeWhichOfTheThreeItIs() {
+        WrittenName name = WrittenName.synthetic("spin", POS);
+        Region wider = new Region(POS, new SourcePos(1, 10));
+
+        assertEquals(Ast.Var.Written.class,
+                Ast.withRegion(Ast.Var.written(name), wider).getClass());
+        assertEquals(Ast.Var.Unanswered.class,
+                Ast.withRegion(Ast.Var.written(name).unanswered(), wider).getClass());
+        assertEquals(Ast.Var.Denoting.class,
+                Ast.withRegion(Ast.Var.denoting(name, DECLARED, REACHED), wider).getClass());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/ast/EverySlotIsAChildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ast/EverySlotIsAChildTest.java
@@ -27,7 +27,7 @@ class EverySlotIsAChildTest {
     private static final SourcePos POS = new SourcePos(1, 1);
 
     private static Ast.Var name(String written) {
-        return new Ast.Var(written, POS);
+        return Ast.Var.written(written, POS);
     }
 
     /** {@code Person { ..base, age: n }} — one name slot, one expression slot. */

--- a/souther-compiler/src/test/java/souther/compiler/check/ASettledTypeAnswersLikeAWrittenOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ASettledTypeAnswersLikeAWrittenOneTest.java
@@ -7,6 +7,7 @@ import souther.compiler.types.Type;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -20,9 +21,9 @@ class ASettledTypeAnswersLikeAWrittenOneTest {
 
     private static final SourcePos POS = new SourcePos(1, 1);
 
-    /** {@code List<'a>} as the parser reads it. */
+    /** {@code List<'a>} as the parser reads it, before resolution has said what it stands for. */
     private static Ast.TypeRef written() {
-        return new Ast.TypeRef("List", new Ast.TypeRef("'a", null, POS), POS);
+        return Ast.TypeRef.written("List", Ast.TypeRef.written("'a", null, POS), POS);
     }
 
     @Test
@@ -39,10 +40,19 @@ class ASettledTypeAnswersLikeAWrittenOneTest {
         assertFalse(HelperInliner.mentionsTypeVar(Ast.TypeRef.of(Type.INT, POS)));
     }
 
-    /** A written reference answers what it answered before, so the two readings agree. */
+    /**
+     * A reference resolution has not read is refused rather than answered off its spelling.
+     *
+     * <p>This runs after resolution, so a reference still {@link Ast.TypeRef.Written} here is a
+     * fault in the compiler. Answering it from the characters — {@code 'a} begins with a quote, so
+     * say yes — is what the reading used to do, and it is a second resolution: the same spelling
+     * means different things in different modules, and the reference no longer says which one it
+     * was written in.
+     */
     @Test
-    void aWrittenTypeAnswersAsItDid() {
-        assertTrue(HelperInliner.mentionsTypeVar(written()));
-        assertFalse(HelperInliner.mentionsTypeVar(new Ast.TypeRef("Int", null, POS)));
+    void aTypeNothingHasReadIsRefused() {
+        assertThrows(IllegalStateException.class, () -> HelperInliner.mentionsTypeVar(written()));
+        assertThrows(IllegalStateException.class,
+                () -> HelperInliner.mentionsTypeVar(Ast.TypeRef.written("Int", null, POS)));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/AValueIsReadUnderTheNameItIsReachedByTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AValueIsReadUnderTheNameItIsReachedByTest.java
@@ -42,7 +42,7 @@ class AValueIsReadUnderTheNameItIsReachedByTest {
         if (!answered.unresolved().isEmpty()) {
             throw answered.unresolved().get(0);
         }
-        return answered.module();
+        return answered.module().module();
     }
 
     /** The value {@code up} publishes, under the name a reader reaches it by — which is how it

--- a/souther-compiler/src/test/java/souther/compiler/check/AWalkTellsAnUnansweredNameFromAnUnreadOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AWalkTellsAnUnansweredNameFromAnUnreadOneTest.java
@@ -1,0 +1,89 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.ReachName;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A walk over a body adds no edge for a name nothing declares, and refuses one nothing has read.
+ *
+ * <p>The two are one thing to a walk that asks whether the name is answered — {@code !(v instanceof
+ * Denoting)} is true of both — and they are not one thing. A name nothing declares is a mistake in
+ * the source, reported where it is written, and a walk carrying on past it is what lets the
+ * definitions beside it still be checked. A name nothing has read is a pass that did not answer its
+ * own nodes, and a walk carrying on past that reads the module as though the author had written an
+ * unknown name: the pass that left it goes unmentioned, and every walk below agrees with it.
+ *
+ * <p>So {@link Ast.Var#answered()} is where the two part company, and a walk asks it rather than
+ * deciding for itself. Which is the whole of issue #703 in one method: the question was being
+ * answered again at each consumer.
+ */
+class AWalkTellsAnUnansweredNameFromAnUnreadOneTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    private static final BindingId BOUND =
+            new BindingId(new BindingOwner.OfValue("demo", "go"), 0);
+
+    /** A name resolution answered with the binding {@code BOUND}. */
+    private static Ast.Var bound() {
+        return Ast.Var.denoting("n", new ValueName.Local("n", BOUND), new ReachName.Bare("n"), POS);
+    }
+
+    // --- the three states, at the one place that tells them apart ---
+
+    @Test
+    void answeredPartsTheThreeWhereEveryWalkUsedToPartThemItself() {
+        assertEquals(Ast.Var.Denoting.class, bound().answered().getClass());
+        assertEquals(null, Ast.Var.written("n", POS).unanswered().answered(),
+                "nothing declares it, so a walk has no edge to add and carries on");
+        assertTrue(assertThrows(IllegalStateException.class,
+                        () -> Ast.Var.written("n", POS).answered())
+                .getMessage().contains("before it was resolved"),
+                "nothing has read it, which is this compiler's mistake and not the author's");
+    }
+
+    // --- and at a walk, which is where it matters ---
+
+    /** {@code ValueCycles} builds the graph of which values read which. */
+    @Test
+    void aNameNothingDeclaresIsNoEdge() {
+        Set<String> read = new LinkedHashSet<>();
+        ValueCycles.valuesRead(Ast.Var.written("nosuch", POS).unanswered(),
+                new LinkedHashMap<>(), read);
+
+        assertEquals(Set.of(), read);
+    }
+
+    @Test
+    void aNameNothingHasReadIsRefusedRatherThanCountedAmongThem() {
+        assertThrows(IllegalStateException.class,
+                () -> ValueCycles.valuesRead(Ast.Var.written("nosuch", POS),
+                        new LinkedHashMap<>(), new LinkedHashSet<>()));
+    }
+
+    /** {@code HelperParams} asks which binding a name is a use of. Same pair. */
+    @Test
+    void theSamePairHoldsWhereAWalkAsksWhichBindingAUseIsOf() {
+        Ast.Binder binder = new Ast.Binder.Bound(bound().written(), BOUND, POS);
+
+        assertTrue(HelperParams.mentions(bound(), binder));
+        assertEquals(false, HelperParams.mentions(
+                Ast.Var.written("n", POS).unanswered(), binder));
+        assertThrows(IllegalStateException.class,
+                () -> HelperParams.mentions(Ast.Var.written("n", POS), binder));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/CallElaboratorNoCalleeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/CallElaboratorNoCalleeTest.java
@@ -102,8 +102,7 @@ class CallElaboratorNoCalleeTest {
     void anUnexpandedCallIsAnInternalError() {
         for (ValueName denotes : List.of(
                 new ValueName.Helper("m", "f"),
-                new ValueName.Stdlib("List", "map"),
-                new ValueName.Unresolved("f"))) {
+                new ValueName.Stdlib("List", "map"))) {
             RuntimeException e = answerFor(denotes);
             assertInstanceOf(IllegalStateException.class, e, denotes.toString());
             assertTrue(e.getMessage().contains("7:3"), () -> "says where: " + e.getMessage());

--- a/souther-compiler/src/test/java/souther/compiler/check/WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest.java
@@ -51,7 +51,7 @@ class WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest {
         if (!answered.unresolved().isEmpty()) {
             throw answered.unresolved().get(0);
         }
-        return answered.module();
+        return answered.module().module();
     }
 
     /** A module declaring one recursive helper that descends on nothing. */

--- a/souther-compiler/src/test/java/souther/compiler/query/EveryTreeAnExpansionIsGivenIsStillWellFoundedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EveryTreeAnExpansionIsGivenIsStillWellFoundedTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.query;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.check.ResolvedModule;
 import souther.compiler.check.HelperInliner;
 import souther.compiler.check.ValueCycles;
 import souther.compiler.diag.CompileException;
@@ -89,12 +90,16 @@ class EveryTreeAnExpansionIsGivenIsStillWellFoundedTest {
     /** Each tree a compile of {@code name} makes, by the stage that makes it. */
     private static Map<String, Ast.Module> treesOf(Db db, String name) {
         Map<String, Key<Ast.Module>> stages = new LinkedHashMap<>();
-        stages.put("resolved", new Names.Resolved(name));
+        // Resolution answers with the tree and the claim that it has been read, which the stages
+        // below it hand on as an ordinary module.
+        Answer<ResolvedModule> resolved = db.ask(new Names.Resolved(name));
+        assertTrue(resolved.present(), "resolved of " + name + ": " + resolved.reports());
         stages.put("derived", new Shapes.Derived(name));
         stages.put("desugared", new Shapes.Desugared(name));
         stages.put("prepared", new Shapes.Prepared(name));
         stages.put("settled", new Bodies.Settled(name));
         Map<String, Ast.Module> out = new LinkedHashMap<>();
+        out.put("resolved", resolved.value().module());
         stages.forEach((stage, key) -> {
             Answer<Ast.Module> answer = db.ask(key);
             assertTrue(answer.present(), stage + " of " + name + ": " + answer.reports());
@@ -153,9 +158,10 @@ class EveryTreeAnExpansionIsGivenIsStillWellFoundedTest {
                     constructs Out
                 let go (i) = Out { n = i.n + step }
                 """), Set.of(), ModulePath.EMPTY).db();
-        Answer<Ast.Module> resolved = db.ask(new Names.Resolved("m.a"));
+        Answer<ResolvedModule> resolved = db.ask(new Names.Resolved("m.a"));
         assertTrue(resolved.present(), "resolution answers; the refusal comes later");
 
-        assertThrows(CompileException.class, () -> ValueCycles.rejectIn(resolved.value(), Map.of()));
+        assertThrows(CompileException.class,
+                () -> ValueCycles.rejectIn(resolved.value().module(), Map.of()));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
@@ -17,8 +17,10 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -59,6 +61,18 @@ class ResolvedValueNamesTest {
 
     private static ValueName denotes(Ast.Expr e) {
         return e instanceof Ast.Var v ? v.denotes() : ((Ast.Apply) e).denotes();
+    }
+
+    /** The name written as {@code written}, whatever state resolution left it in. */
+    private static Ast.Var nameOf(String source, String written) {
+        for (Ast.Expr e : named(resolve(source))) {
+            Ast.Var v = e instanceof Ast.Var name ? name
+                    : ((Ast.Apply) e).function() instanceof Ast.Var f ? f : null;
+            if (v != null && v.name().equals(written)) {
+                return v;
+            }
+        }
+        throw new AssertionError("nothing named `" + written + "` in the resolved module");
     }
 
     /** The one named {@code written}, which each of these writes once. */
@@ -265,7 +279,10 @@ class ResolvedValueNamesTest {
                 let f (n) = nosuch
                 """;
 
-        assertInstanceOf(ValueName.Unresolved.class, denotationOf(source, "nosuch"));
+        Ast.Var name = nameOf(source, "nosuch");
+        assertInstanceOf(Ast.Var.Unanswered.class, name);
+        // and it holds no stand-in for a reader below to take for a declaration
+        assertThrows(IllegalStateException.class, name::denotes);
     }
 
     /** Every name in every body is answered — nothing is left as a spelling for a later reader to
@@ -289,6 +306,7 @@ class ResolvedValueNamesTest {
                 """);
 
         for (Ast.Expr e : named(m)) {
+            assertFalse(e instanceof Ast.Var.Written, "name nothing has read in " + e);
             assertTrue(denotes(e) != null, "unanswered name in " + e);
         }
     }

--- a/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
@@ -38,7 +38,7 @@ class ResolvedValueNamesTest {
         Map<String, String> byId = new LinkedHashMap<>();
         byId.put("a.sou", source);
         Compilation c = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
-        return c.db().ask(new Names.Resolved("m.a")).value();
+        return c.db().ask(new Names.Resolved("m.a")).value().module();
     }
 
     /** Every name used as a value in the module's bodies, in the order it is written. */

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleDeclaresDoesNotChangeWithTheStageTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleDeclaresDoesNotChangeWithTheStageTest.java
@@ -2,6 +2,7 @@ package souther.compiler.query;
 
 import souther.compiler.Compiler;
 import souther.compiler.ast.Ast;
+import souther.compiler.check.ResolvedModule;
 import souther.compiler.check.HelperInliner;
 import souther.compiler.meta.ModulePath;
 
@@ -59,12 +60,16 @@ class WhatAModuleDeclaresDoesNotChangeWithTheStageTest {
     /** Every stage that hands a module over, by the name of the stage. */
     private static Map<String, Ast.Module> stagesOf(Db db, String name) {
         Map<String, Key<Ast.Module>> keys = new LinkedHashMap<>();
-        keys.put("resolved", new Names.Resolved(name));
+        // Resolution answers with the tree and the claim that it has been read, which the stages
+        // below it hand on as an ordinary module.
+        Answer<ResolvedModule> resolved = db.ask(new Names.Resolved(name));
+        assertTrue(resolved.present(), "resolved of " + name + ": " + resolved.reports());
         keys.put("derived", new Shapes.Derived(name));
         keys.put("desugared", new Shapes.Desugared(name));
         keys.put("prepared", new Shapes.Prepared(name));
         keys.put("settled", new Bodies.Settled(name));
         Map<String, Ast.Module> out = new LinkedHashMap<>();
+        out.put("resolved", resolved.value().module());
         keys.forEach((stage, key) -> {
             Answer<Ast.Module> answer = db.ask(key);
             assertTrue(answer.present(), stage + " of " + name + ": " + answer.reports());

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -876,7 +876,7 @@ public final class Analyzer {
                 // a local is named where it is bound and nowhere else; the library and the language
                 // are not this workspace's to rename
                 case ValueName.Local _, ValueName.Stdlib _, ValueName.OfType _,
-                        ValueName.Builtin _, ValueName.Unresolved _ -> null;
+                        ValueName.Builtin _ -> null;
             };
             if (declaring != null) {
                 addExposingAndImportSites(compilation, value.name(), declaring, graph, byUri);
@@ -954,8 +954,7 @@ public final class Analyzer {
             case ValueName.Local _ -> uri;   // bound in the body the cursor is in
             case ValueName.Helper h -> compilation.sourceIdOf(h.module());
             case ValueName.Behavior b -> compilation.sourceIdOf(b.module());
-            case ValueName.Stdlib _, ValueName.OfType _, ValueName.Builtin _,
-                    ValueName.Unresolved _ -> null;
+            case ValueName.Stdlib _, ValueName.OfType _, ValueName.Builtin _ -> null;
         };
     }
 


### PR DESCRIPTION
`Resolve` states an invariant its consumers keep by looking, and #464, #696 and #700 were consumers
keeping it wrong. This puts it in the types.

#703 asked for a measurement before committing to the split. It is recorded on the issue:
https://github.com/souther-lang/souther/issues/703#issuecomment-5281228149 — including the three of
the issue's own premises it changes, and what the split turned out to be about, which was not
producer migration. This describes what changed.

## Three occurrences, and the module

Each of the three node types that carried a nullable answer becomes a sealed set of the states it is
actually in, as `Ast.Binder` already was:

```
TypeRef   Written | Denoting(Type)
Name      Written | Denoting(TypeName) | Unanswered
Var       Written | Denoting(ValueName, ReachName) | Unanswered
```

`denotes()` is one default per type that refuses the states that have no answer and says which they
are — a `Written` one is a fault in this compiler, an `Unanswered` one a mistake in the source
already reported where it is written. `Binder.id()` had written that shape and the comment that goes
with it: this is the one place that says so.

Three states rather than two, because two would put back the thing being removed. A name nothing
declares has been read; it is not waiting to be. `Denoting` refuses a stand-in identity at
construction, so there is no value that says it has been resolved and names nothing.

`Var.Denoting` holding both the denotation and the reach name is the pair invariant those two used
to enforce by hand.

`ResolvedModule` says of the whole module what the three say at each occurrence, which is the part a
signature can carry. It says the pass has been over the tree — not that every name found a
declaration, which is the distinction `Unanswered` exists for. Its constructor is package-private, so
`Resolve` is what mints one, and a pass that rewrites a resolved tree goes through
`with(Ast.Module)`, asked of the module it came from.

## What went with them

**`ValueName.Unresolved` is gone.** Nothing produced it but `Resolve` and `Names`, every reader of it
was a walk asking what a reference means, and there was no scope it stood in — which is the whole
reason `TypeName.unresolved` stays. That one is a fact about the scope resolution reads
(`Names.nameless`), and every reader of it now takes its value from `symbols.resolve(...)`; none
reads one off a tree.

**`ReachName.of` no longer answers a stand-in with `Bare(written)`.** That was the spelling handed
back as an identity-like value, which is the fallback ADR-0067 exists to remove.

**Second reports about one mistake.** Reading the recovery representation as a fact is how an unknown
name came to be told twice: an unknown spread reported as "not a product data", two stand-ins
reported as a duplicate, an unknown match arm reported as "not a case of an optional" and as
"wraps another type". Each is now what it was: nothing to build a further diagnosis on, so the
definition is `Unanswerable` and the ones beside it are still checked.

**`TypeOps.walkFields` carried a `resolving` boolean beside a null test** to say which callers may
meet an unanswered include. The states say it.

**`CallElaborator.typeOfCall` opened with an `IllegalStateException`** for a null denotation — the
pass boundary written as a runtime assertion in one consumer. `denotes()` says it now, once, for all
of them.

The graph and walk readers — `HelperInliner`, `ValueCycles`, `PartialReachability`,
`TotalityChecker`, `Requirements`, `SpecChecker`, `PipelineSigs`, `Bodies`, `HelperNames`,
`NewtypeDesugar`, `HelperParams` — ask which state a reference is in rather than what the stand-in
denoted. A name that answers to nothing reaches no declaration, so it is no edge and no rewrite.

## What this does not do

It does not make the state unrepresentable at each occurrence. A switch over `Ast.Var` is total over
three records, so `Elaborator` carries an arm for the one that cannot be there. Java cannot be told
that a particular module has no `Written` node without a phase parameter on every AST type. The
invariant moved from a convention each consumer keeps to a boundary held by `ResolvedModule` and the
three sealed types; it did not become impossible to express.

`ResolvedModule` stops at `Shapes.Settling`. Past there it reaches `Derived`, `Desugared` and
`Prepared` — the whole-module band #708 left out of scope, and the reason a declaration with no
meaning reaches `Deriver` at all.

## Verification

Each commit, on its own: the full suite green (7297 tests, the compiler module's count unchanged but
for the tests added), the examples corpus compiling, and `souther examples` over crm / invoicing /
issuetracker / ordering — 1769 lines — byte-identical to `develop`.

Refs #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)
