### PR TITLE
Ask what applies a behavior, rather than reading the declaration for it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Prepared.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Prepared.java
@@ -135,6 +135,18 @@ public final class Prepared {
         return desugared.behaviors();
     }
 
+    /**
+     * Whether {@code behavior} is written here with no implementation to run — an injected one (spec
+     * §injected-behavior).
+     *
+     * <p>How the behavior is written. What a compile emitted for it and what a run can apply are
+     * different questions with owners of their own, and this is not an answer to either: a reader
+     * wanting to know whether anything will run a behavior asks what will run it.
+     */
+    public boolean injected(Hir.BehaviorDef behavior) {
+        return Requirements.injected(module(), behavior);
+    }
+
     /** The names its source offers to whatever reads it, which no stage rewrites. */
     public List<String> exposing() {
         return desugared.module().exposing();
@@ -334,6 +346,12 @@ public final class Prepared {
         /** The definitions the module wrote. */
         public List<Desugared.Fn> fns() {
             return module.fns();
+        }
+
+        /** Whether {@code behavior} is written with no implementation to run — an injected one, which
+         *  is what a fake stands in for. How it is written, and no answer to what will run it. */
+        public boolean injected(Hir.BehaviorDef behavior) {
+            return module.injected(behavior);
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Requirements.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Requirements.java
@@ -31,6 +31,22 @@ public final class Requirements {
     private Requirements() {}
 
     /**
+     * Whether {@code behavior} is written with no implementation to run — an injected one, supplied
+     * from Java (spec §injected-behavior).
+     *
+     * <p>How the behavior is written, and nothing else. It answers no question about what a compile
+     * emitted for it or about what a run can apply: those are settled where they happen, and a reader
+     * asking one of them from here would be reading a declaration for a fact about a run.
+     *
+     * <p>Asked of the declaration and not of a name. What is being asked about is the behavior the
+     * module wrote, so a caller hands it over rather than a spelling to look one up by — and there is
+     * then no answer to give for a name that names no behavior.
+     */
+    public static boolean injected(Hir.Module module, Hir.BehaviorDef behavior) {
+        return bodyless(behavior, definedNames(module));
+    }
+
+    /**
      * The injection targets a module builds against: its own behaviors written with no body, and the imported
      * ones it names, whose base lives in the module that declares them (spec §injected-behavior,
      * §composition-with-requirements).
@@ -40,17 +56,30 @@ public final class Requirements {
      * disagree about one behavior.
      */
     public static Set<String> injectedNames(Hir.Module module, Set<String> importedInjected) {
+        Set<String> fns = definedNames(module);
+        Set<String> injected = new LinkedHashSet<>(importedInjected);
+        for (Hir.BehaviorDef bd : module.behaviors()) {
+            if (bodyless(bd, fns)) {
+                injected.add(bd.name());
+            }
+        }
+        return injected;
+    }
+
+    /** The one rule, so the set above and the question about a single behavior cannot come apart: a
+     *  behavior stating only its specification, with no {@code let} of its name to implement it. A
+     *  {@code >->} composition is its own implementation and is never this. */
+    private static boolean bodyless(Hir.BehaviorDef bd, Set<String> fns) {
+        return bd instanceof Hir.SpecBehavior spec && !fns.contains(spec.name());
+    }
+
+    /** The names the module's definitions are written under. */
+    private static Set<String> definedNames(Hir.Module module) {
         Set<String> fns = new LinkedHashSet<>();
         for (Hir.FnDef fn : module.fns()) {
             fns.add(fn.name());
         }
-        Set<String> injected = new LinkedHashSet<>(importedInjected);
-        for (Hir.BehaviorDef bd : module.behaviors()) {
-            if (bd instanceof Hir.SpecBehavior spec && !fns.contains(spec.name())) {
-                injected.add(spec.name());
-            }
-        }
-        return injected;
+        return fns;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -260,7 +260,7 @@ public final class Backend {
             }
         });
         b.rejectBridgeCaseCollisions(module, bridgeCases, localTypes, behaviorClassOwner);
-        Emissions out = new Emissions();
+        Emissions out = new Emissions(module.name());
         behaviorResults.forEach((union, members) -> {
             // the union and its encoder belong to the behavior whose output they are, not to the
             // module, though the behavior did not write them

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Emissions.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Emissions.java
@@ -1,11 +1,14 @@
 package souther.compiler.codegen;
 
+import souther.compiler.generated.GeneratedImplementations;
 import souther.compiler.jvm.GeneratedClass;
 import souther.compiler.jvm.JvmClassName;
 import souther.compiler.jvm.SoutherJvmAbi;
 
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * What a module emits: one class under one JVM name, held beside the Souther identity it was emitted
@@ -33,6 +36,13 @@ public final class Emissions {
     private record Emission(GeneratedClass generated, byte[] bytes) {}
 
     private final Map<JvmClassName, Emission> byName = new LinkedHashMap<>();
+    /** Which module these were emitted for, so a set with nothing of a kind in it still says whose
+     *  it is. */
+    private final String module;
+
+    public Emissions(String module) {
+        this.module = module;
+    }
 
     public void put(GeneratedClass generated, byte[] bytes) {
         JvmClassName name = SoutherJvmAbi.nameOf(generated);
@@ -76,6 +86,29 @@ public final class Emissions {
                     + ", not " + generated + "; one name, and not the same thing under it");
         }
         byName.put(name, new Emission(held.generated(), rewriting.apply(held.bytes())));
+    }
+
+    /**
+     * Which behaviors this emission generated an implementation for.
+     *
+     * <p>The decision as it was made: a behavior is here because an implementation class was put here
+     * for it, so the emitter cannot come to generate one without this saying so, or stop generating
+     * one while this goes on claiming it. A set built alongside the puts would be a second record of
+     * one decision, and the write that forgets to update it is the one nothing catches.
+     *
+     * <p>Read off the identity a class was emitted for and never off what it is called. The name a
+     * behavior's implementation carries is this ABI's business and could be spelled another way
+     * tomorrow, and a reader recovering behaviors from class names would be re-deriving the decision
+     * from its own output — which is the thing this exists to stop.
+     */
+    public GeneratedImplementations implemented() {
+        Set<String> behaviors = new LinkedHashSet<>();
+        for (Emission emission : byName.values()) {
+            if (emission.generated() instanceof GeneratedClass.BehaviorImpl impl) {
+                behaviors.add(impl.behavior());
+            }
+        }
+        return new GeneratedImplementations(module, behaviors);
     }
 
     /** What the compilation hands on: a class loader and a file path want the binary name, and by

--- a/souther-compiler/src/main/java/souther/compiler/examples/Answerer.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/Answerer.java
@@ -23,29 +23,80 @@ import java.util.List;
  * only the second can have an implementation supplied for it — so which of them applies is settled
  * one behavior at a time, and an answerer that resolves between them has an answer for each.
  *
+ * <p>Whether anything applies a behavior at all is answered here too ({@link #of}), and answered
+ * rather than raised. Having nothing to apply is not something an answerer failed to do — it is what
+ * a run over a behavior nothing implements is, and the row it belongs to is right and complete as far
+ * as it goes. Where it is decided is what makes it this one's: a run's rows are held to what that run
+ * was given, and a reader deciding it from how the behavior is written would go on answering from the
+ * declaration once something other than a compile can supply an implementation.
+ *
  * <p>Nothing here reports anything. A diagnostic is a statement about a row and this is not about a
  * row, so what an answerer cannot do it raises and the row says what that means. Three things can go
  * wrong and they are three because what they say is not the same: {@link StandinNotBuilt} is a
  * stand-in that could not be made, {@link ImplementationNotReached} is the implementation not being
  * reachable at all, and {@link InvocationFailure} is the applied code coming back with a failure. Only
- * the last is about the model.
+ * the last is about the model. None of them is having nothing to apply, which is why that is a value.
  */
 public interface Answerer {
 
     /**
-     * What will apply {@code behavior} for this row, with {@code standins} answering for what it
-     * depends on.
+     * What this answerer has for {@code behavior}.
      *
-     * <p>Separate from applying it because the two are separate things to have got as far as. Making a
-     * stand-in into an instance is building the environment the behavior runs in, and a row that could
-     * not get an environment never entered the behavior — which is what its outcome has to be able to
-     * say. So this is where a stand-in that could not be made is raised, and
-     * {@link Applying#to} is where the behavior running is.
+     * <p>Asked before a row states anything and before its stand-ins are gathered, because whether
+     * anything applies a behavior does not depend on either. A row that nothing applies is still held
+     * to everything it can be held to without being run, and asking this first is what lets it be: an
+     * answer of {@link Answer.Nothing} is reached with the row's fixtures already built and validated.
      *
-     * @throws StandinNotBuilt where a stand-in could not be made into something the implementation can
-     *                         be constructed with
+     * <p>Fixed for the run. Two rows about one behavior get the same answer, so nothing about what a
+     * row means depends on when it was asked.
      */
-    Applying applying(String behavior, List<DependencyStandin> standins);
+    Answer of(String behavior);
+
+    /**
+     * Whether anything applies a behavior, and if something does, what.
+     *
+     * <p>A sum and not a nullable one: a reader that has to tell the two apart states it as a
+     * {@code switch}, so an answer it did not consider is a compile error rather than a branch that
+     * silently takes the other way. That is what this is for — the arms may come to say more than they
+     * do here (an implementation supplied from outside a compile is #695), and a reader written
+     * against {@code instanceof} would keep working while meaning something else.
+     */
+    sealed interface Answer {
+
+        /**
+         * Something here applies the behavior.
+         *
+         * <p>What it is is not said. Which of several things applied a row is recorded from the
+         * application itself ({@link Applying#applied}), so a reader of this needs nothing from it
+         * but that it can be applied.
+         */
+        @FunctionalInterface
+        non-sealed interface Something extends Answer {
+
+            /**
+             * It, with {@code standins} answering for what the behavior depends on.
+             *
+             * <p>Separate from applying it because the two are separate things to have got as far as.
+             * Making a stand-in into an instance is building the environment the behavior runs in, and
+             * a row that could not get an environment never entered the behavior — which is what its
+             * outcome has to be able to say. So this is where a stand-in that could not be made is
+             * raised, and {@link Applying#to} is where the behavior running is.
+             *
+             * @throws StandinNotBuilt where a stand-in could not be made into something the
+             *                         implementation can be constructed with
+             */
+            Applying applying(List<DependencyStandin> standins);
+        }
+
+        /**
+         * Nothing this run was given applies the behavior.
+         *
+         * <p>Not a failure and not an absence of an answer. The row is recorded rather than run: what
+         * it holds the behavior to is on the record from the day it is written, and it begins being
+         * run by itself the moment something applies that behavior.
+         */
+        record Nothing() implements Answer {}
+    }
 
     /** A behavior, in the environment one row gives it. */
     interface Applying {

--- a/souther-compiler/src/main/java/souther/compiler/examples/Answering.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/Answering.java
@@ -1,5 +1,6 @@
 package souther.compiler.examples;
 
+import souther.compiler.generated.GeneratedImplementations;
 import souther.compiler.generated.MemoryClassLoader;
 
 /**
@@ -28,12 +29,20 @@ import souther.compiler.generated.MemoryClassLoader;
 public interface Answering {
 
     /**
-     * The answerer for a run over {@code module}, whose values are built in {@code compiled}.
+     * The answerer for a run over the module {@code generated} is of, whose values are built in
+     * {@code compiled}.
      *
-     * @param module   the module whose rows are being evaluated
-     * @param compiled the classes this compile generated, defined once
+     * <p>What the compile generated an implementation for is handed over rather than worked out from
+     * either of the things here. Not from the declarations, because how a behavior is written is not
+     * what a run can apply — that is the question this seam exists to own. And not from the loader:
+     * a class that is not in it is a class that could not be reached, which is a failure, and reading
+     * membership for this would answer that failure with "nothing applies this behavior", which is
+     * not a failure at all.
+     *
+     * @param generated what the compile emitted an implementation for, and which module of
+     * @param compiled  the classes that compile generated, defined once
      */
-    Answerer over(String module, MemoryClassLoader compiled);
+    Answerer over(GeneratedImplementations generated, MemoryClassLoader compiled);
 
     /** The compile's own: the {@code $Impl} it emitted, constructed with the row's stand-ins and
      *  applied, all in the loader the run built. */

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -105,6 +105,15 @@ public final class ExampleVerifier {
      * <p>{@code artifact} is taken whole rather than as its classes and what they implement. Both are
      * of one compile and a run has no use for a pairing of two, so the loader is built from one half
      * of it and the other half goes to {@code answering} from the same value.
+     *
+     * <p>And it has to be of the module whose rows these are, which is checked here because here is
+     * where both are in hand. Past this point the module the rows belong to is gone: an answerer is
+     * given a manifest and a loader, and the manifest is what says which module's implementations it
+     * applies. A run handed another module's artifact would look that module's behaviors up by name —
+     * and a name it has one of would be applied, so a row would be answered by an implementation of
+     * something else rather than failing to find anything.
+     *
+     * @throws IllegalArgumentException where the artifact is of another module
      */
     public static Observations check(souther.compiler.check.Prepared.ExampleExecution module,
                                      Symbols symbols, Map<String, Sig> sigs,
@@ -113,6 +122,11 @@ public final class ExampleVerifier {
                                      ClassLoader parent, Map<String, Hir.FnDef> values,
                                      String sourceId, Deadline deadline, EvaluationPolicy policy,
                                      Answering answering) {
+        if (!artifact.implementations().module().equals(module.name())) {
+            throw new IllegalArgumentException("the rows are `" + module.name()
+                    + "`'s and the artifact is `" + artifact.implementations().module()
+                    + "`'s; what applies a behavior would be looked up in the wrong module");
+        }
         if (module.examples().isEmpty()) {
             return Observations.NONE;
         }

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -1,5 +1,6 @@
 package souther.compiler.examples;
 
+import souther.compiler.generated.EvaluationArtifact;
 import souther.compiler.generated.MemoryClassLoader;
 import souther.compiler.check.BehaviorRequirement;
 import souther.compiler.check.Symbols;
@@ -54,8 +55,9 @@ import java.util.Set;
  * answerer. A row's inputs cross as {@link Handed} and the answer comes back as whatever the answerer
  * applies, read by the one reading a run has.
  *
- * <p>A behavior with a {@code let} body and a {@code >->} composition are evaluable; an injected
- * target is refused ({@code E1902}) — you fake one, you do not example it.
+ * <p>A row whose behavior this run has something applying is evaluated, and one whose behavior
+ * nothing applies is recorded (spec {@code example-pending}). What is refused is a target that is
+ * not a behavior at all — a helper {@code let} of that name ({@code E1902}).
  * A {@code depends on} dependency is satisfied by a fake supplied at the example: a
  * {@code with dep = value} on the row (a constant/value dependency) or a {@code fake dep | table}
  * declaration (an input-keyed function dependency). What the fake answers is read here; making it
@@ -99,10 +101,14 @@ public final class ExampleVerifier {
      * because it is this run's — a row's fixtures are decoded and held to their invariants whether or
      * not there is anything to run them against — and it is handed to {@code answering}, which is what
      * makes an answerer applying this compile's own classes one that can only exist over them.
+     *
+     * <p>{@code artifact} is taken whole rather than as its classes and what they implement. Both are
+     * of one compile and a run has no use for a pairing of two, so the loader is built from one half
+     * of it and the other half goes to {@code answering} from the same value.
      */
     public static Observations check(souther.compiler.check.Prepared.ExampleExecution module,
                                      Symbols symbols, Map<String, Sig> sigs,
-                                     Map<String, byte[]> classes,
+                                     EvaluationArtifact artifact,
                                      Map<String, List<BehaviorRequirement>> requirements,
                                      ClassLoader parent, Map<String, Hir.FnDef> values,
                                      String sourceId, Deadline deadline, EvaluationPolicy policy,
@@ -110,9 +116,9 @@ public final class ExampleVerifier {
         if (module.examples().isEmpty()) {
             return Observations.NONE;
         }
-        MemoryClassLoader loader = new MemoryClassLoader(classes, parent);
+        MemoryClassLoader loader = new MemoryClassLoader(artifact.classes(), parent);
         ExampleVerifier v = new ExampleVerifier(module, symbols, sigs, requirements, loader, values,
-                deadline, policy, answering.over(module.name(), loader));
+                deadline, policy, answering.over(artifact.implementations(), loader));
         v.sourceId = sourceId;
         List<Diagnostic> failures = new ArrayList<>();
         List<RowOutcome> rows = new ArrayList<>();
@@ -263,26 +269,30 @@ public final class ExampleVerifier {
     }
 
     /**
-     * What a row runs: the behavior's name, and what it takes injected in the order its constructor
-     * takes it.
+     * What a row runs: the behavior's name, what it takes injected in the order its constructor takes
+     * it, and what this run has to apply it.
      *
      * <p>Which kind of behavior it is does not survive to here. A row applies the class the module
      * emitted, and that class is reached the same way whichever way the behavior was written — the
      * name says which, and the requirements say what to hand it.
      */
     private record ExampleTarget(String name, List<BehaviorRequirement> requirements,
-                                 boolean pending) {}
+                                 Answerer.Answer answer) {}
 
     /**
-     * The behavior a row is about, and whether there is anything to run it against.
+     * The behavior a row is about, and what this run has to apply it with.
      *
-     * <p>A behavior with a {@code let} body and a {@code >->} composition are applied; an injected one
-     * has no body yet, so its rows are <em>recorded</em> rather than evaluated (spec
-     * {@code example-pending}). That is not a lesser state: a model being migrated onto is injected
-     * everywhere at the start, and the rows harvested from the system it replaces are what says what
-     * each behavior owes. They are checked as far as they can be — every fixture is built, so a value
-     * that breaks an invariant is found the day it is written — and evaluation begins by itself the
-     * moment a {@code let} arrives.
+     * <p>Asked of the answerer rather than read off how the behavior is written. The two say the same
+     * thing while a compile's own classes are the only thing that applies anything, and they come
+     * apart the moment something else can: what a row can be held to is decided by what this run was
+     * given, so it is what this run was given that is asked.
+     *
+     * <p>A row nothing applies is <em>recorded</em> rather than evaluated (spec
+     * {@code example-pending}). That is not a lesser state: a model being migrated onto has nothing
+     * applying anything at the start, and the rows harvested from the system it replaces are what says
+     * what each behavior owes. They are checked as far as they can be — every fixture is built, so a
+     * value that breaks an invariant is found the day it is written — and evaluation begins by itself
+     * the moment something applies the behavior.
      *
      * <p>Null when this module declares no behavior of that name; what to say about that is
      * {@link #notRunnable}'s.
@@ -298,7 +308,7 @@ public final class ExampleVerifier {
                 continue;
             }
             return new ExampleTarget(name, requirements.getOrDefault(name, List.of()),
-                    module.injected(b));
+                    answerer.of(name));
         }
         return null;
     }
@@ -728,14 +738,22 @@ public final class ExampleVerifier {
             return;
         }
         state.got(Stage.FIXTURES_VALIDATED);
-        if (target.pending()) {
-            // Everything a row can be held to without a body has been: its arity, its inputs against
-            // their types and invariants, and its expectation against the output's cases. What is left
-            // needs something to run, and there is nothing yet. A fake is not it — a fake stands in for
-            // a dependency while some *other* behavior's row runs, and this row is about this behavior.
-            state.disposition = Disposition.PENDING;
-            state.failurePhase = FailurePhase.NONE;
-            return;
+        // Stated as a switch and not as a test for one of the two: what a run can have for a behavior
+        // may come to say more than it does here, and a reader written as a test would go on taking one
+        // of its ways with an answer it was never shown.
+        Answerer.Answer.Something applies;
+        switch (target.answer()) {
+            case Answerer.Answer.Nothing _ -> {
+                // Everything a row can be held to without something to run it has been: its arity, its
+                // inputs against their types and invariants, and its expectation against the output's
+                // cases. What is left needs something to apply the behavior, and this run has nothing.
+                // A fake is not it — a fake stands in for a dependency while some *other* behavior's
+                // row runs, and this row is about this behavior.
+                state.disposition = Disposition.PENDING;
+                state.failurePhase = FailurePhase.NONE;
+                return;
+            }
+            case Answerer.Answer.Something something -> applies = something;
         }
         List<DependencyStandin> standins = resolveFakes(fixtures, target, row, out);
         if (standins == null) {
@@ -744,7 +762,7 @@ public final class ExampleVerifier {
         }
         Answerer.Applying applying;
         try {
-            applying = answerer.applying(target.name(), standins);
+            applying = applies.applying(standins);
         } catch (StandinNotBuilt e) {
             // The row states the stand-in and it could not be made into an instance the behavior can
             // be constructed with. Nothing was applied, so the row stops where a row whose dependency

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -36,8 +36,6 @@ import souther.compiler.observe.Stage;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -300,58 +298,18 @@ public final class ExampleVerifier {
                 continue;
             }
             return new ExampleTarget(name, requirements.getOrDefault(name, List.of()),
-                    isPending(module.behaviors(), defined(), name));
+                    module.injected(b));
         }
         return null;
     }
 
-    /**
-     * Whether a behavior of {@code module} has no implementation to run — an injected one (spec
-     * {@code injected-behavior}).
-     *
-     * <p>Asked here by the row evaluation and by the adequacy report, which says of each behavior
-     * which of the two it is. Two statements of it would let a report say a behavior is implemented
-     * while its rows are being recorded rather than run.
-     *
-     * <p>This is how the behavior is written, and it answers no question about what a run saw. What
-     * the rows observed is theirs to say ({@code OutputCaseEvidence}), and a measure decided from
-     * here would be a measure that stops being right as soon as something other than this compile
-     * can apply a behavior.
-     */
-    public static boolean isPending(List<Hir.BehaviorDef> behaviors, Collection<String> defined,
-                                    String name) {
-        for (Hir.BehaviorDef b : behaviors) {
-            if (b.name().equals(name)) {
-                return b instanceof Hir.SpecBehavior && !defined.contains(name);
-            }
-        }
-        return false;
-    }
-
-    /** The names the module's definitions are written under. What this asks of them is that there
-     * is one, so it is handed the names and not the definitions: a reader taking the desugared
-     * definitions would be asking for a claim it has no use for. */
-    public static Set<String> definedNames(List<souther.compiler.check.Desugared.Fn> fns) {
-        Set<String> names = new LinkedHashSet<>();
-        for (souther.compiler.check.Desugared.Fn fn : fns) {
-            names.add(fn.name());
-        }
-        return names;
-    }
-
-    private Collection<String> defined() {
-        return definedNames(module.fns());
-    }
-
-    private boolean hasFn(String name) {
-        return defined().contains(name);
-    }
-
-    /** The injected behavior named {@code name} in this module (a SpecBehavior with no {@code let}),
-     * i.e. a valid target for a fake; null if not found or not injected. */
+    /** The injected behavior named {@code name} in this module — a valid target for a fake; null if
+     * not found or not injected. How a behavior is written is the module's to say, so the rule is
+     * read from there rather than spelled again here. */
     private Hir.SpecBehavior injectedSpec(String name) {
         for (Hir.BehaviorDef b : module.behaviors()) {
-            if (b instanceof Hir.SpecBehavior spec && spec.name().equals(name) && !hasFn(name)) {
+            if (b instanceof Hir.SpecBehavior spec && spec.name().equals(name)
+                    && module.injected(spec)) {
                 return spec;
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/examples/GeneratedImplementation.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/GeneratedImplementation.java
@@ -1,5 +1,6 @@
 package souther.compiler.examples;
 
+import souther.compiler.generated.GeneratedImplementations;
 import souther.compiler.generated.MemoryClassLoader;
 import souther.compiler.jvm.GeneratedClass;
 import souther.compiler.jvm.GeneratedClasses;
@@ -25,12 +26,34 @@ import java.util.function.Function;
  */
 final class GeneratedImplementation implements Answerer {
 
-    private final String module;
+    private final GeneratedImplementations generated;
     private final MemoryClassLoader loader;
 
-    GeneratedImplementation(String module, MemoryClassLoader loader) {
-        this.module = module;
+    GeneratedImplementation(GeneratedImplementations generated, MemoryClassLoader loader) {
+        this.generated = generated;
         this.loader = loader;
+    }
+
+    /**
+     * What this compile emitted for the behavior, if it emitted one.
+     *
+     * <p>Read off the manifest the emission produced. This compile applies what it generated, so what
+     * it generated is the whole of the answer — and it is the emitter's own record of that rather than
+     * the same decision made a second time from the module's declarations. The two agree today; the
+     * one that is right the day they part is the emitter's.
+     *
+     * <p>A behavior it did generate is answered with {@link Answer.Something} whether or not the class
+     * can be loaded. Loading is applying, and an implementation that was generated and cannot be
+     * reached is {@link ImplementationNotReached} — a failure, and not this run having nothing to
+     * apply.
+     */
+    @Override
+    public Answer of(String behavior) {
+        if (!generated.has(behavior)) {
+            return new Answer.Nothing();
+        }
+        Answer.Something something = standins -> applying(behavior, standins);
+        return something;
     }
 
     /**
@@ -39,8 +62,7 @@ final class GeneratedImplementation implements Answerer {
      * <p>Made here rather than when the behavior is applied, because a row whose stand-ins could not
      * be made never entered the behavior and its outcome has to say so.
      */
-    @Override
-    public Applying applying(String behavior, List<DependencyStandin> standins) {
+    private Applying applying(String behavior, List<DependencyStandin> standins) {
         Object[] instances = new Object[standins.size()];
         for (int i = 0; i < standins.size(); i++) {
             instances[i] = instanceOf(standins.get(i));
@@ -94,7 +116,8 @@ final class GeneratedImplementation implements Answerer {
         Object instance;
         java.lang.reflect.Method apply;
         try {
-            c = GeneratedClasses.load(loader, new GeneratedClass.BehaviorImpl(module, behavior));
+            c = GeneratedClasses.load(loader,
+                    new GeneratedClass.BehaviorImpl(generated.module(), behavior));
             if (fakes.length == 0) {
                 instance = openCtor(c).newInstance();
             } else {
@@ -167,7 +190,7 @@ final class GeneratedImplementation implements Answerer {
      * answers. */
     private Object standaloneInstance(DependencyStandin standin) {
         GeneratedClass.BehaviorInterface baseClass =
-                new GeneratedClass.BehaviorInterface(module, standin.dependency());
+                new GeneratedClass.BehaviorInterface(generated.module(), standin.dependency());
         try {
             Class<?> base = GeneratedClasses.load(loader, baseClass);
             java.lang.reflect.Method apply = null;

--- a/souther-compiler/src/main/java/souther/compiler/generated/EvaluationArtifact.java
+++ b/souther-compiler/src/main/java/souther/compiler/generated/EvaluationArtifact.java
@@ -1,0 +1,35 @@
+package souther.compiler.generated;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * What an example run is given to run against: the classes it loads, and what the compile that
+ * emitted them generated an implementation for.
+ *
+ * <p>One value because the two have to be of one compile. Taken apart, a run could be handed one
+ * compile's classes beside another's manifest — and the pair would not disagree anywhere a reader
+ * could see it, because a row asks the manifest whether anything applies its behavior and then asks
+ * the loader for the class, so the mismatch arrives as a class that is not there or, worse, as a row
+ * recorded against a behavior that had something to run it. Made and passed as one, that pairing
+ * cannot be stated.
+ *
+ * <p>The two halves are not of the same extent, and that is the contract:
+ * {@link #implementations}{@code .module()} is the module being evaluated, and {@link #classes} holds
+ * that module's classes and additionally those of every module its rows can reach. A row applies a
+ * behavior of the module it is written for and reaches the rest through generated code, so one
+ * manifest is what a run needs — and one covering every linked module would be answering for
+ * behaviors no answerer here is asked about.
+ *
+ * @param classes         binary name to bytecode, for this module and the ones its rows reach
+ * @param implementations what the module being evaluated generated an implementation for
+ */
+public record EvaluationArtifact(Map<String, byte[]> classes,
+                                 GeneratedImplementations implementations) {
+
+    public EvaluationArtifact {
+        Objects.requireNonNull(classes, "a run says what classes it loads");
+        Objects.requireNonNull(implementations,
+                "a run says what the compile generated an implementation for");
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/generated/EvaluationArtifact.java
+++ b/souther-compiler/src/main/java/souther/compiler/generated/EvaluationArtifact.java
@@ -11,8 +11,12 @@ import java.util.Objects;
  * compile's classes beside another's manifest — and the pair would not disagree anywhere a reader
  * could see it, because a row asks the manifest whether anything applies its behavior and then asks
  * the loader for the class, so the mismatch arrives as a class that is not there or, worse, as a row
- * recorded against a behavior that had something to run it. Made and passed as one, that pairing
- * cannot be stated.
+ * recorded against a behavior that had something to run it. Made and passed as one, no caller has to
+ * keep the two together.
+ *
+ * <p>Which module it is of is not settled here. A run is over one module's rows and this says nothing
+ * about those, so the two being of one module is checked where both are in hand
+ * ({@code ExampleVerifier.check}) rather than claimed by this type.
  *
  * <p>The two halves are not of the same extent, and that is the contract:
  * {@link #implementations}{@code .module()} is the module being evaluated, and {@link #classes} holds

--- a/souther-compiler/src/main/java/souther/compiler/generated/GeneratedImplementations.java
+++ b/souther-compiler/src/main/java/souther/compiler/generated/GeneratedImplementations.java
@@ -1,5 +1,7 @@
 package souther.compiler.generated;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -26,7 +28,11 @@ public record GeneratedImplementations(String module, Set<String> behaviors) {
 
     public GeneratedImplementations {
         Objects.requireNonNull(module, "a manifest says which module it is of");
-        behaviors = Set.copyOf(behaviors);
+        Objects.requireNonNull(behaviors, "a manifest says what it implemented, or that it is empty");
+        // In the order they were emitted. `Set.copyOf` would keep the members and not the order —
+        // its iteration order is salted per JVM run — so anything that came to print or compare this
+        // would read differently from one run to the next, for no change to the module.
+        behaviors = Collections.unmodifiableSet(new LinkedHashSet<>(behaviors));
     }
 
     /** Whether this compile generated an implementation for {@code behavior}. */

--- a/souther-compiler/src/main/java/souther/compiler/generated/GeneratedImplementations.java
+++ b/souther-compiler/src/main/java/souther/compiler/generated/GeneratedImplementations.java
@@ -1,0 +1,36 @@
+package souther.compiler.generated;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Which behaviors of a module this compile generated an implementation for.
+ *
+ * <p>The emitter's own decision, kept. A behavior written with a {@code let} body and a {@code >->}
+ * composition are emitted as classes that apply them, and a behavior written with neither is emitted
+ * as a base for something outside to supply — so what is here is the first kind, and what is not here
+ * is a behavior this compile has nothing to run.
+ *
+ * <p>Read off what the emission put rather than worked out again from how the module is written.
+ * Both answers agree today, and that they agree is a fact about one compile rather than a rule: the
+ * second reader is what makes them able to disagree, and a reader deciding from the declarations
+ * would go on saying a behavior has an implementation after the emitter stopped producing one for it.
+ * Not read off the classes either — a name that is not in a loader is a class that could not be
+ * reached, which is a failure, and reading membership for it would turn that failure into "nothing
+ * applies this", which is not a failure at all.
+ *
+ * @param module     the module these behaviors are of
+ * @param behaviors  the names it generated an implementation for
+ */
+public record GeneratedImplementations(String module, Set<String> behaviors) {
+
+    public GeneratedImplementations {
+        Objects.requireNonNull(module, "a manifest says which module it is of");
+        behaviors = Set.copyOf(behaviors);
+    }
+
+    /** Whether this compile generated an implementation for {@code behavior}. */
+    public boolean has(String behavior) {
+        return behaviors.contains(behavior);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/observe/Applied.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/Applied.java
@@ -10,7 +10,7 @@ package souther.compiler.observe;
  * answered several times with nothing holding the answers together.
  *
  * <p>This says what the run applied and nothing else. How a behavior is written is answered where it
- * is written ({@code ExampleVerifier.isPending}), and a second answer to that question is what this
+ * is written ({@code Prepared.injected}), and a second answer to that question is what this
  * must not become. What the row cost is {@link Counted}, which covers the fixtures as well and so is
  * not a fact about the application alone.
  *

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1353,13 +1353,16 @@ public final class Adequacy {
      */
     static FixtureReader.Construction constructing(Db db, String module, souther.compiler.check.Prepared.ExampleExecution written,
                                                    Symbols symbols) {
-        Map<String, byte[]> classes =
+        // The classes alone: building a value applies no behavior, so what the compile implemented is
+        // not a question this asks.
+        souther.compiler.generated.EvaluationArtifact artifact =
                 db.ask(new Output.EvaluationLinked(module, coverageAsked(db))).value();
         Map<String, List<BehaviorRequirement>> requirements =
                 db.ask(new Bodies.Requirements(module)).value();
-        if (classes == null || requirements == null) {
+        if (artifact == null || requirements == null) {
             return null;
         }
+        Map<String, byte[]> classes = artifact.classes();
         Map<String, Hir.FnDef> values = db.ask(new Bodies.ModuleDefinitions(module)).value();
         // `requirements` is asked above as a readiness condition, not as an input: whether a
         // value builds at this module's boundary is the decoder's answer, and nothing here runs.

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -1,5 +1,7 @@
 package souther.compiler.query;
 
+import souther.compiler.generated.EvaluationArtifact;
+import souther.compiler.generated.GeneratedImplementations;
 import souther.compiler.generated.MemoryClassLoader;
 import souther.compiler.jvm.GeneratedClass;
 import souther.compiler.jvm.SoutherJvmAbi;
@@ -305,14 +307,15 @@ public final class Output {
      * arm that ran as one nothing reaches, and that reads as a gap in the model rather than a fault in
      * the measurement.
      */
-    public record Evaluated(String name, CoverageMode coverage) implements Key<Map<String, byte[]>> {
+    public record Evaluated(String name, CoverageMode coverage)
+            implements Key<EvaluationArtifact> {
         @Override
         public String module() {
             return name;
         }
 
         @Override
-        public Answer<Map<String, byte[]>> compute(Db db) {
+        public Answer<EvaluationArtifact> compute(Db db) {
             Classes.Inputs in = Classes.inputs(db, name);
             if (in == null) {
                 return Answer.absent();
@@ -329,7 +332,9 @@ public final class Output {
                         in.callees(), in.requirements(), in.checked(), in.dischargeClauses(),
                         instrumentation);
                 Classes.stamp(db, name, emitted);
-                return Answer.of(Ordered.map(emitted.byBinaryName()));
+                // The classes and what they implement, from the one emission that decided both.
+                return Answer.of(new EvaluationArtifact(Ordered.map(emitted.byBinaryName()),
+                        emitted.implemented()));
             } catch (CompileException e) {
                 return Answer.absent(e);
             } catch (IllegalStateException _) {
@@ -370,20 +375,26 @@ public final class Output {
      * counts them on the way in, so the counting still does not stop at the import.
      */
     public record EvaluationLinked(String name, CoverageMode coverage)
-            implements Key<Map<String, byte[]>> {
+            implements Key<EvaluationArtifact> {
         @Override
         public String module() {
             return name;
         }
 
         @Override
-        public Answer<Map<String, byte[]>> compute(Db db) {
+        public Answer<EvaluationArtifact> compute(Db db) {
             List<String> reaches = db.ask(new Reaches(name)).value();
             if (reaches == null) {
-                return Answer.of(Map.of());
+                // What this module reaches always includes this module, so there is no such answer.
+                // Absent rather than an empty set of classes with an empty manifest beside it: a
+                // manifest saying nothing is generated is an answer, and it would tell every row that
+                // nothing applies its behavior, which is what a module with no `let` anywhere looks
+                // like. Nothing was worked out, so nothing is said.
+                return Answer.absent();
             }
             Front.Layout.Of layout = db.ask(new Front.Layout()).value();
             Map<String, byte[]> linked = new LinkedHashMap<>();
+            GeneratedImplementations implemented = null;
             // Furthest first, so the module being evaluated is put on last, as Linked does.
             for (int i = reaches.size() - 1; i >= 0; i--) {
                 String reached = reaches.get(i);
@@ -396,7 +407,7 @@ public final class Output {
                 if (layout == null || !layout.idOfModule().containsKey(reached)) {
                     continue;
                 }
-                Answer<Map<String, byte[]>> classes = db.ask(new Evaluated(reached,
+                Answer<EvaluationArtifact> classes = db.ask(new Evaluated(reached,
                         reached.equals(name) ? coverage : CoverageMode.NONE));
                 // A module this compilation declares and could not generate makes this absent rather
                 // than making the set one class short. Evaluating against a set with a hole in it
@@ -406,9 +417,19 @@ public final class Output {
                 if (classes.value() == null) {
                     return Answer.absent(classes.reports());
                 }
-                linked.putAll(classes.value());
+                linked.putAll(classes.value().classes());
+                if (reached.equals(name)) {
+                    implemented = classes.value().implementations();
+                }
             }
-            return Answer.of(Ordered.map(linked));
+            if (implemented == null) {
+                // The module being evaluated was not generated here, so what applies its behaviors is
+                // not known — and an evaluation is over its rows. Absent for the reason the loop above
+                // is absent one class short: a run given no manifest for it would read every one of
+                // its rows as one nothing applies.
+                return Answer.absent();
+            }
+            return Answer.of(new EvaluationArtifact(Ordered.map(linked), implemented));
         }
     }
 
@@ -629,8 +650,11 @@ public final class Output {
                 // a module that did not check states nothing yet
                 return Answer.of(souther.compiler.examples.ExampleStatements.Readings.NONE);
             }
-            Map<String, byte[]> classes =
+            // The classes alone: nothing here applies a behavior, so what the compile implemented is
+            // not a question this asks.
+            EvaluationArtifact artifact =
                     db.ask(new EvaluationLinked(name, CoverageMode.NONE)).value();
+            Map<String, byte[]> classes = artifact == null ? null : artifact.classes();
             Map<String, List<BehaviorRequirement>> requirements =
                     db.ask(new Bodies.Requirements(name)).value();
             List<String> exampleOrigins = db.ask(new Front.ExampleOrigins(name)).value();
@@ -857,8 +881,10 @@ public final class Output {
             if (!db.ask(new Bodies.Checked(name)).present()) {
                 return List.of();   // a module that did not check has nothing to build a value with
             }
-            Map<String, byte[]> classes =
+            // As above: building a table applies no behavior, so only the classes are read.
+            EvaluationArtifact artifact =
                     db.ask(new EvaluationLinked(name, CoverageMode.NONE)).value();
+            Map<String, byte[]> classes = artifact == null ? null : artifact.classes();
             Map<String, List<BehaviorRequirement>> requirements =
                     db.ask(new Bodies.Requirements(name)).value();
             List<String> fakeOrigins = db.ask(new Front.FakeOrigins(name)).value();
@@ -882,7 +908,7 @@ public final class Output {
          * become two evaluations. A row that held under one and failed under the other would be a
          * difference in the measurement, not in the model, and the report has no way to tell.
          */
-        static Answer<Of> evaluate(Db db, String name, String sourceId, Map<String, byte[]> classes,
+        static Answer<Of> evaluate(Db db, String name, String sourceId, EvaluationArtifact artifact,
                                    CoverageMode coverage) {
             Answer<souther.compiler.check.Prepared> prepared = db.ask(new Shapes.Prepared(name));
             Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
@@ -893,7 +919,7 @@ public final class Output {
             if (!db.ask(new Bodies.Checked(name)).present()) {
                 return Answer.absent();   // a module that did not check has nothing to run
             }
-            if (classes == null) {
+            if (artifact == null) {
                 // Arms were asked for and the instrumented classes could not be made. Falling back to
                 // uncounted ones is not open: what holds a row to a budget is the counting, so a row
                 // run against them would be back on the clock. Nothing was observed, and that travels
@@ -921,7 +947,8 @@ public final class Output {
             }
             Map<String, Hir.FnDef> values = db.ask(new Bodies.ModuleDefinitions(name)).value();
             souther.compiler.examples.ExampleVerifier.Observations observed =
-                    souther.compiler.examples.ExampleVerifier.check(rows, scope.value(), sigs.value(), classes,
+                    souther.compiler.examples.ExampleVerifier.check(rows, scope.value(), sigs.value(),
+                            artifact,
                             requirements, evaluationLoader(db),
                             values == null ? Map.of() : values, sourceId, deadlineOf(db),
                             policyOf(db),

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1,6 +1,5 @@
 package souther.compiler.report;
 
-import souther.compiler.examples.ExampleVerifier;
 import souther.compiler.ast.Hir;
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.diag.SourcePos;
@@ -220,8 +219,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             Adequacy.BranchEvidence branch =
                     branches == null ? null : branches.get(behavior.name());
             behaviors.add(new BehaviorReport(behavior.name(),
-                    ExampleVerifier.isPending(module.behaviors(),
-                            ExampleVerifier.definedNames(module.fns()), behavior.name()),
+                    module.injected(behavior),
                     rows.size(), pending,
                     unreadable ? MeasurementStatus.PARTIAL : statusOf(signature, partition, branch),
                     signature, partition, branch,

--- a/souther-compiler/src/test/java/souther/compiler/ADependencyOnThePathIsCountedLikeAnyOtherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ADependencyOnThePathIsCountedLikeAnyOtherTest.java
@@ -155,7 +155,7 @@ class ADependencyOnThePathIsCountedLikeAnyOtherTest {
 
         assertFalse(compilation.db()
                         .ask(new Output.EvaluationLinked("app.calls", Output.CoverageMode.NONE))
-                        .value().containsKey(Emitted.impl("lib.svc", "spin")),
+                        .value().classes().containsKey(Emitted.impl("lib.svc", "spin")),
                 "the body is not regenerated here — it is taken from the jar and counted there");
 
         String sourceId = compilation.exampleSourcesOf("app.calls").get(0);

--- a/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
@@ -450,7 +450,7 @@ class CompileFakeExampleDisagreementTest {
                 c.db().ask(new souther.compiler.query.Shapes.Scope(name)).value(),
                 c.db().ask(new souther.compiler.query.Bodies.Signatures(name)).value(),
                 c.db().ask(new souther.compiler.query.Output.EvaluationLinked(
-                        name, souther.compiler.query.Output.CoverageMode.NONE)).value(),
+                        name, souther.compiler.query.Output.CoverageMode.NONE)).value().classes(),
                 parent,
                 c.db().ask(new souther.compiler.query.Bodies.ModuleDefinitions(name)).value(),
                 c.db().ask(new souther.compiler.query.Front.ExampleOrigins(name)).value(),

--- a/souther-compiler/src/test/java/souther/compiler/codegen/TwoClassesUnderOneNameAreNotOneClassTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/TwoClassesUnderOneNameAreNotOneClassTest.java
@@ -41,7 +41,7 @@ class TwoClassesUnderOneNameAreNotOneClassTest {
 
     @Test
     void aDataAndABehaviorThatCapitalizesOntoItAreOneClass() {
-        Emissions out = new Emissions();
+        Emissions out = new Emissions("demo");
         out.put(QUOTE_DATA, new byte[] {1});
         IllegalStateException refused = assertThrows(IllegalStateException.class,
                 () -> out.put(QUOTE_BEHAVIOR, new byte[] {2}));
@@ -59,7 +59,7 @@ class TwoClassesUnderOneNameAreNotOneClassTest {
      *  and this ABI has one name for them. */
     @Test
     void twoMembersBridgedUnderOneNameAreOneClass() {
-        Emissions out = new Emissions();
+        Emissions out = new Emissions("demo");
         out.put(new GeneratedClass.BridgeCase("demo", TypeSymbols.declared(new TypeKey("a", "Foo"))), new byte[] {1});
         IllegalStateException refused = assertThrows(IllegalStateException.class,
                 () -> out.put(new GeneratedClass.BridgeCase("demo", TypeSymbols.declared(new TypeKey("b", "Foo"))),
@@ -76,7 +76,7 @@ class TwoClassesUnderOneNameAreNotOneClassTest {
      */
     @Test
     void oneIdentityCannotRewriteAnotherThatHasTheSameName() {
-        Emissions out = new Emissions();
+        Emissions out = new Emissions("demo");
         out.put(QUOTE_DATA, new byte[] {1});
         IllegalStateException refused = assertThrows(IllegalStateException.class,
                 () -> out.rewrite(QUOTE_BEHAVIOR, bytes -> new byte[] {2}));
@@ -89,7 +89,7 @@ class TwoClassesUnderOneNameAreNotOneClassTest {
     /** The control: the identity that was emitted may rewrite what it holds, and stays what it is. */
     @Test
     void andTheIdentityThatWasEmittedMayRewriteIt() {
-        Emissions out = new Emissions();
+        Emissions out = new Emissions("demo");
         out.put(QUOTE_DATA, new byte[] {1});
         out.rewrite(QUOTE_DATA, bytes -> new byte[] {(byte) (bytes[0] + 1)});
         assertEquals(2, out.byBinaryName().get(Emitted.value("demo", "Quote"))[0]);
@@ -102,7 +102,7 @@ class TwoClassesUnderOneNameAreNotOneClassTest {
     /** A rewrite of something nothing emitted is refused rather than becoming the emission of it. */
     @Test
     void andNothingCanBeRewrittenThatWasNeverEmitted() {
-        Emissions out = new Emissions();
+        Emissions out = new Emissions("demo");
         IllegalStateException refused = assertThrows(IllegalStateException.class,
                 () -> out.rewrite(QUOTE_DATA, bytes -> new byte[] {1}));
         assertTrue(refused.getMessage().contains("demo.Quote"), refused.getMessage());
@@ -113,7 +113,7 @@ class TwoClassesUnderOneNameAreNotOneClassTest {
      *  escaping lambdas are added. */
     @Test
     void andSoIsOneArrivingWithOthers() {
-        Emissions out = new Emissions();
+        Emissions out = new Emissions("demo");
         out.put(QUOTE_DATA, new byte[] {1});
         Map<GeneratedClass, byte[]> more = new LinkedHashMap<>();
         more.put(new GeneratedClass.Lambda("demo", 0), new byte[] {2});
@@ -125,7 +125,7 @@ class TwoClassesUnderOneNameAreNotOneClassTest {
      *  in. Without it the refusals above would pass on a registry that refused everything. */
     @Test
     void andEveryOtherIdentityIsWritten() {
-        Emissions out = new Emissions();
+        Emissions out = new Emissions("demo");
         out.put(QUOTE_DATA, new byte[] {1});
         out.putAll(Map.of(new GeneratedClass.Encoder(QUOTE_DATA), new byte[] {2}));
         out.put(new GeneratedClass.Decoder(QUOTE_DATA, DecoderKind.JSON), new byte[] {3});

--- a/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
@@ -59,11 +59,11 @@ class ProbedBytecodeTest {
     }
 
     private static Map<String, byte[]> probed(Compilation compilation) {
-        Map<String, byte[]> classes = compilation.db()
+        souther.compiler.generated.EvaluationArtifact artifact = compilation.db()
                 .ask(new Output.Evaluated(compilation.modules().get(0),
                         Output.CoverageMode.ARMS)).value();
-        assertNotNull(classes, "the model under test compiles");
-        return classes;
+        assertNotNull(artifact, "the model under test compiles");
+        return artifact.classes();
     }
 
     /** The classes a class names — what a loader will go looking for when it loads this one. */
@@ -204,9 +204,9 @@ class ProbedBytecodeTest {
         String module = compilation.modules().get(0);
         Map<String, byte[]> plain = compilation.db().ask(new Output.Linked(module)).value();
         Map<String, byte[]> measured = compilation.db()
-                .ask(new Output.Evaluated(module, Output.CoverageMode.ARMS)).value();
+                .ask(new Output.Evaluated(module, Output.CoverageMode.ARMS)).value().classes();
         Map<String, byte[]> linked = compilation.db()
-                .ask(new Output.EvaluationLinked(module, Output.CoverageMode.ARMS)).value();
+                .ask(new Output.EvaluationLinked(module, Output.CoverageMode.ARMS)).value().classes();
         assertNotNull(plain);
         assertNotNull(linked);
 

--- a/souther-compiler/src/test/java/souther/compiler/examples/AnAnswererInAnotherLoaderRunsARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AnAnswererInAnotherLoaderRunsARowTest.java
@@ -131,14 +131,19 @@ class AnAnswererInAnotherLoaderRunsARowTest {
         private String hereNamed;
 
         private Answering asAnswering(Map<String, byte[]> classes, ClassLoader parent) {
-            return (module, compiled) -> {
+            return (generated, compiled) -> {
                 mine = new MemoryClassLoader(classes, parent);
                 return this;
             };
         }
 
         @Override
-        public Applying applying(String behavior, List<DependencyStandin> standins) {
+        public Answer of(String behavior) {
+            Answer.Something something = standins -> applying(behavior, standins);
+            return something;
+        }
+
+        private Applying applying(String behavior, List<DependencyStandin> standins) {
             assertEquals(List.of(), standins, "an example of a `let` body depends on nothing");
             return new Applying() {
 
@@ -200,8 +205,9 @@ class AnAnswererInAnotherLoaderRunsARowTest {
         Compilation c = Compilation.ofSource(MODEL, "Main");
         c.db().ask(new Output.All());
         String name = c.modules().get(0);
-        Map<String, byte[]> classes = c.db()
+        souther.compiler.generated.EvaluationArtifact artifact = c.db()
                 .ask(new Output.EvaluationLinked(name, Output.CoverageMode.NONE)).value();
+        Map<String, byte[]> classes = artifact.classes();
         ClassLoader parent = ExampleVerifier.class.getClassLoader();
         answerer.hereNamed = "example.crossing.倍額";
         answerer.hereLoaded = loaded(new MemoryClassLoader(classes, parent), answerer.hereNamed);
@@ -209,7 +215,7 @@ class AnAnswererInAnotherLoaderRunsARowTest {
                 c.db().ask(new Shapes.Prepared(name)).value().forExamples(),
                 c.db().ask(new Shapes.Scope(name)).value(),
                 c.db().ask(new Bodies.Signatures(name)).value(),
-                classes,
+                artifact,
                 c.db().ask(new Bodies.Requirements(name)).value(),
                 parent,
                 c.db().ask(new Bodies.ModuleDefinitions(name)).value(),

--- a/souther-compiler/src/test/java/souther/compiler/examples/WhereARowStopsIsDecidedByWhichHalfOfTheSeamItReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/WhereARowStopsIsDecidedByWhichHalfOfTheSeamItReachedTest.java
@@ -160,9 +160,9 @@ class WhereARowStopsIsDecidedByWhichHalfOfTheSeamItReachedTest {
     @Test
     void whatAppliedARowIsTheBehaviorsAnswerAndNotTheAnswerersOne() {
         Map<String, Applied> perBehavior = new LinkedHashMap<>();
-        Answerer resolving = (behavior, standins) -> {
+        Answerer resolving = behavior -> {
             Applied its = perBehavior.computeIfAbsent(behavior, _ -> new Applied.GeneratedHere());
-            return new Answerer.Applying() {
+            Answerer.Answer.Something something = _ -> new Answerer.Applying() {
 
                 @Override
                 public Applied applied() {
@@ -174,6 +174,7 @@ class WhereARowStopsIsDecidedByWhichHalfOfTheSeamItReachedTest {
                     throw new InvocationFailure(new IllegalStateException("stopped by the test"));
                 }
             };
+            return something;
         };
 
         List<RowOutcome> rows = evaluated(TWO_BEHAVIORS, resolving).rows();
@@ -211,22 +212,22 @@ class WhereARowStopsIsDecidedByWhichHalfOfTheSeamItReachedTest {
             """;
 
     /** A stand-in the answerer will not make. What it could not make is the whole of what it says. */
-    private static final Answerer REFUSING = (behavior, standins) -> {
+    private static final Answerer REFUSING = something(_ -> standins -> {
         assertEquals(1, standins.size(), "the row does state a stand-in");
         throw new StandinNotBuilt(standins.get(0).dependency(),
                 "its base subclass could not be built: (said by the test)");
-    };
+    });
 
     /** A behavior that stops itself. Read the way the applied code stopping itself is always read. */
-    private static final Answerer FAILING = (behavior, standins) -> applying(_ -> {
+    private static final Answerer FAILING = something(_ -> _ -> applying(_ -> {
         throw new InvocationFailure(new IllegalStateException("it stopped itself"));
-    });
+    }));
 
     /** An answerer whose implementation is not where it looked. */
-    private static final Answerer UNREACHABLE = (behavior, standins) -> applying(_ -> {
+    private static final Answerer UNREACHABLE = something(behavior -> _ -> applying(_ -> {
         throw new ImplementationNotReached("no class of that name (said by the test)",
                 new ClassNotFoundException(behavior));
-    });
+    }));
 
     /**
      * An answerer that cannot put a value in the form it reads.
@@ -235,9 +236,16 @@ class WhereARowStopsIsDecidedByWhichHalfOfTheSeamItReachedTest {
      * built by this compile's own decoders and is always readable back. What is held is what the row
      * makes of a crossing that failed, which is the same whichever of the two raised it.
      */
-    private static final Answerer UNCROSSABLE = (behavior, standins) -> applying(_ -> {
+    private static final Answerer UNCROSSABLE = something(_ -> _ -> applying(_ -> {
         throw new FixtureException("`x` is a Nothing, which is not a type this example can read");
-    });
+    }));
+
+    /** An answerer that has something for every behavior it is asked about, built from what that
+     * something does with the row's stand-ins. */
+    private static Answerer something(
+            Function<String, Answerer.Answer.Something> per) {
+        return per::apply;
+    }
 
     /** An application that says this compile's classes entered the behavior, and runs {@code body}. */
     private static Answerer.Applying applying(Function<List<Handed>, Object> body) {
@@ -269,19 +277,19 @@ class WhereARowStopsIsDecidedByWhichHalfOfTheSeamItReachedTest {
         Compilation c = Compilation.ofSource(model, "Main");
         c.db().ask(new Output.All());
         String name = c.modules().get(0);
-        Map<String, byte[]> classes = c.db()
+        souther.compiler.generated.EvaluationArtifact artifact = c.db()
                 .ask(new Output.EvaluationLinked(name, Output.CoverageMode.NONE)).value();
         return ExampleVerifier.check(
                 c.db().ask(new Shapes.Prepared(name)).value().forExamples(),
                 c.db().ask(new Shapes.Scope(name)).value(),
                 c.db().ask(new Bodies.Signatures(name)).value(),
-                classes,
+                artifact,
                 c.db().ask(new Bodies.Requirements(name)).value(),
                 ExampleVerifier.class.getClassLoader(),
                 c.db().ask(new Bodies.ModuleDefinitions(name)).value(),
                 "Main",
                 Deadline.ofMillis(EvaluationPolicy.DEFAULT.outerTimeout().toMillis()),
                 EvaluationPolicy.DEFAULT,
-                (module, compiled) -> answerer);
+                (generated, compiled) -> answerer);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/examples/WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest.java
@@ -1,0 +1,229 @@
+package souther.compiler.examples;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.generated.EvaluationArtifact;
+import souther.compiler.generated.GeneratedImplementations;
+import souther.compiler.observe.Applied;
+import souther.compiler.observe.Disposition;
+import souther.compiler.observe.FailurePhase;
+import souther.compiler.observe.RowOutcome;
+import souther.compiler.observe.Stage;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Output;
+import souther.compiler.query.Shapes;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Whether anything applies a behavior for a row is what the run's answerer says, and not how the
+ * behavior is written.
+ *
+ * <p>The two say the same thing while a compile's own classes are the only thing that applies
+ * anything, so either could be read for the other without being wrong. They are different questions
+ * all the same, and each test here is one of the ways they come apart:
+ *
+ * <ul>
+ *   <li>a behavior written with no {@code let} that something applies — the row runs;</li>
+ *   <li>a behavior written with a body that nothing applies — the row is recorded;</li>
+ *   <li>a behavior something has an implementation for that cannot be reached — a failure, and not
+ *       a row nothing applies.</li>
+ * </ul>
+ *
+ * <p>The third is the one that says why this is answered rather than derived from what a loader
+ * holds. An implementation that is not where it was looked for is this compiler failing to reach
+ * what it undertook to apply, and answering that with "nothing applies this behavior" would record a
+ * broken compile as a model waiting for a {@code let}.
+ */
+class WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest {
+
+    /** Two behaviors that mean the same thing, one written with a body and one written without. */
+    private static final String MODEL = """
+            module example.applying
+
+            data Amount = Int
+
+            behavior double : (a: Amount) -> Amount
+                constructs Amount
+
+            let double (a) = Amount(a.value * 2)
+
+            behavior doubleFromOutside : (a: Amount) -> Amount
+                constructs Amount
+
+            example double
+              | "twice" : (Amount(1)) -> Amount(2)
+
+            example doubleFromOutside
+              | "twice, from outside" : (Amount(1)) -> Amount(2)
+            """;
+
+    /**
+     * A behavior the module writes no {@code let} for, and a run that has something applying it.
+     *
+     * <p>The row runs, its answer is compared and it holds. Nothing about how the behavior is written
+     * changed — a reader going to the declaration would still find no body — so a row deciding from
+     * there would record this one as pending and the answer it agrees with would never be compared.
+     */
+    @Test
+    void aBehaviorWithNoBodyIsRunWhenTheRunHasSomethingToApplyIt() {
+        ExampleVerifier.Observations observed = evaluated(applyingTheOneWithNoBody());
+
+        RowOutcome row = rowFor(observed, "doubleFromOutside");
+        assertEquals(Stage.COMPARED, row.stage(), "the row was run and its answer compared");
+        assertEquals(Disposition.HELD, row.disposition(), "and it held: " + observed.failures());
+        assertEquals(FailurePhase.NONE, row.failurePhase());
+        assertInstanceOf(Applied.GeneratedHere.class, row.run().applied(),
+                "what applied it is what the answerer said applied it");
+        assertEquals(List.of(), observed.failures());
+    }
+
+    /**
+     * The control, on the same run: a behavior with a body that this run has nothing for.
+     *
+     * <p>Recorded rather than run, and recorded as what a row nothing applies has always been. A
+     * reader deciding from the declaration would have run it against classes this run never offered.
+     */
+    @Test
+    void aBehaviorWithABodyIsRecordedWhenNothingInTheRunAppliesIt() {
+        ExampleVerifier.Observations observed = evaluated(applyingTheOneWithNoBody());
+
+        RowOutcome row = rowFor(observed, "double");
+        assertEquals(Stage.FIXTURES_VALIDATED, row.stage(),
+                "everything it can be held to without being run, it was held to");
+        assertEquals(Disposition.PENDING, row.disposition());
+        assertEquals(FailurePhase.NONE, row.failurePhase(), "which is not a failure");
+        assertInstanceOf(Applied.Nothing.class, row.run().applied());
+        assertEquals(List.of(), observed.failures(),
+                "and nothing is said about a model that may be right");
+    }
+
+    /**
+     * An answerer that says it has an implementation for every behavior and reaches none of them.
+     *
+     * <p>Each row fails and says the behavior was never entered. Not {@code PENDING}: having nothing
+     * to apply and having something that could not be reached are different states, and only the
+     * second is a fault. A reader that decided applicability by looking the class up in the loader
+     * would turn every one of these into the first, and a compile that emitted nothing would report a
+     * corpus of models waiting for a {@code let}.
+     */
+    @Test
+    void anImplementationThatCannotBeReachedIsAFailureAndNotARowNothingApplies() {
+        ExampleVerifier.Observations observed = evaluated(claimingEverythingAndReachingNothing());
+
+        assertEquals(2, observed.rows().size());
+        for (RowOutcome row : observed.rows()) {
+            assertNotEquals(Disposition.PENDING, row.disposition(),
+                    "a row whose implementation could not be reached is not one nothing applies");
+            assertEquals(Disposition.FAILED, row.disposition());
+            assertEquals(FailurePhase.INVOCATION, row.failurePhase());
+            assertEquals(Stage.FIXTURES_VALIDATED, row.stage(), "it never got in");
+            assertInstanceOf(Applied.Nothing.class, row.run().applied(),
+                    "nothing applied it, which is not nothing being able to");
+        }
+        assertEquals(2, observed.failures().size(), "and both rows are told");
+    }
+
+    /**
+     * What this compile itself answers with, held to what it emitted.
+     *
+     * <p>The manifest is the emitter's own record: the behavior with a body is in it and the one
+     * without is not. Those are the two answers the rows above were given, from the one place that
+     * decided them.
+     */
+    @Test
+    void whatACompileAppliesIsWhatItEmittedAnImplementationFor() {
+        GeneratedImplementations generated = artifactOf(compiled(), "example.applying").implementations();
+
+        assertEquals("example.applying", generated.module());
+        assertTrue(generated.has("double"),
+                "it emitted an implementation for the behavior with a body");
+        assertEquals(Set.of("double"), generated.behaviors(),
+                "and for nothing else: a behavior with no `let` is not implemented here");
+    }
+
+    /**
+     * An answerer with something for the behavior that has no body, and nothing for the one that has.
+     *
+     * <p>What it applies is this compile's own implementation of {@code double}, which is what makes
+     * the row that runs have an answer to compare: the two behaviors mean the same thing, so a row
+     * written for either asserts the same value.
+     */
+    private static Answering applyingTheOneWithNoBody() {
+        return (generated, compiled) -> {
+            // The compile's own answerer, told that what it applies is `double` — which is what it
+            // emitted, so this is its manifest and not a claim about anything else.
+            Answerer own = Answering.generatedHere().over(
+                    new GeneratedImplementations(generated.module(), Set.of("double")), compiled);
+            return behavior -> {
+                if (!behavior.equals("doubleFromOutside")) {
+                    return new Answerer.Answer.Nothing();
+                }
+                Answerer.Answer.Something something = standins ->
+                        ((Answerer.Answer.Something) own.of("double")).applying(standins);
+                return something;
+            };
+        };
+    }
+
+    /** An answerer claiming an implementation for every behavior and reaching none of them. */
+    private static Answering claimingEverythingAndReachingNothing() {
+        return (generated, compiled) -> behavior -> {
+            Answerer.Answer.Something something = _ -> new Answerer.Applying() {
+
+                @Override
+                public Applied applied() {
+                    return new Applied.GeneratedHere();
+                }
+
+                @Override
+                public Object to(List<Handed> arguments) {
+                    throw new ImplementationNotReached("no class of that name (said by the test)",
+                            new ClassNotFoundException(behavior));
+                }
+            };
+            return something;
+        };
+    }
+
+    private static RowOutcome rowFor(ExampleVerifier.Observations observed, String target) {
+        List<RowOutcome> rows =
+                observed.rows().stream().filter(r -> r.target().equals(target)).toList();
+        assertEquals(1, rows.size(), "one row is written for `" + target + "`");
+        return rows.get(0);
+    }
+
+    private static ExampleVerifier.Observations evaluated(Answering answering) {
+        Compilation c = compiled();
+        String name = c.modules().get(0);
+        return ExampleVerifier.check(
+                c.db().ask(new Shapes.Prepared(name)).value().forExamples(),
+                c.db().ask(new Shapes.Scope(name)).value(),
+                c.db().ask(new Bodies.Signatures(name)).value(),
+                artifactOf(c, name),
+                c.db().ask(new Bodies.Requirements(name)).value(),
+                ExampleVerifier.class.getClassLoader(),
+                c.db().ask(new Bodies.ModuleDefinitions(name)).value(),
+                "Main",
+                Deadline.ofMillis(EvaluationPolicy.DEFAULT.outerTimeout().toMillis()),
+                EvaluationPolicy.DEFAULT,
+                answering);
+    }
+
+    private static Compilation compiled() {
+        Compilation c = Compilation.ofSource(MODEL, "Main");
+        c.db().ask(new Output.All());
+        return c;
+    }
+
+    private static EvaluationArtifact artifactOf(Compilation c, String name) {
+        return c.db().ask(new Output.EvaluationLinked(name, Output.CoverageMode.NONE)).value();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/examples/WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.generated.EvaluationArtifact;
 import souther.compiler.generated.GeneratedImplementations;
+import souther.compiler.generated.MemoryClassLoader;
 import souther.compiler.observe.Applied;
 import souther.compiler.observe.Disposition;
 import souther.compiler.observe.FailurePhase;
@@ -15,11 +16,13 @@ import souther.compiler.query.Output;
 import souther.compiler.query.Shapes;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -147,6 +150,49 @@ class WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest {
                 "it emitted an implementation for the behavior with a body");
         assertEquals(Set.of("double"), generated.behaviors(),
                 "and for nothing else: a behavior with no `let` is not implemented here");
+    }
+
+    /**
+     * A run over one module's rows, handed another module's artifact.
+     *
+     * <p>Refused where both are in hand. The manifest is what says which module's implementations an
+     * answerer applies, so past this point the module the rows belong to is gone: a behavior of this
+     * module would be looked up in that one, and a name it has one of would be applied — a row
+     * answered by an implementation of something else.
+     */
+    @Test
+    void anArtifactOfAnotherModuleIsRefusedWhereTheRunIsMade() {
+        Compilation mine = compiled();
+        Compilation other = Compilation.ofSource("""
+                module example.elsewhere
+
+                data Amount = Int
+
+                behavior double : (a: Amount) -> Amount
+                    constructs Amount
+
+                let double (a) = Amount(a.value * 99)
+                """, "Main");
+        other.db().ask(new Output.All());
+        String name = mine.modules().get(0);
+
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> ExampleVerifier.check(
+                        mine.db().ask(new Shapes.Prepared(name)).value().forExamples(),
+                        mine.db().ask(new Shapes.Scope(name)).value(),
+                        mine.db().ask(new Bodies.Signatures(name)).value(),
+                        artifactOf(other, "example.elsewhere"),
+                        mine.db().ask(new Bodies.Requirements(name)).value(),
+                        ExampleVerifier.class.getClassLoader(),
+                        mine.db().ask(new Bodies.ModuleDefinitions(name)).value(),
+                        "Main",
+                        Deadline.ofMillis(EvaluationPolicy.DEFAULT.outerTimeout().toMillis()),
+                        EvaluationPolicy.DEFAULT,
+                        Answering.generatedHere()));
+
+        assertTrue(refused.getMessage().contains("example.applying")
+                        && refused.getMessage().contains("example.elsewhere"),
+                "the refusal names both: " + refused.getMessage());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/examples/WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest.java
@@ -153,6 +153,39 @@ class WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest {
     }
 
     /**
+     * The compile's own answerer, asked about a behavior it emitted and whose class is not there.
+     *
+     * <p>It says {@link Answerer.Answer.Something} — the manifest is what it reads, and the manifest
+     * says this compile implemented the behavior. What the class not being there is comes out where
+     * the behavior is applied, as {@link ImplementationNotReached}.
+     *
+     * <p>The one that holds the production answerer to it. Reading the loader here instead would be
+     * the cheaper way to write {@link GeneratedImplementation#of} and would answer this case with
+     * "nothing applies it", turning every implementation this compiler failed to reach into a row
+     * waiting for a {@code let}.
+     */
+    @Test
+    void theCompilesOwnAnswererSaysSomethingForWhatItEmittedEvenWithNoClassToLoad() {
+        GeneratedImplementations manifest =
+                new GeneratedImplementations("example.applying", Set.of("double"));
+        MemoryClassLoader empty =
+                new MemoryClassLoader(Map.of(), ExampleVerifier.class.getClassLoader());
+
+        Answerer answerer = Answering.generatedHere().over(manifest, empty);
+
+        Answerer.Answer answer = answerer.of("double");
+        Answerer.Answer.Something something = assertInstanceOf(Answerer.Answer.Something.class,
+                answer, "the manifest says this compile implemented it, so something applies it");
+        ImplementationNotReached notReached = assertThrows(ImplementationNotReached.class,
+                () -> something.applying(List.of()).to(List.of()),
+                "and the class not being there is said where the behavior is applied");
+        assertTrue(notReached.getMessage().contains("Double"),
+                "naming what could not be reached: " + notReached.getMessage());
+        assertInstanceOf(Answerer.Answer.Nothing.class, answerer.of("doubleFromOutside"),
+                "and what it did not emit is what it has nothing for");
+    }
+
+    /**
      * A run over one module's rows, handed another module's artifact.
      *
      * <p>Refused where both are in hand. The manifest is what says which module's implementations an

--- a/souther-compiler/src/test/java/souther/compiler/query/AnEvaluationSetIsWholeOrAbsentTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnEvaluationSetIsWholeOrAbsentTest.java
@@ -2,8 +2,9 @@ package souther.compiler.query;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.generated.EvaluationArtifact;
+
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -47,7 +48,7 @@ class AnEvaluationSetIsWholeOrAbsentTest {
     /** The module that cannot be generated has no evaluation classes. */
     @Test
     void aModuleThatDoesNotCheckHasNoEvaluationClasses() {
-        Answer<Map<String, byte[]>> broken = compiled().db()
+        Answer<EvaluationArtifact> broken = compiled().db()
                 .ask(new Output.Evaluated("example.broken", Output.CoverageMode.NONE));
 
         assertNull(broken.value(), "nothing was generated for it");
@@ -62,7 +63,7 @@ class AnEvaluationSetIsWholeOrAbsentTest {
      */
     @Test
     void aSetThatReachesItIsAbsentRatherThanShortAClass() {
-        Answer<Map<String, byte[]>> linked = compiled().db()
+        Answer<EvaluationArtifact> linked = compiled().db()
                 .ask(new Output.EvaluationLinked("example.reaches", Output.CoverageMode.NONE));
 
         assertNull(linked.value(),
@@ -82,10 +83,10 @@ class AnEvaluationSetIsWholeOrAbsentTest {
                 """, "Main");
         compilation.answerEverything();
 
-        Map<String, byte[]> linked = compilation.db()
+        EvaluationArtifact linked = compilation.db()
                 .ask(new Output.EvaluationLinked("example.whole", Output.CoverageMode.NONE)).value();
 
         assertNotNull(linked);
-        assertFalse(linked.isEmpty(), "the module's own classes are there");
+        assertFalse(linked.classes().isEmpty(), "the module's own classes are there");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
@@ -118,7 +118,7 @@ class ProbeMappingTest {
     @Test
     void theQueryAnswersWithNothingRatherThanWithAHole() {
         Compilation emitting = compiled();
-        Answer<java.util.Map<String, byte[]>> probed =
+        Answer<souther.compiler.generated.EvaluationArtifact> probed =
                 emitting.db().ask(new Output.Evaluated("no.such.module", Output.CoverageMode.ARMS));
 
         assertTrue(!probed.present() || probed.value() == null);


### PR DESCRIPTION
Closes #747.

## What was wrong

A row asked whether the module writes a `let` for its behavior
(`ExampleVerifier.isPending`) and stopped there when it does not. What it
needed to know was whether this run has anything to apply the behavior,
and the seam that owns that — the answerer #732 introduced — was never
asked. The two coincide today because a compile has one answerer with
nothing for a behavior with no `let`, so either could be read for the
other without being wrong.

They are not one question. A run that resolves between what a compile
generated and an implementation supplied from outside (#695) decides the
set from what it was given, and the branch above would keep answering
from the declaration — recording as *pending* a row that had something to
run it.

The seam could not say it either. `StandinNotBuilt`,
`ImplementationNotReached` and `InvocationFailure` are three things an
answerer could not do; "there is nothing here to apply, and that is not a
failure" is something it can answer, so it wanted a value.

## What this does

**The answerer answers it.** `Answerer.of(behavior)` returns
`Answer.Something | Answer.Nothing`, asked before stand-ins are gathered
— whether anything applies a behavior does not depend on them, and a row
nothing applies is still held to everything it can be held to without
being run. Applying is then `Something.applying(standins)` →
`Applying.to(arguments)`, which keeps the two steps #732 established:
a stand-in that could not be made is raised before the row is recorded as
having entered the behavior. The row reads the answer as a `switch`.

**What a compile applies is what it emitted.** `Emissions` already holds
the `GeneratedClass` identity each class was emitted for, so
`Emissions.implemented()` projects the manifest from what was actually
put — not from class names (the decision re-derived from its own output)
and not from the loader's contents (a class that cannot be reached is
`ImplementationNotReached`, a failure, and answering it with `Nothing`
would record a broken compile as a model waiting for a `let`). The
manifest travels with the classes it was decided beside, as one
`EvaluationArtifact`, so a run cannot be handed one compile's classes and
another's manifest. `Output.Evaluated` and `Output.EvaluationLinked`
answer with that pair; a run whose own module has no manifest is absent
rather than given an empty one.

**`pending` leaves the declaration layer.** The rule was written three
times (`isPending`, `injectedSpec`, `Requirements.injectedNames`); it is
now `Requirements.injected`, asked of the declaration rather than of a
name, with `injectedNames` built from it. Its readers are the ones asking
about the text: the adequacy report, which prints `injected` or
`implemented`, and the fake resolution.

The four questions now have an owner each: how it is declared
(`Requirements.injected`), what this compile implemented
(`GeneratedImplementations`), what this run can apply (`Answerer.Answer`),
and what happened (the row's disposition).

## Acceptance

1. Answered by the run's answerer — `ExampleVerifier.targetOf` asks
   `answerer.of(name)`.
2. Answered rather than raised — `Answer.Nothing` is a value; no fourth
   throw.
3. Every row of the corpus ends as it does today — souther-examples over
   all projects, 21,924 lines, identical to the base jar's output.
4. `isPending` has no reader inside a row's evaluation — it no longer
   exists; the rule lives in `Requirements` and its readers are the
   report and the fake resolution.
5. A reader telling the answers apart states it as a `switch`.

## Tests

Three witnesses, one per distinction, plus one holding the manifest to
the emission:

- a behavior with no `let` that the run applies — the row runs and holds;
- a behavior with a body that the run has nothing for — recorded, with
  `FIXTURES_VALIDATED` / `PENDING` / `NONE` / `Applied.Nothing`;
- an implementation claimed and not reachable — `FAILED` / `INVOCATION`,
  never `PENDING`;
- what a compile applies is exactly what it emitted an implementation for.

Each was measured to go red under the change it refuses: deciding from
the declaration again kills the first and third, recording an unreachable
implementation as pending kills the third, and reading the manifest off a
different identity kills the fourth.

## Verification

- `CI=1 mvn -Plint clean verify` — BUILD SUCCESS. compiler 4548 (4 new),
  fmt 2224, lsp 202, cli 333, all green.
- Each commit is green on its own (4544 at the first, 4548 at the second).
- souther-examples, every project, `examples --generate --boundaries`:
  21,924 lines, `diff` against the base (develop 38c4982) is empty.

## Notes

- The spec's `example-pending` section is unchanged. "An injected
  behavior has no `let` to apply, so a row naming one is recorded" is
  still true of the language: nothing outside a compile applies a
  behavior yet. #695 is what changes it.
- `ExampleVerifier`'s class javadoc claimed an injected target is refused
  as `E1902`. It is not — `E1902` is a target that is not a behavior at
  all — and the sentence is corrected in the paragraph this change
  rewrites anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)