### PR TITLE
Decide an unverified case from what the rows saw

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -308,9 +308,14 @@ public final class ExampleVerifier {
      * Whether a behavior of {@code module} has no implementation to run — an injected one (spec
      * {@code injected-behavior}).
      *
-     * <p>Asked here by the row evaluation and by the adequacy report, which decides what it can measure
-     * from the same answer. Two statements of it would let a report say a behavior is implemented while
-     * its rows are being recorded rather than run.
+     * <p>Asked here by the row evaluation and by the adequacy report, which says of each behavior
+     * which of the two it is. Two statements of it would let a report say a behavior is implemented
+     * while its rows are being recorded rather than run.
+     *
+     * <p>This is how the behavior is written, and it answers no question about what a run saw. What
+     * the rows observed is theirs to say ({@code OutputCaseEvidence}), and a measure decided from
+     * here would be a measure that stops being right as soon as something other than this compile
+     * can apply a behavior.
      */
     public static boolean isPending(List<Hir.BehaviorDef> behaviors, Collection<String> defined,
                                     String name) {

--- a/souther-compiler/src/main/java/souther/compiler/observe/OutputCaseEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/OutputCaseEvidence.java
@@ -49,6 +49,11 @@ public record OutputCaseEvidence(Set<TypeSymbol> declared, Set<TypeSymbol> speci
         return Evidence.missingFrom(declared, verified);
     }
 
+    /** Whether any row observed the behavior produce an output case. */
+    public boolean hasObservedCase() {
+        return !observed.isEmpty();
+    }
+
     public MeasurementStatus status() {
         return Evidence.status(declared, unclassifiedRows);
     }

--- a/souther-compiler/src/main/java/souther/compiler/observe/OutputCaseEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/OutputCaseEvidence.java
@@ -23,10 +23,15 @@ import java.util.Set;
  *
  * @param unclassifiedRows rows whose case could not be read. While this is above zero a missing case
  *                         is undecided rather than missing, because one of those rows may cover it.
+ * @param answeredRows     rows the behavior answered for. Not the size of {@link #observed}: an
+ *                         answer of a type no declaration names is an answer this cannot place, so a
+ *                         run that got one has an empty {@code observed} and a count above zero.
+ *                         What separates a run that produced nothing from one whose answers could not
+ *                         be named is this, and neither of the case sets says it.
  */
 public record OutputCaseEvidence(Set<TypeSymbol> declared, Set<TypeSymbol> specified,
                                  Set<TypeSymbol> observed, Set<TypeSymbol> verified,
-                                 int unclassifiedRows) {
+                                 int unclassifiedRows, int answeredRows) {
 
     public OutputCaseEvidence {
         declared = Evidence.ordered(declared);
@@ -36,7 +41,7 @@ public record OutputCaseEvidence(Set<TypeSymbol> declared, Set<TypeSymbol> speci
     }
 
     public static OutputCaseEvidence none() {
-        return new OutputCaseEvidence(Set.of(), Set.of(), Set.of(), Set.of(), 0);
+        return new OutputCaseEvidence(Set.of(), Set.of(), Set.of(), Set.of(), 0, 0);
     }
 
     /** Cases the behavior can answer with that no row expects. */
@@ -47,11 +52,6 @@ public record OutputCaseEvidence(Set<TypeSymbol> declared, Set<TypeSymbol> speci
     /** Cases no row has confirmed the behavior answers with. */
     public List<TypeSymbol> unverified() {
         return Evidence.missingFrom(declared, verified);
-    }
-
-    /** Whether any row observed the behavior produce an output case. */
-    public boolean hasObservedCase() {
-        return !observed.isEmpty();
     }
 
     public MeasurementStatus status() {

--- a/souther-compiler/src/main/java/souther/compiler/observe/RowOutcome.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/RowOutcome.java
@@ -109,9 +109,17 @@ public record RowOutcome(SourceRef at,
         }
     }
 
+    /** Whether the behavior answered for this row — it was applied and a value came back, which is
+     * what {@link Stage#COMPARED} is reached by. Whether that answer can be named as a case is
+     * {@link #observed}: a value of a type no declaration of the module's names is an answer all the
+     * same, and a run that got one is not a run that produced nothing. */
+    public boolean answered() {
+        return stage.reached(Stage.COMPARED);
+    }
+
     /** Whether this row is evidence that the behavior can answer with {@link #resultArm}. A row that
      * disagreed still saw what it saw. */
     public boolean observed() {
-        return stage.reached(Stage.INVOKED) && resultArm != null;
+        return answered() && resultArm != null;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1501,7 +1501,8 @@ public final class Adequacy {
 
         /** What the rows say about the cases of the signature. Carried at the measurement's own status:
          *  a case nothing here claims is, where some row could not be read, a case nothing *seen*
-         *  claims. */
+         *  claims — which is why these are said at {@code PARTIAL} rather than withheld until every
+         *  row could be read. Which of them are said at all is each measure's own question below. */
         private static void signatureFindings(Hir.BehaviorDef behavior, SignatureEvidence signature,
                                               List<Finding> out) {
             if (signature == null || !signature.status().counted()) {
@@ -1513,13 +1514,19 @@ public final class Adequacy {
                 out.add(new Finding(Kind.OUTPUT_CASE_UNSPECIFIED, behavior.name(), status,
                         behavior.pos(), List.of(missing.name(), behavior.name())));
             }
-            // Where no row saw the behavior answer, every case is unverified and naming each of them
-            // adds nothing to that. Asked of the rows rather than of the declaration: the two agree
-            // only while the one thing that applies a behavior is the compile that generated it, and
-            // a run that did observe an injected behavior's cases would go on saying nothing about
-            // them. Left out here rather than at the printing, so that what a report shows and what a
-            // build is told come from one list.
-            if (output.hasObservedCase()) {
+            // Where the behavior answered for no row, every case is unverified and naming each of
+            // them adds nothing to that. Asked of the rows rather than of the declaration: the two
+            // agree only while the one thing that applies a behavior is the compile that generated
+            // it, and a run that did apply an injected behavior would go on saying nothing about the
+            // cases it was never seen to produce.
+            //
+            // How many rows were answered for, rather than whether any case was observed. A run whose
+            // answers are of a type nothing here names observed no case and produced answers all the
+            // same, and the cases it did not confirm are worth naming exactly as anywhere else.
+            //
+            // Left out here rather than at the printing, so that what a report shows and what a build
+            // is told come from one list.
+            if (output.answeredRows() > 0) {
                 for (TypeSymbol missing : output.unverified()) {
                     if (!output.unspecified().contains(missing)) {
                         out.add(new Finding(Kind.OUTPUT_CASE_UNVERIFIED, behavior.name(), status,
@@ -1791,6 +1798,7 @@ public final class Adequacy {
         Set<TypeSymbol> observed = new LinkedHashSet<>();
         Set<TypeSymbol> verified = new LinkedHashSet<>();
         int unreadableOut = 0;
+        int answered = 0;
 
         List<Type> ins = sig.inputTypes();
         List<Set<TypeSymbol>> declaredIn = new ArrayList<>(ins.size());
@@ -1821,7 +1829,10 @@ public final class Adequacy {
             } else if (!declaredOut.isEmpty()) {
                 unreadableOut++;   // an expectation whose case the text does not say
             }
-            if (row.resultArm() != null) {
+            if (row.answered()) {
+                answered++;
+            }
+            if (row.observed()) {
                 observed.add(row.resultArm());
                 if (held) {
                     verified.add(row.resultArm());
@@ -1849,7 +1860,8 @@ public final class Adequacy {
         }
 
         OutputCaseEvidence output = declaredOut.isEmpty() ? OutputCaseEvidence.none()
-                : new OutputCaseEvidence(declaredOut, specified, observed, verified, unreadableOut);
+                : new OutputCaseEvidence(declaredOut, specified, observed, verified, unreadableOut,
+                        answered);
         List<InputCaseEvidence> inputs = new ArrayList<>(ins.size());
         boolean partial = output.status() == MeasurementStatus.PARTIAL;
         for (int i = 0; i < ins.size(); i++) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -4,7 +4,6 @@ package souther.compiler.query;
 import souther.compiler.diag.DiagnosticCode;
 import souther.compiler.diag.msg.ExampleMessage;
 import souther.compiler.diag.SourcePos;
-import souther.compiler.examples.ExampleVerifier;
 import souther.compiler.examples.FixtureReader;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.BehaviorRequirement;
@@ -1385,8 +1384,9 @@ public final class Adequacy {
         BOUNDARY_UNMET(DiagnosticCode.E1916, true),
         /** An arm of the body no row goes through. */
         ARM_UNREACHED(DiagnosticCode.E1918, true),
-        /** A case some row expects and nothing was seen to produce. Not asked of an injected
-         *  behavior, which has no body to produce anything. */
+        /** A case some row expects and nothing was seen to produce. Said only of a behavior some row
+         *  saw answer with a case: where nothing was observed at all, this is true of every case and
+         *  is what the rows say of themselves. */
         OUTPUT_CASE_UNVERIFIED(null, false),
         /** A class of an axis no row is in. */
         AXIS_CLASS_UNCOVERED(null, false),
@@ -1486,7 +1486,7 @@ public final class Adequacy {
             Map<String, List<Finding>> out = new LinkedHashMap<>();
             for (Hir.BehaviorDef behavior : prepared.value().behaviors()) {
                 List<Finding> found = new ArrayList<>();
-                signatureFindings(behavior, prepared.value(),
+                signatureFindings(behavior,
                         signatures == null ? null : signatures.get(behavior.name()), found);
                 partitionFindings(behavior,
                         partitions == null ? null : partitions.get(behavior.name()), found);
@@ -1502,9 +1502,8 @@ public final class Adequacy {
         /** What the rows say about the cases of the signature. Carried at the measurement's own status:
          *  a case nothing here claims is, where some row could not be read, a case nothing *seen*
          *  claims. */
-        private static void signatureFindings(Hir.BehaviorDef behavior,
-                                              souther.compiler.check.Prepared module,
-                                              SignatureEvidence signature, List<Finding> out) {
+        private static void signatureFindings(Hir.BehaviorDef behavior, SignatureEvidence signature,
+                                              List<Finding> out) {
             if (signature == null || !signature.status().counted()) {
                 return;
             }
@@ -1514,11 +1513,13 @@ public final class Adequacy {
                 out.add(new Finding(Kind.OUTPUT_CASE_UNSPECIFIED, behavior.name(), status,
                         behavior.pos(), List.of(missing.name(), behavior.name())));
             }
-            // An injected behavior produces nothing, so every case of its output is unverified and
-            // saying so of each says nothing. Left out here rather than at the printing, so that what
-            // a report shows and what a build is told come from one list.
-            if (!ExampleVerifier.isPending(module.behaviors(),
-                    ExampleVerifier.definedNames(module.fns()), behavior.name())) {
+            // Where no row saw the behavior answer, every case is unverified and naming each of them
+            // adds nothing to that. Asked of the rows rather than of the declaration: the two agree
+            // only while the one thing that applies a behavior is the compile that generated it, and
+            // a run that did observe an injected behavior's cases would go on saying nothing about
+            // them. Left out here rather than at the printing, so that what a report shows and what a
+            // build is told come from one list.
+            if (output.hasObservedCase()) {
                 for (TypeSymbol missing : output.unverified()) {
                     if (!output.unspecified().contains(missing)) {
                         out.add(new Finding(Kind.OUTPUT_CASE_UNVERIFIED, behavior.name(), status,

--- a/souther-compiler/src/test/java/souther/compiler/WhatIsUnverifiedComesFromWhatTheRowsObservedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatIsUnverifiedComesFromWhatTheRowsObservedTest.java
@@ -1,0 +1,175 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Db;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Which cases are named as unverified, decided from what the rows saw.
+ *
+ * <p>Naming a case as one nothing confirmed is worth saying where some case was confirmed and the
+ * rest were not. Where nothing was seen to be produced at all, every case is unverified and naming
+ * each of them repeats the one thing the run has to say, which the rows already say in their own
+ * right. What separates the two is whether any row observed the behavior answer — not whether the
+ * behavior is written with a {@code let}, which is a different question that happens to agree with
+ * this one while the only thing that applies a behavior is the compile that generated it.
+ */
+class WhatIsUnverifiedComesFromWhatTheRowsObservedTest {
+
+    /**
+     * A run that observed one case names the others, and does not name the one it observed.
+     *
+     * <p>The boundary itself: {@code Approved} is confirmed and stays unnamed, {@code Rejected} is
+     * expected by a row and was never produced, so it is named. A guard that read anything wider than
+     * the rows would either lose the second or add the first.
+     */
+    @Test
+    void aCaseNoRowConfirmedIsNamedWhereAnotherCaseWasObserved() {
+        String source = """
+                module example.decide
+
+                data Yes
+                data No
+                data Flag = Yes | No
+
+                data Approved = { note: String }
+                data Rejected = { note: String }
+
+                behavior decide : (f: Flag) -> Approved | Rejected
+                    constructs Approved, Rejected
+                let decide (f) =
+                    match f with
+                        | Yes -> Approved { note = "yes" }
+                        | No  -> Rejected { note = "no" }
+
+                example decide
+                    | "holds"     : (Yes) -> Approved { note = "yes" }
+                    | "disagrees" : (Yes) -> Rejected { note = "no" }
+                """;
+
+        assertEquals(List.of("Rejected"),
+                unverified(source, "decide"),
+                "the case a row expects and nothing produced is the one worth naming; the case a row "
+                        + "confirmed is not");
+    }
+
+    /**
+     * A behavior with nothing to run it: its rows are recorded, so nothing was observed and no case is
+     * named. What the compile can say about such a behavior is that no row expects a case
+     * ({@code OUTPUT_CASE_UNSPECIFIED}), which it still says.
+     */
+    @Test
+    void anInjectedBehaviorNamesNoUnverifiedCase() {
+        String source = """
+                module example.member
+                import String ( length )
+
+                data MemberId = String
+                    invariant length(value) > 0
+
+                data Found = { id: MemberId }
+                data Missing = { reason: String }
+
+                behavior findMember : (id: MemberId) -> Found | Missing
+
+                example findMember
+                    | "found" : (MemberId("m-1")) -> Found { id = MemberId("m-1") }
+                """;
+
+        assertEquals(List.of(), unverified(source, "findMember"),
+                "nothing applied it, so every case is unverified and naming each says nothing");
+        assertEquals(List.of("Missing"), unspecified(source, "findMember"),
+                "what the rows do and do not ask for is measured the same as anywhere else");
+    }
+
+    /**
+     * A behavior that has a {@code let} and whose rows all stopped before they could apply it. The
+     * run observed nothing, so it says nothing case by case — and what did happen to the rows is
+     * reported where it happened, which is a better answer than a list of cases nobody could have
+     * covered.
+     */
+    @Test
+    void aBehaviorWhoseRowsNeverRanNamesNoUnverifiedCaseAndSaysWhy() {
+        String source = """
+                module example.greet
+                import String ( length )
+
+                data MemberId = String
+                    invariant length(value) > 0
+
+                data Yes
+                data No
+                data Answer = Yes | No
+
+                data Hello = { who: String }
+                data Bye = { who: String }
+
+                behavior asked : (id: MemberId) -> Answer
+
+                behavior greet : (id: MemberId) -> Hello | Bye
+                    depends on asked
+                    constructs Hello, Bye
+                let greet (id, asked) =
+                    match asked(id) with
+                        | Yes -> Hello { who = "hi" }
+                        | No  -> Bye { who = "bye" }
+
+                example greet
+                    | "greeted" : (MemberId("m-1")) -> Hello { who = "hi" }
+                """;
+
+        assertEquals(List.of(), unverified(source, "greet"),
+                "a row that never applied the behavior saw nothing, and a let does not make it a "
+                        + "row that did");
+        assertTrue(codes(source).contains("E1908"),
+                "why the row stopped is reported at the row, which is what the reader is owed here: "
+                        + codes(source));
+    }
+
+    private static List<String> unverified(String source, String behavior) {
+        return named(source, behavior, Adequacy.Kind.OUTPUT_CASE_UNVERIFIED);
+    }
+
+    private static List<String> unspecified(String source, String behavior) {
+        return named(source, behavior, Adequacy.Kind.OUTPUT_CASE_UNSPECIFIED);
+    }
+
+    /** The cases one kind of finding names for one behavior, in the order the findings are held. */
+    private static List<String> named(String source, String behavior, Adequacy.Kind kind) {
+        Compilation compilation = compiled(source);
+        Map<String, List<Adequacy.Finding>> all = compilation.db()
+                .ask(new Adequacy.Findings(compilation.modules().get(0))).value();
+        return all == null ? List.of()
+                : all.getOrDefault(behavior, List.of()).stream()
+                        .filter(f -> f.kind() == kind)
+                        .map(f -> String.valueOf(f.args().get(0)))
+                        .toList();
+    }
+
+    private static List<String> codes(String source) {
+        List<String> codes = new ArrayList<>();
+        for (Db.Found found : compiled(source).db().allReports()) {
+            String code = found.report().diagnostic().code();
+            if (code != null) {
+                codes.add(code);
+            }
+        }
+        return codes;
+    }
+
+    private static Compilation compiled(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        return compilation;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/WhatIsUnverifiedComesFromWhatTheRowsObservedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatIsUnverifiedComesFromWhatTheRowsObservedTest.java
@@ -130,9 +130,39 @@ class WhatIsUnverifiedComesFromWhatTheRowsObservedTest {
         assertEquals(List.of(), unverified(source, "greet"),
                 "a row that never applied the behavior saw nothing, and a let does not make it a "
                         + "row that did");
-        assertTrue(codes(source).contains("E1908"),
+        List<String> codes = codes(source);
+        assertTrue(codes.contains("E1908"),
                 "why the row stopped is reported at the row, which is what the reader is owed here: "
-                        + codes(source));
+                        + codes);
+    }
+
+    /**
+     * A run that answered with a value no declaration here names. The behavior was applied and gave
+     * something back, so which cases it was not seen to produce is worth naming — and no case can be
+     * read off such an answer, so the evidence has an empty {@code observed} and is no measure of
+     * whether anything ran.
+     *
+     * <p>{@code String} is left out of the naming for the reason any unspecified case is: no row asks
+     * for it, so it is reported as unspecified instead.
+     */
+    @Test
+    void anAnswerNoDeclarationNamesIsStillAnAnswer() {
+        String source = """
+                module example.name
+
+                data Missing = { why: String }
+
+                behavior name : (n: Int) -> String | Missing
+                    constructs Missing
+                let name (n) = if n > 0 then "yes" else Missing { why = "no" }
+
+                example name
+                    | "wants Missing, is answered with a String" : (1) -> Missing { why = "no" }
+                """;
+
+        assertEquals(List.of("Missing"), unverified(source, "name"),
+                "the row ran and was answered; that this compile cannot place the answer is not a "
+                        + "reason to stop saying which case nothing confirmed");
     }
 
     private static List<String> unverified(String source, String behavior) {


### PR DESCRIPTION
`OUTPUT_CASE_UNVERIFIED` is left out for a behavior nothing was seen to answer with, because naming
each of its cases repeats the one thing such a run has to say. What was asked to decide that is how
the behavior is written (`ExampleVerifier.isPending`), and that holds only because a compile has one
answerer: no `let`, so nothing generated, so nothing to apply. #695 breaks the middle of that chain,
and the failure is silent — a run that did observe an injected behavior's cases would go on saying
nothing about the ones its implementation was never seen to produce.

The reading moves onto the rows. `OutputCaseEvidence` already holds the case each row saw the
behavior answer with, and a row recorded against an injected behavior stops before applying anything,
so the set is empty for exactly the behaviors the old reading named. `hasObservedCase()` says that
and no more; why an empty one means the cases are not named is the reader's and is written there,
so a later "name them anyway" mode changes nothing in the evidence.

`isPending` keeps the question it is about and loses this one. `Adequacy` no longer reads the
examples package at all, and the two readers left both ask it how a behavior is written: which ones
a row evaluation records rather than runs, and which the report prints as injected.

## What changes for a reader

A behavior with a `let` whose rows all stopped before applying it — a missing fake, say — no longer
has each of its cases named as unconfirmed. Nothing was observed, so the run says so once, and why
the rows stopped is reported where it happened.

## Checks

- Neither direction of this branch was held by a test before: reported-always and suppressed-always
  each broke nothing in the suite. The three tests added fix both directions and the boundary between
  them — a case named where another was observed, the injected behavior, and the one whose rows never
  ran.
- `mvn test` across every module.
- souther-examples (account, businesstrip, crm, hr): every `examples` report generated before and
  after, identical.

Closes #733
