### PR TITLE
Judge a construction by what it builds, and a value by what computes it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/BinaryElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BinaryElaborator.java
@@ -88,8 +88,8 @@ public final class BinaryElaborator {
                 ArithmeticCheck answer = ArithmeticCheck.of(bin.op(), lt, rt,
                         isLiteralExpr(bin.left()), isLiteralExpr(bin.right()), ctx.symbols());
                 yield switch (answer) {
-                    case ArithmeticCheck.Allowed allowed ->
-                            new Core.Binary(bin.op(), left, right, bin.origin(), allowed.resultType(), bin.pos());
+                    case ArithmeticCheck.Allowed allowed -> arithmetic(bin, left, right,
+                            allowed.resultType(), ctx);
                     case ArithmeticCheck.DeferToPlainTypeCheck _ -> {
                         // One type against another: the found-versus-expected block says it better
                         // than a sentence would, and requireType raises or absorbs it.
@@ -269,4 +269,36 @@ public final class BinaryElaborator {
         return (TypeOps.isSingleValueNewtype(lt, symbols) && !TypeOps.isSingleValueNewtype(rt, symbols) && isLiteralExpr(re))
                 || (TypeOps.isSingleValueNewtype(rt, symbols) && !TypeOps.isSingleValueNewtype(lt, symbols) && isLiteralExpr(le));
     }
+
+    /**
+     * The arithmetic, as the value it answers with. Where the operator answers a newtype, that value
+     * is built here: each operand is opened to the number it wraps, the operator works on those, and
+     * the result is constructed again (spec §newtype-arithmetic). Written as the construction it is,
+     * so the invariant is owed where every other invariant is owed, and no reader has to recognise an
+     * expression as a construction to find it.
+     */
+    private static Core arithmetic(Hir.Binary bin, Core left, Core right, Type result,
+                                   CheckContext ctx) {
+        Type base = TypeOps.directNumericNewtypeBase(result, ctx.symbols());
+        if (base == null) {
+            return new Core.Binary(bin.op(), left, right, bin.origin(), result, bin.pos());
+        }
+        Core computed = new Core.Binary(bin.op(), opened(left, ctx), opened(right, ctx), bin.origin(),
+                base, bin.pos());
+        return new Core.Construct(((Type.Ref) result).name(),
+                List.of(new Core.FieldValue(WRAPPED, computed, bin.pos())), result, bin.pos());
+    }
+
+    /** The number an operand carries: a newtype is opened to what it wraps, and anything else is
+     * already the number. Arithmetic admits one layer of newtype ({@link
+     * TypeOps#directNumericNewtypeBase}), so one read reaches it. */
+    private static Core opened(Core operand, CheckContext ctx) {
+        Type base = TypeOps.directNumericNewtypeBase(operand.type(), ctx.symbols());
+        return base == null ? operand
+                : new Core.FieldAccess(operand, WRAPPED, base, operand.pos());
+    }
+
+    /** What a newtype calls the value it wraps (spec §newtype) — the name {@link TypeOps#wrapped}
+     * reads it by, said here so both reach the same field. */
+    private static final String WRAPPED = "value";
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -115,7 +115,7 @@ public final class CallElaborator {
         Type declared = entry.signature().result();
         Map<String, Type> bindings = new HashMap<>();
         BottomInfer.pinResultTypeVars(declared, expected, bindings, ctx.symbols());
-        return new Core.Call(new ReachName.OfLibrary(lib), List.of(),
+        return new Core.Call(new ReachName.OfLibrary(lib), lib, List.of(),
                 TypeOps.toBottom(TypeOps.substitute(declared, bindings)), v.pos());
     }
 
@@ -143,7 +143,7 @@ public final class CallElaborator {
                     new Core.Read(call.written(), local.id(), env.typeOf(local.id()), call.pos()),
                     ca.cores(), result, call.pos());
         }
-        return new Core.Call(call.reachedAs(), ca.cores(), result, call.pos());
+        return new Core.Call(call.reachedAs(), call.denotes(), ca.cores(), result, call.pos());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
@@ -46,9 +46,10 @@ final class Clauses {
     /**
      * @param inTheAnalysisRepresentation the clauses of the module being checked, in the
      *        representation the discharge rules are written at ({@link InliningPolicy#DISCHARGE}). A
-     *        type another module declares is absent, and its clause is read off the declaration in
-     *        the settled form — where the operations have already become the folds they are, so it
-     *        falls outside the fragment.
+     *        type another module declares is not among them and its clauses are read off its
+     *        declaration, which says what its author wrote whether that module was compiled here or
+     *        published and read back (spec §invariant-discharge-representation). What can be
+     *        discharged against a clause is the same either way.
      */
     Clauses(Symbols symbols,
             Map<TypeSymbol, List<Hir.InvariantClause>> inTheAnalysisRepresentation) {

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -642,14 +642,23 @@ public final class DataChecker {
         checkConstruction(c.typeName().written(), c.inits(), List.of(), c.pos(), fields, env, ctx);
     }
 
-    static List<Core.FieldInit> checkConstruction(String typeName, List<Hir.FieldInit> inits,
+    /**
+     * What each declared field of a construction is given, in declaration order — the one place that
+     * answers it. A field written out is given what was written; one no field init names is given the
+     * read of that field off the value spread into the construction, which is a field read like the
+     * one an author writes. So a construction carries no spread past here, and every reader of it
+     * asks the same values in the same order rather than working the spread out again.
+     *
+     * <p>Where several spreads carry one field, the first of them supplies it — one field is given
+     * one value, and which is decided here and not by whichever reader looks.
+     */
+    static List<Core.FieldValue> checkConstruction(String typeName, List<Hir.FieldInit> inits,
                                           List<Core.Read> spreads,
                                           SourcePos pos, Map<String, Type> fields, Scope env,
                                           CheckContext ctx) {
-        Map<String, Hir.FieldInit> byName = new HashMap<>();
-        List<Core.FieldInit> elaborated = new ArrayList<>();
+        Map<String, Core.FieldValue> written = new LinkedHashMap<>();
         for (Hir.FieldInit init : inits) {
-            if (byName.put(init.name(), init) != null) {
+            if (written.containsKey(init.name())) {
                 throw CompileException.of(Diagnostic.at(init.pos())
                         .say(new DataMessage.FieldIsDefinedMoreThanOnce(init.name()))
                         .build());
@@ -668,7 +677,7 @@ public final class DataChecker {
             CheckContext making = ctx.makingAnOptional(ft instanceof Type.OptionOf);
             Core value = Elaborator.liftIntoOption(
                     Elaborator.elaborate(init.value(), env, making, ft), ft, ctx.symbols());
-            elaborated.add(new Core.FieldInit(init.name(), value, init.pos()));
+            written.put(init.name(), new Core.FieldValue(init.name(), value, init.pos()));
             Type vt = value.type();
             // a case value widens to its sum-typed field (spec §sum-data)
             if (!TypeOps.assignable(vt, ft, ctx.symbols())) {
@@ -678,21 +687,21 @@ public final class DataChecker {
                                 .diff(Type.show(vt, ft), Type.show(ft, vt)).say(new DataMessage.AFieldExpectsAnotherType(init.name(), Type.show(ft), Type.show(vt))).build());
             }
         }
-        Map<String, Type> provided = new HashMap<>();
         // the sums spread here, which a field the construction still wants was not in the shared part
         // of — all of them, because naming one of several would pick by position and send the author
         // to open a sum whose cases never had the field
         Set<String> fromSums = new LinkedHashSet<>();
-        for (Core.Read spread : spreads) {
-            String sp = spread.name();
-            Type bound = env.typeOf(spread.binding());
+        List<Spread> spread = new ArrayList<>();
+        for (Core.Read read : spreads) {
+            String sp = read.name();
+            Type bound = env.typeOf(read.binding());
             if (bound instanceof Type.Ref ref
                     && ctx.symbols().declarations().declaration(ref.name().key()) instanceof Hir.SumData sum) {
                 fromSums.add(Type.show(bound));
-                provided.putAll(spreadOfSum(sp, sum, bound, pos, ctx));
+                spread.add(new Spread(read, spreadOfSum(sp, sum, bound, pos, ctx)));
             } else if (bound instanceof Type.Ref ref
                     && ctx.symbols().declarations().declaration(ref.name().key()) instanceof Hir.Data sd) {
-                provided.putAll(TypeOps.fieldTypes(sd, ctx.symbols()));
+                spread.add(new Spread(read, TypeOps.fieldTypes(sd, ctx.symbols())));
             } else {
                 Diagnostic.Builder d = Diagnostic.at(pos)
                         .say(new DataMessage.SpreadIsNotADataValue(sp));
@@ -702,12 +711,15 @@ public final class DataChecker {
                 throw CompileException.of(d.build());
             }
         }
+        List<Core.FieldValue> values = new ArrayList<>();
         for (Map.Entry<String, Type> f : fields.entrySet()) {
-            if (byName.containsKey(f.getKey())) {
+            Core.FieldValue own = written.get(f.getKey());
+            if (own != null) {
+                values.add(own);
                 continue;
             }
-            Type pv = provided.get(f.getKey());
-            if (pv == null) {
+            Spread from = supplying(spread, f.getKey());
+            if (from == null) {
                 Diagnostic.Builder d = Diagnostic.at(pos)
                         .say(new DataMessage.ConstructionIsMissingAField(typeName, f.getKey()));
                 // one rule broken in one of several ways, and the hint is where the way is said. What
@@ -727,14 +739,33 @@ public final class DataChecker {
                 }
                 throw CompileException.of(d.build());
             }
+            Type pv = from.fields().get(f.getKey());
             if (!TypeOps.assignable(pv, f.getValue(), ctx.symbols())) {
                 throw CompileException.of(Diagnostic.at(pos)
                         .say(new DataMessage.SpreadSuppliesTheWrongType(f.getKey(), Type.show(pv),
                                 typeName, Type.show(f.getValue())))
                         .diff(Type.show(pv, f.getValue()), Type.show(f.getValue(), pv)).build());
             }
+            // The value is read at the type the source declares the field, which is the type the
+            // backend loads it at; that it fits the field being given it was decided just above.
+            values.add(new Core.FieldValue(f.getKey(),
+                    new Core.FieldAccess(from.read(), f.getKey(), pv, from.read().pos()),
+                    from.read().pos()));
         }
-        return elaborated;
+        return values;
+    }
+
+    /** A value a construction spreads, and the fields it carries. */
+    private record Spread(Core.Read read, Map<String, Type> fields) {}
+
+    /** The first of {@code spreads} carrying {@code field}, or null where none does. */
+    private static Spread supplying(List<Spread> spreads, String field) {
+        for (Spread s : spreads) {
+            if (s.fields().containsKey(field)) {
+                return s;
+            }
+        }
+        return null;
     }
 
     /** What a spread of a sum copies: the fields of the data every one of its cases spreads. This is

--- a/souther-compiler/src/main/java/souther/compiler/check/Denotations.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Denotations.java
@@ -40,7 +40,8 @@ record Denotations(Map<BindingId, Means> bound) {
     /** What {@code binding} denotes, which is nothing where nothing entered it. */
     Denotes of(BindingId binding) {
         Means given = bound.get(binding);
-        return given != null ? given.denotes() : new Denotes.Nothing();
+        return given != null ? given.denotes()
+                : new Denotes.Nothing(new Naming.Opaque(Naming.Reason.A_BINDING_STANDS_FOR_NOTHING));
     }
 
     /** The value {@code binding} was given, or null where nothing recorded one. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Denotes.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Denotes.java
@@ -4,24 +4,19 @@ import souther.compiler.core.Core;
 
 /**
  * What a binding denotes. A location is somewhere the seeding can have written about and a clause
- * can have named; a term is a value known only by what computes it. Merging those two would put a
- * computed value where a location is expected, which is the shape of a {@code let} answering
- * differently from the expression it was given. A written value is apart from both because what
- * it is has to travel with the name, and nothing is apart because only a term is assigned a form.
+ * can have named; a computed value is known only by the {@link Term} that computes it. Merging those
+ * two would put a computed value where a location is expected, which is the shape of a {@code let}
+ * answering differently from the expression it was given. A written value is apart from both because
+ * what it is has to travel with the name, and nothing is apart because only a computed value is
+ * assigned a form.
+ *
+ * <p>What each is named by is {@link Terms#termOf}'s to say, and not a member here: a place is named
+ * by the term standing for it, and the terms of one reading are held together.
  */
 sealed interface Denotes {
 
-    /** The key this is known by, or {@code null} where it is known by none. */
-    String key();
-
     /** A place: a parameter, a field chain, or another location a binding was given. */
-    record At(Location where) implements Denotes {
-
-        @Override
-        public String key() {
-            return where.toString();
-        }
-    }
+    record At(Location where) implements Denotes {}
 
     /**
      * A value named by the expression that computes it. {@code readable} is true where there is
@@ -29,21 +24,15 @@ sealed interface Denotes {
      * about how it was made; false where only a guard naming it makes a clause readable against
      * it.
      */
-    record Term(String key, boolean readable) implements Denotes {}
+    record Computed(Term term, boolean readable) implements Denotes {}
 
     /**
      * A value written out, kept as what was written. There is no guard an author could add about
      * it, so it is never named at a construction; what it is, though, still has to travel with
      * the name, or the same text would fold where it is written and not where it is bound.
      */
-    record Written(String key, Core value) implements Denotes {}
+    record Written(Term term, Core value) implements Denotes {}
 
     /** Nothing this check can name. */
-    record Nothing() implements Denotes {
-
-        @Override
-        public String key() {
-            return null;
-        }
-    }
+    record Nothing() implements Denotes {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Denotes.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Denotes.java
@@ -33,6 +33,8 @@ sealed interface Denotes {
      */
     record Written(Term term, Core value) implements Denotes {}
 
-    /** Nothing this check can name. */
-    record Nothing() implements Denotes {}
+    /** Nothing this check can name, and why it can name none of it ({@link Naming}). Kept rather
+     * than dropped because the two reasons a value has no name are not one reason: what an injected
+     * behavior answered is unnameable, and a shape this compiler has no term for is unfinished. */
+    record Nothing(Naming.Unnamed why) implements Denotes {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -257,10 +257,10 @@ public final class Elaborator {
                     }
                     spreads.add(new Core.Read(s.bare(), local.id(), env.typeOf(local.id()), s.pos()));
                 }
-                List<Core.FieldInit> inits = DataChecker.checkConstruction(built.written(), nd.inits(),
-                        spreads, nd.pos(), TypeOps.fieldTypes(owner, ctx.symbols()), env, ctx);
-                yield new Core.NewData(built.denotes(), inits, spreads,
-                        Type.ref(built.denotes()), nd.pos());
+                List<Core.FieldValue> values = DataChecker.checkConstruction(built.written(),
+                        nd.inits(), spreads, nd.pos(),
+                        TypeOps.fieldTypes(owner, ctx.symbols()), env, ctx);
+                yield new Core.Construct(built.denotes(), values, Type.ref(built.denotes()), nd.pos());
             }
             case Hir.Match m -> MatchElaborator.elaborateMatch(m, env, ctx, expected);
             case Hir.If iff -> {
@@ -291,7 +291,7 @@ public final class Elaborator {
             }
             case Hir.IfConstructed ic -> {
                 Core built = elaborate(ic.construct(), env, ctx);
-                if (!(built instanceof Core.NewData construct)) {
+                if (!(built instanceof Core.Construct construct)) {
                     throw CompileException.of(Diagnostic.at(ic.construct().reportedAt())
                             .say(new AttemptMessage.ThisIsNotAConstruction())
                             .hint(new AttemptMessage.WriteTheConstructionWhoseInvariantDecides())

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -809,8 +809,11 @@ public final class InvariantChecker {
                             predicates.assumeCond(value.cond(), within, there, false), there, depth));
             return;
         }
-        checkIfConstruction(e, k, at, false);
         switch (e) {
+            case Core.Construct made -> {
+                judge(made, k, at, false);
+                Core.forEachChild(made, child -> walk(child, k, at, depth));
+            }
             case Core.If iff -> {
                 walk(iff.cond(), k, at, depth);
                 walk(iff.then(), predicates.assumeCond(iff.cond(), k, at, true), at, depth);
@@ -821,7 +824,7 @@ public final class InvariantChecker {
                 // branch — so it is checked for a decided violation and never warned about as a
                 // possible one. Its field values are walked on their own so a construction nested
                 // inside an argument is still an ordinary, aborting one.
-                checkIfConstruction(ic.construct(), k, at, true);
+                judge(ic.construct(), k, at, true);
                 Core.forEachChild(ic.construct(), child -> walk(child, k, at, depth));
                 // Reaching `then` is the construction having held, so the binding carries the type's
                 // invariant exactly as an input of that type does — which is a location, and not the
@@ -925,25 +928,16 @@ public final class InvariantChecker {
         return out;
     }
 
-    // --- construction detection & discharge check ----------------------------------------------
+    // --- the discharge check -------------------------------------------------------------------
 
-    private void checkIfConstruction(Core e, Known k, Denotations at, boolean attempted) {
-        if (e instanceof Core.NewData nd && nd.spreads().isEmpty()) {
-            if (symbols.declarations().declaration(nd.typeName().key()) instanceof Hir.Data type) {
-                report(nd, type, nd.pos(), attempted, verdictOf(nd, type, k, at));
-            }
-            return;
-        }
-        // Closed arithmetic over a newtype builds one where it stands: the operands are unwrapped,
-        // the operator applied, and the result constructed again, so the invariant is owed here.
-        if (Terms.asOperator(e) instanceof Core.Binary bin && Terms.isArith(bin.op())
-                && bin.type() instanceof Type.Ref r
-                && symbols.declarations().declaration(r.name().key()) instanceof Hir.Data type && type.newtype()) {
-            BindingId value = clauses.bindingsOf(r.name(), type).get("value");
-            if (value != null && terms.affineOf(bin, at, k) != null) {
-                report(bin, type, bin.pos(), attempted,
-                        verdictOf(r.name(), type, Map.of(value, bin), k, at, true));
-            }
+    /**
+     * What this check says about one construction. Every value a body makes is one of these, so
+     * there is nothing to recognise here: a construction was settled where the tree was built, and
+     * what it builds and what each of its fields is given came with it.
+     */
+    private void judge(Core.Construct made, Known k, Denotations at, boolean attempted) {
+        if (symbols.declarations().declaration(made.typeName().key()) instanceof Hir.Data type) {
+            report(made, type, made.pos(), attempted, verdictOf(made, type, k, at));
         }
     }
 
@@ -952,18 +946,18 @@ public final class InvariantChecker {
      * reaches here: the walk opens it before anything is checked, so what a field is given is a
      * value and not a choice of two.
      */
-    private Judgment verdictOf(Core.NewData nd, Hir.Data type, Known k, Denotations at) {
+    private Judgment verdictOf(Core.Construct nd, Hir.Data type, Known k, Denotations at) {
         Map<String, BindingId> fields = clauses.bindingsOf(nd.typeName(), type);
         Map<BindingId, Core> given = new HashMap<>();
-        for (Core.FieldInit fi : nd.inits()) {
-            BindingId field = fields.get(fi.name());
+        for (Core.FieldValue fv : nd.values()) {
+            BindingId field = fields.get(fv.field());
             if (field == null) {
                 continue;
             }
             // A name given a value written out hands over that value: the clause folds over what
             // was written, wherever the writing was done.
-            Core written = Terms.writtenValue(fi.value(), at);
-            given.put(field, written != null ? written : fi.value());
+            Core written = Terms.writtenValue(fv.value(), at);
+            given.put(field, written != null ? written : fv.value());
         }
         return verdictOf(nd.typeName(), type, given, k, at, !constantlyBuilt(type, nd));
     }
@@ -1173,8 +1167,8 @@ public final class InvariantChecker {
     /** Whether the constant check reads this construction: a newtype's, over a value written where
      * it is built. That check names the clause that failed, so it is left to say it — and it reads
      * the construction as written, so a name given the value is not one it sees. */
-    private static boolean constantlyBuilt(Hir.Data type, Core.NewData nd) {
-        return type.newtype() && nd.inits().size() == 1 && Terms.isWritten(nd.inits().get(0).value());
+    private static boolean constantlyBuilt(Hir.Data type, Core.Construct nd) {
+        return type.newtype() && Terms.isWritten(nd.values().get(0).value());
     }
 
     /** Says what {@code verdict} found. A definite violation is an error and an unproven one a

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -120,9 +120,12 @@ public final class InvariantChecker {
      * the representation the rules are written at ({@link InliningPolicy#DISCHARGE}) rather than the
      * one the backend emits from.
      *
-     * <p>{@code invariants} holds the declarations of the module being checked. A type another module
-     * declares is absent, and its clause is read off the declaration in the settled form — where the
-     * operations have already become the folds they are, so it falls outside the fragment.
+     * <p>{@code invariants} holds the clauses of the module being checked. A type another module
+     * declares is not among them and its clauses are read off its declaration, which for a module
+     * reached through its published classes is the declaration that module published, read back by
+     * this front end (spec §published-modules). Either way the clause read here is the rule its
+     * author wrote, so where a declaration was written does not decide what can be discharged
+     * against it (spec §invariant-discharge-representation).
      */
     public record Source(Hir.Expr body, Map<TypeSymbol, List<Hir.InvariantClause>> invariants) {}
 

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -565,13 +565,6 @@ public final class InvariantChecker {
         end.ifPresent(read -> out.add(new Direct(on.path(), on.measured(), from, read)));
     }
 
-    /** Whether both sides of {@code bin} reach a coordinate, which is what makes it a relation
-     * rather than a bound. */
-    private boolean relates(Core.Binary bin, Map<String, Coordinate> byName, Denotations at) {
-        return byName.containsKey(nameOf(bin.left(), at))
-                && byName.containsKey(nameOf(bin.right(), at));
-    }
-
     /**
      * Files {@code from} under every coordinate this comparison could carry a bound to.
      *

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -66,7 +66,7 @@ import java.util.Set;
  * <p>The walk mirrors {@link TotalityChecker}: a {@code switch} over {@link Core} threading an
  * immutable environment. It is fail-open for what it cannot analyze — an expression or a shape it
  * has no rule for is swallowed, so a limit of this analysis can never reject a valid program. It is
- * not fail-open for this analysis disagreeing with itself: {@link Terms.OneKeyTwoKinds} says one
+ * not fail-open for this analysis disagreeing with itself: {@link Terms.OneTermTwoKinds} says one
  * name was given two values, and swallowing it produces a behavior with no findings, which is what a
  * behavior whose invariants all discharge produces. That one is rethrown ({@link #gaveUp}).
  */
@@ -246,12 +246,12 @@ public final class InvariantChecker {
      *                        then weaker than what the declaration actually says, and a caller
      *                        turning one into an obligation has to know that
      */
-    record Seeded(NumericDomain numbers, Map<String, String> atoms, Map<String, String> held,
+    record Seeded(NumericDomain<Term> numbers, Map<String, Term> atoms, Map<String, Term> held,
                   Reading reading, boolean everyClauseRead) {}
 
     /** {@link Seeded} for one declaration. A declaration this cannot read is one whose fields it says
      * nothing about, which is the same answer as a declaration with no rules — so nothing about the
-     * declaration throws. {@link Terms.OneKeyTwoKinds} is not about the declaration and is not
+     * declaration throws. {@link Terms.OneTermTwoKinds} is not about the declaration and is not
      * caught ({@link #gaveUp}). */
     /**
      * How far a seeding reads at each name it meets.
@@ -355,10 +355,10 @@ public final class InvariantChecker {
             return new Seeded(NumericDomain.top(), Map.of(), Map.of(),
                     new Reading(List.of(), Map.of()), false);
         }
-        Map<String, String> atoms = new LinkedHashMap<>();
+        Map<String, Term> atoms = new LinkedHashMap<>();
         Map<String, Type> typeAt = new LinkedHashMap<>();
-        Map<String, String> held = new LinkedHashMap<>();
-        Map<String, String> keys = new LinkedHashMap<>();
+        Map<String, Term> held = new LinkedHashMap<>();
+        Map<String, Term> keys = new LinkedHashMap<>();
         for (Map.Entry<String, BindingId> field : bindings.entrySet()) {
             Type type = fields.get(field.getKey());
             if (type != null) {
@@ -373,9 +373,9 @@ public final class InvariantChecker {
         // Which of the clauses place an edge, asked once the positions have names to be recognised
         // by.
         Reading reading = c.directsIn(written, at, atoms, keys, held, typeAt);
-        NumericDomain numbers = k.numbers();
+        NumericDomain<Term> numbers = k.numbers();
         for (Map.Entry<String, Count> each : settled.entrySet()) {
-            String atom = atoms.get(each.getKey());
+            Term atom = atoms.get(each.getKey());
             Type type = typeAt.get(each.getKey());
             if (atom == null || type == null) {
                 continue;
@@ -405,16 +405,16 @@ public final class InvariantChecker {
      * ask for what they left.
      */
     private void name(Core value, String path, Type type, Denotations at, Symbols symbols,
-                      int depth, Map<String, String> atoms, Map<String, Type> typeAt,
-                      Map<String, String> held, Map<String, String> keys) {
-        String atom = terms.atomOf(value, at);
+                      int depth, Map<String, Term> atoms, Map<String, Type> typeAt,
+                      Map<String, Term> held, Map<String, Term> keys) {
+        Term atom = terms.atomOf(value, at);
         if (atom != null) {
             atoms.put(path, atom);
         }
         // What the position is called, which every position has and only some are numbers. An
         // enumeration is ordered and carries no atom, so a clause bounding one is recognised by this
         // and by nothing above it.
-        String key = terms.bodyKey(value, at);
+        Term key = terms.bodyKey(value, at);
         if (key != null) {
             keys.put(path, key);
         }
@@ -424,7 +424,7 @@ public final class InvariantChecker {
         // And what a rule counting this position spoke about, which is not what the position is. A
         // list is no number and has no atom above; the count of it has one, and a reader asking how
         // much the position holds is asking about that one.
-        String counted = terms.takenAtomOf(value, type, at);
+        Term counted = terms.takenAtomOf(value, type, at);
         if (counted != null) {
             held.put(path, counted);
         }
@@ -495,14 +495,14 @@ public final class InvariantChecker {
     record Reading(List<Direct> directs, Map<String, List<TypeSymbol>> narrowers) {}
 
     private Reading directsIn(List<Written> stated, Denotations at,
-                                   Map<String, String> atoms, Map<String, String> keys,
-                                   Map<String, String> held, Map<String, Type> typeAt) {
-        Map<String, Coordinate> byName = new LinkedHashMap<>();
+                                   Map<String, Term> atoms, Map<String, Term> keys,
+                                   Map<String, Term> held, Map<String, Type> typeAt) {
+        Map<Term, Coordinate> byName = new LinkedHashMap<>();
         keys.forEach((path, key) -> {
             Carrier carrier = Carrier.ofValue(typeAt.get(path), symbols);
             if (carrier != null) {
                 byName.put(key, new Coordinate(path, false, carrier));
-                String atom = atoms.get(path);
+                Term atom = atoms.get(path);
                 if (atom != null) {
                     byName.put(atom, new Coordinate(path, false, carrier));
                 }
@@ -527,7 +527,7 @@ public final class InvariantChecker {
      * comparisons it had already accounted for.
      */
     private void direct(Core clause, TypeSymbol from, Denotations at,
-                        Map<String, Coordinate> byName, List<Direct> out,
+                        Map<Term, Coordinate> byName, List<Direct> out,
                         Map<String, List<TypeSymbol>> narrowers) {
         if (!(clause instanceof Core.Binary bin)) {
             return;
@@ -580,9 +580,9 @@ public final class InvariantChecker {
      * moved even where the number came from somewhere further off.
      */
     private void relating(Core clause, TypeSymbol from, Denotations at,
-                          Map<String, Coordinate> byName,
+                          Map<Term, Coordinate> byName,
                           Map<String, List<TypeSymbol>> narrowers) {
-        String named = nameOf(clause, at);
+        Term named = nameOf(clause, at);
         Coordinate found = named == null ? null : byName.get(named);
         if (found != null) {
             List<TypeSymbol> had = narrowers.computeIfAbsent(found.path(), _ -> new ArrayList<>());
@@ -604,8 +604,8 @@ public final class InvariantChecker {
      * <p>Then what the position is called, for the positions that are ordered and are not numbers. An
      * enumeration has no atom and a clause can still say where its values stop.
      */
-    private String nameOf(Core e, Denotations at) {
-        String atom = terms.atomOf(e, at);
+    private Term nameOf(Core e, Denotations at) {
+        Term atom = terms.atomOf(e, at);
         return atom != null ? atom : terms.bodyKey(e, at);
     }
 
@@ -718,7 +718,7 @@ public final class InvariantChecker {
 
     /**
      * Analyzes one behavior body against the bindings its inputs are. Nothing the body is throws:
-     * a walk that cannot get through one comes back {@code ABANDONED}. {@link Terms.OneKeyTwoKinds}
+     * a walk that cannot get through one comes back {@code ABANDONED}. {@link Terms.OneTermTwoKinds}
      * is not something the body is and is not caught ({@link #gaveUp}). A {@code null} body is one
      * the analysis representation could not be built or typed for, and is not analyzed at all.
      */
@@ -749,12 +749,12 @@ public final class InvariantChecker {
      * <p>Every place this check swallows a failure comes through here, so what must not be swallowed
      * is refused in one place. A shape the walk has no rule for is what fail-open is for: the
      * run-time check stands for the clause, and reporting the walk's limit as the author's problem is
-     * what the policy avoids. {@link Terms.OneKeyTwoKinds} is not that. It says this check called two
+     * what the policy avoids. {@link Terms.OneTermTwoKinds} is not that. It says this check called two
      * values one value, and what it would produce if caught is a behavior with no findings — which
      * is exactly what a behavior whose invariants all discharge produces.
      */
     static void gaveUp(String where, RuntimeException why) {
-        if (why instanceof Terms.OneKeyTwoKinds) {
+        if (why instanceof Terms.OneTermTwoKinds) {
             throw why;
         }
         List<GaveUp> watching = GAVE_UP;
@@ -1075,14 +1075,14 @@ public final class InvariantChecker {
             return new Judgment(unreadable ? Verdict.UNREPRESENTABLE : Verdict.PROVED,
                     unsettled, settled);
         }
-        NumericDomain dom = k.numbers();
+        NumericDomain<Term> dom = k.numbers();
         // The same clauses read against the same site, under what would be known here had no
         // condition on the path settled anything. What each clause states of the sizes it names holds
         // either way, so both readings take it.
-        NumericDomain alone = k.unguarded().numbers();
+        NumericDomain<Term> alone = k.unguarded().numbers();
         for (Owing owing : owed) {
             for (Predicates.Constraint known : owing.clause().known()) {
-                Map<String, Granularity> kinds = terms.kindsOf(known.form());
+                Map<Term, Granularity> kinds = terms.kindsOf(known.form());
                 dom = dom.assume(known.form(), known.rel(), kinds);
                 alone = alone.assume(known.form(), known.rel(), kinds);
             }
@@ -1500,14 +1500,14 @@ public final class InvariantChecker {
     private Set<Core> sameConditional(Core e, Core.If value, Denotations at) {
         Set<Core> alike = Collections.newSetFromMap(new IdentityHashMap<>());
         alike.add(value);
-        String key = terms.bodyKey(value, at);
+        Term key = terms.bodyKey(value, at);
         if (key != null) {
             collectAlike(e, key, at, alike);
         }
         return alike;
     }
 
-    private void collectAlike(Core e, String key, Denotations at, Set<Core> alike) {
+    private void collectAlike(Core e, Term key, Denotations at, Set<Core> alike) {
         if (e instanceof Core.Block) {
             return;
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/Known.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Known.java
@@ -25,19 +25,19 @@ import java.util.Set;
  * reading refutes took something more than the values to settle. Which something is not recorded, so
  * it is not claimed either.
  */
-record Known(NumericDomain numbers, PredicateFacts facts, List<Quantified> quantified,
-                     Set<String> spoken, Unguarded unguarded) {
+record Known(NumericDomain<Term> numbers, PredicateFacts facts, List<Quantified> quantified,
+                     Set<Term> spoken, Unguarded unguarded) {
 
     /** What holds of the values here whatever the path did — what a type guarantees of a value and
      * what a name was given. It carries no quantifiers and no spoken terms: those decide which
      * clauses are read at all, and both readings are asked about the same clauses. */
-    record Unguarded(NumericDomain numbers, PredicateFacts facts) {
+    record Unguarded(NumericDomain<Term> numbers, PredicateFacts facts) {
 
-        Unguarded taking(LinearForm f, Rel rel, Map<String, Granularity> kinds) {
+        Unguarded taking(LinearForm<Term> f, Rel rel, Map<Term, Granularity> kinds) {
             return new Unguarded(numbers.assume(f, rel, kinds), facts);
         }
 
-        Unguarded taking(String key, boolean positive) {
+        Unguarded taking(Term key, boolean positive) {
             return new Unguarded(numbers, facts.assume(key, positive));
         }
     }
@@ -52,14 +52,14 @@ record Known(NumericDomain numbers, PredicateFacts facts, List<Quantified> quant
     }
 
     /** This, with {@code f rel 0} taken as holding as far as {@code held} reaches. */
-    Known taking(LinearForm f, Rel rel, Held held, Map<String, Granularity> kinds) {
+    Known taking(LinearForm<Term> f, Rel rel, Held held, Map<Term, Granularity> kinds) {
         return new Known(numbers.assume(f, rel, kinds), facts, quantified, spoken,
                 held == Held.OF_THE_VALUE ? unguarded.taking(f, rel, kinds) : unguarded);
     }
 
     /** This, with the predicate {@code key} taken as holding — or as failing, where {@code positive}
      * is false — as far as {@code held} reaches. */
-    Known taking(String key, boolean positive, Held held) {
+    Known taking(Term key, boolean positive, Held held) {
         return new Known(numbers, facts.assume(key, positive), quantified, spoken,
                 held == Held.OF_THE_VALUE ? unguarded.taking(key, positive) : unguarded);
     }
@@ -70,17 +70,17 @@ record Known(NumericDomain numbers, PredicateFacts facts, List<Quantified> quant
      * spoke about is known exactly then, and reading it back out of a domain would mean matching
      * key text, which is how a term that merely reads like another gets mistaken for it.
      */
-    Known speaking(Collection<String> terms) {
+    Known speaking(Collection<Term> terms) {
         if (terms.isEmpty()) {
             return this;
         }
-        Set<String> all = new HashSet<>(spoken);
+        Set<Term> all = new HashSet<>(spoken);
         all.addAll(terms);
         return new Known(numbers, facts, quantified, all, unguarded);
     }
 
     /** Whether an assumption on this path named {@code term}. */
-    boolean speaksOf(String term) {
+    boolean speaksOf(Term term) {
         return spoken.contains(term);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Naming.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Naming.java
@@ -29,7 +29,14 @@ sealed interface Naming {
     Term term();
 
     /** The value, as the term standing for it. */
-    record Named(Term term) implements Naming {}
+    record Named(Term term) implements Naming {
+
+        public Named {
+            // A name and no term is the state this type exists to make unwritable: it is what the
+            // `null` this replaced meant at one of the places it was returned from.
+            java.util.Objects.requireNonNull(term, "a named value is named by a term");
+        }
+    }
 
     /** Everything that is not a name. */
     sealed interface Unnamed extends Naming {
@@ -74,5 +81,24 @@ sealed interface Naming {
     /** {@code term}, or the reason there is none. */
     static Naming of(Term term, Reason absent) {
         return term == null ? new Opaque(absent) : new Named(term);
+    }
+
+    /**
+     * Whether what a name answers is a value two writings of it share, and why it is not where it is
+     * not.
+     *
+     * <p>Apart from {@link Naming} because it is asked of a name rather than of an expression: what
+     * a call to a nameable one is called is built from the call's arguments, which the name knows
+     * nothing about. Answering this with a {@link Named} holding no term would be the state {@link
+     * Named} exists to rule out, and answering it with a {@code boolean} would drop the reason the
+     * other side of it carries.
+     */
+    sealed interface OfAName {
+
+        /** It answers one value wherever it is written with the same arguments. */
+        record Answers() implements OfAName {}
+
+        /** It does not, for {@code reason}. */
+        record AnswersNothing(Reason reason) implements OfAName {}
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Naming.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Naming.java
@@ -11,6 +11,11 @@ package souther.compiler.check;
  * written without recursion was a warning, because that one was expanded and this one was a call
  * nothing here had a case for (#722).
  *
+ * <p>A third silence is beside these and not among them. Whether an analysis ran to the end is a
+ * fact about the analysis and not about any value in it ({@link InvariantChecker.Status}), so it is
+ * held where analyses are and not here: an answer about a value and an answer about a walk are not
+ * two values of one question, and folding them together is how one of them stops being asked.
+ *
  * <p>So the two are apart. {@link Opaque} is this check's own semantics: what an injected behavior
  * answered is a different value each time it is asked, and a function value a body applies may be
  * one. {@link Unsupported} is not a state a compile should reach — the classification is a

--- a/souther-compiler/src/main/java/souther/compiler/check/Naming.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Naming.java
@@ -1,0 +1,73 @@
+package souther.compiler.check;
+
+/**
+ * What the invariant-discharge check calls a value, or why it calls it nothing.
+ *
+ * <p>Every expression gets one of these. The check used to answer with a term or with {@code null},
+ * and the null said two things at once: that the value is one a guard could never be written about,
+ * and that this compiler has no term for the shape it was written in. The first is what the check
+ * is; the second is what it has not finished being, and reading it as the first is how a construction
+ * over a recursive helper's answer came out silent — the same construction over the same helper
+ * written without recursion was a warning, because that one was expanded and this one was a call
+ * nothing here had a case for (#722).
+ *
+ * <p>So the two are apart. {@link Opaque} is this check's own semantics: what an injected behavior
+ * answered is a different value each time it is asked, and a function value a body applies may be
+ * one. {@link Unsupported} is not a state a compile should reach — the classification is a
+ * {@code switch} over {@link souther.compiler.core.Core} with no default, so a shape added later
+ * stops the build rather than arriving here — and where it does arrive it says which shape, so that
+ * what is missing is a name and not a silence.
+ */
+sealed interface Naming {
+
+    /** The term, or {@code null} where this names nothing. */
+    Term term();
+
+    /** The value, as the term standing for it. */
+    record Named(Term term) implements Naming {}
+
+    /** Everything that is not a name. */
+    sealed interface Unnamed extends Naming {
+
+        @Override
+        default Term term() {
+            return null;
+        }
+    }
+
+    /** A value this check cannot name, and the reason it cannot. */
+    record Opaque(Reason reason) implements Unnamed {}
+
+    /** A shape this check has no term for, which is this compiler being unfinished rather than a
+     * value being unnameable. {@code form} names the shape. */
+    record Unsupported(String form) implements Unnamed {}
+
+    /** Why a value is one nothing here can name. */
+    enum Reason {
+
+        /** What a behavior answered (spec §invariant-discharge-terms). Where the behavior is one
+         * injected from outside, its implementation is not the language's and may read the outside
+         * world, so two asks are two answers (spec §injected-behavior). */
+        A_BEHAVIOR_ANSWERED,
+
+        /** What applying a function value answered. What is applied is whatever the binding holds,
+         * and a body may be handed an injected behavior as one (spec §depends-on). */
+        A_FUNCTION_VALUE_WAS_APPLIED,
+
+        /** An expression that answers with no value at all. */
+        NOTHING_IS_ANSWERED,
+
+        /** A binding nothing entered: a value the walk never reached, so there is nothing it stands
+         * for here. */
+        A_BINDING_STANDS_FOR_NOTHING,
+
+        /** A part of it is one of these. Which part and why is the part's own answer; a value is
+         * named all the way down or not at all. */
+        A_PART_NAMES_NOTHING
+    }
+
+    /** {@code term}, or the reason there is none. */
+    static Naming of(Term term, Reason absent) {
+        return term == null ? new Opaque(absent) : new Named(term);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/OccurrenceCounts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OccurrenceCounts.java
@@ -93,7 +93,7 @@ public final class OccurrenceCounts {
         if (seeded == null) {
             return 0;
         }
-        String counted = seeded.held().get(path);
+        Term counted = seeded.held().get(path);
         return counted == null ? 0
                 : CountDomain.leastFrom(seeded.numbers().boundsOf(counted).min());
     }
@@ -102,11 +102,11 @@ public final class OccurrenceCounts {
         if (seeded == null) {
             return true;
         }
-        String counted = seeded.held().get(path);
+        Term counted = seeded.held().get(path);
         if (counted == null) {
             return true;   // nothing counts what is there, so no rule here is about how much it holds
         }
-        NumericDomain.LinearForm from = NumericDomain.LinearForm.atom(counted)
+        NumericDomain.LinearForm<Term> from = NumericDomain.LinearForm.atom(counted)
                 .minus(NumericDomain.LinearForm.constant(BigDecimal.valueOf(count)));
         return !seeded.numbers()
                 .assume(from, against, Map.of(counted, Granularity.DISCRETE))

--- a/souther-compiler/src/main/java/souther/compiler/check/OccurrenceValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OccurrenceValues.java
@@ -71,7 +71,7 @@ public final class OccurrenceValues {
         if (seeded == null) {
             return Cardinality.UNKNOWN;
         }
-        String atom = seeded.atoms().get(path);
+        Term atom = seeded.atoms().get(path);
         if (atom == null) {
             return Cardinality.UNKNOWN;
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/PredicateFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PredicateFacts.java
@@ -20,10 +20,10 @@ final class PredicateFacts {
     private static final PredicateFacts BOTTOM = new PredicateFacts(true, Set.of(), Set.of());
 
     private final boolean bottom;    // contradictory guards — this path is not taken
-    private final Set<String> holds;
-    private final Set<String> fails;
+    private final Set<Term> holds;
+    private final Set<Term> fails;
 
-    private PredicateFacts(boolean bottom, Set<String> holds, Set<String> fails) {
+    private PredicateFacts(boolean bottom, Set<Term> holds, Set<Term> fails) {
         this.bottom = bottom;
         this.holds = holds;
         this.fails = fails;
@@ -34,14 +34,14 @@ final class PredicateFacts {
     }
 
     /** The facts with {@code key} settled. Settling it both ways makes the path infeasible. */
-    PredicateFacts assume(String key, boolean positive) {
+    PredicateFacts assume(Term key, boolean positive) {
         if (bottom) {
             return this;
         }
         if ((positive ? fails : holds).contains(key)) {
             return BOTTOM;
         }
-        Set<String> next = new HashSet<>(positive ? holds : fails);
+        Set<Term> next = new HashSet<>(positive ? holds : fails);
         next.add(key);
         return positive
                 ? new PredicateFacts(false, Set.copyOf(next), fails)
@@ -49,12 +49,12 @@ final class PredicateFacts {
     }
 
     /** Whether the guards prove {@code key} (or its negation, when {@code positive} is false). */
-    boolean entails(String key, boolean positive) {
+    boolean entails(Term key, boolean positive) {
         return bottom || (positive ? holds : fails).contains(key);
     }
 
     /** Whether the guards prove the opposite of what {@code positive} asks of {@code key}. */
-    boolean refutes(String key, boolean positive) {
+    boolean refutes(Term key, boolean positive) {
         return !bottom && (positive ? fails : holds).contains(key);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -54,7 +54,7 @@ final class Predicates {
         Set<Shape> crossed = EnumSet.noneOf(Shape.class);
         Core source = container;
         while (true) {
-            String key = terms.bodyKey(source, at);
+            Term key = terms.bodyKey(source, at);
             if (key != null) {
                 for (Quantified q : k.quantified()) {
                     if (key.equals(q.container()) && q.through().containsAll(crossed)) {
@@ -119,7 +119,7 @@ final class Predicates {
         // The container is the carrying rule's, which is the one argument this predicate is about.
         // What the operation hands its closure answers the same question about the same argument, and
         // is asked here only for the closure.
-        String container = terms.bodyKey(carried.container(), at);
+        Term container = terms.bodyKey(carried.container(), at);
         if (container == null) {
             return;
         }
@@ -136,7 +136,7 @@ final class Predicates {
         return found[0];
     }
 
-    record Constraint(LinearForm form, Rel rel) {}
+    record Constraint(LinearForm<Term> form, Rel rel) {}
 
     /**
      * A predicate stated of a term. {@code keys} is the term as written first, then each container it
@@ -145,10 +145,10 @@ final class Predicates {
      * about a list built from it. {@code positive} is false for a clause written under a negation,
      * and such a clause carries nowhere, since the implication runs the other way.
      */
-    record Fact(List<String> keys, boolean positive) {
+    record Fact(List<Term> keys, boolean positive) {
 
         boolean entailedBy(PredicateFacts facts) {
-            for (String key : keys) {
+            for (Term key : keys) {
                 if (facts.entails(key, positive)) {
                     return true;
                 }
@@ -173,12 +173,12 @@ final class Predicates {
      */
     record Clause(Constraint numeric, Fact fact, List<Constraint> known) {
 
-        boolean dischargedBy(NumericDomain d, PredicateFacts facts) {
+        boolean dischargedBy(NumericDomain<Term> d, PredicateFacts facts) {
             return numeric != null && d.entails(numeric.form(), numeric.rel())
                     || fact != null && fact.entailedBy(facts);
         }
 
-        boolean refutedBy(NumericDomain d, PredicateFacts facts) {
+        boolean refutedBy(NumericDomain<Term> d, PredicateFacts facts) {
             return numeric != null && d.refutes(numeric.form(), numeric.rel())
                     || fact != null && fact.refutedBy(facts);
         }
@@ -276,8 +276,8 @@ final class Predicates {
         Constraint numeric = null;
         if (inv instanceof Core.Binary b && relOf(b.op()) != null) {
             Rel eff = positive ? relOf(b.op()) : negateRel(relOf(b.op()));
-            LinearForm la = eff == null ? null : terms.affineOf(b.left(), at, k);
-            LinearForm ra = eff == null ? null : terms.affineOf(b.right(), at, k);
+            LinearForm<Term> la = eff == null ? null : terms.affineOf(b.left(), at, k);
+            LinearForm<Term> ra = eff == null ? null : terms.affineOf(b.right(), at, k);
             if (la != null && ra != null) {
                 numeric = new Constraint(la.minus(ra), eff);
             }
@@ -286,7 +286,7 @@ final class Predicates {
         // A predicate over a value no guard could be written about is not a predicate a guard will
         // settle, so it is not owed as one — where the domain can say something of that value it has
         // already said it above, and where it cannot the run-time check stands for the clause.
-        List<String> keys = !unnamed.isEmpty() && names(polar.expr(), unnamed)
+        List<Term> keys = !unnamed.isEmpty() && names(polar.expr(), unnamed)
                 ? List.of() : factKeys(polar.expr(), at);
         boolean stated = polar.positive();
         Fact fact = keys.isEmpty() ? null : new Fact(stated ? keys : firstOnly(keys), stated);
@@ -306,7 +306,7 @@ final class Predicates {
         return folded instanceof Boolean b ? b : null;
     }
 
-    static List<String> firstOnly(List<String> keys) {
+    static List<Term> firstOnly(List<Term> keys) {
         return keys.isEmpty() ? keys : List.of(keys.get(0));
     }
 
@@ -343,15 +343,15 @@ final class Predicates {
         if (cond instanceof Core.Binary b) {
             Rel rel = relOf(b.op());
             Rel eff = rel == null ? null : positive ? rel : negateRel(rel);
-            LinearForm la = eff == null ? null : terms.affineOf(b.left(), at, out);
-            LinearForm ra = eff == null ? null : terms.affineOf(b.right(), at, out);
+            LinearForm<Term> la = eff == null ? null : terms.affineOf(b.left(), at, out);
+            LinearForm<Term> ra = eff == null ? null : terms.affineOf(b.right(), at, out);
             if (la != null && ra != null) {
                 LinearForm compared = la.minus(ra);
                 out = out.taking(compared, eff, Known.Held.ON_THE_PATH, terms.kindsOf(compared));
             }
             // What the comparison named, recorded as spoken about: a construction from one of these
             // is one the author has said something about, whichever route ends up carrying it.
-            Set<String> named = new HashSet<>(spokenOf(b.left(), at, la));
+            Set<Term> named = new HashSet<>(spokenOf(b.left(), at, la));
             named.addAll(spokenOf(b.right(), at, ra));
             out = out.speaking(named);
         }
@@ -361,15 +361,15 @@ final class Predicates {
         // Both routes, always: which one carries a clause is decided where the clause is read, and a
         // guard does not know which that will be.
         Polar polar = polar(cond, positive);
-        String key = terms.bodyKey(polar.expr(), at);
+        Term key = terms.bodyKey(polar.expr(), at);
         return key == null ? out : out.taking(key, polar.positive(), Known.Held.ON_THE_PATH);
     }
 
     /** The terms one side of a compared pair names: the expression itself, and each atom of the form it
      * reduced to — {@code leftover + 1} says something about {@code leftover}. */
-    Collection<String> spokenOf(Core side, Denotations at, LinearForm form) {
-        Set<String> named = new HashSet<>(form == null ? Set.of() : form.coefs().keySet());
-        String written = terms.bodyKey(side, at);
+    Collection<Term> spokenOf(Core side, Denotations at, LinearForm<Term> form) {
+        Set<Term> named = new HashSet<>(form == null ? Set.of() : form.coefs().keySet());
+        Term written = terms.bodyKey(side, at);
         if (written != null) {
             named.add(written);
         }
@@ -469,7 +469,7 @@ final class Predicates {
         }
         Core container = DischargeRules.sizeArgOf(call);
         if (container != null) {
-            String atom = terms.sizeAtomOf(call, arg -> terms.bodyKey(arg, at));
+            Term atom = terms.sizeAtomOf(call, arg -> terms.bodyKey(arg, at));
             if (atom != null) {
                 out.add(new Constraint(LinearForm.atom(atom), Rel.GE));   // a size is never negative
                 bounds(call.operation(), DischargeRules.sizeSource(container), at, out);
@@ -506,8 +506,8 @@ final class Predicates {
      * nothing can be said of, and stops the walk. */
     private void stated(ValueName sizeCall, Core container, Core source, Rel rel, Denotations at,
                         List<Constraint> out) {
-        String here = terms.bodyKey(container, at);
-        String there = terms.bodyKey(source, at);
+        Term here = terms.bodyKey(container, at);
+        Term there = terms.bodyKey(source, at);
         if (here == null || there == null) {
             return;
         }
@@ -531,12 +531,12 @@ final class Predicates {
     /** The keys a guard could have settled to establish this clause: the predicate as written, and
      * the same predicate of each container the written one was built from by a construction that
      * carries it. Stating {@code List.all(p, xs)} is stating it of every sublist of {@code xs}. */
-    List<String> factKeys(Core inv, Denotations at) {
-        String written = terms.bodyKey(inv, at);
+    List<Term> factKeys(Core inv, Denotations at) {
+        Term written = terms.bodyKey(inv, at);
         if (written == null) {
             return List.of();
         }
-        List<String> keys = new ArrayList<>();
+        List<Term> keys = new ArrayList<>();
         keys.add(written);
         if (!(inv instanceof Core.PreservedCall call)) {
             return keys;
@@ -559,7 +559,7 @@ final class Predicates {
                 break;
             }
             Core source = built.container();
-            String key = terms.bodyKey(carried.over(next, source), at);
+            Term key = terms.bodyKey(carried.over(next, source), at);
             if (key == null) {
                 break;
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -623,13 +623,13 @@ final class Predicates {
         if (read.isEmpty()) {
             traced = reads.chain(made);   // the closure hands the element straight back
         } else {
-            if (!(made instanceof Core.NewData nd) || !nd.spreads().isEmpty()) {
+            if (!(made instanceof Core.Construct nd)) {
                 return null;
             }
             List<String> copied = null;
-            for (Core.FieldInit fi : nd.inits()) {
-                if (fi.name().equals(read.get(0))) {
-                    copied = reads.chain(fi.value());
+            for (Core.FieldValue given : nd.values()) {
+                if (given.field().equals(read.get(0))) {
+                    copied = reads.chain(given.value());
                 }
             }
             if (copied == null) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Quantified.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Quantified.java
@@ -16,4 +16,4 @@ import java.util.Set;
  * them. The predicate is kept as the block it is, already read where the relation was stated, so
  * every name in it means there what it meant there.
  */
-record Quantified(String container, Set<Shape> through, Core.Block predicate) {}
+record Quantified(Term container, Set<Shape> through, Core.Block predicate) {}

--- a/souther-compiler/src/main/java/souther/compiler/check/Term.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Term.java
@@ -66,8 +66,16 @@ final class Term {
         LET,
         /** A construction, over the values its fields are given in declaration order. */
         BUILT,
-        /** A call the representation kept standing, over its arguments. */
-        CALLED
+        /** A call, over its arguments. */
+        CALLED,
+        /** A value given to an optional position. */
+        SOME,
+        /** The empty optional, at the type of the position it fills. */
+        NONE,
+        /** A value opened, over the scrutinee and each arm's body. */
+        MATCHED,
+        /** An attempted construction, over what it builds and what each of its departures answers. */
+        ATTEMPTED
     }
 
     /** What a shape holds beside its parts: a location, a written value, an operator, the name of an
@@ -172,6 +180,10 @@ final class Term {
                 sb.append('}');
             }
             case CALLED -> joined(sb.append(((ValueName) of).name()).append('('), ", ").append(')');
+            case SOME -> sb.append("Some(").append(parts.get(0).rendered()).append(')');
+            case NONE -> sb.append("None:").append(of);
+            case MATCHED -> joined(sb.append("match("), ", ").append(')');
+            case ATTEMPTED -> joined(sb.append("attempt("), ", ").append(')');
         }
         return sb.toString();
     }
@@ -366,6 +378,35 @@ final class Term {
         Term calledIfBuilt(ValueName operation, List<Term> args) {
             Term made = new Term(Shape.CALLED, operation, args);
             return shared.containsKey(made) ? made : null;
+        }
+
+        /** A value given to an optional position. */
+        Term some(Term value) {
+            return of(Shape.SOME, null, List.of(value));
+        }
+
+        /** The empty optional. Held at the type of the position, since the absent value of one
+         * optional is not the absent value of another. */
+        Term none(souther.compiler.types.Type type) {
+            return of(Shape.NONE, type, List.of());
+        }
+
+        /** A value opened: the scrutinee, and what each arm answers, under the cases that arm takes.
+         * An arm's binding is a parameter of the arm, keyed by where it is bound as a closure's is. */
+        Term matched(Term scrutinee, List<List<TypeSymbol>> cases, List<Term> arms) {
+            List<Term> parts = new ArrayList<>();
+            parts.add(scrutinee);
+            parts.addAll(arms);
+            return of(Shape.MATCHED, List.copyOf(cases), parts);
+        }
+
+        /** An attempted construction: what it builds, what its success answers, and what each of its
+         * departures answers, under the clauses those departures name. */
+        Term attempted(Term built, List<String> clauses, List<Term> answers) {
+            List<Term> parts = new ArrayList<>();
+            parts.add(built);
+            parts.addAll(answers);
+            return of(Shape.ATTEMPTED, List.copyOf(clauses), parts);
         }
 
         /** How many distinct terms this has been asked for — what a test measuring the sharing

--- a/souther-compiler/src/main/java/souther/compiler/check/Term.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Term.java
@@ -1,0 +1,402 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.ValueName;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * What the invariant-discharge check names a value by — the identity two writings of one value
+ * share, and the whole of what a fact set knows about which value it is talking about.
+ *
+ * <p>A value, not a rendering of one. Two terms are the same term when they are built the same way
+ * out of the same parts, and that is the only thing that makes them the same. This was a string
+ * before, written by concatenating the parts' own strings, and the encoding was not injective: a
+ * list of one string element {@code a", "b} and a list of two elements {@code ["a", "b"]} wrote one
+ * key, so a guard about the first discharged a clause about the second. Nothing here can spell one
+ * value the way another spells itself, because nothing here spells anything.
+ *
+ * <p>Equality is structural. {@link Terms} hands every term it builds through an interner, so two
+ * writings of one value are usually one object and the comparison stops at the first line — but that
+ * is an optimisation and not the contract. A term built without going through that interner, or
+ * through another one, is equal to its twin all the same, which is what lets one reading be compared
+ * against another.
+ *
+ * <p>The hash is computed once, when the term is built, out of the hashes its parts already carry.
+ * A chain of terms is a graph and not a tree — a name read twice is one value read twice — so a hash
+ * that walked the parts at every ask would cost what writing the parts out used to cost, which is
+ * the thing that made the string form of this hold a name for each shape rather than the shape.
+ *
+ * <p>Equality of an {@code ==} between two values does not depend on which was written first, so
+ * that shape holds its two parts as a pair with no order. Every other shape is ordered.
+ */
+final class Term {
+
+    /** How a term is built. What a shape means is what {@link Terms} builds it for; this says only
+     * which shapes are told apart. */
+    enum Shape {
+        /** A place: a binding and the fields read from it. */
+        AT,
+        /** A parameter of a closure, named by where it is bound rather than by which binding it is. */
+        BOUND,
+        /** Fields read off a term that is not a place. */
+        ON,
+        INT, DECIMAL, STRING, BOOL, UNIT,
+        /** Arithmetic negation. */
+        NEG,
+        /** The denial of a condition. */
+        NOT,
+        /** An {@code ==}, whose two parts are unordered. */
+        EQ,
+        /** Any other operator, over its two operands in the order written. */
+        OP,
+        LIST, TUPLE,
+        /** One element of a tuple, by index. */
+        PART,
+        /** A conditional, over its condition and its two branches. */
+        CHOICE,
+        /** A closure, over the number of parameters it binds and its body. */
+        CLOSURE,
+        /** A value bound and a body read under it. */
+        LET,
+        /** A construction, over the values its fields are given in declaration order. */
+        BUILT,
+        /** A call the representation kept standing, over its arguments. */
+        CALLED
+    }
+
+    /** What a shape holds beside its parts: a location, a written value, an operator, the name of an
+     * operation, the type and fields of a construction. Compared by its own equality. */
+    private final Object of;
+    private final Shape shape;
+    private final List<Term> parts;
+    private final int hash;
+
+    /**
+     * How a term's hash is mixed with the hashes of its parts.
+     *
+     * <p>An odd number, and not a small one. A term that reads one part twice folds that part in
+     * twice, so the multiplier decides what a chain of those does to the hash it carries up: with
+     * {@code 31}, a part folded twice contributes {@code 32} times what the level under it did, and
+     * thirty-two is two to the fifth — seven links of that shift every bit of the hash out, and from
+     * there every link of the chain hashes alike. The chain is exactly what {@link Terms} builds when
+     * a body names a value and reads it twice, so the terms that collided were the ones the sharing
+     * is for.
+     */
+    private static final int MIX = 0x9E3779B1;
+
+    private Term(Shape shape, Object of, List<Term> parts) {
+        this.shape = shape;
+        this.of = of;
+        this.parts = List.copyOf(parts);
+        int h = shape.hashCode() * MIX + (of == null ? 0 : of.hashCode());
+        h = h * MIX + this.parts.size();
+        if (shape == Shape.EQ) {
+            // an equality is between two values and not from one to the other
+            h = h * MIX + (this.parts.get(0).hash + this.parts.get(1).hash);
+        } else {
+            for (Term part : this.parts) {
+                h = h * MIX + part.hash;
+            }
+        }
+        // A last mix, so that what a level carries up depends on its high bits as well as its low
+        // ones: without it a hash the multiplier only ever shifts left says less the deeper it goes.
+        this.hash = h ^ (h >>> 16);
+    }
+
+    Shape shape() {
+        return shape;
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof Term term) || term.hash != hash || term.shape != shape
+                || !java.util.Objects.equals(term.of, of)) {
+            return false;
+        }
+        if (shape == Shape.EQ) {
+            return (parts.get(0).equals(term.parts.get(0)) && parts.get(1).equals(term.parts.get(1)))
+                    || (parts.get(0).equals(term.parts.get(1))
+                            && parts.get(1).equals(term.parts.get(0)));
+        }
+        return parts.equals(term.parts);
+    }
+
+    /**
+     * How this reads where a person is shown one — a report, a log, this compiler's own tests.
+     *
+     * <p>What it renders as says nothing about what it is. Two terms rendering alike are not thereby
+     * one term, and nothing here reads a rendering back: that is what the string form of this was,
+     * and it is why an escaping bug in it could make one value out of two.
+     */
+    String rendered() {
+        StringBuilder sb = new StringBuilder();
+        switch (shape) {
+            case AT, BOUND -> sb.append(of);
+            case ON -> sb.append(parts.get(0).rendered()).append(path());
+            case INT, DECIMAL, BOOL -> sb.append(of);
+            case STRING -> sb.append('"').append(of).append('"');
+            case UNIT -> sb.append(of);
+            case NEG -> sb.append('-').append(parts.get(0).rendered());
+            case NOT -> sb.append('!').append(parts.get(0).rendered());
+            case EQ -> sb.append('(').append(parts.get(0).rendered()).append(" == ")
+                    .append(parts.get(1).rendered()).append(')');
+            case OP -> sb.append('(').append(parts.get(0).rendered()).append(' ').append(of)
+                    .append(' ').append(parts.get(1).rendered()).append(')');
+            case LIST -> joined(sb.append('['), ", ").append(']');
+            case TUPLE -> joined(sb.append('('), ", ").append(')');
+            case PART -> sb.append(parts.get(0).rendered()).append('.').append(of);
+            case CHOICE -> joined(sb.append("if("), ", ").append(')');
+            case CLOSURE -> joined(sb.append("\\").append(of).append('('), ", ").append(')');
+            case LET -> joined(sb.append("let("), ", ").append(')');
+            case BUILT -> {
+                Built built = (Built) of;
+                sb.append(built.type()).append('{');
+                for (int i = 0; i < parts.size(); i++) {
+                    sb.append(i == 0 ? "" : ", ").append(built.fields().get(i)).append('=')
+                            .append(parts.get(i).rendered());
+                }
+                sb.append('}');
+            }
+            case CALLED -> joined(sb.append(((ValueName) of).name()).append('('), ", ").append(')');
+        }
+        return sb.toString();
+    }
+
+    private StringBuilder joined(StringBuilder sb, String between) {
+        for (int i = 0; i < parts.size(); i++) {
+            sb.append(i == 0 ? "" : between).append(parts.get(i).rendered());
+        }
+        return sb;
+    }
+
+    private String path() {
+        StringBuilder sb = new StringBuilder();
+        for (String field : fields()) {
+            sb.append('.').append(field);
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String toString() {
+        return rendered();
+    }
+
+    /** The type a construction builds and the fields it gives values to, in the order the parts hold
+     * those values. */
+    record Built(TypeSymbol type, List<String> fields) {
+
+        Built {
+            fields = List.copyOf(fields);
+        }
+    }
+
+    /** Where a closure's parameter is bound: which closure down from here, and which parameter. */
+    record At(int depth, int index) {
+
+        @Override
+        public String toString() {
+            return "#" + depth + "." + index;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> fields() {
+        return (List<String>) of;
+    }
+
+    // --- how terms are built -------------------------------------------------------------------
+
+    /**
+     * Terms this analysis has built, each under the one instance of it that stands for it.
+     *
+     * <p>Sharing, not identity. Two writings of one value are equal terms whether or not they were
+     * built here; going through this makes the comparison stop at the first line and makes the hash
+     * a term already carries the one its parts are hashed from. One of these lives as long as the
+     * reading that fills it.
+     */
+    static final class Interner {
+
+        private final Map<Term, Term> shared = new HashMap<>();
+
+        private Term of(Shape shape, Object of, List<Term> parts) {
+            Term made = new Term(shape, of, parts);
+            Term had = shared.putIfAbsent(made, made);
+            return had != null ? had : made;
+        }
+
+        /** The place {@code where} is. */
+        Term at(Location where) {
+            return of(Shape.AT, where, List.of());
+        }
+
+        /** A closure's parameter, by where it is bound. */
+        Term bound(int depth, int index) {
+            return of(Shape.BOUND, new At(depth, index), List.of());
+        }
+
+        /**
+         * {@code base} with {@code fields} read off it, or {@code base} where none are.
+         *
+         * <p>One chain and not a chain of chains: fields read off something that already has fields
+         * read off it are the one path, so a value reached a field at a time and the same value
+         * reached all at once are one term.
+         */
+        Term on(Term base, List<String> fields) {
+            if (fields.isEmpty()) {
+                return base;
+            }
+            if (base.shape == Shape.ON) {
+                List<String> whole = new ArrayList<>(base.fields());
+                whole.addAll(fields);
+                return of(Shape.ON, List.copyOf(whole), base.parts);
+            }
+            return of(Shape.ON, List.copyOf(fields), List.of(base));
+        }
+
+        Term written(long value) {
+            return of(Shape.INT, value, List.of());
+        }
+
+        Term written(BigDecimal value) {
+            return of(Shape.DECIMAL, value, List.of());
+        }
+
+        Term written(String value) {
+            return of(Shape.STRING, value, List.of());
+        }
+
+        Term written(boolean value) {
+            return of(Shape.BOOL, value, List.of());
+        }
+
+        Term unit(TypeSymbol data) {
+            return of(Shape.UNIT, data, List.of());
+        }
+
+        Term negated(Term operand) {
+            return of(Shape.NEG, null, List.of(operand));
+        }
+
+        /** The denial of {@code condition}, and of a denial the condition itself. */
+        Term not(Term condition) {
+            return condition.shape == Shape.NOT ? condition.parts.get(0)
+                    : of(Shape.NOT, null, List.of(condition));
+        }
+
+        /**
+         * The operator over its two operands.
+         *
+         * <p>Six comparisons are three: {@code >} is {@code <} the other way round, and {@code >=}
+         * and {@code <=} are the denials of the other two. So two clauses comparing the same two
+         * terms are one term however the author reached for it, which matters wherever the
+         * comparison is not the whole condition — only there can the denial not be carried by the
+         * polarity instead.
+         */
+        Term operator(Hir.BinOp op, Term left, Term right) {
+            return switch (op) {
+                case EQ -> of(Shape.EQ, null, List.of(left, right));
+                case NE -> not(of(Shape.EQ, null, List.of(left, right)));
+                case LT -> of(Shape.OP, Hir.BinOp.LT, List.of(left, right));
+                case GT -> of(Shape.OP, Hir.BinOp.LT, List.of(right, left));
+                case GE -> not(of(Shape.OP, Hir.BinOp.LT, List.of(left, right)));
+                case LE -> not(of(Shape.OP, Hir.BinOp.LT, List.of(right, left)));
+                default -> of(Shape.OP, op, List.of(left, right));
+            };
+        }
+
+        Term list(List<Term> elements) {
+            return of(Shape.LIST, null, elements);
+        }
+
+        Term tuple(List<Term> elements) {
+            return of(Shape.TUPLE, null, elements);
+        }
+
+        Term part(Term tuple, int index) {
+            return of(Shape.PART, index, List.of(tuple));
+        }
+
+        Term choice(Term condition, Term then, Term els) {
+            return of(Shape.CHOICE, null, List.of(condition, then, els));
+        }
+
+        Term closure(int params, Term body) {
+            return of(Shape.CLOSURE, params, List.of(body));
+        }
+
+        Term let(Term value, Term body) {
+            return of(Shape.LET, null, List.of(value, body));
+        }
+
+        /** A construction, over what each field is given in declaration order. */
+        Term built(TypeSymbol type, List<String> fields, List<Term> values) {
+            return of(Shape.BUILT, new Built(type, fields), values);
+        }
+
+        /** A call to {@code operation} over its arguments — which is what a size taken of a container
+         * is, so a guard's size and a clause's size meet as one value rather than as two spellings
+         * that have to keep agreeing. */
+        Term called(ValueName operation, List<Term> args) {
+            return of(Shape.CALLED, operation, args);
+        }
+
+        /**
+         * The call {@code operation} over {@code args} where this has built one before, and null
+         * where it has not.
+         *
+         * <p>Recognised and not made. A reader asking what was said about a size wants the term a
+         * clause already named it by; answering with a fresh one would put a term nothing has spoken
+         * about where an answer was expected.
+         */
+        Term calledIfBuilt(ValueName operation, List<Term> args) {
+            Term made = new Term(Shape.CALLED, operation, args);
+            return shared.containsKey(made) ? made : null;
+        }
+
+        /** How many distinct terms this has been asked for — what a test measuring the sharing
+         * reads. */
+        int size() {
+            return shared.size();
+        }
+    }
+
+    /** The parts, for a reader that walks one. */
+    List<Term> parts() {
+        return parts;
+    }
+
+    /**
+     * How many distinct terms this one is made of, itself among them — what the representation of it
+     * costs.
+     *
+     * <p>Counted rather than written out. A term is a graph and not a tree: a name read twice is one
+     * value read twice, so writing out what a term holds writes a part once per path to it, and a
+     * chain of them doubles per link. Held once and read from two places, a link costs a link.
+     */
+    int distinct() {
+        java.util.Set<Term> seen = java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+        java.util.Deque<Term> left = new java.util.ArrayDeque<>(List.of(this));
+        while (!left.isEmpty()) {
+            Term term = left.pop();
+            if (seen.add(term)) {
+                left.addAll(term.parts);
+            }
+        }
+        return seen.size();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -191,10 +191,12 @@ final class Terms {
      * {@code null}. */
     LinearForm affineOf(Core e, Denotations at, Known k) {
         return affine(e, at, n -> {
-            if (n instanceof Core.NewData nd && nd.spreads().isEmpty() && nd.inits().size() == 1
-                    && nd.inits().get(0).name().equals("value")
+            // A newtype built around a number is that number here. What makes it one is the
+            // declaration, which `affineScalarBase` asks; a construction of it has the one field the
+            // declaration gives it.
+            if (n instanceof Core.Construct nd
                     && affineScalarBase(Type.ref(nd.typeName())) != null) {
-                return affineOf(nd.inits().get(0).value(), at, k);
+                return affineOf(nd.values().get(0).value(), at, k);
             }
             Core written = writtenValue(n, at);
             if (written != null && written != n) {
@@ -514,18 +516,17 @@ final class Terms {
                 yield value == null || body == null ? null : shared("let(" + value + ", " + body + ")");
             }
             // A construction is a pure function of its fields, and a closure that builds one is what a
-            // mapping usually is. Fields are keyed in name order, so two sites writing them in
-            // different orders write one term.
-            case Core.NewData nd when nd.spreads().isEmpty() -> {
-                List<Core.FieldInit> inits = new ArrayList<>(nd.inits());
-                inits.sort(java.util.Comparator.comparing(Core.FieldInit::name));
+            // mapping usually is. The fields are held in declaration order, so two sites writing them
+            // in different orders — or one of them through a spread — write one term.
+            case Core.Construct nd -> {
                 StringBuilder sb = new StringBuilder(nd.typeName().toString()).append('{');
-                for (int i = 0; i < inits.size(); i++) {
-                    String v = termKey(inits.get(i).value(), at, bound, depth);
+                List<Core.FieldValue> values = nd.values();
+                for (int i = 0; i < values.size(); i++) {
+                    String v = termKey(values.get(i).value(), at, bound, depth);
                     if (v == null) {
                         yield null;
                     }
-                    sb.append(i == 0 ? "" : ", ").append(inits.get(i).name()).append('=').append(v);
+                    sb.append(i == 0 ? "" : ", ").append(values.get(i).field()).append('=').append(v);
                 }
                 yield shared(sb.append('}').toString());
             }
@@ -714,8 +715,8 @@ final class Terms {
             case Core.ListLit list -> list.elements().stream().allMatch(x -> isWritten(x, written));
             case Core.Tuple t -> t.elements().stream().allMatch(x -> isWritten(x, written));
             case Core.OptionSome s -> isWritten(s.value(), written);
-            case Core.NewData nd -> nd.spreads().isEmpty()
-                    && nd.inits().stream().allMatch(fi -> isWritten(fi.value(), written));
+            case Core.Construct nd ->
+                    nd.values().stream().allMatch(v -> isWritten(v.value(), written));
             case Core.LetIn li -> {
                 if (!isWritten(li.value(), written)) {
                     yield false;

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -583,10 +583,11 @@ final class Terms {
             case Core.PreservedCall c -> over(c.args(), at, bound, depth,
                     ps -> interned.called(c.operation(), ps));
             case Core.Call c -> switch (c.fn()) {
-                case Core.Reached reached -> callNaming(reached.denotes()) instanceof Naming.Unnamed absent
-                        ? absent
-                        : over(c.args(), at, bound, depth,
-                                ps -> interned.called(reached.denotes(), ps));
+                case Core.Reached reached -> switch (answersOf(reached.denotes())) {
+                    case Naming.OfAName.AnswersNothing none -> new Naming.Opaque(none.reason());
+                    case Naming.OfAName.Answers ignored -> over(c.args(), at, bound, depth,
+                            ps -> interned.called(reached.denotes(), ps));
+                };
                 // A walk this compiler minted for a shape the backend lowers as a whole. The reading
                 // this check is given keeps no such call, so one arriving is a pass having run over a
                 // tree it was not written for rather than a value nothing can be said of.
@@ -598,7 +599,7 @@ final class Terms {
     }
 
     /**
-     * Whether a call to {@code callee} answers a value two writings of the call share.
+     * Whether {@code callee} answers a value two writings of a call to it share.
      *
      * <p>Asked of what the name was resolved to and of nothing else. A module's own helper is pure
      * and total, a value definition's body obeys a helper's rules, and the language's own operations
@@ -613,13 +614,14 @@ final class Terms {
      * two asks are two answers. What is applied through a binding is the same — the binding may hold
      * an injected behavior, and what it holds is not a question about the name.
      */
-    private Naming callNaming(ValueName callee) {
+    private Naming.OfAName answersOf(ValueName callee) {
         return switch (callee) {
-            case ValueName.Behavior _ -> new Naming.Opaque(Naming.Reason.A_BEHAVIOR_ANSWERED);
+            case ValueName.Behavior _ ->
+                    new Naming.OfAName.AnswersNothing(Naming.Reason.A_BEHAVIOR_ANSWERED);
             case ValueName.Local _ ->
-                    new Naming.Opaque(Naming.Reason.A_FUNCTION_VALUE_WAS_APPLIED);
+                    new Naming.OfAName.AnswersNothing(Naming.Reason.A_FUNCTION_VALUE_WAS_APPLIED);
             case ValueName.Helper _, ValueName.Stdlib _, ValueName.Builtin _, ValueName.OfType _ ->
-                    new Naming.Named(null);
+                    new Naming.OfAName.Answers();
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -65,6 +65,16 @@ final class Terms {
         this.symbols = symbols;
     }
 
+    /**
+     * Where a test in this package reads the shapes this had no term for, and null everywhere else.
+     *
+     * <p>Beside {@link InvariantChecker#WATCHING} and for the same reason. A shape with no term is
+     * silent, and silence is what a value nothing can be said of produces as well — so the difference
+     * between this compiler being unfinished and a value being unnameable has nowhere else to be
+     * read, and a difference nothing can read stops being true without anything failing.
+     */
+    static List<String> UNSUPPORTED;
+
     /** The operator {@code e} is, where it is a library call written as a function, or {@code e}
      * itself. Reading it as the operator is what puts it on the one path the operator already has,
      * rather than on a second path that would have to be kept saying the same thing. */
@@ -469,18 +479,40 @@ final class Terms {
      * {@code null}, and the clause reading it is left opaque.
      */
     private Term termKey(Core raw, Denotations at, Map<BindingId, Term> bound, int depth) {
+        return naming(raw, at, bound, depth).term();
+    }
+
+    /**
+     * What {@code raw} is called, or why it is called nothing.
+     *
+     * <p>Exhaustive over {@link Core} and carrying no default: a shape added to the language is a
+     * compile error here rather than a value the check silently has nothing to say about. Which is
+     * what the shapes below were — a call this reading kept standing fell through to nothing, so a
+     * construction over one was left to the run-time check while the same construction over the same
+     * helper expanded into the body was reported (#722).
+     *
+     * <p>A value is named by what computes it, where what computes it is a function of named parts.
+     * So the parts decide most of this, and what decides the rest is what is being called: a module's
+     * own helper is pure, the language's own operations are, and what an injected behavior answers is
+     * not. That a call is still standing here is not one of the questions — whether a helper was
+     * expanded into this body is a fact about the reading, not about the value it answers.
+     */
+    private Naming naming(Core raw, Denotations at, Map<BindingId, Term> bound, int depth) {
         Core e = asOperator(raw);
         BindingId root = rootBinding(e);
         if (root != null) {
             Term here = bound.get(root);
-            return here != null ? interned.on(here, chainOf(e)) : pathKey(e, at);
+            return here != null ? new Naming.Named(interned.on(here, chainOf(e)))
+                    : Naming.of(pathKey(e, at), Naming.Reason.A_BINDING_STANDS_FOR_NOTHING);
         }
         return switch (e) {
-            case Core.Int i -> interned.written(i.value());
-            case Core.Decimal d -> interned.written(d.value());
-            case Core.Str str -> interned.written(str.value());
-            case Core.Bool b -> interned.written(b.value());
-            case Core.UnitValue u -> interned.unit(u.data());
+            case Core.Read _, Core.FieldAccess _ ->
+                    Naming.of(pathKey(e, at), Naming.Reason.A_BINDING_STANDS_FOR_NOTHING);
+            case Core.Int i -> new Naming.Named(interned.written(i.value()));
+            case Core.Decimal d -> new Naming.Named(interned.written(d.value()));
+            case Core.Str str -> new Naming.Named(interned.written(str.value()));
+            case Core.Bool b -> new Naming.Named(interned.written(b.value()));
+            case Core.UnitValue u -> new Naming.Named(interned.unit(u.data()));
             case Core.Neg n -> over(List.of(n.operand()), at, bound, depth,
                     ps -> interned.negated(ps.get(0)));
             case Core.Binary b -> over(List.of(b.left(), b.right()), at, bound, depth,
@@ -491,16 +523,22 @@ final class Terms {
                     ps -> interned.part(ps.get(0), g.index()));
             case Core.If iff -> over(List.of(iff.cond(), iff.then(), iff.els()), at, bound, depth,
                     ps -> interned.choice(ps.get(0), ps.get(1), ps.get(2)));
+            case Core.OptionSome s -> over(List.of(s.value()), at, bound, depth,
+                    ps -> interned.some(ps.get(0)));
+            case Core.OptionNone none -> new Naming.Named(interned.none(none.type()));
             case Core.Block b -> {
                 Map<BindingId, Term> inner = binding(bound, b.params(), depth);
-                Term body = termKey(b.body(), at, inner, depth + 1);
-                yield body == null ? null : interned.closure(b.params().size(), body);
+                yield named(naming(b.body(), at, inner, depth + 1),
+                        body -> interned.closure(b.params().size(), body));
             }
             case Core.LetIn li -> {
-                Term value = termKey(li.value(), at, bound, depth);
+                Naming value = naming(li.value(), at, bound, depth);
+                if (value instanceof Naming.Unnamed absent) {
+                    yield absent;
+                }
                 Map<BindingId, Term> inner = binding(bound, List.of(li.binder()), depth);
-                Term body = termKey(li.body(), at, inner, depth + 1);
-                yield value == null || body == null ? null : interned.let(value, body);
+                yield named(naming(li.body(), at, inner, depth + 1),
+                        body -> interned.let(value.term(), body));
             }
             // A construction is a pure function of its fields, and a closure that builds one is what a
             // mapping usually is. The fields are held in declaration order, so two sites writing them
@@ -509,28 +547,127 @@ final class Terms {
                     at, bound, depth,
                     ps -> interned.built(nd.typeName(),
                             nd.values().stream().map(Core.FieldValue::field).toList(), ps));
-            // Only the operations the representation kept standing: they are the library\'s own, so
-            // they are pure and one written call is one value. A size taken of a container is one of
-            // these, built by the same call this builds, so a clause\'s size and a guard\'s size are
-            // one term rather than two spellings that meet.
+            case Core.Match m -> {
+                List<Core> arms = new ArrayList<>();
+                arms.add(m.scrutinee());
+                Map<BindingId, Term> outer = bound;
+                List<Naming> answers = new ArrayList<>();
+                for (Core.Case arm : m.cases()) {
+                    Map<BindingId, Term> inner = arm.binding() == null ? outer
+                            : binding(outer, List.of(arm.binding()), depth);
+                    answers.add(naming(arm.body(), at, inner, depth + 1));
+                }
+                Naming scrutinee = naming(m.scrutinee(), at, bound, depth);
+                yield joined(scrutinee, answers,
+                        parts -> interned.matched(parts.get(0),
+                                m.cases().stream().map(Core.Case::caseTypes).toList(),
+                                parts.subList(1, parts.size())));
+            }
+            case Core.IfConstructed ic -> {
+                Naming built = naming(ic.construct(), at, bound, depth);
+                Map<BindingId, Term> inner = binding(bound, List.of(ic.binder()), depth);
+                List<Naming> answers = new ArrayList<>();
+                answers.add(naming(ic.then(), at, inner, depth + 1));
+                for (Core.ElseArm arm : ic.els()) {
+                    answers.add(naming(arm.body(), at, bound, depth));
+                }
+                yield joined(built, answers,
+                        parts -> interned.attempted(parts.get(0),
+                                ic.els().stream().map(arm -> arm.clause().orElse("")).toList(),
+                                parts.subList(1, parts.size())));
+            }
+            // What the language's own operations answer, and what a module's own helper answers, are
+            // functions of what they were given: the first because the language defines them, the
+            // second because a helper is pure (spec §fn-rules). What an injected behavior answers is
+            // neither, and a call to one is named by nothing.
             case Core.PreservedCall c -> over(c.args(), at, bound, depth,
                     ps -> interned.called(c.operation(), ps));
-            default -> null;
+            case Core.Call c -> switch (c.fn()) {
+                case Core.Reached reached -> callNaming(reached.denotes()) instanceof Naming.Unnamed absent
+                        ? absent
+                        : over(c.args(), at, bound, depth,
+                                ps -> interned.called(reached.denotes(), ps));
+                // A walk this compiler minted for a shape the backend lowers as a whole. The reading
+                // this check is given keeps no such call, so one arriving is a pass having run over a
+                // tree it was not written for rather than a value nothing can be said of.
+                case Core.Emitted emitted -> unsupported(emitted.rendered());
+            };
+            case Core.Apply _ -> new Naming.Opaque(Naming.Reason.A_FUNCTION_VALUE_WAS_APPLIED);
+            case Core.Unreachable _ -> new Naming.Opaque(Naming.Reason.NOTHING_IS_ANSWERED);
         };
     }
 
+    /**
+     * Whether a call to {@code callee} answers a value two writings of the call share.
+     *
+     * <p>Asked of what the name was resolved to and of nothing else. A module's own helper is pure
+     * and total, a value definition's body obeys a helper's rules, and the language's own operations
+     * are what the language says they are — so a call to any of them answers one value wherever it is
+     * written with the same arguments. Whether the reading this check is given expanded that helper
+     * into the body is a fact about the reading and not about the value, which is why it is not asked
+     * here: a helper that recurses is left standing and a helper that does not is expanded, and the
+     * two answer the same question about the same call.
+     *
+     * <p>What a behavior answered is named by nothing (spec §invariant-discharge-terms). An injected
+     * one could not be: its implementation is outside the language and may read the outside world, so
+     * two asks are two answers. What is applied through a binding is the same — the binding may hold
+     * an injected behavior, and what it holds is not a question about the name.
+     */
+    private Naming callNaming(ValueName callee) {
+        return switch (callee) {
+            case ValueName.Behavior _ -> new Naming.Opaque(Naming.Reason.A_BEHAVIOR_ANSWERED);
+            case ValueName.Local _ ->
+                    new Naming.Opaque(Naming.Reason.A_FUNCTION_VALUE_WAS_APPLIED);
+            case ValueName.Helper _, ValueName.Stdlib _, ValueName.Builtin _, ValueName.OfType _ ->
+                    new Naming.Named(null);
+        };
+    }
+
+    /** A shape this has no term for, recorded where a test can read that it happened. */
+    private static Naming unsupported(String form) {
+        List<String> watching = UNSUPPORTED;
+        if (watching != null) {
+            watching.add(form);
+        }
+        return new Naming.Unsupported(form);
+    }
+
+    /** {@code made} of what {@code first} and {@code rest} name, or the first of them that names
+     * nothing. */
+    private Naming joined(Naming first, List<Naming> rest,
+                          java.util.function.Function<List<Term>, Term> made) {
+        List<Term> terms = new ArrayList<>();
+        if (first instanceof Naming.Unnamed absent) {
+            return absent;
+        }
+        terms.add(first.term());
+        for (Naming one : rest) {
+            if (one instanceof Naming.Unnamed absent) {
+                return absent;
+            }
+            terms.add(one.term());
+        }
+        return new Naming.Named(made.apply(terms));
+    }
+
+    /** {@code made} of what {@code naming} names, or why it names nothing. */
+    private Naming named(Naming naming, java.util.function.UnaryOperator<Term> made) {
+        return naming instanceof Naming.Unnamed absent ? absent
+                : new Naming.Named(made.apply(naming.term()));
+    }
+
     /** {@code made} of the terms {@code parts} are, or null where any of them is named by nothing. */
-    private Term over(List<Core> parts, Denotations at, Map<BindingId, Term> bound, int depth,
-                      java.util.function.Function<List<Term>, Term> made) {
+    private Naming over(List<Core> parts, Denotations at, Map<BindingId, Term> bound, int depth,
+                        java.util.function.Function<List<Term>, Term> made) {
         List<Term> terms = new ArrayList<>();
         for (Core part : parts) {
-            Term term = termKey(part, at, bound, depth);
-            if (term == null) {
-                return null;
+            Naming one = naming(part, at, bound, depth);
+            if (one instanceof Naming.Unnamed absent) {
+                return absent;
             }
-            terms.add(term);
+            terms.add(one.term());
         }
-        return made.apply(terms);
+        return new Naming.Named(made.apply(terms));
     }
 
     /** {@code bound} with each of {@code binders} keyed by where it is bound rather than by which
@@ -614,10 +751,11 @@ final class Terms {
         if (located != null) {
             return new Denotes.At(located);
         }
-        Term term = bodyKey(e, at);
-        if (term == null) {
-            return new Denotes.Nothing();
+        Naming named = naming(e, at, Map.of(), 0);
+        if (named instanceof Naming.Unnamed absent) {
+            return new Denotes.Nothing(absent);
         }
+        Term term = named.term();
         // Readable where there is something to say of it: a form the numeric domain built, or a rule
         // about how it was made. This is asked of the expression, so a name for it answers the same.
         return new Denotes.Computed(term, affineOf(e, at, k) != null || namedByRule(e, at));

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -49,23 +49,17 @@ final class Terms {
     /** How the values of each atom this has named are spaced. Kept here because this is where an
      * atom's name is made: the key and the kind of number behind it are decided in one step, and
      * anywhere else would be a second place that has to agree about which is which. */
-    private final Map<String, Granularity> atomKinds = new HashMap<>();
+    private final Map<Term, Granularity> atomKinds = new HashMap<>();
     /**
-     * Every canonical shape this has built, and the name it goes by.
+     * The terms this reading has built, each held under the one instance standing for it.
      *
      * <p>What a term is made of is a graph and not a tree: a name read twice is one value read twice,
-     * and `+let (a, b) = t+` reads `+t+` twice by itself. A shape written out in full holds a copy of
-     * each of its parts, so a part read twice is written twice, and a chain of them doubles per link —
-     * twenty-four links asked for more characters than an array can hold. Held under a name, a shape
-     * that reads another holds the name and not the shape, and what a link adds is a name.
-     *
-     * <p>The names are the identity the rest of this asks about, and two shapes are one name exactly
-     * when they are the same shape. That is the same equality the strings had — a shape is compared by
-     * its parts' names, which are compared the same way, all the way down to what a location is
-     * called. So naming an expression still answers what the expression answers, which is what makes a
-     * name an alias.
+     * and {@code let (a, b) = t} reads {@code t} twice by itself. A term holds its parts rather than
+     * a copy of them, and carries the hash they were hashed into, so a chain of them costs a link per
+     * link. Sharing is what makes the comparison stop at the first line; it is not what makes two
+     * terms equal ({@link Term}).
      */
-    private final Map<String, String> shapes = new HashMap<>();
+    private final Term.Interner interned = new Term.Interner();
 
     Terms(Symbols symbols) {
         this.symbols = symbols;
@@ -100,7 +94,7 @@ final class Terms {
      * what made {@code a * b} name nothing where it is written and something where it is bound —
      * which is a name changing what can be said of an expression.
      */
-    LinearForm affine(Core raw, Denotations at, java.util.function.Function<Core, LinearForm> leaf) {
+    LinearForm<Term> affine(Core raw, Denotations at, java.util.function.Function<Core, LinearForm<Term>> leaf) {
         Core e = asOperator(raw);
         if (e instanceof Core.PreservedCall) {
             // A call that folds is the number it folds to. `String.length("1A")` is 2, and a clause
@@ -112,14 +106,14 @@ final class Terms {
                 return LinearForm.constant(folded);
             }
         }
-        LinearForm composed = composed(e, at, leaf);
+        LinearForm<Term> composed = composed(e, at, leaf);
         return composed != null ? composed : leaf.apply(e);
     }
 
     /** {@code e} read as arithmetic over what {@code leaf} answers, or {@code null} where this has no
      * rule for it or the rule it has does not compose. */
-    private LinearForm composed(Core e, Denotations at,
-                                java.util.function.Function<Core, LinearForm> leaf) {
+    private LinearForm<Term> composed(Core e, Denotations at,
+                                java.util.function.Function<Core, LinearForm<Term>> leaf) {
         return switch (e) {
             case Core.Int i -> LinearForm.constant(BigDecimal.valueOf(i.value()));
             case Core.Decimal d -> LinearForm.constant(d.value());
@@ -150,7 +144,7 @@ final class Terms {
             // arithmetic helper becomes, so reading through it is reading the arithmetic the author
             // wrote.
             case Core.LetIn li -> {
-                LinearForm bound = affine(li.value(), at, leaf);
+                LinearForm<Term> bound = affine(li.value(), at, leaf);
                 yield bound == null ? null : affine(li.body(), at,
                         n -> n instanceof Core.Read r && r.binding().equals(li.binder().id())
                                 ? bound : leaf.apply(n));
@@ -177,7 +171,7 @@ final class Terms {
 
     /** A linear form scaled by a constant, when one side is a bare constant (a scalar multiply); null
      * when neither side is constant (a non-linear product). */
-    static LinearForm scale(LinearForm a, LinearForm b) {
+    static <A> LinearForm<A> scale(LinearForm<A> a, LinearForm<A> b) {
         if (a == null || b == null) {
             return null;
         }
@@ -189,7 +183,7 @@ final class Terms {
 
     /** The affine form of an expression: a numeric atom, a newtype construct's wrapped value, or
      * {@code null}. */
-    LinearForm affineOf(Core e, Denotations at, Known k) {
+    LinearForm<Term> affineOf(Core e, Denotations at, Known k) {
         return affine(e, at, n -> {
             // A newtype built around a number is that number here. What makes it one is the
             // declaration, which `affineScalarBase` asks; a construction of it has the one field the
@@ -211,11 +205,11 @@ final class Terms {
             // §invariant-discharge-terms). Read through it, as the `let` node above is read through:
             // the name and the expression it was given are one value, and reading one as an atom of
             // its own leaves a guard on the name saying nothing about the value it was built from.
-            LinearForm given = givenForm(n, at, k);
+            LinearForm<Term> given = givenForm(n, at, k);
             if (given != null) {
                 return given;
             }
-            String atom = atomOf(n, at);
+            Term atom = atomOf(n, at);
             return atom == null ? null : LinearForm.atom(atom);
         });
     }
@@ -225,8 +219,8 @@ final class Terms {
      * given is arithmetic this can read. A name given a location is not this — {@link #atomOf}
      * answers that with the location, which is what the seeding wrote about.
      */
-    private LinearForm givenForm(Core e, Denotations at, Known k) {
-        if (!(e instanceof Core.Read r) || !(at.of(r.binding()) instanceof Denotes.Term)
+    private LinearForm<Term> givenForm(Core e, Denotations at, Known k) {
+        if (!(e instanceof Core.Read r) || !(at.of(r.binding()) instanceof Denotes.Computed)
                 || affineScalarBase(e.type()) == null) {
             return null;
         }
@@ -264,11 +258,11 @@ final class Terms {
         return given == null || given == e ? e : listedOut(given, at);
     }
 
-    static LinearForm negate(LinearForm f) {
+    static <A> LinearForm<A> negate(LinearForm<A> f) {
         return f == null ? null : f.negate();
     }
 
-    static LinearForm add(LinearForm a, LinearForm b, boolean subtract) {
+    static <A> LinearForm<A> add(LinearForm<A> a, LinearForm<A> b, boolean subtract) {
         if (a == null || b == null) {
             return null;
         }
@@ -288,8 +282,8 @@ final class Terms {
      * have been said before a value could be an atom made the first guard about a value the one that
      * could not be read, since it was read to decide whether that value had a name at all.
      */
-    String atomOf(Core e, Denotations at) {
-        String size = sizeAtomOf(e, arg -> bodyKey(arg, at));
+    Term atomOf(Core e, Denotations at) {
+        Term size = sizeAtomOf(e, arg -> bodyKey(arg, at));
         if (size != null) {
             return size;
         }
@@ -299,15 +293,24 @@ final class Terms {
         return named(bodyKey(e, at), granularityOf(e.type()));
     }
 
-    /** {@link #sizeAtom}, with the atom it names recorded as a whole number. A size counts elements,
-     * so there is nothing to decide about it. */
-    String sizeAtomOf(Core e, java.util.function.Function<Core, String> key) {
-        return named(shared(sizeAtom(e, key)), Granularity.DISCRETE);
+    /** The atom of the size {@code e} takes of a container {@code key} can name, or null where it
+     * takes none or names none. */
+    Term sizeAtomOf(Core e, java.util.function.Function<Core, Term> key) {
+        Core container = DischargeRules.sizeArgOf(e);
+        if (container == null) {
+            return null;
+        }
+        Term arg = key.apply(DischargeRules.sizeSource(container));
+        return arg == null ? null : sizeKeyOf(((Core.PreservedCall) e).operation(), arg);
     }
 
-    /** {@link #sizeKey}, with the atom it names recorded. */
-    String sizeKeyOf(ValueName size, String container) {
-        return named(shared(sizeKey(size, container)), Granularity.DISCRETE);
+    /** The size {@code size} takes of {@code container}, named as the whole number it is. A size
+     * counts elements, so there is nothing to decide about how its values are spaced. It is the call
+     * that takes it and nothing besides, which is the term a clause reading one builds and the term a
+     * guard stating one builds — so the two are one value rather than two writings that have to keep
+     * spelling each other alike. */
+    Term sizeKeyOf(ValueName size, Term container) {
+        return named(interned.called(size, List.of(container)), Granularity.DISCRETE);
     }
 
     /**
@@ -325,41 +328,33 @@ final class Terms {
      * a field wants the name a clause already gave it, and answering with a fresh one would put an
      * atom nothing bounds into the domain and call that an answer.
      */
-    String takenAtomOf(Core e, Type type, Denotations at) {
+    Term takenAtomOf(Core e, Type type, Denotations at) {
         ValueName.Stdlib counts = NumericMeasures.takenOf(type, symbols);
         if (counts == null) {
             return null;
         }
-        String container = bodyKey(e, at);
-        return container == null ? null : shapes.get(sizeKey(counts, container));
-    }
-
-    /** {@code shape} under the name it goes by here, so that what reads it reads the name. */
-    private String shared(String shape) {
-        if (shape == null) {
-            return null;
-        }
-        String had = shapes.get(shape);
-        if (had != null) {
-            return had;
-        }
-        String name = "@" + shapes.size();
-        shapes.put(shape, name);
-        return name;
+        Term container = bodyKey(e, at);
+        return container == null ? null : interned.calledIfBuilt(counts, List.of(container));
     }
 
     /**
-     * One name this gave two kinds of number.
+     * One term this gave two kinds of number.
      *
      * <p>Apart from everything else the check can fall over on, and for a reason. Those are shapes it
      * has no rule for, and answering them with silence is what fail-open means. This is the check
-     * disagreeing with itself about one of its own names: two writings it called one value are not
-     * one value, so every relation recorded under that name relates the wrong things. Swallowed, it
-     * produces a body with no findings, which is what a body with nothing to report produces.
+     * disagreeing with itself about one of its own terms: a term is a value, and a value is one kind
+     * of number, so every relation recorded against a term that is two of them relates the wrong
+     * things. Swallowed, it produces a body with no findings, which is what a body with nothing to
+     * report produces.
+     *
+     * <p>What it is about has narrowed. A term was a string written out of its parts, and two values
+     * could write one — a collision this would catch only where the two happened to be numbers spaced
+     * differently. Terms are held by what they are made of now, so that route is gone and what is
+     * left is the check handing one value two spacings.
      */
-    static final class OneKeyTwoKinds extends IllegalStateException {
+    static final class OneTermTwoKinds extends IllegalStateException {
 
-        OneKeyTwoKinds(String message) {
+        OneTermTwoKinds(String message) {
             super(message);
         }
     }
@@ -367,13 +362,13 @@ final class Terms {
     /** {@code key}, with how its values are spaced recorded against it. A key is what a value is
      * called and a kind is what the value is, so one key is one kind: two would mean this named two
      * values alike, and everything recorded under the name would be about neither of them. */
-    private String named(String key, Granularity g) {
+    private Term named(Term key, Granularity g) {
         if (key == null) {
             return null;
         }
         Granularity had = atomKinds.putIfAbsent(key, g);
         if (had != null && had != g) {
-            throw new OneKeyTwoKinds("atom `" + key + "` is " + had + " and " + g);
+            throw new OneTermTwoKinds("atom `" + key.rendered() + "` is " + had + " and " + g);
         }
         return key;
     }
@@ -392,26 +387,26 @@ final class Terms {
 
     /** The spacing of every atom {@code f} is written over, for the domain to record. Every one of
      * them was named here, so one that is not is a form built somewhere this cannot answer for. */
-    Map<String, Granularity> kindsOf(LinearForm f) {
+    Map<Term, Granularity> kindsOf(LinearForm<Term> f) {
         return kindsOfAtoms(f.coefs().keySet());
     }
 
     /** The same, for a name being given a form: the name is an atom too, and its own type says how
      * its values are spaced. */
-    Map<String, Granularity> kindsOf(LinearForm f, String atom, Type type) {
-        Map<String, Granularity> out = new HashMap<>(kindsOf(f));
+    Map<Term, Granularity> kindsOf(LinearForm<Term> f, Term atom, Type type) {
+        Map<Term, Granularity> out = new HashMap<>(kindsOf(f));
         Granularity g = granularityOf(type);
         named(atom, g);
         out.put(atom, g);
         return out;
     }
 
-    private Map<String, Granularity> kindsOfAtoms(Set<String> atoms) {
-        Map<String, Granularity> out = new HashMap<>();
-        for (String atom : atoms) {
+    private Map<Term, Granularity> kindsOfAtoms(Set<Term> atoms) {
+        Map<Term, Granularity> out = new HashMap<>();
+        for (Term atom : atoms) {
             Granularity g = atomKinds.get(atom);
             if (g == null) {
-                throw new IllegalStateException("atom `" + atom + "` was not named here");
+                throw new IllegalStateException("atom `" + atom.rendered() + "` was not named here");
             }
             out.put(atom, g);
         }
@@ -420,7 +415,7 @@ final class Terms {
 
     /** An expression's canonical key: a location names itself, and everything else is read
      * structurally. */
-    String bodyKey(Core e, Denotations at) {
+    Term bodyKey(Core e, Denotations at) {
         return termKey(e, at, Map.of(), 0);
     }
 
@@ -442,33 +437,25 @@ final class Terms {
      * this check's flagging policy rather than a proof: the run-time check stands for the whole of
      * such an invariant. Widening it is a matter of naming more values here.
      */
-    String siteKey(Core e, Denotations at, Known k) {
+    Term siteKey(Core e, Denotations at, Known k) {
         // A value written out is not something a guard can be written about: there is nothing to
         // state of `"xyz"` that the text does not already say. Where a clause reading it folds it is
         // decided before this is asked, and where it does not fold there is no guard that would
         // discharge it, so naming it here would only report what the author cannot answer.
         Denotes d = denotationOf(e, at, k);
-        return readable(d, k) ? d.key() : null;
+        return readable(d, k) ? termOf(d) : null;
     }
 
-    /** The atom key of {@code SIZE_CALL(container)} when {@code key} can name the container, else
-     * {@code null}. */
-    static String sizeAtom(Core e, java.util.function.Function<Core, String> key) {
-        Core container = DischargeRules.sizeArgOf(e);
-        if (container == null) {
-            return null;
-        }
-        String arg = key.apply(DischargeRules.sizeSource(container));
-        return arg == null ? null : sizeKey(((Core.PreservedCall) e).operation(), arg);
+    /** What {@code d} is named by, or null where it is named by nothing. Said here because a place is
+     * named by the term it is, and only this holds the terms. */
+    Term termOf(Denotes d) {
+        return switch (d) {
+            case Denotes.At located -> interned.at(located.where());
+            case Denotes.Computed computed -> computed.term();
+            case Denotes.Written written -> written.term();
+            case Denotes.Nothing ignored -> null;
+        };
     }
-
-    /** How a size over a named container is written as an atom. The same string a call keys as
-     * ({@link #termKey}), said here so a guard's term and a clause's atom cannot drift apart — they
-     * meet by this key and by nothing else. */
-    static String sizeKey(ValueName size, String container) {
-        return size.name() + "(" + container + ")";
-    }
-
 
     /**
      * The canonical key of an expression as a term, or {@code null} when nothing here can be named.
@@ -481,120 +468,79 @@ final class Terms {
      * still the value it is and so is part of the term. Anything outside this grammar keys as
      * {@code null}, and the clause reading it is left opaque.
      */
-    private String termKey(Core raw, Denotations at, Map<BindingId, String> bound, int depth) {
+    private Term termKey(Core raw, Denotations at, Map<BindingId, Term> bound, int depth) {
         Core e = asOperator(raw);
         BindingId root = rootBinding(e);
         if (root != null) {
-            String here = bound.get(root);
-            return here != null ? chainOn(here, e) : pathKey(e, at);
+            Term here = bound.get(root);
+            return here != null ? interned.on(here, chainOf(e)) : pathKey(e, at);
         }
         return switch (e) {
-            case Core.Int i -> Long.toString(i.value());
-            case Core.Decimal d -> d.value().toPlainString() + "m";
-            case Core.Str s -> quoted(s.value());
-            case Core.Bool b -> Boolean.toString(b.value());
-            case Core.UnitValue u -> u.data().toString();
-            case Core.Neg n -> shared(wrap("-", termKey(n.operand(), at, bound, depth)));
-            case Core.Binary b -> {
-                String l = termKey(b.left(), at, bound, depth);
-                String r = termKey(b.right(), at, bound, depth);
-                yield l == null || r == null ? null : shared(binaryKey(b.op(), l, r));
-            }
-            case Core.ListLit l -> shared(elementsKey("[", l.elements(), at, bound, depth, "]"));
-            case Core.Tuple t -> shared(elementsKey("(", t.elements(), at, bound, depth, ")"));
-            case Core.TupleGet g -> shared(wrap("." + g.index(), termKey(g.tuple(), at, bound, depth)));
-            case Core.If iff -> shared(elementsKey("if(", List.of(iff.cond(), iff.then(), iff.els()),
-                    at, bound, depth, ")"));
+            case Core.Int i -> interned.written(i.value());
+            case Core.Decimal d -> interned.written(d.value());
+            case Core.Str str -> interned.written(str.value());
+            case Core.Bool b -> interned.written(b.value());
+            case Core.UnitValue u -> interned.unit(u.data());
+            case Core.Neg n -> over(List.of(n.operand()), at, bound, depth,
+                    ps -> interned.negated(ps.get(0)));
+            case Core.Binary b -> over(List.of(b.left(), b.right()), at, bound, depth,
+                    ps -> interned.operator(b.op(), ps.get(0), ps.get(1)));
+            case Core.ListLit l -> over(l.elements(), at, bound, depth, interned::list);
+            case Core.Tuple t -> over(t.elements(), at, bound, depth, interned::tuple);
+            case Core.TupleGet g -> over(List.of(g.tuple()), at, bound, depth,
+                    ps -> interned.part(ps.get(0), g.index()));
+            case Core.If iff -> over(List.of(iff.cond(), iff.then(), iff.els()), at, bound, depth,
+                    ps -> interned.choice(ps.get(0), ps.get(1), ps.get(2)));
             case Core.Block b -> {
-                Map<BindingId, String> inner = binding(bound, b.params(), depth);
-                yield shared(wrap("\\" + b.params().size(), termKey(b.body(), at, inner, depth + 1)));
+                Map<BindingId, Term> inner = binding(bound, b.params(), depth);
+                Term body = termKey(b.body(), at, inner, depth + 1);
+                yield body == null ? null : interned.closure(b.params().size(), body);
             }
             case Core.LetIn li -> {
-                String value = termKey(li.value(), at, bound, depth);
-                Map<BindingId, String> inner = binding(bound, List.of(li.binder()), depth);
-                String body = termKey(li.body(), at, inner, depth + 1);
-                yield value == null || body == null ? null : shared("let(" + value + ", " + body + ")");
+                Term value = termKey(li.value(), at, bound, depth);
+                Map<BindingId, Term> inner = binding(bound, List.of(li.binder()), depth);
+                Term body = termKey(li.body(), at, inner, depth + 1);
+                yield value == null || body == null ? null : interned.let(value, body);
             }
             // A construction is a pure function of its fields, and a closure that builds one is what a
             // mapping usually is. The fields are held in declaration order, so two sites writing them
             // in different orders — or one of them through a spread — write one term.
-            case Core.Construct nd -> {
-                StringBuilder sb = new StringBuilder(nd.typeName().toString()).append('{');
-                List<Core.FieldValue> values = nd.values();
-                for (int i = 0; i < values.size(); i++) {
-                    String v = termKey(values.get(i).value(), at, bound, depth);
-                    if (v == null) {
-                        yield null;
-                    }
-                    sb.append(i == 0 ? "" : ", ").append(values.get(i).field()).append('=').append(v);
-                }
-                yield shared(sb.append('}').toString());
-            }
-            // Only the operations the representation kept standing: they are the library's own, so
-            // they are pure and one written call is one value.
-            // Named like the rest, and the one whose spelling something else reproduces: a size
-            // atom is built from the same shape by `sizeKey`, so both reach the same name.
-            case Core.PreservedCall c -> shared(
-                    elementsKey(c.operation().name() + "(", c.args(), at, bound, depth, ")"));
+            case Core.Construct nd -> over(nd.values().stream().map(Core.FieldValue::value).toList(),
+                    at, bound, depth,
+                    ps -> interned.built(nd.typeName(),
+                            nd.values().stream().map(Core.FieldValue::field).toList(), ps));
+            // Only the operations the representation kept standing: they are the library\'s own, so
+            // they are pure and one written call is one value. A size taken of a container is one of
+            // these, built by the same call this builds, so a clause\'s size and a guard\'s size are
+            // one term rather than two spellings that meet.
+            case Core.PreservedCall c -> over(c.args(), at, bound, depth,
+                    ps -> interned.called(c.operation(), ps));
             default -> null;
         };
     }
 
-    /** {@code bound} with each of {@code binders} keyed by where it is bound rather than by which
-     * binding it is, so two expressions that differ only in what they bound are one term. */
-    static Map<BindingId, String> binding(Map<BindingId, String> bound,
-                                                  List<Hir.Binder> binders, int depth) {
-        Map<BindingId, String> inner = new HashMap<>(bound);
-        for (int i = 0; i < binders.size(); i++) {
-            inner.put(binders.get(i).id(), "#" + depth + "." + i);
-        }
-        return inner;
-    }
-
-    String elementsKey(String open, List<Core> parts, Denotations at,
-                               Map<BindingId, String> bound, int depth, String close) {
-        StringBuilder sb = new StringBuilder(open);
-        for (int i = 0; i < parts.size(); i++) {
-            String part = termKey(parts.get(i), at, bound, depth);
-            if (part == null) {
+    /** {@code made} of the terms {@code parts} are, or null where any of them is named by nothing. */
+    private Term over(List<Core> parts, Denotations at, Map<BindingId, Term> bound, int depth,
+                      java.util.function.Function<List<Term>, Term> made) {
+        List<Term> terms = new ArrayList<>();
+        for (Core part : parts) {
+            Term term = termKey(part, at, bound, depth);
+            if (term == null) {
                 return null;
             }
-            sb.append(i == 0 ? "" : ", ").append(part);
+            terms.add(term);
         }
-        return sb.append(close).toString();
+        return made.apply(terms);
     }
 
-    /**
-     * A binary as a key. The six comparisons are two: {@code ==} over the pair in a settled order,
-     * since which side is written first is not part of what it says, and {@code <}, with the other
-     * three written as one of those denied. Two clauses comparing the same two terms are then one term
-     * however the author reached for it — which matters wherever the comparison is not the whole
-     * condition, since only there can the denial not be carried by the polarity instead.
-     */
-    static String binaryKey(Hir.BinOp op, String l, String r) {
-        return switch (op) {
-            case EQ -> l.compareTo(r) <= 0 ? cmp("EQ", l, r) : cmp("EQ", r, l);
-            case NE -> "!" + binaryKey(Hir.BinOp.EQ, l, r);
-            case LT -> cmp("LT", l, r);
-            case GT -> cmp("LT", r, l);
-            case GE -> "!" + cmp("LT", l, r);
-            case LE -> "!" + cmp("LT", r, l);
-            default -> cmp(op.toString(), l, r);
-        };
-    }
-
-    static String cmp(String op, String l, String r) {
-        return "(" + l + " " + op + " " + r + ")";
-    }
-
-    /** A string value written into a key with the punctuation the key itself uses escaped, so a value
-     * holding a quote or a comma cannot be read back as a different expression. */
-    static String quoted(String value) {
-        return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
-    }
-
-    static String wrap(String prefix, String inner) {
-        return inner == null ? null : prefix + "(" + inner + ")";
+    /** {@code bound} with each of {@code binders} keyed by where it is bound rather than by which
+     * binding it is, so two expressions that differ only in what they bound are one term. */
+    Map<BindingId, Term> binding(Map<BindingId, Term> bound, List<Hir.Binder> binders, int depth) {
+        Map<BindingId, Term> inner = new HashMap<>(bound);
+        for (int i = 0; i < binders.size(); i++) {
+            inner.put(binders.get(i).id(), interned.bound(depth, i));
+        }
+        return inner;
     }
 
     /** The binding at the head of a {@code x}/{@code x.a.b} chain, or {@code null} if {@code e} is not
@@ -607,9 +553,18 @@ final class Terms {
         };
     }
 
-    /** The field chain of {@code e} rebuilt on {@code head}. */
-    static String chainOn(String head, Core e) {
-        return e instanceof Core.FieldAccess fa ? chainOn(head, fa.target()) + "." + fa.field() : head;
+    /** The fields read along a {@code x.a.b} chain, from the head down. */
+    static List<String> chainOf(Core e) {
+        List<String> out = new ArrayList<>();
+        chainInto(e, out);
+        return out;
+    }
+
+    private static void chainInto(Core e, List<String> out) {
+        if (e instanceof Core.FieldAccess fa) {
+            chainInto(fa.target(), out);
+            out.add(fa.field());
+        }
     }
 
     /**
@@ -620,19 +575,19 @@ final class Terms {
      * rule and is read here of a term too, so a value keyed one way through a binding and the other
      * way through a field is one value.
      */
-    String pathKey(Core e, Denotations at) {
+    Term pathKey(Core e, Denotations at) {
         Location located = locationOf(e, at);
         if (located != null) {
-            return located.toString();
+            return interned.at(located);
         }
         return switch (e) {
-            case Core.Read r -> at.of(r.binding()).key();
+            case Core.Read r -> termOf(at.of(r.binding()));
             case Core.FieldAccess fa -> {
                 if (!Location.isStep(fa.target().type(), fa.field(), symbols)) {
                     yield pathKey(fa.target(), at);
                 }
-                String base = pathKey(fa.target(), at);
-                yield base == null ? null : base + "." + fa.field();
+                Term base = pathKey(fa.target(), at);
+                yield base == null ? null : interned.on(base, List.of(fa.field()));
             }
             default -> null;
         };
@@ -659,13 +614,13 @@ final class Terms {
         if (located != null) {
             return new Denotes.At(located);
         }
-        String term = bodyKey(e, at);
+        Term term = bodyKey(e, at);
         if (term == null) {
             return new Denotes.Nothing();
         }
         // Readable where there is something to say of it: a form the numeric domain built, or a rule
         // about how it was made. This is asked of the expression, so a name for it answers the same.
-        return new Denotes.Term(term, affineOf(e, at, k) != null || namedByRule(e, at));
+        return new Denotes.Computed(term, affineOf(e, at, k) != null || namedByRule(e, at));
     }
 
     /**
@@ -680,7 +635,7 @@ final class Terms {
     static boolean readable(Denotes d, Known k) {
         return switch (d) {
             case Denotes.At _ -> true;
-            case Denotes.Term term -> term.readable() || k.speaksOf(term.key());
+            case Denotes.Computed computed -> computed.readable() || k.speaksOf(computed.term());
             case Denotes.Written _, Denotes.Nothing _ -> false;
         };
     }
@@ -751,7 +706,7 @@ final class Terms {
             return true;
         }
         if (e instanceof Core.Read r) {
-            return at.of(r.binding()) instanceof Denotes.Term t && t.readable();
+            return at.of(r.binding()) instanceof Denotes.Computed t && t.readable();
         }
         Core read = asOperator(e);
         if (read instanceof Core.PreservedCall call

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -67,14 +67,6 @@ final class BodyGen {
         return ctx.fieldTypes(data);
     }
 
-    /** The fields a construction spread copies from a value of {@code src}: a data's own, or the part
-     * every case of a sum spreads, which the sum's sealed interface declares as accessors. */
-    private Map<String, Type> spreadableFields(TypeSymbol src) {
-        return symbols.declarations().declaration(src.key()) instanceof Hir.SumData sum
-                ? TypeOps.commonSpreadFields(sum, symbols)
-                : fieldTypes((Hir.Data) symbols.declarations().declaration(src.key()));
-    }
-
     private Type successType(Hir.RetType ret) {
         return ctx.successType(ret);
     }
@@ -436,10 +428,10 @@ final class BodyGen {
                 case Core.Match m -> emitTailMatch(m, cdB, requiredNames, requiredSuccess, expected);
                 case Core.Call call when tcoName != null && call.name().equals(tcoName)
                         && call.args().size() == tcoParams.size() -> emitSelfTailCall(call);
-                case Core.NewData nd when DataChecker.isInvariantBearing(nd.typeName(), symbols) -> {
+                case Core.Construct nd when DataChecker.isInvariantBearing(nd.typeName(), symbols) -> {
                     ClassDesc cdType = cd(nd.typeName());
                     Map<String, Type> flds = fieldTypes((Hir.Data) symbols.declarations().declaration(nd.typeName().key()));
-                    emitFieldValues(flds, nd.inits(), nd.spreads());
+                    emitFieldValues(flds, nd.values());
                     emitLine(nd);   // re-pin: a field init may have moved the line off the construction
                     code.invokestatic(cdType, "__construct", MethodTypeDesc.of(CD_Result, fieldDescs(flds)));
                     code.invokestatic(CD_ConstraintViolation, "orThrow", MTD_orThrow);
@@ -501,28 +493,14 @@ final class BodyGen {
             ctx.countOneStep(code);
         }
 
-        /** Pushes each field's value in declaration order: an explicit initializer, else the field
-         * carried over from a spread source (ADR-0021). */
-        void emitFieldValues(Map<String, Type> fields, List<Core.FieldInit> inits,
-                             List<Core.Read> spreads) {
-            Map<String, Core.FieldInit> byName = new HashMap<>();
-            for (Core.FieldInit init : inits) {
-                byName.put(init.name(), init);
-            }
-            for (String field : fields.keySet()) {
-                Core.FieldInit init = byName.get(field);
-                if (init != null) {
-                    // push the field's declared type so a field valued by a fold over an empty seed
-                    // materialises its step closure at the field's type (issue #70)
-                    genExpr(init.value(), fields.get(field));
-                    continue;
-                }
-                for (Core.Read sp : spreads) {
-                    if (spreadableFields(((Type.Ref) varType(sp)).name()).containsKey(field)) {
-                        spreadField(sp, field);
-                        break;
-                    }
-                }
+        /** Pushes what each field is given, in the order the construction holds them — which is
+         * declaration order, and which a construction settled when it was built (ADR-0021). Nothing
+         * is worked out here: a field a spread supplied holds the read of it, like any other value. */
+        void emitFieldValues(Map<String, Type> fields, List<Core.FieldValue> values) {
+            for (Core.FieldValue given : values) {
+                // push the field's declared type so a field valued by a fold over an empty seed
+                // materialises its step closure at the field's type (issue #70)
+                genExpr(given.value(), fields.get(given.field()));
             }
         }
 
@@ -753,7 +731,7 @@ final class BodyGen {
                     binary(bin);
                     comparisonProbe(bin);
                 }
-                case Core.NewData nd -> newData(nd);
+                case Core.Construct nd -> construct(nd);
                 case Core.Match m -> match(m, expected);
                 case Core.Call c -> call(c, expected);
                 case Core.Apply a -> applyFn(a, (Type.FnOf) a.fn().type());
@@ -936,7 +914,7 @@ final class BodyGen {
             code.athrow();
         }
 
-        private void newData(Core.NewData nd) {
+        private void construct(Core.Construct nd) {
             Hir.Data owner = (Hir.Data) symbols.declarations().declaration(nd.typeName().key());
             Map<String, Type> flds = fieldTypes(owner);
             ClassDesc cdType = cd(nd.typeName());
@@ -948,7 +926,7 @@ final class BodyGen {
                 // construction goes through __construct just as it does in tail (see emitTail): the
                 // invariant runs and orThrow either yields the value or aborts with a
                 // ConstraintViolation. orThrow returns Object, so narrow it back to the value type.
-                emitFieldValues(flds, nd.inits(), nd.spreads());
+                emitFieldValues(flds, nd.values());
                 emitLine(nd);   // re-pin: a field init may have moved the line off the construction
                 finishInvariantConstruct(cdType, flds);
                 return;
@@ -957,7 +935,7 @@ final class BodyGen {
             if (!walksInside(nd)) {
                 code.new_(cdType);
                 code.dup();
-                emitFieldValues(flds, nd.inits(), nd.spreads());
+                emitFieldValues(flds, nd.values());
                 code.invokespecial(cdType, "<init>", ctor);
                 return;
             }
@@ -966,7 +944,7 @@ final class BodyGen {
             // `<init>`, and the verifier will not carry one over a jump. So the fields are built first
             // and held in slots, exactly as a newtype's single field already is, and the construction
             // itself is the straight line at the end.
-            emitFieldValues(flds, nd.inits(), nd.spreads());
+            emitFieldValues(flds, nd.values());
             List<Type> fieldTypes = new ArrayList<>(flds.values());
             int[] held = new int[fieldTypes.size()];
             for (int i = fieldTypes.size() - 1; i >= 0; i--) {
@@ -1007,10 +985,10 @@ final class BodyGen {
          * value position and tail position part company.
          */
         private Attempt emitAttempt(Core.IfConstructed ic) {
-            Core.NewData nd = ic.construct();
+            Core.Construct nd = ic.construct();
             Map<String, Type> flds = fieldTypes((Hir.Data) symbols.declarations().declaration(nd.typeName().key()));
             ClassDesc cdType = cd(nd.typeName());
-            emitFieldValues(flds, nd.inits(), nd.spreads());
+            emitFieldValues(flds, nd.values());
             emitLine(ic);   // re-pin: a field init may have moved the line off the construction
             code.invokestatic(cdType, "__construct", MethodTypeDesc.of(CD_Result, fieldDescs(flds)));
 
@@ -1103,38 +1081,8 @@ final class BodyGen {
             code.checkcast(cdType);
         }
 
-        /** Wraps a base value (Int/Decimal) already on the stack into a single-value newtype, running
-         * its invariant check — the closed-arithmetic counterpart of {@link #newData}. An
-         * invariant-bearing newtype goes through {@code __construct}/{@code orThrow} (aborts on
-         * violation, which a behavior's guard is meant to have discharged); a plain newtype is stashed
-         * and built with {@code new}/{@code <init>}. */
-        private Type wrapNewtypeValue(TypeSymbol ntName, Type base) {
-            Hir.Data owner = (Hir.Data) symbols.declarations().declaration(ntName.key());
-            Map<String, Type> flds = fieldTypes(owner);
-            ClassDesc cdType = cd(ntName);
-            if (DataChecker.isInvariantBearing(ntName, symbols) || symbols.scope().isForeign(ntName)) {
-                finishInvariantConstruct(cdType, flds);
-            } else {
-                int s = slot(base);
-                store(code, s, base);
-                code.new_(cdType);
-                code.dup();
-                load(code, s, base);
-                code.invokespecial(cdType, "<init>",
-                        MethodTypeDesc.of(ConstantDescs.CD_void, fieldDescs(flds)));
-            }
-            return Type.ref(ntName);
-        }
-
         Type varType(Core.Read read) {
             return locals.get(read.binding()).type();
-        }
-
-        void spreadField(Core.Read spreadVar, String field) {
-            Var v = locals.get(spreadVar.binding());
-            TypeSymbol srcName = ((Type.Ref) v.type()).name();
-            load(code, v.slot(), v.type());
-            emitFieldRead(code, srcName, field, spreadableFields(srcName).get(field));
         }
 
         // --- the surface Intrinsics drives to emit a shipped primitive (ADR-0028) ---
@@ -1669,15 +1617,11 @@ final class BodyGen {
                 // a zero divisor; Decimal does not overflow, and its `/` rounds by the default scale/mode.
                 // Case handling for a zero divisor is the divide/remainder functions, not the operator.
                 case ADD, SUB, MUL, DIV -> {
-                    // Newtype arithmetic (closed `+`/`-`, or scalar `*`/`/` by a plain number) opens
-                    // each operand to its base, computes on the base, then re-wraps the result into the
-                    // newtype (re-checking its invariant). A non-newtype operand (a scalar) is left as
-                    // is — unwrapNewtypeValue is a no-op. `closedNewtypeArithResult` returns null when
-                    // neither operand is a newtype (plain base arithmetic), leaving the value unwrapped.
-                    Type lraw = genExpr(bin.left());
-                    Type t = unwrapNewtypeValue(lraw);
-                    Type rraw = genExpr(bin.right());
-                    unwrapNewtypeValue(rraw);
+                    // The operands are numbers here: newtype arithmetic is a construction over the
+                    // values its operands wrap, and it was written as one where the tree was built
+                    // (spec §newtype-arithmetic), so nothing is opened or re-wrapped at the operator.
+                    Type t = genExpr(bin.left());
+                    genExpr(bin.right());
                     if (t == Type.DECIMAL) {
                         switch (bin.op()) {
                             case ADD -> code.invokevirtual(CD_BigDecimal, "add", MTD_bdArith);
@@ -1693,11 +1637,6 @@ final class BodyGen {
                             default  -> "divideExact";
                         };
                         code.invokestatic(CD_IntMath, m, MTD_intExact);
-                    }
-                    // Closed `+`/`-` and scalar `*`/`/` stay in the newtype: when the checker typed
-                    // this expression as one, re-wrap the base value it left on the stack.
-                    if (bin.type() instanceof Type.Ref ref) {
-                        wrapNewtypeValue(ref.name(), t);
                     }
                 }
                 case CONCAT -> {
@@ -2010,10 +1949,8 @@ final class BodyGen {
                     collectFree(bin.right(), bound, free);
                 }
                 case Core.Neg neg -> collectFree(neg.operand(), bound, free);
-                case Core.NewData nd -> {
-                    nd.inits().forEach(i -> collectFree(i.value(), bound, free));
-                    nd.spreads().forEach(sp -> reaches(sp, bound, free));
-                }
+                case Core.Construct nd ->
+                        nd.values().forEach(v -> collectFree(v.value(), bound, free));
                 case Core.If iff -> {
                     collectFree(iff.cond(), bound, free);
                     collectFree(iff.then(), bound, free);

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
@@ -30,6 +30,7 @@ import java.lang.constant.MethodTypeDesc;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -1532,14 +1533,19 @@ final class CodecGen {
         // The decoder is still AST-level; elaborate its field inits so the shared emitFieldValues
         // consumes one representation, with the type the checker decides for each (ADR-0021, #81).
         // The field's declared type is pushed in, as the checker does when it checks a construction.
-        List<Core.FieldInit> inits = new ArrayList<>();
+        // a decoder's construction gives every field a value of its own, and they are put in
+        // declaration order here as a construction in a body already holds them
+        Map<String, Hir.FieldInit> written = new HashMap<>();
         for (Hir.FieldInit init : construct.inits()) {
-            inits.add(new Core.FieldInit(init.name(),
-                    gen.elaborate(init.value(), fields.get(init.name())), init.pos()));
+            written.put(init.name(), init);
         }
-        // a decoder's construction gives every field a value of its own; nothing builds one with a
-        // spread, so there is no binding to copy from here
-        gen.emitFieldValues(fields, inits, List.of());
+        List<Core.FieldValue> values = new ArrayList<>();
+        for (String field : fields.keySet()) {
+            Hir.FieldInit init = written.get(field);
+            values.add(new Core.FieldValue(field,
+                    gen.elaborate(init.value(), fields.get(field)), init.pos()));
+        }
+        gen.emitFieldValues(fields, values);
         code.invokestatic(cdName, "__construct", MethodTypeDesc.of(CD_Result, fieldDescs(fields)));
         // Souther construction Result -> Raoh boundary Result. An invariant failure becomes a
         // Raoh failure (spec §violation-destination, §decoder-role); success wraps the constructed value.

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -221,7 +221,7 @@ public sealed interface Core {
      * the {@code Result} carries selects one; the checker has already established that every named
      * clause is answered, so one always matches.
      */
-    record IfConstructed(NewData construct, Hir.Binder binder, Core then, List<ElseArm> els,
+    record IfConstructed(Construct construct, Hir.Binder binder, Core then, List<ElseArm> els,
                          CoverageOrigin origin, Type type, SourcePos pos) implements Core {}
 
     /** One departure of an attempted construction: the clause it answers ({@link Optional#empty()}
@@ -268,18 +268,24 @@ public sealed interface Core {
      * pattern's name count, checked against the tuple's size (ADR-0036). */
     record TupleGet(Core tuple, int index, int arity, Type type, SourcePos pos) implements Core {}
 
-    record FieldInit(String name, Core value, SourcePos pos) {}
+    /** What one field of a construction is given. {@code pos} is where the value was written, which
+     * for a field a spread supplies is the spread. */
+    record FieldValue(String field, Core value, SourcePos pos) {}
 
-    /** {@code spreads} are the bindings the construction copies fields from — reads, not binders:
-     * a spread names a value in force, it does not introduce one. */
-    record NewData(TypeSymbol typeName, List<FieldInit> inits, List<Read> spreads, Type type,
-                   SourcePos pos) implements Core {
-
-        /** How each spread source was written, in order. */
-        public List<String> spreadNames() {
-            return spreads.stream().map(Read::name).toList();
-        }
-    }
+    /**
+     * Making a value of a declared type — the one node a body creates a representation with. Every
+     * way a source writes one is this: a record literal, a literal spreading another value's fields,
+     * a newtype's constructor, and the arithmetic that re-wraps a newtype (spec §newtype-arithmetic).
+     * What a construction builds is therefore settled once, where this is built, rather than worked
+     * out again by each reader from the shape it was written in.
+     *
+     * <p>{@code values} is every declared field, in declaration order, and holds no spread: the
+     * value a spread supplies is the read of that field off the spread source, resolved here. A
+     * reader asking what this builds asks {@code values}, and the order it asks in is the order the
+     * fields are evaluated.
+     */
+    record Construct(TypeSymbol typeName, List<FieldValue> values, Type type,
+                     SourcePos pos) implements Core {}
 
     /** {@code bindType} is the type the case binding takes inside the arm — the case type a union
      * narrows to, or the element a {@code Some x} opens. */
@@ -308,11 +314,12 @@ public sealed interface Core {
      *
      * <ul>
      *   <li>An expression slot takes any Core expression.</li>
-     *   <li>A name slot takes only a {@link Read}: a construction's spread copies the fields of a
-     *       binding and an applied function is a binding holding one, and the backend loads that
-     *       binding's slot, so an expression there would have nothing to be loaded from.</li>
-     *   <li>A construction slot takes only a {@link NewData}: an attempt tests whether a construction
-     *       holds, and there is no other kind of expression whose invariant could fail.</li>
+     *   <li>A name slot takes only a {@link Read}: an applied function is a binding holding one, and
+     *       the backend loads that binding's slot, so an expression there would have nothing to be
+     *       loaded from.</li>
+     *   <li>A construction slot takes only a {@link Construct}: an attempt tests whether a
+     *       construction holds, and there is no other kind of expression whose invariant could
+     *       fail.</li>
      * </ul>
      *
      * <p>This is the one place that says which slots a node has, and both {@link #mapChildren} and
@@ -321,7 +328,7 @@ public sealed interface Core {
      */
     private static Core atSlots(Core e, java.util.function.UnaryOperator<Core> atExpr,
                                 java.util.function.UnaryOperator<Read> atName,
-                                java.util.function.UnaryOperator<NewData> atConstruction) {
+                                java.util.function.UnaryOperator<Construct> atConstruction) {
         return switch (e) {
             case Int x -> x;
             case Decimal x -> x;
@@ -357,7 +364,7 @@ public sealed interface Core {
                 yield args == p.args() ? p
                         : new PreservedCall(p.operation(), args, p.type(), p.pos());
             }
-            // what is applied is a binding holding a function: a name slot, the same kind a spread is
+            // what is applied is a binding holding a function, which the backend loads: a name slot
             case Apply a -> {
                 Read fn = atName.apply(a.fn());
                 List<Core> args = each(a.args(), atExpr);
@@ -372,7 +379,7 @@ public sealed interface Core {
                         : new If(cond, then, els, iff.origin(), iff.type(), iff.pos());
             }
             case IfConstructed ic -> {
-                NewData construct = atConstruction.apply(ic.construct());
+                Construct construct = atConstruction.apply(ic.construct());
                 Core then = atExpr.apply(ic.then());
                 List<ElseArm> els = each(ic.els(), arm -> {
                     Core body = atExpr.apply(arm.body());
@@ -410,7 +417,7 @@ public sealed interface Core {
                 yield tuple == tg.tuple() ? tg
                         : new TupleGet(tuple, tg.index(), tg.arity(), tg.type(), tg.pos());
             }
-            case NewData nd -> atSlots(nd, atExpr, atName);
+            case Construct nd -> atSlots(nd, atExpr);
             case Match m -> {
                 Core scrutinee = atExpr.apply(m.scrutinee());
                 List<Case> cases = each(m.cases(), c -> {
@@ -425,23 +432,22 @@ public sealed interface Core {
     }
 
     /**
-     * The same for a construction, whose type is kept: it has an expression slot per field and a name
-     * slot per spread, and no others.
+     * The same for a construction, whose type is kept: it has an expression slot per declared field
+     * and no others. What a spread supplied is one of those slots, resolved before this is built, so
+     * a pass rewrites it as it rewrites any other value a field is given.
      *
      * <p>Said once and read twice — by the walk above, where a construction is an expression like any
-     * other, and by {@link #mapChildren(NewData, java.util.function.UnaryOperator,
+     * other, and by {@link #mapChildren(Construct, java.util.function.UnaryOperator,
      * java.util.function.UnaryOperator)}, which is how a pass recurses through the one an attempt
      * holds.
      */
-    private static NewData atSlots(NewData nd, java.util.function.UnaryOperator<Core> atExpr,
-                                   java.util.function.UnaryOperator<Read> atName) {
-        List<Read> spreads = each(nd.spreads(), atName);
-        List<FieldInit> inits = each(nd.inits(), i -> {
-            Core value = atExpr.apply(i.value());
-            return value == i.value() ? i : new FieldInit(i.name(), value, i.pos());
+    private static Construct atSlots(Construct nd, java.util.function.UnaryOperator<Core> atExpr) {
+        List<FieldValue> values = each(nd.values(), v -> {
+            Core value = atExpr.apply(v.value());
+            return value == v.value() ? v : new FieldValue(v.field(), value, v.pos());
         });
-        return spreads == nd.spreads() && inits == nd.inits() ? nd
-                : new NewData(nd.typeName(), inits, spreads, nd.type(), nd.pos());
+        return values == nd.values() ? nd
+                : new Construct(nd.typeName(), values, nd.type(), nd.pos());
     }
 
     /** {@code xs} with {@code f} applied to each, or {@code xs} itself where none of them changed. */
@@ -470,7 +476,7 @@ public sealed interface Core {
      */
     static Core mapChildren(Core e, java.util.function.UnaryOperator<Core> onExprSlot,
                             java.util.function.UnaryOperator<Read> onNameSlot,
-                            java.util.function.UnaryOperator<NewData> onConstructionSlot) {
+                            java.util.function.UnaryOperator<Construct> onConstructionSlot) {
         return atSlots(e, onExprSlot, onNameSlot, onConstructionSlot);
     }
 
@@ -481,8 +487,7 @@ public sealed interface Core {
      */
     static Core mapAll(Core e, java.util.function.UnaryOperator<Core> onExprSlot,
                        java.util.function.UnaryOperator<Read> onNameSlot) {
-        return atSlots(e, onExprSlot, onNameSlot,
-                nd -> atSlots(nd, onExprSlot, onNameSlot));
+        return atSlots(e, onExprSlot, onNameSlot, nd -> atSlots(nd, onExprSlot));
     }
 
     /**
@@ -491,18 +496,18 @@ public sealed interface Core {
      *
      * <p>A construction slot is not a leaf the way a name slot is, so a pass that recurses has to say
      * how it recurses into one. Handing it back unchanged stops the pass at an attempt, which no pass
-     * means: what an attempt tries to build is as much part of the body as anything else.
+     * means: what an attempt tries to build is as much part of the body as anything else. It takes
+     * only the expression operator, a construction having none of the other slot kinds.
      */
-    static NewData mapChildren(NewData nd, java.util.function.UnaryOperator<Core> onExprSlot,
-                               java.util.function.UnaryOperator<Read> onNameSlot) {
-        return atSlots(nd, onExprSlot, onNameSlot);
+    static Construct mapChildren(Construct nd, java.util.function.UnaryOperator<Core> onExprSlot) {
+        return atSlots(nd, onExprSlot);
     }
 
     /**
      * Applies {@code f} to each direct child of {@code e} — the read-only counterpart of
      * {@link #mapChildren}. Every slot is a child whatever kind it is, so a pass that asks what a
-     * body reads reaches the binding a spread copies and the binding an application invokes without
-     * knowing that either position exists.
+     * body reads reaches the binding an application invokes, and the construction an attempt tests,
+     * without knowing that either position exists.
      */
     static void forEachChild(Core e, java.util.function.Consumer<Core> f) {
         atSlots(e, child -> {

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -86,8 +86,18 @@ public sealed interface Core {
         String rendered();
     }
 
-    /** A callee some module named, under the name that module reaches it by. */
-    record Reached(ReachName name) implements CallTarget {
+    /**
+     * A callee some module named: the name that module reaches it by, and what that name was
+     * resolved to.
+     *
+     * <p>Both, because they answer different questions and neither is derived from the other. The
+     * backend emits the method the reach name spells; a reader asking what kind of thing was called —
+     * a module's own helper, one of the language's operations, a behavior whose implementation comes
+     * from outside — asks what the name denotes. Working the second out of the first would be
+     * resolving a name this compiler resolved already, and a bare spelling reaches a helper and an
+     * injected behavior alike.
+     */
+    record Reached(ReachName name, ValueName denotes) implements CallTarget {
 
         @Override
         public String rendered() {
@@ -148,9 +158,9 @@ public sealed interface Core {
      */
     record Call(CallTarget fn, List<Core> args, Type type, SourcePos pos) implements Core {
 
-        /** A call to a name, as the name it reaches. */
-        public Call(ReachName fn, List<Core> args, Type type, SourcePos pos) {
-            this(new Reached(fn), args, type, pos);
+        /** A call to a name, as the name it reaches and what that name denotes. */
+        public Call(ReachName fn, ValueName denotes, List<Core> args, Type type, SourcePos pos) {
+            this(new Reached(fn, denotes), args, type, pos);
         }
 
         /** The callee as it renders — the reach name for a call to one, the operation's own

--- a/souther-compiler/src/main/java/souther/compiler/core/GrowingFold.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/GrowingFold.java
@@ -82,7 +82,7 @@ public final class GrowingFold {
      *  a {@code filter} builds both, and the two builds are then joined into one. */
     public static Core rewrite(Core body) {
         Core mapped = Core.mapChildren(body, GrowingFold::rewrite, s -> s,
-                nd -> Core.mapChildren(nd, GrowingFold::rewrite, s -> s));
+                nd -> Core.mapChildren(nd, GrowingFold::rewrite));
         if (mapped instanceof Core.Call call) {
             Core built = built(call);
             if (built != null) {
@@ -332,7 +332,7 @@ public final class GrowingFold {
                     body.type(), c.pos());
         }
         return Core.mapChildren(e, child -> piped(child, outer, refused), s -> s,
-                nd -> Core.mapChildren(nd, child -> piped(child, outer, refused), s -> s));
+                nd -> Core.mapChildren(nd, child -> piped(child, outer, refused)));
     }
 
     /** The step with its appends turned into adds, or null when the step does something else with the

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -339,7 +339,7 @@ public final class CoverageSites {
                 case Core.OptionSome s -> walk(s.value(), inside);
                 case Core.Tuple t -> t.elements().forEach(el -> walk(el, inside));
                 case Core.TupleGet tg -> walk(tg.tuple(), inside);
-                case Core.NewData nd -> nd.inits().forEach(init -> walk(init.value(), inside));
+                case Core.Construct nd -> nd.values().forEach(given -> walk(given.value(), inside));
                 case Core.If iff -> {
                     walk(iff.cond(), inside);
                     int then = armOf(Site.Kind.THEN, "then", iff, iff.origin(), 0, iff.then(), inside);
@@ -365,7 +365,7 @@ public final class CoverageSites {
                     byNode.put(m, arms);
                 }
                 case Core.IfConstructed ic -> {
-                    ic.construct().inits().forEach(init -> walk(init.value(), inside));
+                    ic.construct().values().forEach(given -> walk(given.value(), inside));
                     int[] arms = new int[1 + ic.els().size()];
                     arms[0] = armOf(Site.Kind.CONSTRUCTED, "constructed", ic, ic.origin(), 0,
                             ic.then(), inside);

--- a/souther-compiler/src/main/java/souther/compiler/coverage/NormalReturn.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/NormalReturn.java
@@ -45,7 +45,7 @@ public final class NormalReturn {
             case Core.TupleGet tg -> of(tg.tuple());
             case Core.Tuple t -> all(t.elements());
             case Core.ListLit lit -> all(lit.elements());
-            case Core.NewData nd -> nd.inits().stream().allMatch(init -> of(init.value()));
+            case Core.Construct nd -> nd.values().stream().allMatch(given -> of(given.value()));
             // The callee's own body is not read; its arguments are evaluated before it is reached.
             case Core.Call c -> all(c.args());
             case Core.Apply a -> all(a.args());
@@ -63,7 +63,7 @@ public final class NormalReturn {
             case Core.Match m -> of(m.scrutinee())
                     && m.cases().stream().anyMatch(arm -> of(arm.body()));
             case Core.IfConstructed ic ->
-                    ic.construct().inits().stream().allMatch(init -> of(init.value()))
+                    ic.construct().values().stream().allMatch(given -> of(given.value()))
                             && (of(ic.then()) || ic.els().stream().anyMatch(arm -> of(arm.body())));
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
@@ -26,65 +26,65 @@ import java.util.Set;
  * immutable — each operation returns a fresh domain, threaded functionally like
  * {@code TotalityChecker}'s scope map.
  */
-public final class NumericDomain {
+public final class NumericDomain<A> {
 
     /** A comparison of a {@link LinearForm} against zero. */
     public enum Rel { GE, GT, LE, LT, EQ, NE }
 
     /** An affine form {@code const + Σ coef·atom} over the domain's atoms. */
-    public record LinearForm(BigDecimal constant, Map<String, BigDecimal> coefs) {
-        public static LinearForm constant(BigDecimal c) {
-            return new LinearForm(c, Map.of());
+    public record LinearForm<A>(BigDecimal constant, Map<A, BigDecimal> coefs) {
+        public static <A> LinearForm<A> constant(BigDecimal c) {
+            return new LinearForm<>(c, Map.of());
         }
 
-        public static LinearForm atom(String a) {
-            return new LinearForm(BigDecimal.ZERO, Map.of(a, BigDecimal.ONE));
+        public static <A> LinearForm<A> atom(A a) {
+            return new LinearForm<>(BigDecimal.ZERO, Map.of(a, BigDecimal.ONE));
         }
 
-        public LinearForm plus(LinearForm o) {
-            Map<String, BigDecimal> m = new HashMap<>(coefs);
+        public LinearForm<A> plus(LinearForm<A> o) {
+            Map<A, BigDecimal> m = new HashMap<>(coefs);
             o.coefs.forEach((k, v) -> m.merge(k, v, BigDecimal::add));
             m.values().removeIf(v -> v.signum() == 0);
-            return new LinearForm(constant.add(o.constant), m);
+            return new LinearForm<>(constant.add(o.constant), m);
         }
 
-        public LinearForm negate() {
-            Map<String, BigDecimal> m = new HashMap<>();
+        public LinearForm<A> negate() {
+            Map<A, BigDecimal> m = new HashMap<>();
             coefs.forEach((k, v) -> m.put(k, v.negate()));
-            return new LinearForm(constant.negate(), m);
+            return new LinearForm<>(constant.negate(), m);
         }
 
-        public LinearForm minus(LinearForm o) {
+        public LinearForm<A> minus(LinearForm<A> o) {
             return plus(o.negate());
         }
 
         /** This form scaled by a constant {@code k} (a scalar multiply). */
-        public LinearForm times(BigDecimal k) {
+        public LinearForm<A> times(BigDecimal k) {
             if (k.signum() == 0) {
                 return constant(BigDecimal.ZERO);
             }
-            Map<String, BigDecimal> m = new HashMap<>();
+            Map<A, BigDecimal> m = new HashMap<>();
             coefs.forEach((key, v) -> m.put(key, v.multiply(k)));
-            return new LinearForm(constant.multiply(k), m);
+            return new LinearForm<>(constant.multiply(k), m);
         }
     }
 
     /** A form asserted {@code f <= 0} (or {@code f < 0}) and kept as written, because its shape is
      * neither an interval nor a difference. */
-    private record Asserted(LinearForm f, boolean strict) {}
+    private record Asserted<A>(LinearForm<A> f, boolean strict) {}
 
     private final boolean bottom;                              // an infeasible path (guards contradict)
-    private final Map<String, Endpoint> lo;                    // atom -> lower bound (absent = -inf)
-    private final Map<String, Endpoint> hi;                    // atom -> upper bound (absent = +inf)
-    private final Map<String, Map<String, Endpoint>> diff;     // diff[a][b] = tightest known (a - b)
-    private final List<Asserted> kept;                         // forms outside both shapes, as written
-    private final Map<String, Granularity> kinds;              // atom -> how its values are spaced
-    private final Map<String, Set<Loss>> losses;               // atom -> what was not recorded of it
-    private Map<String, Map<String, Endpoint>> closed;         // diff closed transitively, on first ask
+    private final Map<A, Endpoint> lo;                    // atom -> lower bound (absent = -inf)
+    private final Map<A, Endpoint> hi;                    // atom -> upper bound (absent = +inf)
+    private final Map<A, Map<A, Endpoint>> diff;     // diff[a][b] = tightest known (a - b)
+    private final List<Asserted<A>> kept;                         // forms outside both shapes, as written
+    private final Map<A, Granularity> kinds;              // atom -> how its values are spaced
+    private final Map<A, Set<Loss>> losses;               // atom -> what was not recorded of it
+    private Map<A, Map<A, Endpoint>> closed;         // diff closed transitively, on first ask
 
-    private NumericDomain(boolean bottom, Map<String, Endpoint> lo, Map<String, Endpoint> hi,
-                          Map<String, Map<String, Endpoint>> diff, List<Asserted> kept,
-                          Map<String, Granularity> kinds, Map<String, Set<Loss>> losses) {
+    private NumericDomain(boolean bottom, Map<A, Endpoint> lo, Map<A, Endpoint> hi,
+                          Map<A, Map<A, Endpoint>> diff, List<Asserted<A>> kept,
+                          Map<A, Granularity> kinds, Map<A, Set<Loss>> losses) {
         this.bottom = bottom;
         this.lo = lo;
         this.hi = hi;
@@ -94,8 +94,8 @@ public final class NumericDomain {
         this.losses = losses;
     }
 
-    public static NumericDomain top() {
-        return new NumericDomain(false, Map.of(), Map.of(), Map.of(), List.of(), Map.of(), Map.of());
+    public static <A> NumericDomain<A> top() {
+        return new NumericDomain<>(false, Map.of(), Map.of(), Map.of(), List.of(), Map.of(), Map.of());
     }
 
     /**
@@ -132,7 +132,7 @@ public final class NumericDomain {
      *                  wrongly sharpened on or silently left blunt, and neither shows up as a
      *                  failure anywhere near where the guess was made.
      */
-    public NumericDomain assume(LinearForm f, Rel rel, Map<String, Granularity> atomKinds) {
+    public NumericDomain<A> assume(LinearForm<A> f, Rel rel, Map<A, Granularity> atomKinds) {
         NumericDomain d = knowing(f.coefs().keySet(), atomKinds);
         if (d.bottom) {
             return d;
@@ -171,9 +171,9 @@ public final class NumericDomain {
      * spacings under one key means the naming and the typing disagree, and the answer to that is to
      * stop rather than to pick the safer of the two.
      */
-    private NumericDomain knowing(Set<String> atoms, Map<String, Granularity> atomKinds) {
-        Map<String, Granularity> next = null;
-        for (String atom : atoms) {
+    private NumericDomain<A> knowing(Set<A> atoms, Map<A, Granularity> atomKinds) {
+        Map<A, Granularity> next = null;
+        for (A atom : atoms) {
             Granularity given = atomKinds.get(atom);
             if (given == null) {
                 throw new IllegalStateException("no granularity given for atom `" + atom + "`");
@@ -192,7 +192,7 @@ public final class NumericDomain {
             next.put(atom, given);
         }
         return next == null ? this
-                : new NumericDomain(bottom, lo, hi, diff, kept, Map.copyOf(next), losses);
+                : new NumericDomain<>(bottom, lo, hi, diff, kept, Map.copyOf(next), losses);
     }
 
     /**
@@ -205,7 +205,7 @@ public final class NumericDomain {
      * is no step, and the end stays where the constraint put it and says that the value is not its
      * own. A form of neither shape keeps its strictness as written.
      */
-    private NumericDomain addLe(LinearForm g, boolean strict) {
+    private NumericDomain<A> addLe(LinearForm<A> g, boolean strict) {
         if (bottom) {
             // Nothing holds here, so nothing asserted of it holds either. Read again rather than
             // built on: a bottom domain keeps no bounds, and the sisters below derive feasibility
@@ -214,14 +214,14 @@ public final class NumericDomain {
             // where a contradicted one came back satisfiable.
             return this;
         }
-        Map<String, BigDecimal> c = g.coefs();
+        Map<A, BigDecimal> c = g.coefs();
         if (c.isEmpty()) {
             boolean ok = strict ? g.constant().signum() < 0 : g.constant().signum() <= 0;
             return ok ? this : bottom();
         }
         if (c.size() == 1) {
-            Map.Entry<String, BigDecimal> e = c.entrySet().iterator().next();
-            String a = e.getKey();
+            Map.Entry<A, BigDecimal> e = c.entrySet().iterator().next();
+            A a = e.getKey();
             BigDecimal k = e.getValue();
             // k·a + const <= 0  =>  a <= -const/k (k>0, an upper bound)  or  a >= -const/k (k<0, a
             // lower bound). Round an inexact quotient conservatively — toward +inf for an upper bound,
@@ -236,23 +236,23 @@ public final class NumericDomain {
                     : new Endpoint(Count.of(bound), !strict);
             return upper ? withHi(a, end) : withLo(a, end);
         }
-        String[] ab = unitDiffAtoms(c);
+        List<A> ab = unitDiffAtoms(c);
         if (ab != null) {
             // a - b <= -const. A difference of two whole numbers is a whole number, and only then:
             // one dense atom on either side leaves the difference with no smallest step, so the
             // bound stays where the constant put it and says the value is outside it.
             BigDecimal bound = g.constant().negate();
-            Endpoint end = kinds.get(ab[0]) == Granularity.DISCRETE
-                    && kinds.get(ab[1]) == Granularity.DISCRETE
+            Endpoint end = kinds.get(ab.get(0)) == Granularity.DISCRETE
+                    && kinds.get(ab.get(1)) == Granularity.DISCRETE
                     ? Endpoint.inclusive(whole(bound, true, strict))
                     : new Endpoint(Count.of(bound), !strict);
-            return withDiff(ab[0], ab[1], end);
+            return withDiff(ab.get(0), ab.get(1), end);
         }
         // Neither shape holds it — a sum of two lengths, say. Keeping the form as written is what lets
         // a guard restating an invariant discharge it, which is the promise the flagging rests on.
-        List<Asserted> next = new ArrayList<>(kept);
+        List<Asserted<A>> next = new ArrayList<>(kept);
         next.add(new Asserted(g, strict));
-        return new NumericDomain(false, lo, hi, diff, List.copyOf(next), kinds,
+        return new NumericDomain<>(false, lo, hi, diff, List.copyOf(next), kinds,
                 with(Loss.KEPT_UNPROJECTABLE, c.keySet()));
     }
 
@@ -280,13 +280,13 @@ public final class NumericDomain {
 
     /** The two atoms of a unit difference {@code {a:+1, b:-1}} as {@code {a, b}}, or {@code null} if
      * {@code c} is not a two-atom form with coefficients +1 and -1. */
-    private static String[] unitDiffAtoms(Map<String, BigDecimal> c) {
+    private static <A> List<A> unitDiffAtoms(Map<A, BigDecimal> c) {
         if (c.size() != 2) {
             return null;
         }
-        String a = null;
-        String b = null;
-        for (Map.Entry<String, BigDecimal> e : c.entrySet()) {
+        A a = null;
+        A b = null;
+        for (Map.Entry<A, BigDecimal> e : c.entrySet()) {
             if (e.getValue().compareTo(BigDecimal.ONE) == 0) {
                 a = e.getKey();
             } else if (e.getValue().compareTo(BigDecimal.ONE.negate()) == 0) {
@@ -295,7 +295,7 @@ public final class NumericDomain {
                 return null;
             }
         }
-        return a != null && b != null ? new String[] {a, b} : null;
+        return a != null && b != null ? List.of(a, b) : null;
     }
 
     /** True for {@code GT}/{@code LT} (a strict comparison). */
@@ -311,7 +311,7 @@ public final class NumericDomain {
     // --- entails / refutes ---------------------------------------------------------------------
 
     /** Whether the domain proves {@code f rel 0} (the construction's invariant is discharged). */
-    public boolean entails(LinearForm f, Rel rel) {
+    public boolean entails(LinearForm<A> f, Rel rel) {
         if (bottom) {
             return true;   // an infeasible path discharges anything
         }
@@ -327,7 +327,7 @@ public final class NumericDomain {
     /** Whether the domain proves {@code ¬(f rel 0)} — the invariant is <em>definitely</em> violated
      * on this path (a compile error, the path-sensitive generalization of the constant check). The
      * negation flips both bits of the comparison: {@code ¬(f >= 0)} is {@code f < 0}, etc. */
-    public boolean refutes(LinearForm f, Rel rel) {
+    public boolean refutes(LinearForm<A> f, Rel rel) {
         if (bottom || rel == Rel.EQ) {
             return false;   // an unreachable path violates nothing; equality is never refuted here
         }
@@ -352,7 +352,7 @@ public final class NumericDomain {
      * relations over each other is arbitrary linear reasoning and a different fragment to state; this
      * one is what the domain already decides in, reached through one relation it does not.
      */
-    private boolean proveLe(LinearForm g, boolean strict) {
+    private boolean proveLe(LinearForm<A> g, boolean strict) {
         if (proveBaseLe(g, strict)) {
             return true;
         }
@@ -369,7 +369,7 @@ public final class NumericDomain {
     /** The same over what this derives in: an interval bound on the whole form, or a bound on a
      * difference of two atoms read through the closure. The kept relations are not read here — this
      * is what a residual is proven against, and reading them would let one stand on another. */
-    private boolean proveBaseLe(LinearForm g, boolean strict) {
+    private boolean proveBaseLe(LinearForm<A> g, boolean strict) {
         Endpoint hiG = upperBound(g);
         if (hiG != null) {
             int s = at(hiG).signum();
@@ -379,9 +379,9 @@ public final class NumericDomain {
                 return true;
             }
         }
-        String[] ab = unitDiffAtoms(g.coefs());
+        List<A> ab = unitDiffAtoms(g.coefs());
         if (ab != null) {
-            Endpoint diffBound = closedDiff(ab[0], ab[1]);     // proven upper bound on (a - b)
+            Endpoint diffBound = closedDiff(ab.get(0), ab.get(1));     // proven upper bound on (a - b)
             if (diffBound != null) {
                 Count bound = Count.of(g.constant().negate());   // want a - b <= -const
                 int s = at(diffBound).compareTo(bound);
@@ -400,10 +400,10 @@ public final class NumericDomain {
      * reach its edge is one the sum cannot reach either, so a single exclusive contribution makes the
      * total exclusive.
      */
-    private Endpoint upperBound(LinearForm f) {
+    private Endpoint upperBound(LinearForm<A> f) {
         Count acc = Count.of(f.constant());
         boolean inclusive = true;
-        for (Map.Entry<String, BigDecimal> e : f.coefs().entrySet()) {
+        for (Map.Entry<A, BigDecimal> e : f.coefs().entrySet()) {
             BigDecimal k = e.getValue();
             Endpoint b = k.signum() > 0 ? bestHi(e.getKey()) : bestLo(e.getKey());
             if (b == null) {
@@ -419,9 +419,9 @@ public final class NumericDomain {
      * {@code a - b <= d} and {@code b <= c} give {@code a <= c + d}, which is what relates the size of
      * a filtered list to a bound on the list it came from. A value at the end reached that way needs
      * every end on the way to be reachable, so the derived end is its own only where both are. */
-    private Endpoint bestHi(String a) {
+    private Endpoint bestHi(A a) {
         Endpoint best = hi.get(a);
-        for (Map.Entry<String, Endpoint> b : hi.entrySet()) {
+        for (Map.Entry<A, Endpoint> b : hi.entrySet()) {
             if (b.getKey().equals(a)) {
                 continue;
             }
@@ -437,9 +437,9 @@ public final class NumericDomain {
 
     /** The tightest lower bound on an atom, the same way: {@code b - a <= d} and {@code b >= c} give
      * {@code a >= c - d}. */
-    private Endpoint bestLo(String a) {
+    private Endpoint bestLo(A a) {
         Endpoint best = lo.get(a);
-        for (Map.Entry<String, Endpoint> b : lo.entrySet()) {
+        for (Map.Entry<A, Endpoint> b : lo.entrySet()) {
             if (b.getKey().equals(a)) {
                 continue;
             }
@@ -462,7 +462,7 @@ public final class NumericDomain {
      * {@code b <= 1440} bounds {@code a} at 1440 though nothing was ever asserted about {@code a}
      * alone. That is the whole point of asking here rather than reading what was put in.
      */
-    public Bounds boundsOf(String atom) {
+    public Bounds boundsOf(A atom) {
         return bottom ? new Bounds(null, null) : new Bounds(bestLo(atom), bestHi(atom));
     }
 
@@ -474,7 +474,7 @@ public final class NumericDomain {
      * denser. Read off what was recorded rather than off the ends, because ends that happen to be
      * whole are what a dense value between two of them has as well.
      */
-    public Granularity spacingOf(String atom) {
+    public Granularity spacingOf(A atom) {
         return kinds.get(atom);
     }
 
@@ -526,24 +526,24 @@ public final class NumericDomain {
      * name says nothing about how many minutes a day has.
      */
     /** What was asserted about one atom and not recorded. */
-    public Set<Loss> lossesAt(String atom) {
+    public Set<Loss> lossesAt(A atom) {
         return losses.getOrDefault(atom, Set.of());
     }
 
     /** Every atom something was lost about. */
-    public Set<String> lossyAtoms() {
+    public Set<A> lossyAtoms() {
         return losses.keySet();
     }
 
-    private NumericDomain losing(Loss loss, Set<String> atoms) {
-        Map<String, Set<Loss>> next = with(loss, atoms);
+    private NumericDomain<A> losing(Loss loss, Set<A> atoms) {
+        Map<A, Set<Loss>> next = with(loss, atoms);
         return next == losses ? this
-                : new NumericDomain(bottom, lo, hi, diff, kept, kinds, next);
+                : new NumericDomain<>(bottom, lo, hi, diff, kept, kinds, next);
     }
 
-    private Map<String, Set<Loss>> with(Loss loss, Set<String> atoms) {
-        Map<String, Set<Loss>> next = null;
-        for (String atom : atoms) {
+    private Map<A, Set<Loss>> with(Loss loss, Set<A> atoms) {
+        Map<A, Set<Loss>> next = null;
+        for (A atom : atoms) {
             if (losses.getOrDefault(atom, Set.of()).contains(loss)) {
                 continue;
             }
@@ -560,29 +560,29 @@ public final class NumericDomain {
 
     // --- immutable updates ---------------------------------------------------------------------
 
-    private NumericDomain bottom() {
-        return new NumericDomain(true, Map.of(), Map.of(), Map.of(), List.of(), kinds, losses);
+    private NumericDomain<A> bottom() {
+        return new NumericDomain<>(true, Map.of(), Map.of(), Map.of(), List.of(), kinds, losses);
     }
 
-    private NumericDomain withHi(String a, Endpoint bound) {
-        Map<String, Endpoint> nhi = new HashMap<>(hi);
+    private NumericDomain<A> withHi(A a, Endpoint bound) {
+        Map<A, Endpoint> nhi = new HashMap<>(hi);
         nhi.merge(a, bound, Endpoint::upper);
-        NumericDomain d = new NumericDomain(false, lo, nhi, diff, kept, kinds, losses);
+        NumericDomain d = new NumericDomain<>(false, lo, nhi, diff, kept, kinds, losses);
         return d.feasible() ? d : bottom();
     }
 
-    private NumericDomain withLo(String a, Endpoint bound) {
-        Map<String, Endpoint> nlo = new HashMap<>(lo);
+    private NumericDomain<A> withLo(A a, Endpoint bound) {
+        Map<A, Endpoint> nlo = new HashMap<>(lo);
         nlo.merge(a, bound, Endpoint::lower);
-        NumericDomain d = new NumericDomain(false, nlo, hi, diff, kept, kinds, losses);
+        NumericDomain d = new NumericDomain<>(false, nlo, hi, diff, kept, kinds, losses);
         return d.feasible() ? d : bottom();
     }
 
-    private NumericDomain withDiff(String a, String b, Endpoint bound) {
-        Map<String, Map<String, Endpoint>> nd = new HashMap<>();
+    private NumericDomain<A> withDiff(A a, A b, Endpoint bound) {
+        Map<A, Map<A, Endpoint>> nd = new HashMap<>();
         diff.forEach((k, v) -> nd.put(k, new HashMap<>(v)));
         nd.computeIfAbsent(a, k -> new HashMap<>()).merge(b, bound, Endpoint::upper);
-        NumericDomain d = new NumericDomain(false, lo, hi, nd, kept, kinds, losses);
+        NumericDomain d = new NumericDomain<>(false, lo, hi, nd, kept, kinds, losses);
         return d.feasible() ? d : bottom();
     }
 
@@ -598,7 +598,7 @@ public final class NumericDomain {
      * about {@code a} — so both are asked here rather than at the atom the assertion happened to name.
      */
     private boolean feasible() {
-        for (Map.Entry<String, Map<String, Endpoint>> row : closed().entrySet()) {
+        for (Map.Entry<A, Map<A, Endpoint>> row : closed().entrySet()) {
             Endpoint cycle = row.getValue().get(row.getKey());
             // `a - a` is zero, so a cycle bounding it below zero is a contradiction — and so is one
             // bounding it at zero without admitting it.
@@ -607,7 +607,7 @@ public final class NumericDomain {
                 return false;
             }
         }
-        for (String a : lo.keySet()) {
+        for (A a : lo.keySet()) {
             if (!Endpoint.someValueLiesBetween(bestLo(a), bestHi(a))) {
                 return false;
             }
@@ -616,36 +616,36 @@ public final class NumericDomain {
     }
 
     /** The tightest proven upper bound on {@code a - b}, or {@code null} if none is known. */
-    private Endpoint closedDiff(String a, String b) {
+    private Endpoint closedDiff(A a, A b) {
         if (a.equals(b)) {
             return Endpoint.inclusive(Count.ZERO);
         }
-        Map<String, Endpoint> row = closed().get(a);
+        Map<A, Endpoint> row = closed().get(a);
         return row == null ? null : row.get(b);
     }
 
     /** The difference facts closed transitively — {@code a - b <= c} with {@code b - d <= e} gives
      * {@code a - d <= c + e} — computed once for the domain and read by every query it answers, since
      * a bound on one atom is derived through the differences to every other. */
-    private Map<String, Map<String, Endpoint>> closed() {
+    private Map<A, Map<A, Endpoint>> closed() {
         if (closed == null) {
             closed = close(diff);
         }
         return closed;
     }
 
-    private static Map<String, Map<String, Endpoint>> close(Map<String, Map<String, Endpoint>> diff) {
-        Set<String> atoms = new HashSet<>(diff.keySet());
+    private static <A> Map<A, Map<A, Endpoint>> close(Map<A, Map<A, Endpoint>> diff) {
+        Set<A> atoms = new HashSet<>(diff.keySet());
         diff.values().forEach(r -> atoms.addAll(r.keySet()));
-        Map<String, Map<String, Endpoint>> d = new HashMap<>();
+        Map<A, Map<A, Endpoint>> d = new HashMap<>();
         diff.forEach((a, row) -> d.put(a, new HashMap<>(row)));
-        for (String through : atoms) {
-            Map<String, Endpoint> from = d.get(through);
+        for (A through : atoms) {
+            Map<A, Endpoint> from = d.get(through);
             if (from == null) {
                 continue;
             }
-            List<Map.Entry<String, Endpoint>> hops = List.copyOf(from.entrySet());
-            for (String a : atoms) {
+            List<Map.Entry<A, Endpoint>> hops = List.copyOf(from.entrySet());
+            for (A a : atoms) {
                 if (a.equals(through)) {
                     continue;   // a hop from an atom to itself only repeats a cycle already recorded
                 }
@@ -653,7 +653,7 @@ public final class NumericDomain {
                 if (toThrough == null) {
                     continue;
                 }
-                for (Map.Entry<String, Endpoint> hop : hops) {
+                for (Map.Entry<A, Endpoint> hop : hops) {
                     // A path reaches its end only where every hop on it does.
                     Endpoint candidate = new Endpoint(
                             at(toThrough).plus(at(hop.getValue())),
@@ -668,8 +668,8 @@ public final class NumericDomain {
         return d;
     }
 
-    private static Endpoint edge(Map<String, Map<String, Endpoint>> d, String a, String b) {
-        Map<String, Endpoint> row = d.get(a);
+    private static <A> Endpoint edge(Map<A, Map<A, Endpoint>> d, A a, A b) {
+        Map<A, Endpoint> row = d.get(a);
         return row == null ? null : row.get(b);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
@@ -133,7 +133,7 @@ public final class NumericDomain<A> {
      *                  failure anywhere near where the guess was made.
      */
     public NumericDomain<A> assume(LinearForm<A> f, Rel rel, Map<A, Granularity> atomKinds) {
-        NumericDomain d = knowing(f.coefs().keySet(), atomKinds);
+        NumericDomain<A> d = knowing(f.coefs().keySet(), atomKinds);
         if (d.bottom) {
             return d;
         }
@@ -567,14 +567,14 @@ public final class NumericDomain<A> {
     private NumericDomain<A> withHi(A a, Endpoint bound) {
         Map<A, Endpoint> nhi = new HashMap<>(hi);
         nhi.merge(a, bound, Endpoint::upper);
-        NumericDomain d = new NumericDomain<>(false, lo, nhi, diff, kept, kinds, losses);
+        NumericDomain<A> d = new NumericDomain<>(false, lo, nhi, diff, kept, kinds, losses);
         return d.feasible() ? d : bottom();
     }
 
     private NumericDomain<A> withLo(A a, Endpoint bound) {
         Map<A, Endpoint> nlo = new HashMap<>(lo);
         nlo.merge(a, bound, Endpoint::lower);
-        NumericDomain d = new NumericDomain<>(false, nlo, hi, diff, kept, kinds, losses);
+        NumericDomain<A> d = new NumericDomain<>(false, nlo, hi, diff, kept, kinds, losses);
         return d.feasible() ? d : bottom();
     }
 
@@ -582,7 +582,7 @@ public final class NumericDomain<A> {
         Map<A, Map<A, Endpoint>> nd = new HashMap<>();
         diff.forEach((k, v) -> nd.put(k, new HashMap<>(v)));
         nd.computeIfAbsent(a, k -> new HashMap<>()).merge(b, bound, Endpoint::upper);
-        NumericDomain d = new NumericDomain<>(false, lo, hi, nd, kept, kinds, losses);
+        NumericDomain<A> d = new NumericDomain<>(false, lo, hi, nd, kept, kinds, losses);
         return d.feasible() ? d : bottom();
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Exclusions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Exclusions.java
@@ -65,7 +65,7 @@ public final class Exclusions {
             if (NormalReturn.of(arm.body())) {
                 continue;
             }
-            List<String> why = UnreachableReasons.of(arm.body(), symbols);
+            List<String> why = UnreachableReasons.of(arm.body());
             // Cases written together on one arm are one run of code, and it answers nothing for every
             // one of them.
             arm.caseTypes().forEach(each -> excluded.put(each, why));

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -7,6 +7,7 @@ import souther.compiler.check.Carrier;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Place;
 import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeOps;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.diag.SourceRef;
@@ -437,12 +438,12 @@ public final class GuardThresholds {
         // `Carrier` gives everywhere else.
         NumericTerm term = termOf(comparison.left(), parameters, symbols);
         Place value = constantOf(comparison.right(),
-                Carrier.ofValue(comparison.left().type(), symbols));
+                Carrier.ofValue(comparison.left().type(), symbols), symbols);
         if (term == null || value == null) {
             // `100000 >= cost` says what `cost <= 100000` says; read the position-bearing side first.
             term = termOf(comparison.right(), parameters, symbols);
             value = constantOf(comparison.left(),
-                    Carrier.ofValue(comparison.right().type(), symbols));
+                    Carrier.ofValue(comparison.right().type(), symbols), symbols);
             op = mirrored(op);
         }
         if (term == null || value == null) {
@@ -589,7 +590,7 @@ public final class GuardThresholds {
      * literal is asked, asked of the same place, so an invariant and a {@code guard} at one position
      * cannot admit different rules.
      */
-    static Place constantOf(Core e, Carrier carrier) {
+    static Place constantOf(Core e, Carrier carrier, Symbols symbols) {
         if (carrier == null) {
             return null;
         }
@@ -597,12 +598,14 @@ public final class GuardThresholds {
             case Core.Int i -> carrier.onTheGrid(Count.of(i.value()));
             case Core.Decimal d -> carrier.onTheGrid(Count.of(d.value()));
             case Core.Neg n -> {
-                Place inner = constantOf(n.operand(), carrier);
+                Place inner = constantOf(n.operand(), carrier, symbols);
                 yield inner == null ? null : Count.number(inner).negate();
             }
-            // A newtype written around a constant is that constant at this location.
-            case Core.NewData nd when nd.inits().size() == 1 && nd.spreads().isEmpty() ->
-                    constantOf(nd.inits().get(0).value(), carrier);
+            // A newtype written around a constant is that constant at this location. What makes it
+            // one is the declaration: a data of one field that is not a newtype wraps its value
+            // rather than being it.
+            case Core.Construct nd when TypeOps.numericBase(Type.ref(nd.typeName()), symbols) != null ->
+                    constantOf(nd.values().get(0).value(), carrier, symbols);
             // A temporal written the way a model writes one. Read by what the construction answers
             // with rather than by the name in front of it, so one reaches this however it is spelled.
             case Core.Call call when call.args().size() == 1

--- a/souther-compiler/src/main/java/souther/compiler/partition/ProducedCases.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ProducedCases.java
@@ -111,7 +111,7 @@ public final class ProducedCases {
                 }
             }
             case Core.UnitValue u -> produce(u.data(), under, reachable, declared, seen);
-            case Core.NewData nd -> produce(nd.typeName(), under, reachable, declared, seen);
+            case Core.Construct nd -> produce(nd.typeName(), under, reachable, declared, seen);
             // Everything else answers something this cannot name: a call, a name read from a binding,
             // a function value. The top of the lattice, which keeps every case owed.
             case null, default -> produce(null, under, reachable, declared, seen);

--- a/souther-compiler/src/main/java/souther/compiler/partition/UnreachableReasons.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/UnreachableReasons.java
@@ -1,17 +1,11 @@
 package souther.compiler.partition;
 
-import souther.compiler.ast.Hir;
-import souther.compiler.check.Symbols;
-import souther.compiler.check.TypeOps;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.NormalReturn;
-import souther.compiler.types.Type;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -38,48 +32,48 @@ public final class UnreachableReasons {
 
     /** Every reason reached along the paths that answer nothing, in the order they are evaluated and
      * without repeats. Empty where the expression answers a value. */
-    public static List<String> of(Core e, Symbols symbols) {
+    public static List<String> of(Core e) {
         Set<String> found = new LinkedHashSet<>();
-        collect(e, symbols, found);
+        collect(e, found);
         return List.copyOf(found);
     }
 
-    private static void collect(Core e, Symbols symbols, Set<String> into) {
+    private static void collect(Core e, Set<String> into) {
         if (NormalReturn.of(e)) {
             return;
         }
         switch (e) {
             case Core.Unreachable u -> into.add(u.reason());
             case Core.LetIn li -> collect(
-                    NormalReturn.of(li.value()) ? li.body() : li.value(), symbols, into);
+                    NormalReturn.of(li.value()) ? li.body() : li.value(), into);
             case Core.If iff -> {
                 if (!NormalReturn.of(iff.cond())) {
-                    collect(iff.cond(), symbols, into);
+                    collect(iff.cond(), into);
                 } else {
-                    collect(iff.then(), symbols, into);
-                    collect(iff.els(), symbols, into);
+                    collect(iff.then(), into);
+                    collect(iff.els(), into);
                 }
             }
             case Core.Match m -> {
                 if (!NormalReturn.of(m.scrutinee())) {
-                    collect(m.scrutinee(), symbols, into);
+                    collect(m.scrutinee(), into);
                 } else {
-                    m.cases().forEach(arm -> collect(arm.body(), symbols, into));
+                    m.cases().forEach(arm -> collect(arm.body(), into));
                 }
             }
-            case Core.NewData nd -> {
-                Core stops = evaluated(nd, symbols);
+            case Core.Construct nd -> {
+                Core stops = evaluated(nd);
                 if (stops != null) {
-                    collect(stops, symbols, into);
+                    collect(stops, into);
                 }
             }
             case Core.IfConstructed ic -> {
-                Core stops = evaluated(ic.construct(), symbols);
+                Core stops = evaluated(ic.construct());
                 if (stops != null) {
-                    collect(stops, symbols, into);
+                    collect(stops, into);
                 } else {
-                    collect(ic.then(), symbols, into);
-                    ic.els().forEach(arm -> collect(arm.body(), symbols, into));
+                    collect(ic.then(), into);
+                    ic.els().forEach(arm -> collect(arm.body(), into));
                 }
             }
             // Anything else answers nothing because something it evaluates first does, and the rest
@@ -87,41 +81,21 @@ public final class UnreachableReasons {
             default -> {
                 Core stops = firstThatAborts(children(e));
                 if (stops != null) {
-                    collect(stops, symbols, into);
+                    collect(stops, into);
                 }
             }
         }
     }
 
     /**
-     * The initializer a construction stops at, or null where every one of them answers.
+     * The value a construction stops at, or null where every one of them answers.
      *
-     * <p>Read in declaration order, which is the order the fields are pushed. Written order would
-     * name whichever {@code unreachable} the author put uppermost, and a construction that names its
-     * fields in another order than the data declares them is ordinary.
+     * <p>Read in the order the construction holds its fields, which is the order they are pushed:
+     * the construction settled that when it was built, so what stops it is asked here rather than
+     * worked out again from how the fields were written.
      */
-    private static Core evaluated(Core.NewData nd, Symbols symbols) {
-        Map<String, Core> byName = new LinkedHashMap<>();
-        nd.inits().forEach(init -> byName.put(init.name(), init.value()));
-        List<Core> inOrder = new ArrayList<>();
-        for (String field : declaredFields(nd, symbols)) {
-            Core value = byName.remove(field);
-            if (value != null) {
-                inOrder.add(value);
-            }
-        }
-        inOrder.addAll(byName.values());   // a field the declaration does not have, if one ever is
-        return firstThatAborts(inOrder);
-    }
-
-    /** The fields as the data declares them, or nothing where this construction's type cannot be
-     * read — in which case the initializers keep the order they were written in. */
-    private static List<String> declaredFields(Core.NewData nd, Symbols symbols) {
-        if (symbols == null || !(symbols.declarations().declaration(nd.typeName().key()) instanceof Hir.Data data)) {
-            return List.of();
-        }
-        Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
-        return List.copyOf(fields.keySet());
+    private static Core evaluated(Core.Construct nd) {
+        return firstThatAborts(nd.values().stream().map(Core.FieldValue::value).toList());
     }
 
     /** The first of a run of strict positions that does not answer, which is where evaluation stops

--- a/souther-compiler/src/test/java/souther/compiler/AFieldTakesItsValueFromOneSourceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AFieldTakesItsValueFromOneSourceTest.java
@@ -1,0 +1,118 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Where more than one spread carries a field, the first of them supplies it, and that is the whole
+ * of the rule — the value that reaches the field at run time, the type the field is checked
+ * against, and what the construction is read as all name the same source.
+ *
+ * <p>This is held because the two used to disagree. What ran took the first spread carrying the
+ * field; what was type-checked took the last, since the fields each spread supplies were collected
+ * into one map. A construction now resolves each field once, where it is elaborated, so there is one
+ * winner for a reader to see. The rule follows what already ran; the spec says only that a spread
+ * copies the fields of one value and that surplus ones are ignored (§record-literal), so what
+ * several spreads do about one field is written down there rather than derived from here.
+ */
+class AFieldTakesItsValueFromOneSourceTest {
+
+    private static final String MODULE = """
+            module demo
+
+            data From = { n: Int, tag: String }
+            data Also = { n: Int, other: Int }
+            data Odd  = { n: String, other: Int }
+
+            data T = { n: Int, tag: String }
+
+            data In = { from: From, also: Also }
+
+            behavior pick : (i: In) -> T
+                constructs T
+
+            let pick (i) = %s
+            """;
+
+    private Map<?, ?> run(String body) throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(
+                Compiler.compile(MODULE.formatted(body)), getClass().getClassLoader());
+        Map<String, Object> from = new HashMap<>();
+        from.put("n", 1);
+        from.put("tag", "first");
+        Map<String, Object> also = new HashMap<>();
+        also.put("n", 2);
+        also.put("other", 9);
+        Map<String, Object> in = new HashMap<>();
+        in.put("from", from);
+        in.put("also", also);
+        Object value = Codecs.decoded(loader, "demo.In", in);
+        Object behavior = Emitted.behavior(loader, "demo", "pick").getConstructor().newInstance();
+        return (Map<?, ?>) Codecs.encode(loader, "demo.T", Codecs.apply(behavior, value));
+    }
+
+    @Test
+    void theFirstSpreadCarryingTheFieldSuppliesIt() throws Exception {
+        assertEquals(1L, run("T { ...i.from, ...i.also }").get("n"));
+        assertEquals(2L, run("T { ...i.also, ...i.from }").get("n"));
+    }
+
+    @Test
+    void aFieldWrittenOutBeatsEverySpread() throws Exception {
+        assertEquals(7L, run("T { ...i.from, ...i.also, n = 7 }").get("n"));
+    }
+
+    /**
+     * The field is checked against the type of the spread that supplies it. A later spread carrying
+     * the same name carries it no more than any other surplus field it has.
+     *
+     * <p>This program was refused (E1016) while the two answers differed: the type came from the
+     * last spread carrying the field and the value from the first, so a field the first supplied
+     * correctly was refused for the second's type — a type error about a value that was never going
+     * to be read.
+     */
+    @Test
+    void aLaterSpreadsFieldOfAnotherTypeIsSurplus() {
+        Compiler.compile("""
+                module demo
+
+                data From = { n: Int, tag: String }
+                data Odd  = { n: String, other: Int }
+                data T = { n: Int, tag: String }
+                data In = { from: From, also: Odd }
+
+                behavior pick : (i: In) -> T
+                    constructs T
+
+                let pick (i) = T { ...i.from, ...i.also }
+                """);
+    }
+
+    /** The same program with the sources the other way round is refused, which is what says the
+     * first spread is the one being read rather than that neither is. */
+    @Test
+    void theFirstSpreadsFieldOfAnotherTypeIsRefused() {
+        CompileException refused = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+
+                data From = { n: Int, tag: String }
+                data Odd  = { n: String, other: Int }
+                data T = { n: Int, tag: String }
+                data In = { from: From, also: Odd }
+
+                behavior pick : (i: In) -> T
+                    constructs T
+
+                let pick (i) = T { ...i.also, ...i.from }
+                """));
+
+        assertEquals("E1016", refused.diagnostics().get(0).code());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AConstructionIsJudgedByWhatItBuildsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AConstructionIsJudgedByWhatItBuildsTest.java
@@ -148,6 +148,37 @@ class AConstructionIsJudgedByWhatItBuildsTest {
                 """.formatted(constructs == null ? "" : "Money,", body));
     }
 
+    /**
+     * A value opened is judged as a value chosen is.
+     *
+     * <p>Two ways of writing one choice: a {@code match} over a sum, and an {@code if} over what
+     * decides it. The check named the second and not the first, so a construction over what a
+     * {@code match} answered was left to the run-time check while the same construction over an
+     * {@code if} was reported — the same spelling difference this issue is about, at another node.
+     */
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {
+            "match i.s with | A -> i.n | B -> 0 - i.n",
+            "if i.flag then i.n else 0 - i.n",
+    })
+    void aChoiceIsJudgedHoweverItIsWritten(String chosen) {
+        reads(Verdict.UNKNOWN, """
+                module demo
+
+                data A
+                data B
+                data S = A | B
+                data In = { s: S, flag: Bool, n: Int }
+
+                data NonNeg = Int
+                    invariant nonNegative = value >= 0
+
+                behavior make : (i: In) -> NonNeg
+                    constructs NonNeg
+                let make (i) = NonNeg(%s)
+                """.formatted(chosen));
+    }
+
     /** A construction the values themselves refute is refuted whichever way it is written. */
     @Test
     void aRefutedConstructionIsRefutedInEitherSpelling() {

--- a/souther-compiler/src/test/java/souther/compiler/check/AConstructionIsJudgedByWhatItBuildsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AConstructionIsJudgedByWhatItBuildsTest.java
@@ -1,0 +1,185 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.check.InvariantChecker.Said;
+import souther.compiler.check.InvariantChecker.Verdict;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * A construction is judged by the value it builds, not by the way it was written (issue #722).
+ *
+ * <p>Every source form that makes a value of a declared type is one node by the time anything reads
+ * it, holding what each field is given (spec §invariant-discharge). So the spellings below are one
+ * construction: a literal writing its fields, a literal spreading them from another value, one
+ * spreading them from a sum whose cases share them, one spreading them from a field path, and the
+ * arithmetic that builds a newtype from two of its own. Each is asked the same question about the
+ * same values, and the answer is the same.
+ *
+ * <p>Both answers are held. A test that only showed the unguarded spellings warning would pass on a
+ * check that had stopped discharging anything, and one that only showed the guarded spellings silent
+ * would pass on a check that had stopped reading them.
+ */
+class AConstructionIsJudgedByWhatItBuildsTest {
+
+    private static final String TYPES = """
+            module demo
+
+            data Common = { id: Int, n: Int }
+            data A = { ...Common, a: Int }
+            data B = { ...Common, b: Int }
+            data S = A | B
+            data Box = { inner: Common }
+
+            data NonNeg = { id: Int, n: Int }
+                invariant nonNeg = n >= 0
+
+            data TooSmall
+            """;
+
+    /** The construction, reached with nothing known about what it is given. */
+    private static String unguarded(String input, String body) {
+        return TYPES + """
+
+                behavior make : (%s) -> NonNeg
+                    constructs NonNeg
+                let make (x) = %s
+                """.formatted(input, body);
+    }
+
+    /** The same, with a guard that establishes the invariant. */
+    private static String guarded(String input, String body, String guard) {
+        return TYPES + """
+
+                behavior make : (%s) -> NonNeg | TooSmall
+                    constructs NonNeg, TooSmall
+                let make (x) = {
+                    guard %s else TooSmall
+                    %s
+                }
+                """.formatted(input, guard, body);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {
+            "NonNeg { id = x.id, n = x.n }",
+            "NonNeg { ...x }",
+    })
+    void aRecordsFieldsAreOneConstructionHoweverTheyAreSupplied(String body) {
+        reads(Verdict.UNKNOWN, unguarded("x: Common", body));
+        reads(Verdict.PROVED, guarded("x: Common", body, "x.n >= 0"));
+    }
+
+    /**
+     * A sum whose cases all spread one data is a spread source, and the field read off it is the
+     * field every case carries — the same value the written-out spelling reads.
+     */
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {
+            "NonNeg { id = x.id, n = x.n }",
+            "NonNeg { ...x }",
+    })
+    void aSumsSharedPartIsOneConstructionHoweverItIsSupplied(String body) {
+        reads(Verdict.UNKNOWN, unguarded("x: S", body));
+        reads(Verdict.PROVED, guarded("x: S", body, "x.n >= 0"));
+    }
+
+    /** A spread naming a field path is bound before the construction, and reads the same place. */
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {
+            "NonNeg { id = x.inner.id, n = x.inner.n }",
+            "NonNeg { ...x.inner }",
+    })
+    void aFieldPathIsOneConstructionHoweverItIsSupplied(String body) {
+        reads(Verdict.UNKNOWN, unguarded("x: Box", body));
+        reads(Verdict.PROVED, guarded("x: Box", body, "x.inner.n >= 0"));
+    }
+
+    private static final String MONEY = """
+            module demo
+
+            data Money = Decimal
+                invariant nonNeg = value >= 0m
+
+            data TooSmall
+            """;
+
+    /**
+     * Closed arithmetic over a newtype builds one, and is that construction: what it is given is the
+     * number its operands wrap, which is what writing the constructor around that subtraction gives
+     * it. So the two are judged alike, and the guard that discharges one discharges the other.
+     *
+     * <p>What they do not share is {@code constructs}: re-wrapping a value of a type is not minting
+     * one from raw data, and the authority to mint is written only where minting happens
+     * (spec §newtype-arithmetic). That the two are one construction here and two things there is the
+     * point — the invariant is owed wherever a value is built, and the authority is about where a
+     * value comes from.
+     */
+    @ParameterizedTest(name = "{0}")
+    @CsvSource(delimiter = '|', value = {
+            "held - fee                     |",
+            "Money(held.value - fee.value)  | constructs Money",
+    })
+    void arithmeticOverANewtypeIsTheConstructionItMakes(String body, String constructs) {
+        reads(Verdict.UNKNOWN, MONEY + """
+
+                behavior make : (held: Money, fee: Money) -> Money
+                    %s
+                let make (held, fee) = %s
+                """.formatted(constructs == null ? "" : constructs, body));
+        reads(Verdict.PROVED, MONEY + """
+
+                behavior make : (held: Money, fee: Money) -> Money | TooSmall
+                    constructs %s TooSmall
+                let make (held, fee) = {
+                    guard fee <= held else TooSmall
+                    %s
+                }
+                """.formatted(constructs == null ? "" : "Money,", body));
+    }
+
+    /** A construction the values themselves refute is refuted whichever way it is written. */
+    @Test
+    void aRefutedConstructionIsRefutedInEitherSpelling() {
+        reads(Verdict.REFUTED_ALONE, MONEY + """
+
+                behavior make : (held: Money) -> Money
+                    constructs Money
+                let make (held) = Money(0m - 1m)
+                """);
+    }
+
+    /** The verdicts this check reached on constructions of {@code NonNeg} or {@code Money}, which is
+     * where a construction that was never judged at all shows up: as none. */
+    private static void reads(Verdict expected, String source) {
+        List<Said> said = Collections.synchronizedList(new ArrayList<>());
+        InvariantChecker.WATCHING = said;
+        try {
+            Compiler.compileWithWarnings(source);
+        } catch (souther.compiler.diag.CompileException refused) {
+            // A construction the values refute is an error, and the verdict that says so was reached
+            // before it was raised. So which verdict is what is asked, and not whether it compiles —
+            // but only where a refutation is what was expected. Any other refusal is this test's own
+            // program being wrong, and swallowing it would leave `no construction was judged`
+            // standing for `the module did not compile`.
+            if (!expected.refuted()) {
+                throw refused;
+            }
+        } finally {
+            InvariantChecker.WATCHING = null;
+        }
+        List<Verdict> reached = said.stream().map(Said::verdict).toList();
+        assertFalse(reached.isEmpty(), "no construction was judged at all");
+        assertEquals(List.of(expected), reached);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AHelperCallIsNameableWhetherOrNotItWasExpandedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AHelperCallIsNameableWhetherOrNotItWasExpandedTest.java
@@ -1,0 +1,152 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.check.InvariantChecker.Said;
+import souther.compiler.check.InvariantChecker.Verdict;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * What a helper answers is a value the check can name, and whether the reading it is given expanded
+ * that helper into the body is not part of the question (issue #722).
+ *
+ * <p>The reading the check reads keeps the language's own operations standing and expands a module's
+ * own {@code let}s into the body it was called from (spec §invariant-discharge-representation). A
+ * helper that recurses cannot be expanded, so it stays a call — and a call was a shape the naming had
+ * no case for, so a construction over one was left to the run-time check while the same construction
+ * over a helper that happens not to recurse was reported. Recursion is a fact about the helper's own
+ * body; the value it answers is a function of what it was given either way.
+ *
+ * <p>What makes it nameable is what the name was resolved to: a module's own helper is pure and
+ * total (spec §fn-rules), so two writings of one call with the same arguments are one value. What a
+ * behavior answers is named by nothing, and that is here too — both spellings of it, so that the
+ * rule is read as being about the callee rather than about which of them was expanded.
+ */
+class AHelperCallIsNameableWhetherOrNotItWasExpandedTest {
+
+    private static final String TYPES = """
+            module demo
+
+            data NonNeg = Int
+                invariant nonNegative = value >= 0
+
+            data TooSmall
+            """;
+
+    /** The construction over what the helper answered, with nothing known about it. */
+    private static String unguarded(String helper) {
+        return TYPES + """
+
+                %s
+
+                behavior go : (n: Int) -> NonNeg
+                    constructs NonNeg
+                let go (n) = NonNeg(step(n))
+                """.formatted(helper);
+    }
+
+    /** The same, with a guard about the call. */
+    private static String guarded(String helper) {
+        return TYPES + """
+
+                %s
+
+                behavior go : (n: Int) -> NonNeg | TooSmall
+                    constructs NonNeg, TooSmall
+                let go (n) = {
+                    guard step(n) >= 0 else TooSmall
+                    NonNeg(step(n))
+                }
+                """.formatted(helper);
+    }
+
+    private static final String EXPANDED = "let step (n: Int): Int = n - 1";
+    private static final String STANDING =
+            "partial let step (n: Int): Int = if n <= 0 then n - 1 else step(n - 1)";
+
+    /**
+     * Both are unproven, and a guard about the call establishes both.
+     *
+     * <p>The guard is what says the report is not a trap. A construction is reported only where a
+     * guard could silence it, so a call the check names has to be one an author can write a guard
+     * about — and the guard that does it here says of the call exactly what the clause needs.
+     */
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {EXPANDED, STANDING})
+    void aHelperCallIsNamedByItsCall(String helper) {
+        reads(Verdict.UNKNOWN, unguarded(helper));
+        reads(Verdict.PROVED, guarded(helper));
+    }
+
+    /**
+     * What a behavior answers is named by nothing, whichever way it is reached.
+     *
+     * <p>Held beside the helper because the two used to differ by which of them this reading had
+     * expanded. They differ by what was called.
+     */
+    @Test
+    void aBehaviorsAnswerIsNamedByNothing() {
+        reads(Verdict.UNREPRESENTABLE, TYPES + """
+
+                behavior step : (n: Int) -> Int
+
+                behavior go : (n: Int) -> NonNeg
+                    constructs NonNeg
+                    depends on step
+                let go (n, step) = NonNeg(step(n))
+                """);
+    }
+
+    /**
+     * Nothing in a body reaches the naming as a shape it has no term for.
+     *
+     * <p>Which is the difference {@link Naming.Unsupported} is for. A value nothing can be said of is
+     * silent, and so is a shape this compiler has not got round to, and production cannot tell them
+     * apart — the run-time check stands either way. So the second is measured rather than reasoned
+     * about, over a body that reaches the shapes a fold and a combinator lower into.
+     */
+    @Test
+    void nothingInABodyIsAShapeWithNoTerm() {
+        List<String> unsupported = Collections.synchronizedList(new ArrayList<>());
+        Terms.UNSUPPORTED = unsupported;
+        try {
+            Compiler.compileWithWarnings(TYPES + """
+
+                    data Total = Int
+                        invariant nonNegative = value >= 0
+
+                    let doubled (xs: List<Int>): List<Int> = List.map(x -> x * 2, xs)
+
+                    behavior go : (xs: List<Int>) -> Total
+                        constructs Total
+                    let go (xs) = Total(List.sum(doubled(List.filter(x -> x >= 0, xs))))
+                    """);
+        } finally {
+            Terms.UNSUPPORTED = null;
+        }
+
+        assertEquals(List.of(), unsupported, "shapes the naming had no term for");
+    }
+
+    private static void reads(Verdict expected, String source) {
+        List<Said> said = Collections.synchronizedList(new ArrayList<>());
+        InvariantChecker.WATCHING = said;
+        try {
+            Compiler.compileWithWarnings(source);
+        } finally {
+            InvariantChecker.WATCHING = null;
+        }
+        List<Verdict> reached = said.stream().map(Said::verdict).toList();
+        assertFalse(reached.isEmpty(), "no construction was judged at all");
+        assertEquals(List.of(expected), reached);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest.java
@@ -19,14 +19,15 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * What a canonical key costs when the term it names reads a named value twice.
+ * What a term costs when it reads a named value twice.
  *
  * <p>What terms are made of is a graph and not a tree. A name read twice is one value read twice, and
- * `+let (a, b) = t+` reads `+t+` twice by itself, so a chain of those is a graph whose nodes grow by
- * one per link and whose paths double. A key holding each of its parts in full holds one copy per
- * path — twenty-four links asked for more characters than an array can hold.
+ * {@code let (a, b) = t} reads {@code t} twice by itself, so a chain of those is a graph whose nodes
+ * grow by one per link and whose paths double. A term holding each of its parts in full holds one
+ * copy per path — twenty-four links once asked for more characters than an array can hold, when a
+ * term was the string it was written out as.
  *
- * <p>Held on the size of the key rather than on the time a compile takes. Time is what the growth
+ * <p>Held on the size of the term rather than on the time a compile takes. Time is what the growth
  * showed up as last: the chain measured flat right up to the link that asked for two gigabytes at
  * once, because the walk is one lookup per name and only what it wrote doubled. What was wrong is the
  * size of the representation, so that is what is measured, and it is measured where it is built.
@@ -41,44 +42,53 @@ class ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest {
     private static final BindingOwner OWNER = new BindingOwner.OfValue("m", "f");
 
     /** {@code v0 = 1 + 1}, then {@code v(i) = v(i-1) + v(i-1)}: each link names one value and reads
-     *  it twice. Answers the key of the last link. */
-    private static String chainKey(Terms terms, int links) {
+     *  it twice. Answers the term of the last link. */
+    private static Term chainTerm(Terms terms, int links) {
+        return chain(terms, links).get(links);
+    }
+
+    /** The term of each link, the first one first. */
+    private static List<Term> chain(Terms terms, int links) {
+        List<Term> along = new java.util.ArrayList<>();
         Denotations at = Denotations.none();
         Core value = new Core.Binary(Hir.BinOp.ADD, new Core.Int(1, Type.INT, NOWHERE),
                 new Core.Int(1, Type.INT, NOWHERE), CoverageOrigin.unwritten(), Type.INT, NOWHERE);
-        String key = terms.bodyKey(value, at);
+        Term term = terms.bodyKey(value, at);
+        along.add(term);
         for (int i = 0; i < links; i++) {
             BindingId id = new BindingId(OWNER, i);
-            at = at.binding(id, value, new Denotes.Term(key, true));
+            at = at.binding(id, value, new Denotes.Computed(term, true));
             Core read = new Core.Read("v" + i, id, Type.INT, NOWHERE);
             value = new Core.Binary(Hir.BinOp.ADD, read, read, CoverageOrigin.unwritten(),
                     Type.INT, NOWHERE);
-            key = terms.bodyKey(value, at);
+            term = terms.bodyKey(value, at);
+            along.add(term);
         }
-        return key;
+        return along;
     }
 
-    private static int keyLength(int links) {
-        String key = chainKey(new Terms(Symbols.none()), links);
-        return key == null ? -1 : key.length();
+    private static int held(int links) {
+        Term term = chainTerm(new Terms(Symbols.none()), links);
+        return term == null ? -1 : term.distinct();
     }
 
     /**
-     * A link adds a name to read, and a name is what a link adds.
+     * A link adds a term, and a term is what a link adds.
      *
-     * <p>Asked at four lengths as one map, because what is held is that the number does not follow the
-     * chain — one length is met by any growth at all, and it was met by one that doubled.
+     * <p>Asked at four lengths as one map, because what is held is that the size does not follow the
+     * paths through the chain — one length is met by any growth at all, and it was met by one that
+     * doubled.
      */
     @Test
     void aLinkCostsTheSameWhateverIsUnderIt() {
-        // Asked shortest first and held as it goes, so that a key which follows the chain is caught
+        // Asked shortest first and held as it goes, so that a term which follows the paths is caught
         // at the length where it is still a number and not at the one where it is an allocation.
         Map<Integer, Integer> measured = new LinkedHashMap<>();
         for (int links : List.of(4, 8, 16, 32)) {
-            int length = keyLength(links);
-            measured.put(links, length);
-            assertTrue(length > 0 && length <= 16,
-                    "a key names one shape and is read as a name: " + measured);
+            int size = held(links);
+            measured.put(links, size);
+            assertTrue(size > 0 && size <= 2 * links + 4,
+                    "a link holds the term under it rather than a copy of it: " + measured);
         }
     }
 
@@ -86,28 +96,65 @@ class ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest {
      * The chain a compile met, at a length the growth never allowed.
      *
      * <p>Twenty-four links is where it stopped, having asked for two gigabytes. A thousand is past
-     * every length that was reachable, and the key is still a name.
+     * every length that was reachable, and the term is still one term per link.
      */
     @Test
-    void aChainLongerThanTheOldLimitIsStillOneName() {
-        assertTrue(keyLength(1000) <= 16, "the key at a thousand links: " + keyLength(1000));
+    void aChainLongerThanTheOldLimitIsStillOneTermPerLink() {
+        assertTrue(held(1000) <= 2004, "the term at a thousand links holds: " + held(1000));
     }
 
     /**
-     * Naming a shape does not merge two shapes that differ.
+     * Sharing a term does not merge two terms that differ.
      *
-     * <p>Which is the property the keys are for: two terms are one key exactly when they compute one
+     * <p>Which is the property terms are for: two writings are one term exactly when they compute one
      * value, and that is what makes naming an expression not change what is known of it. A chain of
      * four and a chain of five read alike at every link but the last.
      */
     @Test
-    void twoShapesThatDifferAreTwoNames() {
+    void twoShapesThatDifferAreTwoTerms() {
         Terms terms = new Terms(Symbols.none());
-        String four = chainKey(terms, 4);
-        String five = chainKey(terms, 5);
-        String fourAgain = chainKey(terms, 4);
+        Term four = chainTerm(terms, 4);
+        Term five = chainTerm(terms, 5);
+        Term fourAgain = chainTerm(terms, 4);
 
-        assertEquals(four, fourAgain, "one shape is one name");
+        assertEquals(four, fourAgain, "one shape is one term");
         assertNotEquals(four, five, "and two shapes are two");
+    }
+
+    /**
+     * A link's term is told apart from every other link's by its hash alone.
+     *
+     * <p>Which is what a term being held in a map asks of it. A term reading one part twice folds
+     * that part in twice, so a chain of them multiplies the hash it carries up by a fixed amount at
+     * every link; where that amount is a power of two, the bits of a level's own hash are gone a few
+     * links later and every link from there hashes alike. Nothing about the terms says so — they are
+     * distinct, they compare distinct, and the map holding them turns into a list, so a chain of a
+     * thousand links takes what a chain of a hundred took cubed.
+     */
+    @Test
+    void eachLinkHashesApartFromTheOthers() {
+        List<Term> along = chain(new Terms(Symbols.none()), 64);
+        java.util.Set<Term> terms = new java.util.HashSet<>(along);
+        java.util.Set<Integer> hashes = new java.util.HashSet<>();
+        along.forEach(term -> hashes.add(term.hashCode()));
+
+        assertEquals(65, terms.size(), "sixty-five links are sixty-five terms");
+        assertEquals(terms.size(), hashes.size(), "and each is hashed apart from the rest");
+    }
+
+    /**
+     * A term built by one reading equals its twin built by another.
+     *
+     * <p>Sharing is what makes the comparison cheap and is not what makes two terms equal. Two
+     * readings of one program — one compile against another, a test comparing what two spellings
+     * name — hold terms from different interners, and they are the same terms.
+     */
+    @Test
+    void aTermBuiltByAnotherReadingIsTheSameTerm() {
+        Term here = chainTerm(new Terms(Symbols.none()), 6);
+        Term there = chainTerm(new Terms(Symbols.none()), 6);
+
+        assertEquals(here, there, "two readings name one value alike");
+        assertEquals(here.hashCode(), there.hashCode(), "and hash it alike");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest.java
@@ -122,24 +122,30 @@ class ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest {
     }
 
     /**
-     * A link's term is told apart from every other link's by its hash alone.
+     * This chain does not hash into one bucket.
      *
-     * <p>Which is what a term being held in a map asks of it. A term reading one part twice folds
-     * that part in twice, so a chain of them multiplies the hash it carries up by a fixed amount at
-     * every link; where that amount is a power of two, the bits of a level's own hash are gone a few
-     * links later and every link from there hashes alike. Nothing about the terms says so — they are
-     * distinct, they compare distinct, and the map holding them turns into a list, so a chain of a
-     * thousand links takes what a chain of a hundred took cubed.
+     * <p>Not a law about hashing. Two values may share a hash and nothing is wrong; what is held is
+     * that <em>this family</em> does not collapse, because it is the family the sharing exists for
+     * and it collapsed. A term reading one part twice folds that part in twice, so a chain of them
+     * multiplies the hash it carries up by a fixed amount per link, and with a multiplier of 31 that
+     * amount is thirty-two — two to the fifth, so seven links shift a level's own hash out and every
+     * link past that hashes alike. Nothing about the terms says so: they are distinct, they compare
+     * distinct, and only the table holding them turns into a list. A thousand links took 8.7 seconds
+     * where a hundred took 20 milliseconds.
+     *
+     * <p>Held as a spread and not as a time, since a time is a fact about the machine. A mixing that
+     * ties a few of these together is not this defect; one that ties most of them together is.
      */
     @Test
-    void eachLinkHashesApartFromTheOthers() {
-        List<Term> along = chain(new Terms(Symbols.none()), 64);
+    void theChainDoesNotHashIntoOneBucket() {
+        List<Term> along = chain(new Terms(Symbols.none()), 1000);
         java.util.Set<Term> terms = new java.util.HashSet<>(along);
         java.util.Set<Integer> hashes = new java.util.HashSet<>();
         along.forEach(term -> hashes.add(term.hashCode()));
 
-        assertEquals(65, terms.size(), "sixty-five links are sixty-five terms");
-        assertEquals(terms.size(), hashes.size(), "and each is hashed apart from the rest");
+        assertEquals(1001, terms.size(), "a thousand links are a thousand terms");
+        assertTrue(hashes.size() > terms.size() * 0.9,
+                "and they are spread over hashes: " + hashes.size() + " of " + terms.size());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/OneNameIsOneValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneNameIsOneValueTest.java
@@ -9,6 +9,7 @@ import souther.compiler.types.Type;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -40,20 +41,45 @@ class OneNameIsOneValueTest {
         Terms terms = new Terms(Symbols.none());
         BindingId binding = binding();
         Denotations at = Denotations.none().location(binding);
-        String whole = terms.atomOf(new Core.Read("n", binding, Type.INT, POS), at);
+        Term whole = terms.atomOf(new Core.Read("n", binding, Type.INT, POS), at);
         assertNotNull(whole, "a location is an atom");
-        Terms.OneKeyTwoKinds refused = assertThrows(Terms.OneKeyTwoKinds.class,
+        Terms.OneTermTwoKinds refused = assertThrows(Terms.OneTermTwoKinds.class,
                 () -> terms.atomOf(new Core.Read("n", binding, Type.DECIMAL, POS), at),
                 "the same name, standing for a number spaced the other way");
-        assertTrue(refused.getMessage().contains(whole),
+        assertTrue(refused.getMessage().contains(whole.rendered()),
                 "and it says which name: " + refused.getMessage());
+    }
+
+    /**
+     * Two values one writing of them once ran together are two terms.
+     *
+     * <p>A term was a string built out of its parts' strings, and the punctuation the string used was
+     * punctuation a value could hold: the one-element list below and the two-element one wrote the
+     * same characters, so a guard about either discharged a clause about the other. What separates
+     * them now is that neither is written at all — a term holds its parts, and a list of one is a
+     * list of one whatever that one spells.
+     */
+    @Test
+    void twoValuesThatOnceWroteOneNameAreTwoTerms() {
+        Terms terms = new Terms(Symbols.none());
+        Denotations at = Denotations.none();
+        Core.Str awkward = new Core.Str("a\", \"b", Type.STRING, POS);
+
+        Term one = terms.bodyKey(new Core.ListLit(java.util.List.of(awkward),
+                Type.list(Type.STRING), POS), at);
+        Term two = terms.bodyKey(new Core.ListLit(java.util.List.of(
+                new Core.Str("a", Type.STRING, POS), new Core.Str("b", Type.STRING, POS)),
+                Type.list(Type.STRING), POS), at);
+
+        assertNotNull(one);
+        assertNotEquals(one, two, "a list of one element and a list of two are two values");
     }
 
     @Test
     void theCheckDoesNotSwallowItsOwnContradiction() {
-        assertThrows(Terms.OneKeyTwoKinds.class,
+        assertThrows(Terms.OneTermTwoKinds.class,
                 () -> InvariantChecker.gaveUp("analyze",
-                        new Terms.OneKeyTwoKinds("atom `n` is DISCRETE and DENSE")),
+                        new Terms.OneTermTwoKinds("atom `n` is DISCRETE and DENSE")),
                 "recording it would leave a behavior looking like one with nothing to report");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereADeclarationCameFromDoesNotDecideItsDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereADeclarationCameFromDoesNotDecideItsDischargeTest.java
@@ -1,0 +1,137 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.check.InvariantChecker.Said;
+import souther.compiler.check.InvariantChecker.Verdict;
+import souther.compiler.meta.ModulePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * A construction is read against the same clauses wherever the type declaring them was written
+ * (spec §invariant-discharge-representation).
+ *
+ * <p>Three provenances for one declaration: written in the module doing the constructing, imported
+ * from a module compiled beside it, and imported from a module compiled on its own and reached
+ * through nothing but its published classes. The clauses are the same clauses, so the verdicts are
+ * the same verdicts — a guard that discharges an invariant discharges it, and one that leaves it
+ * unproven leaves it unproven.
+ *
+ * <p>Held because the specification said otherwise. It said a clause arriving from another module
+ * arrives as the computation it became and is outside the dischargeable fragment even where the same
+ * clause written here would be inside it. Measured, all three of these discharge; the sentence
+ * described a compiler that had already stopped being this one, and nothing failed when it stopped
+ * (#722). Where a published declaration is put back together from is the compiler's business, and
+ * this is what the language says instead.
+ */
+class WhereADeclarationCameFromDoesNotDecideItsDischargeTest {
+
+    private static final String LIBRARY = """
+            module lib
+            exposing (Amount, Bag)
+
+            data Amount = Decimal
+                invariant nonNegative = value >= 0m
+
+            data Bag = List<Int>
+                invariant nonEmpty = List.length(value) >= 1
+            """;
+
+    /** The same declarations, written where they are used. */
+    private static final String OWN = """
+            data Amount = Decimal
+                invariant nonNegative = value >= 0m
+
+            data Bag = List<Int>
+                invariant nonEmpty = List.length(value) >= 1
+            """;
+
+    private static final String USES = """
+            data TooSmall
+
+            behavior take : (paid: Decimal) -> Amount | TooSmall
+                constructs Amount, TooSmall
+            let take (paid) = {
+                guard paid >= 0m else TooSmall
+                Amount(paid)
+            }
+
+            behavior fill : (xs: List<Int>) -> Bag | TooSmall
+                constructs Bag, TooSmall
+            let fill (xs) = {
+                guard List.length(xs) >= 1 else TooSmall
+                Bag(xs)
+            }
+            """;
+
+    /** Both constructions guarded, so both are established wherever the clauses came from. */
+    @Test
+    void aGuardEstablishesAnInvariantWhereverItWasDeclared() {
+        assertEquals(List.of(Verdict.PROVED, Verdict.PROVED), inTheSameModule(USES));
+        assertEquals(List.of(Verdict.PROVED, Verdict.PROVED), imported(USES));
+        assertEquals(List.of(Verdict.PROVED, Verdict.PROVED), importedFromClasses(USES));
+    }
+
+    /** And neither guarded, so both are unproven wherever they came from — the same test with the
+     * guards taken out, so that agreement is not agreement on silence. */
+    @Test
+    void anUnguardedConstructionIsUnprovenWhereverItWasDeclared() {
+        String unguarded = """
+                behavior take : (paid: Decimal) -> Amount
+                    constructs Amount
+                let take (paid) = Amount(paid)
+
+                behavior fill : (xs: List<Int>) -> Bag
+                    constructs Bag
+                let fill (xs) = Bag(xs)
+                """;
+
+        assertEquals(List.of(Verdict.UNKNOWN, Verdict.UNKNOWN), inTheSameModule(unguarded));
+        assertEquals(List.of(Verdict.UNKNOWN, Verdict.UNKNOWN), imported(unguarded));
+        assertEquals(List.of(Verdict.UNKNOWN, Verdict.UNKNOWN), importedFromClasses(unguarded));
+    }
+
+    private static List<Verdict> inTheSameModule(String uses) {
+        return verdicts(() -> Compiler.compileWithWarnings("module app\n\n" + OWN + "\n" + uses));
+    }
+
+    private static List<Verdict> imported(String uses) {
+        return verdicts(() -> Compiler.compileModulesWithWarnings(
+                List.of(LIBRARY, app(uses))));
+    }
+
+    /** The library compiled on its own, and its classes handed over as the whole of what the second
+     * compile knows about it. */
+    private static List<Verdict> importedFromClasses(String uses) {
+        Map<String, byte[]> classes = Compiler.compile(LIBRARY);
+        ModulePath path = classes::get;
+        return verdicts(() -> Compiler.compileModulesWithWarnings(List.of(app(uses)), path));
+    }
+
+    private static String app(String uses) {
+        return "module app\n\nimport lib ( Amount, Bag )\n\n" + uses;
+    }
+
+    private static List<Verdict> verdicts(Runnable compile) {
+        List<Said> said = Collections.synchronizedList(new ArrayList<>());
+        InvariantChecker.WATCHING = said;
+        try {
+            compile.run();
+        } finally {
+            InvariantChecker.WATCHING = null;
+        }
+        List<Verdict> reached = said.stream()
+                .filter(one -> one.type().equals("Amount") || one.type().equals("Bag"))
+                .map(Said::verdict).toList();
+        assertFalse(reached.isEmpty(), "no construction was judged at all");
+        return reached;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/core/EverySlotIsAChildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/core/EverySlotIsAChildTest.java
@@ -51,11 +51,13 @@ class EverySlotIsAChildTest {
         return new Core.Read(name, new BindingId(OWNER, ordinal), Type.INT, POS);
     }
 
-    /** {@code Person { ..base, age: 1 }}. */
-    private static Core.NewData construction() {
-        return new Core.NewData(PERSON,
-                List.of(new Core.FieldInit("age", new Core.Int(1, Type.INT, POS), POS)),
-                List.of(read("base", 0)),
+    /** {@code Person { ...base, age = 1 }} as a construction holds it: the spread resolved into the
+     * read of the field it supplies. */
+    private static Core.Construct construction() {
+        return new Core.Construct(PERSON,
+                List.of(new Core.FieldValue("name",
+                                new Core.FieldAccess(read("base", 0), "name", Type.STRING, POS), POS),
+                        new Core.FieldValue("age", new Core.Int(1, Type.INT, POS), POS)),
                 Type.ref(PERSON), POS);
     }
 
@@ -70,9 +72,16 @@ class EverySlotIsAChildTest {
                 .map(c -> ((Core.Read) c).name()).toList();
     }
 
+    /** What each field is given is a child, and a binding one of them reads is reached through it.
+     * A pass that asks which bindings a body reaches has to be given them, or it undercounts — which
+     * is what a construction holding a spread beside its fields used to be about. */
     @Test
-    void aSpreadIsAChild() {
-        assertEquals(List.of("base"), namesIn(childrenOf(construction())));
+    void whatEachFieldIsGivenIsAChild() {
+        List<Core> children = childrenOf(construction());
+
+        assertEquals(List.of("FieldAccess", "Int"),
+                children.stream().map(c -> c.getClass().getSimpleName()).toList());
+        assertEquals(List.of("base"), namesIn(childrenOf(children.get(0))));
     }
 
     /**
@@ -99,7 +108,7 @@ class EverySlotIsAChildTest {
                 List.of(new Core.ElseArm(Optional.empty(), new Core.Int(1, Type.INT, POS))),
                 ORIGIN, Type.INT, POS);
 
-        assertTrue(childrenOf(attempt).stream().anyMatch(c -> c instanceof Core.NewData),
+        assertTrue(childrenOf(attempt).stream().anyMatch(c -> c instanceof Core.Construct),
                 "the construction itself, rather than the field values inside it");
     }
 
@@ -133,8 +142,9 @@ class EverySlotIsAChildTest {
 
     @Test
     void aWalkThatChangesNothingKeepsTheNodeItWalked() {
-        Core.NewData built = construction();
+        Core.Construct built = construction();
 
         assertSame(built, Core.mapChildren(built, c -> c, n -> n, b -> b));
+        assertSame(built, Core.mapChildren(built, c -> c));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/numeric/ADomainHoldingNothingHoldsNothingFurtherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/ADomainHoldingNothingHoldsNothingFurtherTest.java
@@ -25,13 +25,13 @@ class ADomainHoldingNothingHoldsNothingFurtherTest {
 
     private static final Map<String, Granularity> COUNTS = Map.of("n", Granularity.DISCRETE);
 
-    private static NumericDomain.LinearForm nMinus(long count) {
-        return NumericDomain.LinearForm.atom("n")
-                .minus(NumericDomain.LinearForm.constant(BigDecimal.valueOf(count)));
+    private static NumericDomain.LinearForm<String> nMinus(long count) {
+        return NumericDomain.LinearForm.<String>atom("n")
+                .minus(NumericDomain.LinearForm.<String>constant(BigDecimal.valueOf(count)));
     }
 
-    private static NumericDomain atLeastTwo() {
-        return NumericDomain.top().assume(nMinus(2), NumericDomain.Rel.GE, COUNTS);
+    private static NumericDomain<String> atLeastTwo() {
+        return NumericDomain.<String>top().assume(nMinus(2), NumericDomain.Rel.GE, COUNTS);
     }
 
     @Test
@@ -55,7 +55,7 @@ class ADomainHoldingNothingHoldsNothingFurtherTest {
 
     @Test
     void whatHoldsNothingKeepsHoldingNothing() {
-        NumericDomain none = atLeastTwo().assume(nMinus(1), NumericDomain.Rel.LE, COUNTS);
+        NumericDomain<String> none = atLeastTwo().assume(nMinus(1), NumericDomain.Rel.LE, COUNTS);
         assertTrue(none.assume(nMinus(0), NumericDomain.Rel.EQ, COUNTS).isBottom());
         assertTrue(none.assume(nMinus(5), NumericDomain.Rel.GE, COUNTS).isBottom());
     }

--- a/souther-compiler/src/test/java/souther/compiler/numeric/AKeptRelationComposesWithWhatTheDomainProvesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/AKeptRelationComposesWithWhatTheDomainProvesTest.java
@@ -31,16 +31,16 @@ class AKeptRelationComposesWithWhatTheDomainProvesTest {
     private static final String D = "d";
     private static final String E = "e";
 
-    private static LinearForm atom(String a) {
-        return LinearForm.atom(a);
+    private static LinearForm<String> atom(String a) {
+        return LinearForm.<String>atom(a);
     }
 
-    private static LinearForm num(long n) {
-        return LinearForm.constant(BigDecimal.valueOf(n));
+    private static LinearForm<String> num(long n) {
+        return LinearForm.<String>constant(BigDecimal.valueOf(n));
     }
 
     /** {@code a + b - c}, which is of neither shape: three atoms, so it is kept as written. */
-    private static LinearForm aPlusBMinus(String c) {
+    private static LinearForm<String> aPlusBMinus(String c) {
         return atom(A).plus(atom(B)).minus(atom(c));
     }
 
@@ -56,7 +56,7 @@ class AKeptRelationComposesWithWhatTheDomainProvesTest {
      * the second is a difference; nothing but their sum reaches the goal. */
     @Test
     void aKeptRelationComposesWithADifference() {
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(aPlusBMinus(C), Rel.LE, dense(A, B, C))
                 .assume(atom(C).minus(atom(D)), Rel.LE, dense(C, D));
 
@@ -68,7 +68,7 @@ class AKeptRelationComposesWithWhatTheDomainProvesTest {
      * particular but whatever the domain proves of the residual. */
     @Test
     void aKeptRelationComposesWithAnIntervalBound() {
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(aPlusBMinus(C), Rel.LE, dense(A, B, C))
                 .assume(atom(C).minus(num(100)), Rel.LE, dense(C));
 
@@ -80,7 +80,7 @@ class AKeptRelationComposesWithWhatTheDomainProvesTest {
      * {@code a + b < d}. */
     @Test
     void aStrictResidualCarriesItsStrictnessToTheGoal() {
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(aPlusBMinus(C), Rel.LE, dense(A, B, C))
                 .assume(atom(C).minus(atom(D)), Rel.LT, dense(C, D));
 
@@ -91,7 +91,7 @@ class AKeptRelationComposesWithWhatTheDomainProvesTest {
      * {@code a + b < d}, so the residual is only asked for what the premise did not already give. */
     @Test
     void aStrictKeptRelationLeavesTheResidualNothingToProve() {
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(aPlusBMinus(C), Rel.LT, dense(A, B, C))
                 .assume(atom(C).minus(atom(D)), Rel.LE, dense(C, D));
 
@@ -102,7 +102,7 @@ class AKeptRelationComposesWithWhatTheDomainProvesTest {
      * {@code a + b = d} admitted, so {@code a + b < d} does not follow. */
     @Test
     void twoNonStrictRelationsDoNotProveAStrictGoal() {
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(aPlusBMinus(C), Rel.LE, dense(A, B, C))
                 .assume(atom(C).minus(atom(D)), Rel.LE, dense(C, D));
 
@@ -114,7 +114,7 @@ class AKeptRelationComposesWithWhatTheDomainProvesTest {
      * residual of either against the goal is of neither shape too and nothing proves it. */
     @Test
     void twoKeptRelationsAreNotAddedTogether() {
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(aPlusBMinus(C), Rel.LE, dense(A, B, C))
                 .assume(atom(C).minus(atom(D)).minus(atom(E)), Rel.LE, dense(C, D, E));
 

--- a/souther-compiler/src/test/java/souther/compiler/numeric/NumericDomainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/NumericDomainTest.java
@@ -30,16 +30,16 @@ class NumericDomainTest {
     private static final String A = "a";
     private static final String B = "b";
 
-    private static LinearForm atom(String a) {
-        return LinearForm.atom(a);
+    private static LinearForm<String> atom(String a) {
+        return LinearForm.<String>atom(a);
     }
 
-    private static LinearForm num(long n) {
-        return LinearForm.constant(BigDecimal.valueOf(n));
+    private static LinearForm<String> num(long n) {
+        return LinearForm.<String>constant(BigDecimal.valueOf(n));
     }
 
     /** {@code coefficient · atom}, which is how a bound with a divisor is written. */
-    private static LinearForm times(long coefficient, String a) {
+    private static LinearForm<String> times(long coefficient, String a) {
         return atom(a).times(BigDecimal.valueOf(coefficient));
     }
 
@@ -60,12 +60,12 @@ class NumericDomainTest {
     }
 
     /** Whether the domain proves {@code a <= n}. */
-    private static boolean provesAtMost(NumericDomain d, String a, long n) {
+    private static boolean provesAtMost(NumericDomain<String> d, String a, long n) {
         return d.entails(atom(a).minus(num(n)), Rel.LE);
     }
 
     /** Whether the domain proves {@code a >= n}. */
-    private static boolean provesAtLeast(NumericDomain d, String a, long n) {
+    private static boolean provesAtLeast(NumericDomain<String> d, String a, long n) {
         return d.entails(atom(a).minus(num(n)), Rel.GE);
     }
 
@@ -75,7 +75,7 @@ class NumericDomainTest {
      * refuses {@code a = 2.5} — a value the constraint admits. */
     @Test
     void anUpperBoundWithARemainderIsNeverRoundedDown() {
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(times(2, A).minus(num(5)), Rel.LE, dense(A));
 
         assertTrue(provesAtMost(d, A, 3), "2a <= 5 gives a <= 2.5, so a <= 3 follows");
@@ -85,7 +85,7 @@ class NumericDomainTest {
     /** The mirror: {@code -2a <= -5} is {@code a >= 2.5}, and rounding up would refuse 2.5. */
     @Test
     void aLowerBoundWithARemainderIsNeverRoundedUp() {
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(times(-2, A).plus(num(5)), Rel.LE, dense(A));
 
         assertTrue(provesAtLeast(d, A, 2), "-2a + 5 <= 0 gives a >= 2.5, so a >= 2 follows");
@@ -96,7 +96,7 @@ class NumericDomainTest {
      * bound: a remainder under an integer atom is a value the atom cannot take. */
     @Test
     void aWholeNumberBoundIsSharpenedByItsSpacing() {
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(times(2, A).minus(num(5)), Rel.LE, whole(A));
 
         assertTrue(provesAtMost(d, A, 2), "no integer over two satisfies 2a <= 5");
@@ -105,7 +105,7 @@ class NumericDomainTest {
 
     @Test
     void aWholeNumberLowerBoundIsSharpenedTheOtherWay() {
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(times(-2, A).plus(num(5)), Rel.LE, whole(A));
 
         assertTrue(provesAtLeast(d, A, 3), "no integer under three satisfies a >= 2.5");
@@ -117,7 +117,7 @@ class NumericDomainTest {
     /** {@code a < 3} over the reals bounds nothing below 3, and that is the whole of it. */
     @Test
     void aStrictBoundOnADenseAtomGivesNothingTighterThanTheValue() {
-        NumericDomain d = NumericDomain.top().assume(atom(A).minus(num(3)), Rel.LT, dense(A));
+        NumericDomain<String> d = NumericDomain.<String>top().assume(atom(A).minus(num(3)), Rel.LT, dense(A));
 
         assertTrue(provesAtMost(d, A, 3));
         assertFalse(provesAtMost(d, A, 2), "2.5 is under three and over two");
@@ -126,7 +126,7 @@ class NumericDomainTest {
     /** {@code a < 3} over the integers is {@code a <= 2}. */
     @Test
     void aStrictBoundOnAWholeNumberStepsDownToTheNextValue() {
-        NumericDomain d = NumericDomain.top().assume(atom(A).minus(num(3)), Rel.LT, whole(A));
+        NumericDomain<String> d = NumericDomain.<String>top().assume(atom(A).minus(num(3)), Rel.LT, whole(A));
 
         assertTrue(provesAtMost(d, A, 2));
         assertFalse(provesAtMost(d, A, 1), "a = 2 satisfies it");
@@ -135,7 +135,7 @@ class NumericDomainTest {
     /** And {@code a > 3} is {@code a >= 4}. */
     @Test
     void aStrictLowerBoundOnAWholeNumberStepsUp() {
-        NumericDomain d = NumericDomain.top().assume(atom(A).minus(num(3)), Rel.GT, whole(A));
+        NumericDomain<String> d = NumericDomain.<String>top().assume(atom(A).minus(num(3)), Rel.GT, whole(A));
 
         assertTrue(provesAtLeast(d, A, 4));
         assertFalse(provesAtLeast(d, A, 5), "a = 4 satisfies it");
@@ -150,7 +150,7 @@ class NumericDomainTest {
      */
     @Test
     void aStrictLowerBoundOnADenseAtomKeepsTheValueOutOfItsOwnRange() {
-        NumericDomain d = NumericDomain.top().assume(atom(A), Rel.GT, dense(A));
+        NumericDomain<String> d = NumericDomain.<String>top().assume(atom(A), Rel.GT, dense(A));
 
         assertEquals(Endpoint.exclusive(Count.of(BigDecimal.ZERO)), d.boundsOf(A).min());
     }
@@ -166,7 +166,7 @@ class NumericDomainTest {
      */
     @Test
     void aStrictDifferenceBetweenWholeNumbersStepsTheBoundThrough() {
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(atom(A).minus(atom(B)), Rel.LT, whole(A, B))
                 .assume(atom(B).minus(num(1440)), Rel.LE, whole(B));
 
@@ -180,7 +180,7 @@ class NumericDomainTest {
     void aStrictDifferenceWithOneDenseSideTakesNoStep() {
         Map<String, Granularity> mixed = new LinkedHashMap<>(whole(A));
         mixed.putAll(dense(B));
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(atom(A).minus(atom(B)), Rel.LT, mixed)
                 .assume(atom(B).minus(num(1440)), Rel.LE, dense(B));
 
@@ -192,7 +192,7 @@ class NumericDomainTest {
      * 1439.5} satisfies {@code a < b <= 1440}. */
     @Test
     void aStrictDifferenceOverDecimalsHasNoStepToTake() {
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(atom(A).minus(atom(B)), Rel.LT, dense(A, B))
                 .assume(atom(B).minus(num(1440)), Rel.LE, dense(B));
 
@@ -204,7 +204,7 @@ class NumericDomainTest {
      * every relational invariant in {@code souther-examples} is, and why they move nothing. */
     @Test
     void aNonStrictDifferenceBetweenEqualDomainsNarrowsNothing() {
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(atom(A).minus(atom(B)), Rel.LE, whole(A, B))
                 .assume(atom(B).minus(num(1440)), Rel.LE, whole(B))
                 .assume(atom(A).negate(), Rel.LE, whole(A));
@@ -217,7 +217,7 @@ class NumericDomainTest {
 
     @Test
     void aBoundReachesAnAtomThroughAChainOfDifferences() {
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(atom(A).minus(atom(B)), Rel.LE, whole(A, B))
                 .assume(atom(B).minus(atom("c")), Rel.LE, whole(B, "c"))
                 .assume(atom("c").minus(num(10)), Rel.LE, whole("c"));
@@ -227,7 +227,7 @@ class NumericDomainTest {
 
     @Test
     void contradictingBoundsMakeThePathInfeasible() {
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(atom(A).minus(num(1)), Rel.GE, whole(A))
                 .assume(atom(A), Rel.LE, whole(A));
 
@@ -238,7 +238,7 @@ class NumericDomainTest {
 
     @Test
     void anIntervalAndADifferenceOverWholeNumbersLoseNothing() {
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(atom(A).minus(atom(B)), Rel.LT, whole(A, B))
                 .assume(atom(B).minus(num(1440)), Rel.LE, whole(B))
                 .assume(atom(A).negate(), Rel.LE, whole(A));
@@ -249,7 +249,7 @@ class NumericDomainTest {
     /** A loss names the atoms the rule was written about, which is what a reader of it is told. */
     @Test
     void aLossNamesTheAtomsTheRuleWasWrittenAbout() {
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(atom(A), Rel.NE, whole(A))
                 .assume(atom(B).minus(num(10)), Rel.LE, whole(B));
 
@@ -261,7 +261,7 @@ class NumericDomainTest {
      * the whole of what was asserted and so no loss. */
     @Test
     void aStrictBoundOnADenseAtomIsKeptAsAnEndTheRangeDoesNotReach() {
-        NumericDomain interval = NumericDomain.top()
+        NumericDomain<String> interval = NumericDomain.<String>top()
                 .assume(atom(A).minus(num(3)), Rel.LT, dense(A));
 
         assertEquals(Endpoint.exclusive(Count.of(3)), interval.boundsOf(A).max());
@@ -272,7 +272,7 @@ class NumericDomainTest {
      * value it steps onto is one the rule admits. */
     @Test
     void aStrictBoundOnAWholeNumberIsNoLoss() {
-        NumericDomain d = NumericDomain.top().assume(atom(A).minus(num(3)), Rel.LT, whole(A));
+        NumericDomain<String> d = NumericDomain.<String>top().assume(atom(A).minus(num(3)), Rel.LT, whole(A));
 
         assertEquals(Endpoint.inclusive(Count.of(2)), d.boundsOf(A).max());
         assertTrue(d.projectionIsLossless());
@@ -281,7 +281,7 @@ class NumericDomainTest {
     /** A disequality is a hole in a range, and a range is all this holds. */
     @Test
     void aDisequalityIsRecordedAsALoss() {
-        NumericDomain d = NumericDomain.top().assume(atom(A), Rel.NE, whole(A));
+        NumericDomain<String> d = NumericDomain.<String>top().assume(atom(A), Rel.NE, whole(A));
 
         assertEquals(Set.of(NumericDomain.Loss.DROPPED_DISEQUALITY), d.lossesAt(A));
     }
@@ -289,7 +289,7 @@ class NumericDomainTest {
     /** A form of neither shape proves things and no bound is derived through it. */
     @Test
     void aFormOfNeitherShapeIsRecordedAsALoss() {
-        NumericDomain d = NumericDomain.top()
+        NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(atom(A).plus(atom(B)).minus(num(10)), Rel.LE, whole(A, B));
 
         assertEquals(Set.of(A, B), d.lossyAtoms());
@@ -304,7 +304,7 @@ class NumericDomainTest {
      * naming and the typing disagree, and the answer is to stop rather than to take the safer one. */
     @Test
     void oneAtomIsOneKindOfNumber() {
-        NumericDomain d = NumericDomain.top().assume(atom(A).minus(num(3)), Rel.LE, whole(A));
+        NumericDomain<String> d = NumericDomain.<String>top().assume(atom(A).minus(num(3)), Rel.LE, whole(A));
 
         IllegalStateException thrown = assertThrows(IllegalStateException.class,
                 () -> d.assume(atom(A).minus(num(1)), Rel.GE, dense(A)));
@@ -316,13 +316,13 @@ class NumericDomainTest {
     @Test
     void anAtomWithNoSpacingIsRefusedRatherThanAssumed() {
         assertThrows(IllegalStateException.class,
-                () -> NumericDomain.top().assume(atom(A).minus(num(3)), Rel.LE, Map.of()));
+                () -> NumericDomain.<String>top().assume(atom(A).minus(num(3)), Rel.LE, Map.of()));
     }
 
     /** A form over no atoms needs none: {@code 1 <= 0} is decided by arithmetic. */
     @Test
     void aConstantFormNeedsNoSpacingAtAll() {
-        assertTrue(NumericDomain.top().assume(num(1), Rel.LE, Map.of()).isBottom());
-        assertFalse(NumericDomain.top().assume(num(-1), Rel.LE, Map.of()).isBottom());
+        assertTrue(NumericDomain.<String>top().assume(num(1), Rel.LE, Map.of()).isBottom());
+        assertFalse(NumericDomain.<String>top().assume(num(-1), Rel.LE, Map.of()).isBottom());
     }
 }

--- a/specification.adoc
+++ b/specification.adoc
@@ -1372,7 +1372,9 @@ let settle (xs, bill) = {
 
 A value the procedure cannot name all the way down is not a term. What names a call is what the call was resolved to: a `+let+` of this module or of another is pure and total (<<fn-rules>>), and the language's own operations are what the language defines, so a call to either answers one value wherever it is written with the same arguments. What a `+behavior+` answered is named by nothing, and neither is what applying a function value answered — a function a body was handed may be a behavior injected from outside (<<injected-behavior>>), whose implementation is not the language's and may answer differently each time it is asked. So neither is a size taken of one, nor arithmetic over one.
 
-That a helper's body was written into the body that called it, rather than left as the call, is not one of these questions. A `+let+` that recurses cannot be written in, and answers the same value it would have answered written in; a clause about a construction from either is read the same way. A value that is not a number the procedure carries is not a term either, unless a guard on the path states something about it — a string a call handed back is named by nothing a clause could be read against, and a construction from one is left to the run-time check.
+That a helper's body was written into the body that called it, rather than left as the call, is not one of these questions. A `+let+` that recurses cannot be written in, and answers the same value it would have answered written in; a clause about a construction from either is read the same way.
+
+A value the procedure does not carry as a number is a term all the same where what computes it is one — a string a `+let+` answered is the term that call is. What it has none of is anything said about it: the procedure carries no strings, and there is no rule about the operation, so a clause is read against such a value only where a guard on the path has stated something about that very term. Until one has, a construction from it is left to the run-time check, and the silence is that nothing could be asked rather than that the value has no name.
 
 [,souther]
 ----

--- a/specification.adoc
+++ b/specification.adoc
@@ -1302,6 +1302,8 @@ If the business decides "return a different result when the amount is negative",
 
 An invariant is checked at run time on every construction (<<invariant-mvp>>), and inside the domain a violation aborts (<<violation-destination>>). The compiler *also* checks, per behavior, whether each construction's invariant is *established* where the value is built — so a construction that must abort is caught at compile time, and one a guard makes safe is confirmed.
 
+[[a-construction-is-judged-by-what-it-builds]]A construction is judged by what it builds. What each field is given is what the check reads, whether the source wrote that field a value, took it from another value with a `+...+` spread (<<record-literal>>), or wrote no field at all — a newtype's constructor and the arithmetic that re-wraps one (<<newtype-arithmetic>>) build a value like any other and owe its invariant where they stand. Two ways of writing one construction are one construction: they owe the same clauses, over the same values, and come to the same verdict.
+
 The check is intraprocedural. Within a behavior's `+let+` body it seeds what the input types guarantee — a newtype's own invariant, a product data's invariant over its fields — which is sound because an input of type `+T+` was built through `+T+`'s checked construction. It refines that along each `+guard+` / `+if+` guard (<<guard>>, <<if>>), and at every construction asks whether the guards prove its invariant.
 
 * *Discharged* — the guards prove the invariant. No diagnostic; the construction cannot abort here (overflow aside).
@@ -1350,7 +1352,9 @@ let build (rows) = {
 
 A size taken of a container built by an operation is read through that operation, by the rules in <<invariant-discharge-preservation>>. A size taken of anything else — of what a behavior answered — is not a term, and a clause needing it is left to the run-time check.
 
-Beyond those, a term is any number the procedure can name by what computes it. `+List.sum(xs)+` is a term, and so is `+a * b+`, which the arithmetic below does not read. Naming a value says that two writings of it are one value, and says nothing else: nothing follows from `+List.sum+` being a sum, and nothing has to. A `+guard List.sum(xs) >= bill+` states a relation about that value, `+List.sum(xs) - bill+` is arithmetic over it, and the two meet because both mentions of the call are the same value. A term exists before anything is said about it, so the first guard to mention one states what it states, exactly as a later one does.
+Beyond those, a value is named by what computes it wherever that computation is a function of named parts. `+List.sum(xs)+` is a term, and so is `+a * b+`, which the arithmetic below does not read, and so is a value chosen by an `+if+` or opened by a `+match+`, and one built by a construction. Naming a value says that two writings of it are one value, and says nothing else: nothing follows from `+List.sum+` being a sum, and nothing has to. A `+guard List.sum(xs) >= bill+` states a relation about that value, `+List.sum(xs) - bill+` is arithmetic over it, and the two meet because both mentions of the call are the same value. A term exists before anything is said about it, so the first guard to mention one states what it states, exactly as a later one does.
+
+What is named and what is known of it are two questions, and the second is the one that has rules. A named value the procedure has no rule about is still a value a guard can be written about, and a construction from one is reported as unproven rather than left unsaid — the author is told that the invariant was read here and not established, which is a different thing from its not having been read. Giving the procedure a rule about an operation moves such a construction from unproven to discharged without anything being named differently.
 
 [,souther]
 ----
@@ -1366,7 +1370,9 @@ let settle (xs, bill) = {
 }
 ----
 
-A value the procedure cannot name all the way down is not a term. What a behavior answered is named by nothing, so neither is a size taken of it nor arithmetic over it. A value that is not a number the procedure carries is not a term either, unless a guard on the path states something about it — a string a call handed back is named by nothing a clause could be read against, and a construction from one is left to the run-time check.
+A value the procedure cannot name all the way down is not a term. What names a call is what the call was resolved to: a `+let+` of this module or of another is pure and total (<<fn-rules>>), and the language's own operations are what the language defines, so a call to either answers one value wherever it is written with the same arguments. What a `+behavior+` answered is named by nothing, and neither is what applying a function value answered — a function a body was handed may be a behavior injected from outside (<<injected-behavior>>), whose implementation is not the language's and may answer differently each time it is asked. So neither is a size taken of one, nor arithmetic over one.
+
+That a helper's body was written into the body that called it, rather than left as the call, is not one of these questions. A `+let+` that recurses cannot be written in, and answers the same value it would have answered written in; a clause about a construction from either is read the same way. A value that is not a number the procedure carries is not a term either, unless a guard on the path states something about it — a string a call handed back is named by nothing a clause could be read against, and a construction from one is left to the run-time check.
 
 [,souther]
 ----
@@ -1410,9 +1416,11 @@ let toQty (cart) = one(cart)
 [#invariant-discharge-representation]
 ==== What the check reads
 
-The check reads a behavior's body and the invariants around it at the level the rules above are written at: the standard library's operations are operations, and the `+let+`s a body or an invariant names are expanded into it (<<blocks>>). The two go together. The language defines what `+List.map+` does to a length, and every module has that definition, so a call to it says something on its own. A `+let+` carries no such definition, so what it says is its body — the one another module published as readily as the one written here.
+The check reads a behavior's body and the invariants around it at the level the rules above are written at: the standard library's operations are operations, and a `+let+` a body or an invariant names is read as its body where its body can be written in (<<blocks>>). The language defines what `+List.map+` does to a length, and every module has that definition, so a call to it says something on its own. A `+let+` carries no such definition, so what there is to know about it is what its body does — the body of one another module published as readily as of one written here.
 
-An invariant that arrives from another module arrives expanded (<<published-modules>>), so a clause of an imported type is read as the computation it became rather than as the operations it was written as. Such a clause is outside the statically dischargeable fragment even where the same clause written here would be inside it. A clause written here is inside it whatever it names: an imported value or helper is substituted before the check reads the clause (<<invariant-expressions>>), so the rule the check reads is the rule the author wrote.
+Reading a `+let+` as its body is how more is known, and not how it is named. A `+let+` that recurses is read as the call it is, and the value it answers is named all the same (<<invariant-discharge-terms>>): what is lost is the arithmetic inside it, so a clause is discharged there by a guard about the call rather than by the body's own steps. Nothing about a construction's verdict turns on which of the two a reading did.
+
+[[provenance-does-not-decide-the-fragment]]Where a declaration was written does not decide what can be discharged against it. A type declared in this module, one imported from a module compiled in the same run, and one imported from a module compiled separately and reached through its published classes all state the same invariant, and a construction of any of them is read against the same clauses and comes to the same verdict (<<published-modules>>). How a published declaration travels is the compiler's business; that it says what its author wrote is the language's.
 
 An operation the rules name is named as the call that survives to here, which is not every spelling an author can write: `+List.fold+` is the walk `+List.foldFrom+` from the head (<<stdlib-list>>) and is rewritten to it before any of this, so it is the second name the rules are written against. A rule under a name nothing here holds could not be reached, which is why the compiler's own tests hold each rule to a program that fires it.
 
@@ -2018,6 +2026,8 @@ PreApproved { ...request, preApprovedAt = now(), preApprover = approverId }
 To replace only some fields while keeping the same type, also write the type name and use a spread.
 
 [[a-spread-copies-a-product]]What is spread MUST be a product data, or a sum whose cases all spread one. There has to be a set of fields to copy, and a sum whose cases share nothing has none.
+
+[[a-field-is-supplied-once]]A field is supplied once. A field the literal writes takes the value written, whatever any spread carries; where several spreads carry one field, the first of them supplies it and the rest carry it no more than they carry any other field the literal does not want. So what every field of the construction is given is settled by the literal alone, and it is the same answer wherever it is asked — what runs, what the field's type is checked against, and what the invariant check reads.
 
 [[a-spread-supplies-what-the-fields-need]]What a spread provides MUST have the type the field it lands on needs. Copying by name is not copying by shape: two fields of one name and two types are two fields. If `+x+` has type `+Member+`, write `+Member { ...x, address = newAddress }+`. No dedicated update syntax is provided.
 


### PR DESCRIPTION
Issue #722 reported two constructions the invariant-discharge check is silent about and one sentence of the specification that does not hold. The two silences are the same defect at two nodes: what the check judges, and what it can name, were each an enumeration of the shapes someone had written a case for, and everything outside the enumeration came back as silence — which is what a discharged invariant also produces.

Four changes, each with a success condition that is something disappearing.

## A — one node the whole compiler reads a construction as (05b9fdc4)

`Core.NewData` and `Core.FieldInit` become `Core.Construct` holding every declared field in declaration order with the value it is given. A spread is resolved into the read of that field off the spread source where the construction is elaborated, and closed newtype arithmetic lowers to the same node over the numbers its operands wrap.

Gone: `checkIfConstruction`, `wrapNewtypeValue`, `BodyGen.spreadField`/`spreadableFields`, the declaration-order recovery in `UnreachableReasons` and the `Symbols` it took to do it, and the six places using `spreads().isEmpty()` as a stand-in for a semantic question. The three `__construct` emissions left in a body (tail, value position, attempt) are three codegen contexts for one node.

Found on the way: the multi-spread winner was the last spread for type checking and the first for what ran. Unified on what ran, and written down (`[[a-field-is-supplied-once]]`).

## C — a term is a value, not a rendering of one (55cb1d3d)

The naming was a string built out of its parts' strings, and the encoding was not injective — #229 was a guard about a one-element list discharging a clause about a two-element one. `Term` holds what it is made of; two terms are equal when they are built the same way out of equal parts. Sharing is an interner and an optimisation, not the contract: a term built by another reading is equal to its twin.

`NumericDomain` is generic over what names an atom, so the numeric package stays a domain over named atoms. `Terms.sizeKey` goes: a size is the call that takes it, so a guard's size and a clause's size are one value rather than two spellings that have to keep agreeing.

A real defect came out of the move. Folding a term's hash with `h * 31 + part.hash` gives a term that reads one part twice a factor of 32 per link, and thirty-two is a power of two — seven links shift a level's own hash out and every link past that hashes alike. That chain is exactly what a body naming a value and reading it twice builds: a thousand links took 8.7 seconds where a hundred took 20 milliseconds. Mixed with a large odd multiplier and an avalanche, and held by a test that asks the chain to spread over hashes rather than by a time.

## B — a value is named by what computes it (09a2a2d4)

`Naming` splits the silence in two: `Opaque(reason)` is this check's semantics, `Unsupported(form)` is this compiler being unfinished. The classification is a switch over `Core` with no default, so a shape added to the language stops the build.

What a call answers is named by what the call was resolved to. `Core.Reached` now carries the `ValueName` beside the reach name it already held — a bare spelling reaches a module's helper and an injected behavior alike, and resolving it again downstream would be resolving a name this compiler resolved already. A `let` is pure and total, so a call to one answers a value two writings share; a `behavior`'s answer is named by nothing, and so is what applying a function value answers. Whether the reading expanded a helper — which is what `HelperGraph.recurses` decides — does not appear in the nameability path.

## D — the specification says what the check does (8b8b8740)

The sentence putting an imported invariant outside the dischargeable fragment is replaced by the law that where a declaration was written does not decide what can be discharged against it. Terms are written as the rule they are rather than as a list of shapes. Naming a value and having a rule about it are said apart.

## What was measured

**Corpus, A:** one new warning, `crm/quoting.sou:460` — the `Quote` built with a spread in `renewQuote`. The `Quote` written out field by field at `:244` already warned on develop, so the corpus held the defect and now the two agree.

**Corpus, C:** identical to A. Nothing about the identity change widens what can be named.

**Corpus, B:** three new warnings, and each was attributed by removing the rule that produced it.

| mutant (that rule alone reverted) | corpus |
|---|---|
| helper/stdlib/builtin call opaque again | 16 — unchanged |
| `Some`/`None` unnamed again | 16 — unchanged |
| attempted construction unnamed again | 16 — unchanged |
| **`match` unnamed again** | **13 — identical to C** |

So all three come from `match` becoming nameable, and naming what a call answers changes nothing in this corpus. The call mutant is not inert: reverting it fails `aHelperCallIsNamedByItsCall` on the standing-call spelling, which is the reproduction from the issue. A count would have said the call rule was unnecessary; what it measures is this corpus's coverage, not the rule.

`match` becoming nameable closed a second spelling difference nobody had reported: a construction over what an `if` chose was judged and the same construction over what a `match` answered was not.

All three new warnings are the same shape — `Int.clamp(0, 100, …)` bounding a value the procedure has no rule for. The value is named, the clause is read, and nothing establishes it. A guard about the same call silences it, which is what says the report is not a trap, and a preservation rule for the operation would discharge it later without anything being named differently.

## The laws, and where they are held

- construction invariance — `AConstructionIsJudgedByWhatItBuildsTest`
- denotation invariance — `AHelperCallIsNameableWhetherOrNotItWasExpandedTest`
- provenance invariance — `WhereADeclarationCameFromDoesNotDecideItsDischargeTest`, over three provenances including a library compiled on its own and handed over as nothing but its classes
- identity — `OneNameIsOneValueTest`, `ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest`
- field precedence — `AFieldTakesItsValueFromOneSourceTest`

None of the three reproductions from the issue survives as a test of its own.

## Reading the issue when it is closed

The issue explains the second case through `HelperGraph.recurses`, and that is how the missing rule became observable rather than the rule itself. Recursion decides whether a helper's body can be written into its caller, which is a fact about the reading; what a call answers is a value either way.

Green on every module (compiler 4410).