### PR TITLE
Read nothing off the type a name that denotes nothing leaves behind

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/PipelineSigs.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PipelineSigs.java
@@ -170,11 +170,15 @@ public final class PipelineSigs {
         // §declared-composition-output): neither a missing case (too narrow) nor an extra one (too wide) is
         // accepted.
         if (pipe.declaredOut() != null) {
+            // What was written is read first, and whether it can be compared with what is produced
+            // is asked of the reading. A member no arm can name is a mistake in the declaration
+            // itself, and it is the author's whether or not something beside it went unresolved.
+            Type declaredOut = TypeOps.successType(pipe.declaredOut());
             if (TypeOps.restsOnAnUnresolvedName(pipe.declaredOut())) {
                 throw new Unanswerable(pipe.declaredOut().pos());
             }
             Set<TypeSymbol> inferred = TypeOps.leafCases(out, symbols);
-            Set<TypeSymbol> declared = TypeOps.leafCases(TypeOps.successType(pipe.declaredOut()), symbols);
+            Set<TypeSymbol> declared = TypeOps.leafCases(declaredOut, symbols);
             if (!inferred.equals(declared)) {
                 throw CompileException.of(Diagnostic.at(pipe.pos())
                                 

--- a/souther-compiler/src/main/java/souther/compiler/check/PipelineSigs.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PipelineSigs.java
@@ -170,6 +170,9 @@ public final class PipelineSigs {
         // §declared-composition-output): neither a missing case (too narrow) nor an extra one (too wide) is
         // accepted.
         if (pipe.declaredOut() != null) {
+            if (TypeOps.restsOnAnUnresolvedName(pipe.declaredOut())) {
+                throw new Unanswerable(pipe.declaredOut().pos());
+            }
             Set<TypeSymbol> inferred = TypeOps.leafCases(out, symbols);
             Set<TypeSymbol> declared = TypeOps.leafCases(TypeOps.successType(pipe.declaredOut()), symbols);
             if (!inferred.equals(declared)) {

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -214,6 +214,9 @@ public final class SpecChecker {
                                 .hint(new DeclarationMessage.WriteTheOutputSignature(pipe.name(), PipelineSigs.caseList(inferred)))
                                 .say(new DeclarationMessage.AnExposedCompositionDeclaresItsOutput(pipe.name())).build());
             }
+            if (TypeOps.restsOnAnUnresolvedName(declared)) {
+                throw new Unanswerable(declared.pos());
+            }
             Set<TypeSymbol> declaredCases = TypeOps.leafCases(TypeOps.successType(declared), symbols);
             if (!inferred.equals(declaredCases)) {
                 throw CompileException.of(Diagnostic.at(pipe.pos())

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -214,10 +214,14 @@ public final class SpecChecker {
                                 .hint(new DeclarationMessage.WriteTheOutputSignature(pipe.name(), PipelineSigs.caseList(inferred)))
                                 .say(new DeclarationMessage.AnExposedCompositionDeclaresItsOutput(pipe.name())).build());
             }
+            // What was written is read first, and whether it can be compared with what is produced
+            // is asked of the reading. A member no arm can name is a mistake in the declaration
+            // itself, and it is the author's whether or not something beside it went unresolved.
+            Type declaredOut = TypeOps.successType(declared);
             if (TypeOps.restsOnAnUnresolvedName(declared)) {
                 throw new Unanswerable(declared.pos());
             }
-            Set<TypeSymbol> declaredCases = TypeOps.leafCases(TypeOps.successType(declared), symbols);
+            Set<TypeSymbol> declaredCases = TypeOps.leafCases(declaredOut, symbols);
             if (!inferred.equals(declaredCases)) {
                 throw CompileException.of(Diagnostic.at(pipe.pos())
                                 

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -209,7 +209,8 @@ public final class TypeOps {
      * <p>An output with a member resting on a name that denotes nothing has no case set, and is the
      * type that absorbs — the same answer a single such case already gives, so one mistake has one
      * recovery wherever it is written. A check that would hold such an output against what is
-     * produced asks {@link #restsOnAnUnresolvedName} first and abandons.
+     * produced reads it here first, so that what is wrong with the union itself is still said, and
+     * then asks {@link #restsOnAnUnresolvedName} whether there is a case set to compare.
      */
     public static Type successType(Hir.RetType ret) {
         List<Type> members = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -203,7 +203,14 @@ public final class TypeOps {
         };
     }
 
-    /** The output type of a behavior return: a single case, or a union of two or more cases. */
+    /**
+     * The output type of a behavior return: a single case, or a union of two or more cases.
+     *
+     * <p>An output with a member resting on a name that denotes nothing has no case set, and is the
+     * type that absorbs — the same answer a single such case already gives, so one mistake has one
+     * recovery wherever it is written. A check that would hold such an output against what is
+     * produced asks {@link #restsOnAnUnresolvedName} first and abandons.
+     */
     public static Type successType(Hir.RetType ret) {
         List<Type> members = new ArrayList<>();
         for (Hir.TypeTerm t : ret.cases()) {
@@ -212,22 +219,52 @@ public final class TypeOps {
         if (members.size() == 1) {
             return members.get(0);
         }
+        // Every member is read before anything is said, because the two ways a member can fail to
+        // be one are different mistakes and the author owns only one of them. A member that cannot
+        // be written in an arm is theirs, and is reported wherever it stands. A member whose name
+        // denotes nothing was reported where that name was written, and what this reading finds
+        // there is that same mistake: the output has no case set at all, so it takes the type that
+        // absorbs and this says nothing further.
         Set<TypeSymbol> names = new LinkedHashSet<>();
+        boolean unknown = false;
         for (Type m : members) {
-            TypeSymbol name = memberName(m);
-            if (name == null) {
-                throw CompileException.of(Diagnostic
+            switch (memberName(m)) {
+                case MemberName.Named named -> names.add(named.name());
+                case MemberName.NoType _ -> unknown = true;
+                case MemberName.NotAMember _ -> throw CompileException.of(Diagnostic
                                 .at(ret.pos()).say(new TypeMessage.NotAUnionMember(Type.show(m))).build());
             }
-            names.add(name);
         }
-        return Type.union(names);
+        return unknown ? Type.ERRONEOUS : Type.union(names);
     }
 
     /**
+     * What a union member goes by, which is three answers and not two.
+     *
+     * <p>A member the compiler could not work out a type for and a member whose type cannot be one
+     * are not the same finding, and a reader that gets one answer for both reports the second
+     * sentence about the first: that a name denoting nothing is not the kind of thing an arm can
+     * name. Kept apart here so that a reader has to say which of the two it is acting on, and a
+     * reader added later cannot decide it by not noticing.
+     */
+    sealed interface MemberName {
+
+        /** The case name this member is written and dispatched under. */
+        record Named(TypeSymbol name) implements MemberName {}
+
+        /** A type no arm can name, so no union can carry it. */
+        record NotAMember() implements MemberName {}
+
+        /** A member resting on a name that denotes nothing, reported where that name was written. */
+        record NoType() implements MemberName {}
+    }
+
+    private static final MemberName NOT_A_MEMBER = new MemberName.NotAMember();
+    private static final MemberName NO_TYPE = new MemberName.NoType();
+
+    /**
      * The case name a union member goes by: a data type's own name, or the name a primitive is
-     * written under in a match arm ({@code Int} in {@code Int | NoAnswer}). Null for a type that
-     * cannot be a member.
+     * written under in a match arm ({@code Int} in {@code Int | NoAnswer}).
      *
      * <p>A member has to be nominal and has to tell itself apart from the other members at run time,
      * because that is what a {@code match} arm and a Java {@code switch} both dispatch on. A
@@ -236,22 +273,28 @@ public final class TypeOps {
      * {@code Option} and a function fail it the same way. That they also have no arm form to write
      * is the surface showing the same fact.
      */
-    static TypeSymbol memberName(Type m) {
+    static MemberName memberName(Type m) {
+        // The type that absorbs stands where the compiler could not work one out. It is not a shape
+        // this question has an answer about, and reading it as one is how the name that denotes
+        // nothing came to be reported a second time as a member an arm could not name.
+        if (m instanceof Type.Erroneous) {
+            return NO_TYPE;
+        }
         if (m instanceof Type.Ref r) {
-            return r.name();
+            return new MemberName.Named(r.name());
         }
         // Exhaustive over the primitives rather than a chain of comparisons, and reading the one
-        // spelling table rather than repeating it. A chain answers null for a primitive added later
-        // without asking anyone, and null here reads as "this is not a name a member can be written
-        // as" — which is the truth about Raw and about nothing else.
+        // spelling table rather than repeating it. A chain answers "not a member" for a primitive
+        // added later without asking anyone, and that answer is the truth about Raw and about
+        // nothing else.
         if (m instanceof Type.Prim p) {
             return switch (p) {
                 case INT, STRING, BOOL, DECIMAL, DATE, TIME, DATETIME, INSTANT ->
-                        TypeSymbol.primitive(p.shown());
-                case RAW -> null;
+                        new MemberName.Named(TypeSymbol.primitive(p.shown()));
+                case RAW -> NOT_A_MEMBER;
             };
         }
-        return null;
+        return NOT_A_MEMBER;
     }
 
     /** Builds a Ref (one name) or Union (two or more) from a set of case names. */
@@ -266,12 +309,23 @@ public final class TypeOps {
         return t instanceof Type.Ref || t instanceof Type.Union;
     }
 
+    /**
+     * The case names {@code t} carries, which is none for a type that carries no name.
+     *
+     * <p>Both ways of carrying none are none here, on purpose: this asks which names are on a type
+     * and nothing about why a type has none. Where the difference matters is a declaration held
+     * against what is produced — an output resting on a name that denotes nothing has no case set
+     * rather than the empty one — and that is asked at those checks by
+     * {@link #restsOnAnUnresolvedName}, before either side is turned into names.
+     */
     public static Set<TypeSymbol> namesOf(Type t) {
         if (t instanceof Type.Union u) {
             return u.members();
         }
-        TypeSymbol name = memberName(t);
-        return name == null ? Set.of() : Set.of(name);
+        return switch (memberName(t)) {
+            case MemberName.Named named -> Set.of(named.name());
+            case MemberName.NotAMember _, MemberName.NoType _ -> Set.of();
+        };
     }
 
     /** Case names of a stage output, treating a {@code Raw} encoder output as the case {@code "Raw"}
@@ -473,6 +527,22 @@ public final class TypeOps {
 
     private static boolean erroneous(Hir.RetType ret) {
         return ret != null && ret.cases().stream().anyMatch(TypeOps::erroneous);
+    }
+
+    /**
+     * Whether a written output rests on a name that denotes nothing.
+     *
+     * <p>Asked by the two checks that hold a declared output against what is produced. The case set
+     * of such an output is not the empty set — there is no answer to take a set from — and comparing
+     * against it says the declaration names nothing of what the body or the composition builds,
+     * which is the unresolved name arriving a second time under a sentence about the declaration.
+     * Those checks abandon instead, and the name is reported where it was written.
+     *
+     * <p>Read off what was written rather than off the type it stands for, because that is where
+     * the reference sits and there is nothing to lose on the way.
+     */
+    static boolean restsOnAnUnresolvedName(Hir.RetType ret) {
+        return erroneous(ret);
     }
 
     private static boolean erroneous(Hir.TypeTerm term) {

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -219,12 +219,13 @@ public final class TypeOps {
         if (members.size() == 1) {
             return members.get(0);
         }
-        // Every member is read before anything is said, because the two ways a member can fail to
-        // be one are different mistakes and the author owns only one of them. A member that cannot
-        // be written in an arm is theirs, and is reported wherever it stands. A member whose name
-        // denotes nothing was reported where that name was written, and what this reading finds
-        // there is that same mistake: the output has no case set at all, so it takes the type that
-        // absorbs and this says nothing further.
+        // The two ways a member can fail to be one are different mistakes, and the author owns only
+        // one of them. A member that cannot be written in an arm is theirs and is reported where it
+        // stands, as the first such member always was. A member whose name denotes nothing was
+        // reported where that name was written, and what this reading finds there is that same
+        // mistake: the output has no case set at all, so it takes the type that absorbs and this
+        // says nothing further. Finding one does not end the reading, because a member the author
+        // does own may be written after it.
         Set<TypeSymbol> names = new LinkedHashSet<>();
         boolean unknown = false;
         for (Type m : members) {

--- a/souther-compiler/src/test/java/souther/compiler/ANameThatDenotesNothingIsSaidOnceWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ANameThatDenotesNothingIsSaidOnceWhereverItIsWrittenTest.java
@@ -1,0 +1,184 @@
+package souther.compiler;
+
+import souther.compiler.diag.msg.ParseMessage;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Located;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A type name that denotes nothing costs one diagnostic, wherever a type may be written (issue
+ * #672).
+ *
+ * <p>{@code CascadeStopsAtTheCauseTest} holds this for what a body does with a value whose type
+ * could not be worked out. This holds it for the name itself, in every position the specification
+ * says a type is written in ({@code a-type-is-written-in-a-type-position}), written both on its own
+ * and as one member of a union — the second because a union's members are read by a rule of their
+ * own, which is where the cascade this was written for came from.
+ *
+ * <p>The name is reported and what was written takes the type that absorbs, which is what lets the
+ * rest of the module still be checked. What must not follow is a second sentence read off that
+ * type: that it is not a shape an arm can name, or that an output declares no cases at all. Both
+ * were being said — the first in every position a union can be written in, the second where a
+ * declared output is held against what is produced — and neither names anything an author can fix.
+ *
+ * <p>The code is asserted and not the count alone. A cell answering with one diagnostic that is no
+ * longer the unresolved name has stopped asking the question, and a count reads that as the rule
+ * holding.
+ *
+ * <p>The name is written qualified. A bare one is not this mistake: a name nothing declares, read
+ * where a type goes, declares a unit data type (spec {@code [#unit-data]}), so there is nothing
+ * unresolved about it and nothing to report once.
+ */
+class ANameThatDenotesNothingIsSaidOnceWhereverItIsWrittenTest {
+
+    /** The module a qualified reference names. A qualified reference needs no import, so nothing
+     * else is in the source and no unused-import warning is in the answer. */
+    private static final String UP = """
+            module up exposing ( Amount )
+
+            data Amount = Int
+            """;
+
+    /** How the one mistake is spelled, beside the spelling that names something — which is what
+     * says whether the position reads the form at all. */
+    private record Spelling(String name, String denotesNothing, String denotesSomething) {}
+
+    private static final List<Spelling> SPELLINGS = List.of(
+            new Spelling("on its own", "up.Nope", "up.Amount"),
+            new Spelling("as a union member", "A | up.Nope", "A | up.Amount"));
+
+    /** Something to write where a position needs a value beside the type. It is not of the type
+     * written above it, and does not have to be: what a position says about a value it was given is
+     * that position's own question, asked by the control as much as by the probe. It builds what
+     * the position that takes a value is allowed to build, so that the source stands for a reason
+     * of its own rather than for the name being read. */
+    private static final String VALUE = "A { a = 1 }";
+
+    /**
+     * The cells where the form cannot be written at all, so there is no name in them to report on.
+     * Read rather than re-fitted: an entry leaving this list is a position that has come to admit a
+     * union, and an entry arriving is one that has stopped.
+     */
+    private static final List<String> NOT_WRITABLE = List.of(
+            "data field as a union member",
+            "newtype base as a union member",
+            "type argument as a union member",
+            "tuple member as a union member");
+
+    private static List<Diagnostic> diagnose(String source) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("up.sou", UP);
+        byId.put("demo.sou", source);
+        return Located.diagnosticsOf(Compiler.diagnoseModules(byId, Set.of()))
+                .getOrDefault("demo.sou", List.of());
+    }
+
+    /** Whether the reading stopped at the form, which is an answer about no name at all. */
+    private static boolean refusedTheForm(List<Diagnostic> found) {
+        return found.stream().anyMatch(d -> d.said() instanceof ParseMessage);
+    }
+
+    private static String shown(List<Diagnostic> found) {
+        List<String> out = new ArrayList<>();
+        for (Diagnostic d : found) {
+            out.add(d.code() + " " + d.values());
+        }
+        return out.toString();
+    }
+
+    @Test
+    void theNameIsReportedAndNothingIsReadOffTheTypeItLeftBehind() {
+        List<String> notWritable = new ArrayList<>();
+        List<String> answered = new ArrayList<>();
+        for (TypePositions.Position position : TypePositions.ALL) {
+            for (Spelling spelling : SPELLINGS) {
+                String cell = position.name() + " " + spelling.name();
+                if (refusedTheForm(diagnose(position.of(spelling.denotesSomething(), VALUE)))) {
+                    notWritable.add(cell);
+                    continue;
+                }
+                List<Diagnostic> found =
+                        diagnose(position.of(spelling.denotesNothing(), VALUE));
+                if (found.size() != 1 || !"E1506".equals(found.get(0).code())) {
+                    answered.add(cell + ": " + shown(found));
+                }
+            }
+        }
+
+        assertEquals(NOT_WRITABLE, notWritable,
+                "which positions cannot be written a union; read the change rather than re-fitting");
+        assertEquals(List.of(), answered,
+                "the name that denotes nothing, and nothing read off the type it left behind");
+    }
+
+    /**
+     * A member no arm can name is still reported when a member beside it denotes nothing.
+     *
+     * <p>The two are different mistakes and the author owns both: the list is a member they wrote
+     * and can rewrite, and withholding it because something else in the same union went unresolved
+     * would cost them a build to learn it. What is withheld is only what is read off the type the
+     * unresolved name left behind.
+     */
+    @Test
+    void aMemberNoArmCanNameIsSaidBesideAMemberThatDenotesNothing() {
+        List<Diagnostic> found = diagnose("""
+                module demo
+
+                data A = { a: Int }
+
+                behavior go : (i: A) -> List<Int> | up.Nope
+                    constructs A
+
+                let go (i) = A { a = 1 }
+                """);
+
+        assertEquals(List.of("E1506", "E1613"),
+                found.stream().map(Diagnostic::code).sorted().toList(),
+                "the name nothing declares, and the member no arm can name: " + shown(found));
+        assertEquals(List.of(), found.stream()
+                        .filter(d -> d.values().containsValue("?")).map(Diagnostic::code).toList(),
+                "the member named is the one written, not the type the other member left behind: "
+                        + shown(found));
+    }
+
+    /**
+     * A composition over a stage whose output rests on a name that denotes nothing.
+     *
+     * <p>Not a cell of the sweep above: what the name is written into is one stage's own output, and
+     * what would read the type it left behind is the routing of the composition beside it — which
+     * would say these two behaviors cannot be composed, naming what the stage answers as {@code ?}.
+     * It does not, because a signature holding the type that absorbs is abandoned where it is built
+     * ({@code SignatureBoundary}) and no stage signature carries one. Held here so that the
+     * composition is measured rather than reasoned about.
+     */
+    @Test
+    void aCompositionOverAStageThatAnswersNothingIsToldOnlyTheName() {
+        List<Diagnostic> found = diagnose("""
+                module demo
+
+                data A = { a: Int }
+                data Out = { v: Int }
+
+                behavior s1 : (i: Out) -> up.Nope constructs A
+                let s1 (i) = A { a = 1 }
+
+                behavior s2 : (i: A) -> A constructs A
+                let s2 (i) = A { a = i.a }
+
+                behavior go = s1 >-> s2
+                """);
+
+        assertEquals(List.of("E1506"), found.stream().map(Diagnostic::code).toList(),
+                "the name that denotes nothing, and nothing about composing what it left: "
+                        + shown(found));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/ANameThatDenotesNothingIsSaidOnceWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ANameThatDenotesNothingIsSaidOnceWhereverItIsWrittenTest.java
@@ -11,6 +11,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -109,6 +110,22 @@ class ANameThatDenotesNothingIsSaidOnceWhereverItIsWrittenTest {
         return found.stream().anyMatch(d -> d.said() instanceof ParseMessage);
     }
 
+    /**
+     * The type that absorbs standing where a type goes: on its own, or inside a union, a
+     * collection, a tuple or a function type. It is shown as {@code ?} and nothing else is.
+     *
+     * <p>An optional is not this. Its {@code ?} is written onto the type it is made of
+     * ({@code Int?}), so it never stands where a type begins — which is why the whole value cannot
+     * simply be compared against {@code ?}, and why looking for the character anywhere in it would
+     * call every optional a leak.
+     */
+    private static final Pattern ABSORBING = Pattern.compile("(^|[<,(|]\\s*)\\?");
+
+    private static boolean namesTheTypeThatAbsorbs(Diagnostic d) {
+        return d.values().values().stream()
+                .anyMatch(v -> ABSORBING.matcher(String.valueOf(v)).find());
+    }
+
     private static String shown(List<Diagnostic> found) {
         List<String> out = new ArrayList<>();
         for (Diagnostic d : found) {
@@ -133,7 +150,7 @@ class ANameThatDenotesNothingIsSaidOnceWhereverItIsWrittenTest {
                 if (!spelling.answered().equals(found.stream().map(Diagnostic::code).sorted().toList())) {
                     answered.add(cell + ": " + shown(found));
                 }
-                if (found.stream().anyMatch(d -> d.values().containsValue("?"))) {
+                if (found.stream().anyMatch(ANameThatDenotesNothingIsSaidOnceWhereverItIsWrittenTest::namesTheTypeThatAbsorbs)) {
                     naming.add(cell + ": " + shown(found));
                 }
             }
@@ -141,10 +158,12 @@ class ANameThatDenotesNothingIsSaidOnceWhereverItIsWrittenTest {
 
         assertEquals(NOT_WRITABLE, notWritable,
                 "which positions cannot be written a union; read the change rather than re-fitting");
-        assertEquals(List.of(), answered,
-                "the name that denotes nothing, what is wrong beside it, and nothing else");
+        // The sharper of the two first: a diagnostic naming the type that absorbs says nothing an
+        // author could go looking for, whatever else is right about the answer it is part of.
         assertEquals(List.of(), naming,
                 "the type a name that denotes nothing leaves behind is named in nothing");
+        assertEquals(List.of(), answered,
+                "the name that denotes nothing, what is wrong beside it, and nothing else");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/ANameThatDenotesNothingIsSaidOnceWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ANameThatDenotesNothingIsSaidOnceWhereverItIsWrittenTest.java
@@ -48,13 +48,27 @@ class ANameThatDenotesNothingIsSaidOnceWhereverItIsWrittenTest {
             data Amount = Int
             """;
 
-    /** How the one mistake is spelled, beside the spelling that names something — which is what
-     * says whether the position reads the form at all. */
-    private record Spelling(String name, String denotesNothing, String denotesSomething) {}
+    /**
+     * How the one mistake is spelled, beside the spelling that names something — which is what says
+     * whether the position reads the form at all — and what the position is to answer.
+     *
+     * <p>The third carries a second mistake the author owns: a member no arm can name. It is theirs
+     * to fix whatever went unresolved beside it, so it is still said, and withholding it would cost
+     * them a build to learn it. What is withheld is only what is read off the type the unresolved
+     * name left behind.
+     */
+    private record Spelling(String name, String denotesNothing, String denotesSomething,
+                            List<String> answered) {}
 
     private static final List<Spelling> SPELLINGS = List.of(
-            new Spelling("on its own", "up.Nope", "up.Amount"),
-            new Spelling("as a union member", "A | up.Nope", "A | up.Amount"));
+            new Spelling("on its own", "up.Nope", "up.Amount", List.of("E1506")),
+            new Spelling("as a union member", "A | up.Nope", "A | up.Amount", List.of("E1506")),
+            new Spelling("as a union member beside one no arm can name",
+                    "List<Int> | up.Nope", "List<Int> | up.Amount", List.of("E1506", "E1613")),
+            // The same two members the other way round. What the reading finds first is not what it
+            // reports, so a reading rewritten to stop at the unresolved member is caught here.
+            new Spelling("as a union member before one no arm can name",
+                    "up.Nope | List<Int>", "up.Amount | List<Int>", List.of("E1506", "E1613")));
 
     /** Something to write where a position needs a value beside the type. It is not of the type
      * written above it, and does not have to be: what a position says about a value it was given is
@@ -70,9 +84,17 @@ class ANameThatDenotesNothingIsSaidOnceWhereverItIsWrittenTest {
      */
     private static final List<String> NOT_WRITABLE = List.of(
             "data field as a union member",
+            "data field as a union member beside one no arm can name",
+            "data field as a union member before one no arm can name",
             "newtype base as a union member",
+            "newtype base as a union member beside one no arm can name",
+            "newtype base as a union member before one no arm can name",
             "type argument as a union member",
-            "tuple member as a union member");
+            "type argument as a union member beside one no arm can name",
+            "type argument as a union member before one no arm can name",
+            "tuple member as a union member",
+            "tuple member as a union member beside one no arm can name",
+            "tuple member as a union member before one no arm can name");
 
     private static List<Diagnostic> diagnose(String source) {
         Map<String, String> byId = new LinkedHashMap<>();
@@ -99,6 +121,7 @@ class ANameThatDenotesNothingIsSaidOnceWhereverItIsWrittenTest {
     void theNameIsReportedAndNothingIsReadOffTheTypeItLeftBehind() {
         List<String> notWritable = new ArrayList<>();
         List<String> answered = new ArrayList<>();
+        List<String> naming = new ArrayList<>();
         for (TypePositions.Position position : TypePositions.ALL) {
             for (Spelling spelling : SPELLINGS) {
                 String cell = position.name() + " " + spelling.name();
@@ -106,10 +129,12 @@ class ANameThatDenotesNothingIsSaidOnceWhereverItIsWrittenTest {
                     notWritable.add(cell);
                     continue;
                 }
-                List<Diagnostic> found =
-                        diagnose(position.of(spelling.denotesNothing(), VALUE));
-                if (found.size() != 1 || !"E1506".equals(found.get(0).code())) {
+                List<Diagnostic> found = diagnose(position.of(spelling.denotesNothing(), VALUE));
+                if (!spelling.answered().equals(found.stream().map(Diagnostic::code).sorted().toList())) {
                     answered.add(cell + ": " + shown(found));
+                }
+                if (found.stream().anyMatch(d -> d.values().containsValue("?"))) {
+                    naming.add(cell + ": " + shown(found));
                 }
             }
         }
@@ -117,37 +142,9 @@ class ANameThatDenotesNothingIsSaidOnceWhereverItIsWrittenTest {
         assertEquals(NOT_WRITABLE, notWritable,
                 "which positions cannot be written a union; read the change rather than re-fitting");
         assertEquals(List.of(), answered,
-                "the name that denotes nothing, and nothing read off the type it left behind");
-    }
-
-    /**
-     * A member no arm can name is still reported when a member beside it denotes nothing.
-     *
-     * <p>The two are different mistakes and the author owns both: the list is a member they wrote
-     * and can rewrite, and withholding it because something else in the same union went unresolved
-     * would cost them a build to learn it. What is withheld is only what is read off the type the
-     * unresolved name left behind.
-     */
-    @Test
-    void aMemberNoArmCanNameIsSaidBesideAMemberThatDenotesNothing() {
-        List<Diagnostic> found = diagnose("""
-                module demo
-
-                data A = { a: Int }
-
-                behavior go : (i: A) -> List<Int> | up.Nope
-                    constructs A
-
-                let go (i) = A { a = 1 }
-                """);
-
-        assertEquals(List.of("E1506", "E1613"),
-                found.stream().map(Diagnostic::code).sorted().toList(),
-                "the name nothing declares, and the member no arm can name: " + shown(found));
-        assertEquals(List.of(), found.stream()
-                        .filter(d -> d.values().containsValue("?")).map(Diagnostic::code).toList(),
-                "the member named is the one written, not the type the other member left behind: "
-                        + shown(found));
+                "the name that denotes nothing, what is wrong beside it, and nothing else");
+        assertEquals(List.of(), naming,
+                "the type a name that denotes nothing leaves behind is named in nothing");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/NoTypePositionAnswersWithADelimiterTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/NoTypePositionAnswersWithADelimiterTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BinaryOperator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -43,82 +42,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class NoTypePositionAnswersWithADelimiterTest {
 
-    /** A type position, as the whole source it is written in, given a form and a value of it. */
-    private record Position(String name, BinaryOperator<String> source) {}
-
     /** A form the type position admits somewhere, with something of that type to write. */
     private record Form(String type, String value) {}
-
-    private static final String CASES = """
-            data A = { a: Int }
-            data B = { b: Int }
-            data Out = { v: Int }
-            """;
-
-    private static final String RUN = """
-
-            behavior run : (i: Out) -> Out
-                constructs Out
-
-            let run (i) = Out { v = 1 }
-            """;
-
-    /** Two stages to write a composition over. The composition's inferred output is `A`. */
-    private static final String STAGES = """
-
-            behavior s1 : (i: Out) -> A
-                constructs A
-
-            let s1 (i) = A { a = 1 }
-
-            behavior s2 : (i: A) -> A
-                constructs A
-
-            let s2 (i) = A { a = i.a }
-            """;
-
-    /** A position whose source needs only the form written into it. */
-    private static Position at(String name, String body) {
-        return new Position(name,
-                (type, value) -> "module demo\n\n" + CASES + "\n" + body.formatted(type) + RUN);
-    }
-
-    /** A position that has to be given a value of the form as well as the form. */
-    private static Position valued(String name, String body) {
-        return new Position(name,
-                (type, value) -> "module demo\n\n" + CASES + "\n" + body.formatted(type, value) + RUN);
-    }
-
-    /** Every position `a-type-is-written-in-a-type-position` names. */
-    private static final List<Position> POSITIONS = List.of(
-            at("data field", "data Hold = { x: %s }\n"),
-            at("newtype base", "data Hold = %s\n"),
-            at("behavior parameter",
-                    "behavior go : (i: %s) -> A\n    constructs A\n\nlet go (i) = A { a = 1 }\n"),
-            at("behavior output",
-                    "behavior go : (i: Out) -> %s\n    constructs A\n\nlet go (i) = A { a = 1 }\n"),
-            at("composition declared output", STAGES + "\nbehavior go = s1 >-> s2\n    -> %s\n"),
-            new Position("composition output in exposing",
-                    (type, value) ->
-                            "module demo exposing (A, B, Out, s1, s2, run, go : %s)\n\n".formatted(type)
-                                    + CASES + STAGES + "\nbehavior go = s1 >-> s2\n" + RUN),
-            at("helper parameter", "let aux (h: %s) = 1\n"),
-            valued("helper declared return", "let aux (n: Int) : %s = %s\n"),
-            new Position("local binding annotation",
-                    (type, value) -> "module demo\n\n" + CASES + """
-
-                            behavior run : (i: Out) -> Out
-                                constructs Out, A
-
-                            let run (i) = {
-                                let a: %s = %s
-                                Out { v = 1 }
-                            }
-                            """.formatted(type, value)),
-            at("type argument", "let aux (h: List<%s>) = 1\n"),
-            at("tuple member", "let aux (h: (%s, Int)) = 1\n"),
-            at("function type parameter", "let aux (f: (%s) -> Int) = 1\n"),
-            at("function type result", "let aux (f: (Int) -> %s) = 1\n"));
 
     /** The forms, each with something of it to write where a position needs a value. */
     private static final List<Form> FORMS = List.of(
@@ -130,7 +55,7 @@ class NoTypePositionAnswersWithADelimiterTest {
             new Form("A", "A { a = 1 }"));
 
     /**
-     * How many of the {@link #POSITIONS} × {@link #FORMS} cells are refused at all. Pinned so the
+     * How many of the {@link TypePositions#ALL} × {@link #FORMS} cells are refused at all. Pinned so the
      * delimiter assertion cannot come to pass by everything compiling; what refuses what is elsewhere.
      */
     private static final int REFUSED = 36;
@@ -148,11 +73,11 @@ class NoTypePositionAnswersWithADelimiterTest {
         List<String> bare = new ArrayList<>();
         List<String> neverCompiles = new ArrayList<>();
         int refused = 0;
-        for (Position position : POSITIONS) {
+        for (TypePositions.Position position : TypePositions.ALL) {
             int accepted = 0;
             for (Form form : FORMS) {
                 try {
-                    Compiler.compile(position.source().apply(form.type(), form.value()));
+                    Compiler.compile(position.of(form.type(), form.value()));
                     accepted++;
                 } catch (CompileException e) {
                     refused++;

--- a/souther-compiler/src/test/java/souther/compiler/TypePositions.java
+++ b/souther-compiler/src/test/java/souther/compiler/TypePositions.java
@@ -1,0 +1,100 @@
+package souther.compiler;
+
+import java.util.List;
+import java.util.function.BinaryOperator;
+
+/**
+ * Every position the specification says a type is written in
+ * (`a-type-is-written-in-a-type-position`), as whole sources to write one into.
+ *
+ * <p>One list, read by every sweep over the positions. Written out once per sweep it becomes a copy
+ * of the specification's table that nothing compares against the other copies, and a position added
+ * to the language is then covered by whichever sweeps happened to be updated. What each sweep asks
+ * of a cell is its own; which cells there are is this.
+ *
+ * <p>{@code type} is the form written into the position, and {@code value} is something of that
+ * form for the positions that need a value beside the type; a position that needs none ignores it.
+ */
+final class TypePositions {
+
+    private TypePositions() {}
+
+    /** A type position, as the whole source it is written in, given a form and a value of it. */
+    record Position(String name, BinaryOperator<String> source) {
+
+        /** The source with {@code type} written into this position. */
+        String of(String type, String value) {
+            return source.apply(type, value);
+        }
+    }
+
+    private static final String CASES = """
+            data A = { a: Int }
+            data B = { b: Int }
+            data Out = { v: Int }
+            """;
+
+    private static final String RUN = """
+
+            behavior run : (i: Out) -> Out
+                constructs Out
+
+            let run (i) = Out { v = 1 }
+            """;
+
+    /** Two stages to write a composition over. The composition's inferred output is `A`. */
+    private static final String STAGES = """
+
+            behavior s1 : (i: Out) -> A
+                constructs A
+
+            let s1 (i) = A { a = 1 }
+
+            behavior s2 : (i: A) -> A
+                constructs A
+
+            let s2 (i) = A { a = i.a }
+            """;
+
+    private static final String HEAD = "module demo\n\n" + CASES + "\n";
+
+    /** A position whose source needs only the form written into it. */
+    private static Position at(String name, String body) {
+        return new Position(name, (type, value) -> HEAD + body.formatted(type) + RUN);
+    }
+
+    /** A position that has to be given a value of the form as well as the form. */
+    private static Position valued(String name, String body) {
+        return new Position(name, (type, value) -> HEAD + body.formatted(type, value) + RUN);
+    }
+
+    static final List<Position> ALL = List.of(
+            at("data field", "data Hold = { x: %s }\n"),
+            at("newtype base", "data Hold = %s\n"),
+            at("behavior parameter",
+                    "behavior go : (i: %s) -> A\n    constructs A\n\nlet go (i) = A { a = 1 }\n"),
+            at("behavior output",
+                    "behavior go : (i: Out) -> %s\n    constructs A\n\nlet go (i) = A { a = 1 }\n"),
+            at("composition declared output", STAGES + "\nbehavior go = s1 >-> s2\n    -> %s\n"),
+            new Position("composition output in exposing",
+                    (type, value) ->
+                            "module demo exposing (A, B, Out, s1, s2, run, go : %s)\n\n".formatted(type)
+                                    + CASES + STAGES + "\nbehavior go = s1 >-> s2\n" + RUN),
+            at("helper parameter", "let aux (h: %s) = 1\n"),
+            valued("helper declared return", "let aux (n: Int) : %s = %s\n"),
+            new Position("local binding annotation",
+                    (type, value) -> HEAD + """
+
+                            behavior run : (i: Out) -> Out
+                                constructs Out, A
+
+                            let run (i) = {
+                                let a: %s = %s
+                                Out { v = 1 }
+                            }
+                            """.formatted(type, value)),
+            at("type argument", "let aux (h: List<%s>) = 1\n"),
+            at("tuple member", "let aux (h: (%s, Int)) = 1\n"),
+            at("function type parameter", "let aux (f: (%s) -> Int) = 1\n"),
+            at("function type result", "let aux (f: (Int) -> %s) = 1\n"));
+}


### PR DESCRIPTION
A type name that denotes nothing is reported where it is written, and what it names becomes the type that absorbs so the rest of the module is still checked. Two rules then read that type as though it were one an author had written, and each said a second thing about the one mistake. This is #672.

`TypeOps.memberName` answered `null` both for a type no arm can name — a list, an option, a function, `Raw` — and for a type nothing could be worked out for. The union rule read the one answer and reported the second sentence about the first: that `?` cannot be a union member, naming a spelling the author never wrote and could not write.

```
5:32 [E1506] `up` declares no `Refused`.
5:26 [E1613] `?` cannot be a union member: a member is a type a `match` arm can name — …
```

The other rule is quieter. The leaf cases of the type that absorbs are the empty set, so a declared composition output resting on such a name was held against what the composition produces as a declaration naming no case at all, and the sentence saying so named nothing:

```
13:8  [E1506] `up` declares no `Refused`.
12:1  [E1604] behavior go declares its output as , but the pipeline produces A.
```

## What changed

`memberName` gives three answers — the case name, a type no arm can name, a member resting on a name that denotes nothing — and a reader has to say which it is acting on. `successType` reads the members: the first no arm can name is reported as it always was, and finding one that rests on an unresolved name does not end the reading, because a member the author owns may be written after it. Such a member makes the whole output the type that absorbs, which is the same answer a lone such case already gave.

The two checks that hold a declared output against what is produced — `SpecChecker.checkExposedPipeOutputs` and `PipelineSigs.signatures` — read the declaration first, so that what is wrong with the union itself is still said, and then ask `restsOnAnUnresolvedName` whether there is a case set to compare — abandoning the definition if there is not, which is what is already done for a name a body rests on. Both sit inside an `Unanswerable` boundary already, so no second recovery is introduced.

`leafCases` keeps the contract it had: of its callers only those two read a declaration an author wrote, and the rest read a sum this compilation already knows. `namesOf` keeps it too — it asks which names are on a type, not why a type has none.

## What it is measured against

The sweep over the positions a type is written in is a test of its own. It crosses them with the name written alone, written as one member of a union, and written beside a member no arm can name — that one in both orders, because a reading rewritten to stop at the unresolved member passes one order and fails the other. What each cell must answer is the codes and not the count, because a cell answering with one diagnostic that is no longer the name has stopped asking the question. Every cell is also asked whether anything it says names the type that absorbs, looked for where a type begins rather than anywhere in a value, so that `A | ?` and `List<?>` are caught and `Int?` is not.

Against the commit before the fix, eleven cells report a second thing: nine `E1613`, and two `E1604` with an empty declaration. Against the commit before the ordering was corrected, exactly the two composition cells lose the `E1613` they should keep. The cells where a union cannot be written are derived from what the same form naming something answers, so a position that comes to admit one is swept without being added anywhere.

One case is held beside the sweep: a composition over a stage whose output rests on such a name, where what would read the type left behind is the routing beside it. That one says only the name, because a signature holding the type that absorbs is abandoned where it is built, and it is measured here rather than reasoned about.

The list of positions moves to `TypePositions` in the first commit, so the two sweeps over them read one list rather than a copy each.

Every module's tests pass. `souther-examples`, all fifteen projects through `examples --generate --boundaries`, is 21,433 lines identical to the same run on a jar built from `develop`.

## Not in this change

The issue's second pair — `E1818` on a helper that calls a behavior, then `E1006` on the behavior that calls the helper — was investigated and is not a cascade. A behavior's `let` may call a behavior with an empty requirement set, so the direct call compiles with nothing reported; and a behavior's `constructs` is its own and adds nothing to its caller's, so `f` does not build `Y` whether or not the helper is in the way. Both spellings are measured. `E1006` is true on its own and its hint is the right one to follow. The issue body records this so it is not opened again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
