### PR TITLE
Preserve source provenance through helper expansion

### DIFF
--- a/souther-bench/src/test/java/souther/bench/CorpusTest.java
+++ b/souther-bench/src/test/java/souther/bench/CorpusTest.java
@@ -2,6 +2,10 @@ package souther.bench;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Compilation;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  * That every corpus still compiles. The benchmarks themselves are not run here — a shared machine
  * says nothing reliable about how long anything takes — but what they are measured against has to
@@ -14,6 +18,49 @@ class CorpusTest {
     void everyCorpusCompiles() {
         for (Corpus corpus : Corpus.all()) {
             corpus.check(corpus.compile());
+        }
+    }
+
+    /**
+     * That something here is still several sources compiled as one.
+     *
+     * <p>What a corpus is for is measuring the compiler against a model of the size someone writes,
+     * and a model that size is written in several files that name each other. A corpus that lost
+     * that — a file dropped, a corpus replaced by a smaller one — would go on compiling and go on
+     * being timed, and every question about what happens between two modules would be asked of
+     * inputs that have only one. The failure is silent by construction: nothing about a single-file
+     * compile looks wrong.
+     *
+     * <p>What this does not claim: that a body here is spliced across a module. The corpora import
+     * each other's types and none of them calls the other's helpers, so nothing measured here
+     * exercises a body copied out of another module's file. That is held by
+     * {@code ACopiedBodyIsReadAgainstAFileThisCompileHasTest} on a fixture written for it.
+     */
+    @Test
+    void someCorpusIsSeveralSourcesHandedOverAsOneCompile() {
+        for (Corpus corpus : Corpus.all()) {
+            if (corpus.sources().size() < 2) {
+                continue;
+            }
+            Compilation compilation = corpus.compile();
+            if (compilation.modules().size() >= 2) {
+                return;
+            }
+        }
+        throw new AssertionError("no corpus hands several sources naming several modules to one"
+                + " compile: " + Corpus.all().stream()
+                        .map(c -> c + " (" + c.sources().size() + " sources)").toList());
+    }
+
+    /** And a corpus of one source is one on purpose, not one that lost its files: it names one
+     *  module, so there was never a second file for it to have lost. */
+    @Test
+    void aCorpusOfOneSourceNamesOneModule() {
+        for (Corpus corpus : Corpus.all()) {
+            if (corpus.sources().size() == 1) {
+                assertTrue(corpus.compile().modules().size() == 1,
+                        () -> corpus + " is one source and names several modules");
+            }
         }
     }
 }

--- a/souther-cli/src/test/java/souther/cli/WhatStrictRefusesIsWhatTheRowsDoNotCoverTest.java
+++ b/souther-cli/src/test/java/souther/cli/WhatStrictRefusesIsWhatTheRowsDoNotCoverTest.java
@@ -280,7 +280,7 @@ class WhatStrictRefusesIsWhatTheRowsDoNotCoverTest {
                 null, List.of());
         return new AdequacyReport(AdequacyReport.SCHEMA_VERSION, "test", Adequacy.Level.ALL,
                 MeasurementStatus.COMPLETE,
-                List.of(new AdequacyReport.ModuleReport("example.wide", MeasurementStatus.COMPLETE,
+                List.of(new AdequacyReport.ModuleReport("example.wide", "wide.sou", MeasurementStatus.COMPLETE,
                         List.of(), List.of(behavior))))
                 .adequacy();
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/BottomInfer.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BottomInfer.java
@@ -3,7 +3,6 @@ package souther.compiler.check;
 import souther.compiler.ast.Hir;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
-import souther.compiler.diag.SourcePos;
 import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
@@ -127,14 +126,19 @@ public final class BottomInfer {
      *       accumulator whose type is the fold's result. A higher-order function that merely takes a
      *       closure and an empty collection ({@code List.map}/{@code filter} over {@code []}) does not
      *       match, so its step failure is not relabelled as a fold-seed error; and</li>
-     *   <li>the seed's source position differs from the call's. A combinator inlined onto its call
-     *       site (e.g. {@code List.map}'s internal {@code []} accumulator, which desugars to a
-     *       {@code List.foldFrom}) carries the call's own position; the caller never wrote an empty
-     *       seed there, so it is excluded.</li>
+     *   <li>the seed is written where it stands. A combinator whose body this compile cannot show
+     *       (e.g. {@code List.map}'s internal {@code []} accumulator, which desugars to a
+     *       {@code List.foldFrom}) is copied onto the call, and its seed stands in for a line of
+     *       {@code souther.list}; the caller never wrote an empty seed there, so it is excluded.</li>
      * </ul>
+     *
+     * <p>Asked of the seed rather than worked out from its coordinate. Comparing the seed's position
+     * with the call's answered this by the fact that a copy is given the call's own — which was true
+     * and was a coincidence: it is the same inference from a coordinate that had a helper of another
+     * module reported at its caller, and it says nothing about a seed written where the copy came
+     * from. The position says which it is now, so it is read.
      */
-    static int untypedEmptySeed(List<Hir.Expr> args, Type.FnOf fn, Map<String, Type> bind,
-                                        SourcePos callPos) {
+    static int untypedEmptySeed(List<Hir.Expr> args, Type.FnOf fn, Map<String, Type> bind) {
         int seed = 1;
         if (fn.params().size() <= seed || args.size() <= seed) {
             return -1;
@@ -144,7 +148,7 @@ public final class BottomInfer {
                 && fn.params().get(seed).equals(fn.result());
         if (foldShaped
                 && isEmptyCollectionLiteral(args.get(seed))
-                && !args.get(seed).pos().equals(callPos)
+                && !args.get(seed).pos().isOutOfSight()
                 && Type.mentions(TypeOps.substitute(fn.params().get(seed), bind), BottomInfer::isBottom)) {
             return seed;
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -450,7 +450,7 @@ public final class CallElaborator {
                 }
             }
         } catch (CompileException stepError) {
-            int seed = BottomInfer.untypedEmptySeed(args, signature, bind, call.pos());
+            int seed = BottomInfer.untypedEmptySeed(args, signature, bind);
             if (seed < 0 || !BottomInfer.reportsUnresolvedBottom(stepError)) {
                 throw stepError;
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/CitableRegion.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CitableRegion.java
@@ -45,7 +45,24 @@ record CitableRegion(Region region) {
         if (!Objects.equals(start, end)) {
             throw new NotOnePlace(start, end);
         }
-        return start == null ? Optional.empty() : Optional.of(new CitableRegion(region));
+        return canShow(region.start()) ? Optional.of(new CitableRegion(region)) : Optional.empty();
+    }
+
+    /**
+     * Whether this compile can show the reader the place {@code where} names.
+     *
+     * <p>The question this type is about, on its own, for the callers holding a point rather than a
+     * stretch — {@link HelperInliner} deciding whether a body it is copying may keep the positions it
+     * was written at. Both read it here: a compile that answered the same question two ways would
+     * quote one place and refuse to quote the other, which is how a helper of a module compiled
+     * alongside came to be treated as shipped source.
+     *
+     * <p>A position was read from a source of this compile or it was not, and the sources of a
+     * compile are exactly the ones it was handed: the standard library and a module read back off the
+     * module path are parsed from text that names no source, which is what says so.
+     */
+    static boolean canShow(SourcePos where) {
+        return where != null && where.sourceId() != null;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -15,6 +15,7 @@ import souther.compiler.diag.msg.DeclarationMessage;
 import souther.compiler.diag.msg.HelperMessage;
 import souther.compiler.diag.Region;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.diag.WrittenAt;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -1207,11 +1208,14 @@ public final class HelperInliner {
         // and nothing left afterwards says the two came from one application.
         Map<String, Type> applied = instantiation(helper, mine);
         Arguments arguments = bindArguments(rawCall, call, helper, args, applied, ours);
-        // a prelude helper's body is stamped with the call site, so errors inside it point at
-        // the user's call, not at the shipped source of souther.*
+        // A body this compile cannot show is copied with the call site stamped over it, so a report
+        // from inside it points at the user's call rather than at a line nobody holds — and the
+        // stamp says that is what it is doing, so nothing downstream reads the call as the place the
+        // code is written.
+        WrittenAt written = whereTheBodyIs(call, helper);
         Renaming renaming = new Renaming(arguments.subst(), new Copy(helper.writtenBody(), ours),
-                keepsItsPositions(call) ? null : call.pos(),
-                keepsItsPositions(call) ? null : call.region());
+                written instanceof WrittenAt.OutOfSight out ? call.pos().standingInFor(out) : null,
+                written instanceof WrittenAt.OutOfSight out ? standingIn(call.region(), out) : null);
         Hir.Expr body = inline(rename(helper.writtenBody(), renaming));   // expand nested helpers too
         List<Hir.Bound> bound = new ArrayList<>(arguments.bound());
         // A scoped lambda the body still names was passed rather than applied, so nothing
@@ -1917,22 +1921,40 @@ public final class HelperInliner {
     }
 
     /**
-     * Whether expanding this helper leaves the positions in its body alone. A module-own helper does:
-     * its body lies in the user's file, so it is already where a diagnostic should point. A lambda
-     * given to a fn parameter does too: it is the caller's own code, and a lambda written in a prelude
-     * body was stamped with the call site when that body was renamed, so either way its positions are
-     * the ones to report. Everything else is a prelude helper, whose body lies in the shipped source of
-     * {@code souther.*} and is stamped with the call site instead.
+     * Where the body this call expands is written, as far as this compile can show it: {@link
+     * WrittenAt#HERE} when the copy may keep the positions it was written at, and what it stands in
+     * for when it may not.
+     *
+     * <p>Asked of the one thing that decides it — whether this compile can show the reader the place
+     * those positions name ({@link CitableRegion#canShow}). It used to be asked of the module that
+     * declared the body, which is a different question that happened to have the same answer while
+     * the only body from elsewhere was the standard library's. A module of the same project answers
+     * them differently: its body is in a file the reader holds, and it was being treated as shipped
+     * source — reported at the call, with the caret sized for a construction three files away.
+     *
+     * <p>A lambda is not asked. It is not a declaration and has no source of its own: one the caller
+     * wrote is in the caller's file, and one written in a body from elsewhere was given the call site
+     * when that body was copied. Either way its positions are the ones already decided for the body
+     * holding it, and asking again would answer about the wrong thing.
      */
-    private boolean keepsItsPositions(Hir.Apply call) {
-        return switch (call.denotes()) {
-            // a lambda, wherever it came from: the caller wrote it, or a prelude body wrote it and
-            // was stamped with the call site when that body was renamed
-            case ValueName.Local _ -> true;
-            case ValueName.Helper helper -> helper.module().equals(table.module());
-            case ValueName.Stdlib _, ValueName.Behavior _, ValueName.OfType _,
-                    ValueName.Builtin _ -> false;
-        };
+    private WrittenAt whereTheBodyIs(Hir.Apply call, Hir.FnDef helper) {
+        if (call.denotes() instanceof ValueName.Local || CitableRegion.canShow(helper.pos())) {
+            return WrittenAt.HERE;
+        }
+        // Reached rather than declared: `List.map` is what a reader here writes and what a report
+        // about it should quote, and which module declares it is the other half, read off the
+        // declaration rather than split back out of the name.
+        return new WrittenAt.OutOfSight(call.reaches());
+    }
+
+    /** {@code call}'s own place, said to stand in for a body written out of sight — what a copy that
+     *  may not keep its own positions is given, ends and all, so no part of it claims to be written
+     *  where the rest of it only stands. */
+    private static Region standingIn(Region call, WrittenAt out) {
+        if (call == null || call.start() == null || call.end() == null) {
+            return call;
+        }
+        return new Region(call.start().standingInFor(out), call.end().standingInFor(out));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -570,6 +570,12 @@ public final class Compilation {
      * <p>Always answered, whatever the compile tells a caller about its sources. What a source is
      * called here is how a report is filed and how its regions are quoted; what a caller is told is
      * {@link #sourceIdOf(Db.Found)}, and the two are not the same question.
+     *
+     * <p>Which module the report is a failure of is a third question and not this one. A report
+     * points into another module wherever the code it is about was written there — an invariant of
+     * this module reaching a construction in a helper another module declares — and the caret stays
+     * on that code, because that is what the report is about. Where it is said is
+     * {@link #publishSourceIdsOf(Db.Found)}.
      */
     private String locatedSourceIdOf(Db.Found found) {
         String claimed = found.claimedSourceId();
@@ -577,6 +583,18 @@ public final class Compilation {
             return claimed;
         }
         return found.module() == null ? null : sourceIdOf(found.module());
+    }
+
+    /**
+     * Whether {@code found}'s caret is in a file of some module other than the one it was found
+     * about.
+     *
+     * <p>Answered only where both are known, so this is yes when the compile can say the file is
+     * another module's, and never because it could not say whose it is.
+     */
+    private boolean pointsIntoAnotherModule(Db.Found found) {
+        String owner = moduleOf(locatedSourceIdOf(found));
+        return found.module() != null && owner != null && !owner.equals(found.module());
     }
 
     /**
@@ -594,6 +612,14 @@ public final class Compilation {
      *
      * <p>Read off the regions rather than off a list of files, so every entry is somewhere the
      * report has something to show.
+     *
+     * <p>A caret in another module's file is the second case whether or not the site that found it
+     * said so. A rule of this module is broken by code written in another — an invariant here
+     * reaching a construction in a helper declared there — and the caret belongs on that code, which
+     * is what has to change. Said only there, the module whose rule it is would be told nothing: its
+     * author would have a compile that fails and a clean file in front of them. Said only here, the
+     * author would be sent to a call that constructs nothing. It is written in two files, so it is
+     * said in both, which is what this already does for a report that asks.
      */
     public List<String> publishSourceIdsOf(Db.Found found) {
         String primary = locatedSourceIdOf(found);
@@ -601,7 +627,7 @@ public final class Compilation {
         if (primary != null) {
             saidAt.add(primary);
         }
-        if (found.report().delivery().saidAtEveryRegion()) {
+        if (found.report().delivery().saidAtEveryRegion() || pointsIntoAnotherModule(found)) {
             for (LabeledRegion label : found.report().diagnostic().secondary()) {
                 String where = label.sourceIdOr(primary);
                 if (where != null && !saidAt.contains(where)) {

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -3,6 +3,7 @@ package souther.compiler.report;
 import souther.compiler.examples.ExampleVerifier;
 import souther.compiler.ast.Hir;
 import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.diag.SourcePos;
 import souther.compiler.diag.SourceRef;
 import souther.compiler.meta.ModuleMetadata;
 import souther.compiler.check.Prepared;
@@ -72,7 +73,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         UNDETERMINED
     }
 
-    public record ModuleReport(String module, MeasurementStatus status,
+    public record ModuleReport(String module, String declaredIn, MeasurementStatus status,
                                List<Incompleteness> incompleteness, List<BehaviorReport> behaviors) {
         public ModuleReport {
             incompleteness = List.copyOf(incompleteness);
@@ -232,7 +233,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         for (BehaviorReport behavior : behaviors) {
             status = status.and(behavior.status());
         }
-        return new ModuleReport(name, status, incompleteness, behaviors);
+        return new ModuleReport(name, compilation.sourceIdOf(name), status, incompleteness,
+                behaviors);
     }
 
     /** This report with only the modules and behaviors the caller asked about. A name that matches
@@ -263,7 +265,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             for (BehaviorReport shownBehavior : behaviors) {
                 status = status.and(shownBehavior.status());
             }
-            kept.add(new ModuleReport(m.module(), status, gaps, behaviors));
+            kept.add(new ModuleReport(m.module(), m.declaredIn(), status, gaps, behaviors));
             overall = overall.and(status);
         }
         return new AdequacyReport(schemaVersion, compilerVersion, askedLevel, overall,
@@ -413,7 +415,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                         behavior.rows(), behavior.pending()));
                 signature(out, behavior);
                 partition(out, behavior);
-                branch(out, behavior);
+                branch(out, behavior, module.declaredIn(), names);
                 // Under the behavior it names, because a reason printed at the module's foot is
                 // read as belonging to whichever behavior came last. That was survivable while the
                 // only reasons naming one were rare; a position that could not be read is not.
@@ -655,7 +657,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      * arms and says nothing about their combinations, and a report that said "paths covered" would
      * invite an author to stop looking exactly where there is more to find.
      */
-    private static void branch(StringBuilder out, BehaviorReport behavior) {
+    private static void branch(StringBuilder out, BehaviorReport behavior,
+                               String declaredIn, SourceNameResolver names) {
         Adequacy.BranchEvidence branch = behavior.branch();
         if (branch == null) {
             return;
@@ -682,17 +685,35 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         boolean decided = branch.status() == MeasurementStatus.COMPLETE;
         out.append(String.format("    branch      %d/%d%s%n", branch.coveredObligations(),
                 branch.obligations(), decided ? "" : "   (undecided: a row was not read)"));
-        // The position alone: an arm is part of a body, and a body is written in the module's own
-        // source, which the section this is under already names. Only a row can be somewhere else.
-        // Named only where every row was read: an arm a row that never finished might have gone
-        // through is undecided, and calling it unreached sends the author after a row that exists.
+        // The position alone where the arm is in the module's own source, which the section this is
+        // under already names. It is not always: a body is spliced into whatever calls it, so an arm
+        // written in a helper another module declares is in that module's file, and there the file is
+        // named with it. Named only where every row was read: an arm a row that never finished might
+        // have gone through is undecided, and calling it unreached sends the author after a row that
+        // exists.
         if (!decided) {
             return;
         }
         for (Adequacy.Finding f : behavior.of(Adequacy.Kind.ARM_UNREACHED)) {
             out.append(String.format("      · no row goes through `%s` (%s)%n",
-                    f.args().get(0), f.at()));
+                    f.args().get(0), where(f.at(), declaredIn, names)));
         }
+    }
+
+    /**
+     * Where a site is, as this report writes it: the position on its own where it is in the source
+     * the section is about, and the file with it where it is not.
+     *
+     * <p>A line and a column are a place only beside a file. They read as one here because the
+     * section names the module and nearly everything it reports is written there — and a coordinate
+     * from another file, printed the same way, points at whatever happens to sit at those numbers in
+     * the one the reader has in mind.
+     */
+    private static String where(SourcePos at, String declaredIn, SourceNameResolver names) {
+        if (at == null || at.sourceId() == null || at.sourceId().equals(declaredIn)) {
+            return String.valueOf(at);
+        }
+        return names.nameOf(at.sourceId()) + ":" + at;
     }
 
     /**

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -713,5 +713,8 @@ example.the-evaluation-spent-its-steps=The evaluation of this row did not finish
 example.spending-the-budget-is-not-diverging=What the counting shows is that the evaluation did not finish, not that the model does not: a `partial` recursion that never stops reaches this, and so does one that would have stopped shortly after. If the model does finish and needs more, raise `souther.example.step.limit`; otherwise bound the loop or make the recursion structural.
 example.the-evaluation-reached-its-depth-limit=The evaluation of this row reached its recursion-depth limit of {limit}.
 example.reaching-the-depth-limit-is-not-diverging=What the counting shows is that the recursion went deeper than the limit, not that it never bottoms out. If the data really is that deep, raise `souther.example.recursion.depth`; otherwise recurse on a part of the argument so it bottoms out.
+# --- where a report's caret stands in for code this compile has no source for ---
+written-at.the-code-is-written-out-of-sight=The code is written in `{declaration}`, which this compile has no source for, so this is where it was reached from and not where it is.
+
 cli.help.command=`souther` has no command `{0}`
 cli.help.arguments=`souther help` is written about one command; it was given {0}

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -708,5 +708,8 @@ example.the-evaluation-spent-its-steps=この行の評価が、{budget} ステ�
 example.spending-the-budget-is-not-diverging=計数が示しているのは評価が終わらなかったことで、モデルが停止しないことではありません。止まらない `partial` な再帰もここに来ますし、あと少しで止まったものも来ます。モデルが実際に停止していてもっと必要なら `souther.example.step.limit` を上げてください。そうでなければループを押さえるか、再帰を構造的にしてください。
 example.the-evaluation-reached-its-depth-limit=この行の評価が、再帰深度の上限 {limit} に達しました。
 example.reaching-the-depth-limit-is-not-diverging=計数が示しているのは再帰が上限より深く進んだことで、底に到達しないことではありません。データが本当にそれだけ深いなら `souther.example.recursion.depth` を上げてください。そうでなければ引数の一部で再帰して底に到達するようにしてください。
+# --- where a report's caret stands in for code this compile has no source for ---
+written-at.the-code-is-written-out-of-sight=そのコードは `{declaration}` に書かれていて、このコンパイルはそのソースを持っていません。ここは書かれた場所ではなく、そこへ到達した場所です。
+
 cli.help.command=`souther` に `{0}` というコマンドはありません。
 cli.help.arguments=`souther help` は1つのコマンドについて書きますが、{0} が指定されています。

--- a/souther-compiler/src/test/java/souther/compiler/check/ACopiedBodyIsReadAgainstAFileThisCompileHasTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ACopiedBodyIsReadAgainstAFileThisCompileHasTest.java
@@ -1,0 +1,181 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.Compiler;
+import souther.compiler.ast.Hir;
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.diag.WrittenAt;
+import souther.compiler.frontend.CstFrontend;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The two things a body carries once it has been copied into somewhere else, and which of them each
+ * answers.
+ *
+ * <p>A body is spliced into everything that calls it. Where it came from a source this compile
+ * holds, the copy keeps the positions it was written at. Where it did not — the standard library, a
+ * module read back off the module path — those positions name a file nobody holds, so the copy is
+ * given the call site, and every rule checked on it reports at a coordinate in the caller's file.
+ *
+ * <p>Two claims, and they are separate. Every coordinate a check reads is one this compile can quote,
+ * or a report lands on a line the reader is not looking at. And a coordinate that was given rather
+ * than written says so, all the way down to what the backend is built from — or a rule reported from
+ * there states its subject is at a place it is not, which nothing about the coordinate could
+ * contradict.
+ */
+class ACopiedBodyIsReadAgainstAFileThisCompileHasTest {
+
+    /** A body that reaches the standard library, whose source no compile of a user model has. */
+    private static final String OVER_THE_LIBRARY = """
+            module demo
+
+            data Kept
+            data Dropped
+            data Mark = Kept | Dropped
+
+            data Item = { mark: Mark }
+
+            let kept (items: List<Item>): Int =
+                List.length(List.filter(i -> i.mark == Kept, items))
+            """;
+
+    private static final String DECLARING = """
+            module up exposing ( doubled )
+            let doubled (x: Int): Int = x + x
+            """;
+
+    private static final String IMPORTING = """
+            module down
+            import up ( doubled )
+
+            data Count = Int
+                invariant value >= 0
+
+            behavior twice : (n: Int) -> Count
+                constructs Count
+            let twice (n) = Count(doubled(n))
+            """;
+
+    // --- every coordinate a check reads is one this compile can quote ---------------------------
+
+    @Test
+    void everyPositionInAnExpandedBodyNamesASourceThisCompileHas() {
+        List<SourcePos> positions = positionsIn(expanded(OVER_THE_LIBRARY, "kept"));
+
+        List<SourcePos> nowhere = positions.stream().filter(p -> p.sourceId() == null).toList();
+        assertEquals(List.of(), nowhere,
+                "a copy read against the caller's file carries coordinates of that file");
+    }
+
+    /** And the walk is looking at copied nodes while it says so: a body holding none would pass this
+     *  by having nothing to be wrong about. */
+    @Test
+    void andSomeOfThemWereCopiedFromOutOfSight() {
+        List<SourcePos> positions = positionsIn(expanded(OVER_THE_LIBRARY, "kept"));
+
+        assertFalse(positions.stream().noneMatch(SourcePos::isOutOfSight),
+                "the fixture expands a library body, so some of what was walked came from one");
+    }
+
+    /** The other half of the same rule: a body whose source this compile does have keeps the
+     *  positions it was written at, so nothing about it stands in for anything. */
+    @Test
+    void aBodyThisCompileHasTheSourceOfIsNotStoodInFor() {
+        List<SourcePos> positions = positionsIn(coreOf(
+                Map.of("down.sou", IMPORTING, "up.sou", DECLARING), ModulePath.EMPTY,
+                "down", "twice"));
+
+        assertTrue(positions.stream().anyMatch(p -> "up.sou".equals(p.sourceId())),
+                "the imported body was spliced in, keeping the file it was written in");
+        assertEquals(List.of(), positions.stream().filter(SourcePos::isOutOfSight).toList(),
+                "a place this compile can show is not a place anything stands in for");
+    }
+
+    // --- and the answer survives being lowered --------------------------------------------------
+
+    /**
+     * What the backend is built from carries it too. {@code Core} keeps a coordinate and no expansion
+     * structure, so a rule checked there — the invariant-discharge reader, which reports at a
+     * construction — has the coordinate and nothing else to ask.
+     */
+    @Test
+    void aCoordinateGivenToACopyStillSaysSoInCore() {
+        List<SourcePos> positions = positionsIn(coreOf(Map.of("down.sou", IMPORTING),
+                published(DECLARING), "down", "twice"));
+
+        assertEquals(List.of(), positions.stream().filter(p -> p.sourceId() == null).toList(),
+                "every coordinate the backend is built from names a source this compile has");
+        assertTrue(positions.stream().anyMatch(p ->
+                        new WrittenAt.OutOfSight("up.doubled").equals(p.writtenAt())),
+                "the body came from a module read off the path, and the lowering did not forget");
+    }
+
+    // --- the fixtures ---------------------------------------------------------------------------
+
+    /** {@code behavior}'s body with every helper call expanded, as a check downstream reads it. */
+    private static Hir.Expr expanded(String source, String fn) {
+        var parsed = CstFrontend.parseWithSlices(source, null, "demo.sou");
+        Hir.Module module = Resolve.module(parsed.module(), SyntaxSymbols.of(parsed.module()));
+        HelperInliner inliner = HelperInliner.forModule(module);
+        Hir.FnDef body = inliner.held().get(fn);
+        assertNotNull(body, "the fn under test is one of the module's own");
+        return inliner.inline(body.writtenBody(), inliner.bodyOf(fn));
+    }
+
+    private static Core coreOf(Map<String, String> sources, ModulePath path, String module,
+                               String behavior) {
+        Compilation compilation = Compilation.ofDocuments(sources, Set.of(), path);
+        compilation.answerEverything();
+        Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
+        assertNotNull(checked, "the model under test compiles");
+        Core body = checked.behaviorBodies().get(behavior);
+        assertNotNull(body, "the behavior under test has a body");
+        return body;
+    }
+
+    /** The declaring module as another project built it: classes alone, no source. */
+    private static ModulePath published(String source) {
+        Map<String, byte[]> classes = Compiler.compileModules(List.of(source));
+        return classes::get;
+    }
+
+    private static List<SourcePos> positionsIn(Hir.Expr e) {
+        List<SourcePos> out = new ArrayList<>();
+        walk(e, out);
+        return out;
+    }
+
+    private static void walk(Hir.Expr e, List<SourcePos> out) {
+        if (e.pos() != null) {
+            out.add(e.pos());
+        }
+        Hir.forEachChild(e, c -> walk(c, out));
+    }
+
+    private static List<SourcePos> positionsIn(Core e) {
+        List<SourcePos> out = new ArrayList<>();
+        walk(e, out);
+        return out;
+    }
+
+    private static void walk(Core e, List<SourcePos> out) {
+        if (e.pos() != null) {
+            out.add(e.pos());
+        }
+        Core.forEachChild(e, c -> walk(c, out));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AHelperSaysTheSameThingWhereverItIsDeclaredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AHelperSaysTheSameThingWhereverItIsDeclaredTest.java
@@ -1,0 +1,233 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.DiagnosticRenderer;
+import souther.compiler.diag.LabeledRegion;
+import souther.compiler.diag.Located;
+import souther.compiler.diag.Messages;
+import souther.compiler.diag.Region;
+import souther.compiler.diag.WrittenAt;
+import souther.compiler.diag.msg.InvariantMessage;
+import souther.compiler.diag.msg.WrittenAtMessage;
+import souther.compiler.meta.ModulePath;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * One helper, moved between modules, and what a report about the code inside it does with the move.
+ *
+ * <p>The helper builds a data, and an invariant that calls it is refused for reaching a construction.
+ * Which module the helper is declared in is not part of that rule, so what the report says about it
+ * must not turn on the move either — and it did: a helper of another module was treated as shipped
+ * source and reported at the call, with the caret sized for a construction in a file the caret was
+ * not in.
+ *
+ * <p>What the move may change is one thing only: whether this compile can show the reader the place.
+ * A module compiled alongside is a file the reader holds; one read back off the module path is not,
+ * and there the report says where the code is rather than pointing somewhere it is not.
+ */
+class AHelperSaysTheSameThingWhereverItIsDeclaredTest {
+
+    /** The helper, and the construction inside it a report has to send the reader to. */
+    private static final String HELPER =
+            "let atLeastZero (x: Int): Bool = Yen(0).value <= x";
+
+    private static final String ONE_MODULE = """
+            module m
+            data Yen = Int invariant value >= 0
+            %s
+            data Table = Int
+                invariant ok = atLeastZero(value)
+            """.formatted(HELPER);
+
+    private static final String DECLARING = """
+            module up exposing ( Yen, atLeastZero )
+            data Yen = Int invariant value >= 0
+            %s
+            """.formatted(HELPER);
+
+    private static final String CALLING = """
+            module down
+            import up ( atLeastZero )
+            data Table = Int
+                invariant ok = atLeastZero(value)
+            """;
+
+    // --- the two spellings a compile can show both halves of -----------------------------------
+
+    @Test
+    void aHelperOfThisModuleIsReportedAtTheConstruction() {
+        Diagnostic one = only(diagnosticsOf(Map.of("m.sou", ONE_MODULE)), "m.sou");
+
+        assertInstanceOf(InvariantMessage.TheNamedClauseConstructsAData.class, one.said());
+        assertEquals("Yen", quoted(ONE_MODULE, one.region()),
+                "the caret is on the construction, which is what the rule is about");
+        assertEquals(WrittenAt.HERE, one.pos().writtenAt(),
+                "the construction is in a file this compile has, so the caret is at the code");
+    }
+
+    /**
+     * The same helper, declared next door. The report is the one above with the construction in
+     * another file, which is where the reader has to go.
+     */
+    @Test
+    void aHelperOfAnotherModuleCompiledAlongsideIsReportedAtTheConstructionToo() {
+        Diagnostic one = only(diagnosticsOf(Map.of("up.sou", DECLARING, "down.sou", CALLING)),
+                "down.sou");
+
+        assertInstanceOf(InvariantMessage.TheNamedClauseConstructsAData.class, one.said());
+        assertEquals("Yen", quoted(DECLARING, one.region()),
+                "the caret is on the construction, in the file the helper is written in");
+        assertEquals("up.sou", one.pos().sourceId());
+        assertEquals(WrittenAt.HERE, one.pos().writtenAt());
+    }
+
+    /**
+     * And the clause is labelled in both, because what makes the construction wrong is written where
+     * the data is and not where the helper is.
+     */
+    @Test
+    void theClauseThatReachesItIsLabelledWhicheverModuleTheHelperIsIn() {
+        LabeledRegion own = onlyLabel(only(diagnosticsOf(Map.of("m.sou", ONE_MODULE)), "m.sou"));
+        LabeledRegion across = onlyLabel(
+                only(diagnosticsOf(Map.of("up.sou", DECLARING, "down.sou", CALLING)), "down.sou"));
+
+        assertInstanceOf(InvariantMessage.TheClauseReachesThatConstruction.class, own.said());
+        assertInstanceOf(InvariantMessage.TheClauseReachesThatConstruction.class, across.said());
+        assertEquals("invariant ok = atLeastZero(value)", quoted(ONE_MODULE, own.region()));
+        assertEquals("invariant ok = atLeastZero(value)", quoted(CALLING, across.region()));
+    }
+
+    /**
+     * And both files are told, because the problem is written in both. The construction is in
+     * {@code up} and what forbids it is in {@code down}, and neither reads as the whole of it: an
+     * author sent only to {@code up} is looking at a helper that is fine to call from anywhere else,
+     * and an author sent only to {@code down} is looking at a call that constructs nothing.
+     *
+     * <p>Said once each, anchored at what that file holds. The entry carries the source its primary
+     * region is in whichever file it was published to, which is what a reader turns into a caret in
+     * one file and a link into the other.
+     */
+    @Test
+    void bothFilesAreToldAndNeitherIsSilent() {
+        Map<String, List<Located>> byFile = diagnosticsOf(Map.of("up.sou", DECLARING,
+                "down.sou", CALLING));
+
+        assertEquals(1, byFile.get("up.sou").size(), () -> "" + byFile.get("up.sou"));
+        assertEquals(1, byFile.get("down.sou").size(), () -> "" + byFile.get("down.sou"));
+        assertEquals("up.sou", byFile.get("down.sou").get(0).primarySourceId(),
+                "the caret is on the construction wherever the report is published");
+        assertEquals(byFile.get("up.sou").get(0).diagnostic().identity(),
+                byFile.get("down.sou").get(0).diagnostic().identity(),
+                "one problem, said in the two files it is written in");
+    }
+
+    // --- the spelling a compile can show only one half of --------------------------------------
+
+    /**
+     * The helper read back off the module path. Its body is spliced in the same way and the rule is
+     * broken in the same way; what is different is that this compile has no source to quote it from,
+     * so the caret is where the code was reached from — and says so, rather than reading as the place
+     * the construction is written.
+     */
+    @Test
+    void aHelperReadOffTheModulePathIsSaidToBeOutOfSight() {
+        Diagnostic one = only(diagnosticsOf(Map.of("down.sou", CALLING), published(DECLARING)),
+                "down.sou");
+
+        assertInstanceOf(InvariantMessage.TheNamedClauseConstructsAData.class, one.said(),
+                "the rule broken is the same rule");
+        assertEquals(new WrittenAt.OutOfSight("up.atLeastZero"), one.pos().writtenAt());
+        assertEquals("down.sou", one.pos().sourceId(),
+                "the caret is in the file the reader is compiling, since there is no other");
+    }
+
+    /** And it claims no width there. The width a report about a construction measures is the
+     *  construction's, and the caret is on a call whose text is its own length — three columns sized
+     *  for `Yen` landing on `atL`. */
+    @Test
+    void aCaretThatOnlyStandsInClaimsNoWidth() {
+        Diagnostic one = only(diagnosticsOf(Map.of("down.sou", CALLING), published(DECLARING)),
+                "down.sou");
+
+        assertEquals(one.region().start(), one.region().end(),
+                "a stand-in points, it does not underline text it did not measure");
+    }
+
+    /** And every reader is told, because the sentence is said off the caret rather than by the site
+     *  that reported the rule. */
+    @Test
+    void whatTheCaretStandsInForIsInTheBodyEveryRendererReads() {
+        Diagnostic one = only(diagnosticsOf(Map.of("down.sou", CALLING), published(DECLARING)),
+                "down.sou");
+
+        String body = DiagnosticRenderer.body(one, Locale.ENGLISH);
+        String about = Messages.render(
+                new WrittenAtMessage.TheCodeIsWrittenOutOfSight("up.atLeastZero"), Locale.ENGLISH);
+        assertTrue(body.contains(about), () -> body);
+    }
+
+    /** The one it is held against: with the source there, nothing is said about sight, because there
+     *  is nothing to say. */
+    @Test
+    void nothingIsSaidAboutSightWhereTheSourceIsThere() {
+        Diagnostic one = only(diagnosticsOf(Map.of("up.sou", DECLARING, "down.sou", CALLING)),
+                "down.sou");
+
+        String body = DiagnosticRenderer.body(one, Locale.ENGLISH);
+        String about = Messages.render(
+                new WrittenAtMessage.TheCodeIsWrittenOutOfSight("up.atLeastZero"), Locale.ENGLISH);
+        assertTrue(!body.contains(about), () -> body);
+    }
+
+    // --- the fixtures --------------------------------------------------------------------------
+
+    private static Map<String, List<Located>> diagnosticsOf(Map<String, String> sources) {
+        return diagnosticsOf(sources, ModulePath.EMPTY);
+    }
+
+    private static Map<String, List<Located>> diagnosticsOf(Map<String, String> sources,
+                                                            ModulePath path) {
+        return Compiler.diagnoseModules(sources, Set.of(), path);
+    }
+
+    /** The declaring module as another project built it: classes alone, no source. */
+    private static ModulePath published(String source) {
+        Map<String, byte[]> classes = Compiler.compileModules(List.of(source));
+        return classes::get;
+    }
+
+    private static Diagnostic only(Map<String, List<Located>> byFile, String sourceId) {
+        List<Located> here = byFile.get(sourceId);
+        assertNotNull(here, () -> "no entry for " + sourceId + " in " + byFile.keySet());
+        assertEquals(1, here.size(), () -> "expected one diagnostic, got " + here);
+        return here.get(0).diagnostic();
+    }
+
+    private static LabeledRegion onlyLabel(Diagnostic d) {
+        assertEquals(1, d.secondary().size(), () -> "expected one label, got " + d.secondary());
+        return d.secondary().get(0);
+    }
+
+    /** The characters {@code at} covers, cut out of the source it names — what the reader is shown
+     *  under the caret, which is the claim a marker makes. */
+    private static String quoted(String source, Region at) {
+        assertNotNull(at, "a report that points at nothing quotes nothing");
+        List<String> lines = List.of(source.split("\n", -1));
+        String line = lines.get(at.start().line() - 1);
+        int from = at.start().column() - 1;
+        int to = at.end().line() == at.start().line() ? at.end().column() - 1 : line.length();
+        return line.substring(from, Math.min(to, line.length()));
+    }
+}

--- a/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
@@ -198,8 +198,23 @@ public final class Diagnostic {
             return this;
         }
 
+        /**
+         * The place, over the {@code width} units of text it is about — and over none of them where
+         * the place only stands in for code written out of sight.
+         *
+         * <p>The width is measured on the text the report is about, and where that text is out of
+         * sight the coordinate is somewhere else: a call in the caller's file, whose own text is
+         * whatever length it happens to be. Underlining a construction's width from there covers
+         * however many characters of the call the two numbers happen to agree on — three columns
+         * sized for {@code Yen} landing on {@code atL}. A point claims what is true, which is that
+         * this is where the code was reached from.
+         */
         public Builder at(SourcePos pos, int width) {
-            this.region = pos == null ? null : Region.ofWidth(pos, width);
+            if (pos == null) {
+                this.region = null;
+            } else {
+                this.region = pos.isOutOfSight() ? Region.point(pos) : Region.ofWidth(pos, width);
+            }
             return this;
         }
 

--- a/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticRenderer.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticRenderer.java
@@ -1,5 +1,7 @@
 package souther.compiler.diag;
 
+import souther.compiler.diag.msg.WrittenAtMessage;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -69,12 +71,33 @@ public interface DiagnosticRenderer {
         return said.toString();
     }
 
-    /** The message body, from what it says or the compatibility literal. */
+    /**
+     * The message body, from what it says or the compatibility literal, with what its caret stands
+     * in for said after it.
+     *
+     * <p>Here because this is what every reader reads: the terminal, the JSON, an editor, and the
+     * text an exception carries. A caret that stands in for code written out of sight is in the
+     * caller's file and is not where the code is, and a body that did not say so reads as a claim
+     * about the line under it — which is what {@code E2011} made of a call that constructs nothing.
+     * Said off the caret rather than at the sites that report one, so a rule checked on a copied body
+     * says it without being written to.
+     */
     static String body(Diagnostic d, Locale locale) {
         java.util.Objects.requireNonNull(locale, Messages.NEEDS_A_LANGUAGE);
-        if (d.literalMessage() != null) {
-            return d.literalMessage();
+        String said = d.literalMessage() != null ? d.literalMessage()
+                : d.said() == null ? "" : Messages.render(d.said(), locale);
+        if (!(caretStandsInFor(d) instanceof WrittenAt.OutOfSight out)) {
+            return said;
         }
-        return d.said() == null ? "" : Messages.render(d.said(), locale);
+        String about = Messages.render(
+                new WrittenAtMessage.TheCodeIsWrittenOutOfSight(out.declaration()),
+                locale);
+        return said.isEmpty() ? about : said + " " + about;
+    }
+
+    /** What this report's caret stands in for, or {@link WrittenAt#HERE} where it is at the code —
+     *  and where it points at nothing at all, there being no claim about a place to qualify. */
+    private static WrittenAt caretStandsInFor(Diagnostic d) {
+        return d.pos() == null ? WrittenAt.HERE : d.pos().writtenAt();
     }
 }

--- a/souther-syntax/src/main/java/souther/compiler/diag/Region.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Region.java
@@ -24,9 +24,7 @@ public record Region(SourcePos start, SourcePos end) {
      * same line — the length of the text it covers, not the room that text takes on a screen. The
      * end is in the file the start is in: a region does not leave the source it began in. */
     public static Region ofWidth(SourcePos start, int width) {
-        int w = Math.max(0, width);
-        return new Region(start,
-                new SourcePos(start.line(), start.column() + w, start.sourceId()));
+        return new Region(start, start.along(Math.max(0, width)));
     }
 
     /**

--- a/souther-syntax/src/main/java/souther/compiler/diag/SourcePos.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/SourcePos.java
@@ -1,8 +1,18 @@
 package souther.compiler.diag;
 
+import java.util.Objects;
+
 /**
- * A place in a source: a 1-based line and column, and the source they were read from. Every AST node
- * and token carries one so that compile errors can point at the source (spec §non-functional).
+ * Where a node is placed in this compile, and whether that is where its code is written: a 1-based
+ * line and column, the source they were read from, and {@link WrittenAt}. Every AST node and token
+ * carries one so that compile errors can point at the source (spec §non-functional).
+ *
+ * <p>The coordinate is <b>where this compile places the node</b>, which is where the code is written
+ * for everything a source was read for and is not for a copy that could not keep its own positions.
+ * Reading the line as the line the code is on is right only where {@link #writtenAt()} says so, and
+ * a reader that wants the second question answered asks it rather than inferring it from the first:
+ * inferring it is what {@code BottomInfer} did, by comparing an argument's coordinate with its
+ * call's, and what {@code HelperInliner} did, by comparing the declaring module with its own.
  *
  * <p>A line and a column are enough while one file is being read and not enough afterwards. A
  * module's {@code example} rows, fake tables and values are written in the module's own source and
@@ -17,21 +27,61 @@ package souther.compiler.diag;
  * asking what is under a cursor — it compares the coordinates, which is what
  * {@code Names.spans} does.
  *
- * @param sourceId the source this was read from, or null for a position that was read from none: a
- *        node the compiler synthesized, or a module read off the module path, which is in no source
- *        of the compile that is reading it
+ * <p>{@link #writtenAt()} is the other half of the same question and the reason it is here rather
+ * than beside it: an expansion gives a copy the call site where it cannot give it its own positions,
+ * and after that the coordinate is a place in the caller's file which is not where the code is. That
+ * is a fact about this coordinate, so it travels with it — through every pass that rebuilds a node
+ * keeping its position, which is all of them.
+ *
+ * @param line the 1-based line this node is placed at
+ * @param column the 1-based column this node is placed at, in UTF-16 code units
+ * @param sourceId the source the coordinate is in, or null for a position that is in none: a node
+ *        the compiler synthesized, or a module read off the module path, which is in no source of
+ *        the compile that is reading it
+ * @param writtenAt whether the code this names is written at the coordinate, or the coordinate
+ *        stands in for code written out of sight ({@link WrittenAt})
  */
-public record SourcePos(int line, int column, String sourceId) {
+public record SourcePos(int line, int column, String sourceId, WrittenAt writtenAt) {
 
     public SourcePos {
         if (sourceId != null && sourceId.isBlank()) {
             throw new IllegalArgumentException("a source id names a source or is absent, never blank");
         }
+        Objects.requireNonNull(writtenAt, "a position says whether the code it names is written at it");
+    }
+
+    /** A place a source was read for, where the code it names is written. */
+    public SourcePos(int line, int column, String sourceId) {
+        this(line, column, sourceId, WrittenAt.HERE);
     }
 
     /** A position read from no source. */
     public SourcePos(int line, int column) {
-        this(line, column, null);
+        this(line, column, null, WrittenAt.HERE);
+    }
+
+    /**
+     * This coordinate, standing in for code written out of sight — what an expansion gives a copy it
+     * cannot give its own positions.
+     *
+     * <p>Set here and nowhere else that a source is read: a coordinate a parser made is where the
+     * code is, by construction, and one that says otherwise was made by a pass that put code
+     * somewhere it was not written.
+     */
+    public SourcePos standingInFor(WrittenAt out) {
+        return new SourcePos(line, column, sourceId, out);
+    }
+
+    /** The same place, {@code units} along the same line — the other end of a region of that width.
+     *  It stands in for whatever this stands in for: the two ends are one place. */
+    public SourcePos along(int units) {
+        return new SourcePos(line, column + units, sourceId, writtenAt);
+    }
+
+    /** Whether the code this names is written somewhere this compile cannot show, this coordinate
+     *  being where it was reached from instead. */
+    public boolean isOutOfSight() {
+        return writtenAt instanceof WrittenAt.OutOfSight;
     }
 
     @Override

--- a/souther-syntax/src/main/java/souther/compiler/diag/Spot.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Spot.java
@@ -13,7 +13,15 @@ import souther.compiler.diag.msg.Message;
  */
 public record Spot(String sourceId, Region region, Message said) {
 
-    /** The primary region of {@code d}, in {@code sourceId}. */
+    /**
+     * The primary region of {@code d}, in {@code sourceId}.
+     *
+     * <p>Told rather than read off the region, although the region carries a source of its own. What
+     * a caller is quoting from is the caller's answer: a compile of one file hides source ids
+     * altogether and names none, and a view built on the region's would be about a file that caller
+     * never speaks of. Whoever hands this a name is the one holding the files, and what it has to
+     * hand over is where the primary region is — which is what {@code Located} carries.
+     */
     public static Spot primary(Diagnostic d, String sourceId) {
         return new Spot(sourceId, d.region(), null);
     }

--- a/souther-syntax/src/main/java/souther/compiler/diag/WrittenAt.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/WrittenAt.java
@@ -1,0 +1,55 @@
+package souther.compiler.diag;
+
+import java.util.Objects;
+
+/**
+ * Whether a coordinate is where the code it names is written, or stands in for code written
+ * somewhere this compile cannot show.
+ *
+ * <p>A body is spliced into everything that calls it, and a copy is read against the caller's file.
+ * Where the copy came from a source this compile holds, the copy keeps the positions it was written
+ * at and there is nothing to say: the coordinate is the place. Where it came from one this compile
+ * has no source for — the standard library, a module read back off the module path — those positions
+ * name a file nobody holds, so the copy is given the call site instead. That coordinate is a place
+ * in the caller's file, and it is not where the code is.
+ *
+ * <p>Both facts have to travel, because a report needs both and cannot work either out from the
+ * other. Where the caret goes is the coordinate; whether the caret is at the code is this. A
+ * coordinate that carried only the first says a construction is at a call that constructs nothing —
+ * which is what {@code E2011} said of {@code mk(n)}, in those words, before this existed.
+ *
+ * <p>It travels on the coordinate rather than on the node because the coordinate is what every pass
+ * already carries. A slot beside it would be one more thing each of the places that rebuilds a node
+ * has to pass on, and a rebuild that passed the wrong one would compile — which is the shape of
+ * defect this is here to close, written a second time.
+ *
+ * <p>Two states, and a reader must say which it means: reading it off a null would put "the code is
+ * here" and "nobody said" under one answer.
+ */
+public sealed interface WrittenAt {
+
+    /** The code this coordinate names is written at it. */
+    record Here() implements WrittenAt {}
+
+    /**
+     * The coordinate stands in for code written in {@code declaration}, which this compile has no
+     * source for. It is where the code was reached from — the call the body was spliced into — and
+     * not where the code is, so a report anchored on it says so rather than claiming the place.
+     *
+     * @param declaration the name a reader here reaches that code by: {@code helpers.atLeastZero},
+     *        {@code List.map}. How it is reached and not which module declares it — a name reached
+     *        from out of sight is qualified, so it is already enough to look the code up by, and the
+     *        declaring module is a second value a report would have to show and has nothing to add
+     *        ({@code List.map} is declared in {@code souther.list}, which is not how anyone reaches
+     *        it)
+     */
+    record OutOfSight(String declaration) implements WrittenAt {
+
+        public OutOfSight {
+            Objects.requireNonNull(declaration, "code out of sight is reached by a name");
+        }
+    }
+
+    /** The ordinary answer: what every coordinate a source was read for carries. */
+    WrittenAt HERE = new Here();
+}

--- a/souther-syntax/src/main/java/souther/compiler/diag/msg/Message.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/msg/Message.java
@@ -38,5 +38,5 @@ package souther.compiler.diag.msg;
 public sealed interface Message permits ArithmeticMessage, AttemptMessage, BehaviorMessage,
         CodecMessage, DataMessage, DeclarationMessage, ExampleMessage, HelperMessage, ImportMessage,
         InjectionMessage, InvariantMessage, MatchMessage, ModuleMessage, NameMessage, ParseMessage,
-        TypeMessage {
+        TypeMessage, WrittenAtMessage {
 }

--- a/souther-syntax/src/main/java/souther/compiler/diag/msg/Supporting.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/msg/Supporting.java
@@ -1,8 +1,9 @@
 package souther.compiler.diag.msg;
 
 /**
- * The role of being said alongside the subject — a hint under it, or a label on a second place it
- * points at. What to write instead, or what the other place is.
+ * The role of being said alongside the subject — a hint under it, a label on a second place it
+ * points at, or a statement the body carries about where the caret is. What to write instead, what
+ * the other place is, or what this place stands in for.
  *
  * <p>Disjoint from {@link Reported} rather than a widening of it, and outside the {@link Message}
  * hierarchy for the reason given there. A sentence wanted in both roles is two records, the way a

--- a/souther-syntax/src/main/java/souther/compiler/diag/msg/WrittenAtMessage.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/msg/WrittenAtMessage.java
@@ -1,0 +1,18 @@
+package souther.compiler.diag.msg;
+
+/**
+ * What a report says about the sources it is reading, rather than about the model written in them.
+ */
+public sealed interface WrittenAtMessage extends Message {
+
+    /**
+     * Said by every report whose caret stands in for code written somewhere this compile has no
+     * source for — so the caret is not read as the place the code is.
+     *
+     * <p>Not written at any of the sites that report one. A body from out of sight is copied with
+     * the call site stamped over it, and every rule checked on that copy reports at a coordinate in
+     * the caller's file; a sentence each of those sites had to remember is a sentence the next rule
+     * added will not say. It is said off the coordinate instead, once, wherever a body is rendered.
+     */
+    record TheCodeIsWrittenOutOfSight(String declaration) implements WrittenAtMessage, Supporting {}
+}


### PR DESCRIPTION
## Summary

Preserve whether a compiler position is where copied code was actually written, rather than reconstructing that fact later from module ownership or coordinate equality.

A helper body now keeps its written provenance when its position has to be stamped onto a citable call site. Diagnostics can therefore distinguish a real source location from a proxy location without each checker learning about helper expansion.

This fixes #734 for helpers from both source modules and the module path.

## What changed

`SourcePos` now carries `WrittenAt`:

* `Here` — the coordinate is also where the node was written.
* `OutOfSight(declaration)` — the coordinate is where this compile places the node, while the copied code was written in a declaration whose source this compile cannot show.

The `SourcePos` contract now states this distinction explicitly: its coordinate is where this compile places a node, not necessarily its written location.

`HelperInliner` no longer decides whether to preserve a copied body's positions from the declaring module. It asks the same citability question as `CitableRegion`, so a helper in another source module keeps its real positions while a helper read from the module path receives a proxy position carrying `OutOfSight`.

The provenance travels through lowering because it is part of `SourcePos`, which every Core node already carries. No additional origin field has to be forwarded independently by Core constructors.

`DiagnosticRenderer` renders `OutOfSight` positions as proxies. It uses the call extent rather than inventing the copied construct's width and says where the code is actually written:

> The code is written in `helpers.atLeastZero`, which this compile has no source for, so this is where it was reached from and not where it is.

This applies uniformly to Human, JSON, LSP, and legacy diagnostics. In particular, E2010/E2011 acquire the correct explanation without changes to `InvariantChecker`.

`BottomInfer` also stopped reconstructing provenance by comparing a fold seed's coordinate with its call's coordinate. It now asks `isOutOfSight()` directly, leaving no semantic consumer of `SourcePos.equals`.

Diagnostic publication remains separate from diagnostic location. A report involving source from more than one module is published to every relevant source rather than assigning ownership from the primary marker.

The adequacy renderer now includes the filename when an arm is located in another source file.

## Result

For the same helper body, moving only the declaration between modules no longer changes the diagnostic structure:

```text
same module
primary    m.sou:3:34          Yen(0)
secondary  m.sou:5:5           invariant ok = ...

another module, source present
primary    helpers.sou:3:34    Yen(0)
secondary  m.sou:4:5           invariant ok = ...
```

For a helper read from the module path:

```text
primary    m.sou:4:20          atLeastZero(value)
```

the marker is explicitly described as the place from which the unavailable code was reached, not as the place where the construction was written.

## Validation

* Full suite: 4510 passing.
* `CI=1 mvn -Plint verify`: `BUILD SUCCESS`.
* `souther-examples`: 15 projects compared against the base jar.
* Compile-output delta against base: 61 lines.
* E2011: 79 → 81.
* ICE: 0.
* Adequacy: 21,925 lines, 85-line explained delta.
* Two new test classes, 12 tests.
* Five mutations were introduced independently and every one was killed:

  * restore module-based position policy
  * break multi-source delivery
  * drop provenance while stamping
  * restore width clamping
  * remove the proxy-location explanation

The two additional E2011 reports are intentional. Three distinct constructions in `employee.sou` previously collapsed onto one stamped call position and were merged by `Diagnostic.Identity`; preserving their real locations exposes the obligations separately.

The corpus sentinel deliberately does **not** claim that the benchmark exercises cross-module body splicing. Measurement showed that its modules import one another's types but none calls another module's helpers. Cross-module splice semantics are therefore held by the dedicated fixtures rather than changing the benchmark inputs merely to exercise this fix.

Fixes #734.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
