### PR TITLE
Ask what a name names of the form that has an answer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,10 +208,14 @@
                 <version>3.15.0</version>
                 <configuration>
                     <compilerArgs>
-                        <!-- javac prints a hundred warnings per compilation and stops counting.
-                             A report that stops at a round number reads as the whole of what was
-                             found, so the limit is raised past anything this build produces. -->
+                        <!-- javac prints a hundred warnings per compilation and stops counting, and
+                             a hundred errors likewise. A report that stops at a round number reads
+                             as the whole of what was found — a change that breaks two hundred call
+                             sites is read as breaking a hundred — so both limits are raised past
+                             anything this build produces. -->
                         <arg>-Xmaxwarns</arg>
+                        <arg>100000</arg>
+                        <arg>-Xmaxerrs</arg>
                         <arg>100000</arg>
                         <arg>-XDcompilePolicy=simple</arg>
                         <arg>--should-stop=ifError=FLOW</arg>

--- a/souther-cli/src/main/java/souther/cli/Runner.java
+++ b/souther-cli/src/main/java/souther/cli/Runner.java
@@ -231,9 +231,23 @@ public final class Runner {
     private static String dependencyNames(Hir.SpecBehavior spec) {
         List<String> names = new java.util.ArrayList<>();
         for (Hir.Var dep : spec.dependsOn()) {
-            names.add(dep.bare());
+            names.add(named(dep));
         }
         return String.join(", ", names);
+    }
+
+    /**
+     * The name a declared dependency or a pipeline stage is reached by.
+     *
+     * <p>Everything below the compile above names something: {@code Compiler.compiled} raises on the
+     * first error and a name that denotes nothing is one, so this reads a module that got past it.
+     * One arriving here would be `run` working from a module the compile refused.
+     */
+    private static String named(Hir.Var name) {
+        return switch (name) {
+            case Hir.Var.Denoting d -> d.bare();
+            case Hir.Var.Unanswered u -> throw u.unexpectedHere();
+        };
     }
 
     /**
@@ -316,8 +330,8 @@ public final class Runner {
                 specs.put(spec.name(), spec);
             }
         }
-        for (Hir.Var named : PipelineSigs.flattenStages(pipe.stages(), pipeStages, pipe.pos())) {
-            String stage = named.bare();
+        for (Hir.Var each : PipelineSigs.flattenStages(pipe.stages(), pipeStages, pipe.pos())) {
+            String stage = named(each);
             if (!implemented.contains(stage)) {
                 return new Blocker("run.pipeline.noimpl",
                         "`" + pipe.name() + "` is a pipeline whose stage `" + stage

--- a/souther-compiler/src/main/java/souther/compiler/ast/Hir.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Hir.java
@@ -228,19 +228,15 @@ public interface Hir {
         }
 
         /**
-         * The declaration this names, for a reader that is asking which one it is.
+         * This name where it names a declaration, and null where resolution read it and found none.
          *
-         * <p>Refused for an {@link Unanswered} one, which is a mistake in the source reported where
-         * the name is written: there is no declaration to hand back, and a reader that wants to go
-         * on without one asks which of the two it is rather than taking the spelling. This is the
-         * one place that says so.
+         * <p>The one way from here to the declaration. What names it — {@link Denoting#type()} — is
+         * the answered form's, so a reader arrives at it through this projection or through
+         * narrowing to the two forms, and says what it does with an {@link Unanswered} name where it
+         * makes that choice.
          */
-        default TypeSymbol denotes() {
-            if (this instanceof Denoting denoting) {
-                return denoting.type();
-            }
-            throw new IllegalStateException("`" + written() + "` at " + pos()
-                    + " denotes nothing and was read as though it did");
+        default Denoting answered() {
+            return this instanceof Denoting denoting ? denoting : null;
         }
 
         /** The same name, read and found to name nothing. */
@@ -277,8 +273,28 @@ public interface Hir {
          * — which {@code Names.Unbuilt} is what settles, so the rest of the module goes on being
          * answered. This is an answer. A name nothing has looked at is {@link Ast.Name}, and the
          * two were one value for as long as a missing identity stood for both.
+         *
+         * <p>What a reader does on meeting one is the reader's to say, and the readers here say one
+         * of two things. A walk that recovers — reads no declaration, states no type, builds
+         * nothing — passes it over: what is wrong is reported already. A reader whose input is
+         * built from answered names only says so with {@link #unexpectedHere()}, naming the
+         * construction that makes it so. The order the passes run in makes nothing so: a
+         * compilation goes on answering after an error, so only a producer that leaves them out can
+         * be named.
          */
         record Unanswered(WrittenName name) implements Name {
+
+            /**
+             * The claim that this name is somewhere it could not have reached.
+             *
+             * <p>Not a reading: there is nothing here to read, and what a reader arriving here is
+             * saying is that its input was built from answered names. The caller throws it, and
+             * names beside the throw the construction it is standing on.
+             */
+            public IllegalStateException unexpectedHere() {
+                return new IllegalStateException("`" + written() + "` at " + pos()
+                        + " denotes nothing and was read as though it did");
+            }
 
             @Override
             public String toString() {
@@ -1631,62 +1647,21 @@ public interface Hir {
          * <p>What a walk over a body asks. An edge, a substitution, a rewrite is about what a name
          * stands for; a name nothing declares stands for nothing, so there is no edge to add and
          * nothing to rewrite, and the mistake was reported where the name is written.
+         *
+         * <p>The one way from here to what a name names. What a declaration-reading observation
+         * needs — {@link Denoting#denotes()}, {@link Denoting#reachedAs()} — is the answered form's,
+         * so a reader arrives at it through this projection or through narrowing to the two forms,
+         * and says what it does with an {@link Unanswered} name where it makes that choice.
          */
         default Denoting answered() {
             return this instanceof Denoting denoting ? denoting : null;
         }
 
-        /**
-         * What this name names, for a reader that is asking which declaration it is and has no
-         * answer to give where there is none.
-         *
-         * <p>{@link #answered()} is for the reader that has: a walk that adds no edge for a name
-         * nothing declares. This one is for a reader that would have to make something up.
-         */
-        default ValueName denotes() {
-            Denoting names = answered();
-            if (names == null) {
-                throw new IllegalStateException("`" + name() + "` at " + pos()
-                        + " denotes nothing and was read as though it did");
-            }
-            return names.denotes();
-        }
-
-        /**
-         * How this module reaches what the name names — what a table keyed by a declaration's name
-         * is looked up with. The reading counterpart of {@link Apply#reaches()}: {@link #name()} is
-         * the name the source writes, which an import may have let go without its qualifier.
-         */
-        default ReachName reachedAs() {
-            Denoting names = answered();
-            if (names == null) {
-                throw new IllegalStateException("`" + name() + "` at " + pos()
-                        + " reaches nothing this module can name");
-            }
-            return names.reachedAs();
-        }
-
-        /** As {@link #denotes()}, by the bare name of what it names. */
-        default String bare() {
-            return denotes().name();
-        }
-
-        /**
-         * As {@link #reachedAs()}, rendered.
-         *
-         * <p>Never the spelling. An import lets a name be written without its qualifier, so the
-         * spelling misses in the very table this is asked for, and a table answers a key it has not
-         * got with silence. Every pass that writes a reference of its own says what it means
-         * (ADR-0067), so there is no tree downstream of resolution for a fallback to have been for.
-         */
-        default String reaches() {
-            return reachedAs().rendered();
-        }
-
         /** Whether this name denotes nothing — read by resolution, and reported where it was
-         * written. */
+         * written. Asked of {@link #answered()} rather than of the form, so that what a name
+         * answers and whether it answered cannot come apart. */
         default boolean unresolved() {
-            return this instanceof Unanswered;
+            return answered() == null;
         }
 
         /**
@@ -1700,13 +1675,6 @@ public interface Hir {
          */
         default Var denoting(ValueName resolved, ReachName reachedAs) {
             return new Denoting(written(), resolved, reachedAs, region());
-        }
-
-        /** The same name denoting {@code resolved}, reached as it already was — for a pass that
-         * changes what a name says about where its construction came from and not which declaration
-         * it reaches. */
-        default Var denoting(ValueName resolved) {
-            return new Denoting(written(), resolved, reachedAs(), region());
         }
 
         /** The same name, over {@code region} — whichever of the two it is. */
@@ -1736,6 +1704,32 @@ public interface Hir {
                 heldBy(written, region);
             }
 
+            /** As {@link #denotes()}, by the bare name of what it names. */
+            public String bare() {
+                return denotes().name();
+            }
+
+            /**
+             * As {@link #reachedAs()}, rendered — what a table keyed by a declaration's name is
+             * looked up with.
+             *
+             * <p>Never the spelling. An import lets a name be written without its qualifier, so the
+             * spelling misses in the very table this is asked for, and a table answers a key it has
+             * not got with silence. Every pass that writes a reference of its own says what it
+             * means (ADR-0067), so there is no tree downstream of resolution for a fallback to have
+             * been for.
+             */
+            public String reaches() {
+                return reachedAs().rendered();
+            }
+
+            /** The same name denoting {@code resolved}, reached as it already was — for a pass that
+             * changes what a name says about where its construction came from and not which
+             * declaration it reaches. */
+            public Var denoting(ValueName resolved) {
+                return new Denoting(written(), resolved, reachedAs(), region());
+            }
+
             @Override
             public String toString() {
                 return name();
@@ -1748,11 +1742,30 @@ public interface Hir {
          * <p>Reported where it is written, or on the import line or the module that could not be
          * read — whichever could say what is wrong. It carries neither answer, so a reader below has
          * no spelling to match and no report to repeat.
+         *
+         * <p>What a reader does on meeting one is the reader's to say, and the readers here say one
+         * of two things. A walk that recovers — adds no edge, states no type, settles no call —
+         * passes it over: what is wrong is reported already. A reader whose input is built from
+         * answered names only says so with {@link #unexpectedHere()}, naming the construction that
+         * makes it so. The order the passes run in makes nothing so: a compilation goes on
+         * answering after an error, so only a producer that leaves them out can be named.
          */
         record Unanswered(WrittenName written, Region region) implements Var {
 
             public Unanswered {
                 heldBy(written, region);
+            }
+
+            /**
+             * The claim that this name is somewhere it could not have reached.
+             *
+             * <p>Not a reading: there is nothing here to read, and what a reader arriving here is
+             * saying is that its input was built from answered names. The caller throws it, and
+             * names beside the throw the construction it is standing on.
+             */
+            public IllegalStateException unexpectedHere() {
+                return new IllegalStateException("`" + name() + "` at " + pos()
+                        + " denotes nothing and was read as though it did");
             }
 
             @Override
@@ -1910,40 +1923,18 @@ public interface Hir {
         }
 
         /**
-         * The name of the declaration this application reaches, or the empty spelling where it
-         * reaches none — what a table keyed by a declaration's name is looked up with.
-         *
-         * <p>A library name is filed under its qualifier whether or not an import let it be written
-         * bare, so that is what it answers; every other name is filed as it is written. The empty
-         * answer is not a convention: it is what applying something that is not a name leaves, and
-         * no declaration is named the empty spelling.
-         *
-         * <p>Never {@link #written()}: a spelling a report quotes is not what this application
-         * reaches, and a lowering that put one there would otherwise have every table in the
-         * compiler looked up with it.
-         */
-        public String reaches() {
-            return function instanceof Var v ? v.reaches() : "";
-        }
-
-        /** How this module reaches what the application applies, or null where what it applies is
-         * not a name. Settled at resolution and carried, so it says the same thing whichever passes
-         * have run. */
-        public ReachName reachedAs() {
-            return function instanceof Var v ? v.reachedAs() : null;
-        }
-
-        /** What the name this applies denotes, or null where what it applies is not a name. */
-        public ValueName denotes() {
-            return function instanceof Var v ? v.denotes() : null;
-        }
-
-        /**
-         * As {@link Var#answered()}, of the name this applies.
+         * As {@link Var#answered()}, of the name this applies — and what a reader asking which
+         * declaration this reaches goes through.
          *
          * <p>Null the two ways there is no declaration to look up: what is applied is not a name,
          * or it is one nothing declares. A callee nothing has read yet is refused there, as it is
          * of a name standing on its own.
+         *
+         * <p>What the answered form says — {@link Var.Denoting#denotes()},
+         * {@link Var.Denoting#reachedAs()}, {@link Var.Denoting#reaches()} — is read off it here
+         * rather than carried across by this one. Carried, it would answer for a callee that is not
+         * a name and for one that names nothing in the same value, and a reader would have neither
+         * to hand.
          */
         public Var.Denoting answered() {
             return function instanceof Var v ? v.answered() : null;

--- a/souther-compiler/src/main/java/souther/compiler/ast/StructuralCost.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/StructuralCost.java
@@ -117,10 +117,14 @@ public final class StructuralCost {
     /**
      * What a name reaches, for counting what substituting it would cost: the body substituted
      * there, or null where the name stands for itself.
+     *
+     * <p>Asked of a name that names something. Nothing is substituted for one that names nothing,
+     * so the question does not arise for it, and asking it would be asking what a name reaches of a
+     * name that reaches nowhere.
      */
     @FunctionalInterface
     public interface Reaches {
-        Hir.Expr substitutedAt(Hir.Var name);
+        Hir.Expr substitutedAt(Hir.Var.Denoting name);
     }
 
     /**
@@ -181,7 +185,7 @@ public final class StructuralCost {
             // reaches is an answer resolution gives, and the tree this is measured on before that
             // has none — a definition is counted as written the moment it is parsed, and nothing is
             // substituted into it there.
-            if (node instanceof Hir.Var name) {
+            if (node instanceof Hir.Var.Denoting name) {
                 Hir.Expr body = reaches.substitutedAt(name);
                 if (body != null && !Path.holds(step.path(), name.reaches())) {
                     todo.add(new Step(body, step.above(), name,
@@ -203,7 +207,7 @@ public final class StructuralCost {
     /** Whether applying this splices a body here, which is what makes its arguments bindings. */
     private static boolean isExpanded(Hir.Expr e, Reaches reaches) {
         return e instanceof Hir.Apply apply
-                && apply.function() instanceof Hir.Var applied
+                && apply.function() instanceof Hir.Var.Denoting applied
                 && reaches.substitutedAt(applied) != null;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/BottomInfer.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BottomInfer.java
@@ -77,7 +77,7 @@ public final class BottomInfer {
         if (e instanceof Hir.RowCollection row) {
             return row.elements().isEmpty();
         }
-        return e instanceof Hir.Var v && v.denotes() instanceof ValueName.Stdlib lib
+        return e instanceof Hir.Var.Denoting v && v.denotes() instanceof ValueName.Stdlib lib
                 && Prelude.isEmptyCollectionValue(lib.qualified());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -104,7 +104,7 @@ public final class CallElaborator {
      * <p>The Core is the one the application spelling produced, so nothing downstream of here tells
      * the two apart — which is what keeps a growing fold's seed the seed it was.
      */
-    static Core libraryValue(Hir.Var v, CheckContext ctx, Type expected) {
+    static Core libraryValue(Hir.Var.Denoting v, CheckContext ctx, Type expected) {
         if (!(v.denotes() instanceof ValueName.Stdlib lib)) {
             return null;
         }
@@ -125,25 +125,31 @@ public final class CallElaborator {
             // reported where the name was written; this definition has no meaning to work out
             throw new Unanswerable(call.pos());
         }
+        // What this applies, as the name that names it — null where what is applied is not a name,
+        // which the typing below refuses where it reads the callee.
+        Hir.Var.Denoting callee = call.answered();
         // A call this representation said it keeps standing, asked before anything tries to expand or
         // resolve it: what it names is settled, and the only question left is its signature. Asked of
         // the representation and not of the operation — whether anything downstream has a rule about
         // it is not this walk's business, and a kept call with no rule types like any other.
-        CompleteSignature kept = ctx.preserved().signatureOf(call.denotes());
+        CompleteSignature kept = callee == null
+                ? null : ctx.preserved().signatureOf(callee.denotes());
         if (kept != null) {
-            return preservedCall(call, kept, env, ctx, expected);
+            return preservedCall(call, callee, kept, env, ctx, expected);
         }
         CallArgs ca = new CallArgs(call.args(), env, ctx);
         Type result = typeOfCall(ca, call, env, ctx, expected);
         // applying something this body binds is a different operation from calling something
         // declared elsewhere, and it is the only one that carries a binding into the emitted tree
-        if (call.denotes() instanceof ValueName.Local local
+        if (callee != null && callee.denotes() instanceof ValueName.Local local
                 && env.typeOf(local.id()) instanceof Type.FnOf) {
             return new Core.Apply(
                     new Core.Read(call.written(), local.id(), env.typeOf(local.id()), call.pos()),
                     ca.cores(), result, call.pos());
         }
-        return new Core.Call(call.reachedAs(), call.denotes(), ca.cores(), result, call.pos());
+        // Typing the call above refuses what is not a name outright, so what is left here names a
+        // declaration and says which one and how this module reaches it.
+        return new Core.Call(callee.reachedAs(), callee.denotes(), ca.cores(), result, call.pos());
     }
 
     /**
@@ -155,7 +161,8 @@ public final class CallElaborator {
      * business with a call left standing meets it as itself rather than as an ordinary call it might
      * try to emit.
      */
-    private static Core preservedCall(Hir.Apply call, CompleteSignature kept, Scope env,
+    private static Core preservedCall(Hir.Apply call, Hir.Var.Denoting callee,
+                                      CompleteSignature kept, Scope env,
                                       CheckContext ctx, Type expected) {
         List<Type> params = kept.params();
         CallArgs ca = new CallArgs(call.args(), env, ctx);
@@ -183,7 +190,7 @@ public final class CallElaborator {
                 }
             }
         }
-        return new Core.PreservedCall(call.denotes(), ca.cores(),
+        return new Core.PreservedCall(callee.denotes(), ca.cores(),
                 TypeOps.substitute(kept.result(), bind), call.pos());
     }
 
@@ -350,7 +357,11 @@ public final class CallElaborator {
      * with itself and not something an author can act on.
      */
     static RuntimeException noCallee(Hir.Apply call) {
-        return switch (call.denotes()) {
+        if (call.answered() == null) {
+            return new IllegalStateException("`" + call.written()
+                    + "` applies something that is not a name, at " + call.pos());
+        }
+        return switch (call.answered().denotes()) {
             // a behavior named from a helper `let` or a `>->` composition, neither of which reaches
             // one (spec [#calling-a-behavior])
             case ValueName.Behavior _ -> CompileException.of(Diagnostic.at(call.appliedAt())
@@ -483,12 +494,13 @@ public final class CallElaborator {
             // reported where the name was written; this definition has no meaning to work out
             throw new Unanswerable(call.pos());
         }
-        if (call.denotes() == null) {
+        Hir.Var.Denoting callee = call.answered();
+        if (callee == null) {
             throw new IllegalStateException("`" + call.written()
                     + "` applies something that is not a name, at " + call.pos());
         }
-        boolean library = call.denotes() instanceof ValueName.Stdlib;
-        Prelude.PreludeEntry entry = library ? Prelude.entry(call.reaches()) : null;
+        boolean library = callee.denotes() instanceof ValueName.Stdlib;
+        Prelude.PreludeEntry entry = library ? Prelude.entry(callee.reaches()) : null;
         // A declaration written with no parameter list is a value ([#fn-declaration]), and an empty
         // `()` would be a second spelling of it. The library was the last place that spelling was
         // still accepted.
@@ -528,11 +540,11 @@ public final class CallElaborator {
             }
             return applied.result();
         }
-        return switch (library ? call.reaches() : "") {
+        return switch (library ? callee.reaches() : "") {
             case "Date", "Time", "DateTime", "Instant" -> {
                 arity(call, 1);
                 ca.type(0);   // the literal text, which temporalLiteral parses
-                yield temporalLiteral(call);
+                yield temporalLiteral(call, callee);
             }
             default -> {
                 // a function-typed value in scope (a helper's function parameter) applied to
@@ -540,7 +552,7 @@ public final class CallElaborator {
                 // reaches here — NewtypeDesugar has lowered it to a NewData literal.
                 // a function value in force, or a recursive helper's signature: which of the two
                 // is the denotation's to say, and only one of them is bound here
-                if (env.of(call.denotes(), call.written()) instanceof Type.FnOf fn) {
+                if (env.of(callee.denotes(), call.written()) instanceof Type.FnOf fn) {
                     if (args.size() != fn.params().size()) {
                         throw CompileException.of(Diagnostic
                                         .at(call.appliedAt())
@@ -553,7 +565,7 @@ public final class CallElaborator {
                 // of name this reaches and not of whether the spelling holds a dot: a field read
                 // applied (`deps.count(x)`) is quoted with a dot in it and reaches a binding, and
                 // what is wrong with it is that it is not a function, which the report below says.
-                if (call.reachedAs() instanceof ReachName.OfLibrary) {
+                if (callee.reachedAs() instanceof ReachName.OfLibrary) {
                     throw CompileException.of(Diagnostic
                                     .at(call.appliedAt()).say(new NameMessage.NotAStandardLibraryFunction(call.written())).build());
                 }
@@ -562,18 +574,18 @@ public final class CallElaborator {
                 // which is this compiler having failed to do one of them rather than anything the
                 // author wrote. Said outright: reported as a wrong library call, it named a library
                 // the author never wrote.
-                if (call.reachedAs() instanceof ReachName.OfModule reached) {
+                if (callee.reachedAs() instanceof ReachName.OfModule reached) {
                     throw new IllegalStateException("`" + reached + "` was neither expanded nor"
                             + " bound before the call to it at " + call.pos() + " was typed");
                 }
                 // a required behavior called inline (spec §unmarked-output, §fn), or one that requires nothing and
                 // is called by name (spec [#calling-a-behavior]). Both are typed against the callee's
                 // declaration; where the behavior comes from at run time is the backend's to know.
-                ReqSig callee = ctx.reqs().get(call.reaches());
-                if (callee == null) {
-                    callee = ctx.callees().get(call.reaches());
+                ReqSig required = ctx.reqs().get(callee.reaches());
+                if (required == null) {
+                    required = ctx.callees().get(callee.reaches());
                 }
-                if (callee == null) {
+                if (required == null) {
                     Elaborator.optionCaseWritten(call.written(), call.pos());
                     CompileException bareLibraryName = StdlibNames.writtenBare(
                             call.written(), call.written(), call.name().region());
@@ -582,11 +594,11 @@ public final class CallElaborator {
                     }
                     throw noCallee(call);
                 }
-                arity(call, callee.params().size());
-                for (int i = 0; i < callee.params().size(); i++) {
-                    ca.require(i, callee.params().get(i), "argument " + (i + 1) + " of " + call.written());
+                arity(call, required.params().size());
+                for (int i = 0; i < required.params().size(); i++) {
+                    ca.require(i, required.params().get(i), "argument " + (i + 1) + " of " + call.written());
                 }
-                yield callee.success();
+                yield required.success();
             }
         };
     }
@@ -700,8 +712,8 @@ public final class CallElaborator {
      * temporal at all). This form spells one out; a temporal computed from values comes from the
      * boundary, from the arithmetic, or from {@code Date.fromParts} / {@code Time.fromParts}, which
      * answer a case where the parts name no such moment. */
-    static Type temporalLiteral(Hir.Apply call) {
-        Type.Prim kind = Type.Prim.named(call.reaches());
+    static Type temporalLiteral(Hir.Apply call, Hir.Var.Denoting callee) {
+        Type.Prim kind = Type.Prim.named(callee.reaches());
         if (!(call.args().get(0) instanceof Hir.StringLit lit)) {
             throw CompileException.of(Diagnostic
                             .at(call.appliedAt()).say(new TypeMessage.ATemporalTakesAWrittenString(call.written())).build());

--- a/souther-compiler/src/main/java/souther/compiler/check/CardinalityTransfer.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CardinalityTransfer.java
@@ -67,7 +67,11 @@ final class CardinalityTransfer {
                 // of them has none.
                 Cardinality across = Cardinality.NO_VALUE;
                 for (Hir.Name each : sum.cases()) {
-                    across = across.plus(known(solution, each.denotes()));
+                    // A case naming nothing carries no values in, which is what it adds: it is
+                    // reported where it is written and says nothing about how many the sum has.
+                    if (each.answered() instanceof Hir.Name.Denoting names) {
+                        across = across.plus(known(solution, names.type()));
+                    }
                 }
                 yield across;
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
@@ -426,7 +426,7 @@ public sealed interface Carrier {
             // A case is named rather than written, so the literal is a name and what it denotes says
             // which case it is. Read off the denotation and not the text: a case is reachable under
             // an alias, and two enumerations may declare cases spelled the same way.
-            case Ordinal ordinal -> e instanceof Hir.Var v
+            case Ordinal ordinal -> e instanceof Hir.Var.Denoting v
                     && v.denotes() instanceof ValueName.OfType named
                     ? ordinal.at(named.type()) : null;
             case Text _ -> e instanceof Hir.StringLit lit
@@ -439,7 +439,8 @@ public sealed interface Carrier {
      *  §a-temporal-value-is-written-as-a-literal), so it is read here rather than run. */
     private static Count temporal(Hir.Expr e, String written,
                                   java.util.function.Function<String, Count> countOf) {
-        return e instanceof Hir.Apply call && written.equals(call.reaches())
+        return e instanceof Hir.Apply call && call.answered() != null
+                && written.equals(call.answered().reaches())
                 && call.args().size() == 1 && call.args().get(0) instanceof Hir.StringLit iso
                 ? countOf.apply(iso.value()) : null;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Combinators.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Combinators.java
@@ -96,7 +96,10 @@ final class Combinators {
      * was handed, so one that exists has both.
      */
     static Written handedTo(Hir.Apply call) {
-        Combinator rule = of(call.denotes());
+        // A call applying a name nothing declares hands its closure to no operation this table
+        // has: there is no declaration to find a rule under, and what is wrong with it is reported
+        // where the name is written.
+        Combinator rule = call.answered() == null ? null : of(call.answered().denotes());
         if (rule == null || rule.closureArg() >= call.args().size()
                 || rule.containerArg() >= call.args().size()
                 || !(call.args().get(rule.closureArg()) instanceof Hir.Block step)) {

--- a/souther-compiler/src/main/java/souther/compiler/check/ConstEval.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstEval.java
@@ -244,7 +244,12 @@ public final class ConstEval {
 
     private static Optional<Object> call(Hir.Apply call) {
         List<Hir.Expr> args = call.args();
-        switch (call.reaches()) {
+        // Applying a name nothing declares is not a constant. There is no operation to fold it to,
+        // and the name is reported where it is written.
+        if (call.answered() == null) {
+            return Optional.empty();
+        }
+        switch (call.answered().reaches()) {
             case "String.length" -> {
                 if (args.size() == 1 && eval(args.get(0)).orElse(null) instanceof String s) {
                     return Optional.of((long) s.length());

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -70,11 +70,12 @@ public final class DataChecker {
     }
 
     private static void collectConstChecks(Hir.Expr e, Symbols symbols, List<ConstCheck> out) {
-        if (e instanceof Hir.NewData nd && !(nd.typeName() instanceof Hir.Name.Unanswered)
-                && symbols.declarations().declaration(nd.typeName().denotes().key()) instanceof Hir.Data nt
-                && nt.newtype() && isInvariantBearing(nd.typeName().denotes(), symbols)) {
+        if (e instanceof Hir.NewData nd
+                && nd.typeName().answered() instanceof Hir.Name.Denoting built
+                && symbols.declarations().declaration(built.type().key()) instanceof Hir.Data nt
+                && nt.newtype() && isInvariantBearing(built.type(), symbols)) {
             CallElaborator.newtypeConstantArg(nd).ifPresent(v ->
-                    out.add(new ConstCheck(nd.typeName().written(), nd.typeName().denotes(), v, nd.pos())));
+                    out.add(new ConstCheck(nd.typeName().written(), built.type(), v, nd.pos())));
         }
         TypeChecker.forEachChild(e, c -> collectConstChecks(c, symbols, out));
     }
@@ -194,9 +195,13 @@ public final class DataChecker {
                 // which it can. A value carries the construction its definition made, whatever module
                 // declares the type: the definition is where the value is made, and a body that names
                 // it compares against a limit rather than setting one.
-                Map<TypeSymbol, String> side = carried(nd, nd.typeName().denotes())
-                        ? out.carried() : out.originated();
-                side.putIfAbsent(nd.typeName().denotes(), nd.typeName().name().quoted());
+                // A construction naming nothing builds no type to record; it is reported where the
+                // name is written, and the fields written under it are still walked.
+                if (nd.typeName().answered() instanceof Hir.Name.Denoting built) {
+                    Map<TypeSymbol, String> side = carried(nd, built.type())
+                            ? out.carried() : out.originated();
+                    side.putIfAbsent(built.type(), nd.typeName().name().quoted());
+                }
                 for (Hir.FieldInit init : nd.inits()) {
                     collectConstructs(init.value(), out, symbols, recConstructs);
                 }
@@ -212,7 +217,8 @@ public final class DataChecker {
                 // on a value, none of them are this body's: the value's definition is what reached
                 // the helper, and the call is standing in for constructions that would have been
                 // marked had the helper been expandable.
-                Constructs viaHelper = recConstructs.get(call.reaches());
+                Constructs viaHelper = call.answered() == null
+                        ? null : recConstructs.get(call.answered().reaches());
                 if (viaHelper != null) {
                     out.absorb(call.origin().viaValueReference() ? viaHelper.allCarried() : viaHelper);
                 }
@@ -260,7 +266,7 @@ public final class DataChecker {
             // it is asked of a construction node — it is the same question about the same thing.
             // `constructs` governs what this compilation declares; a unit the language gives
             // (`HALF_UP`) is vocabulary, not business data — as `None` is.
-            case Hir.Var v when v.denotes() instanceof ValueName.OfType named
+            case Hir.Var.Denoting v when v.denotes() instanceof ValueName.OfType named
                     && symbols.declarations().declaredByCompilation(named.type().key())
                     && symbols.declarations().declaration(named.type().key()) instanceof Hir.UnitData -> {
                 Map<TypeSymbol, String> side = named.origin().carried(named.type())
@@ -305,10 +311,10 @@ public final class DataChecker {
             // A name nothing declares denotes no type, so there is no type here for another to be
             // the same as. It was reported where it is written; calling it a duplicate as well
             // would be a second report about the one mistake.
-            if (n instanceof Hir.Name.Unanswered) {
+            if (n.answered() == null) {
                 continue;
             }
-            if (!seen.add(n.denotes())) {
+            if (!seen.add(n.answered().type())) {
                 throw duplicate(n.written(), where, pos);
             }
         }
@@ -337,7 +343,12 @@ public final class DataChecker {
             return null;
         }
         for (Hir.Name caseName : s.cases()) {
-            if (target.equals(caseName.denotes())) {
+            // A case naming nothing is no step of a cycle, and it is reported on the declaration
+            // that writes it — which may be another module's, and not one this check was handed.
+            if (!(caseName.answered() instanceof Hir.Name.Denoting names)) {
+                continue;
+            }
+            if (target.equals(names.type())) {
                 List<String> out = new ArrayList<>();
                 for (TypeSymbol seen : path) {
                     out.add(seen.name());
@@ -345,12 +356,13 @@ public final class DataChecker {
                 out.add(caseName.written());
                 return out;
             }
-            if (symbols.declarations().declaration(caseName.denotes().key()) instanceof Hir.SumData && path.add(caseName.denotes())) {
+            if (symbols.declarations().declaration(names.type().key()) instanceof Hir.SumData
+                    && path.add(names.type())) {
                 List<String> found = sumCycle(target, symbols, path);
                 if (found != null) {
                     return found;
                 }
-                path.remove(caseName.denotes());
+                path.remove(names.type());
             }
         }
         return null;
@@ -364,6 +376,21 @@ public final class DataChecker {
         return out;
     }
 
+    /**
+     * The declaration a name written in the declaration being checked names.
+     *
+     * <p>Every name written in one of these was answered. A declaration holding a name that names
+     * nothing has no meaning to check — {@code Names.Unbuilt} collects it and {@code Names.Definition}
+     * hands it to nobody — and {@code TypeChecker} checks only the declarations it was handed. One
+     * arriving here is this compiler checking a declaration that was not among them.
+     */
+    private static TypeSymbol names(Hir.Name name) {
+        return switch (name) {
+            case Hir.Name.Denoting d -> d.type();
+            case Hir.Name.Unanswered u -> throw u.unexpectedHere();
+        };
+    }
+
     static void checkSum(Hir.SumData sum, Symbols symbols) {
         rejectDuplicateTypes(sum.cases(), "the sum `" + sum.name() + "`", sum.pos());
         // A generated sum is a sealed interface, and its `permits` is settled when its own module is
@@ -371,11 +398,11 @@ public final class DataChecker {
         // being a member: no value satisfies the type and an exhaustive switch over it has no arms
         // (ADR-0057, the declared-sum counterpart of E1606).
         for (Hir.Name c : sum.cases()) {
-            if (symbols.scope().isForeign(c.denotes())) {
+            if (symbols.scope().isForeign(names(c))) {
                 throw CompileException.of(Diagnostic
                                 .at(c.name().reportedAt())
                                 
-                                .hint(new BehaviorMessage.ASumsCasesAreDeclaredWithIt(c.written())).say(new BehaviorMessage.ACaseIsDeclaredInAnotherModule(c.written(), sum.name(), c.denotes().module())).build());
+                                .hint(new BehaviorMessage.ASumsCasesAreDeclaredWithIt(c.written())).say(new BehaviorMessage.ACaseIsDeclaredInAnotherModule(c.written(), sum.name(), names(c).module())).build());
             }
         }
         List<String> cycle = sumCycle(sum.declares(), symbols, new LinkedHashSet<>());
@@ -388,8 +415,8 @@ public final class DataChecker {
             // §sum-discrimination)
             Set<TypeSymbol> dispatchable = TypeOps.leafCases(Type.ref(sum.declares()), symbols);
             for (Hir.Variant v : disc.variants()) {
-                Hir.Def caseDef = symbols.declarations().declaration(v.caseType().denotes().key());
-                if (!dispatchable.contains(v.caseType().denotes())) {
+                Hir.Def caseDef = symbols.declarations().declaration(names(v.caseType()).key());
+                if (!dispatchable.contains(names(v.caseType()))) {
                     throw CompileException.of(Diagnostic.at(v.pos())
                             .say(new CodecMessage.NotACaseOf(v.caseType().written(), sum.name()))
                             .build());
@@ -420,12 +447,12 @@ public final class DataChecker {
             Set<TypeSymbol> covered = new HashSet<>();
             Set<TypeSymbol> encodable = TypeOps.leafCases(Type.ref(sum.declares()), symbols);
             for (Hir.EncVariant v : enc.variants()) {
-                if (!encodable.contains(v.caseType().denotes())) {
+                if (!encodable.contains(names(v.caseType()))) {
                     throw CompileException.of(Diagnostic.at(v.pos())
                             .say(new CodecMessage.NotACaseOf(v.caseType().written(), sum.name()))
                             .build());
                 }
-                Hir.Def caseDef = symbols.declarations().declaration(v.caseType().denotes().key());
+                Hir.Def caseDef = symbols.declarations().declaration(names(v.caseType()).key());
                 boolean caseEncodes = caseDef instanceof Hir.UnitData
                         || (caseDef instanceof Hir.Data d && d.encoder().isPresent())
                         || (caseDef instanceof Hir.SumData s && s.encoder().isPresent());
@@ -434,7 +461,7 @@ public final class DataChecker {
                             .say(new CodecMessage.CaseNeedsAnEncoder(v.caseType().written()))
                             .build());
                 }
-                covered.add(v.caseType().denotes());
+                covered.add(names(v.caseType()));
             }
             for (TypeSymbol caseName : encodable) {
                 if (!covered.contains(caseName)) {
@@ -620,12 +647,12 @@ public final class DataChecker {
             case Hir.SetDecRef s -> Type.set(decRefType(s.element(), symbols));
             case Hir.PrimDecRef p -> TypeOps.primType(p.kind());
             case Hir.DataDecRef d -> {
-                if (!hasDecoder(symbols.declarations().declaration(d.typeName().denotes().key()))) {
+                if (!hasDecoder(symbols.declarations().declaration(names(d.typeName()).key()))) {
                     throw CompileException.of(Diagnostic.at(d.pos())
                             .say(new CodecMessage.HasNoDecoder(d.typeName().written()))
                             .build());
                 }
-                yield Type.ref(d.typeName().denotes());
+                yield Type.ref(names(d.typeName()));
             }
             case Hir.ListDecRef l -> Type.list(decRefType(l.element(), symbols));
             case Hir.OptionDecRef o -> Type.option(decRefType(o.element(), symbols));
@@ -635,7 +662,7 @@ public final class DataChecker {
 
     private static void checkConstruct(Hir.Construct c, CheckContext ctx, Map<String, Type> fields,
                                        Scope env) {
-        if (!c.typeName().denotes().equals(ctx.data().declares())) {
+        if (!names(c.typeName()).equals(ctx.data().declares())) {
             throw CompileException.of(Diagnostic.at(c.pos())
                     .say(new CodecMessage.TheDecoderBuildsAnotherType(ctx.data().name(),
                             c.typeName().written()))
@@ -852,12 +879,12 @@ public final class DataChecker {
             }
             case Hir.EncodeRaw e -> {
                 if (!hasEncoder(ctx.symbols().declarations()
-                        .declaration(e.typeName().denotes().key()))) {
+                        .declaration(names(e.typeName()).key()))) {
                     throw CompileException.of(Diagnostic.at(e.pos())
                             .say(new CodecMessage.HasNoEncoder(e.typeName().written()))
                             .build());
                 }
-                Elaborator.requireType(e.arg(), Type.ref(e.typeName().denotes()), env, ctx,
+                Elaborator.requireType(e.arg(), Type.ref(names(e.typeName())), env, ctx,
                         "argument of " + e.typeName().written() + ".encode");
             }
             case Hir.ListEnc le -> {
@@ -900,10 +927,10 @@ public final class DataChecker {
             }
             case Hir.DataEnc d -> {
                 // the element may be a product or a sum: `List<事前承認理由>` holds a sum (spec §encoder-derivation)
-                Hir.Def def = symbols.declarations().declaration(d.typeName().denotes().key());
+                Hir.Def def = symbols.declarations().declaration(names(d.typeName()).key());
                 boolean hasEncoder = (def instanceof Hir.Data dd && dd.encoder().isPresent())
                         || (def instanceof Hir.SumData sd && sd.encoder().isPresent());
-                if (!elemType.equals(Type.ref(d.typeName().denotes())) || !hasEncoder) {
+                if (!elemType.equals(Type.ref(names(d.typeName()))) || !hasEncoder) {
                     throw elemEncMismatch(d.typeName().written(), elemType, pos);
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -201,7 +201,7 @@ public final class Elaborator {
             // A name nothing answered has no meaning to work out, and the definition it is in has
             // none either: reported where it is written, and abandoned here.
             case Hir.Var.Unanswered v -> throw new Unanswerable(v.pos());
-            case Hir.Var v -> switch (v.denotes()) {
+            case Hir.Var.Denoting v -> switch (v.denotes()) {
                 // A binding with no type here is not a naming question: an inference probe types a
                 // body before the binding it asks about has one, and reads the report to find out.
                 case ValueName.Local local when env.typeOf(local.id()) != null ->
@@ -238,11 +238,11 @@ public final class Elaborator {
             case Hir.Apply call -> CallElaborator.elaborateCall(call, env, ctx, expected);
             case Hir.Binary bin -> BinaryElaborator.elaborateBinary(bin, env, ctx);
             case Hir.NewData nd -> {
-                Hir.Name built = nd.typeName();
-                if (built instanceof Hir.Name.Unanswered) {
+                if (!(nd.typeName().answered() instanceof Hir.Name.Denoting built)) {
+                    // reported where the name is written; this definition has no meaning to work out
                     throw new Unanswerable(nd.pos());
                 }
-                if (!(ctx.symbols().declarations().declaration(built.denotes().key()) instanceof Hir.Data owner)) {
+                if (!(ctx.symbols().declarations().declaration(built.type().key()) instanceof Hir.Data owner)) {
                     throw CompileException.of(Diagnostic
                                     .at(built.name().reportedAt())
                                     .say(new DataMessage.ItCannotBeConstructedHere(built.name().quoted())).build());
@@ -254,15 +254,17 @@ public final class Elaborator {
                 // fields, so it is refused the way the name would be anywhere else a value goes.
                 List<Core.Read> spreads = new ArrayList<>();
                 for (Hir.Var s : nd.spreads()) {
-                    if (!(s.answered() != null && s.denotes() instanceof ValueName.Local local)) {
+                    if (!(s.answered() instanceof Hir.Var.Denoting named
+                            && named.denotes() instanceof ValueName.Local local)) {
                         throw notAValue(s, env);
                     }
-                    spreads.add(new Core.Read(s.bare(), local.id(), env.typeOf(local.id()), s.pos()));
+                    spreads.add(new Core.Read(named.bare(), local.id(), env.typeOf(local.id()),
+                            s.pos()));
                 }
                 List<Core.FieldValue> values = DataChecker.checkConstruction(built.written(),
                         nd.inits(), spreads, nd.pos(),
                         TypeOps.fieldTypes(owner, ctx.symbols()), env, ctx, nd.fields());
-                yield new Core.Construct(built.denotes(), values, Type.ref(built.denotes()), nd.pos());
+                yield new Core.Construct(built.type(), values, Type.ref(built.type()), nd.pos());
             }
             case Hir.Match m -> MatchElaborator.elaborateMatch(m, env, ctx, expected);
             case Hir.If iff -> {
@@ -642,7 +644,9 @@ public final class Elaborator {
      */
     private static void checkOpens(Hir.LetIn li, Type valueType, Symbols symbols) {
         String opened = li.opens().written();
-        TypeSymbol layer = li.opens().denotes();
+        // A name that names nothing opens nothing: it is reported where it is written, and what is
+        // said here — that it is not a newtype — would be a second report about the one mistake.
+        TypeSymbol layer = li.opens().answered() == null ? null : li.opens().answered().type();
         if (TypeOps.newtypeInner(layer, symbols) == null) {
             throw CompileException.of(Diagnostic
                             .at(li.pos())
@@ -872,7 +876,7 @@ public final class Elaborator {
      */
     private static Type arrivesAs(Hir.Given g, Hir.Expansion ex, Scope env, CheckContext ctx) {
         Type is = g.arrivesAs() != null ? TypeOps.resolveParamType(g.arrivesAs())
-                : g.value() instanceof Hir.Var v
+                : g.value() instanceof Hir.Var.Denoting v
                         && env.of(v.denotes(), v.reaches()) instanceof Type.FnOf fn ? fn : null;
         return is == null ? null : instantiated(is, ex);
     }
@@ -935,7 +939,8 @@ public final class Elaborator {
      * it as, and what it is declared as is carried on the boundary instead.
      */
     private static boolean inSight(Hir.Expr function, Scope env) {
-        if (function instanceof Hir.Var v && v.denotes() instanceof ValueName.Local local) {
+        if (function instanceof Hir.Var.Denoting v
+                && v.denotes() instanceof ValueName.Local local) {
             return env.holds(local.id());
         }
         return reads(function, env);
@@ -948,8 +953,9 @@ public final class Elaborator {
      * where it is applied and not here. Where it is not, it is left to the body that applies it.
      */
     private static boolean reads(Hir.Expr e, Scope env) {
-        if (e instanceof Hir.Apply call && call.denotes() instanceof ValueName.Helper
-                && env.of(call.denotes(), call.reaches()) == null) {
+        if (e instanceof Hir.Apply call && call.answered() instanceof Hir.Var.Denoting callee
+                && callee.denotes() instanceof ValueName.Helper
+                && env.of(callee.denotes(), callee.reaches()) == null) {
             return false;
         }
         boolean[] all = {true};
@@ -1104,7 +1110,8 @@ public final class Elaborator {
         if (e instanceof Hir.Apply call) {
             handedOver(binder, call, env, ctx, out);
         }
-        if (e instanceof Hir.Apply call && call.denotes() instanceof ValueName.Local applied
+        if (e instanceof Hir.Apply call && call.answered() != null
+                && call.answered().denotes() instanceof ValueName.Local applied
                 && applied.id().equals(binder.id())
                 && call.args().stream().noneMatch(a -> reaches(a, inner))) {
             List<Type> argTypes = new ArrayList<>();
@@ -1122,7 +1129,8 @@ public final class Elaborator {
                 // A name given to this function is this function: what the second name is used for is
                 // what the first one is used for. Followed rather than left to the applications alone,
                 // because an alias may be the only thing that is ever applied or handed over.
-                if (li.value() instanceof Hir.Var v && v.denotes() instanceof ValueName.Local local
+                if (li.value() instanceof Hir.Var.Denoting v
+                        && v.denotes() instanceof ValueName.Local local
                         && local.id().equals(binder.id())) {
                     collectApplications(li.binder(), li.body(), env, ctx, out, inner);
                 }
@@ -1158,12 +1166,13 @@ public final class Elaborator {
      */
     private static void handedOver(Hir.Binder binder, Hir.Apply call, Scope env, CheckContext ctx,
                                    List<List<Type>> out) {
-        CompleteSignature kept = ctx.preserved().signatureOf(call.denotes());
+        CompleteSignature kept = call.answered() == null
+                ? null : ctx.preserved().signatureOf(call.answered().denotes());
         if (kept == null || kept.params().size() != call.args().size()) {
             return;
         }
         for (int i = 0; i < call.args().size(); i++) {
-            if (!(call.args().get(i) instanceof Hir.Var v)
+            if (!(call.args().get(i) instanceof Hir.Var.Denoting v)
                     || !(v.denotes() instanceof ValueName.Local local)
                     || !local.id().equals(binder.id())
                     || !(kept.params().get(i) instanceof Type.FnOf declared)) {
@@ -1206,8 +1215,8 @@ public final class Elaborator {
             return false;
         }
         ValueName denotes = switch (e) {
-            case Hir.Var v -> v.denotes();
-            case Hir.Apply c -> c.denotes();
+            case Hir.Var.Denoting v -> v.denotes();
+            case Hir.Apply c when c.answered() != null -> c.answered().denotes();
             default -> null;
         };
         if (denotes instanceof ValueName.Local local && inner.contains(local.id())) {
@@ -1470,7 +1479,7 @@ public final class Elaborator {
         optionCaseWritten(v.name(), v.pos());
         // A name that was answered is not an unknown one, and saying it is sends the reader looking
         // for a spelling mistake. What it denotes is what cannot stand here, so that is the report.
-        String denotes = switch (v.denotes()) {
+        String denotes = switch (v.answered().denotes()) {
             case ValueName.Behavior _ -> "a behavior";
             case ValueName.Builtin _ -> "written at the position that reads it, not evaluated";
             // Reached from a name slot the inliner does not substitute into — a spread. In an

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -644,9 +644,14 @@ public final class Elaborator {
      */
     private static void checkOpens(Hir.LetIn li, Type valueType, Symbols symbols) {
         String opened = li.opens().written();
-        // A name that names nothing opens nothing: it is reported where it is written, and what is
-        // said here — that it is not a newtype — would be a second report about the one mistake.
-        TypeSymbol layer = li.opens().answered() == null ? null : li.opens().answered().type();
+        // A name nothing declares was reported where it is written, and what is left here is not a
+        // question about it: what the binding opens has no type, so the body under it would be
+        // checked against a shape nothing states. Abandoned as a name standing anywhere else in a
+        // body is, rather than passed on as an absent type for the reading below to take for one.
+        if (!(li.opens().answered() instanceof Hir.Name.Denoting opens)) {
+            throw new Unanswerable(li.opens().pos());
+        }
+        TypeSymbol layer = opens.type();
         if (TypeOps.newtypeInner(layer, symbols) == null) {
             throw CompileException.of(Diagnostic
                             .at(li.pos())

--- a/souther-compiler/src/main/java/souther/compiler/check/FixtureEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FixtureEvidence.java
@@ -44,6 +44,11 @@ public record FixtureEvidence(Symbols symbols, Map<String, Hir.FnDef> values,
      * What {@code e} is declared to be, or null where no declaration says — which is where a helper
      * stands, since what a helper was declared to answer with is not read and what it supplied is
      * its answer's to say.
+     *
+     * <p>Null is this walk's word for absence, and every caller reads it as that and nothing else:
+     * the expression states no type here. A name resolution answered with nothing is one of the
+     * ways — it names no declaration to read a type off, and the mistake in it is reported where it
+     * is written.
      */
     public Type declaredTypeOf(Hir.Expr e) {
         return declaredTypeOf(e, new HashSet<>(), new HashMap<>(bound));
@@ -52,7 +57,8 @@ public record FixtureEvidence(Symbols symbols, Map<String, Hir.FnDef> values,
     /** As above, from a walk that already has names in force and a record of what it has entered. */
     public Type declaredTypeOf(Hir.Expr e, Set<ValueName> seen, Map<BindingId, Hir.Expr> inForce) {
         return switch (e) {
-            case Hir.NewData nd -> Type.ref(nd.typeName().denotes());
+            case Hir.NewData nd -> nd.typeName().answered() == null
+                    ? null : Type.ref(nd.typeName().answered().type());
             // `AmountN(100)` is the newtype's construction written in call form (ADR-0032).
             case Hir.Apply c when constructsANewtype(c) -> Type.ref(constructs(c));
             case Hir.FieldAccess fa -> {
@@ -72,10 +78,13 @@ public record FixtureEvidence(Symbols symbols, Map<String, Hir.FnDef> values,
                     }
                 }
             }
+            // A name resolution answered with nothing states no type: there is no declaration to
+            // read one off, and what is wrong with the name is reported where it is written.
+            case Hir.Var v when v.answered() == null -> null;
             case Hir.Var v -> {
-                ValueName denotes = v.denotes();
+                ValueName denotes = v.answered().denotes();
                 // A name reached twice is the cycle the reading itself reports; this walk only stops.
-                if (denotes == null || !seen.add(denotes)) {
+                if (!seen.add(denotes)) {
                     yield null;
                 }
                 Hir.Expr body = denotes instanceof ValueName.Local local
@@ -122,7 +131,8 @@ public record FixtureEvidence(Symbols symbols, Map<String, Hir.FnDef> values,
     }
 
     private static TypeSymbol constructs(Hir.Apply c) {
-        return c.denotes() instanceof ValueName.OfType named ? named.type() : null;
+        return c.answered() != null && c.answered().denotes() instanceof ValueName.OfType named
+                ? named.type() : null;
     }
 
     // --- what a declaration says, asked of the resolution and never of a spelling ------------------
@@ -151,7 +161,10 @@ public record FixtureEvidence(Symbols symbols, Map<String, Hir.FnDef> values,
         Map<String, Hir.TypeRef> out = new LinkedHashMap<>();
         if (symbols.declarations().declaration(typeName.key()) instanceof Hir.Data d) {
             for (Hir.Name inc : d.includes()) {
-                out.putAll(fieldTypes(inc.denotes(), symbols));
+                // A spread naming nothing brings in no fields; it is reported where it is written.
+                if (inc.answered() instanceof Hir.Name.Denoting named) {
+                    out.putAll(fieldTypes(named.type(), symbols));
+                }
             }
             for (Hir.Field f : d.fields()) {
                 // an example builds its input through a decoder, so a field with no external

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -466,12 +466,13 @@ public final class HelperInliner {
      */
     private static void kernelCallsIn(Hir.Expr e, FixtureEvidence evidence,
                                       Map<String, Hir.FnDef> out) {
-        if (e instanceof Hir.Apply call && call.answered() != null
-                && call.denotes() instanceof ValueName.Stdlib) {
-            Prelude.PreludeEntry entry = Prelude.entry(call.reaches());
+        if (e instanceof Hir.Apply call
+                && call.answered() instanceof Hir.Var.Denoting callee
+                && callee.denotes() instanceof ValueName.Stdlib) {
+            Prelude.PreludeEntry entry = Prelude.entry(callee.reaches());
             if (entry != null && entry.declaration().body() instanceof Hir.FnBody.Intrinsic
                     && !entry.declaration().params().isEmpty()
-                    && FixtureApplication.settle(call.reaches(), entry.declaration(),
+                    && FixtureApplication.settle(callee.reaches(), entry.declaration(),
                             FixtureArgumentTypes.of(call, evidence), evidence.symbols())
                             instanceof FixtureApplication.Settled(var settled)) {
                 FixtureCallable.Realization realization = FixtureCallable.resolve(settled);
@@ -616,7 +617,7 @@ public final class HelperInliner {
         if (call.answered() == null) {
             return call;   // it reaches no library name, so there is no sugar to write out
         }
-        Prelude.Rewrite rewrite = Prelude.rewriteOf(call.reaches());
+        Prelude.Rewrite rewrite = Prelude.rewriteOf(call.answered().reaches());
         if (rewrite == null || call.args().size() != rewrite.keptArgs()) {
             return call;
         }
@@ -697,10 +698,10 @@ public final class HelperInliner {
      * boundary is read in is what answers for it.
      */
     private Hir.RetType arrivesAs(Hir.Expr arg) {
-        if (!(arg instanceof Hir.Var v) || v.answered() == null) {
+        if (!(arg instanceof Hir.Var v) || !(v.answered() instanceof Hir.Var.Denoting named)) {
             return null;
         }
-        Hir.FnDef is = expands(v.denotes(), v.reaches());
+        Hir.FnDef is = expands(named);
         if (is == null || is.declaredReturn() == null) {
             return null;
         }
@@ -784,12 +785,12 @@ public final class HelperInliner {
         if (call.answered() == null) {
             return null;   // it reaches no declaration, so none of them declares anything
         }
-        Prelude.Rewrite rewrite = Prelude.rewriteOf(call.reaches());
+        Prelude.Rewrite rewrite = Prelude.rewriteOf(call.answered().reaches());
         if (rewrite != null && call.args().size() == rewrite.keptArgs()) {
             Hir.FnDef target = table.reached(rewrite.target().qualified());
             return target == null ? null : target.params().subList(0, rewrite.keptArgs());
         }
-        Hir.FnDef helper = table.reached(call.reaches());
+        Hir.FnDef helper = table.reached(call.answered().reaches());
         return helper == null ? null : helper.params();
     }
 
@@ -850,22 +851,26 @@ public final class HelperInliner {
      * module declares is the lambda — with nothing to tell the two apart by.
      */
     private Hir.FnDef appliedHelper(Hir.Apply call) {
-        if (call.appliesAName() && call.answered() == null) {
-            return null;   // it names nothing, so no body stands behind it
+        if (call.answered() == null) {
+            // it names nothing, or what is applied is not a name at all: either way no body stands
+            // behind it, and the expression works out what is applied
+            return null;
         }
-        return expands(call.denotes(), call.reaches());
+        return expands(call.answered());
     }
 
     /**
-     * The body {@code denotes} stands for here, or null where no body stands behind it.
+     * The body {@code named} stands for here, or null where no body stands behind it.
      *
      * <p>The one place that answers it, so a name applied and a name handed over get the same answer.
-     * {@code reachedBy} is how the name is written here — bare for a definition of this module,
-     * qualified for the library and for what another module publishes — which is the namespace the
-     * table is keyed by; which namespace to look in is decided by the denotation, never by the text.
+     * The two halves of the answer arrive together, as one name: how it is written here — bare for a
+     * definition of this module, qualified for the library and for what another module publishes —
+     * is the namespace the table is keyed by, and which namespace to look in is decided by what it
+     * denotes, never by the text. A name that names nothing has neither, so it is not asked at all.
      */
-    private Hir.FnDef expands(ValueName denotes, String reachedBy) {
-        return switch (denotes) {
+    private Hir.FnDef expands(Hir.Var.Denoting named) {
+        String reachedBy = named.reaches();
+        return switch (named.denotes()) {
             // applying something that is not a name: what is applied is worked out by the expression,
             // and no declaration stands behind it
             case null -> null;
@@ -911,7 +916,7 @@ public final class HelperInliner {
         for (int i = 0; i < callee.params().size() && i < out.size(); i++) {
             Hir.RetType declared = callee.params().get(i).type();
             Hir.FnType want = declared == null ? null : declared.asFn();
-            if (want == null || !(out.get(i) instanceof Hir.Var v)
+            if (want == null || !(out.get(i) instanceof Hir.Var.Denoting v)
                     || !(v.denotes() instanceof ValueName.Local local)
                     || !writing.dependencies().contains(local.id())) {
                 continue;
@@ -994,9 +999,8 @@ public final class HelperInliner {
 
     /** The body {@code name} would put here, or null where the name stands for itself — asked as
      *  {@link #valueOf} and {@link #expandCall} ask it, so what is counted is what is spliced. */
-    private Hir.Expr substitutedAt(Hir.Var name) {
-        if (name.answered() == null
-                || !(name.denotes() instanceof ValueName.Helper)
+    private Hir.Expr substitutedAt(Hir.Var.Denoting name) {
+        if (!(name.denotes() instanceof ValueName.Helper)
                 || graph.recurses(name.reaches())) {
             return null;
         }
@@ -1087,7 +1091,7 @@ public final class HelperInliner {
                 // A binding that holds a function, read into another binding: the second names the
                 // same function, so it is registered under it. Nothing is copied — what a name means
                 // is what it was given, and here it was given a binding.
-                Hir.FnDef aliased = value instanceof Hir.Var v ? expands(v.denotes(), v.reaches()) : null;
+                Hir.FnDef aliased = value instanceof Hir.Var.Denoting v ? expands(v) : null;
                 if (aliased != null) {
                     BindingId alias = li.binder().id();
                     writing.scopedLambdas().put(alias, new ScopedLambda(aliased));
@@ -1174,10 +1178,14 @@ public final class HelperInliner {
             args.add(inline(a));
         }
         Hir.FnDef helper = appliedHelper(call);
+        // What is applied, where it is a name that names something. A body stands behind nothing
+        // else, so where this is absent the call is left as it is.
+        Hir.Var.Denoting callee = call.answered();
         // a recursive helper is reached by the name it is declared under; a lambda a binding
         // holds is not one, whatever it is called
-        boolean standing = !(call.denotes() instanceof ValueName.Local)
-                && graph.recurses(call.reaches());
+        boolean standing = callee != null
+                && !(callee.denotes() instanceof ValueName.Local)
+                && graph.recurses(callee.reaches());
         if (helper == null || standing) {
             // builtin, injected behavior, a function-typed parameter, or a recursive helper —
             // a recursive helper is lowered to a method, so its call stays a Call (spec §fn-declaration);
@@ -1200,7 +1208,7 @@ public final class HelperInliner {
         // declared return is carried on, and every binding copied out of the callee's body.
         // One minter, so no two of them are the same binding, and a reader can ask of any of
         // them which call it came from.
-        BindingOwner mine = new BindingOwner.Expansion(writing.into(), call.denotes(), next());
+        BindingOwner mine = new BindingOwner.Expansion(writing.into(), callee.denotes(), next());
         Hir.Binders ours = new Hir.Binders(mine);
         // What the callee's signature leaves open, this call decides. Its variables are
         // instantiated once, here, over the whole signature at once — so a variable it wrote
@@ -1229,7 +1237,7 @@ public final class HelperInliner {
             }
         });
         arguments.unreduced().keySet().forEach(writing.scopedLambdas()::remove);
-        return new Hir.Expansion(call.denotes(), mine, bound, arguments.given(),
+        return new Hir.Expansion(callee.denotes(), mine, bound, arguments.given(),
                 instantiated(helper.declaredReturn(), applied), body, call.pos(), call.region());
     }
 
@@ -1242,7 +1250,8 @@ public final class HelperInliner {
      * the parameter count is reported against the lambda instead.
      */
     private CompileException wrongArity(Hir.Apply call, Hir.FnDef helper, int given) {
-        ScopedLambda applied = call.denotes() instanceof ValueName.Local local
+        ScopedLambda applied = call.answered() != null
+                && call.answered().denotes() instanceof ValueName.Local local
                 ? writing.scopedLambdas().get(local.id()) : null;
         LambdaOrigin origin = applied == null ? null : applied.origin();
         if (origin != null) {
@@ -1305,7 +1314,7 @@ public final class HelperInliner {
                 given.add(new Hir.Given(instantiated(p.type(), applied), arg,
                         references(helper.writtenBody(), p.binder().id()), arrivesAs(arg)));
                 Hir.FnType declares = declaredFn(p.type(), applied);
-                if (arg instanceof Hir.Var fnName && fnName.answered() != null) {
+                if (arg instanceof Hir.Var.Denoting fnName) {
                     // A name handed to a function parameter is substituted through: what
                     // applies it applies what it stands for. What it stands for is declared
                     // somewhere — a helper's own parameter, a binding, a function an
@@ -1415,8 +1424,8 @@ public final class HelperInliner {
      * declines to make: a {@code let} with no parameter list is a value and is written without
      * {@code ()}, and there is no block taking no parameter to expand it to.
      */
-    private OptionalInt declarationArity(Hir.Var v) {
-        if (v.answered() == null) {
+    private OptionalInt declarationArity(Hir.Var name) {
+        if (!(name.answered() instanceof Hir.Var.Denoting v)) {
             return OptionalInt.empty();   // it stands for no declaration to take anything
         }
         int arity = switch (v.denotes()) {
@@ -1462,17 +1471,18 @@ public final class HelperInliner {
             int k = next();
             return inline(etaExpand(v, arity.getAsInt(), i -> "$v" + k + "_" + i));
         }
-        if (v.answered() == null || !(v.denotes() instanceof ValueName.Helper)) {
+        if (!(v.answered() instanceof Hir.Var.Denoting named)
+                || !(named.denotes() instanceof ValueName.Helper)) {
             return v;
         }
-        Hir.FnDef value = table.reached(v.reaches());
+        Hir.FnDef value = table.reached(named.reaches());
         // Asked with the name the table was asked with. The graph is keyed as the table is, and a
         // spelling agrees with that key only where a pass has already written it out qualified.
-        if (value == null || value.body() == null || graph.recurses(v.reaches())) {
+        if (value == null || value.body() == null || graph.recurses(named.reaches())) {
             return v;
         }
-        Hir.Expr settled = settled(v);
-        return settled != null ? settled : substituted(v.reaches(), value.writtenBody());
+        Hir.Expr settled = settled(named);
+        return settled != null ? settled : substituted(named.reaches(), value.writtenBody());
     }
 
     /**
@@ -1492,7 +1502,7 @@ public final class HelperInliner {
      * (ADR-0072), so what stands there is this reference's, and a report about it belongs where the
      * name was written rather than in the body it came from.
      */
-    private Hir.Expr settled(Hir.Var v) {
+    private Hir.Expr settled(Hir.Var.Denoting v) {
         Type type = settledValues.valueKept(v.denotes());
         if (type == null) {
             return null;
@@ -1570,7 +1580,8 @@ public final class HelperInliner {
                 spreads.add(spread);
                 continue;
             }
-            Hir.Binder name = writing.binders().binder("$s" + next() + "_" + spread.bare(), spread.pos());
+            Hir.Binder name = writing.binders().binder(
+                    "$s" + next() + "_" + spread.answered().bare(), spread.pos());
             bound.add(name);
             values.add(substituted(spread.name(), value.writtenBody()));
             spreads.add(Hir.Var.local(name, spread.pos()));
@@ -1614,12 +1625,13 @@ public final class HelperInliner {
         if (call.answered() == null) {
             return call;   // it reaches nothing, so it is no named block to desugar
         }
-        Integer idx = BLOCK_ARG.get(call.reaches());
+        Integer idx = BLOCK_ARG.get(call.answered().reaches());
         if (idx == null || idx >= call.args().size()
-                || !(call.args().get(idx) instanceof Hir.Var v) || v.answered() == null) {
+                || !(call.args().get(idx) instanceof Hir.Var v)
+                || !(v.answered() instanceof Hir.Var.Denoting named)) {
             return call;
         }
-        Hir.FnDef helper = expands(v.denotes(), v.reaches());
+        Hir.FnDef helper = expands(named);
         if (helper == null) {
             return call;   // a bare name that stands for no body is left for the type checker to report
         }
@@ -1942,13 +1954,15 @@ public final class HelperInliner {
      * holding it, and asking again would answer about the wrong thing.
      */
     private WrittenAt whereTheBodyIs(Hir.Apply call, Hir.FnDef helper) {
-        if (call.denotes() instanceof ValueName.Local || CitableRegion.canShow(helper.pos())) {
+        if (call.answered() == null
+                || call.answered().denotes() instanceof ValueName.Local
+                || CitableRegion.canShow(helper.pos())) {
             return WrittenAt.HERE;
         }
         // Reached rather than declared: `List.map` is what a reader here writes and what a report
         // about it should quote, and which module declares it is the other half, read off the
         // declaration rather than split back out of the name.
-        return new WrittenAt.OutOfSight(call.reaches());
+        return new WrittenAt.OutOfSight(call.answered().reaches());
     }
 
     /** {@code call}'s own place, said to stand in for a body written out of sight — what a copy that
@@ -1985,9 +1999,9 @@ public final class HelperInliner {
      * spelling comes out of an expansion a unit short and a qualified one written over a line break
      * comes out as far as its spelling is long.
      */
-    private Hir.Var renameVar(Hir.Var v, Renaming renaming) {
-        if (v.answered() == null) {
-            return v;   // it names nothing, so there is nothing to rename it to
+    private Hir.Var renameVar(Hir.Var name, Renaming renaming) {
+        if (!(name.answered() instanceof Hir.Var.Denoting v)) {
+            return name;   // it names nothing, so there is nothing to rename it to
         }
         Substituted stands = renaming.substituted(v.denotes());
         if (stands != null) {
@@ -2018,8 +2032,8 @@ public final class HelperInliner {
      * against the module's definitions: a binding in force wins over a declaration, and a spread is
      * no exception.
      */
-    private Hir.FnDef valueSpread(Hir.Var spread) {
-        if (spread.answered() == null
+    private Hir.FnDef valueSpread(Hir.Var name) {
+        if (!(name.answered() instanceof Hir.Var.Denoting spread)
                 || !(spread.denotes() instanceof ValueName.Helper)) {
             return null;
         }
@@ -2042,8 +2056,8 @@ public final class HelperInliner {
      */
     private static boolean references(Hir.Expr e, BindingId binding) {
         ValueName denotes = switch (e) {
-            case Hir.Var v when v.answered() != null -> v.denotes();
-            case Hir.Apply c when c.answered() != null -> c.denotes();
+            case Hir.Var.Denoting v -> v.denotes();
+            case Hir.Apply c when c.answered() != null -> c.answered().denotes();
             default -> null;
         };
         if (denotes instanceof ValueName.Local local && local.id().equals(binding)) {
@@ -2099,14 +2113,14 @@ public final class HelperInliner {
             // the recursive `foldFrom` and not the wrapper it wrote.
             case Hir.Apply call when call.answered() instanceof Hir.Var.Denoting callee
                     && !(callee.denotes() instanceof ValueName.Local) -> {
-                String fn = "List.fold".equals(call.reaches()) ? "List.foldFrom" : call.reaches();
+                String fn = "List.fold".equals(callee.reaches())
+                        ? "List.foldFrom" : callee.reaches();
                 if (table.containsKey(fn)) {
                     out.add(fn);
                 }
             }
-            case Hir.Var v when v.answered() != null
-                    && (v.denotes() instanceof ValueName.Helper
-                            || v.denotes() instanceof ValueName.Stdlib) -> {
+            case Hir.Var.Denoting v when v.denotes() instanceof ValueName.Helper
+                    || v.denotes() instanceof ValueName.Stdlib -> {
                 if (table.containsKey(v.reaches())) {
                     out.add(v.reaches());
                 }
@@ -2132,7 +2146,8 @@ public final class HelperInliner {
                 && !(callee.denotes() instanceof ValueName.Local)) {
             // `List.fold` desugars to `List.foldFrom` before inlining, so a body that folds reaches the
             // recursive `foldFrom` — recursion classification and prelude-injection must see that.
-            String fn = "List.fold".equals(call.reaches()) ? "List.foldFrom" : call.reaches();
+            String fn = "List.fold".equals(callee.reaches())
+                    ? "List.foldFrom" : callee.reaches();
             if (table.containsKey(fn)) {
                 out.add(fn);
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
@@ -155,10 +155,11 @@ public final class HelperNames {
             // what is underlined for it is the stretch the name it replaced was read over — not the
             // application's, which takes in arguments this pass did not touch.
             case Hir.Apply call when call.answered() != null
-                    && foreign(call.denotes(), which) ->
+                    && foreign(call.answered().denotes(), which) ->
                     new Hir.Apply(
-                            Hir.Var.respelled(qualifiedName(call.denotes()), call.denotes(),
-                                    ofModule(call.denotes()), call.function().pos(),
+                            Hir.Var.respelled(qualifiedName(call.answered().denotes()),
+                                    call.answered().denotes(),
+                                    ofModule(call.answered().denotes()), call.function().pos(),
                                     call.function().region()),
                             call.args(), call.origin(), call.pos(), call.region());
             case Hir.Var v -> qualified(v, which);
@@ -168,9 +169,10 @@ public final class HelperNames {
 
     /** {@code name} written qualified where it denotes a helper {@code which} accepts. */
     private static Hir.Var qualified(Hir.Var name, Predicate<ValueName.Helper> which) {
-        return name.answered() != null && foreign(name.denotes(), which)
-                ? Hir.Var.respelled(qualifiedName(name.denotes()), name.denotes(),
-                        ofModule(name.denotes()), name.pos(), name.region())
+        return name.answered() instanceof Hir.Var.Denoting named
+                && foreign(named.denotes(), which)
+                ? Hir.Var.respelled(qualifiedName(named.denotes()), named.denotes(),
+                        ofModule(named.denotes()), name.pos(), name.region())
                 : name;
     }
 
@@ -289,7 +291,7 @@ public final class HelperNames {
         // A name nothing declares reaches no helper: it was reported where it is written, and a
         // walk that asks what a name stands for has no edge to add for it.
         ValueName denotes = switch (e) {
-            case Hir.Apply call when call.answered() != null -> call.denotes();
+            case Hir.Apply call when call.answered() != null -> call.answered().denotes();
             case Hir.Var.Denoting v -> v.denotes();
             default -> null;
         };

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -337,7 +337,7 @@ final class HelperParams {
      * know which node kinds bind: what the name resolved to already says it.
      */
     private static boolean refersTo(Hir.Expr e, BindingId id) {
-        return e instanceof Hir.Var v && v.answered() != null
+        return e instanceof Hir.Var.Denoting v
                 && v.denotes() instanceof ValueName.Local local && local.id().equals(id);
     }
 
@@ -573,7 +573,8 @@ final class HelperParams {
             }
             // the value the attempt built is in force over the success arm, at the type it was built as
             Scope built = ic.construct() instanceof Hir.NewData nd
-                    ? env.with(ic.binder(), Type.ref(nd.typeName().denotes())) : env;
+                    && nd.typeName().answered() instanceof Hir.Name.Denoting names
+                    ? env.with(ic.binder(), Type.ref(names.type())) : env;
             List<Reading> arms = new ArrayList<>();
             arms.add(new Reading(ic.then(), built));
             for (Hir.ElseArm arm : ic.els()) {
@@ -870,7 +871,10 @@ final class HelperParams {
             if (c.binding() == null || c.caseTypes().size() != 1) {
                 return env;
             }
-            TypeSymbol arm = c.caseTypes().get(0).denotes();
+            if (c.caseTypes().get(0).answered() == null) {
+                return env;   // it names no case, so it binds nothing this can say the type of
+            }
+            TypeSymbol arm = c.caseTypes().get(0).answered().type();
             Type bound = scrutinee instanceof Type.OptionOf opt && TypeSymbol.SOME.equals(arm)
                     ? opt.element() : MatchElaborator.caseBindType(arm);
             return bound == null ? env : MatchElaborator.bound(env, c.binding(), bound);
@@ -1015,7 +1019,9 @@ final class HelperParams {
 
         /** Each field of a construction, asked for the type that field holds. */
         private void visitInits(Hir.NewData nd, Scope env, BindingId target) {
-            Hir.Data data = symbols.declarations().declaration(nd.typeName().denotes().key()) instanceof Hir.Data d ? d : null;
+            Hir.Data data = nd.typeName().answered() instanceof Hir.Name.Denoting names
+                    && symbols.declarations().declaration(names.type().key()) instanceof Hir.Data d
+                    ? d : null;
             for (Hir.FieldInit init : nd.inits()) {
                 visit(init.value(), env, target,
                         data == null ? null : TypeOps.fieldType(data, init.name(), symbols));
@@ -1038,13 +1044,18 @@ final class HelperParams {
          * the parameter is annotated instead.
          */
         private Type.FnOf calleeSignature(Hir.Apply call, Scope env) {
-            if (call.denotes() instanceof ValueName.Local local) {
+            // What is applied names no declaration, so there is no signature to read: the name is
+            // reported where it is written, and the argument is left to be read on its own.
+            if (call.answered() == null) {
+                return null;
+            }
+            if (call.answered().denotes() instanceof ValueName.Local local) {
                 // What is applied is this binding, whatever else carries its spelling. A declaration
                 // of the same name is a different thing, so where the scope cannot say what the
                 // binding holds, nothing here can.
                 return env.typeOf(local.id()) instanceof Type.FnOf sig ? sig : null;
             }
-            String fn = call.reaches();
+            String fn = call.answered().reaches();
             ReqSig req = reqSigs.get(fn);
             if (req != null) {
                 return new Type.FnOf(req.params(), req.success());

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -343,7 +343,8 @@ public final class HelperTyping {
 
     /** A call in {@code body} to a behavior, which no helper reaches (spec [#calling-a-behavior]). */
     private static Optional<Hir.Apply> callToABehavior(Hir.Expr body) {
-        if (body instanceof Hir.Apply call && call.denotes() instanceof ValueName.Behavior) {
+        if (body instanceof Hir.Apply call && call.answered() != null
+                && call.answered().denotes() instanceof ValueName.Behavior) {
             return Optional.of(call);
         }
         List<Hir.Apply> found = new ArrayList<>();
@@ -409,7 +410,8 @@ public final class HelperTyping {
     /** The first application of {@code name} in {@code e}, for the report to underline, or null where
      * the clause holds none (a lowering wrote the call without a name of its own). */
     private static Hir.Apply firstCallTo(Hir.Expr e, String name) {
-        if (e instanceof Hir.Apply call && call.reaches().equals(name)) {
+        if (e instanceof Hir.Apply call && call.answered() != null
+                && call.answered().reaches().equals(name)) {
             return call;
         }
         Hir.Apply[] found = new Hir.Apply[1];
@@ -489,7 +491,8 @@ public final class HelperTyping {
 
     /** Rejects a call to an injected behavior inside a recursive helper: it is pure (spec §fn-declaration). */
     private static void rejectInjectedCalls(Hir.Expr e, String helper, Set<String> injected) {
-        if (e instanceof Hir.Apply call && injected.contains(call.reaches())) {
+        if (e instanceof Hir.Apply call && call.answered() != null
+                && injected.contains(call.answered().reaches())) {
             throw CompileException.of(Diagnostic
                             .at(call.appliedAt()).say(new NameMessage.ARecursiveHelperIsPure(helper, call.written())).build());
         }
@@ -643,7 +646,7 @@ public final class HelperTyping {
             if (!TypeOps.assignable(got, want.result(), symbols)) {
                 throw blockReturnMismatch(h, paramName, want.result(), got, lambda);
             }
-        } else if (arg instanceof Hir.Var v
+        } else if (arg instanceof Hir.Var.Denoting v
                 && env.of(v.denotes(), v.name()) instanceof Type vt && !(vt instanceof Type.FnOf)) {
             throw CompileException.of(Diagnostic.at(arg.pos())
                     .say(new HelperMessage.AValueWhereAFunctionIsTaken(paramName, h.name(),
@@ -696,8 +699,9 @@ public final class HelperTyping {
 
     /** Collects the names in {@code names} that {@code e} calls (a recursive-helper call graph edge). */
     private static void collectCalls(Hir.Expr e, Set<String> out, Set<String> names) {
-        if (e instanceof Hir.Apply call && names.contains(call.reaches())) {
-            out.add(call.reaches());
+        if (e instanceof Hir.Apply call && call.answered() != null
+                && names.contains(call.answered().reaches())) {
+            out.add(call.answered().reaches());
         }
         TypeChecker.forEachChild(e, c -> collectCalls(c, out, names));
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantBound.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantBound.java
@@ -221,7 +221,7 @@ public record InvariantBound(boolean lower, Endpoint end) {
     private static boolean takesSizeOf(Hir.Expr e, ValueName measure, String subject) {
         return e instanceof Hir.Apply call && call.args().size() == 1
                 && call.args().get(0) instanceof Hir.Var arg && arg.name().equals(subject)
-                && call.function() instanceof Hir.Var fn && measure.equals(fn.denotes());
+                && call.function() instanceof Hir.Var.Denoting fn && measure.equals(fn.denotes());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
@@ -57,7 +57,8 @@ public final class MatchElaborator {
                 continue;
             }
             List<TypeSymbol> others = TypeOps.caseNames(sum);
-            if (others.contains(written.denotes()) && !cases.containsAll(others)) {
+            if (written.answered() != null && others.contains(written.answered().type())
+                    && !cases.containsAll(others)) {
                 otherSum = sum.name();
                 break;
             }
@@ -193,10 +194,10 @@ public final class MatchElaborator {
      * for.
      */
     private static TypeSymbol names(Hir.Name arm) {
-        if (arm instanceof Hir.Name.Unanswered) {
+        if (!(arm.answered() instanceof Hir.Name.Denoting named)) {
             throw new Unanswerable(arm.pos());
         }
-        return arm.denotes();
+        return named.type();
     }
 
     /** The type a match case binds. A primitive-named case (e.g. {@code Int} in {@code Int |

--- a/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
@@ -95,7 +95,8 @@ public final class NewtypeDesugar {
                 // same spelling as the type it shadows, and rewrite an application of it into a
                 // construction — both of which compile, so the meaning would change in silence.
                 TypeSymbol built = call.answered() != null
-                        && call.denotes() instanceof ValueName.OfType named ? named.type() : null;
+                        && call.answered().denotes() instanceof ValueName.OfType named
+                        ? named.type() : null;
                 if (built != null && symbols.declarations().declaration(built.key()) instanceof Hir.Data nt && nt.newtype()) {
                     if (args.size() != 1) {
                         throw CompileException.of(Diagnostic

--- a/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
@@ -151,10 +151,10 @@ final class PartialReachability {
      * not be written where a value goes. A value takes none and is read rather than handed over.
      */
     boolean isPartialFunctionNamed(Hir.Var v) {
-        if (v.answered() == null) {
+        if (!(v.answered() instanceof Hir.Var.Denoting named)) {
             return false;   // it names no helper, partial or otherwise
         }
-        Hir.FnDef declared = declarationOf(v.denotes(), v.reachedAs(), inliner);
+        Hir.FnDef declared = declarationOf(named, inliner);
         return declared != null && declared.partial() && !declared.params().isEmpty();
     }
 
@@ -255,15 +255,15 @@ final class PartialReachability {
         switch (e) {
             // A name nothing answered reaches no declaration, so it makes no edge.
             case Hir.Apply call when call.answered() != null -> {
-                Hir.FnDef applied = declarationOf(call.denotes(), call.reachedAs(), inliner);
+                Hir.FnDef applied = declarationOf(call.answered(), inliner);
                 if (applied != null) {
-                    out.add(keyOf(call.denotes(), call.reachedAs()));
+                    out.add(keyOf(call.answered()));
                 }
             }
-            case Hir.Var v when v.answered() != null -> {
-                Hir.FnDef read = declarationOf(v.denotes(), v.reachedAs(), inliner);
+            case Hir.Var.Denoting v -> {
+                Hir.FnDef read = declarationOf(v, inliner);
                 if (read != null && read.params().isEmpty()) {
-                    out.add(keyOf(v.denotes(), v.reachedAs()));
+                    out.add(keyOf(v));
                 }
             }
             default -> { }
@@ -282,19 +282,18 @@ final class PartialReachability {
      * today, so keeping it changes no answer; leaving it out would make that a premise of the check
      * rather than a fact about the library, and one the library could stop honouring in silence.
      */
-    private static String keyOf(ValueName denotes, ReachName reachedAs) {
-        return switch (denotes) {
+    private static String keyOf(Hir.Var.Denoting named) {
+        return switch (named.denotes()) {
             // Which key it is, the reference says: settled where the name was resolved and carried
             // here. What decides whether there is a node at all is what the name denotes — a binding
             // spelled like a helper reaches no declaration however it is written.
-            case ValueName.Helper _, ValueName.Stdlib _ -> reachedAs.rendered();
+            case ValueName.Helper _, ValueName.Stdlib _ -> named.reaches();
             case null, default -> null;
         };
     }
 
-    private static Hir.FnDef declarationOf(ValueName denotes, ReachName reachedAs,
-                                           HelperInliner inliner) {
-        String key = keyOf(denotes, reachedAs);
+    private static Hir.FnDef declarationOf(Hir.Var.Denoting named, HelperInliner inliner) {
+        String key = keyOf(named);
         return key == null ? null : inliner.helper(key);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/PipelineSigs.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PipelineSigs.java
@@ -109,17 +109,19 @@ public final class PipelineSigs {
             // A stage that names nothing was reported where it is written. It is no pipeline to
             // splice in, and the composition it is part of is abandoned where its signature is
             // asked for rather than here.
-            List<Hir.Var> sub = s.unresolved() ? null : pipeStages.get(s.bare());
+            List<Hir.Var> sub = s.answered() instanceof Hir.Var.Denoting named
+                    ? pipeStages.get(named.bare()) : null;
             if (sub == null) {
                 out.add(s);
                 continue;
             }
-            if (!inProgress.add(s.bare())) {
+            String named = s.answered().bare();
+            if (!inProgress.add(named)) {
                 throw CompileException.of(Diagnostic
                                 .at(pos).say(new BehaviorMessage.APipelineComposesWithItself(s.name())).build());
             }
             flattenInto(sub, pipeStages, out, inProgress, pos);
-            inProgress.remove(s.bare());
+            inProgress.remove(named);
         }
     }
 
@@ -133,10 +135,10 @@ public final class PipelineSigs {
      */
     public static Sig stageSig(Hir.Var stage, Map<String, Sig> sigs, Symbols symbols,
                                SourcePos pos) {
-        if (stage.unresolved()) {
+        if (!(stage.answered() instanceof Hir.Var.Denoting named)) {
             throw new Unanswerable(stage.pos());
         }
-        Sig s = sigs.get(stage.bare());
+        Sig s = sigs.get(named.bare());
         if (s == null) {
             // The behavior is declared by a module this compilation could not work out — reported
             // on that module, whose author is the one who can act on it.

--- a/souther-compiler/src/main/java/souther/compiler/check/Requirements.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Requirements.java
@@ -125,17 +125,17 @@ public final class Requirements {
             case Hir.SpecBehavior spec -> {
                 for (Hir.Var req : spec.dependsOn()) {
                     // Reported where it is written; it names no requirement to propagate.
-                    if (!req.unresolved()) {
-                        add(acc, req.bare(), name);
+                    if (req.answered() instanceof Hir.Var.Denoting named) {
+                        add(acc, named.bare(), name);
                     }
                 }
             }
             case Hir.PipeBehavior pipe -> {
                 for (Hir.Var stage : pipe.stages()) {
-                    if (stage.unresolved()) {
+                    if (!(stage.answered() instanceof Hir.Var.Denoting named)) {
                         continue;   // it names no behavior, so it carries no requirement in
                     }
-                    String s = stage.bare();
+                    String s = named.bare();
                     if (injected.contains(s)) {
                         // the stage is the dependency: the composition holds it in a field and
                         // applies it there (spec §composition-with-requirements)

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -1498,10 +1498,10 @@ public final class Resolve {
      * synthesized by an earlier pass rather than written, so there is nothing to point at, and a
      * name nothing answered is an absence rather than a declaration to record. */
     private Hir.Name answered(Hir.Name n) {
-        if (n instanceof Hir.Name.Unanswered) {
+        if (!(n.answered() instanceof Hir.Name.Denoting names)) {
             failed++;
         } else if (n.pos() != null) {
-            denotations.add(new TypeUse(n.name(), n.denotes()));
+            denotations.add(new TypeUse(n.name(), names.type()));
         }
         return n;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -60,11 +60,11 @@ public final class SpecChecker {
             switch (b) {
                 case Hir.SpecBehavior spec -> {
                     for (Hir.Var req : spec.dependsOn()) {
-                        if (req.unresolved()) {
+                        if (!(req.answered() instanceof Hir.Var.Denoting named)) {
                             continue;   // it names no behavior, so it is no edge of this graph
                         }
-                        if (names.contains(req.bare()) && !out.contains(req.bare())) {
-                            out.add(req.bare());
+                        if (names.contains(named.bare()) && !out.contains(named.bare())) {
+                            out.add(named.bare());
                         }
                     }
                     Hir.FnDef fn = fns.get(spec.name());
@@ -78,11 +78,11 @@ public final class SpecChecker {
                 }
                 case Hir.PipeBehavior pipe -> {
                     for (Hir.Var stage : pipe.stages()) {
-                        if (stage.unresolved()) {
+                        if (!(stage.answered() instanceof Hir.Var.Denoting named)) {
                             continue;   // it names no behavior, so it is no edge of this graph
                         }
-                        if (names.contains(stage.bare()) && !out.contains(stage.bare())) {
-                            out.add(stage.bare());
+                        if (names.contains(named.bare()) && !out.contains(named.bare())) {
+                            out.add(named.bare());
                         }
                     }
                 }
@@ -136,10 +136,11 @@ public final class SpecChecker {
                 continue;
             }
             for (Hir.Var required : spec.dependsOn()) {
-                if (required.unresolved() || reqSigs.containsKey(required.bare())) {
+                if (!(required.answered() instanceof Hir.Var.Denoting named)
+                        || reqSigs.containsKey(named.bare())) {
                     continue;
                 }
-                String req = required.bare();
+                String req = named.bare();
                 // Three ways a name can be wrong here, told apart because the fix differs. A
                 // behavior that depends on nothing has nothing to inject and is called instead; a
                 // composition cannot be rested on because its requirements are not written; a name
@@ -148,7 +149,7 @@ public final class SpecChecker {
                 // rather than the unknown one — scanning this module's own behaviors would only find
                 // the local ones. All are reported at the name, as the clause that names nothing is.
                 boolean dependsOnNothing = calleeSigs.containsKey(req);
-                boolean aComposition = required.denotes() instanceof ValueName.Behavior;
+                boolean aComposition = named.denotes() instanceof ValueName.Behavior;
                 throw CompileException.of(Diagnostic.at(required.written().reportedAt())
                         .say(dependsOnNothing
                                 ? new DeclarationMessage
@@ -272,8 +273,14 @@ public final class SpecChecker {
             }
         }
         for (int i = 0; i < nReq; i++) {
+            // A clause naming nothing names no parameter for this one to be out of order against;
+            // it is reported where it is written, and the parameters beside it are still held to
+            // the ones that do.
+            if (!(spec.dependsOn().get(i).answered() instanceof Hir.Var.Denoting named)) {
+                continue;
+            }
             String got = fn.params().get(nBusiness + i).name();
-            String want = spec.dependsOn().get(i).bare();
+            String want = named.bare();
             if (!got.equals(want)) {
                 throw CompileException.of(Diagnostic
                                 .at(fn.pos()).say(new BehaviorMessage.AnInjectedParameterIsOutOfOrder(fn.name(), got, want)).build());
@@ -355,7 +362,12 @@ public final class SpecChecker {
             }
             for (Hir.Name declaredName : spec.constructs()) {
                 String name = declaredName.written();
-                if (!constructed.builds(declaredName.denotes())) {
+                // A name that names nothing declares no construction to be kept or removed; it is
+                // reported where it is written.
+                if (declaredName.answered() == null) {
+                    continue;
+                }
+                if (!constructed.builds(declaredName.answered().type())) {
                     disagreements.add(Diagnostic.at(spec.pos())
                                     .hint(new DeclarationMessage.RemoveTheConstructsEntry(name)).say(new DeclarationMessage.ItDeclaresConstructsAndNeverBuilds(spec.name(), name)).build());
                 }
@@ -370,7 +382,10 @@ public final class SpecChecker {
         List<String> actual = requiredCalls(body, reqSigs.keySet());
         List<String> declared = new ArrayList<>();
         for (Hir.Var required : spec.dependsOn()) {
-            declared.add(required.bare());
+            // Reported where it is written; it declares no requirement for a call to answer to.
+            if (required.answered() instanceof Hir.Var.Denoting named) {
+                declared.add(named.bare());
+            }
         }
         for (String call : actual) {
             if (!declared.contains(call)) {
@@ -466,7 +481,10 @@ public final class SpecChecker {
                                                  boolean exposeAll, Set<String> exposed) {
         for (Hir.Name name : spec.constructs()) {
             String c = name.written();
-            TypeSymbol built = name.denotes();
+            if (name.answered() == null) {
+                continue;   // it names no type to be built from outside; reported where written
+            }
+            TypeSymbol built = name.answered().type();
             if (symbols.declarations().declaration(built.key()) instanceof Hir.UnitData) {
                 continue;   // a unit has a generated factory
             }
@@ -665,10 +683,10 @@ public final class SpecChecker {
             List<Hir.Var> stages = PipelineSigs.flattenStages(pipe.stages(), pipeStages,
                     pipe.pos());
             for (int i = 1; i < stages.size(); i++) {
-                if (stages.get(i).unresolved()) {
+                if (!(stages.get(i).answered() instanceof Hir.Var.Denoting named)) {
                     continue;   // reported where it is written; it declares no arity to hold it to
                 }
-                String stage = stages.get(i).bare();
+                String stage = named.bare();
                 Integer n = arity.get(stage);
                 if (n != null && n != 1) {
                     throw CompileException.of(Diagnostic
@@ -688,8 +706,8 @@ public final class SpecChecker {
 
     private static void collectRequiredCalls(Hir.Expr e, Set<String> requiredNames, List<String> out) {
         if (e instanceof Hir.Apply call && call.answered() != null
-                && requiredNames.contains(call.reaches())
-                && !out.contains(call.reaches())) {
+                && requiredNames.contains(call.answered().reaches())
+                && !out.contains(call.answered().reaches())) {
             out.add(call.written());
         }
         // Every subexpression, through the one exhaustive walk — a call to an injected behavior may

--- a/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
@@ -316,7 +316,7 @@ final class TotalityChecker {
                 walk(li.body(), group, paramNames, ltInner, eqInner, calls);
             }
             case Hir.Apply call -> {
-                if (group.contains(call.reaches())) {
+                if (call.answered() != null && group.contains(call.answered().reaches())) {
                     calls.add(new RecCall(call.written(), call, lt, eq));
                 }
                 Combinators.Written handed = Combinators.handedTo(call);
@@ -353,7 +353,7 @@ final class TotalityChecker {
     private static Set<BindingId> rootParams(Hir.Expr e, Map<BindingId, Set<BindingId>> lt,
                                           Map<BindingId, Set<BindingId>> eq, Set<BindingId> paramNames) {
         return switch (e) {
-            case Hir.Var v when v.denotes() instanceof ValueName.Local local -> {
+            case Hir.Var.Denoting v when v.denotes() instanceof ValueName.Local local -> {
                 Set<BindingId> s = new HashSet<>();
                 if (paramNames.contains(local.id())) {
                     s.add(local.id());
@@ -373,7 +373,7 @@ final class TotalityChecker {
     private static Set<BindingId> strictSmaller(Hir.Expr e, Map<BindingId, Set<BindingId>> lt,
                                              Map<BindingId, Set<BindingId>> eq, Set<BindingId> paramNames) {
         return switch (e) {
-            case Hir.Var v when v.denotes() instanceof ValueName.Local local ->
+            case Hir.Var.Denoting v when v.denotes() instanceof ValueName.Local local ->
                     lt.getOrDefault(local.id(), Set.of());
             case Hir.FieldAccess fa -> rootParams(fa.target(), lt, eq, paramNames);
             default -> Set.of();
@@ -384,7 +384,7 @@ final class TotalityChecker {
      * field access is strictly smaller, not equal, so it is not here (it is in {@link #strictSmaller}). */
     private static Set<BindingId> eqRoots(Hir.Expr e, Map<BindingId, Set<BindingId>> eq,
                                           Set<BindingId> paramNames) {
-        if (e instanceof Hir.Var v && v.denotes() instanceof ValueName.Local local) {
+        if (e instanceof Hir.Var.Denoting v && v.denotes() instanceof ValueName.Local local) {
             Set<BindingId> s = new HashSet<>();
             if (paramNames.contains(local.id())) {
                 s.add(local.id());
@@ -429,7 +429,7 @@ final class TotalityChecker {
 
     private static void collectOwnCalls(Hir.Expr e, Set<String> own, Set<String> out) {
         if (e instanceof Hir.Apply call && call.answered() != null
-                && own.contains(call.reaches())) {
+                && own.contains(call.answered().reaches())) {
             out.add(call.written());
         }
         forEachChild(e, c -> collectOwnCalls(c, own, out));

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeCardinality.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeCardinality.java
@@ -233,7 +233,12 @@ public final class TypeCardinality {
         Set<TypeSymbol> named = new LinkedHashSet<>();
         switch (def) {
             case Hir.UnitData _ -> { }
-            case Hir.SumData sum -> sum.cases().forEach(each -> named.add(each.denotes()));
+            // A case naming nothing names no declaration for this to have read.
+ 	    case Hir.SumData sum -> sum.cases().forEach(each -> {
+                if (each.answered() instanceof Hir.Name.Denoting names) {
+                    named.add(names.type());
+                }
+            });
             case Hir.Data data ->
                     TypeOps.fieldTypes(data, symbols).values().forEach(each -> names(each, named));
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -290,8 +290,8 @@ public final class TypeChecker {
                 for (Hir.Var req : spec.dependsOn()) {
                     // A name nothing answered is no name for another to be a duplicate of, and it
                     // was reported where it is written.
-                    if (!req.unresolved()) {
-                        required.add(req.bare());
+                    if (req.answered() instanceof Hir.Var.Denoting named) {
+                        required.add(named.bare());
                     }
                 }
                 DataChecker.rejectDuplicateNames(required, "`depends on`", spec.pos());

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -407,11 +407,14 @@ public final class TypeOps {
         return leaves;
     }
 
-    /** A sum's cases: what each name it lists denotes. */
+    /** A sum's cases: what each name it lists denotes. A name that denotes nothing lists no case —
+     * it is reported where it is written, and a reader counting the cases counts what is there. */
     public static List<TypeSymbol> caseNames(Hir.SumData sum) {
         List<TypeSymbol> names = new ArrayList<>();
         for (Hir.Name c : sum.cases()) {
-            names.add(c.denotes());
+            if (c.answered() instanceof Hir.Name.Denoting named) {
+                names.add(named.type());
+            }
         }
         return names;
     }
@@ -1058,13 +1061,13 @@ public final class TypeOps {
         // through spreads, holds no such field at all.
         Map<String, String> suppliedBy = new LinkedHashMap<>();
         for (Hir.Name inc : data.includes()) {
-            if (inc instanceof Hir.Name.Unanswered) {
+            if (!(inc.answered() instanceof Hir.Name.Denoting names)) {
                 // Nothing declares it, which was reported where it is written. It brings in no
                 // fields, and complaining here that it is not a product data would be a second
                 // report about the one mistake.
                 continue;
             }
-            TypeSymbol included = inc.denotes();
+            TypeSymbol included = names.type();
             if (!(symbols.declarations().declaration(included.key()) instanceof Hir.Data id)) {
                 throw CompileException.of(Diagnostic.at(inc.name().reportedAt())
                         .say(new DataMessage.SpreadIsNotAProductData(inc.written()))
@@ -1119,7 +1122,9 @@ public final class TypeOps {
      * not a product. Only {@link #fieldTypes} turns those into a diagnostic, and every declared data
      * goes through it; the readers asked about one field or one invariant answer for what they see. */
     private static Hir.Data spreadTarget(Hir.Name inc, Symbols symbols) {
-        return symbols.declarations().declaration(inc.denotes().key()) instanceof Hir.Data d ? d : null;
+        return inc.answered() instanceof Hir.Name.Denoting named
+                && symbols.declarations().declaration(named.type().key()) instanceof Hir.Data d
+                ? d : null;
     }
 
     /** Whether a data has a field of that name, without resolving any type. */
@@ -1187,7 +1192,7 @@ public final class TypeOps {
     private static void collectSpreadAncestors(Hir.Data data, Symbols symbols, Set<TypeSymbol> out) {
         for (Hir.Name inc : data.includes()) {
             Hir.Data included = spreadTarget(inc, symbols);
-            if (included != null && out.add(inc.denotes())) {
+            if (included != null && out.add(inc.answered().type())) {
                 collectSpreadAncestors(included, symbols, out);
             }
         }
@@ -1254,7 +1259,7 @@ public final class TypeOps {
         for (Hir.Name inc : data.includes()) {
             Hir.Data id = spreadTarget(inc, symbols);
             if (id != null) {
-                invs.addAll(declaredInvariants(inc.denotes(), id, symbols, form));
+                invs.addAll(declaredInvariants(inc.answered().type(), id, symbols, form));
             }
         }
         List<Hir.InvariantClause> own = named == null ? null : form.apply(named);

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
@@ -127,8 +127,7 @@ public final class ValueCycles {
         if (e == null) {
             return;
         }
-        if (e instanceof Hir.Var v && v.answered() != null
-                && v.denotes() instanceof ValueName.Helper) {
+        if (e instanceof Hir.Var.Denoting v && v.denotes() instanceof ValueName.Helper) {
             Hir.FnDef d = reachable.get(v.reaches());
             if (d != null && d.params().isEmpty()) {
                 out.add(v.reaches());

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -179,7 +179,7 @@ public final class Backend {
         for (Hir.Def def : module.defs()) {
             if (def instanceof Hir.SumData sum) {
                 for (Hir.Name caseName : sum.cases()) {
-                    caseToSums.computeIfAbsent(caseName.denotes().name(), k -> new ArrayList<>())
+                    caseToSums.computeIfAbsent(names(caseName).name(), k -> new ArrayList<>())
                             .add(new GeneratedClass.Value(sum.declares()));
                 }
             }
@@ -324,9 +324,9 @@ public final class Backend {
                     for (Hir.Name tn : spec.constructs()) {
                         // a field-bearing data or newtype; de-duplicated so a repeated `constructs`
                         // entry does not emit the factory method twice (a duplicate-method class file)
-                        if (b.symbols.declarations().declaration(tn.denotes().key()) instanceof Hir.Data
-                                && seenConstruct.add(tn.denotes())) {
-                            dataConstructs.add(tn.denotes());
+                        if (b.symbols.declarations().declaration(names(tn).key()) instanceof Hir.Data
+                                && seenConstruct.add(names(tn))) {
+                            dataConstructs.add(names(tn));
                         }
                     }
                 }
@@ -354,7 +354,7 @@ public final class Backend {
                 continue;
             }
             for (Hir.Var req : spec.dependsOn()) {
-                String name = req.bare();
+                String name = reachedBy(req);
                 if (requiredNames.contains(name)) {
                     continue;
                 }
@@ -1192,9 +1192,40 @@ public final class Backend {
     private static List<String> requiredBy(Hir.SpecBehavior spec) {
         List<String> names = new ArrayList<>();
         for (Hir.Var req : spec.dependsOn()) {
-            names.add(req.bare());
+            names.add(reachedBy(req));
         }
         return names;
+    }
+
+    /**
+     * The name a dependency or a pipeline stage is reached by.
+     *
+     * <p>Every name in a module reaching the backend was answered. {@code Bodies.Checked} hands over
+     * an elaboration only where {@code Names.Sound} holds of the module, and that is false as soon
+     * as resolution reports a name denoting nothing; {@code Output.Classes} builds what it generates
+     * from that answer and from nothing else. So one arriving here is not a mistake in the source —
+     * it is this module being emitted with a hole in it, which is the thing that gate is for.
+     */
+    /**
+     * The declaration a type name written in a module being generated names.
+     *
+     * <p>Answered for the same reason {@link #reachedBy} is: what reaches the backend is an
+     * elaboration {@code Bodies.Checked} handed over, and it hands one over only where
+     * {@code Names.Sound} holds of the module — which resolution makes false as soon as it reports
+     * a name denoting nothing.
+     */
+    static TypeSymbol names(Hir.Name name) {
+        return switch (name) {
+            case Hir.Name.Denoting d -> d.type();
+            case Hir.Name.Unanswered u -> throw u.unexpectedHere();
+        };
+    }
+
+    private static String reachedBy(Hir.Var named) {
+        return switch (named) {
+            case Hir.Var.Denoting d -> d.bare();
+            case Hir.Var.Unanswered u -> throw u.unexpectedHere();
+        };
     }
 
     private byte[] generatePipe(Hir.PipeBehavior pipe, Set<String> requiredNames,
@@ -1225,11 +1256,11 @@ public final class Backend {
                 List<Hir.Var> stages = flat;
                 // stage 0 consumes the pipeline's arguments unconditionally
                 Type mainline = PipelineSigs.stageSig(stages.get(0), sigs, symbols, pipe.pos()).outputType();
-                applyFirstStage(code, cdP, stages.get(0).bare(), arity, requiredNames, behaviorDeps,
+                applyFirstStage(code, cdP, reachedBy(stages.get(0)), arity, requiredNames, behaviorDeps,
                         mainline, arity + 1);
                 Label end = code.newLabel();
                 for (int i = 1; i < stages.size(); i++) {
-                    String stage = stages.get(i).bare();
+                    String stage = reachedBy(stages.get(i));
                     Sig g = PipelineSigs.stageSig(stages.get(i), sigs, symbols, pipe.pos());
                     if (TypeOps.isDataLike(mainline)) {
                         // Apply g only when the running value is one of the main-line cases it

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
@@ -237,7 +237,7 @@ final class CodecGen {
     /** Invokes a type's static {@code decoder()}/{@code encoder()} factory, as an interface
      * method reference when the type is a sum (its factory lives on a sealed interface). */
     private void invokeCodec(CodeBuilder code, Hir.Name typeName, String method, MethodTypeDesc mtd) {
-        invokeCodec(code, typeName.denotes(), method, mtd);
+        invokeCodec(code, Backend.names(typeName), method, mtd);
     }
 
     private void invokeCodec(CodeBuilder code, TypeSymbol type, String method, MethodTypeDesc mtd) {
@@ -255,7 +255,7 @@ final class CodecGen {
             // membership in this sum requires of it (spec §encoder-derivation).
             cb.withMethodBody("encode", MTD_Rencode, ClassFile.ACC_PUBLIC, code -> {
                 for (Hir.EncVariant v : enc.variants()) {
-                    TypeSymbol caseName = v.caseType().denotes();
+                    TypeSymbol caseName = Backend.names(v.caseType());
                     code.aload(1);
                     code.instanceOf(cd(caseName));
                     Label next = code.newLabel();
@@ -308,7 +308,7 @@ final class CodecGen {
                     // what is under `"value"` and reads it as the standalone value it is, while a
                     // product and a unit read the discriminated object they are part of. So a wrapped
                     // case is read from under a key, which is not always this source's own decoder.
-                    if (TypeOps.caseShape(v.caseType().denotes(), symbols) == CaseShape.WRAPPED) {
+                    if (TypeOps.caseShape(Backend.names(v.caseType()), symbols) == CaseShape.WRAPPED) {
                         code.loadConstant(CaseShape.ENVELOPE_KEY);
                         emitUnderAKeyDecoder(code, v.caseType(), src);
                         code.invokestatic(srcFieldOwner(src), "field", srcFieldMtd(src));
@@ -534,7 +534,7 @@ final class CodecGen {
                 return false;   // an enumeration is a bare column, not a whole row (issue #161)
             }
             for (Hir.Name written : sum.cases()) {
-                TypeSymbol caseName = written.denotes();
+                TypeSymbol caseName = Backend.names(written);
                 Hir.Def caseDef = symbols.declarations().declaration(caseName.key());
                 if (caseDef instanceof Hir.UnitData) continue;   // the discriminator alone, no column
                 if (!(caseDef instanceof Hir.Data d)) return false;   // a nested sum is not a row
@@ -849,7 +849,7 @@ final class CodecGen {
     }
 
     boolean isMapInput(Hir.Name typeName) {
-        return isMapInputOf(symbols.declarations().declaration(typeName.denotes().key()));
+        return isMapInputOf(symbols.declarations().declaration(Backend.names(typeName).key()));
     }
 
     private boolean isMapInputOf(Hir.Def def) {
@@ -1212,7 +1212,7 @@ final class CodecGen {
     private Type bindType(Hir.DecRef ref) {
         return switch (ref) {
             case Hir.PrimDecRef p -> TypeOps.primType(p.kind());
-            case Hir.DataDecRef d -> Type.ref(d.typeName().denotes());
+            case Hir.DataDecRef d -> Type.ref(Backend.names(d.typeName()));
             case Hir.ListDecRef l -> Type.list(bindType(l.element()));
             case Hir.SetDecRef s -> Type.set(bindType(s.element()));
             case Hir.OptionDecRef o -> Type.option(bindType(o.element()));

--- a/souther-compiler/src/main/java/souther/compiler/codegen/InvariantConstraints.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/InvariantConstraints.java
@@ -171,7 +171,7 @@ public final class InvariantConstraints {
 
     /** The literal bound {@code size(value)} is compared against, or null when this is not that shape. */
     private static Integer sizeBound(String size, Hir.Expr left, Hir.Expr right) {
-        if (!(left instanceof Hir.Apply call) || !call.reaches().equals(size)
+        if (!(left instanceof Hir.Apply call) || !applies(call, size)
                 || call.args().size() != 1 || !isValue(call.args().get(0))) {
             return null;
         }
@@ -188,7 +188,7 @@ public final class InvariantConstraints {
         // same way the check asks — one reading of which expressions are compile-time strings and of
         // what one composes to, so a pattern the check accepted cannot arrive here unrecognised and
         // lose its constraint. It has been compiled once at check time, so it is known well-formed.
-        if (base == Type.STRING && "String.matches".equals(call.reaches()) && call.args().size() == 2
+        if (base == Type.STRING && applies(call, "String.matches") && call.args().size() == 2
                 && isValue(call.args().get(1))) {
             return ConstEval.evalString(call.args().get(0)).map(Pattern::new);
         }
@@ -196,7 +196,7 @@ public final class InvariantConstraints {
         // no two are equal, by the same value equality (spec §collections, ADR-0009). A projection that
         // is not the identity says it of something else — the elements' products, their ids — and Raoh
         // has no constraint for that, so the clause keeps its own check.
-        if (base instanceof Type.ListOf && "List.allDistinctBy".equals(call.reaches())
+        if (base instanceof Type.ListOf && applies(call, "List.allDistinctBy")
                 && call.args().size() == 2 && isValue(call.args().get(1))
                 && isIdentity(call.args().get(0))) {
             return Optional.of(new Unique());
@@ -205,7 +205,7 @@ public final class InvariantConstraints {
     }
 
     private static Optional<Constraint> ofStringLength(Hir.BinOp op, Hir.Expr left, Hir.Expr right) {
-        if (!(left instanceof Hir.Apply call) || !"String.length".equals(call.reaches())
+        if (!(left instanceof Hir.Apply call) || !applies(call, "String.length")
                 || call.args().size() != 1 || !isValue(call.args().get(0))) {
             return Optional.empty();
         }
@@ -278,13 +278,24 @@ public final class InvariantConstraints {
         return e instanceof Hir.Var v && v.name().equals(VALUE);
     }
 
+    /**
+     * Whether {@code call} applies {@code operation} — asked of what the name reaches, which is what
+     * a library operation is filed under whether or not an import let it be written bare.
+     *
+     * <p>A call applying a name nothing declares applies no operation this recognises. There is no
+     * constraint to map it to, and the clause keeps the check it already has.
+     */
+    private static boolean applies(Hir.Apply call, String operation) {
+        return call.answered() != null && operation.equals(call.answered().reaches());
+    }
+
     /** Whether a projection hands back what it was given — {@code x -> x}, however the parameter is
      * spelled. A block with one parameter is how a lambda arrives here (spec §blocks). The body reads
      * the parameter when it reads that binding; a name spelled like it, bound elsewhere, is another
      * value. */
     private static boolean isIdentity(Hir.Expr e) {
         return e instanceof Hir.Block b && b.params().size() == 1
-                && b.body() instanceof Hir.Var v
+                && b.body() instanceof Hir.Var.Denoting v
                 && v.denotes() instanceof ValueName.Local local
                 && local.id().equals(b.params().get(0).id());
     }

--- a/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
@@ -187,7 +187,10 @@ final class ValueClassGen {
         ClassDesc cdX = cd(sum);
         List<ClassDesc> caseCds = new ArrayList<>();
         for (Hir.Name caseName : sum.cases()) {
-            caseCds.add(cd(caseName.denotes()));
+            // Every name in a module the backend generates was answered: `Bodies.Checked` hands an
+            // elaboration over only where `Names.Sound` holds of the module, which resolution makes
+            // false as soon as it reports a name denoting nothing.
+            caseCds.add(cd(Backend.names(caseName)));
         }
         boolean enumeration = TypeOps.isUnitOnlySum(sum, symbols);
         List<TypeSymbol> cases = TypeOps.leafCases(sum, symbols);

--- a/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
+++ b/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
@@ -288,7 +288,13 @@ public final class Deriver {
             return;   // a sum that reaches itself; DataChecker reports it, this only has to terminate
         }
         for (Hir.Name caseName : s.cases()) {
-            if (symbols.declarations().declaration(caseName.denotes().key()) instanceof Hir.SumData nested) {
+            // A case naming nothing is no sum to descend into and no leaf to derive a codec for; it
+            // is reported where it is written.
+            if (caseName.answered() == null) {
+                continue;
+            }
+            if (symbols.declarations().declaration(caseName.answered().type().key())
+                    instanceof Hir.SumData nested) {
                 collectLeafCases(nested, symbols, out, visiting);
             } else if (!out.contains(caseName)) {
                 out.add(caseName);
@@ -299,7 +305,7 @@ public final class Deriver {
     private static List<Hir.Variant> tagVariants(Hir.SumData s, List<Hir.Name> cases) {
         List<Hir.Variant> variants = new ArrayList<>();
         for (Hir.Name caseName : cases) {
-            variants.add(new Hir.Variant(caseName.denotes().name(), caseName, s.pos()));
+            variants.add(new Hir.Variant(caseName.answered().type().name(), caseName, s.pos()));
         }
         return variants;
     }
@@ -307,7 +313,7 @@ public final class Deriver {
     private static List<Hir.EncVariant> encVariants(Hir.SumData s, List<Hir.Name> cases) {
         List<Hir.EncVariant> variants = new ArrayList<>();
         for (Hir.Name caseName : cases) {
-            variants.add(new Hir.EncVariant(caseName, caseName.denotes().name(), s.pos()));
+            variants.add(new Hir.EncVariant(caseName, caseName.answered().type().name(), s.pos()));
         }
         return variants;
     }

--- a/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
@@ -375,7 +375,8 @@ public final class FixtureReader {
      * under, so a row spelling that type qualified asserts the same case.
      */
     TypeSymbol caseOnly(Hir.Expr expected) {
-        return expected instanceof Hir.Var v && v.denotes() instanceof ValueName.OfType named
+        return expected instanceof Hir.Var.Denoting v
+                && v.denotes() instanceof ValueName.OfType named
                 ? named.type() : null;
     }
 
@@ -484,7 +485,8 @@ public final class FixtureReader {
      * silently, since a miss is what a table keyed by names does with a key it has not got.
      */
     private static TypeSymbol constructs(Hir.Apply c) {
-        return c.denotes() instanceof ValueName.OfType named ? named.type() : null;
+        return c.answered() != null && c.answered().denotes() instanceof ValueName.OfType named
+                ? named.type() : null;
     }
 
     /** Whether an application is a newtype's construction written in call form (ADR-0032). */
@@ -722,11 +724,11 @@ public final class FixtureReader {
             case Hir.LetIn let -> helperAnswer(let.body(), followed);
             // a binding holds what it was bound to; a value stands for the body it was defined as.
             // A name that denotes a type is a case, and no helper answered it.
-            case Hir.Var v when v.denotes() instanceof ValueName.Local local -> {
+            case Hir.Var.Denoting v when v.denotes() instanceof ValueName.Local local -> {
                 Hir.Expr held = bindings.get(local.id());
                 yield held == null ? null : helperAnswer(held, followed);
             }
-            case Hir.Var v when v.denotes() instanceof ValueName.Helper -> {
+            case Hir.Var.Denoting v when v.denotes() instanceof ValueName.Helper -> {
                 Hir.Expr body = followed.add(v.name()) ? valueBody(v.name()) : null;
                 yield body == null ? null : helperAnswer(body, followed);
             }
@@ -800,7 +802,8 @@ public final class FixtureReader {
      */
     private TypeSymbol constructedCase(Hir.Expr e, Set<String> followed, List<TypeSymbol> worn) {
         return switch (e) {
-            case Hir.NewData nd -> nd.typeName().denotes();
+            case Hir.NewData nd -> nd.typeName().answered() == null
+                    ? null : nd.typeName().answered().type();
             case Hir.Apply c when constructsANewtype(c) -> {
                 TypeSymbol named = constructs(c);
                 yield wears(named, c, worn)
@@ -820,7 +823,11 @@ public final class FixtureReader {
 
     /** The case a bare name stands for: the type it denotes where it denotes one — a unit case, or a
      * case written bare — and otherwise the case the value or binding it names constructs. */
-    private TypeSymbol namedCase(Hir.Var v, Set<String> followed, List<TypeSymbol> worn) {
+    private TypeSymbol namedCase(Hir.Var name, Set<String> followed, List<TypeSymbol> worn) {
+        if (!(name.answered() instanceof Hir.Var.Denoting v)) {
+            // it names nothing, so it stands for no case; reported where it is written
+            return null;
+        }
         return switch (v.denotes()) {
             case ValueName.OfType named -> named.type();
             case ValueName.Local local -> {
@@ -1098,7 +1105,9 @@ public final class FixtureReader {
                     bindings.remove(binding);
                 }
             }
-            case Hir.Var v -> {
+            // A name that names nothing falls to the reading below with everything else a field
+            // cannot be taken off, and is refused there rather than guessed at here.
+            case Hir.Var.Denoting v -> {
                 ValueName denotes = v.denotes();
                 Hir.Expr body = denotes instanceof ValueName.Local local ? bindings.get(local.id())
                         : denotes instanceof ValueName.Helper ? valueBody(v.name()) : null;
@@ -1356,13 +1365,16 @@ public final class FixtureReader {
     private Stated states(Hir.Expr e) {
         return switch (e) {
             case Hir.LetIn _ -> ELSEWHERE;
-            case Hir.NewData nd -> new Stated.Name(nd.typeName().denotes());
+            case Hir.NewData nd when nd.typeName().answered() != null ->
+                    new Stated.Name(nd.typeName().answered().type());
             case Hir.Var v -> statedByName(v);
             case Hir.Apply c when appliedHelper(c) != null -> ELSEWHERE;
             case Hir.Apply c when constructsANewtype(c) -> caseNamed(constructs(c));
             // `Date("…")` is a temporal, and `Set.fromList([…])` a collection: values under no name.
-            case Hir.Apply c when Type.Prim.named(c.reaches()) != null
-                    || "Set.fromList".equals(c.reaches()) || "Map.fromList".equals(c.reaches()) ->
+            case Hir.Apply c when c.answered() != null
+                    && (Type.Prim.named(c.answered().reaches()) != null
+                            || "Set.fromList".equals(c.answered().reaches())
+                            || "Map.fromList".equals(c.answered().reaches())) ->
                     STATES_NO_NAME;
             case Hir.Apply _ -> ELSEWHERE;
             case Hir.FieldAccess fa -> {
@@ -1417,7 +1429,11 @@ public final class FixtureReader {
         return resolved == null ? STATES_NO_NAME : new Stated.Name(resolved);
     }
 
-    private Stated statedByName(Hir.Var v) {
+    private Stated statedByName(Hir.Var name) {
+        if (!(name.answered() instanceof Hir.Var.Denoting v)) {
+            // it names nothing, and the reading that follows says so where it is written
+            return ELSEWHERE;
+        }
         return switch (v.denotes()) {
             case ValueName.OfType of -> new Stated.Name(of.type());
             case ValueName.Builtin b when b.name().equals("None") -> ABSENCE;
@@ -1496,7 +1512,10 @@ public final class FixtureReader {
      * <p>Which of the four it is was settled where the name was written, so it is not worked out
      * again here: a binding in force is the value it holds, whatever else bears its spelling.
      */
-    private Object named(Hir.Var v, Position at, Admission admission) {
+    private Object named(Hir.Var name, Position at, Admission admission) {
+        if (!(name.answered() instanceof Hir.Var.Denoting v)) {
+            throw new FixtureException("`" + name.name() + "` is not a value a fixture can name");
+        }
         return switch (v.denotes()) {
             // `None` maps to a null, which the optional decoder reads as the absent optional
             // (spec §absence-is-written-as-null, absent/null -> None), the same as omitting a `T?` field
@@ -1640,7 +1659,7 @@ public final class FixtureReader {
      * ({@code Map.empty}), so it is read in {@link #named}.
      */
     private Object collectionOrNewtype(Hir.Apply c, Position at, Admission admission) {
-        if ("Set.fromList".equals(c.reaches()) || "Map.fromList".equals(c.reaches())) {
+        if (isFromList(c)) {
             if (c.args().size() != 1) {
                 throw new FixtureException("`" + c.written() + "` takes one argument");
             }
@@ -1666,8 +1685,7 @@ public final class FixtureReader {
      * a helper however it is spelled. Asked wherever an application has to be told from a construction,
      * so the two readers of a call cannot come to different answers. */
     private Applied appliedHelper(Hir.Apply c) {
-        if ("Set.fromList".equals(c.reaches()) || "Map.fromList".equals(c.reaches())
-                || constructsANewtype(c)) {
+        if (isFromList(c) || constructsANewtype(c)) {
             return null;
         }
         String reached = helperKey(c);
@@ -1686,12 +1704,25 @@ public final class FixtureReader {
      * reach name the reference carries, settled at resolution and not worked out again here.
      */
     private String helperKey(Hir.Apply c) {
-        return switch (c.denotes()) {
-            case ValueName.Helper _, ValueName.Stdlib _ -> c.reaches();
+        if (c.answered() == null) {
+            // what applying something that is not a name leaves, and what a name nothing declares
+            // leaves: neither reaches a declaration for a table to answer about
+            return null;
+        }
+        return switch (c.answered().denotes()) {
+            case ValueName.Helper _, ValueName.Stdlib _ -> c.answered().reaches();
             case ValueName.Local _, ValueName.OfType _, ValueName.Builtin _,
                     ValueName.Behavior _ -> null;
-            case null -> null;   // what applying something that is not a name leaves
+            case null -> null;
         };
+    }
+
+    /** Whether {@code c} is the collection notation a fixture writes as its elements — asked of what
+     *  the callee reaches, as every other question about which operation a call applies is. */
+    private static boolean isFromList(Hir.Apply c) {
+        return c.answered() != null
+                && ("Set.fromList".equals(c.answered().reaches())
+                        || "Map.fromList".equals(c.answered().reaches()));
     }
 
     /**
@@ -1809,7 +1840,8 @@ public final class FixtureReader {
     }
 
     private Object newtypeInner(Hir.Apply c, Position at, Admission admission) {
-        Type.Prim written = Type.Prim.named(c.reaches());
+        Type.Prim written = c.answered() == null
+                ? null : Type.Prim.named(c.answered().reaches());
         if (written != null && written.temporal()) {
             // a written date: the decoders take the parsed temporal, not its text (a Date field's
             // neutral form is a LocalDate), so the fixture hands over the same value the checker read
@@ -1846,21 +1878,31 @@ public final class FixtureReader {
     }
 
     private Object record(Hir.NewData nd, Position at, Admission admission) {
+        // A construction naming nothing builds no value a fixture can supply, and the name it wrote
+        // is reported where it is written.
+        if (nd.typeName().answered() == null) {
+            throw new FixtureException("`" + nd.typeName().written()
+                    + "` is not a type a fixture can build");
+        }
         // `金額(500)` is the record literal `金額 { value = 500 }` written in call form (ADR-0032), and
         // a value's body reaches here already written the second way. Either spelling is the newtype's
         // own neutral form — its inner value — not a field map.
-        TypeSymbol built = nd.typeName().denotes();
+        TypeSymbol built = nd.typeName().answered().type();
         if (neutral.isNewtype(built) && nd.spreads().isEmpty() && nd.inits().size() == 1
                 && nd.inits().get(0).name().equals("value")) {
             Position base = Position.declaredBy(neutral.newtypeBaseType(built));
             return neutral.newtypeAt(at, built,
                     neutral.shaped(raw(nd.inits().get(0).value(), base, below(admission)), base));
         }
-        Map<String, Hir.TypeRef> declared = neutral.fieldTypes(nd.typeName().denotes());
+        Map<String, Hir.TypeRef> declared = neutral.fieldTypes(nd.typeName().answered().type());
         Map<String, Object> map = new LinkedHashMap<>();
         // `...base` copies the fields of a value, and the fields written after it replace what it
         // brought.
-        for (Hir.Var ref : nd.spreads()) {
+        for (Hir.Var spreadName : nd.spreads()) {
+            if (!(spreadName.answered() instanceof Hir.Var.Denoting ref)) {
+                throw new FixtureException("`" + spreadName.name()
+                        + "` is not a value a fixture can spread");
+            }
             // A spread names a value in force, so what it copies is what that name denotes: a binding
             // holds what it was bound to, and a definition stands for its body. A definition is
             // reached by the name this row spells it with — a definition of this module by its own
@@ -1878,7 +1920,7 @@ public final class FixtureReader {
             // opens states no value of the construction's type, while the fields it copies were
             // written at their own positions and hold there.
             Object copied = expandedValue(ref.denotes(), value,
-                    Position.at(Type.ref(nd.typeName().denotes())),
+                    Position.at(Type.ref(nd.typeName().answered().type())),
                     admission == Admission.UNHELD ? admission : Admission.HELD_BELOW);
             if (!(copied instanceof Map<?, ?> fields)) {
                 throw new FixtureException("`" + spread + "` is not a record, so it has no fields to"
@@ -1909,7 +1951,7 @@ public final class FixtureReader {
             }
             map.put(fi.name(), v);
         }
-        neutral.tagged(at, nd.typeName().denotes(), map);
+        neutral.tagged(at, nd.typeName().answered().type(), map);
         return map;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/examples/NeutralForm.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/NeutralForm.java
@@ -203,7 +203,8 @@ final class NeutralForm {
         }
         Hir.Discriminate reads = sum.decoder().get();
         for (Hir.Variant variant : reads.variants()) {
-            if (caseName.equals(variant.caseType().denotes())) {
+            if (variant.caseType().answered() instanceof Hir.Name.Denoting names
+                    && caseName.equals(names.type())) {
                 map.putIfAbsent(reads.key(), variant.tag());
                 return;
             }

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -1068,8 +1068,8 @@ public final class Bodies {
         Set<String> names = new HashSet<>();
         for (Hir.Var req : spec.value().dependsOn()) {
             // Reported where it is written; it names no parameter for a body to be held to.
-            if (!req.unresolved()) {
-                names.add(req.bare());
+            if (req.answered() instanceof Hir.Var.Denoting named) {
+                names.add(named.bare());
             }
         }
         return names;

--- a/souther-compiler/src/test/java/souther/compiler/ARowApplyingAnIntrinsicRefusesANameItCannotAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowApplyingAnIntrinsicRefusesANameItCannotAnswerTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * A name nothing declares, standing in a row that applies an intrinsic, is the naming error
@@ -75,5 +76,34 @@ class ARowApplyingAnIntrinsicRefusesANameItCannotAnswerTest {
     @Test
     void theSameCallSpelledAsCoreDeclaresItIsSettled() {
         assertEquals(List.of("ok"), verdict("Decimal.round(2, HALF_UP, 1.005m)"));
+    }
+
+    /**
+     * And a body writing the same call answers the same, as it did before the row did.
+     *
+     * <p>What decided the answer was the walk a row's operands go through and nothing about the
+     * call, so the body is held here beside the row: a fix that settled the row by teaching that
+     * walk to make something up would show as the two coming apart.
+     */
+    @Test
+    void aBodyWritingTheSameCallIsTheSameNamingError() {
+        String body = """
+                module demo
+
+                data Ok = { n: Int }
+
+                behavior take : (d: Decimal) -> Ok
+                    constructs Ok
+                let take (d) = Ok { n = 1 }
+
+                let round2 (r: Decimal) : Decimal = Decimal.round(2, HalfUp, r)
+                """;
+        try {
+            Compiler.compile(body);
+            fail("`HalfUp` names nothing in a body either");
+        } catch (CompileException e) {
+            assertEquals(List.of("E1023"),
+                    e.diagnostics().stream().map(Diagnostic::code).toList(), e.getMessage());
+        }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/ARowApplyingAnIntrinsicRefusesANameItCannotAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowApplyingAnIntrinsicRefusesANameItCannotAnswerTest.java
@@ -1,0 +1,79 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A name nothing declares, standing in a row that applies an intrinsic, is the naming error
+ * resolution already reported.
+ *
+ * <p>The walk that settles which instance an intrinsic is emitted for reads the row's arguments,
+ * and an argument can be a name resolution answered with nothing. What that walk may do with one is
+ * fail to settle the call: the mistake was reported where the name is written, and reported once —
+ * a second producer repeating it says the same thing twice about one fact.
+ *
+ * <p>Held against every argument position and against a callee that goes nowhere near that walk,
+ * because what decides the answer is neither. A name that denotes nothing is a naming error
+ * wherever it is written.
+ */
+class ARowApplyingAnIntrinsicRefusesANameItCannotAnswerTest {
+
+    private static final String MODULE = """
+            module demo
+
+            data Ok = { n: Int }
+
+            behavior take : (d: Decimal) -> Ok
+                constructs Ok
+            let take (d) = Ok { n = 1 }
+
+            example take
+                | "row" : (%s) -> Ok { n = 1 }
+            """;
+
+    private static List<String> verdict(String operand) {
+        try {
+            Compiler.compile(MODULE.formatted(operand));
+            return List.of("ok");
+        } catch (CompileException e) {
+            return e.diagnostics().stream().map(Diagnostic::code).toList();
+        }
+    }
+
+    /**
+     * Every unresolved name a row's call is written over is the one naming error, once.
+     *
+     * <p>Asked as one map, because what is held is that the answer does not vary with the callee or
+     * the position: a case fixing the one that failed is satisfied by a second answer written for
+     * the others.
+     */
+    @Test
+    void aNameNothingDeclaresInAnIntrinsicsRowCallIsTheNamingErrorOnce() {
+        Map<String, String> operands = new LinkedHashMap<>();
+        operands.put("a misspelt mode", "Decimal.round(2, HalfUp, 1.005m)");
+        operands.put("an unresolved first argument", "Decimal.round(nope, HALF_UP, 1.005m)");
+        operands.put("an unresolved value argument", "Decimal.round(2, HALF_UP, nope)");
+        operands.put("a misspelt mode of divide", "Decimal.divide(1.0m, 2.0m, 2, HalfUp)");
+        operands.put("a callee that is not an intrinsic", "Int.max(1, nope)");
+
+        Map<String, List<String>> expected = new LinkedHashMap<>();
+        operands.forEach((what, _) -> expected.put(what, List.of("E1023")));
+        Map<String, List<String>> got = new LinkedHashMap<>();
+        operands.forEach((what, operand) -> got.put(what, verdict(operand)));
+        assertEquals(expected, got);
+    }
+
+    /** The same call, spelled as core declares the mode, is settled and run. */
+    @Test
+    void theSameCallSpelledAsCoreDeclaresItIsSettled() {
+        assertEquals(List.of("ok"), verdict("Decimal.round(2, HALF_UP, 1.005m)"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileDestructuringTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileDestructuringTest.java
@@ -3,6 +3,7 @@ package souther.compiler;
 import souther.compiler.diag.msg.TypeMessage;
 import souther.compiler.diag.msg.BehaviorMessage;
 import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
 
 import org.junit.jupiter.api.Test;
 
@@ -290,6 +291,32 @@ class CompileDestructuringTest {
                 }
                 """));
         assertInstanceOf(TypeMessage.NotANewtypeToOpenInABinding.class, e.diagnostic().said(), e.getMessage());
+    }
+
+    /**
+     * A pattern naming nothing is the naming error, once, and the compile ends saying it.
+     *
+     * <p>Beside the three rules above rather than among them. Each of those holds a name against
+     * what it names; this one has nothing to hold it against, so the reading stops where the name
+     * is and what is left of the definition is not asked about. Read as a rule, a name that names
+     * nothing would be answered "it is not a newtype", which is a second sentence about the one
+     * mistake — and asked of the declaration it does not have, an internal error.
+     */
+    @Test
+    void openingSomethingNothingDeclaresIsTheNamingErrorOnce() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                import List ( length )
+                data Tags = List<String>
+
+                behavior countTags : (t: Tags) -> Int
+                let countTags (t) = {
+                    let Tgas(xs) = t
+                    length(xs)
+                }
+                """));
+        assertEquals(List.of("E1023"), e.diagnostics().stream().map(Diagnostic::code).toList(),
+                e.getMessage());
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/CompilePostfixApplicationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePostfixApplicationTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * An argument list applies to the expression before it, not only to a name. What is applied is
@@ -147,7 +148,8 @@ class CompilePostfixApplicationTest {
     }
 
     private static int occurrences(Hir.Expr e, String callee) {
-        int[] n = {e instanceof Hir.Apply a && callee.equals(a.reaches()) ? 1 : 0};
+        int[] n = {e instanceof Hir.Apply a && a.answered() != null
+                && callee.equals(a.answered().reaches()) ? 1 : 0};
         Hir.forEachChild(e, c -> n[0] += occurrences(c, callee));
         return n[0];
     }
@@ -318,11 +320,11 @@ class CompilePostfixApplicationTest {
 
         assertTrue(named.appliesAName());
         assertEquals("List.map", named.written());
-        assertEquals("List.map", named.reaches());
+        assertEquals("List.map", named.answered().reaches());
 
         assertFalse(nameless.appliesAName());
         assertEquals("", nameless.written(), "there is no spelling to quote");
-        assertEquals("", nameless.reaches(), "and no declaration to look up");
+        assertNull(nameless.answered(), "and no declaration to look up");
     }
 
     /**
@@ -341,6 +343,7 @@ class CompilePostfixApplicationTest {
                 java.util.List.of(), souther.compiler.types.ConstructionOrigin.own(), "d.count", at, null);
 
         assertEquals("d.count", lowered.written(), "a report quotes what the author wrote");
-        assertEquals("$fn0", lowered.reaches(), "a table is looked up with the binding");
+        assertEquals("$fn0", lowered.answered().reaches(),
+                "a table is looked up with the binding");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/ast/ANameAnsweredHalfwayIsRefusedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ast/ANameAnsweredHalfwayIsRefusedTest.java
@@ -91,7 +91,7 @@ class ANameAnsweredHalfwayIsRefusedTest {
         Hir.Var resolved = new Hir.Var.Denoting(spin, DECLARED,
                 new ReachName.OfModule("demo", "spin"), spin.region());
 
-        assertEquals("spin", resolved.bare());
-        assertEquals("demo.spin", resolved.reaches());
+        assertEquals("spin", resolved.answered().bare());
+        assertEquals("demo.spin", resolved.answered().reaches());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/ast/ANameNothingDeclaresIsNotAResolvedNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ast/ANameNothingDeclaresIsNotAResolvedNameTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -50,24 +52,43 @@ class ANameNothingDeclaresIsNotAResolvedNameTest {
     }
 
     /**
-     * Read and found nothing, it refuses the question — and says which of the two it is refusing,
-     * because what a reader does next differs. This is a mistake in the source, reported where it is
-     * written, and the declaration holding it has no meaning to work out.
+     * Read and found nothing, it has no declaration to give, and says so by being the form that
+     * carries none. This is a mistake in the source, reported where it is written, and the
+     * declaration holding it has no meaning to work out.
      */
     @Test
-    void aNameNothingDeclaresRefusesTheQuestion() {
+    void aNameNothingDeclaresCarriesNoDeclaration() {
         Hir.Name unanswered = new Hir.Name.Unanswered(WrittenName.of("Invoice", POS));
 
         assertEquals("Invoice", unanswered.written());
-        IllegalStateException e = assertThrows(IllegalStateException.class, unanswered::denotes);
-        assertTrue(e.getMessage().contains("denotes nothing"), e.getMessage());
+        assertNull(unanswered.answered());
     }
 
-    /** Answered, it says which declaration. */
+    /**
+     * And which declaration a name names is asked of the form that has one.
+     *
+     * <p>Asked of {@link Hir.Name} it could be asked of one that names nothing, which every reader
+     * then had to remember not to do; a reader that forgot compiled and threw where the name was
+     * read rather than where it was reported.
+     */
     @Test
-    void aResolvedNameSaysWhatItDenotes() {
+    void whichDeclarationANameNamesIsNotAskedOfANameThatMayHaveNone() {
         assertEquals(DECLARED,
-                new Hir.Name.Denoting(WrittenName.of("Invoice", POS), DECLARED).denotes());
+                new Hir.Name.Denoting(WrittenName.of("Invoice", POS), DECLARED).type());
+
+        for (java.lang.reflect.Method m : Hir.Name.class.getDeclaredMethods()) {
+            assertNotEquals("denotes", m.getName(),
+                    "what a name denotes is the answered form's to say");
+        }
+    }
+
+    /** A reader whose input is built from answered names says so, naming the name it met. */
+    @Test
+    void aReaderThatWasNotToMeetOneSaysWhichNameItMet() {
+        Hir.Name.Unanswered nothing = new Hir.Name.Unanswered(WrittenName.of("Invoice", POS));
+
+        assertTrue(nothing.unexpectedHere().getMessage().contains("`Invoice`"));
+        assertTrue(nothing.unexpectedHere().getMessage().contains("denotes nothing"));
     }
 
     /** And there is no third answer for a reader below the pass to tell apart. */

--- a/souther-compiler/src/test/java/souther/compiler/ast/ANameUsedAsAValueHasTwoAnswersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ast/ANameUsedAsAValueHasTwoAnswersTest.java
@@ -11,6 +11,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -40,7 +41,7 @@ class ANameUsedAsAValueHasTwoAnswersTest {
 
     private static final ReachName REACHED = new ReachName.OfModule("demo", "spin");
 
-    private static Hir.Var denoting(WrittenName name) {
+    private static Hir.Var.Denoting denoting(WrittenName name) {
         return new Hir.Var.Denoting(name, DECLARED, REACHED, name.region());
     }
 
@@ -48,17 +49,48 @@ class ANameUsedAsAValueHasTwoAnswersTest {
         return new Hir.Var.Unanswered(name, name.region());
     }
 
-    /** Read and found nothing, a name refuses both answers — and says which of the two questions it
-     * is refusing, because what a reader does about each differs. */
+    /** Read and found nothing, a name has neither answer to give, and says so by being the form
+     * that carries neither. What it does carry is where it is written. */
     @Test
-    void aNameNothingAnswersToRefusesBothAnswers() {
+    void aNameNothingAnswersToCarriesNeitherAnswer() {
         Hir.Var nothing = unanswered(WrittenName.of("spin", POS));
 
         assertEquals("spin", nothing.name());
         assertTrue(nothing.unresolved());
-        assertTrue(assertThrows(IllegalStateException.class, nothing::bare)
-                .getMessage().contains("denotes nothing"));
-        assertThrows(IllegalStateException.class, nothing::reaches);
+        assertNull(nothing.answered());
+    }
+
+    /**
+     * And what a name names is asked of the form that has an answer, never of the two together.
+     *
+     * <p>The observations that read a declaration — what it denotes, how it is reached, either of
+     * them rendered — are {@link Hir.Var.Denoting}'s. Put on {@link Hir.Var} they could be asked of
+     * a name that answers nothing, which every reader then had to remember not to do; a reader that
+     * forgot compiled and threw where the name was read rather than where it was reported. So the
+     * question is not "did every reader remember" but "can it be written at all".
+     */
+    @Test
+    void whatANameNamesIsNotAskedOfANameThatMayNotAnswer() {
+        Set<String> answeredOnly = Set.of("denotes", "reachedAs", "bare", "reaches");
+        Set<String> onTheInterface = new java.util.TreeSet<>();
+        for (java.lang.reflect.Method m : Hir.Var.class.getDeclaredMethods()) {
+            if (answeredOnly.contains(m.getName())) {
+                onTheInterface.add(m.getName());
+            }
+        }
+
+        assertEquals(Set.of(), onTheInterface);
+    }
+
+    /** A reader whose input is built from answered names says so, and what it says names the name
+     * and where it is written. */
+    @Test
+    void aReaderThatWasNotToMeetOneSaysWhichNameItMet() {
+        WrittenName spin = WrittenName.of("spin", POS);
+        Hir.Var.Unanswered nothing = new Hir.Var.Unanswered(spin, spin.region());
+
+        assertTrue(nothing.unexpectedHere().getMessage().contains("`spin`"));
+        assertTrue(nothing.unexpectedHere().getMessage().contains("denotes nothing"));
     }
 
     /**
@@ -68,7 +100,7 @@ class ANameUsedAsAValueHasTwoAnswersTest {
      */
     @Test
     void anAnsweredNameIsAnsweredOnBothCounts() {
-        Hir.Var answered = denoting(WrittenName.of("spin", POS));
+        Hir.Var.Denoting answered = denoting(WrittenName.of("spin", POS));
 
         assertEquals("spin", answered.bare());
         assertEquals("demo.spin", answered.reaches());

--- a/souther-compiler/src/test/java/souther/compiler/partition/AGeneratedFixtureSaysWhatItsNamesDenoteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AGeneratedFixtureSaysWhatItsNamesDenoteTest.java
@@ -88,10 +88,10 @@ class AGeneratedFixtureSaysWhatItsNamesDenoteTest {
 
         List<String> unanswered = new ArrayList<>();
         for (Hir.Expr node : nodes) {
-            if (node instanceof Hir.Var name && name.denotes() == null) {
+            if (node instanceof Hir.Var name && name.answered() == null) {
                 unanswered.add(name.name());
             }
-            if (node instanceof Hir.NewData nd && nd.typeName().denotes() == null) {
+            if (node instanceof Hir.NewData nd && nd.typeName().answered() == null) {
                 unanswered.add(nd.typeName().written());
             }
         }
@@ -108,7 +108,7 @@ class AGeneratedFixtureSaysWhatItsNamesDenoteTest {
     void everyNameInARowAnswersWhatItReaches() {
         List<String> reached = new ArrayList<>();
         for (Hir.Expr node : everyNodeOfEveryRow()) {
-            if (node instanceof Hir.Var name) {
+            if (node instanceof Hir.Var.Denoting name) {
                 reached.add(name.reaches());
             }
         }

--- a/souther-compiler/src/test/java/souther/compiler/query/AReachNameSurvivesWhereARewriteCannotGoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AReachNameSurvivesWhereARewriteCannotGoTest.java
@@ -110,13 +110,15 @@ class AReachNameSurvivesWhereARewriteCannotGoTest {
     @Test
     void andItIsReachedByTheNameTheReaderReachesItBy() {
         assertEquals(List.of(new ReachName.OfModule("lib", "flatten")),
-                calls(inWhatWasHandedOver(taken())).stream().map(Hir.Apply::reachedAs).toList(),
+                calls(inWhatWasHandedOver(taken())).stream()
+                        .map(call -> call.answered().reachedAs()).toList(),
                 "reached under the module that declares it, which is how `app` keys the method");
     }
 
     private static List<Hir.Apply> calls(List<Hir.Apply> found) {
         return found.stream()
-                .filter(call -> call.denotes() != null && call.denotes().name().equals("flatten"))
+                .filter(call -> call.answered() != null
+                        && call.answered().denotes().name().equals("flatten"))
                 .toList();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/OneModuleIsExpandedAgainstOneTableTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/OneModuleIsExpandedAgainstOneTableTest.java
@@ -99,8 +99,9 @@ class OneModuleIsExpandedAgainstOneTableTest {
     private static void namedSpreads(Hir.Expr e, HelperTable table, Set<String> out) {
         if (e instanceof Hir.NewData nd) {
             for (Hir.Var spread : nd.spreads()) {
-                if (table.reaches(spread.reaches())) {
-                    out.add(spread.reaches());
+                if (spread.answered() instanceof Hir.Var.Denoting named
+                        && table.reaches(named.reaches())) {
+                    out.add(named.reaches());
                 }
             }
         }

--- a/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -60,7 +61,9 @@ class ResolvedValueNamesTest {
     }
 
     private static ValueName denotes(Hir.Expr e) {
-        return e instanceof Hir.Var v ? v.denotes() : ((Hir.Apply) e).denotes();
+        Hir.Var.Denoting named = e instanceof Hir.Var v
+                ? v.answered() : ((Hir.Apply) e).answered();
+        return named == null ? null : named.denotes();
     }
 
     /** The name written as {@code written}, whatever state resolution left it in. */
@@ -196,7 +199,7 @@ class ResolvedValueNamesTest {
 
         for (Hir.Expr e : named(resolve(source))) {
             if (e instanceof Hir.Apply call && call.written().equals("List.length")) {
-                assertEquals("List.length", call.reaches());
+                assertEquals("List.length", call.answered().reaches());
                 return;
             }
         }
@@ -281,8 +284,9 @@ class ResolvedValueNamesTest {
 
         Hir.Var name = nameOf(source, "nosuch");
         assertInstanceOf(Hir.Var.Unanswered.class, name);
-        // and it holds no stand-in for a reader below to take for a declaration
-        assertThrows(IllegalStateException.class, name::denotes);
+        // and it holds no stand-in for a reader below to take for a declaration: what a name names
+        // is the answered form's to say, and this is not one
+        assertNull(name.answered());
     }
 
     /** Every name in every body is answered — nothing is left as a spelling for a later reader to
@@ -369,7 +373,7 @@ class ResolvedValueNamesTest {
 
         List<ValueName.Local> reads = new ArrayList<>();
         for (Hir.Expr e : named(m)) {
-            if (e instanceof Hir.Var v && v.name().equals("x")
+            if (e instanceof Hir.Var.Denoting v && v.name().equals("x")
                     && v.denotes() instanceof ValueName.Local local) {
                 reads.add(local);
             }


### PR DESCRIPTION
Closes #740 — a row applying an intrinsic ended a compile with an internal error when an argument named nothing.

## What was wrong

`Hir.Var` and `Hir.Name` are each split into the two answers resolution has: a form that names a declaration and a form that names nothing. The observations that read a declaration were not. `denotes()`, `reachedAs()`, `bare()` and `reaches()` stood on the interface, so they could be asked of a name that answers nothing, and answered by throwing; `Hir.Apply` carried three of them across from the name it applies. Keeping that safe was a convention every reader had to remember — 213 call sites for the value names, 66 more for the type names — and a reader that forgot compiled, then threw where the name was read rather than where it was reported.

That is what #740 is. `FixtureEvidence.declaredTypeOf` reads a row's arguments to settle which instance of an intrinsic to emit a method for, and it read `denotes()` of a name without asking whether the name denotes anything. Its own `denotes == null` test beside it was dead code — the reader it guarded does not return null, it throws — which says plainly enough what the author took the API to be.

#737 closed three of these by walking the readers of `denotes()`. This one was in a walk that runs before them, so it was not in that set. Answering "is any reader left" one report at a time is what this stops.

## What changed

Those observations are `Denoting`'s now, on all three types, and `Apply` answers only `answered()`. A reader arrives at what a name names through that projection or by narrowing to the two forms, which is where it says what it does with a name that answers nothing — so the question is no longer whether every reader remembered, but whether such a read can be written at all.

`unresolved()` is derived from `answered()` rather than implemented per form, so "did it answer" and "what did it answer" cannot come apart.

`Unanswered` carries `unexpectedHere()`: not a reading — there is nothing to read — but the claim that a reader's input was built from answered names. Three readers make it, and each names the producer that guarantees it beside the throw:

- `Backend.reachedBy` / `Backend.names` (and `Runner.named` in the CLI): `Bodies.Checked` hands an elaboration over only where `Names.Sound` holds of the module, which resolution makes false as soon as it reports a name denoting nothing; `Output.Classes` builds what it generates from that answer and nothing else.
- `DataChecker.names`: `Names.Unbuilt` collects a declaration holding a name that names nothing, `Names.Definition` hands it to nobody, and `TypeChecker` checks only the declarations it was handed.

The order the passes run in is not cited anywhere, and cannot be: a compilation goes on answering after an error. Where a producer could not be named, the reader recovers instead.

Two readers stopped taking one fact as two arguments on the way (`PartialReachability.keyOf`/`declarationOf` and `HelperInliner.expands` took a denotation and a reach name separately, and now take the answered name).

## Measured

- The matrix from the issue is a test: every argument position and both intrinsics answer E1023 exactly once, `Int.max(1, nope)` answers the same, and the correctly spelled call still settles. It fails with the internal error on the parent commit.
- `CI=1 mvn -Plint clean verify` BUILD SUCCESS — compiler 4519, formatter 2224, LSP 202, CLI 333, all modules green.
- souther-examples, all 14 projects, against a base jar built from `develop`: `examples --generate --boundaries` identical over 21,924 lines, and `compile` output identical once the temporary output directory is normalised out of it. No behaviour changed anywhere the corpus reaches.

## One change outside the issue

`pom.xml` raises `-Xmaxerrs` beside the `-Xmaxwarns` already there, with the same reason: javac stops printing at a hundred, and a report that stops at a round number reads as the whole of what was found. This work hit it — 213 call sites were counted as 100 — but it is a build-report change, not part of the fix, and it is its own commit so it can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)