### PR TITLE
Read what an operation guarantees of what it answers

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -864,12 +864,19 @@ final class DischargeRules {
         return e instanceof Core.PreservedCall call ? Bound.CHOICES.get(call.operation()) : null;
     }
 
-    /** Those of them the bounding table has, by name, for the test that holds each to a construction
-     * it discharges. */
-    static Set<String> boundedNames() {
-        Set<String> names = new LinkedHashSet<>();
-        boundedOperations().forEach(operation -> names.add(operation.toString()));
-        return names;
+    /**
+     * The bounding table's rows, by the name of the operation each is about — one entry per row, so
+     * an operation bounded at both ends appears twice.
+     *
+     * <p>For the test that holds each row to a construction it discharges. By row and not by
+     * operation: one program needs one of an operation's rows, so a set of names would be satisfied
+     * by a rule that had been written for one end and never fired for the other.
+     */
+    static List<String> boundedRows() {
+        List<String> rows = new ArrayList<>();
+        Bound.BOUNDS.forEach((operation, bounds) ->
+                bounds.forEach(bound -> rows.add(operation.toString())));
+        return rows;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -407,6 +407,11 @@ final class DischargeRules {
         return new ResultBound(null, BigDecimal.valueOf(n), rel, new Provided.Always());
     }
 
+    /** The same, where the operation answers that only under a condition on its arguments. */
+    private static ResultBound resultIs(Rel rel, long n, Provided provided) {
+        return new ResultBound(null, BigDecimal.valueOf(n), rel, provided);
+    }
+
     /** {@code result rel argument + offset}. */
     private static ResultBound resultIs(Rel rel, Reads argument, long offset, Provided provided) {
         return new ResultBound(argument, BigDecimal.valueOf(offset), rel, provided);
@@ -421,10 +426,11 @@ final class DischargeRules {
      * past, and it is read the same way — asserted into the domain where a clause is read and where a
      * condition is assumed alike.
      *
-     * <p>{@code Int.floorMod} is here for its lower bound alone and for its upper bound only where
-     * the divisor reads as a constant above zero: the result takes the sign of the divisor, so a
-     * divisor that could be negative bounds it in the other direction, and a divisor the check cannot
-     * read bounds it nowhere. Its {@code 0} is not a case at all — the operation aborts.
+     * <p>{@code Int.floorMod} states both its ends only where the divisor reads as a constant above
+     * zero, and neither of them otherwise. The result takes the sign of the divisor — {@code
+     * floorMod(1, -3)} is {@code -2} — so a divisor that could be negative puts it the other side of
+     * zero, and the lower end is as much the divisor's to decide as the upper one. A divisor the
+     * check cannot read bounds it nowhere. Its {@code 0} is not a case at all: the operation aborts.
      *
      * <p>{@code Decimal.toInt} is within one of what it rounds, whichever mode it is handed. What a
      * single mode does more narrowly — {@code HALF_UP} rounds to within a half — is a second rule and
@@ -434,7 +440,7 @@ final class DischargeRules {
             op("Int", "abs"), List.of(resultIs(Rel.GE, 0)),
             op("Decimal", "abs"), List.of(resultIs(Rel.GE, 0)),
             op("Int", "floorMod"), List.of(
-                    resultIs(Rel.GE, 0),
+                    resultIs(Rel.GE, 0, new Provided.ConstantAboveZero(at(1))),
                     resultIs(Rel.LT, at(1), 0, new Provided.ConstantAboveZero(at(1)))),
             op("Decimal", "toInt"), List.of(
                     resultIs(Rel.GT, at(1), -1, new Provided.Always()),

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -2,9 +2,12 @@ package souther.compiler.check;
 
 import souther.compiler.ast.Hir;
 import souther.compiler.core.Core;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.numeric.NumericDomain.Rel;
 import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -15,7 +18,8 @@ import java.util.function.Predicate;
 
 /**
  * What the language's own operations do to the properties the invariant-discharge check tracks
- * (spec §invariant-discharge-preservation).
+ * (spec §invariant-discharge-preservation), and what each guarantees of what it answers
+ * (spec §invariant-discharge-guarantees).
  *
  * <p>These are the tables that decide how much of a model the language tracks rather than leaves to a
  * run-time check, and each is stated per operation because that is the level an author writes at. It
@@ -341,6 +345,311 @@ final class DischargeRules {
     static final Set<ValueName> NOT_A_SIZE = Set.of();
 
     /**
+     * What has to hold of the arguments before a bound on the result does.
+     *
+     * <p>Of the arguments and of nothing else. A condition the path establishes is what the arguments
+     * are known to be at one call, and a rule resting on one would hold where a guard was written and
+     * not where the operation was — which is a statement about the program rather than about the
+     * operation.
+     */
+    sealed interface Provided {
+
+        /** Whether {@code call} is one this rule holds at. */
+        boolean holdsAt(Core.PreservedCall call, java.util.function.Function<Core, BigDecimal> folded);
+
+        /** Nothing: the bound is what the operation does, whatever it is given. */
+        record Always() implements Provided {
+            @Override
+            public boolean holdsAt(Core.PreservedCall call,
+                                   java.util.function.Function<Core, BigDecimal> folded) {
+                return true;
+            }
+        }
+
+        /**
+         * An argument that reads as a constant above zero.
+         *
+         * <p>Constant, and not written as one. What a name was given is what the name is, here as
+         * everywhere else the check reads a value ({@link Terms#affineOf}), so {@code floorMod(x, k)}
+         * under {@code let k = 100} is the same call as {@code floorMod(x, 100)} — one spelling of a
+         * value the check has already read. Requiring the digits at the call would make a rule the
+         * author cannot predict from what the value is, only from where it was written.
+         */
+        record ConstantAboveZero(Reads argument) implements Provided {
+            @Override
+            public boolean holdsAt(Core.PreservedCall call,
+                                   java.util.function.Function<Core, BigDecimal> folded) {
+                BigDecimal at = folded.apply(argument.of(call));
+                return at != null && at.signum() > 0;
+            }
+        }
+    }
+
+    /**
+     * One bound an operation's result has, as the domain holds bounds: the result against a constant,
+     * or the result against one argument and a constant.
+     *
+     * <p>The shape is the domain's ({@link NumericDomain}) and is what a row may say. A rule of
+     * another shape — a result between two arguments, a result no greater than a sum — is one the
+     * domain would take in and derive nothing from, so it is not writable here rather than written
+     * and silently dropped.
+     *
+     * @param against  the argument the result is bounded against, or null where the bound is a
+     *                 constant one
+     * @param offset   added to that argument, or the constant itself where there is no argument
+     * @param rel      how the result stands to it
+     * @param provided what has to hold of the arguments for this to be the operation's answer
+     */
+    record ResultBound(Reads against, BigDecimal offset, Rel rel, Provided provided) {}
+
+    /** {@code result rel n}. */
+    private static ResultBound resultIs(Rel rel, long n) {
+        return new ResultBound(null, BigDecimal.valueOf(n), rel, new Provided.Always());
+    }
+
+    /** {@code result rel argument + offset}. */
+    private static ResultBound resultIs(Rel rel, Reads argument, long offset, Provided provided) {
+        return new ResultBound(argument, BigDecimal.valueOf(offset), rel, provided);
+    }
+
+    /**
+     * What holds of an operation's result wherever the call is written.
+     *
+     * <p>Each row is a fact about the operation, so it is stated at every call and not only where
+     * something was guarded: {@code Int.abs(x)} is not negative whatever {@code x} is. That is the
+     * same kind of statement {@link Predicates#sizeFacts} already makes of every size call it walks
+     * past, and it is read the same way — asserted into the domain where a clause is read and where a
+     * condition is assumed alike.
+     *
+     * <p>{@code Int.floorMod} is here for its lower bound alone and for its upper bound only where
+     * the divisor reads as a constant above zero: the result takes the sign of the divisor, so a
+     * divisor that could be negative bounds it in the other direction, and a divisor the check cannot
+     * read bounds it nowhere. Its {@code 0} is not a case at all — the operation aborts.
+     *
+     * <p>{@code Decimal.toInt} is within one of what it rounds, whichever mode it is handed. What a
+     * single mode does more narrowly — {@code HALF_UP} rounds to within a half — is a second rule and
+     * is not stated here, since the mode is an argument this reads nothing of.
+     */
+    private static final Map<ValueName, List<ResultBound>> BOUNDS_ON_THE_RESULT = Map.of(
+            op("Int", "abs"), List.of(resultIs(Rel.GE, 0)),
+            op("Decimal", "abs"), List.of(resultIs(Rel.GE, 0)),
+            op("Int", "floorMod"), List.of(
+                    resultIs(Rel.GE, 0),
+                    resultIs(Rel.LT, at(1), 0, new Provided.ConstantAboveZero(at(1)))),
+            op("Decimal", "toInt"), List.of(
+                    resultIs(Rel.GT, at(1), -1, new Provided.Always()),
+                    resultIs(Rel.LT, at(1), 1, new Provided.Always())));
+
+    /**
+     * The operations answering a number this bounds nothing of, in two groups.
+     *
+     * <p>Their result is not bounded by their arguments at all. The arithmetic and its function forms
+     * answer a number that may be anywhere, and what relates it to the operands is that it <em>is</em>
+     * the operands' arithmetic, which a term already reads ({@link #OPERATOR_CALLS}). A comparison
+     * answers a sign, and what that sign says is the order it decides ({@link #ORDERS}) rather than a
+     * range it lies in.
+     *
+     * <p>Their result is one of the arguments, decided by the arguments. A bound on such a result is
+     * what {@link #CHOOSES} derives from the case it is in — stating it here as well would be one
+     * operation answering to two tables, and the two would come apart the day the library changes
+     * which argument it answers.
+     *
+     * <p>{@code Decimal.round} answers a value at another scale, which is a bound of a shape a row
+     * cannot state: how far it moved depends on the scale it was handed. {@code Decimal.fromInt}
+     * answers the number it was given, which {@link #ANSWERS_ITS_ARGUMENT} states as the stronger
+     * thing it is — the two values are one, not one within reach of the other.
+     */
+    static final Set<ValueName> BOUNDS_NOTHING = Set.of(
+            op("Int", "add"), op("Int", "subtract"), op("Int", "multiply"),
+            op("Decimal", "add"), op("Decimal", "subtract"), op("Decimal", "multiply"),
+            op("Int", "compare"), op("Decimal", "compare"),
+            op("Int", "min"), op("Int", "max"), op("Int", "clamp"),
+            op("Decimal", "min"), op("Decimal", "max"), op("Decimal", "clamp"),
+            op("Decimal", "fromInt"), op("Decimal", "round"));
+
+    /**
+     * How far an operation moved the value it was given, stated through the measure that counts two
+     * such values apart: {@code measure(of, result) == per · amount}.
+     *
+     * <p>The statement a shift makes is not a bound on what it answers — a date is not a number — so
+     * it is written in the one language the check has about such values, which is the number a
+     * measure answers of two of them. That number is what an invariant over a pair of dates is
+     * written in as well, so the rule and the clause meet without either being rewritten.
+     *
+     * @param measure the library's operation counting the two apart, in the order {@code (of, result)}
+     * @param of      the argument the result was shifted from
+     * @param amount  the argument saying by how much
+     * @param per     how many of what the measure counts one of {@code amount} is
+     */
+    record Shift(ValueName.Stdlib measure, Reads of, Reads amount, BigDecimal per) {}
+
+    private static Shift shifts(String module, String measure, Reads of, Reads amount, long per) {
+        return new Shift(new ValueName.Stdlib(module, measure), of, amount,
+                BigDecimal.valueOf(per));
+    }
+
+    /**
+     * The operations that move a value by an amount, each with what it did stated through a measure.
+     *
+     * <p>Every one of them works on a local value, where a day is a day and an hour is sixty
+     * minutes ({@code Temporals}), so what each states is exact rather than usually true.
+     *
+     * <p>{@code Date.addMonths} and {@code Date.addYears} are not here and are not oversights: months
+     * and years hold different numbers of days, so neither states a count of the one measure a pair
+     * of dates has. What a path knows of such a shift — that a later month is not earlier — is
+     * something else, and follows from what is known of the arguments rather than from the operation.
+     */
+    private static final Map<ValueName, Shift> SHIFTS = Map.of(
+            op("Date", "addDays"), shifts("Date", "daysBetween", at(1), at(0), 1),
+            op("DateTime", "addMinutes"), shifts("DateTime", "minutesBetween", at(1), at(0), 1),
+            op("DateTime", "addHours"), shifts("DateTime", "minutesBetween", at(1), at(0), 60),
+            op("DateTime", "addDays"), shifts("DateTime", "minutesBetween", at(1), at(0), 1440));
+
+    /** The operations that move a value by an amount the measures this has cannot count. A month and
+     * a year are not a fixed number of days, so a date shifted by either stands at a distance no rule
+     * here can write. */
+    static final Set<ValueName> SHIFTS_BY_NOTHING_MEASURABLE = Set.of(
+            op("Date", "addMonths"), op("Date", "addYears"));
+
+    /** A relation between two arguments: {@code left rel right}. What a case of a piecewise
+     * definition is reached under, written in the arguments the operation was given and in nothing
+     * else. */
+    record ArgumentsStand(Reads left, Rel rel, Reads right) {}
+
+    private static ArgumentsStand where(Reads left, Rel rel, Reads right) {
+        return new ArgumentsStand(left, rel, right);
+    }
+
+    /** One case of an operation's definition: the argument it answers there, and what holds of the
+     * arguments where it does. */
+    record Choice(Reads answers, List<ArgumentsStand> given) {}
+
+    private static Choice answers(Reads argument, ArgumentsStand... given) {
+        return new Choice(argument, List.of(given));
+    }
+
+    /**
+     * An operation's definition, as the cases it is written in.
+     *
+     * <p>The list is exhaustive: the conditions of its cases cover everything the operation can be
+     * given, so what holds in every case holds of the result. That is the whole of what makes a
+     * reading of these sound, and it is a claim about the list rather than about any row in it — a
+     * case left out does not make the others wrong, it makes a clause provable that the values can
+     * fail. So the cases are written as the library writes them, in the order it writes them, and
+     * each is held to a program that reaches it.
+     */
+    record Choices(List<Choice> cases) {}
+
+    private static Choices choices(Choice... cases) {
+        return new Choices(List.of(cases));
+    }
+
+    /**
+     * The operations that answer one of the values they were given, as the cases they are defined in.
+     *
+     * <p>Each is the library's own definition read back: {@code min(a, b)} is {@code a} where
+     * {@code a < b} and {@code b} otherwise, and {@code clamp(lo, hi, n)} is written as a chain of
+     * two conditions, so the second and third cases carry the denial of what stands before them.
+     * Carrying it is not tidiness — {@code clamp} does not ask that {@code lo} be below {@code hi},
+     * and where it is not, the case that answers {@code hi} is reached with {@code n} above
+     * {@code lo}. A rule that said the result is between the two would prove a clause the values
+     * fail.
+     *
+     * <p>Stated here rather than as bounds on the result ({@link #BOUNDS_ON_THE_RESULT}) because
+     * what these answer depends on the arguments, and a bound that does not may not be written for
+     * them. The bounds a case gives — a smaller of two is no greater than either — follow from the
+     * case and are derived where a clause is read, so they are not a second table to keep in step
+     * with this one.
+     */
+    private static final Map<ValueName, Choices> CHOOSES = Map.of(
+            op("Int", "min"), choices(
+                    answers(at(0), where(at(0), Rel.LT, at(1))),
+                    answers(at(1), where(at(0), Rel.GE, at(1)))),
+            op("Decimal", "min"), choices(
+                    answers(at(0), where(at(0), Rel.LT, at(1))),
+                    answers(at(1), where(at(0), Rel.GE, at(1)))),
+            op("Int", "max"), choices(
+                    answers(at(0), where(at(0), Rel.GT, at(1))),
+                    answers(at(1), where(at(0), Rel.LE, at(1)))),
+            op("Decimal", "max"), choices(
+                    answers(at(0), where(at(0), Rel.GT, at(1))),
+                    answers(at(1), where(at(0), Rel.LE, at(1)))),
+            op("Int", "clamp"), choices(
+                    answers(at(0), where(at(2), Rel.LT, at(0))),
+                    answers(at(1), where(at(2), Rel.GE, at(0)), where(at(2), Rel.GT, at(1))),
+                    answers(at(2), where(at(2), Rel.GE, at(0)), where(at(2), Rel.LE, at(1)))),
+            op("Decimal", "clamp"), choices(
+                    answers(at(0), where(at(2), Rel.LT, at(0))),
+                    answers(at(1), where(at(2), Rel.GE, at(0)), where(at(2), Rel.GT, at(1))),
+                    answers(at(2), where(at(2), Rel.GE, at(0)), where(at(2), Rel.LE, at(1)))));
+
+    /**
+     * The operations answering a number that answer none of their arguments back, in three groups.
+     *
+     * <p>They compute a new number. The arithmetic and its function forms are this: what
+     * {@code a + b} answers is neither {@code a} nor {@code b}, whatever they are.
+     *
+     * <p>They answer something about the arguments. {@code compare} answers a sign, {@code floorMod}
+     * a remainder, {@code abs} a distance, {@code toInt} the whole number a value rounds to, and
+     * {@code round} a value at another scale — none of which is one of the values handed in, though
+     * each of the last four is one where the argument already had that shape. That the answer
+     * <em>can</em> be an argument is not what this asks: a case is one the operation is defined by,
+     * and reading a coincidence as a case would state a condition the definition does not have.
+     *
+     * <p>{@code Decimal.fromInt} answers the number it was given in another type, which
+     * {@link #ANSWERS_ITS_ARGUMENT} states unconditionally. A case would put a condition on a
+     * statement that has none.
+     */
+    static final Set<ValueName> CHOOSES_NOTHING = Set.of(
+            op("Int", "add"), op("Int", "subtract"), op("Int", "multiply"),
+            op("Decimal", "add"), op("Decimal", "subtract"), op("Decimal", "multiply"),
+            op("Int", "compare"), op("Decimal", "compare"), op("Int", "floorMod"),
+            op("Int", "abs"), op("Decimal", "abs"), op("Decimal", "toInt"), op("Decimal", "round"),
+            op("Decimal", "fromInt"));
+
+    /**
+     * The operations whose result is the number an argument already is, and which argument that is.
+     *
+     * <p>Such a call is read into the form its argument has rather than given an atom of its own, so
+     * a guard about the argument settles a clause about the call. {@code Decimal.fromInt(n)} is the
+     * one the library has: every {@code Int} is a {@code Decimal} exactly, and the widening states
+     * nothing of its own.
+     *
+     * <p>Not a choice among arguments ({@link #CHOOSES}). What a choice answers is one of two values,
+     * decided by the arguments, and which one it is has to be reasoned about case by case; this
+     * answers one value unconditionally, in another type. Reading the second as a choice with one
+     * candidate would put every value-preserving conversion under a table about selection, and the
+     * two stop being one question the moment the library gains a conversion that is not a widening.
+     */
+    private static final Map<ValueName, Reads> ANSWERS_ITS_ARGUMENT =
+            Map.of(op("Decimal", "fromInt"), at(0));
+
+    /**
+     * The operations answering a number from a number that answer none of them back, in three groups.
+     *
+     * <p>They compute a new number from their operands. The arithmetic and its function forms are
+     * this, and what they answer is already read as arithmetic over the operands themselves
+     * ({@link #OPERATOR_CALLS}) rather than as one of them.
+     *
+     * <p>They answer something about the arguments rather than one of them: {@code compare} a sign,
+     * {@code floorMod} a remainder, {@code abs} a distance with the sign dropped, {@code toInt} the
+     * whole number a value rounds to, {@code round} a value at another scale. What such a result is
+     * bounded by is {@link #BOUNDS_ON_THE_RESULT}, which is a different statement from being a value
+     * that was already there.
+     *
+     * <p>They answer one of their arguments, and which one depends on the arguments. That is
+     * {@link #CHOOSES}, and a rule that dropped the condition would say {@code Int.min(a, b)} is
+     * {@code a}.
+     */
+    static final Set<ValueName> ANSWERS_NO_ARGUMENT_OF_ITS_OWN = Set.of(
+            op("Int", "add"), op("Int", "subtract"), op("Int", "multiply"),
+            op("Decimal", "add"), op("Decimal", "subtract"), op("Decimal", "multiply"),
+            op("Int", "compare"), op("Decimal", "compare"), op("Int", "floorMod"),
+            op("Int", "abs"), op("Decimal", "abs"), op("Decimal", "toInt"), op("Decimal", "round"),
+            op("Int", "min"), op("Int", "max"), op("Int", "clamp"),
+            op("Decimal", "min"), op("Decimal", "max"), op("Decimal", "clamp"));
+
+    /**
      * The library's function forms of the arithmetic operators, and the operator each one is. They
      * reach the same kernel in the same argument order — {@code Int.add} is {@code IntMath.addExact},
      * which is what {@code +} emits — so the two spellings compute one value and are read as one term.
@@ -497,6 +806,100 @@ final class DischargeRules {
         return ORDERS.keySet();
     }
 
+    static Set<ValueName> formOperations() {
+        return Bound.FORMS.keySet();
+    }
+
+    /** Those of them the read-through table has, by name, for the test that holds each to a
+     * construction it discharges. */
+    static Set<String> formNames() {
+        Set<String> names = new LinkedHashSet<>();
+        formOperations().forEach(operation -> names.add(operation.toString()));
+        return names;
+    }
+
+    static Set<ValueName> boundedOperations() {
+        return Bound.BOUNDS.keySet();
+    }
+
+    static Set<ValueName> choosingOperations() {
+        return Bound.CHOICES.keySet();
+    }
+
+    /** Those of them the choosing table has, by name, for the test that holds each case to a
+     * program that reaches it. */
+    static Set<String> choosingNames() {
+        Set<String> names = new LinkedHashSet<>();
+        choosingOperations().forEach(operation -> names.add(operation.toString()));
+        return names;
+    }
+
+    static Set<ValueName> shiftingOperations() {
+        return Bound.MEASURED.keySet();
+    }
+
+    /** Those of them the shifting table has, by name, for the test that holds each to a construction
+     * it discharges. */
+    static Set<String> shiftingNames() {
+        Set<String> names = new LinkedHashSet<>();
+        shiftingOperations().forEach(operation -> names.add(operation.toString()));
+        return names;
+    }
+
+    /** What {@code e} states through a measure, or null where it is not a shift this has a rule
+     * about. */
+    static Shift shiftBy(Core e) {
+        return e instanceof Core.PreservedCall call ? Bound.MEASURED.get(call.operation()) : null;
+    }
+
+    /** The cases {@code e} is defined in, or null where it is not a call to an operation that
+     * answers one of the values it was given. */
+    static Choices chosenBy(Core e) {
+        return e instanceof Core.PreservedCall call ? Bound.CHOICES.get(call.operation()) : null;
+    }
+
+    /** Those of them the bounding table has, by name, for the test that holds each to a construction
+     * it discharges. */
+    static Set<String> boundedNames() {
+        Set<String> names = new LinkedHashSet<>();
+        boundedOperations().forEach(operation -> names.add(operation.toString()));
+        return names;
+    }
+
+    /**
+     * The bounds {@code call}'s result has here: the operation's rows, less those whose condition on
+     * the arguments this call does not meet.
+     *
+     * @param constant what an argument reads as, or null where it reads as no constant. Asked of the
+     *                 caller because what a value is read as is the reading's answer and not a
+     *                 property of the syntax at the call.
+     */
+    static List<ResultBound> boundsOn(Core.PreservedCall call,
+                                      Function<Core, BigDecimal> constant) {
+        List<ResultBound> rows = Bound.BOUNDS.get(call.operation());
+        if (rows == null) {
+            return List.of();
+        }
+        List<ResultBound> holding = new ArrayList<>(rows.size());
+        for (ResultBound row : rows) {
+            if (row.provided().holdsAt(call, constant)) {
+                holding.add(row);
+            }
+        }
+        return holding;
+    }
+
+    /** The argument whose number {@code e} answers, or null where it is not a call this reads as one
+     * of its arguments. The value itself and not a term for it: what it is read as is the form the
+     * argument already has, which is the caller's to build. */
+    static Core answersItsArgument(Core e) {
+        if (!(e instanceof Core.PreservedCall call)) {
+            return null;
+        }
+        Reads reads = Bound.FORMS.get(call.operation());
+        return reads == null ? null : reads.of(call);
+    }
+
     /** Those of them the building table has, by name, for the test that holds each to a construction
      * it discharges. */
     static Set<String> builtNames() {
@@ -518,6 +921,9 @@ final class DischargeRules {
      * declaration is wrong whether or not a program calls it, and finding out when one does is the
      * same silence deferred.
      *
+     * <p>A numeric rule names no part of what an operation hands a closure, since such an operation
+     * hands none, so it is bound with no derived position for a written one to be held against.
+     *
      * <p>Read on the first ask and not before, as {@link Combinators} and {@link Preserved} are: what
      * this requires of the library is required of a check that reads these rules, and a checker that
      * reads none must not be held to it.
@@ -536,6 +942,77 @@ final class DischargeRules {
         private static final Map<ValueName, List<Reads>> LOWER_BOUNDS =
                 bindEach(NO_SMALLER_THAN, CONTAINER, Question::holdsElements,
                         "a container the result is no smaller than");
+        private static final Map<ValueName, Reads> FORMS =
+                bind(ANSWERS_ITS_ARGUMENT, Function.identity(), null, Question::isANumber,
+                        "the argument whose number the result is");
+        private static final Map<ValueName, List<ResultBound>> BOUNDS =
+                bindBounds(BOUNDS_ON_THE_RESULT);
+        private static final Map<ValueName, Choices> CHOICES = bindChoices(CHOOSES);
+        private static final Map<ValueName, Shift> MEASURED = bindShifts(SHIFTS);
+    }
+
+    /**
+     * As {@link #bind}, for a rule stating a shift through a measure: the amount is a number, the
+     * value shifted is of the type the measure counts, and the measure counts two of what the
+     * operation answers. A rule pairing an operation with a measure of something else would state a
+     * relation between two values that have none.
+     */
+    private static Map<ValueName, Shift> bindShifts(Map<ValueName, Shift> rules) {
+        rules.forEach((operation, shift) -> {
+            bind(Map.of(operation, shift.amount()), Function.identity(), null, Question::isANumber,
+                    "the amount a shift moves by");
+            Prelude.PreludeEntry counts = Prelude.entry(shift.measure().qualified());
+            if (counts == null) {
+                throw new IllegalStateException("the rule about " + operation + " counts through "
+                        + shift.measure().qualified() + ", which the library does not declare");
+            }
+            Prelude.PreludeEntry shifted = Prelude.entry(((ValueName.Stdlib) operation).qualified());
+            List<Type> counted = counts.signature().params();
+            if (counted.size() != 2 || !Question.isANumber(counts.signature().result())
+                    || !counted.get(0).equals(shifted.signature().result())
+                    || !counted.get(1).equals(shifted.signature().result())) {
+                throw new IllegalStateException(shift.measure().qualified()
+                        + " does not count two of what " + operation + " answers apart as a number");
+            }
+            bind(Map.of(operation, shift.of()), Function.identity(), null,
+                    t -> t.equals(shifted.signature().result()),
+                    "the value a shift moves from");
+        });
+        return rules;
+    }
+
+    /** As {@link #bind}, for the arguments a case names: the one it answers, and the two sides of
+     * each condition it is reached under. */
+    private static Map<ValueName, Choices> bindChoices(Map<ValueName, Choices> rules) {
+        rules.forEach((operation, choices) -> choices.cases().forEach(choice -> {
+            List<Reads> named = new ArrayList<>();
+            named.add(choice.answers());
+            choice.given().forEach(stands -> {
+                named.add(stands.left());
+                named.add(stands.right());
+            });
+            named.forEach(one -> bind(Map.of(operation, one), Function.identity(), null,
+                    Question::isANumber, "an argument a case of the definition names"));
+        }));
+        return rules;
+    }
+
+    /** As {@link #bind}, for the arguments a bound names: the one the result is bounded against, and
+     * the one a condition on the rule reads. Each is a separate claim about a separate argument. */
+    private static Map<ValueName, List<ResultBound>> bindBounds(
+            Map<ValueName, List<ResultBound>> rules) {
+        rules.forEach((operation, bounds) -> bounds.forEach(bound -> {
+            List<Reads> named = new ArrayList<>();
+            if (bound.against() != null) {
+                named.add(bound.against());
+            }
+            if (bound.provided() instanceof Provided.ConstantAboveZero constant) {
+                named.add(constant.argument());
+            }
+            named.forEach(one -> bind(Map.of(operation, one), Function.identity(), null,
+                    Question::isANumber, "an argument a bound on the result names"));
+        }));
+        return rules;
     }
 
     /** As {@link #bind}, for a rule that names more than one argument: each is held to the
@@ -580,7 +1057,7 @@ final class DischargeRules {
                 throw new IllegalStateException("argument " + (position + 1) + " of "
                         + library.qualified() + " is not " + what);
             }
-            if (at instanceof Reads.At && Combinators.of(operation) != null
+            if (at instanceof Reads.At && derived != null && Combinators.of(operation) != null
                     && derived.positionIn(operation) == position) {
                 throw new IllegalStateException("the rule about " + what + " for "
                         + library.qualified()

--- a/souther-compiler/src/main/java/souther/compiler/check/Known.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Known.java
@@ -65,6 +65,19 @@ record Known(NumericDomain<Term> numbers, PredicateFacts facts, List<Quantified>
     }
 
     /**
+     * This, where the conditions on the path cannot all hold, so nothing here is reached.
+     *
+     * <p>Said as a contradiction in the numbers, which is how the domain already records that it
+     * holds nothing. The reading that ignores the path is left as it was: it is the guards that
+     * cannot all hold, not the values that fail, and a construction under them is one the program
+     * never builds rather than one it builds wrongly.
+     */
+    Known reachingNothing() {
+        return taking(LinearForm.constant(java.math.BigDecimal.ONE), Rel.LE, Held.ON_THE_PATH,
+                Map.of());
+    }
+
+    /**
      * This, with each of {@code terms} recorded as one an assumption on this path named. It is
      * recorded where the assumption is made rather than searched for afterwards: what a guard
      * spoke about is known exactly then, and reading it back out of a domain would mean matching

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -8,6 +8,7 @@ import souther.compiler.check.DischargeRules.Carrying;
 import souther.compiler.check.DischargeRules.Projection;
 import souther.compiler.check.DischargeRules.Shape;
 import souther.compiler.check.DischargeRules.Source;
+import souther.compiler.numeric.Granularity;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.NumericDomain.LinearForm;
 import souther.compiler.numeric.NumericDomain.Rel;
@@ -22,6 +23,7 @@ import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -161,9 +163,87 @@ final class Predicates {
         }
     }
 
+    /**
+     * One case of a clause read over an operation that answers one of the values it was given: the
+     * clause with that value standing where the call did, and what holds of the arguments there.
+     *
+     * @param kinds how the values of every atom either of them names are spaced, so that a case can
+     *              be taken into a domain without asking anything further of the caller
+     */
+    record Case(Constraint numeric, List<Constraint> given, Map<Term, Granularity> kinds) {
+
+        /** {@code d} with this case's conditions on the arguments taken as holding. */
+        private NumericDomain<Term> in(NumericDomain<Term> d) {
+            NumericDomain<Term> out = d;
+            for (Constraint one : given) {
+                out = out.assume(one.form(), one.rel(), kinds);
+            }
+            return out;
+        }
+    }
+
+    /**
+     * A clause read as the cases the operation standing under it is defined in.
+     *
+     * <p>What a case holds is its condition on the arguments and the equality saying the call
+     * answered that argument, and it is reached where those and what is known here can hold at once.
+     * The equality is what ties the two readings of one value together: without it a guard written
+     * about the call would stand outside every case, and this would answer about a value the rest of
+     * the check is talking about separately.
+     *
+     * <p>So, over the cases that are reached: all of them proving the clause is the clause
+     * established, all of them refuting it is the clause refused, and anything else is unsettled.
+     * The cases are exhaustive ({@link DischargeRules.Choices}), which is what makes the first two
+     * statements about the result rather than about a case of it.
+     *
+     * <p>No case reached is not the clause established. It says the guards cannot all hold, and a
+     * value the program never builds establishes nothing — while the reading that takes the call as
+     * an unknown still has whatever a guard said about it, and answers there. Calling it vacuously
+     * proven would have this establishing a clause that reading refuses, which is the check
+     * disagreeing with itself about one value rather than an answer. The same holds when the cases
+     * come to be multiplied out.
+     *
+     * <p>One operation to a clause. Where a clause names two of them the cases multiply, and what
+     * that costs is a decision this does not have to make yet — such a clause is read as it stands,
+     * which proves less and states nothing false.
+     */
+    record Piecewise(List<Case> cases) {
+
+        boolean entailedBy(NumericDomain<Term> d) {
+            boolean reached = false;
+            for (Case one : cases) {
+                NumericDomain<Term> here = one.in(d);
+                if (here.isBottom()) {
+                    continue;
+                }
+                if (!here.entails(one.numeric().form(), one.numeric().rel())) {
+                    return false;
+                }
+                reached = true;
+            }
+            return reached;
+        }
+
+        boolean refutedBy(NumericDomain<Term> d) {
+            boolean reached = false;
+            for (Case one : cases) {
+                NumericDomain<Term> here = one.in(d);
+                if (here.isBottom()) {
+                    continue;
+                }
+                if (!here.refutes(one.numeric().form(), one.numeric().rel())) {
+                    return false;
+                }
+                reached = true;
+            }
+            return reached;
+        }
+    }
+
     /** A clause that cannot hold, said in the language the domain reads: {@code -1 >= 0}. */
     static final Clause VIOLATED = new Clause(
-            new Constraint(LinearForm.constant(BigDecimal.ONE.negate()), Rel.GE), null, List.of());
+            new Constraint(LinearForm.constant(BigDecimal.ONE.negate()), Rel.GE), null, List.of(),
+            null);
 
     /**
      * One clause of an invariant, and the two ways it can come out: a relation for the domain to
@@ -171,15 +251,17 @@ final class Predicates {
      * present either one discharging the clause is enough — a guard is written one way and a clause
      * another, and which of the two routes carries it is not the author's concern.
      */
-    record Clause(Constraint numeric, Fact fact, List<Constraint> known) {
+    record Clause(Constraint numeric, Fact fact, List<Constraint> known, Piecewise piecewise) {
 
         boolean dischargedBy(NumericDomain<Term> d, PredicateFacts facts) {
             return numeric != null && d.entails(numeric.form(), numeric.rel())
+                    || piecewise != null && piecewise.entailedBy(d)
                     || fact != null && fact.entailedBy(facts);
         }
 
         boolean refutedBy(NumericDomain<Term> d, PredicateFacts facts) {
             return numeric != null && d.refutes(numeric.form(), numeric.rel())
+                    || piecewise != null && piecewise.refutedBy(d)
                     || fact != null && fact.refutedBy(facts);
         }
     }
@@ -274,12 +356,17 @@ final class Predicates {
             }
         }
         Constraint numeric = null;
+        Piecewise piecewise = null;
         if (inv instanceof Core.Binary b && relOf(b.op()) != null) {
             Rel eff = positive ? relOf(b.op()) : negateRel(relOf(b.op()));
             LinearForm<Term> la = eff == null ? null : terms.affineOf(b.left(), at, k);
             LinearForm<Term> ra = eff == null ? null : terms.affineOf(b.right(), at, k);
             if (la != null && ra != null) {
                 numeric = new Constraint(la.minus(ra), eff);
+                // The same clause read as the cases of whatever chooses inside it. Both readings are
+                // kept: a guard may name the call itself, which the clause as it stands is what
+                // settles, and reading it case by case never takes that away.
+                piecewise = piecewiseOf(numeric, inv, at, k);
             }
         }
         Polar polar = polar(inv, positive);
@@ -295,7 +382,8 @@ final class Predicates {
         }
         List<Constraint> known = new ArrayList<>();
         sizeFacts(inv, at, known);
-        return Owed.of(new Clause(numeric, fact, known));
+        resultFacts(inv, at, k, known);
+        return Owed.of(new Clause(numeric, fact, known, piecewise));
     }
 
     /** Whether {@code inv} is decided outright: the clause, with the construction's own values
@@ -332,9 +420,11 @@ final class Predicates {
             return assumeCond(under, k, at, !positive);
         }
         Known out = k;
-        // What holds of the sizes the condition names, whichever way the condition itself is read.
+        // What holds of the sizes the condition names, and of what the operations in it answer,
+        // whichever way the condition itself is read.
         List<Constraint> known = new ArrayList<>();
         sizeFacts(cond, at, known);
+        resultFacts(cond, at, k, known);
         for (Constraint c : known) {
             // A size is never negative whether or not the condition holds, so this holds of the value
             // and not of the path — the condition is only where the container got named.
@@ -478,6 +568,150 @@ final class Predicates {
         for (Core arg : call.args()) {
             sizeFacts(arg, at, out);
         }
+    }
+
+    /**
+     * What is known of the result of every operation an expression names, whatever its arguments are:
+     * an absolute value is not negative, a remainder by a written divisor is below it.
+     *
+     * <p>The sibling of {@link #sizeFacts}, and read in both the places that one is: what an
+     * operation guarantees holds where a clause is read against the call and where a condition names
+     * it alike. A bound whose rule asks something of the arguments is stated only where the arguments
+     * answer, and what they are read as is this reading's answer — a name given a constant is that
+     * constant, here as everywhere.
+     */
+    void resultFacts(Core e, Denotations at, Known k, List<Constraint> out) {
+        // A name is what it was given, as in `sizeFacts`: an operation's guarantee does not depend on
+        // whether its call was written where it is read or bound first.
+        if (e instanceof Core.Read r && at.valueOf(r.binding()) != null) {
+            resultFacts(at.valueOf(r.binding()), at, k, out);
+            return;
+        }
+        if (!(e instanceof Core.PreservedCall call)) {
+            Core.forEachChild(e, child -> resultFacts(child, at, k, out));
+            return;
+        }
+        Term result = terms.atomOf(call, at);
+        if (result != null) {
+            for (DischargeRules.ResultBound bound
+                    : DischargeRules.boundsOn(call, arg -> constantOf(arg, at, k))) {
+                LinearForm<Term> against = bound.against() == null
+                        ? LinearForm.constant(bound.offset())
+                        : addTo(terms.affineOf(bound.against().of(call), at, k), bound.offset());
+                if (against != null) {
+                    out.add(new Constraint(LinearForm.atom(result).minus(against), bound.rel()));
+                }
+            }
+        }
+        shiftFact(call, at, k, out);
+        for (Core arg : call.args()) {
+            resultFacts(arg, at, k, out);
+        }
+    }
+
+    /**
+     * {@code owed} read as the cases of the one operation inside it that answers a value it was
+     * given, or null where there is no such operation, where there is more than one, or where a case
+     * could not be read.
+     *
+     * <p>The substitution is made in the form and not in the expression. What the clause reads may be
+     * the call as written or a name that was given it, and both arrive here as the one atom the call
+     * keys as — so replacing the atom answers both, where rewriting the expression would answer the
+     * first and leave the second saying nothing.
+     */
+    private Piecewise piecewiseOf(Constraint owed, Core inv, Denotations at, Known k) {
+        Map<Term, Core.PreservedCall> choosing = new LinkedHashMap<>();
+        chosenCalls(inv, at, choosing);
+        choosing.keySet().retainAll(owed.form().coefs().keySet());
+        if (choosing.size() != 1) {
+            return null;
+        }
+        Term atom = choosing.keySet().iterator().next();
+        Core.PreservedCall call = choosing.get(atom);
+        BigDecimal coefficient = owed.form().coefs().get(atom);
+        List<Case> cases = new ArrayList<>();
+        for (DischargeRules.Choice one : DischargeRules.chosenBy(call).cases()) {
+            LinearForm<Term> answered = terms.affineOf(one.answers().of(call), at, k);
+            if (answered == null) {
+                return null;
+            }
+            LinearForm<Term> instead = owed.form()
+                    .minus(LinearForm.atom(atom).times(coefficient))
+                    .plus(answered.times(coefficient));
+            List<Constraint> given = new ArrayList<>(one.given().size() + 1);
+            Map<Term, Granularity> kinds = new HashMap<>(terms.kindsOf(instead));
+            // What the call answers here, said of the call itself: in this case the two are one
+            // value. Without it a guard written about the call would stand outside the cases, and a
+            // clause could come out established by these and refused by that.
+            LinearForm<Term> answeredHere = LinearForm.atom(atom).minus(answered);
+            given.add(new Constraint(answeredHere, Rel.EQ));
+            kinds.putAll(terms.kindsOf(answeredHere));
+            for (DischargeRules.ArgumentsStand stands : one.given()) {
+                LinearForm<Term> left = terms.affineOf(stands.left().of(call), at, k);
+                LinearForm<Term> right = terms.affineOf(stands.right().of(call), at, k);
+                if (left == null || right == null) {
+                    return null;
+                }
+                LinearForm<Term> between = left.minus(right);
+                given.add(new Constraint(between, stands.rel()));
+                kinds.putAll(terms.kindsOf(between));
+            }
+            cases.add(new Case(new Constraint(instead, owed.rel()), List.copyOf(given),
+                    Map.copyOf(kinds)));
+        }
+        return new Piecewise(List.copyOf(cases));
+    }
+
+    /** Every call inside {@code e} that answers one of the values it was given, by the atom it keys
+     * as. A name is what it was given, as everywhere else a value is read. */
+    private void chosenCalls(Core e, Denotations at, Map<Term, Core.PreservedCall> out) {
+        if (e instanceof Core.Read r && at.valueOf(r.binding()) != null) {
+            chosenCalls(at.valueOf(r.binding()), at, out);
+            return;
+        }
+        if (e instanceof Core.PreservedCall call && DischargeRules.chosenBy(call) != null) {
+            Term atom = terms.atomOf(call, at);
+            if (atom != null) {
+                out.put(atom, call);
+            }
+        }
+        Core.forEachChild(e, child -> chosenCalls(child, at, out));
+    }
+
+    /**
+     * What {@code call} states through the measure that counts what it shifted and what it answered
+     * apart, where it is a shift this has a rule about.
+     *
+     * <p>The measure over the two values is the atom a clause written in that measure builds, so the
+     * fact and the clause meet at one term. Where either value is named by nothing there is no such
+     * atom, and nothing is stated.
+     */
+    private void shiftFact(Core.PreservedCall call, Denotations at, Known k, List<Constraint> out) {
+        DischargeRules.Shift shift = DischargeRules.shiftBy(call);
+        if (shift == null) {
+            return;
+        }
+        Term from = terms.bodyKey(shift.of().of(call), at);
+        Term to = terms.bodyKey(call, at);
+        LinearForm<Term> amount = terms.affineOf(shift.amount().of(call), at, k);
+        if (from == null || to == null || amount == null) {
+            return;
+        }
+        out.add(new Constraint(
+                LinearForm.atom(terms.measureKeyOf(shift.measure(), from, to))
+                        .minus(amount.times(shift.per())),
+                Rel.EQ));
+    }
+
+    /** {@code form} with {@code offset} added, or null where the form could not be read. */
+    private static LinearForm<Term> addTo(LinearForm<Term> form, BigDecimal offset) {
+        return form == null ? null : form.plus(LinearForm.constant(offset));
+    }
+
+    /** The constant {@code e} reads as, or null where it reads as none. */
+    private BigDecimal constantOf(Core e, Denotations at, Known k) {
+        LinearForm<Term> form = terms.affineOf(e, at, k);
+        return form == null || !form.coefs().isEmpty() ? null : form.constant();
     }
 
     /** How the size of a container relates to the size of what it was built from, down the chain.

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -255,14 +255,32 @@ final class Predicates {
 
         boolean dischargedBy(NumericDomain<Term> d, PredicateFacts facts) {
             return numeric != null && d.entails(numeric.form(), numeric.rel())
-                    || piecewise != null && piecewise.entailedBy(d)
-                    || fact != null && fact.entailedBy(facts);
+                    || fact != null && fact.entailedBy(facts)
+                    || piecewise != null && !decidedAsWritten(d, facts) && piecewise.entailedBy(d);
         }
 
         boolean refutedBy(NumericDomain<Term> d, PredicateFacts facts) {
             return numeric != null && d.refutes(numeric.form(), numeric.rel())
-                    || piecewise != null && piecewise.refutedBy(d)
-                    || fact != null && fact.refutedBy(facts);
+                    || fact != null && fact.refutedBy(facts)
+                    || piecewise != null && !decidedAsWritten(d, facts) && piecewise.refutedBy(d);
+        }
+
+        /**
+         * Whether the clause as written already came out one way or the other.
+         *
+         * <p>The cases are asked only where it did not. Both readings are sound, so they can differ
+         * only where the path cannot be taken — the guards contradict, and each is answering about a
+         * value the program never builds. Where that is visible in the guards it is said there
+         * ({@link #noCaseSatisfies}) and neither reading is reached; where it is not, this is what
+         * keeps one clause from coming out established and refused at once, which is a check
+         * contradicting itself rather than an answer. What the cases are for is a clause the reading
+         * that takes the call as an unknown cannot settle, and that is untouched.
+         */
+        private boolean decidedAsWritten(NumericDomain<Term> d, PredicateFacts facts) {
+            return numeric != null
+                    && (d.entails(numeric.form(), numeric.rel())
+                            || d.refutes(numeric.form(), numeric.rel()))
+                    || fact != null && (fact.entailedBy(facts) || fact.refutedBy(facts));
         }
     }
 
@@ -418,6 +436,13 @@ final class Predicates {
         Core under = negated(cond);
         if (under != null) {
             return assumeCond(under, k, at, !positive);
+        }
+        // A condition no case of what it is written over can satisfy is one this branch is never
+        // entered under, however little is known of the call itself. Asked of what held on the way
+        // in, before any of the condition is taken as holding, and asked here rather than left to
+        // the construction below: a value the program never builds is not one to report about.
+        if (noCaseSatisfies(cond, k, at, positive)) {
+            return k.reachingNothing();
         }
         Known out = k;
         // What holds of the sizes the condition names, and of what the operations in it answer,
@@ -607,6 +632,30 @@ final class Predicates {
         for (Core arg : call.args()) {
             resultFacts(arg, at, k, out);
         }
+    }
+
+    /**
+     * Whether {@code cond}, asserted with polarity {@code positive}, fails in every case an
+     * operation inside it is defined in — so the branch it guards is not entered.
+     *
+     * <p>The same reading the construction below does, done where the condition is taken instead.
+     * Without it what an operation answers is read at one of the two and not the other, and a path
+     * the cases show cannot be taken is walked as though it could: the construction under it is then
+     * reported against guards that cannot all hold, which is a diagnostic about a value the program
+     * never builds.
+     */
+    private boolean noCaseSatisfies(Core cond, Known k, Denotations at, boolean positive) {
+        if (!(cond instanceof Core.Binary b) || relOf(b.op()) == null) {
+            return false;
+        }
+        Rel stated = positive ? relOf(b.op()) : negateRel(relOf(b.op()));
+        LinearForm<Term> la = stated == null ? null : terms.affineOf(b.left(), at, k);
+        LinearForm<Term> ra = stated == null ? null : terms.affineOf(b.right(), at, k);
+        if (la == null || ra == null) {
+            return false;
+        }
+        Piecewise cases = piecewiseOf(new Constraint(la.minus(ra), stated), cond, at, k);
+        return cases != null && cases.refutedBy(k.numbers());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -437,13 +437,6 @@ final class Predicates {
         if (under != null) {
             return assumeCond(under, k, at, !positive);
         }
-        // A condition no case of what it is written over can satisfy is one this branch is never
-        // entered under, however little is known of the call itself. Asked of what held on the way
-        // in, before any of the condition is taken as holding, and asked here rather than left to
-        // the construction below: a value the program never builds is not one to report about.
-        if (noCaseSatisfies(cond, k, at, positive)) {
-            return k.reachingNothing();
-        }
         Known out = k;
         // What holds of the sizes the condition names, and of what the operations in it answer,
         // whichever way the condition itself is read.
@@ -454,6 +447,15 @@ final class Predicates {
             // A size is never negative whether or not the condition holds, so this holds of the value
             // and not of the path — the condition is only where the container got named.
             out = out.taking(c.form(), c.rel(), Known.Held.OF_THE_VALUE, terms.kindsOf(c.form()));
+        }
+        // A condition no case of what it is written over can satisfy is one this branch is never
+        // entered under, and a value the program never builds is not one to report about. Asked of
+        // everything the condition itself established and not only of what held on the way in: a
+        // size and what an operation answers hold of the value however the condition comes out, and
+        // a case read without them is one this would call reachable where the construction below,
+        // which is handed the same facts, would not.
+        if (noCaseSatisfies(cond, out, at, positive)) {
+            return out.reachingNothing();
         }
         if (cond instanceof Core.Binary b) {
             Rel rel = relOf(b.op());

--- a/souther-compiler/src/main/java/souther/compiler/check/Question.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Question.java
@@ -242,6 +242,120 @@ enum Question {
         }
     },
 
+    /**
+     * What holds of the number it answers wherever it is called ({@link DischargeRules#boundsOn}).
+     * Asked of an operation answering a number from a number: a bound is stated against the arguments,
+     * so an operation given none has nothing for a row to bound its result against.
+     */
+    BOUNDS("what bounds the number it answers") {
+        @Override
+        boolean asksOf(Prelude.Signature signature) {
+            return isANumber(signature.result())
+                    && signature.params().stream().anyMatch(Question::isANumber);
+        }
+
+        @Override
+        boolean answeredFor(ValueName operation) {
+            return DischargeRules.boundedOperations().contains(operation);
+        }
+
+        @Override
+        Set<ValueName> answeredOperations() {
+            return DischargeRules.boundedOperations();
+        }
+
+        @Override
+        Set<ValueName> nothingSaidOf() {
+            return DischargeRules.BOUNDS_NOTHING;
+        }
+    },
+
+    /**
+     * What it states through the measure that counts what it shifted and what it answered apart
+     * ({@link DischargeRules#shiftBy}). Asked of an operation answering a value of the kind one of
+     * its arguments is, given a number — which is the shape moving a value by an amount has.
+     */
+    MEASURE("what it states through the measure counting the two apart") {
+        @Override
+        boolean asksOf(Prelude.Signature signature) {
+            return signature.result() != null && !isANumber(signature.result())
+                    && signature.params().contains(signature.result())
+                    && signature.params().stream().anyMatch(Question::isANumber)
+                    && isCounted(signature.result());
+        }
+
+        @Override
+        boolean answeredFor(ValueName operation) {
+            return DischargeRules.shiftingOperations().contains(operation);
+        }
+
+        @Override
+        Set<ValueName> answeredOperations() {
+            return DischargeRules.shiftingOperations();
+        }
+
+        @Override
+        Set<ValueName> nothingSaidOf() {
+            return DischargeRules.SHIFTS_BY_NOTHING_MEASURABLE;
+        }
+    },
+
+    /**
+     * Whether it answers one of the values it was given, and in which cases
+     * ({@link DischargeRules#chosenBy}). Asked of an operation answering a number from a number: what
+     * such an operation answers may be one of its arguments, decided by the arguments.
+     */
+    CHOICE("whether it answers one of its arguments, and in which cases") {
+        @Override
+        boolean asksOf(Prelude.Signature signature) {
+            return isANumber(signature.result())
+                    && signature.params().stream().anyMatch(Question::isANumber);
+        }
+
+        @Override
+        boolean answeredFor(ValueName operation) {
+            return DischargeRules.choosingOperations().contains(operation);
+        }
+
+        @Override
+        Set<ValueName> answeredOperations() {
+            return DischargeRules.choosingOperations();
+        }
+
+        @Override
+        Set<ValueName> nothingSaidOf() {
+            return DischargeRules.CHOOSES_NOTHING;
+        }
+    },
+
+    /**
+     * Whether the number it answers is a number it was given ({@link DischargeRules#answersItsArgument}).
+     * Asked of an operation answering a number from a number, which is the shape a value re-expressed
+     * has — the result may be one of the arguments read again rather than a number computed from them.
+     */
+    FORM("whether the number it answers is one it was given") {
+        @Override
+        boolean asksOf(Prelude.Signature signature) {
+            return isANumber(signature.result())
+                    && signature.params().stream().anyMatch(Question::isANumber);
+        }
+
+        @Override
+        boolean answeredFor(ValueName operation) {
+            return DischargeRules.formOperations().contains(operation);
+        }
+
+        @Override
+        Set<ValueName> answeredOperations() {
+            return DischargeRules.formOperations();
+        }
+
+        @Override
+        Set<ValueName> nothingSaidOf() {
+            return DischargeRules.ANSWERS_NO_ARGUMENT_OF_ITS_OWN;
+        }
+    },
+
     /** Which operator it is the function form of ({@link DischargeRules#operator}). Asked of an
      * operation over two numbers answering a number of the same kind. */
     OPERATOR("which operator it computes") {
@@ -315,6 +429,30 @@ enum Question {
      * question as what puts an operation in range of one. */
     static boolean holdsElements(Type t) {
         return t instanceof Type.ListOf || t instanceof Type.SetOf || t instanceof Type.MapOf;
+    }
+
+    /**
+     * Whether the library counts two values of {@code t} apart as a number.
+     *
+     * <p>What makes moving a value by an amount a question with an answer. A list shortened by three
+     * and a string padded to a width are shifts as much as a date a day on is, and neither says
+     * anything <em>through a measure</em>, because the library has none that counts two lists or two
+     * strings apart — a size counts one of them. So the range is read off the declarations, and the
+     * day the library gains such a measure the operations of that kind come into range and are asked.
+     */
+    private static boolean isCounted(Type t) {
+        return Prelude.entries().values().stream().anyMatch(entry -> {
+            List<Type> counted = entry.signature().params();
+            return isANumber(entry.signature().result()) && counted.size() == 2
+                    && counted.get(0).equals(t) && counted.get(1).equals(t);
+        });
+    }
+
+    /** Whether {@code t} is one of the kinds of number the domain relates arithmetically. Read where
+     * the numeric rules are bound as well: what such a rule may be written about is the same question
+     * as what puts an operation in range of one. */
+    static boolean isANumber(Type t) {
+        return t == Type.Prim.INT || t == Type.Prim.DECIMAL;
     }
 
     /** Whether {@code t} is something the check can name the size of — a container, or a string. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -206,6 +206,14 @@ final class Terms {
             if (written != null && written != n) {
                 return affineOf(written, at, k);
             }
+            // An operation answering a number it was given is that number here, whatever type it
+            // answers it in: `Decimal.fromInt(n)` is `n`, so a guard about `n` is about the call as
+            // well. Read through rather than made an atom of its own, which would leave the two
+            // unrelated and the guard saying nothing about the construction.
+            Core answered = DischargeRules.answersItsArgument(n);
+            if (answered != null) {
+                return affineOf(answered, at, k);
+            }
             // A list written out has as many elements as it is written with, whatever they are.
             BigDecimal counted = writtenSize(n, at);
             if (counted != null) {
@@ -321,6 +329,20 @@ final class Terms {
      * spelling each other alike. */
     Term sizeKeyOf(ValueName size, Term container) {
         return named(interned.called(size, List.of(container)), Granularity.DISCRETE);
+    }
+
+    /**
+     * The number {@code measure} answers of {@code from} and {@code to}, named as the call it is.
+     *
+     * <p>The same shape a clause writing that measure builds, so a rule stated in it and an invariant
+     * written in it name one value. How its values are spaced is read off what the library declares
+     * the measure to answer, which is what a clause reading the call is named with too — a count of
+     * whole days is one thing wherever it is written.
+     */
+    Term measureKeyOf(ValueName.Stdlib measure, Term from, Term to) {
+        Prelude.PreludeEntry counts = Prelude.entry(measure.qualified());
+        return named(interned.called(measure, List.of(from, to)),
+                granularityOf(counts.signature().result()));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantOneDenotationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantOneDenotationTest.java
@@ -131,11 +131,16 @@ class CompileInvariantOneDenotationTest {
      * <p>Being able to point at a value and knowing something about it are two things. The check
      * names this call — the two writings of it are one value — and names nothing that settles
      * {@code value >= 0} of it, which is a clause left standing rather than a clause never asked.
+     *
+     * <p>The witness is a product, whose two factors are values and not a factor and a count: that
+     * is outside the arithmetic the domain derives in, so the product is one unknown. A remainder
+     * was the witness until the check gained a rule about what {@code Int.floorMod} answers — which
+     * did not make this any less true, only made that call one the check does say something about.
      */
     @Test
     void aCallNothingHasSaidAnythingAboutIsOwedItsClause() {
         assertEquals(1, warnings(Compiler.compileWithWarnings(
-                        EACHES.formatted("Eaches(Int.floorMod(eaches.value, pack.value))"))),
+                        EACHES.formatted("Eaches(Int.multiply(eaches.value, pack.value))"))),
                 "the call is a value the clause is read against, and nothing here discharges it");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/ARuleAboutAnOperationsResultCarriesSomethingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARuleAboutAnOperationsResultCarriesSomethingTest.java
@@ -19,6 +19,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * tables' own rather than a list written beside them: a rule added with no program that fires it
  * fails this, and so does a program left behind by a rule that was removed.
  *
+ * <p>A row and not an operation. An operation whose rule is more than one statement — a remainder is
+ * bounded at both ends, a rounded value is within one of what it rounds either way — has a program
+ * for each, since one program needs one of them and would leave the other free to be dropped.
+ *
  * <p>Held to what the library declares as well. Each of these compiles, so a row naming an argument
  * the declaration does not have, or reading a value of a kind the rule is not about, is a failure
  * here and not a silence at whichever call arrives first.
@@ -60,6 +64,27 @@ class ARuleAboutAnOperationsResultCarriesSomethingTest {
                             else Bad
                         AtLeastTen(Decimal.toInt(HALF_UP, d))
                     }
+                    """),
+            // The other end of the same operation. One program needs one of the two rows, so a row
+            // with no program of its own could be dropped and nothing here would say so.
+            new Discharges("Decimal.toInt", """
+                    module demo
+                    data Bad
+                    data BelowTen = Int
+                        invariant value < 10
+                    behavior whole : (d: Decimal) -> BelowTen | Bad constructs BelowTen, Bad
+                    let whole (d) = {
+                        guard d <= 9.0m
+                            else Bad
+                        BelowTen(Decimal.toInt(HALF_UP, d))
+                    }
+                    """),
+            new Discharges("Int.floorMod", """
+                    module demo
+                    data NonNeg = Int
+                        invariant value >= 0
+                    behavior wrap : (x: Int) -> NonNeg constructs NonNeg
+                    let wrap (x) = NonNeg(Int.floorMod(x, 100))
                     """));
 
     private static final List<Discharges> CHOOSING = List.of(

--- a/souther-compiler/src/test/java/souther/compiler/check/ARuleAboutAnOperationsResultCarriesSomethingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARuleAboutAnOperationsResultCarriesSomethingTest.java
@@ -1,6 +1,9 @@
 package souther.compiler.check;
 
 import souther.compiler.Compiler;
+import souther.compiler.check.InvariantChecker.GaveUp;
+import souther.compiler.check.InvariantChecker.Said;
+import souther.compiler.check.InvariantChecker.Verdict;
 import souther.compiler.diag.Severity;
 
 import org.junit.jupiter.api.Test;
@@ -195,9 +198,12 @@ class ARuleAboutAnOperationsResultCarriesSomethingTest {
                 .collect(Collectors.toCollection(TreeSet::new));
     }
 
+    /** One program per row, counted: a table gaining a second bound for an operation it already has
+     * a program for fails this until the new end gets one of its own. */
     @Test
     void everyBoundHasAConstructionThatFiresIt() {
-        assertEquals(new TreeSet<>(DischargeRules.boundedNames()), namesOf(BOUNDED));
+        assertEquals(DischargeRules.boundedRows().stream().sorted().toList(),
+                BOUNDED.stream().map(Discharges::operation).sorted().toList());
     }
 
     @Test
@@ -215,6 +221,15 @@ class ARuleAboutAnOperationsResultCarriesSomethingTest {
         assertEquals(new TreeSet<>(DischargeRules.formNames()), namesOf(READ_AS_THEIR_ARGUMENT));
     }
 
+    /**
+     * Each program, read for what the check actually did rather than for what it did not say.
+     *
+     * <p>An analysis that fell over reports nothing, and a construction that discharged reports
+     * nothing, and the two are one silence at the boundary ({@link InvariantChecker#GAVE_UP}). So a
+     * program is held to three things: nothing was given up on, a construction was reached at all,
+     * and every construction reached came out proven. Counting warnings alone would pass on a rule
+     * that threw on its first call.
+     */
     @Test
     void eachRuleDischargesWhatItsProgramNeeds() {
         List<String> carriedNothing = new ArrayList<>();
@@ -223,10 +238,28 @@ class ARuleAboutAnOperationsResultCarriesSomethingTest {
         all.addAll(SHIFTING);
         all.addAll(READ_AS_THEIR_ARGUMENT);
         for (Discharges one : all) {
-            long warnings = Compiler.compileWithWarnings(one.module()).warnings().stream()
-                    .filter(d -> d.severity() == Severity.WARNING).count();
-            if (warnings > 0) {
-                carriedNothing.add(one.operation());
+            List<Said> said = new ArrayList<>();
+            List<GaveUp> gaveUp = new ArrayList<>();
+            InvariantChecker.WATCHING = said;
+            InvariantChecker.GAVE_UP = gaveUp;
+            long warnings;
+            try {
+                warnings = Compiler.compileWithWarnings(one.module()).warnings().stream()
+                        .filter(d -> d.severity() == Severity.WARNING).count();
+            } finally {
+                InvariantChecker.WATCHING = null;
+                InvariantChecker.GAVE_UP = null;
+            }
+            if (!gaveUp.isEmpty()) {
+                carriedNothing.add(one.operation() + " — the analysis stopped at "
+                        + gaveUp.get(0).where() + ": " + gaveUp.get(0).why());
+            } else if (said.isEmpty()) {
+                carriedNothing.add(one.operation() + " — no construction was reached");
+            } else if (!said.stream().allMatch(s -> s.verdict() == Verdict.PROVED)) {
+                carriedNothing.add(one.operation() + " — " + said.stream()
+                        .map(s -> s.type() + " " + s.verdict()).toList());
+            } else if (warnings > 0) {
+                carriedNothing.add(one.operation() + " — " + warnings + " warnings");
             }
         }
         assertEquals(List.of(), carriedNothing,

--- a/souther-compiler/src/test/java/souther/compiler/check/ARuleAboutAnOperationsResultCarriesSomethingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARuleAboutAnOperationsResultCarriesSomethingTest.java
@@ -1,0 +1,210 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A rule about what an operation answers is worth having only where a construction discharges
+ * because of it. So every row of every table is held here to a program that does, and the set is the
+ * tables' own rather than a list written beside them: a rule added with no program that fires it
+ * fails this, and so does a program left behind by a rule that was removed.
+ *
+ * <p>Held to what the library declares as well. Each of these compiles, so a row naming an argument
+ * the declaration does not have, or reading a value of a kind the rule is not about, is a failure
+ * here and not a silence at whichever call arrives first.
+ */
+class ARuleAboutAnOperationsResultCarriesSomethingTest {
+
+    private record Discharges(String operation, String module) {}
+
+    private static final List<Discharges> BOUNDED = List.of(
+            new Discharges("Int.abs", """
+                    module demo
+                    data NonNeg = Int
+                        invariant value >= 0
+                    behavior far : (x: Int) -> NonNeg constructs NonNeg
+                    let far (x) = NonNeg(Int.abs(x))
+                    """),
+            new Discharges("Decimal.abs", """
+                    module demo
+                    data NonNegD = Decimal
+                        invariant value >= 0.0m
+                    behavior far : (d: Decimal) -> NonNegD constructs NonNegD
+                    let far (d) = NonNegD(Decimal.abs(d))
+                    """),
+            new Discharges("Int.floorMod", """
+                    module demo
+                    data Pct = Int
+                        invariant value >= 0 && value <= 100
+                    behavior wrap : (x: Int) -> Pct constructs Pct
+                    let wrap (x) = Pct(Int.floorMod(x, 100))
+                    """),
+            new Discharges("Decimal.toInt", """
+                    module demo
+                    data Bad
+                    data AtLeastTen = Int
+                        invariant value >= 10
+                    behavior whole : (d: Decimal) -> AtLeastTen | Bad constructs AtLeastTen, Bad
+                    let whole (d) = {
+                        guard d >= 11.0m
+                            else Bad
+                        AtLeastTen(Decimal.toInt(HALF_UP, d))
+                    }
+                    """));
+
+    private static final List<Discharges> CHOOSING = List.of(
+            new Discharges("Int.min", """
+                    module demo
+                    data Bad
+                    data NonNeg = Int
+                        invariant value >= 0
+                    behavior smaller : (a: Int, b: Int) -> NonNeg | Bad constructs NonNeg, Bad
+                    let smaller (a, b) = {
+                        guard a >= 0
+                            else Bad
+                        guard b >= 0
+                            else Bad
+                        NonNeg(Int.min(a, b))
+                    }
+                    """),
+            new Discharges("Decimal.min", """
+                    module demo
+                    data Bad
+                    data NonNegD = Decimal
+                        invariant value >= 0.0m
+                    behavior smaller : (a: Decimal, b: Decimal) -> NonNegD | Bad
+                        constructs NonNegD, Bad
+                    let smaller (a, b) = {
+                        guard a >= 0.0m
+                            else Bad
+                        guard b >= 0.0m
+                            else Bad
+                        NonNegD(Decimal.min(a, b))
+                    }
+                    """),
+            new Discharges("Int.max", """
+                    module demo
+                    data NonNeg = Int
+                        invariant value >= 0
+                    behavior larger : (x: Int) -> NonNeg constructs NonNeg
+                    let larger (x) = NonNeg(Int.max(0, x))
+                    """),
+            new Discharges("Decimal.max", """
+                    module demo
+                    data NonNegD = Decimal
+                        invariant value >= 0.0m
+                    behavior larger : (d: Decimal) -> NonNegD constructs NonNegD
+                    let larger (d) = NonNegD(Decimal.max(0.0m, d))
+                    """),
+            new Discharges("Int.clamp", """
+                    module demo
+                    data Pct = Int
+                        invariant value >= 0 && value <= 100
+                    behavior score : (x: Int) -> Pct constructs Pct
+                    let score (x) = Pct(Int.clamp(0, 100, x))
+                    """),
+            new Discharges("Decimal.clamp", """
+                    module demo
+                    data Rate = Decimal
+                        invariant value >= 0.0m && value <= 1.0m
+                    behavior capped : (d: Decimal) -> Rate constructs Rate
+                    let capped (d) = Rate(Decimal.clamp(0.0m, 1.0m, d))
+                    """));
+
+    private static final List<Discharges> SHIFTING = List.of(
+            new Discharges("Date.addDays", """
+                    module demo
+                    data Span = { from: Date, to: Date }
+                        invariant Date.daysBetween(from, to) >= 0
+                    behavior makeSpan : (d: Date) -> Span constructs Span
+                    let makeSpan (d) = Span { from = d, to = Date.addDays(1, d) }
+                    """),
+            new Discharges("DateTime.addMinutes", """
+                    module demo
+                    data Window = { opens: DateTime, closes: DateTime }
+                        invariant DateTime.minutesBetween(opens, closes) >= 30
+                    behavior makeWindow : (dt: DateTime) -> Window constructs Window
+                    let makeWindow (dt) = Window { opens = dt, closes = DateTime.addMinutes(30, dt) }
+                    """),
+            new Discharges("DateTime.addHours", """
+                    module demo
+                    data Window = { opens: DateTime, closes: DateTime }
+                        invariant DateTime.minutesBetween(opens, closes) >= 60
+                    behavior makeWindow : (dt: DateTime) -> Window constructs Window
+                    let makeWindow (dt) = Window { opens = dt, closes = DateTime.addHours(1, dt) }
+                    """),
+            new Discharges("DateTime.addDays", """
+                    module demo
+                    data Window = { opens: DateTime, closes: DateTime }
+                        invariant DateTime.minutesBetween(opens, closes) >= 1440
+                    behavior makeWindow : (dt: DateTime) -> Window constructs Window
+                    let makeWindow (dt) = Window { opens = dt, closes = DateTime.addDays(1, dt) }
+                    """));
+
+    private static final List<Discharges> READ_AS_THEIR_ARGUMENT = List.of(
+            new Discharges("Decimal.fromInt", """
+                    module demo
+                    data Bad
+                    data NonNegD = Decimal
+                        invariant value >= 0.0m
+                    behavior widen : (n: Int) -> NonNegD | Bad constructs NonNegD, Bad
+                    let widen (n) = {
+                        guard n >= 0
+                            else Bad
+                        NonNegD(Decimal.fromInt(n))
+                    }
+                    """));
+
+    private static Set<String> namesOf(List<Discharges> programs) {
+        return programs.stream().map(Discharges::operation)
+                .collect(Collectors.toCollection(TreeSet::new));
+    }
+
+    @Test
+    void everyBoundHasAConstructionThatFiresIt() {
+        assertEquals(new TreeSet<>(DischargeRules.boundedNames()), namesOf(BOUNDED));
+    }
+
+    @Test
+    void everyChoiceHasAConstructionThatFiresIt() {
+        assertEquals(new TreeSet<>(DischargeRules.choosingNames()), namesOf(CHOOSING));
+    }
+
+    @Test
+    void everyShiftHasAConstructionThatFiresIt() {
+        assertEquals(new TreeSet<>(DischargeRules.shiftingNames()), namesOf(SHIFTING));
+    }
+
+    @Test
+    void everyReadThroughHasAConstructionThatFiresIt() {
+        assertEquals(new TreeSet<>(DischargeRules.formNames()), namesOf(READ_AS_THEIR_ARGUMENT));
+    }
+
+    @Test
+    void eachRuleDischargesWhatItsProgramNeeds() {
+        List<String> carriedNothing = new ArrayList<>();
+        List<Discharges> all = new ArrayList<>(BOUNDED);
+        all.addAll(CHOOSING);
+        all.addAll(SHIFTING);
+        all.addAll(READ_AS_THEIR_ARGUMENT);
+        for (Discharges one : all) {
+            long warnings = Compiler.compileWithWarnings(one.module()).warnings().stream()
+                    .filter(d -> d.severity() == Severity.WARNING).count();
+            if (warnings > 0) {
+                carriedNothing.add(one.operation());
+            }
+        }
+        assertEquals(List.of(), carriedNothing,
+                "the clause should discharge from what the operation answers, and does not");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AShiftIsStatedThroughTheMeasureThatCountsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AShiftIsStatedThroughTheMeasureThatCountsItTest.java
@@ -1,0 +1,60 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.Diagnostic;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * An operation that shifts a value by an amount states what it did through the measure that counts
+ * the two apart: a date a day after another is a day after it, and that is the same number
+ * {@code Date.daysBetween} answers. So a clause written in that measure reads the shift, and needs
+ * no guard restating it.
+ *
+ * <p>A shift by an amount the measure does not fix says nothing: months and years hold different
+ * numbers of days, so {@code Date.addMonths} moves a date by a count no rule here can write.
+ */
+class AShiftIsStatedThroughTheMeasureThatCountsItTest {
+
+    private static List<String> codesOf(String module) {
+        return Compiler.compileWithWarnings(module).warnings().stream()
+                .map(Diagnostic::code)
+                .toList();
+    }
+
+    private static final String TYPES = """
+            module demo
+            data Span = { from: Date, to: Date }
+                invariant Date.daysBetween(from, to) >= 0
+            data Window = { opens: DateTime, closes: DateTime }
+                invariant DateTime.minutesBetween(opens, closes) >= 60
+            """;
+
+    @Test
+    void aDateADayOnIsADayAfterTheOneItWasBuiltFrom() {
+        assertEquals(List.of(), codesOf(TYPES + """
+                behavior makeSpan : (d: Date) -> Span constructs Span
+                let makeSpan (d) = Span { from = d, to = Date.addDays(1, d) }
+                """));
+    }
+
+    @Test
+    void anHourOnIsSixtyMinutesOn() {
+        assertEquals(List.of(), codesOf(TYPES + """
+                behavior makeWindow : (dt: DateTime) -> Window constructs Window
+                let makeWindow (dt) = Window { opens = dt, closes = DateTime.addHours(1, dt) }
+                """));
+    }
+
+    @Test
+    void aMonthOnIsNoFixedNumberOfDays() {
+        assertEquals(List.of("E2011"), codesOf(TYPES + """
+                behavior makeSpan : (d: Date) -> Span constructs Span
+                let makeSpan (d) = Span { from = d, to = Date.addMonths(1, d) }
+                """));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperationThatChoosesIsReadCaseByCaseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperationThatChoosesIsReadCaseByCaseTest.java
@@ -1,0 +1,194 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * An operation that answers one of the values it was given is read as the cases its definition is
+ * written in: which argument it answers, and what holds of the arguments where it answers that one.
+ * A clause holds of the result exactly when it holds in every case, and fails of it when it fails in
+ * every case that is reached at all.
+ *
+ * <p>Stated case by case rather than as a bound on the result, because a bound would have to hold
+ * whatever the arguments are. {@code Int.clamp(lo, hi, n)} is total and does not ask that {@code lo}
+ * be below {@code hi}: where it is not, the result is not inside both of them, and the rule that
+ * said it was would prove a clause the values can fail.
+ */
+class AnOperationThatChoosesIsReadCaseByCaseTest {
+
+    private static final String TYPES = """
+            module demo
+            data NonNeg = Int
+                invariant value >= 0
+            data Pct = Int
+                invariant value >= 0 && value <= 100
+            data AtLeastFifty = Int
+                invariant value >= 50
+            data AboveTen = Int
+                invariant value > 10
+            data Middle = Int
+                invariant value > 4 && value < 6
+            data Bad
+            """;
+
+    private static List<String> codesOf(String module) {
+        return Compiler.compileWithWarnings(module).warnings().stream()
+                .map(Diagnostic::code)
+                .toList();
+    }
+
+    @Test
+    void aSmallerOfTwoIsWhatBothOfThemAre() {
+        assertEquals(List.of(), codesOf(TYPES + """
+                behavior smaller : (a: Int, b: Int) -> NonNeg | Bad constructs NonNeg, Bad
+                let smaller (a, b) = {
+                    guard a >= 0
+                        else Bad
+                    guard b >= 0
+                        else Bad
+                    NonNeg(Int.min(a, b))
+                }
+                """));
+    }
+
+    @Test
+    void aLargerOfTwoIsAtLeastEitherOfThem() {
+        assertEquals(List.of(), codesOf(TYPES + """
+                behavior atLeastZero : (x: Int) -> NonNeg constructs NonNeg
+                let atLeastZero (x) = NonNeg(Int.max(0, x))
+                """));
+    }
+
+    @Test
+    void aClampedValueIsInsideBoundsWrittenTheRightWayRound() {
+        assertEquals(List.of(), codesOf(TYPES + """
+                behavior score : (x: Int) -> Pct constructs Pct
+                let score (x) = Pct(Int.clamp(0, 100, x))
+                """));
+    }
+
+    /**
+     * The case that answers the value itself, on its own. What the path knows of that value puts
+     * both ends out of reach — a value above four is not below zero, and one below six is not above
+     * ten — so the clause is established by the third case and by nothing else.
+     */
+    @Test
+    void aClampedValueInsideBothEndsIsTheValueItself() {
+        assertEquals(List.of(), codesOf(TYPES + """
+                behavior narrow : (n: Int) -> Middle | Bad constructs Middle, Bad
+                let narrow (n) = {
+                    guard n > 4
+                        else Bad
+                    guard n < 6
+                        else Bad
+                    Middle(Int.clamp(0, 10, n))
+                }
+                """));
+    }
+
+    @Test
+    void aClampWhoseBoundsAreTheWrongWayRoundEstablishesNeither() {
+        assertEquals(List.of("E2011"), codesOf(TYPES + """
+                behavior score : (x: Int) -> AtLeastFifty constructs AtLeastFifty
+                let score (x) = AtLeastFifty(Int.clamp(50, 0, x))
+                """));
+    }
+
+    @Test
+    void aSmallerOfTwoIsNotEstablishedByTheFirstOfThemAlone() {
+        assertEquals(List.of("E2011"), codesOf(TYPES + """
+                behavior smaller : (a: Int, b: Int) -> NonNeg | Bad constructs NonNeg, Bad
+                let smaller (a, b) = {
+                    guard a >= 0
+                        else Bad
+                    NonNeg(Int.min(a, b))
+                }
+                """));
+    }
+
+    @Test
+    void aSmallerOfTwoIsNotEstablishedByTheSecondOfThemAlone() {
+        assertEquals(List.of("E2011"), codesOf(TYPES + """
+                behavior smaller : (a: Int, b: Int) -> NonNeg | Bad constructs NonNeg, Bad
+                let smaller (a, b) = {
+                    guard b >= 0
+                        else Bad
+                    NonNeg(Int.min(a, b))
+                }
+                """));
+    }
+
+    @Test
+    void aLargerOfTwoIsNotHeldDownByTheFirstOfThemAlone() {
+        assertEquals(List.of("E2011"), codesOf(TYPES + """
+                behavior larger : (a: Int, b: Int) -> Pct | Bad constructs Pct, Bad
+                let larger (a, b) = {
+                    guard a >= 0 && a <= 100
+                        else Bad
+                    guard b >= 0
+                        else Bad
+                    Pct(Int.max(a, b))
+                }
+                """));
+    }
+
+    @Test
+    void aLargerOfTwoIsNotHeldDownByTheSecondOfThemAlone() {
+        assertEquals(List.of("E2011"), codesOf(TYPES + """
+                behavior larger : (a: Int, b: Int) -> Pct | Bad constructs Pct, Bad
+                let larger (a, b) = {
+                    guard a >= 0
+                        else Bad
+                    guard b >= 0 && b <= 100
+                        else Bad
+                    Pct(Int.max(a, b))
+                }
+                """));
+    }
+
+    /**
+     * A guard about the call itself and the cases the call is defined in are two readings of one
+     * value, and they have to agree. Where the guards cannot all hold, they disagree about what
+     * cannot happen — the case reading finds no case left, the reading that takes the call as an
+     * unknown still has the guard's bound — and a clause that came out established by one and
+     * refused by the other is a check contradicting itself rather than an answer.
+     */
+    @Test
+    void aGuardAboutTheCallItselfIsReadAlongsideTheCases() {
+        String module = TYPES + """
+                behavior odd : (a: Int, b: Int) -> AboveTen | Bad constructs AboveTen, Bad
+                let odd (a, b) = {
+                    guard a >= 10
+                        else Bad
+                    guard b >= 10
+                        else Bad
+                    guard Int.min(a, b) <= 3
+                        else Bad
+                    AboveTen(Int.min(a, b))
+                }
+                """;
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(module));
+        assertEquals("E2010", e.diagnostic().code(),
+                "the guard puts the value below what the invariant asks: " + e.getMessage());
+    }
+
+    @Test
+    void aChoiceEveryCaseOfWhichFailsIsRefused() {
+        String module = TYPES + """
+                behavior small : (x: Int) -> AboveTen constructs AboveTen
+                let small (x) = AboveTen(Int.min(0, x))
+                """;
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(module));
+        assertEquals("E2010", e.diagnostic().code(),
+                "a smaller of two, neither of which can be above ten, is a definite violation: "
+                        + e.getMessage());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperationThatChoosesIsReadCaseByCaseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperationThatChoosesIsReadCaseByCaseTest.java
@@ -155,15 +155,19 @@ class AnOperationThatChoosesIsReadCaseByCaseTest {
     }
 
     /**
-     * A guard about the call itself and the cases the call is defined in are two readings of one
-     * value, and they have to agree. Where the guards cannot all hold, they disagree about what
-     * cannot happen — the case reading finds no case left, the reading that takes the call as an
-     * unknown still has the guard's bound — and a clause that came out established by one and
-     * refused by the other is a check contradicting itself rather than an answer.
+     * A guard is read as the cases too, so a guard no case can satisfy is one the walk does not go
+     * past. Both numbers here are at least ten, so neither of the two the smaller of them can be is
+     * three or less: the third guard always takes the other way out, and the construction under it
+     * is not reached.
+     *
+     * <p>Nothing is reported there. A construction the program never builds is not one to report
+     * about — and a construction whose guards contradict is where the two readings would otherwise
+     * come out one established and the other refused, which is a check contradicting itself rather
+     * than an answer.
      */
     @Test
-    void aGuardAboutTheCallItselfIsReadAlongsideTheCases() {
-        String module = TYPES + """
+    void aGuardNoCaseCanSatisfyIsNotWalkedPast() {
+        assertEquals(List.of(), codesOf(TYPES + """
                 behavior odd : (a: Int, b: Int) -> AboveTen | Bad constructs AboveTen, Bad
                 let odd (a, b) = {
                     guard a >= 10
@@ -174,10 +178,30 @@ class AnOperationThatChoosesIsReadCaseByCaseTest {
                         else Bad
                     AboveTen(Int.min(a, b))
                 }
-                """;
-        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(module));
-        assertEquals("E2010", e.diagnostic().code(),
-                "the guard puts the value below what the invariant asks: " + e.getMessage());
+                """));
+    }
+
+    /**
+     * The same where the contradiction is not in a guard about the call. Each of the two the smaller
+     * of them can be is below zero once {@code c} is added, and the third guard asks for the sum to
+     * be at least zero — so the construction is not reached, and neither reading of it is asked.
+     * Read against forms the domain keeps as written, where the equality tying a case to the call is
+     * not what settles it.
+     */
+    @Test
+    void guardsThatCannotAllHoldAreNotWalkedPastEitherWhereTheFormsAreKeptAsWritten() {
+        assertEquals(List.of(), codesOf(TYPES + """
+                behavior sum : (a: Int, b: Int, c: Int) -> NonNeg | Bad constructs NonNeg, Bad
+                let sum (a, b, c) = {
+                    guard a + c < 0
+                        else Bad
+                    guard b + c < 0
+                        else Bad
+                    guard Int.min(a, b) + c >= 0
+                        else Bad
+                    NonNeg(Int.min(a, b) + c)
+                }
+                """));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperationThatChoosesIsReadCaseByCaseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperationThatChoosesIsReadCaseByCaseTest.java
@@ -204,6 +204,39 @@ class AnOperationThatChoosesIsReadCaseByCaseTest {
                 """));
     }
 
+    /**
+     * A guard is read against everything the condition itself establishes, not only against what
+     * held on the way in. Neither absolute value is negative, so neither of the two the smaller of
+     * them can be is either, and the guard asking for one below zero is never taken. Reading the
+     * cases before what the operations under them answer would call both cases reachable, and the
+     * construction beyond a guard that cannot hold would be reported.
+     */
+    @Test
+    void aGuardIsReadAgainstWhatTheOperationsInsideItAnswer() {
+        assertEquals(List.of(), codesOf(TYPES + """
+                behavior nearest : (a: Int, b: Int) -> NonNeg | Bad constructs NonNeg, Bad
+                let nearest (a, b) = {
+                    guard Int.min(Int.abs(a), Int.abs(b)) < 0
+                        else Bad
+                    NonNeg(Int.min(Int.abs(a), Int.abs(b)))
+                }
+                """));
+    }
+
+    /** The same for what a size answers, which is known the same way and read at the same point. */
+    @Test
+    void aGuardIsReadAgainstTheSizesInsideItToo() {
+        assertEquals(List.of(), codesOf(TYPES + """
+                behavior shorter : (xs: List<Int>, ys: List<Int>) -> NonNeg | Bad
+                    constructs NonNeg, Bad
+                let shorter (xs, ys) = {
+                    guard Int.min(List.length(xs), List.length(ys)) < 0
+                        else Bad
+                    NonNeg(Int.min(List.length(xs), List.length(ys)))
+                }
+                """));
+    }
+
     @Test
     void aChoiceEveryCaseOfWhichFailsIsRefused() {
         String module = TYPES + """

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperationsOwnGuaranteeDischargesAClauseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperationsOwnGuaranteeDischargesAClauseTest.java
@@ -1,0 +1,108 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What an operation guarantees of its own result holds wherever the call is written, so a
+ * construction standing over one owes nothing the operation has already established. The guard such
+ * a report would ask for restates the operation.
+ *
+ * <p>Every construction here is written in a behavior, which is where a construction is judged: a
+ * value definition builds its result outside any path, and nothing is read of one.
+ */
+class AnOperationsOwnGuaranteeDischargesAClauseTest {
+
+    private static final String TYPES = """
+            module demo
+            data NonNeg = Int
+                invariant value >= 0
+            data NonNegD = Decimal
+                invariant value >= 0.0m
+            data Bad
+            """;
+
+    private static List<String> warningsOf(String module) {
+        return Compiler.compileWithWarnings(module).warnings().stream()
+                .filter(d -> d.severity() == Severity.WARNING)
+                .map(Diagnostic::code)
+                .toList();
+    }
+
+    @Test
+    void aDecimalMadeFromAnIntIsThatNumber() {
+        assertEquals(List.of(), warningsOf(TYPES + """
+                behavior widen : (n: Int) -> NonNegD | Bad constructs NonNegD, Bad
+                let widen (n) = {
+                    guard n >= 0
+                        else Bad
+                    NonNegD(Decimal.fromInt(n))
+                }
+                """));
+    }
+
+    @Test
+    void anAbsoluteValueIsNeverNegative() {
+        assertEquals(List.of(), warningsOf(TYPES + """
+                behavior distance : (x: Int) -> NonNeg constructs NonNeg
+                let distance (x) = NonNeg(Int.abs(x))
+                """));
+    }
+
+    @Test
+    void aRemainderIsNeverNegative() {
+        assertEquals(List.of(), warningsOf(TYPES + """
+                behavior wrap : (x: Int) -> NonNeg constructs NonNeg
+                let wrap (x) = NonNeg(Int.floorMod(x, 100))
+                """));
+    }
+
+    @Test
+    void aRemainderIsBelowADivisorReadAsAConstant() {
+        assertEquals(List.of(), warningsOf(TYPES + """
+                data Pct = Int
+                    invariant value >= 0 && value <= 100
+                behavior wrap : (x: Int) -> Pct constructs Pct
+                let wrap (x) = Pct(Int.floorMod(x, 100))
+                """));
+    }
+
+    @Test
+    void aRemainderByADivisorThatIsNotAConstantIsNotBoundedAbove() {
+        assertEquals(List.of("E2011"), warningsOf(TYPES + """
+                data Pct = Int
+                    invariant value >= 0 && value <= 100
+                behavior wrap : (x: Int, k: Int) -> Pct constructs Pct
+                let wrap (x, k) = Pct(Int.floorMod(x, k))
+                """));
+    }
+
+    @Test
+    void aRoundedDecimalIsWithinOneOfWhatItRounds() {
+        assertEquals(List.of(), warningsOf(TYPES + """
+                data AtLeastTen = Int
+                    invariant value >= 10
+                behavior whole : (d: Decimal) -> AtLeastTen | Bad constructs AtLeastTen, Bad
+                let whole (d) = {
+                    guard d >= 11.0m
+                        else Bad
+                    AtLeastTen(Decimal.toInt(HALF_UP, d))
+                }
+                """));
+    }
+
+    @Test
+    void aValueNoOperationBoundsIsStillReported() {
+        assertEquals(List.of("E2011"), warningsOf(TYPES + """
+                behavior plain : (x: Int) -> NonNeg constructs NonNeg
+                let plain (x) = NonNeg(x)
+                """));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperationsOwnGuaranteeDischargesAClauseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperationsOwnGuaranteeDischargesAClauseTest.java
@@ -74,6 +74,27 @@ class AnOperationsOwnGuaranteeDischargesAClauseTest {
                 """));
     }
 
+    /**
+     * A remainder takes the sign of its divisor, so a negative divisor puts it the other side of
+     * zero: {@code Int.floorMod(1, 0 - 3)} is {@code -2}. Neither end of it is known without knowing
+     * the divisor is above zero.
+     */
+    @Test
+    void aRemainderByANegativeDivisorIsNotKnownToBeNonNegative() {
+        assertEquals(List.of("E2011"), warningsOf(TYPES + """
+                behavior wrap : (x: Int) -> NonNeg constructs NonNeg
+                let wrap (x) = NonNeg(Int.floorMod(x, 0 - 3))
+                """));
+    }
+
+    @Test
+    void aRemainderByADivisorThatIsNotAConstantIsNotKnownToBeNonNegative() {
+        assertEquals(List.of("E2011"), warningsOf(TYPES + """
+                behavior wrap : (x: Int, k: Int) -> NonNeg constructs NonNeg
+                let wrap (x, k) = NonNeg(Int.floorMod(x, k))
+                """));
+    }
+
     @Test
     void aRemainderByADivisorThatIsNotAConstantIsNotBoundedAbove() {
         assertEquals(List.of("E2011"), warningsOf(TYPES + """

--- a/specification.adoc
+++ b/specification.adoc
@@ -1570,6 +1570,8 @@ let score (raw) = Pct(Int.clamp(0, 100, raw)) // discharged: every case is insid
 
 A case is reached where its condition, the equality saying the call answered that argument, and what the path already establishes can hold at once. What the path knows can put a case out of reach: a value the guards put above four and below six is neither below zero nor above ten, so `+Int.clamp(0, 10, n)+` answers `+n+` and the clause is read there and nowhere else.
 
+A clause reads one such operation. Where it names two — `+Int.min(a, b) + Int.min(c, d) >= 0+` — the cases are not multiplied out, and the clause is left to the run-time check however much is known of the four arguments.
+
 Over the cases that are reached, the clause is established where every one of them establishes it and refused where every one of them refuses it — `+AboveTen(Int.min(0, x))+` is neither of two numbers above ten, and is reported as a violation the values decide. Where no case is reached at all the guards cannot all hold, and this says nothing: a value the program never builds establishes nothing, and what a guard said about the call itself is what answers there.
 
 *A shift stated through a measure.* An operation that moves a value by an amount says how far through the operation that counts two such values apart, which is what an invariant over a pair of them is written in.

--- a/specification.adoc
+++ b/specification.adoc
@@ -1526,6 +1526,70 @@ The field the closure copied need not be the one the clause names: when the clos
 
 This is bounded to a field *copied*. A field the closure computes from others — `+code = String.concat([r.sku, r.name])+` — is not this: two rows that differ can land on one value, and nothing about the result follows.
 
+[#invariant-discharge-guarantees]
+==== What an operation guarantees of what it answers
+
+<<invariant-discharge-preservation>> says what carries across an operation from what it was built from. An operation also says something on its own: `+Int.clamp(0, 100, x)+` is between 0 and 100 whatever `+x+` is, and a construction standing over it owes nothing a guard would have to restate. What each operation guarantees is stated here, in the same way and for the same reason: an author predicts which constructions are judged safe by reading it.
+
+A guarantee takes one of four forms.
+
+*A bound on the result.* It holds wherever the call is written, and is read into the clause as it stands.
+
+[cols="2,3"]
+|===
+| the operation | what holds of its result
+
+| `+Int.abs+`, `+Decimal.abs+` | not negative
+| `+Int.floorMod(x, k)+` | not negative; and below `+k+` where `+k+` reads as a constant above zero
+| `+Decimal.toInt(mode, d)+` | within one of `+d+`, whichever mode it is handed
+|===
+
+A divisor that is not a constant here bounds the remainder nowhere: `+Int.floorMod+` takes the sign of its divisor, so a divisor that could be negative puts the result the other side of zero. A name given a constant is that constant, so `+let k = 100+` and a written `+100+` are one divisor.
+
+*One of the values it was given.* What such an operation answers depends on what it was given, so it is stated as the cases its definition is written in, and a clause holds of the result when it holds in every case.
+
+[cols="2,3"]
+|===
+| the operation | the cases
+
+| `+Int.min(a, b)+`, `+Decimal.min+` | `+a+` where `+a < b+`; `+b+` otherwise
+| `+Int.max(a, b)+`, `+Decimal.max+` | `+a+` where `+a > b+`; `+b+` otherwise
+| `+Int.clamp(lo, hi, n)+`, `+Decimal.clamp+` | `+lo+` where `+n < lo+`; `+hi+` where `+n >= lo+` and `+n > hi+`; `+n+` otherwise
+|===
+
+So a smaller of two non-negative numbers is non-negative, and a value clamped to `+0+` and `+100+` is a percentage. `+clamp+` does not ask that `+lo+` be below `+hi+`: written the other way round it answers `+lo+` for a low `+n+` and `+hi+` for a high one, and a clause that only the ordering would establish is not discharged.
+
+[,souther]
+----
+data Pct = Int
+    invariant value >= 0 && value <= 100
+
+behavior score : (raw: Int) -> Pct
+let score (raw) = Pct(Int.clamp(0, 100, raw)) // discharged: every case is inside both ends
+----
+
+A case is reached where its condition, the equality saying the call answered that argument, and what the path already establishes can hold at once. What the path knows can put a case out of reach: a value the guards put above four and below six is neither below zero nor above ten, so `+Int.clamp(0, 10, n)+` answers `+n+` and the clause is read there and nowhere else.
+
+Over the cases that are reached, the clause is established where every one of them establishes it and refused where every one of them refuses it — `+AboveTen(Int.min(0, x))+` is neither of two numbers above ten, and is reported as a violation the values decide. Where no case is reached at all the guards cannot all hold, and this says nothing: a value the program never builds establishes nothing, and what a guard said about the call itself is what answers there.
+
+*A shift stated through a measure.* An operation that moves a value by an amount says how far through the operation that counts two such values apart, which is what an invariant over a pair of them is written in.
+
+[cols="2,3"]
+|===
+| the operation | what holds
+
+| `+Date.addDays(n, d)+` | `+Date.daysBetween(d, result)+` is `+n+`
+| `+DateTime.addMinutes(n, dt)+` | `+DateTime.minutesBetween(dt, result)+` is `+n+`
+| `+DateTime.addHours(n, dt)+` | `+DateTime.minutesBetween(dt, result)+` is `+60 * n+`
+| `+DateTime.addDays(n, dt)+` | `+DateTime.minutesBetween(dt, result)+` is `+1440 * n+`
+|===
+
+`+Date.addMonths+` and `+Date.addYears+` state nothing: months and years hold different numbers of days, so neither moves a date by a count `+Date.daysBetween+` can name.
+
+*A value it was already given.* `+Decimal.fromInt(n)+` answers the number `+n+` is, so a clause about the call and a guard about `+n+` are about one value rather than two.
+
+An operation not named here guarantees nothing that can be relied on, and a clause over what it answered is left to the run-time check. What is known of the arguments at one call is a different question: it is what the path establishes, and it is read where the clause is.
+
 [#invariant-discharge-quantified]
 ==== A relation over every element, read at the element
 

--- a/specification.adoc
+++ b/specification.adoc
@@ -1540,11 +1540,11 @@ A guarantee takes one of four forms.
 | the operation | what holds of its result
 
 | `+Int.abs+`, `+Decimal.abs+` | not negative
-| `+Int.floorMod(x, k)+` | not negative; and below `+k+` where `+k+` reads as a constant above zero
+| `+Int.floorMod(x, k)+` | not negative, and below `+k+` — both only where `+k+` reads as a constant above zero
 | `+Decimal.toInt(mode, d)+` | within one of `+d+`, whichever mode it is handed
 |===
 
-A divisor that is not a constant here bounds the remainder nowhere: `+Int.floorMod+` takes the sign of its divisor, so a divisor that could be negative puts the result the other side of zero. A name given a constant is that constant, so `+let k = 100+` and a written `+100+` are one divisor.
+Neither end is known without the divisor: `+Int.floorMod+` takes the sign of its divisor, so a divisor that could be negative puts the result the other side of zero — `+Int.floorMod(1, 0 - 3)+` is `+-2+` — and one the check cannot read says nothing about either end. A name given a constant is that constant, so `+let k = 100+` and a written `+100+` are one divisor. A divisor that is above zero for some other reason — a parameter whose type says so — is not read here: what an operation guarantees holds wherever it is called, and that one holds where the caller happens to have such a value.
 
 *One of the values it was given.* What such an operation answers depends on what it was given, so it is stated as the cases its definition is written in, and a clause holds of the result when it holds in every case.
 


### PR DESCRIPTION
Closes #749.

An invariant clause standing over a library call was owed a guard that restated the operation. `Pct(Int.clamp(0, 100, x))` warned, and the guard the report asked for was `guard Int.clamp(0, 100, x) >= 0`.

## What an operation guarantees, as four questions

Each has its range read off the declarations and its negative answers written down, so an operation the library gains is unanswered until someone answers it (`AnOperationTheLibraryGainsIsAnsweredForTest`).

| question | what it asks | answered for |
| --- | --- | --- |
| bounds | what holds of the result wherever it is called | `Int.abs`, `Decimal.abs`, `Int.floorMod`, `Decimal.toInt` |
| choice | which argument it answers, and in which cases | `min`, `max`, `clamp`, for `Int` and `Decimal` |
| measure | what it states through the measure counting two values apart | `Date.addDays`, `DateTime.addMinutes`, `DateTime.addHours`, `DateTime.addDays` |
| form | whether the number it answers is one it was given | `Decimal.fromInt` |

## `clamp` is cases, not bounds

The issue proposed `r >= lo`, `r <= hi` as unconditional rows. Reading the library refutes that: `Int.clamp` is `if n < lo then lo else if n > hi then hi else n` and is total, so `clamp(50, 0, x)` answers `0` for a high `x`. `min` and `max` are the same shape.

So they are stated as the cases their definitions are written in, with the condition each case is reached under. That reads more than a bound would — `min(a, b) >= 0` follows from guards on both arguments, which no difference row states — and it refuses where every reached case refuses, so `AboveTen(Int.min(0, x))` is an E2010.

A case holds its condition **and** the equality saying the call answered that argument. Without the equality a guard naming the call stands outside every case, and one clause came out established by the cases and refused by the reading that takes the call as an unknown. Where no case is reached the guards cannot all hold, and this says nothing rather than proving the clause vacuously.

## Measured

- souther-examples: **80 E2011 → 70**, none added, no new E2010. The 10: `clamp` at `crm.sou:556,635` and `forecasting.sou:362` and `billing.sou:388`; `Decimal.abs` at `billing.sou:323`; `Decimal.max` at `billing.sou:469,481`; `Decimal.min` at `returns.sou:201`; `Date.addDays` at `quoting.sou:255,676`. `inventory.sou:259` is not among them: its divisor is above zero by `PackSize`'s invariant rather than as a constant this reads, which is what the caller has rather than what the operation answers.
- The issue's probe discharges in full; a construction nothing bounds still warns.
- 7,554 tests green across all modules.

What is left of the issue's list needs what the path knows of the arguments (#750) or rests on `Date.addMonths`, which states nothing here and says so.

## Notes for review

- `Int.abs` is `if n < 0 then 0 - n else n`; the one value with no positive counterpart aborts on overflow, so `r >= 0` holds wherever it answers.
- `Int.floorMod`'s divisor is read as a constant rather than required to be written as one — a name given `100` is that divisor, as everywhere else the check reads a value.
- One clause reads one choosing operation; more than one is left unsettled rather than multiplied out. The spec says so.
- A guard is read as the cases too, and against everything the condition itself established: a condition no case can satisfy is one its branch is never entered under, so the construction beyond it is not reported against. Where that is not visible in the guards, the cases are asked only of a clause the as-written reading left undecided, so one clause cannot come out established and refused at once.
- `NumericDomain` is unchanged. The `Decimal.toInt` tightening on discrete atoms is not here: no program fires it.
- `CompileInvariantOneDenotationTest` used `Int.floorMod` as a call nothing is known about. The rule still holds; the witness is now a product.
- Spec: §invariant-discharge-guarantees, beside §invariant-discharge-terms and §invariant-discharge-preservation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
