### PR TITLE
Let the place a fixture value stands answer for its form, and nothing else

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
@@ -147,7 +147,7 @@ public final class FixtureReader {
     /** The same, saying whether what is read is a value the model is given or one it is compared
      *  against. */
     private Object built(Hir.Expr written, FixtureShape shape, Admission admission) {
-        return decode(shape, raw(written, shape.type(), admission));
+        return decode(shape, raw(written, Position.at(shape.type()), admission));
     }
 
     /**
@@ -192,7 +192,8 @@ public final class FixtureReader {
             // Already built. Reading it back through the output's decoder would state nothing for a
             // stand-in written as an application, so what is left to ask of it is the form it is in
             // and whether it is what the dependency answers with.
-            neutral.requireWrittenForm(answer, whole == null ? null : whole.type());
+            neutral.requireWrittenForm(answer,
+                    whole == null ? Position.UNREAD : Position.at(whole.type()));
             return admitted(answer, out, whole);
         }
         if (whole != null) {
@@ -204,7 +205,7 @@ public final class FixtureReader {
         }
         // An answer of several types has no one decoder, so the value is read as written and what
         // admits it is which case it turned out to be.
-        return admitted(raw(written), out, null);
+        return admitted(raw(written, Position.UNREAD), out, null);
     }
 
     /**
@@ -568,7 +569,8 @@ public final class FixtureReader {
             return;
         }
         decode(FixtureShape.of(Type.ref(built), symbols),
-                neutral.shaped(raw(nd, Type.ref(built), Admission.HELD), Type.ref(built)));
+                neutral.shaped(raw(nd, Position.at(Type.ref(built)), Admission.HELD),
+                        Position.at(Type.ref(built))));
     }
 
     /**
@@ -664,7 +666,8 @@ public final class FixtureReader {
         // states the type this newtype requires of it, so its decoder has nothing it could coerce.
         if (base != null && !TypeOps.effectiveInvariants(declared(built), symbols).isEmpty()) {
             decode(FixtureShape.of(Type.ref(built), symbols),
-                    neutral.shaped(raw(argument, base, Admission.HELD), base));
+                    neutral.shaped(raw(argument, Position.at(base), Admission.HELD),
+                            Position.at(base)));
         }
         Map<String, Asserted> field = new LinkedHashMap<>();
         field.put("value", held);
@@ -1202,21 +1205,17 @@ public final class FixtureReader {
 
     // --- raw evaluation of a fixture expression -----------------------------------------------
 
-    /** Turns a fixture expression into its neutral (decoder-input) form: a literal to a boxed value,
-     * a newtype construction to its inner value, a record construction to a field map. */
-    private Object raw(Hir.Expr e) {
-        return raw(e, null);
-    }
-
     /**
-     * The neutral form of a written fixture value. {@code expected} is the type of the position it is
-     * written in, where the caller knows it: a bare case name travels differently depending on the sum
-     * it is read as, and only the position says which sum that is. It may be null — a fixture whose
-     * position has no declared type — and then the case's own sums decide, which is right whenever
-     * they agree.
+     * The neutral form of a written fixture value — a literal to a boxed value, a newtype
+     * construction to its inner value, a record construction to a field map.
+     *
+     * <p>{@code at} is what reads the value where it is written: a bare case name travels differently
+     * depending on the sum it is read as, and only the place it stands says which sum that is. Where
+     * nothing reads it ({@link Position#UNREAD}) nothing is written beside the case, which is the
+     * case's own form.
      */
-    private Object raw(Hir.Expr e, Type expected) {
-        return raw(e, expected, Admission.HELD);
+    private Object raw(Hir.Expr e, Position at) {
+        return raw(e, at, Admission.HELD);
     }
 
     /**
@@ -1248,28 +1247,29 @@ public final class FixtureReader {
         return admission == Admission.UNHELD ? Admission.UNHELD : Admission.HELD;
     }
 
-    /** As above, saying whether this frame is one that states a value at {@code expected}. */
-    private Object raw(Hir.Expr e, Type expected, Admission admission) {
+    /** As above, saying whether this frame is one that states a value at {@code at}. */
+    private Object raw(Hir.Expr e, Position at, Admission admission) {
         if (admission == Admission.HELD) {
-            admitWritten(e, expected);
+            admitWritten(e, at);
         }
         Admission inside = below(admission);
         return switch (e) {
             case Hir.IntLit i -> i.value();
             case Hir.DecimalLit d -> d.value();
-            case Hir.StringLit s -> text(s, expected);
+            case Hir.StringLit s -> text(s, at);
             case Hir.BoolLit b -> b.value();
-            case Hir.Neg n -> negate(raw(n.operand()));
+            // An operand of an arithmetic fold is a literal, so nothing reads it as anything.
+            case Hir.Neg n -> negate(raw(n.operand(), Position.UNREAD));
             case Hir.Binary bin -> fold(bin);
             // The three that go on at this same position, so what this frame is read under travels
             // with them: a name stands for a body, a `let` for its own body, and an application for
             // the value it answers with.
-            case Hir.Apply c -> collectionOrNewtype(c, expected, admission);
-            case Hir.Var v -> named(v, expected, admission);
-            case Hir.LetIn let -> bound(let, expected, admission);
-            case Hir.NewData nd -> record(nd, expected, admission);
+            case Hir.Apply c -> collectionOrNewtype(c, at, admission);
+            case Hir.Var v -> named(v, at, admission);
+            case Hir.LetIn let -> bound(let, at, admission);
+            case Hir.NewData nd -> record(nd, at, admission);
             case Hir.ListLit l -> {
-                Type element = NeutralForm.elementOf(expected);
+                Position element = at.element();
                 List<Object> out = new ArrayList<>();
                 for (Hir.Expr el : l.elements()) {
                     out.add(raw(el, element, inside));
@@ -1279,14 +1279,14 @@ public final class FixtureReader {
             // a `(key, value)` pair: only a `Map` field's entries are written this way, and `shaped`
             // collects them into the map the decoder reads (a tuple is not a data field type itself).
             case Hir.Tuple t -> {
-                List<Type> parts = NeutralForm.entryTypes(expected, t.elements().size());
+                List<Position> parts = at.parts(t.elements().size());
                 List<Object> out = new ArrayList<>();
                 for (int i = 0; i < t.elements().size(); i++) {
-                    out.add(raw(t.elements().get(i), parts == null ? null : parts.get(i), inside));
+                    out.add(raw(t.elements().get(i), parts.get(i), inside));
                 }
                 yield out;
             }
-            case Hir.FieldAccess fa -> rawProjection(fa, expected, admission);
+            case Hir.FieldAccess fa -> rawProjection(fa, at, admission);
             default -> throw new FixtureException("an example fixture must be a literal or a construction");
         };
     }
@@ -1303,7 +1303,7 @@ public final class FixtureReader {
     private sealed interface Projected {
 
         /** Built by this reader, under the type a declaration gives it. */
-        record Declared(Type type, Object value) implements Projected {}
+        record Declared(Position at, Object value) implements Projected {}
 
         /** A helper's answer, before it became a form: the value itself says what it is. */
         record Live(Object value, String written) implements Projected {}
@@ -1352,7 +1352,9 @@ public final class FixtureReader {
      *  evidence it carries is stated in, so the value and the type it is read at come from one place. */
     private Projected projectedAtItsDeclaredType(Hir.Expr e, Admission below) {
         Type declared = declaredTypeOf(e, new HashSet<>());
-        return new Projected.Declared(declared, raw(e, declared, below));
+        // Nothing declares what a name that stands for no value is, so nothing reads it here either.
+        Position at = declared == null ? Position.UNREAD : Position.at(declared);
+        return new Projected.Declared(at, raw(e, at, below));
     }
 
     /** One step of a chain: evidence in, evidence out. */
@@ -1378,7 +1380,8 @@ public final class FixtureReader {
                 }
                 yield new Projected.Live(taken, written + "." + fa.field());
             }
-            case Projected.Declared(Type type, Object value) -> {
+            case Projected.Declared(Position at, Object value) -> {
+                Type type = at instanceof Position.At(Type read) ? read : null;
                 Type taken = type == null ? null : fieldTypeOf(type, fa.field());
                 if (taken == null) {
                     // A value that has no fields at all and a record that has not this one are two
@@ -1393,14 +1396,14 @@ public final class FixtureReader {
                 // for it. What makes this one is the declaration and not the shape the value
                 // happens to have — a bare number is not a newtype for having reached here.
                 if (type instanceof Type.Ref r && neutral.isNewtype(r.name())) {
-                    yield new Projected.Declared(taken, value);
+                    yield new Projected.Declared(Position.at(taken), value);
                 }
                 if (!(value instanceof Map<?, ?> fields)) {
                     throw new FixtureException("`" + fa.field()
                             + "` is read off a value that is not a record, so it has no field to take");
                 }
                 // A `?` field holding nothing leaves its key out, which is the absent optional itself.
-                yield new Projected.Declared(taken, fields.get(fa.field()));
+                yield new Projected.Declared(Position.at(taken), fields.get(fa.field()));
             }
         };
     }
@@ -1409,21 +1412,21 @@ public final class FixtureReader {
      * A field taken off a value, in the neutral form the decoder reads. Only the outermost step
      * stands at a position, so only it admits and only it becomes a form.
      */
-    private Object rawProjection(Hir.FieldAccess fa, Type expected, Admission admission) {
+    private Object rawProjection(Hir.FieldAccess fa, Position at, Admission admission) {
         return switch (projectTarget(fa, admission)) {
             // Held by `states` before this frame was read, but built at the position the field
             // declares rather than at this one. A neutral form is decided by a position and not
             // only by a type, so a newtype admitted into a sum that lists it is written the way
             // that position reads before it reaches a decoder.
-            case Projected.Declared(Type type, Object value) -> neutral.reread(value, type, expected);
+            case Projected.Declared(Position built, Object value) -> neutral.reread(value, built, at);
             case Projected.Live(Object value, String written) -> {
                 // What the answer says is read off the answer, so a field holding an empty
                 // collection names no element type here — the limit every helper's answer is read
                 // under, and not one taking a field off it introduces.
                 if (admission == Admission.HELD) {
-                    admitBuilt(value, expected, written);
+                    admitBuilt(value, at, written);
                 }
-                yield neutral.of(value, expected, written);
+                yield neutral.of(value, at, written);
             }
         };
     }
@@ -1520,7 +1523,12 @@ public final class FixtureReader {
      * anything reaches a decoder, and at every frame rather than at the outermost one — a field, an
      * element and a helper's argument are each a position a value is written at.
      */
-    private void admitWritten(Hir.Expr e, Type expected) {
+    private void admitWritten(Hir.Expr e, Position at) {
+        // Nothing says what stands here, so nothing is asked of what does — the answer `admits` gives
+        // for every other position it has no reading of.
+        if (!(at instanceof Position.At(Type expected))) {
+            return;
+        }
         Admits admits = admits(expected);
         Admits held = admits instanceof Admits.OrAbsent(Admits under) ? under : admits;
         if (held instanceof Admits.Unsaid) {
@@ -1705,8 +1713,10 @@ public final class FixtureReader {
      * {@code List<Int>} has not answered a {@code List<AmountN>}, and reading it back element by
      * element would put each number where a name stands.
      */
-    private void admitBuilt(Object answer, Type expected, String written) {
-        if (holds(answer, expected)) {
+    private void admitBuilt(Object answer, Position at, String written) {
+        // Where nothing reads the value there is no type it could fail to be a value of; what admits
+        // a helper's answer there is the case it turned out to be, asked where the answer stands.
+        if (!(at instanceof Position.At(Type expected)) || holds(answer, expected)) {
             return;
         }
         throw new FixtureException("`" + written + "` answered with a `" + nameOfBuilt(answer)
@@ -1747,8 +1757,8 @@ public final class FixtureReader {
      * a helper returned asks too: a row reaches the neutral form both ways, and the rule is about the
      * form.
      */
-    private Object text(Hir.StringLit s, Type expected) {
-        if (neutral.temporalUnder(expected) instanceof Type.Prim temporal) {
+    private Object text(Hir.StringLit s, Position at) {
+        if (neutral.temporalUnder(at) instanceof Type.Prim temporal) {
             throw NeutralForm.notWrittenAsATemporal(temporal, s.value());
         }
         return s.value();
@@ -1760,28 +1770,28 @@ public final class FixtureReader {
      * <p>Which of the four it is was settled where the name was written, so it is not worked out
      * again here: a binding in force is the value it holds, whatever else bears its spelling.
      */
-    private Object named(Hir.Var v, Type expected, Admission admission) {
+    private Object named(Hir.Var v, Position at, Admission admission) {
         return switch (v.denotes()) {
             // `None` maps to a null, which the optional decoder reads as the absent optional
             // (spec §absence-is-written-as-null, absent/null -> None), the same as omitting a `T?` field
             case ValueName.Builtin b when b.name().equals("None") -> null;
             case ValueName.OfType named
                     when symbols.declarations().declaration(named.type().key()) instanceof Hir.UnitData ->
-                    unitInput(named.type(), expected);
+                    unitInput(named.type(), at);
             case ValueName.Local local -> {
                 Hir.Expr held = bindings.get(local.id());
                 if (held == null) {
                     throw new FixtureException("`" + v.name()
                             + "` is bound to no value a fixture can name");
                 }
-                yield expandedValue(local, held, expected, admission);
+                yield expandedValue(local, held, at, admission);
             }
             case ValueName.Helper helper -> {
                 Hir.Expr value = valueBody(v.name());
                 if (value == null) {
                     throw new FixtureException("`" + v.name() + "` is not a value a fixture can name");
                 }
-                yield expandedValue(helper, value, expected, admission);
+                yield expandedValue(helper, value, at, admission);
             }
             // `Map.empty` / `Set.empty`: a library value, not a library call, so there is no method to
             // run and its value is known from the name alone. It is the empty collection, which a row
@@ -1796,19 +1806,19 @@ public final class FixtureReader {
 
     /** A unit case as a fixture writes it: a unit's decoder ignores the input, so an empty map
      * stands in. */
-    private Object unitInput(TypeSymbol caseName, Type expected) {
+    private Object unitInput(TypeSymbol caseName, Position at) {
         {
             // A fixture is built in the neutral form the boundary reads, so a case of an enumeration
             // is written the way that sum travels: its name, bare (issue #161). The same unit data may
             // be a case of an enumeration and of a sum that has a field-bearing case, and those travel
             // differently — so the position's own type decides, and the case's sums answer only where
             // the position does not say.
-            if (caseName != null && neutral.readsABareName(expected, caseName)) {
+            if (caseName != null && neutral.readsABareName(at)) {
                 return caseName.name();
             }
             Map<String, Object> unit = new LinkedHashMap<>();
             // a unit case read through a sum still needs the tag that sum's decoder reads
-            neutral.tagged(expected, caseName, unit);
+            neutral.tagged(at, caseName, unit);
             return unit;
         }
     }
@@ -1825,11 +1835,11 @@ public final class FixtureReader {
 
     /** A {@code let} inside a fixture: its name stands for what it was bound to while the body is
      * built, and a binding of the same spelling that was already in force is put back afterwards. */
-    private Object bound(Hir.LetIn let, Type expected, Admission admission) {
+    private Object bound(Hir.LetIn let, Position at, Admission admission) {
         BindingId binding = let.binder().id();
         bindings.put(binding, let.value());
         try {
-            return raw(let.body(), expected, admission);
+            return raw(let.body(), at, admission);
         } finally {
             // a binding of its own, so there is nothing of an outer one to put back
             bindings.remove(binding);
@@ -1867,9 +1877,9 @@ public final class FixtureReader {
      */
     private final Deque<ValueName> expanding = new ArrayDeque<>();
 
-    private Object expandedValue(ValueName named, Hir.Expr body, Type expected,
+    private Object expandedValue(ValueName named, Hir.Expr body, Position at,
                                  Admission admission) {
-        return expanding(named, () -> raw(body, expected, admission));
+        return expanding(named, () -> raw(body, at, admission));
     }
 
     /**
@@ -1903,17 +1913,17 @@ public final class FixtureReader {
      * <p>The empty collection is admitted for the same reason, but it is named rather than applied
      * ({@code Map.empty}), so it is read in {@link #named}.
      */
-    private Object collectionOrNewtype(Hir.Apply c, Type expected, Admission admission) {
+    private Object collectionOrNewtype(Hir.Apply c, Position at, Admission admission) {
         if ("Set.fromList".equals(c.reaches()) || "Map.fromList".equals(c.reaches())) {
             if (c.args().size() != 1) {
                 throw new FixtureException("`" + c.written() + "` takes one argument");
             }
-            return raw(c.args().get(0), expected, admission);
+            return raw(c.args().get(0), at, admission);
         }
         if (appliedHelper(c) instanceof Applied helper) {
-            return applied(c, helper, expected, admission);
+            return applied(c, helper, at, admission);
         }
-        return newtypeInner(c, expected, admission);
+        return newtypeInner(c, at, admission);
     }
 
     /**
@@ -2010,15 +2020,15 @@ public final class FixtureReader {
      * a field of a record and an element of a list alike. An application that encloses nothing is
      * {@link #helperAnswer}: there the value itself is what the row asserts.
      */
-    private Object applied(Hir.Apply c, Applied helper, Type expected, Admission admission) {
+    private Object applied(Hir.Apply c, Applied helper, Position at, Admission admission) {
         Object answer = answered(c, helper);
         // Before the value becomes a form. A neutral form is what its position reads, so a `Long`
         // read as an `Amount` is a form nothing can tell from the one `Amount(1)` writes — which is
         // the whole of what this holds the helper to.
         if (admission == Admission.HELD) {
-            admitBuilt(answer, expected, c.written());
+            admitBuilt(answer, at, c.written());
         }
-        return neutral.of(answer, expected, c.written());
+        return neutral.of(answer, at, c.written());
     }
 
     /** The value a helper answers with, run as the method its module emits. Its arguments are fixtures
@@ -2063,7 +2073,7 @@ public final class FixtureReader {
                 : helper.reached();
     }
 
-    private Object newtypeInner(Hir.Apply c, Type expected, Admission admission) {
+    private Object newtypeInner(Hir.Apply c, Position at, Admission admission) {
         Type.Prim written = Type.Prim.named(c.reaches());
         if (written != null && written.temporal()) {
             // a written date: the decoders take the parsed temporal, not its text (a Date field's
@@ -2095,23 +2105,21 @@ public final class FixtureReader {
         // the argument is shaped against what the newtype wraps, the same way a record fixture
         // shapes a field's value: a `Map` newtype's entry pairs become a map, a `Set` newtype's
         // written list stays a list for its decoder to dedupe
-        return neutral.newtypeAt(expected, built,
-                neutral.shaped(raw(c.args().get(0),
-                                neutral.shapeOf(neutral.newtypeBaseType(built)), below(admission)),
-                        neutral.shapeOf(neutral.newtypeBaseType(built))));
+        Position base = Position.declaredBy(neutral.newtypeBaseType(built));
+        return neutral.newtypeAt(at, built,
+                neutral.shaped(raw(c.args().get(0), base, below(admission)), base));
     }
 
-    private Object record(Hir.NewData nd, Type expected, Admission admission) {
+    private Object record(Hir.NewData nd, Position at, Admission admission) {
         // `金額(500)` is the record literal `金額 { value = 500 }` written in call form (ADR-0032), and
         // a value's body reaches here already written the second way. Either spelling is the newtype's
         // own neutral form — its inner value — not a field map.
         TypeSymbol built = nd.typeName().denotes();
         if (neutral.isNewtype(built) && nd.spreads().isEmpty() && nd.inits().size() == 1
                 && nd.inits().get(0).name().equals("value")) {
-            return neutral.newtypeAt(expected, built,
-                    neutral.shaped(raw(nd.inits().get(0).value(),
-                                    neutral.shapeOf(neutral.newtypeBaseType(built)), below(admission)),
-                            neutral.shapeOf(neutral.newtypeBaseType(built))));
+            Position base = Position.declaredBy(neutral.newtypeBaseType(built));
+            return neutral.newtypeAt(at, built,
+                    neutral.shaped(raw(nd.inits().get(0).value(), base, below(admission)), base));
         }
         Map<String, Hir.TypeRef> declared = neutral.fieldTypes(nd.typeName().denotes());
         Map<String, Object> map = new LinkedHashMap<>();
@@ -2134,7 +2142,8 @@ public final class FixtureReader {
             // another (`Filed { ...d, filedOn = on }`, where `d` is a `Document`). So the frame this
             // opens states no value of the construction's type, while the fields it copies were
             // written at their own positions and hold there.
-            Object copied = expandedValue(ref.denotes(), value, Type.ref(nd.typeName().denotes()),
+            Object copied = expandedValue(ref.denotes(), value,
+                    Position.at(Type.ref(nd.typeName().denotes())),
                     admission == Admission.UNHELD ? admission : Admission.HELD_BELOW);
             if (!(copied instanceof Map<?, ?> fields)) {
                 throw new FixtureException("`" + spread + "` is not a record, so it has no fields to"
@@ -2153,9 +2162,8 @@ public final class FixtureReader {
             }
         }
         for (Hir.FieldInit fi : nd.inits()) {
-            Object v = neutral.shaped(raw(fi.value(), neutral.shapeOf(declared.get(fi.name())),
-                            below(admission)),
-                    neutral.shapeOf(declared.get(fi.name())));
+            Position field = Position.declaredBy(declared.get(fi.name()));
+            Object v = neutral.shaped(raw(fi.value(), field, below(admission)), field);
             // `None` on a `T?` field yields a null; leave the key out so the optional decoder reads it as
             // absent (spec §absence-is-written-as-null, absent -> None), the same neutral form as omitting
             // the field. A spread already wrote the field, so leaving the key out means taking it back out —
@@ -2166,7 +2174,7 @@ public final class FixtureReader {
             }
             map.put(fi.name(), v);
         }
-        neutral.tagged(expected, nd.typeName().denotes(), map);
+        neutral.tagged(at, nd.typeName().denotes(), map);
         return map;
     }
 
@@ -2181,8 +2189,8 @@ public final class FixtureReader {
     }
 
     private Object fold(Hir.Binary b) {
-        Object l = raw(b.left());
-        Object r = raw(b.right());
+        Object l = raw(b.left(), Position.UNREAD);
+        Object r = raw(b.right(), Position.UNREAD);
         if (l instanceof Long x && r instanceof Long y) {
             return switch (b.op()) {
                 case ADD -> x + y;
@@ -2206,7 +2214,7 @@ public final class FixtureReader {
 
     private Object decode(FixtureShape shape, Object rawValue) {
         Type type = shape.type();
-        Object raw = neutral.shaped(rawValue, type);
+        Object raw = neutral.shaped(rawValue, Position.at(type));
         Decoder<Object, ?> decoder = decoderFor(shape);
         Result<?> result;
         try {

--- a/souther-compiler/src/main/java/souther/compiler/examples/NeutralForm.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/NeutralForm.java
@@ -60,7 +60,7 @@ final class NeutralForm {
      * @param helper the helper that produced the value, for the reason a row is given when it cannot be
      *               read back
      */
-    Object of(Object live, Type position, String helper) {
+    Object of(Object live, Position position, String helper) {
         if (live == null) {
             return live;
         }
@@ -73,10 +73,12 @@ final class NeutralForm {
             }
             return live;
         }
-        Type opened = open(position);
+        Position opened = position.opened();
         if (live instanceof Map<?, ?> m) {
-            Type key = opened instanceof Type.MapOf map ? map.key() : null;
-            Type value = opened instanceof Type.MapOf map ? map.value() : null;
+            Position key = opened instanceof Position.At(Type type) && type instanceof Type.MapOf map
+                    ? Position.at(map.key()) : Position.UNREAD;
+            Position value = opened instanceof Position.At(Type type) && type instanceof Type.MapOf map
+                    ? Position.at(map.value()) : Position.UNREAD;
             Map<Object, Object> out = new LinkedHashMap<>();
             for (Map.Entry<?, ?> e : m.entrySet()) {
                 out.put(of(e.getKey(), key, helper), of(e.getValue(), value, helper));
@@ -84,7 +86,7 @@ final class NeutralForm {
             return out;
         }
         if (live instanceof Iterable<?> it) {
-            Type element = elementOf(opened);
+            Position element = opened.element();
             List<Object> out = new ArrayList<>();
             for (Object e : it) {
                 out.add(of(e, element, helper));
@@ -107,7 +109,7 @@ final class NeutralForm {
         }
         if (!(symbols.declarations().declaration(caseName.key()) instanceof Hir.Data data)) {
             // a unit case: its name where the position reads one, else the tag its sum's decoder reads
-            if (readsABareName(position, caseName)) {
+            if (readsABareName(position)) {
                 return caseName.name();
             }
             Map<String, Object> unit = new LinkedHashMap<>();
@@ -115,15 +117,15 @@ final class NeutralForm {
             return unit;
         }
         if (data.newtype()) {
-            Type base = shapeOf(newtypeBaseType(caseName));
+            Position base = Position.declaredBy(newtypeBaseType(caseName));
             return newtypeAt(position, caseName,
                     shaped(of(field(live, "value", helper), base, helper), base));
         }
         Map<String, Hir.TypeRef> declared = fieldTypes(caseName);
         Map<String, Object> out = new LinkedHashMap<>();
         for (Map.Entry<String, Hir.TypeRef> f : declared.entrySet()) {
-            Type type = shapeOf(f.getValue());
-            Object value = shaped(of(field(live, f.getKey(), helper), type, helper), type);
+            Position at = Position.declaredBy(f.getValue());
+            Object value = shaped(of(field(live, f.getKey(), helper), at, helper), at);
             // an absent optional is left out, the same neutral form a fixture writes for `None`
             if (value != null) {
                 out.put(f.getKey(), value);
@@ -166,23 +168,27 @@ final class NeutralForm {
      * this being answered by searching every visible sum for one that lists the case, which is a
      * question about the case rather than about the position it stands at.
      *
+     * <p>{@link Position.Unread} writes nothing, and nothing is worked out for it. A place no type
+     * reads asks for nothing beside the case, so what stands there is the case's own form — which is
+     * what a position typed by the case itself writes, and what a union answer writes, since a union
+     * has no decoder to read a discriminator with. Asking the sums that list the case instead is the
+     * same question as above with the position dropped from it, and it makes a value's form move when
+     * a sum nothing here reads it through is declared.
+     *
      * <p>A field the fixture wrote itself is never replaced. A case whose own field is named like its
      * sum's discriminator is already ambiguous at the boundary — the case encoder and the sum encoder
      * both claim that key — and overwriting here would hide that behind an example that passes while
      * decoding something the author did not write. Leaving the written value in place makes the row
      * fail on the tag it cannot match, which is the honest outcome.
      */
-    void tagged(Type declaredType, TypeSymbol caseName, Map<String, Object> map) {
+    void tagged(Position position, TypeSymbol caseName, Map<String, Object> map) {
         if (caseName == null) {
             return;
         }
-        if (declaredType == null) {
-            taggedWithoutADeclaredType(caseName, map);
-            return;
-        }
-        // Anything but a sum reads the case as itself: its own type, and — since a union is written
-        // only as a behavior's own answer, where it arrives with no declared type below — nothing else.
-        if (!(open(declaredType) instanceof Type.Ref ref)
+        // Anything but a sum reads the case as itself: its own type, a union — which is written only
+        // as a behavior's own answer and has no decoder — and a place nothing reads.
+        if (!(position.opened() instanceof Position.At(Type type))
+                || !(type instanceof Type.Ref ref)
                 || !(symbols.declarations().declaration(ref.name().key()) instanceof Hir.SumData sum)
                 || sum.decoder().isEmpty()) {
             return;
@@ -196,39 +202,14 @@ final class NeutralForm {
         }
     }
 
-    /**
-     * The same, where the position has no declared type to read the case through: an answer of
-     * several types, which admission and not a decoder decides ({@code FixtureReader}), and a value
-     * written where nothing says what it stands at.
-     *
-     * <p>Nothing here can be asked of the position, so the sums that list the case answer instead.
-     * That is right for as long as they agree, and today they cannot disagree: every discriminator is
-     * derived — keyed {@code "type"} and tagged with the case's own name — and a sum's cases are
-     * declared in its own module, so one case has one tag however many sums list it (issue #683
-     * measured this). A written discriminator would end the agreement and this fallback with it.
-     */
-    private void taggedWithoutADeclaredType(TypeSymbol caseName, Map<String, Object> map) {
-        for (Hir.Def def : symbols.visible()) {
-            if (!(def instanceof Hir.SumData sum) || sum.decoder().isEmpty()) {
-                continue;
-            }
-            for (Hir.Variant variant : sum.decoder().get().variants()) {
-                if (caseName.equals(variant.caseType().denotes())) {
-                    map.putIfAbsent(sum.decoder().get().key(), variant.tag());
-                    return;
-                }
-            }
-        }
-    }
-
     /** Gives a value the neutral shape its declared type decodes from. A {@code Map} is written as a
      * list of {@code (key, value)} pairs — Elm's {@code Dict.fromList}, and the same list literal a
      * {@code Set} takes — while the decoder wants a map, so the pairs are collected here. Everything
      * else passes through; a {@code List} written as a list stays one, since the declared type, not the
      * literal, decides. Read on the checked type, so it applies wherever a value is decoded: a field of
      * a record fixture, and a behavior's argument or output. */
-    Object shaped(Object v, Type type) {
-        if (type == null || v == null) {
+    Object shaped(Object v, Position position) {
+        if (v == null || !(position instanceof Position.At(Type type))) {
             return v;
         }
         if (type instanceof Type.MapOf map && v instanceof List<?> entries) {
@@ -241,7 +222,8 @@ final class NeutralForm {
                 // Both sides. A key is a position of the same kind as a value, so an inner
                 // collection written in key position is the neutral form of that collection
                 // and not the list of pairs it was written as.
-                m.put(shaped(pair.get(0), map.key()), shaped(pair.get(1), map.value()));
+                m.put(shaped(pair.get(0), Position.at(map.key())),
+                        shaped(pair.get(1), Position.at(map.value())));
             }
             return m;
         }
@@ -254,7 +236,7 @@ final class NeutralForm {
             if (element != null) {
                 List<Object> out = new ArrayList<>(elements.size());
                 for (Object e : elements) {
-                    out.add(shaped(e, element));
+                    out.add(shaped(e, Position.at(element)));
                 }
                 return out;
             }
@@ -279,7 +261,7 @@ final class NeutralForm {
      * <p>Takes a case already resolved: a name spelled here would have to be one
      * {@link Symbols#resolve} answers to, which an imported type's declared name is not.
      */
-    Object newtypeAt(Type position, TypeSymbol caseName, Object inner) {
+    Object newtypeAt(Position position, TypeSymbol caseName, Object inner) {
         Map<String, Object> envelope = new LinkedHashMap<>();
         tagged(position, caseName, envelope);
         if (envelope.isEmpty()) {
@@ -299,9 +281,34 @@ final class NeutralForm {
      *
      * <p>Only the widening direction has to be answered, because it is the only one admission lets
      * through: a case reaches a position typed by a sum that lists it, never the other way.
+     *
+     * <p>Moving to a {@link Position.Unread} leaves the value as it stands. What a position adds is
+     * what it asks to be written beside the case, and a place nothing reads asks for nothing — it
+     * does not ask for what is already there to come off. Re-rendering a value into the case's own
+     * form on the way to one would lose what the form it is in carries: an enumeration's {@code
+     * "Draft"} says which case it is, and the {@code {}} it would become says nothing, with nothing
+     * left to put it back from.
+     *
+     * <p>Moving from one is not a reading. A value whose form nothing decided is in the case's own
+     * form, and that form does not say which case it is — {@code {}} is every unit case — so there is
+     * nothing here to write a discriminator from. Nothing asks for it: a value reaches this having
+     * been built at the type a declaration gave it, and a projection whose target declares nothing is
+     * refused before it gets here. Stated rather than answered with the value, which would be right
+     * only for as long as that stays true.
      */
-    Object reread(Object value, Type from, Type to) {
-        if (value == null || from == null || to == null || from.equals(to)) {
+    Object reread(Object value, Position from, Position to) {
+        if (from instanceof Position.At(Type a) && to instanceof Position.At(Type b)) {
+            return reread(value, a, b);
+        }
+        if (from instanceof Position.Unread && to instanceof Position.At) {
+            throw new IllegalStateException("a value nothing read is in the case's own form, which"
+                    + " does not say which case it is, so it cannot be read at " + to);
+        }
+        return value;
+    }
+
+    private Object reread(Object value, Type from, Type to) {
+        if (value == null || from.equals(to)) {
             return value;
         }
         if (from instanceof Type.OptionOf a) {
@@ -329,7 +336,7 @@ final class NeutralForm {
         }
         if (from instanceof Type.Ref r && isNewtype(r.name())) {
             // Bare here, because `from` is the newtype's own reference and reads it as itself.
-            return newtypeAt(to, r.name(), value);
+            return newtypeAt(Position.at(to), r.name(), value);
         }
         // A unit case travels as a bare name where its position reads one — an enumeration — and
         // carries its sum's discriminator where it does not. So a case standing at an enumeration
@@ -345,11 +352,11 @@ final class NeutralForm {
                         || symbols.declarations().declaration(caseName.key()) instanceof Hir.Data) {
                     continue;
                 }
-                if (readsABareName(to, caseName)) {
+                if (readsABareName(Position.at(to))) {
                     return written;
                 }
                 Map<String, Object> unit = new LinkedHashMap<>();
-                tagged(to, caseName, unit);
+                tagged(Position.at(to), caseName, unit);
                 return unit;
             }
         }
@@ -363,34 +370,19 @@ final class NeutralForm {
                 : type instanceof Type.SetOf s ? s.element() : null;
     }
 
-    /** As above, for a construction written as a call, where the name is what the row spelled. */
-    /** Whether the position this case is written in reads a bare name: it is typed as an enumeration,
-     * or it is untyped here and every sum that lists the case is one. */
-    boolean readsABareName(Type expected, TypeSymbol caseName) {
-        Type position = open(expected);
-        return position != null
-                ? TypeOps.isUnitOnlySum(position, symbols)
-                : onlyEnumerationsList(caseName);
-    }
-
-    /** Whether every sum that lists this case is an enumeration, so its neutral form is its name
-     * wherever it is written. Asked only where the position has no declared type to read it as. */
-    private boolean onlyEnumerationsList(TypeSymbol caseName) {
-        boolean listed = false;
-        for (Hir.Def def : symbols.visible()) {
-            if (!(def instanceof Hir.SumData sum) || sum.decoder().isEmpty()) {
-                continue;
-            }
-            for (Hir.Variant variant : sum.decoder().get().variants()) {
-                if (caseName.equals(variant.caseType().denotes())) {
-                    if (!TypeOps.isUnitOnlySum(sum, symbols)) {
-                        return false;
-                    }
-                    listed = true;
-                }
-            }
-        }
-        return listed;
+    /**
+     * Whether this place reads a unit case as a bare name: it is typed as an enumeration, whose
+     * external form is the case's name (spec §sum-discrimination).
+     *
+     * <p>A question about the place and not about the case standing there, which is why the case is
+     * not asked for. Where nothing reads the value the answer is no: a name is what a sum of units
+     * writes a case as, and nothing here is that sum. Answered by asking whether every sum that lists
+     * the case is an enumeration, it moved with a declaration nothing here reads the value through —
+     * a case listed only by an enumeration wrote its bare name until another sum listed it too.
+     */
+    boolean readsABareName(Position position) {
+        return position.opened() instanceof Position.At(Type type)
+                && TypeOps.isUnitOnlySum(type, symbols);
     }
 
     /** A data's fields by name, following the `...includes` it composes in (spec §data). */
@@ -439,30 +431,6 @@ final class NeutralForm {
 
     // --- reading a position's type ----------------------------------------------------------------
 
-    /** What a written list holds, when the position says: a list's or a set's element, or a map's
-     * entry pair. An optional is opened first — writing a value for a `T?` field writes a `T`. */
-    static Type elementOf(Type expected) {
-        return switch (open(expected)) {
-            case Type.ListOf l -> l.element();
-            case Type.SetOf s -> s.element();
-            case Type.MapOf m -> Type.tuple(List.of(m.key(), m.value()));
-            case null, default -> null;
-        };
-    }
-
-    /** The types of a written tuple's parts, or null when the position does not say. A map's entry is
-     * the pair that carries its key type, which is where an enumeration key is written. */
-    static List<Type> entryTypes(Type expected, int arity) {
-        Type opened = open(expected);
-        if (opened instanceof Type.MapOf m && arity == 2) {
-            return List.of(m.key(), m.value());
-        }
-        if (opened instanceof Type.TupleOf t && t.elements().size() == arity) {
-            return t.elements();
-        }
-        return null;
-    }
-
     static Type open(Type t) {
         return t instanceof Type.OptionOf o ? open(o.element()) : t;
     }
@@ -480,9 +448,9 @@ final class NeutralForm {
      * author wrote, and what a helper returned. Stated on one side and read from the other, the two
      * would answer differently about the same position.
      */
-    Type.Prim temporalUnder(Type position) {
+    Type.Prim temporalUnder(Position position) {
         Set<TypeSymbol> through = new LinkedHashSet<>();
-        Type at = open(position);
+        Type at = position.opened() instanceof Position.At(Type type) ? type : null;
         while (true) {
             if (at instanceof Type.Prim prim) {
                 // Which primitives are temporal is asked of each one, so a primitive added later is
@@ -519,20 +487,20 @@ final class NeutralForm {
      * fixture. The walk stops at anything nominal — a generated value's fields are the types they were
      * declared as, so there is nothing there a fixture could have written wrongly.
      */
-    void requireWrittenForm(Object live, Type position) {
+    void requireWrittenForm(Object live, Position position) {
         if (live instanceof String text && temporalUnder(position) instanceof Type.Prim temporal) {
             throw notWrittenAsATemporal(temporal, text);
         }
-        Type opened = open(position);
-        if (live instanceof Map<?, ?> entries && opened instanceof Type.MapOf map) {
+        Position opened = position.opened();
+        if (live instanceof Map<?, ?> entries
+                && opened instanceof Position.At(Type type) && type instanceof Type.MapOf map) {
             for (Map.Entry<?, ?> e : entries.entrySet()) {
-                requireWrittenForm(e.getKey(), map.key());
-                requireWrittenForm(e.getValue(), map.value());
+                requireWrittenForm(e.getKey(), Position.at(map.key()));
+                requireWrittenForm(e.getValue(), Position.at(map.value()));
             }
             return;
         }
-        Type element = elementOf(opened);
-        if (element != null && live instanceof Iterable<?> elements) {
+        if (opened.element() instanceof Position.At element && live instanceof Iterable<?> elements) {
             for (Object e : elements) {
                 requireWrittenForm(e, element);
             }

--- a/souther-compiler/src/main/java/souther/compiler/examples/Position.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/Position.java
@@ -1,0 +1,105 @@
+package souther.compiler.examples;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.types.Type;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * What reads the value written at one place in a fixture.
+ *
+ * <p>A neutral form is the case's own form plus whatever the type reading it there asks to be written
+ * beside it: a discriminator where that type is a sum, the bare name where it is an enumeration, the
+ * {@code "value"} envelope where a newtype is read through a sum (spec §sum-discrimination). So the
+ * form is a question about the place a value stands and not about the value, and this is what the
+ * place answers with.
+ *
+ * <p>{@link Unread} is the other answer and is one of the two rather than the absence of one. A
+ * behavior answering with several types has no one decoder, so what stands in for it is admitted by
+ * being one of the cases and read by nothing ({@code FixtureReader}); a field no declaration names
+ * says nothing about what it holds. Neither is a place where some other type reads the case, so
+ * neither asks for anything to be written beside it. Nothing is inferred there — in particular not
+ * from the sums that happen to list the case, which says where the case may be read rather than
+ * where it is, and moves when a sum nothing here reads the value through is declared elsewhere.
+ *
+ * <p>Written as a type so that a reader deciding a form has to say which of the two it has. The same
+ * state carried as a null {@code Type} was re-read at each method that took one, and that is where a
+ * search over every visible sum got in.
+ *
+ * <p>{@link Unread} says there is no reader, and says nothing about a type. It is not a type that is
+ * unknown, not one still to be worked out, and not one this cannot read: those are answers about a
+ * type, and each has somewhere of its own to be answered — what a fixture may be built through is
+ * {@link FixtureShape}'s, and a whole answer that is several types is a shape that does not exist
+ * rather than a place nothing reads. Widening this to hold any of them would put back the state the
+ * null {@code Type} was, under a better name.
+ */
+sealed interface Position {
+
+    /** Read through {@code type}, which is what asks for what is written beside the case. */
+    record At(Type type) implements Position {
+
+        public At {
+            if (type == null) {
+                throw new IllegalArgumentException("a position that reads a value has a type;"
+                        + " Position.UNREAD is the one that does not");
+            }
+        }
+    }
+
+    /** Nothing reads the value here, so nothing is written beside it. */
+    record Unread() implements Position {}
+
+    Position UNREAD = new Unread();
+
+    /** Read through {@code type}. */
+    static Position at(Type type) {
+        return new At(type);
+    }
+
+    /**
+     * Read through what a declaration writes at this place, and {@link #UNREAD} where no declaration
+     * names it — a field a fixture wrote that the data does not declare, or a newtype's base where
+     * the type it wraps has no written form.
+     */
+    static Position declaredBy(Hir.TypeRef declared) {
+        return declared == null ? UNREAD : at(declared.denotes());
+    }
+
+    /** The place a value stands at where an optional makes room for it: writing a value for a `T?`
+     *  field writes a `T`, so the optional is opened before the form is asked for. */
+    default Position opened() {
+        return this instanceof At(Type type) && type instanceof Type.OptionOf o
+                ? at(o.element()).opened()
+                : this;
+    }
+
+    /** Where a written list's elements stand: a list's or a set's element, or a map's entry pair. */
+    default Position element() {
+        if (!(opened() instanceof At(Type type))) {
+            return UNREAD;
+        }
+        return switch (type) {
+            case Type.ListOf l -> at(l.element());
+            case Type.SetOf s -> at(s.element());
+            case Type.MapOf m -> at(Type.tuple(List.of(m.key(), m.value())));
+            default -> UNREAD;
+        };
+    }
+
+    /** Where the parts of a written tuple of {@code arity} stand. A map's entry is the pair carrying
+     *  its key type, which is where an enumeration key is written. Always {@code arity} places, so a
+     *  tuple written where nothing says what it holds is read part by part like any other. */
+    default List<Position> parts(int arity) {
+        List<Type> types = !(opened() instanceof At(Type type)) ? null : switch (type) {
+            case Type.MapOf m when arity == 2 -> List.of(m.key(), m.value());
+            case Type.TupleOf t when t.elements().size() == arity -> t.elements();
+            default -> null;
+        };
+        List<Position> out = new ArrayList<>(arity);
+        for (int i = 0; i < arity; i++) {
+            out.add(types == null ? UNREAD : at(types.get(i)));
+        }
+        return List.copyOf(out);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/examples/AValueWearsTheEnvelopeThePositionReadsItThroughTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AValueWearsTheEnvelopeThePositionReadsItThroughTest.java
@@ -16,6 +16,7 @@ import souther.compiler.types.TypeSymbol;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * The envelope a value wears is the one the position reads it through, not one its case is owed
@@ -47,21 +48,40 @@ class AValueWearsTheEnvelopeThePositionReadsItThroughTest {
             data Appeal = Decision | Withdrawn
             """;
 
-    private final Compilation compilation = compiled();
+    /**
+     * A second module: the same declarations and one more sum, which lists {@code Filed} beside a
+     * case that bears a field.
+     *
+     * <p>{@code Filed} because it is the case the two modules disagree about if membership is what
+     * answers. In the first, the only sum listing it is the enumeration {@code Stage}, so a search
+     * over the sums answers "a bare name"; in the second, {@code Revision} is not an enumeration, so
+     * the same search answers "the tag {@code Stage} reads it under". Nothing reads a value through
+     * either sum where the form below is asked for, so neither may be part of the answer.
+     */
+    private static final String AND_ANOTHER_SUM = MODULE + """
+
+            data Revision = Filed | Note
+            """;
+
+    private final Compilation compilation = compiled(MODULE);
     private final Symbols symbols = compilation.symbols("demo");
     private final NeutralForm neutral = new NeutralForm(symbols);
 
-    private static Compilation compiled() {
-        Compilation c = Compilation.ofSource(MODULE, "Main");
+    private static Compilation compiled(String module) {
+        Compilation c = Compilation.ofSource(module, "Main");
         c.answerEverything();
         return c;
     }
 
     /** A value of {@code type}, as a helper would have answered with one: through its own decoder,
      *  which is the one place a case is built here without going through a sum. */
-    @SuppressWarnings("unchecked")
     private Object value(String type, Object written) throws Exception {
-        Decoder<Object, ?> decoder = (Decoder<Object, ?>) compilation.loader()
+        return value(compilation, type, written);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object value(Compilation from, String type, Object written) throws Exception {
+        Decoder<Object, ?> decoder = (Decoder<Object, ?>) from.loader()
                 .loadClass("demo." + type).getMethod("decoder").invoke(null);
         return ((Ok<?>) decoder.decode(written, Path.ROOT)).value();
     }
@@ -78,8 +98,12 @@ class AValueWearsTheEnvelopeThePositionReadsItThroughTest {
         return value("Paid", 500L);
     }
 
-    private Type at(String type) {
-        return Type.ref(TypeSymbols.declared(new TypeKey(symbols.module(), type)));
+    private Position at(String type) {
+        return at(symbols, type);
+    }
+
+    private static Position at(Symbols symbols, String type) {
+        return Position.at(Type.ref(TypeSymbols.declared(new TypeKey(symbols.module(), type))));
     }
 
     @Test
@@ -94,13 +118,14 @@ class AValueWearsTheEnvelopeThePositionReadsItThroughTest {
     }
 
     /**
-     * Two sums may list one case. That they read it under the same key and tag is a fact about
-     * derivation and not about either position: every discriminator is derived, keyed {@code "type"}
-     * and tagged with the case's own name, so there is nothing here for a position to disagree about
-     * yet. Held so that #698 — a written discriminator — has to come past it.
+     * Two sums may list one case, and each writes what it reads the case under. That the two agree
+     * today is a fact about derivation — every discriminator is derived, keyed {@code "type"} and
+     * tagged with the case's own name — and not one either answer rests on: each is read off the
+     * decoder of the sum at the position, so a sum that read it under another key would move its own
+     * position and no other.
      */
     @Test
-    void twoDerivedSumsThatListOneCaseCurrentlyAgreeOnItsDiscriminator() throws Exception {
+    void eachSumThatListsOneCaseWritesWhatItReadsItUnder() throws Exception {
         assertEquals(neutral.of(approved(), at("Decision"), "h"),
                 neutral.of(approved(), at("Outcome"), "h"));
     }
@@ -138,14 +163,66 @@ class AValueWearsTheEnvelopeThePositionReadsItThroughTest {
     }
 
     /**
-     * Where the position has no declared type — an answer of several types, which admission and not
-     * a decoder decides — the sums that list the case answer instead. Held here because it is the
-     * one thing the position cannot be asked for, and because it is right only for as long as every
-     * discriminator is derived (issue #683).
+     * Where nothing reads the value — an answer of several types, which admission and not a decoder
+     * decides, and a place no declaration names — the case is written as it is on its own. A
+     * discriminator is what a sum reading the case asks to be written beside it, and there is no such
+     * sum here; a bare name is what an enumeration reads, and there is no such enumeration either.
+     *
+     * <p>The same forms a position typed by the case itself gives, which is what the two tests above
+     * hold.
      */
     @Test
-    void aPositionWithNoDeclaredTypeIsAnsweredByTheSumsThatListTheCase() throws Exception {
-        assertEquals(Map.of("id", 1L, "type", "Approved"), neutral.of(approved(), null, "h"));
-        assertEquals(Map.of("type", "Draft"), neutral.of(unit("Draft"), null, "h"));
+    void aPlaceNothingReadsWritesTheCaseAsItIsOnItsOwn() throws Exception {
+        assertEquals(Map.of("id", 1L), neutral.of(approved(), Position.UNREAD, "h"));
+        assertEquals(Map.of(), neutral.of(unit("Draft"), Position.UNREAD, "h"));
+    }
+
+    /**
+     * And it is the same form when another sum listing the case is declared. A sum nothing here reads
+     * the value through says where the case may be read and not where it is, so it is no part of the
+     * answer. A rule reading membership could not hold this: declaring {@code Revision} moved what it
+     * answered for a case standing somewhere else entirely.
+     *
+     * <p>The form itself is stated rather than the two being compared with each other, because both
+     * would move together under a rule that reads membership.
+     */
+    @Test
+    void anotherSumListingTheCaseDoesNotMoveWhatAPlaceNothingReadsWrites() throws Exception {
+        Compilation with = compiled(AND_ANOTHER_SUM);
+        Symbols theirs = with.symbols("demo");
+        NeutralForm and = new NeutralForm(theirs);
+        assertEquals(Map.of(), neutral.of(unit("Filed"), Position.UNREAD, "h"));
+        assertEquals(Map.of(), and.of(value(with, "Filed", Map.of()), Position.UNREAD, "h"));
+        // and each sum that does read it there still writes what it reads it under
+        assertEquals("Filed", and.of(value(with, "Filed", Map.of()), at(theirs, "Stage"), "h"));
+        assertEquals(Map.of("type", "Filed"),
+                and.of(value(with, "Filed", Map.of()), at(theirs, "Revision"), "h"));
+    }
+
+    /**
+     * A value moving to a place nothing reads keeps the form it is in. What a position adds is what
+     * it asks to be written beside the case; a place that reads nothing asks for nothing, and does
+     * not ask for what is already there to come off. Rendering the case's own form here would lose
+     * which case it is — {@code "Draft"} says, the {@code {}} it would become does not, and nothing
+     * is left to put it back from.
+     */
+    @Test
+    void aValueRereadWhereNothingReadsItKeepsTheFormItIsIn() {
+        assertEquals("Draft", neutral.reread("Draft", at("Stage"), Position.UNREAD));
+        assertEquals(Map.of("id", 1L, "type", "Approved"),
+                neutral.reread(Map.of("id", 1L, "type", "Approved"), at("Decision"), Position.UNREAD));
+    }
+
+    /**
+     * The other direction is not a reading and says so. A value nothing read is in the case's own
+     * form, which does not say which case it is — every unit case is {@code {}} there — so no
+     * discriminator could be written from it. Nothing asks for it today: a projection whose target
+     * declares nothing is refused before a value reaches this. Held so that a call site added later
+     * is told, rather than being handed the value back unchanged and reading it as an answer.
+     */
+    @Test
+    void aValueNothingReadIsNotRereadAtAPosition() {
+        assertThrows(IllegalStateException.class,
+                () -> neutral.reread(Map.of(), Position.UNREAD, at("Step")));
     }
 }


### PR DESCRIPTION
The issue read this as a constraint on a feature that does not exist yet: an untyped fixture position
is answered by the sums that list the case, which is right only while every sum agrees on the
discriminator, and a custom discriminator would end that. Measured, it is not about the future. It is
the reconstruction #683 removed from the typed path, still in place on the other one, and it already
broke referential stability inside today's rules.

## What the search did

A neutral form is the case's own form plus what the type reading it there asks to be written beside
it — a discriminator where that type is a sum, the bare name where it is an enumeration, the `"value"`
envelope where a newtype is read through a sum. Where the position said nothing, that second part came
from two searches over `symbols.visible()`: `taggedWithoutADeclaredType` took the key and tag of the
first sum listing the case, and `onlyEnumerationsList` asked whether every sum listing it is an
enumeration. Both answer where the case *may* be read, and the question is where it *is*.

So a declaration nothing reads the value through moved the form. Against the pre-change compiler,
adding `data Revision = Filed | Note` to a module whose only sum listing `Filed` is an enumeration
moves what a `Filed` standing at a place nothing reads is written as:

```
module as it was      Filed -> "Filed"
with Revision added   Filed -> {"type": "Filed"}
```

The second search disagreed with the union rule as well. A behavior's answer union writes `"type"`
with the member's name, and travels as a bare name when every *member* is a unit
(`specification.adoc` §jvm-anonymous-union, `CodecGen.generateResultUnionEncoder`), while
`onlyEnumerationsList` asked about the *sums that list the case*. Two different questions that
happened not to be compared.

## What is here

**`Position`** — `At(Type)` or `Unread`, and `Unread` is one of the two answers rather than the
absence of one. A behavior answering several types has no one decoder, so what stands in for it is
admitted by being one of the cases and read by nothing; a field no declaration names says nothing
about what it holds. Neither is a place where some other type reads the case, so neither asks for
anything to be written beside it — leaving the case's own form, which is what a position typed by the
case itself already wrote, and what a union position already wrote by falling through `tagged`.

`Unread` says there is no reader and says nothing about a type. A type that is unknown, one still to
be worked out, one no decoder reads — those are answers about a type and have somewhere of their own:
what a fixture may be built through stays `FixtureShape`'s, and `ofWholeAnswer` answering nothing for
several types stays a shape that does not exist rather than a place nothing reads. It is deliberately
not widened to hold them, since that is the state the null `Type` was, under a better name.

**The searches are gone**, with the state that reached them. `NeutralForm.of`, `tagged`,
`readsABareName`, `newtypeAt`, `reread`, `shaped`, `requireWrittenForm` and `temporalUnder` take a
`Position`, as does `FixtureReader`'s raw chain; `elementOf`/`entryTypes` became `Position.element()`
and `parts(n)`. `readsABareName` no longer takes the case — whether a bare name is read is the place's
to answer, and taking the case was the shape of the question that went looking.

**`reread` states its contract.** To an `Unread` the value stands as it is: a place that reads nothing
asks for nothing and does not ask for what is there to come off, which would turn an enumeration's
`"Draft"` into a `{}` that no longer says which case it is. From one is refused rather than answered
with the value — `{}` is every unit case, so no discriminator could be written from it. No call site
has that direction today (`takeField` refuses a projection whose target declares nothing), which is
why it is stated rather than left as a harmless identity for a later call site to fall into.

## Verification

- `mvn clean test` green across every module — compiler 4362 (4359 before, three tests added), cli
  333, lsp 202, syntax 113, fmt 98, runtime 2224, bench 4.
- Instrumented, the two searches ran three times over the compiler suite, all from the one test
  calling `NeutralForm.of` with no position and none from a compiled source.
- souther-examples swept with `examples --generate --boundaries`, 39 files and 21,630 lines of output,
  identical before and after — so in that corpus nothing the compiler produces read what the searches
  wrote. That is a measurement over the corpus, not a proof over every input.
- The added tests were held against the pre-change compiler: the form at a place nothing reads was
  `{"id":1,"type":"Approved"}` where it is now `{"id":1}`, and the invariance test uses `Filed`
  because that is the case whose answer the old rule moved — written with `Draft` it passed before the
  change and fixed nothing.

Refs #698


🤖 Generated with [Claude Code](https://claude.com/claude-code)
