### PR TITLE
Carry what a module's import lines brought in wherever the module goes

### DIFF
--- a/souther-cli/src/main/java/souther/cli/Main.java
+++ b/souther-cli/src/main/java/souther/cli/Main.java
@@ -316,7 +316,7 @@ public final class Main {
                     : Compiler.analyzedModules(texts, path, warnings, measure);
             // Said first, and whatever the command answers with after. What is wrong with the source
             // is the same news whether the rest of this reports, refuses, or succeeds.
-            List<Located> errors = compilation.errors(compilation.db().allReports());
+            List<Located> errors = compilation.errors();
             List<Located> said = new ArrayList<>(errors);
             said.addAll(warnings);
             report(said, sources, render);

--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -221,19 +221,19 @@ public final class Compiler {
         compilation.measure(measure);
         Db db = compilation.db();
 
-        CompileException structural = compilation.failure(compilation.structuralReports());
+        CompileException structural = compilation.structuralFailure();
         if (structural != null) {
             throw structural;
         }
 
         db.ask(new Output.All());
-        CompileException failed = compilation.failure(db.allReports());
+        CompileException failed = compilation.failure();
         if (failed != null) {
             throw failed;
         }
         for (String module : compilation.modules()) {
             if (!db.ask(new Output.ConstConstructions(module)).present()) {
-                CompileException bad = compilation.failure(db.allReports());
+                CompileException bad = compilation.failure();
                 if (bad != null) {
                     throw bad;
                 }
@@ -265,7 +265,7 @@ public final class Compiler {
         for (String module : compilation.modules()) {
             compilation.answerWarnings(module);
         }
-        warningsOut.addAll(compilation.warnings(db.allReports()));
+        warningsOut.addAll(compilation.warnings());
         return compilation;
     }
 
@@ -309,7 +309,7 @@ public final class Compiler {
         return driven(() -> {
             compilation.measure(measure);
             compilation.answerEverything();
-            warningsOut.addAll(compilation.warnings(compilation.db().allReports()));
+            warningsOut.addAll(compilation.warnings());
             return compilation;
         });
     }
@@ -436,13 +436,13 @@ public final class Compiler {
         compilation.measure(measure);
         Db db = compilation.db();
 
-        CompileException structural = compilation.failure(compilation.structuralReports());
+        CompileException structural = compilation.structuralFailure();
         if (structural != null) {
             throw structural;
         }
 
         db.ask(new Output.All());
-        CompileException failed = compilation.failure(db.allReports());
+        CompileException failed = compilation.failure();
         if (failed != null) {
             throw failed;
         }
@@ -454,7 +454,7 @@ public final class Compiler {
         List<String> exampleSources = new ArrayList<>();
         for (String module : compilation.modules()) {
             if (!db.ask(new Output.ConstConstructions(module)).present()) {
-                CompileException bad = compilation.failure(db.allReports());
+                CompileException bad = compilation.failure();
                 if (bad != null) {
                     throw bad;
                 }
@@ -472,7 +472,7 @@ public final class Compiler {
         for (String module : compilation.modules()) {
             compilation.answerWarnings(module);
         }
-        warningsOut.addAll(compilation.warnings(db.allReports()));
+        warningsOut.addAll(compilation.warnings());
         if (!exampleFailures.isEmpty()) {
             throw CompileException.ofAllInSources(exampleFailures, exampleSources,
                     ExampleVerifier.legacySummary(exampleFailures));

--- a/souther-compiler/src/main/java/souther/compiler/check/Exposing.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Exposing.java
@@ -7,8 +7,10 @@ import souther.compiler.diag.msg.ImportMessage;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -56,7 +58,19 @@ public final class Exposing {
      * {@code let}.
      */
     public record Checked(Ast.Module module, Map<String, ValueName.Stdlib> exposed,
-                          List<Diagnostic> conflicts) {}
+                          List<Diagnostic> conflicts) {
+
+        /**
+         * Copied, because this is an answer a compilation remembers and an answer it remembers is a
+         * value. What decides whether the work that read one has to be done again is whether the new
+         * answer equals the old, so a caller able to reach into a remembered one could change what
+         * every reader of it sees without anything being asked again.
+         */
+        public Checked {
+            exposed = Collections.unmodifiableMap(new LinkedHashMap<>(exposed));
+            conflicts = List.copyOf(conflicts);
+        }
+    }
 
     /**
      * {@code module} read for its library imports: checked, dropped, and what they brought in.

--- a/souther-compiler/src/main/java/souther/compiler/check/Exposing.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Exposing.java
@@ -18,14 +18,19 @@ import java.util.Set;
  * module reaches the library either qualified ({@code List.map}) or by importing the names it wants
  * — {@code import List ( map, filter )} — after which it may write them bare.
  *
- * <p>What the imports bring in is answered as a table ({@link #read}) and nothing in the
- * module is rewritten. A name written bare stays written bare, and what it means where it is written
- * is settled once, by resolution, with the bindings in force — an import is the last thing consulted
- * and a binding in force wins over it. A declaration of that name does not shadow it: the two are a
- * conflict, refused on the import line, and the declaration standing as the name's meaning after
- * that is what recovery does with a module that will not be emitted. The
- * {@code import List ( ... )} lines are then dropped ({@link #withoutLibraryImports}), having been
- * checked.
+ * <p>What the imports bring in is answered as a table and nothing in the module is rewritten. A name
+ * written bare stays written bare, and what it means where it is written is settled once, by
+ * resolution, with the bindings in force — an import is the last thing consulted and a binding in
+ * force wins over it. A declaration of that name does not shadow it: the two are a conflict, refused
+ * on the import line, and the declaration standing as the name's meaning after that is what recovery
+ * does with a module that will not be emitted. The {@code import List ( ... )} lines are then
+ * dropped, having been checked.
+ *
+ * <p>The table and the module without those lines are one answer ({@link #check}), because a module
+ * that has had them dropped is unreadable without it. There is no way to take the second and leave
+ * the first: a reader of a module off the class path did exactly that, and an invariant that called
+ * a name its module imported bare then resolved against nothing in every project but the one that
+ * wrote it.
  *
  * <p>It mirrors Elm's {@code import List exposing (map)}: the qualified access always works, and the
  * import merely lets a name be written without its qualifier. A name exposed from two libraries at
@@ -36,8 +41,13 @@ public final class Exposing {
     private Exposing() {}
 
     /**
-     * What the imports bring in, the imports that are not the library's, and the import lines that
-     * name something this module already declares.
+     * A module with its {@code import List ( ... )} lines dropped, what those lines brought in, and
+     * the ones that name something the module already declares.
+     *
+     * <p>One value, because the first two are one fact. The module no longer says what its bare
+     * names mean and the table is the only thing that does, so a caller holding the module holds the
+     * table with it — wherever that module travels, and whether it was read from a source or off the
+     * class path.
      *
      * <p>A collision is answered rather than thrown because it is one module's mistake and not a
      * reason to stop reading. Thrown, it escaped the question that asked for this module and took
@@ -45,13 +55,24 @@ public final class Exposing {
      * reading this file" for the whole workspace while the author was part-way through writing a
      * {@code let}.
      */
-    public record Validated(Map<String, ValueName.Stdlib> exposed, List<Ast.Import> kept,
-                            List<Diagnostic> conflicts) {}
+    public record Checked(Ast.Module module, Map<String, ValueName.Stdlib> exposed,
+                          List<Diagnostic> conflicts) {}
 
-    /** Both answers at once, for a reader that wants them both and should ask once. */
-    public static Validated read(Ast.Module module) {
-        return validate(module);
+    /**
+     * {@code module} read for its library imports: checked, dropped, and what they brought in.
+     *
+     * <p>Nothing in the module is rewritten. A name written bare is still written bare, and what it
+     * means is one question asked in one place — resolution, against {@link Checked#exposed}.
+     */
+    public static Checked check(Ast.Module module) {
+        Validated validated = validate(module);
+        return new Checked(withoutLibraryImports(module, validated.kept()), validated.exposed(),
+                validated.conflicts());
     }
+
+    /** What {@link #validate} answers, before the module is rebuilt around it. */
+    private record Validated(Map<String, ValueName.Stdlib> exposed, List<Ast.Import> kept,
+                             List<Diagnostic> conflicts) {}
 
     /**
      * The library names an import brings in, with the three things an import can get wrong reported:
@@ -117,14 +138,7 @@ public final class Exposing {
         return new Validated(exposed, kept, conflicts);
     }
 
-    /**
-     * {@code module} with its {@code import List ( ... )} lines dropped, having checked them.
-     *
-     * <p>What they brought in is answered by {@link #read} and settled where the bindings
-     * are known. Nothing in the module is rewritten here: a name written bare is still written bare,
-     * and what it means is one question asked in one place.
-     */
-    public static Ast.Module withoutLibraryImports(Ast.Module module, List<Ast.Import> kept) {
+    private static Ast.Module withoutLibraryImports(Ast.Module module, List<Ast.Import> kept) {
         if (kept.size() == module.imports().size()) {
             return module;
         }

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -57,11 +57,11 @@ public final class Bodies {
 
         @Override
         public Answer<Set<String>> compute(Db db) {
-            Front.FromPath.Of path = db.ask(new Front.FromPath()).value();
-            if (path != null && path.injected().containsKey(name)) {
+            Front.FromPath.OnThePath onThePath = Front.onThePath(db, name);
+            if (onThePath != null) {
                 // A module off the path published which of its behaviors are injection targets,
                 // because the fn that decides is not published with it.
-                return Answer.of(path.injected().get(name));
+                return Answer.of(onThePath.injectedBehaviors());
             }
             Ast.Module m = db.ask(new Front.Available(name)).value();
             if (m == null) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -446,8 +446,10 @@ public final class Compilation {
      *
      * <p>Where a report goes is the report's to say, not this method's: an error in an imported
      * module lands on that module's document however far away it was asked for, and a failing
-     * example row lands on the file the row was written in. A report about something the caller does
-     * not have — a module read off the path — has nowhere to go and is left out.
+     * example row lands on the file the row was written in. A report about a module the caller has
+     * no document for is said where that module was reached from, which is a document the caller
+     * does have ({@link #reports()}) — left as it was found it would have nowhere to go, and a
+     * compile that emitted nothing would publish nothing to say why.
      *
      * <p>This is the only place one report becomes several entries. A problem written in two files is
      * said in both, so an author editing either is told, and each entry carries the source its
@@ -461,7 +463,7 @@ public final class Compilation {
         for (String id : sourceIds()) {
             byId.put(id, new ArrayList<>());
         }
-        for (Db.Found found : db.allReports()) {
+        for (Db.Found found : reports()) {
             String primary = locatedSourceIdOf(found);
             for (String id : publishSourceIdsOf(found)) {
                 List<Located> on = byId.get(id);
@@ -473,6 +475,73 @@ public final class Compilation {
         Map<String, List<Located>> published = new LinkedHashMap<>();
         byId.forEach((id, found) -> published.put(id, List.copyOf(found)));
         return published;
+    }
+
+    /**
+     * Everything this compilation found, as a reader may be shown it.
+     *
+     * <p>The one set. What a terminal is told and what an editor is told are the same problems said
+     * the same way, so both read this and neither reads {@link Db#allReports()} — two readings of one
+     * set is how a failure came to stop a build on the command line and leave an editor showing a
+     * clean file.
+     *
+     * <p>What a reading adds is where a report may be sent. A question about a module read off the
+     * class path is answered against text this compile reassembled from what the module published,
+     * and a report it finds carries a coordinate in that text: a line and a column of a file nobody
+     * holds. Filed as it stands, it lands wherever those numbers happen to fall in the file the
+     * author is looking at, or nowhere at all. So it is said at the nearest place on the way to that
+     * module a source of this compilation writes — the {@code import} line naming it, or the one
+     * naming whichever dependency led there — with the code's own home named rather than pointed at
+     * ({@link Diagnostic#reachedFrom}).
+     */
+    public List<Db.Found> reports() {
+        List<Db.Found> reports = new ArrayList<>();
+        for (Db.Found found : db.allReports()) {
+            reports.add(citable(found));
+        }
+        return reports;
+    }
+
+    /**
+     * {@code found} where a reader can be sent to it — itself, for the reports whose coordinate was
+     * read from a source this compile holds.
+     *
+     * <p>Asked of the module the question was about and not of the coordinate alone. A body copied
+     * out of a module off the path is already given the call site it was spliced into
+     * ({@link souther.compiler.diag.WrittenAt}), so a coordinate left naming no source is one read
+     * from a declaration this compile never had a file for.
+     *
+     * <p>The English a raised report carried is dropped with the move. It was rendered with the old
+     * coordinate written into it, and a message that says one place beside a caret at another is the
+     * defect twice.
+     */
+    private Db.Found citable(Db.Found found) {
+        SourcePos at = found.report().diagnostic().pos();
+        if (at == null || at.sourceId() != null || found.module() == null) {
+            return found;
+        }
+        Front.FromPath.OnThePath onThePath = Front.onThePath(db, found.module());
+        if (onThePath == null || onThePath.reachedFrom() == null) {
+            return found;
+        }
+        return new Db.Found(found.module(), found.sourceId(), Report.saidAt(
+                found.report().diagnostic().reachedFrom(onThePath.reachedFrom(), found.module()),
+                found.report().delivery()));
+    }
+
+    /** The one failure these sources have, or null when they have none. */
+    public CompileException failure() {
+        return failure(reports());
+    }
+
+    /**
+     * The failure among {@link #structuralReports()}, or null when there is none — what a caller
+     * that stops before any module is looked at asks for.
+     *
+     * <p>Its own method so that {@link #failure(List)} can stay private.
+     */
+    public CompileException structuralFailure() {
+        return failure(structuralReports());
     }
 
     /**
@@ -512,8 +581,12 @@ public final class Compilation {
      * positions, and a secondary diagnostic is the checker's to withhold where it should not be said
      * at all. This decides how the errors are presented; whether one of them should have been
      * reported is the checker's own question.
+     *
+     * <p>Not public. The reports a surface reads are the ones {@link #reports()} answers, and a
+     * caller able to pass a list of its own is one able to pass the set before it was read for where
+     * a reader can be sent. What is left inside this package is this ordering rule and its test.
      */
-    public CompileException failure(List<Db.Found> found) {
+    CompileException failure(List<Db.Found> found) {
         List<Db.Found> errors = new ArrayList<>();
         for (Db.Found f : found) {
             if (f.report().isError()) {
@@ -651,8 +724,9 @@ public final class Compilation {
      * one thing to be told about on a terminal; the second telling is what an editor needs, and that
      * is {@link #diagnostics()}.
      */
-    public List<Located> warnings(List<Db.Found> found) {
+    public List<Located> warnings() {
         List<Located> warnings = new ArrayList<>();
+        List<Db.Found> found = reports();
         for (Db.Found f : found) {
             if (!f.report().isError()) {
                 warnings.add(new Located(f.report().diagnostic(), sourceIdOf(f)));
@@ -669,8 +743,9 @@ public final class Compilation {
      * already read past it, and showing a reader one error beside an account of everything else
      * would leave them to wonder what the rest of the errors were.
      */
-    public List<Located> errors(List<Db.Found> found) {
+    public List<Located> errors() {
         List<Located> errors = new ArrayList<>();
+        List<Db.Found> found = reports();
         for (Db.Found f : found) {
             if (f.report().isError()) {
                 errors.add(new Located(f.report().diagnostic(), sourceIdOf(f)));

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -525,38 +525,26 @@ public final class Compilation {
      * ({@link souther.compiler.diag.WrittenAt}), so a coordinate left naming no source is one read
      * from a declaration this compile never had a file for.
      *
-     * <p>The English a raised report carried is dropped with the move. It was rendered with the old
-     * coordinate written into it, and a message that says one place beside a caret at another is the
-     * defect twice.
+     * <p>What a raised report carried as the text its pass threw it with is dropped with the move
+     * ({@link Report#legacyMessage}). That text was rendered with the old coordinate written into
+     * it, and a message naming one place beside a caret at another is the defect twice. The body of
+     * a {@link Diagnostic#literal} is not that and is not dropped: it is the whole of what such a
+     * diagnostic says, there being no message under it to render again.
      */
     private Db.Found citable(Db.Found found) {
         Diagnostic said = found.report().diagnostic();
-        Diagnostic sendable = reachable(said, found.module());
-        return sendable == said ? found
-                : new Db.Found(found.module(), found.sourceId(),
-                        Report.saidAt(sendable, found.report().delivery()));
-    }
-
-    /**
-     * {@code said} where a reader can be sent to every place it points at.
-     *
-     * <p>Its caret first, where that was read from a text this compile has no file for. Then its
-     * second regions, whatever its caret turned out to be: a body spliced in from out of sight is
-     * given the call site, so a report about one has a caret a reader can be sent to and may still
-     * carry a label built over the body it was copied from — pointed at a file that does not have
-     * it, which is the same defect a region over.
-     */
-    private Diagnostic reachable(Diagnostic said, String module) {
         SourcePos at = said.pos();
-        if (at == null || at.sourceId() != null || module == null) {
-            return said.saidOnlyWhereAReaderCanBeSent();
+        if (at == null || at.sourceId() != null || found.module() == null) {
+            return found;
         }
-        Front.FromPath.OnThePath onThePath = Front.onThePath(db, module);
+        Front.FromPath.OnThePath onThePath = Front.onThePath(db, found.module());
         if (onThePath == null || onThePath.reachedFrom().isEmpty()) {
-            return said.saidOnlyWhereAReaderCanBeSent();
+            return found;
         }
-        return said.reachedFrom(onThePath.reachedFrom(), module,
-                new ModuleMessage.ItIsReachedFromHereToo());
+        return new Db.Found(found.module(), found.sourceId(), Report.saidAt(
+                said.reachedFrom(onThePath.reachedFrom(), found.module(),
+                        new ModuleMessage.ItIsReachedFromHereToo()),
+                found.report().delivery()));
     }
 
     /** The one failure these sources have, or null when they have none. */

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -6,6 +6,7 @@ import souther.compiler.check.Symbols;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.LabeledRegion;
+import souther.compiler.diag.msg.ModuleMessage;
 import souther.compiler.diag.Located;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.meta.ModulePath;
@@ -260,7 +261,9 @@ public final class Compilation {
     /**
      * Answers everything there is to answer about these sources — the classes, the constant
      * constructions, the examples — without deciding anything about what was found. A caller that
-     * wants every problem at once asks for this and then reads {@link Db#allReports()}.
+     * wants every problem at once asks for this and then reads {@link #reports()}, or one of the
+     * readings of it: {@link #failure()}, {@link #errors()}, {@link #warnings()},
+     * {@link #diagnostics()}.
      */
     public void answerEverything() {
         structuralReports();
@@ -495,12 +498,23 @@ public final class Compilation {
      * ({@link Diagnostic#reachedFrom}).
      */
     public List<Db.Found> reports() {
-        List<Db.Found> reports = new ArrayList<>();
+        // Read again for repeats, because reading for where a reader can be sent is what makes two
+        // of them. Coordinates in a module's own reassembled text tell apart two findings this
+        // compilation collected separately; said at the place that module was reached from, both
+        // are one sentence at one caret, and an author shown it twice has nothing to tell them
+        // apart by either.
+        Map<Repeat, Db.Found> reports = new LinkedHashMap<>();
         for (Db.Found found : db.allReports()) {
-            reports.add(citable(found));
+            Db.Found said = citable(found);
+            reports.putIfAbsent(new Repeat(said.module(), locatedSourceIdOf(said),
+                    said.report().problem()), said);
         }
-        return reports;
+        return new ArrayList<>(reports.values());
     }
+
+    /** One thing said once: what {@link Db#allReports()} tells apart before a report is read for
+     *  where it may be said, asked again of what that reading left. */
+    private record Repeat(String module, String sourceId, Diagnostic.Identity problem) {}
 
     /**
      * {@code found} where a reader can be sent to it — itself, for the reports whose coordinate was
@@ -516,17 +530,33 @@ public final class Compilation {
      * defect twice.
      */
     private Db.Found citable(Db.Found found) {
-        SourcePos at = found.report().diagnostic().pos();
-        if (at == null || at.sourceId() != null || found.module() == null) {
-            return found;
+        Diagnostic said = found.report().diagnostic();
+        Diagnostic sendable = reachable(said, found.module());
+        return sendable == said ? found
+                : new Db.Found(found.module(), found.sourceId(),
+                        Report.saidAt(sendable, found.report().delivery()));
+    }
+
+    /**
+     * {@code said} where a reader can be sent to every place it points at.
+     *
+     * <p>Its caret first, where that was read from a text this compile has no file for. Then its
+     * second regions, whatever its caret turned out to be: a body spliced in from out of sight is
+     * given the call site, so a report about one has a caret a reader can be sent to and may still
+     * carry a label built over the body it was copied from — pointed at a file that does not have
+     * it, which is the same defect a region over.
+     */
+    private Diagnostic reachable(Diagnostic said, String module) {
+        SourcePos at = said.pos();
+        if (at == null || at.sourceId() != null || module == null) {
+            return said.saidOnlyWhereAReaderCanBeSent();
         }
-        Front.FromPath.OnThePath onThePath = Front.onThePath(db, found.module());
-        if (onThePath == null || onThePath.reachedFrom() == null) {
-            return found;
+        Front.FromPath.OnThePath onThePath = Front.onThePath(db, module);
+        if (onThePath == null || onThePath.reachedFrom().isEmpty()) {
+            return said.saidOnlyWhereAReaderCanBeSent();
         }
-        return new Db.Found(found.module(), found.sourceId(), Report.saidAt(
-                found.report().diagnostic().reachedFrom(onThePath.reachedFrom(), found.module()),
-                found.report().delivery()));
+        return said.reachedFrom(onThePath.reachedFrom(), module,
+                new ModuleMessage.ItIsReachedFromHereToo());
     }
 
     /** The one failure these sources have, or null when they have none. */

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -2,6 +2,7 @@ package souther.compiler.query;
 
 import souther.compiler.check.Prelude;
 import souther.compiler.ast.Ast;
+import souther.compiler.ast.WrittenName;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.msg.ModuleMessage;
@@ -191,21 +192,28 @@ public final class Front {
     }
 
     /**
-     * One module as its source declared it, with the standard-library {@code exposing} lines already
-     * rewritten and its name checked against the reserved namespace.
+     * One module a source declared, read for its standard-library imports: the module without those
+     * lines and what they brought in, together, with its name checked against the reserved
+     * namespace.
      *
-     * <p>The rows of every {@code examples for} file naming it are appended here, so a module's
-     * examples are its examples wherever they were written. Which file a row came from is
-     * {@link Names.Examples}' business, not this one's.
+     * <p>Both halves from one reading. What a bare name means is decided against the table, and the
+     * module the table is about is the one the rows of every {@code examples for} file naming it
+     * have joined — a value an attached file declares collides with an import of that spelling the
+     * same way one in the model file does. Read a second time from the model file alone, the table
+     * would answer for a module nothing else in this compilation holds.
+     *
+     * <p>The rows themselves join here for the same reason: a module's examples are its examples
+     * wherever they were written. Which file a row came from is {@link Names.Examples}' business,
+     * not this one's.
      */
-    public record Exposed(String name) implements Key<Ast.Module> {
+    public record Checked(String name) implements Key<Exposing.Checked> {
         @Override
         public String module() {
             return name;
         }
 
         @Override
-        public Answer<Ast.Module> compute(Db db) {
+        public Answer<Exposing.Checked> compute(Db db) {
             Layout.Of layout = db.ask(new Layout()).value();
             if (layout == null) {
                 return Answer.absent();
@@ -232,19 +240,18 @@ public final class Front {
             // read here is still the model file's lines.
             Ast.Module joined = withAttachedRows(db, raw, layout.exampleFilesOf()
                     .getOrDefault(name, List.of()));
-            Exposing.Validated imports = Exposing.read(joined);
-            Ast.Module whole = Exposing.withoutLibraryImports(joined, imports.kept());
-            if (imports.conflicts().isEmpty()) {
-                return Answer.of(whole);
+            Exposing.Checked checked = Exposing.check(joined);
+            if (checked.conflicts().isEmpty()) {
+                return Answer.of(checked);
             }
             // A library import naming something this module declares. Reported here because this is
             // where the import lines are read, and reported rather than raised so the rest of the
             // module — and every other file beside it — is still read and still answers.
             List<Report> reports = new ArrayList<>();
-            for (Diagnostic conflict : imports.conflicts()) {
+            for (Diagnostic conflict : checked.conflicts()) {
                 reports.add(Report.of(conflict));
             }
-            return Answer.of(whole, reports);
+            return Answer.of(checked, reports);
         }
 
         /**
@@ -292,6 +299,35 @@ public final class Front {
     }
 
     /**
+     * One module as its source declared it, with the standard-library {@code exposing} lines already
+     * dropped.
+     *
+     * <p>The half of {@link Checked} that a reader walking declarations wants. What those lines
+     * brought in is the other half and is asked for as {@link LibraryNames}: nearly everything here
+     * reads the module and would be rebuilt by an edit to any import line if it held the table too.
+     * Neither half is computed twice — both are projections of the one reading.
+     *
+     * <p>What the reading found comes with it. Asking for a module is how a reader finds out whether
+     * reading it went wrong ({@link Names.Sound}), and a projection that answered the module and
+     * kept the reports to itself would say a module with a refused import line was read cleanly.
+     * The reports are the same reports, so a compilation collecting them sees one of each.
+     */
+    public record Exposed(String name) implements Key<Ast.Module> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Ast.Module> compute(Db db) {
+            Answer<Exposing.Checked> checked = db.ask(new Checked(name));
+            return checked.present()
+                    ? Answer.of(checked.value().module(), checked.reports())
+                    : Answer.absent(checked.reports());
+        }
+    }
+
+    /**
      * The modules this compilation reaches that no source declares, read off the path. A module
      * found there brings its own reaches with it, so a dependency of a dependency arrives too.
      *
@@ -300,28 +336,52 @@ public final class Front {
      */
     public record FromPath() implements Key<FromPath.Of> {
 
-        public record Of(Map<String, Ast.Module> modules, Map<String, Set<String>> injected) {}
+        /**
+         * One module off the path, and everything about it this compilation cannot work out again
+         * from the module alone.
+         *
+         * <p>One record and not a map apiece. Each of these is a fact about the module that was lost
+         * on the way in — the injection targets because no {@code let} was published, the library
+         * names because the lines that carried them are dropped once read, where it was reached
+         * because a source of this compile is the only place a reader can be sent. A second map is a
+         * second place to remember to fill, and the one that was not filled is what left an
+         * invariant's bare names denoting nothing.
+         *
+         * @param reachedFrom the nearest place in a source of this compilation on the way to this
+         *        module: the import line that names it, or the one naming whichever module off the
+         *        path led here. Null only where nothing this compile can quote reached it.
+         */
+        public record OnThePath(Ast.Module module, Set<String> injectedBehaviors,
+                                Map<String, ValueName.Stdlib> libraryNames, SourcePos reachedFrom) {}
+
+        public record Of(Map<String, OnThePath> modules) {}
 
         @Override
         public Answer<Of> compute(Db db) {
             Layout.Of layout = db.ask(new Layout()).value();
             ModulePath path = db.ask(new Path()).value();
             if (layout == null || path == null) {
-                return Answer.of(new Of(Map.of(), Map.of()));
+                return Answer.of(new Of(Map.of()));
             }
             PublishedModule.Classes classes = path.declarations();
-            Map<String, Ast.Module> found = new LinkedHashMap<>();
-            Map<String, Set<String>> injected = new LinkedHashMap<>();
+            Map<String, OnThePath> found = new LinkedHashMap<>();
             List<Report> reports = new ArrayList<>();
             // What is waiting to be read, and — for one a module off the path needs — which module
             // needs it, so an incomplete path is reported as that rather than as an import nobody
             // wrote.
             Deque<String> pending = new ArrayDeque<>();
             Map<String, String> neededBy = new LinkedHashMap<>();
+            // Where a source of this compile named each of them. A module reached only through
+            // another off the path inherits that one's place: the import line naming the dependency
+            // is the nearest thing a reader here holds, and there is no line naming the rest.
+            Map<String, SourcePos> reachedFrom = new LinkedHashMap<>();
             for (String declared : layout.idOfModule().keySet()) {
                 Ast.Module m = db.ask(new Exposed(declared)).value();
                 if (m != null) {
-                    pending.addAll(reaches(m));
+                    reaches(m).forEach((reach, where) -> {
+                        reachedFrom.putIfAbsent(reach, where);
+                        pending.add(reach);
+                    });
                 }
             }
             Set<String> tried = new HashSet<>();
@@ -345,16 +405,19 @@ public final class Front {
                     reports.add(reserved);
                     continue;
                 }
-                Ast.Module m = Exposing.withoutLibraryImports(published.module(),
-                        Exposing.read(published.module()).kept());
-                found.put(name, m);
-                injected.put(name, published.injectedBehaviors());
-                for (String reach : reaches(m)) {
+                Exposing.Checked checked = Exposing.check(published.module());
+                SourcePos here = reachedFrom.get(name);
+                found.put(name, new OnThePath(checked.module(), published.injectedBehaviors(),
+                        checked.exposed(), here));
+                for (String reach : reaches(checked.module()).keySet()) {
                     neededBy.putIfAbsent(reach, name);
+                    if (here != null) {
+                        reachedFrom.putIfAbsent(reach, here);
+                    }
                     pending.add(reach);
                 }
             }
-            return Answer.of(new Of(Ordered.map(found), Ordered.map(injected)), reports);
+            return Answer.of(new Of(Ordered.map(found)), reports);
         }
     }
 
@@ -378,9 +441,8 @@ public final class Front {
             if (exposed.present()) {
                 return Answer.of(exposed.value());
             }
-            FromPath.Of path = db.ask(new FromPath()).value();
-            Ast.Module fromPath = path == null ? null : path.modules().get(name);
-            return fromPath == null ? Answer.absent() : Answer.of(fromPath);
+            FromPath.OnThePath fromPath = onThePath(db, name);
+            return fromPath == null ? Answer.absent() : Answer.of(fromPath.module());
         }
     }
 
@@ -421,8 +483,10 @@ public final class Front {
     /**
      * The library names a module's imports let it write bare, keyed by the bare spelling.
      *
-     * <p>Read from the module as its source declared it, because {@link Exposed} drops the import
-     * lines once it has checked them: what they brought in outlives the lines themselves.
+     * <p>Asked of every module this compilation has and not only of the ones a source declared. The
+     * import lines are dropped once checked, so what they brought in outlives them and has to be
+     * carried; a module off the path carries it the same way, and answering an empty table there
+     * left every bare name in a published invariant denoting nothing.
      */
     public record LibraryNames(String name) implements Key<Map<String, ValueName.Stdlib>> {
         @Override
@@ -432,24 +496,20 @@ public final class Front {
 
         @Override
         public Answer<Map<String, ValueName.Stdlib>> compute(Db db) {
-            Layout.Of layout = db.ask(new Layout()).value();
-            if (layout == null) {
-                return Answer.absent();
+            Answer<Exposing.Checked> checked = db.ask(new Checked(name));
+            if (checked.present()) {
+                return Answer.of(Ordered.map(checked.value().exposed()));
             }
-            String id = layout.idOfModule().get(name);
-            if (id == null) {
-                return Answer.of(Map.of());   // read from the path, where the lines are already gone
-            }
-            Answer<CstFrontend.Parsed> parsed = db.ask(new Parsed(id));
-            if (!parsed.present()) {
-                return Answer.absent();
-            }
-            try {
-                return Answer.of(Ordered.map(Exposing.read(parsed.value().module()).exposed()));
-            } catch (CompileException e) {
-                return Answer.absent(e);   // reported where the import is checked
-            }
+            FromPath.OnThePath onThePath = onThePath(db, name);
+            return onThePath == null ? Answer.absent()
+                    : Answer.of(Ordered.map(onThePath.libraryNames()));
         }
+    }
+
+    /** What the path carries for {@code name}, or null when no module of that name came off it. */
+    static FromPath.OnThePath onThePath(Db db, String name) {
+        FromPath.Of path = db.ask(new FromPath()).value();
+        return path == null ? null : path.modules().get(name);
     }
 
     public record Exposes(String name) implements Key<Set<String>> {
@@ -485,8 +545,8 @@ public final class Front {
         public Answer<Set<String>> compute(Db db) {
             Ast.Module m = db.ask(new Exposed(name)).value();
             if (m == null) {
-                FromPath.Of path = db.ask(new FromPath()).value();
-                m = path == null ? null : path.modules().get(name);
+                FromPath.OnThePath fromPath = onThePath(db, name);
+                m = fromPath == null ? null : fromPath.module();
             }
             return m == null ? Answer.absent() : Answer.of(Names.behaviorNames(m));
         }
@@ -800,18 +860,20 @@ public final class Front {
      * reference needs an import line, so reading only the import lines would leave a module it
      * reaches unread.
      */
-    static Set<String> reaches(Ast.Module m) {
-        Set<String> names = new LinkedHashSet<>();
+    static Map<String, SourcePos> reaches(Ast.Module m) {
+        Map<String, SourcePos> names = new LinkedHashMap<>();
         Map<String, String> aliases = new HashMap<>();
         for (Ast.Import imp : m.imports()) {
-            names.add(imp.module());
+            names.putIfAbsent(imp.module(), imp.pos());
             if (imp.alias() != null) {
                 aliases.put(imp.alias(), imp.module());
             }
         }
-        List<String> written = new ArrayList<>();
+        List<WrittenName> written = new ArrayList<>();
         for (Ast.TypeRef ref : Names.typeRefs(m)) {
-            written.add(ref.name());
+            if (ref.written() != null) {
+                written.add(ref.written());
+            }
         }
         for (Ast.BehaviorDef b : m.behaviors()) {
             List<Ast.Var> named = switch (b) {
@@ -819,14 +881,14 @@ public final class Front {
                 case Ast.SpecBehavior spec -> spec.dependsOn();
             };
             for (Ast.Var ref : named) {
-                written.add(ref.name());
+                written.add(ref.written());
             }
         }
-        for (String name : written) {
-            int dot = name.lastIndexOf('.');
+        for (WrittenName ref : written) {
+            int dot = ref.canonical().lastIndexOf('.');
             if (dot > 0) {
-                String qualifier = name.substring(0, dot);
-                names.add(aliases.getOrDefault(qualifier, qualifier));
+                String qualifier = ref.canonical().substring(0, dot);
+                names.putIfAbsent(aliases.getOrDefault(qualifier, qualifier), ref.pos());
             }
         }
         names.remove(m.name());

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -368,14 +368,22 @@ public final class Front {
             }
         }
 
-        public record Of(Map<String, OnThePath> modules) {}
+        /**
+         * @param modules the ones this compilation may read declarations from
+         * @param refused the ones it will not, and knows are there all the same — a module that
+         *        took a name no module may take. Which of those two a name is settles two different
+         *        questions, and answering only the first made a module that is on the path and
+         *        refused come back as one nobody has heard of: the author was told both that it took
+         *        a reserved name and that there is no such module.
+         */
+        public record Of(Map<String, OnThePath> modules, Set<String> refused) {}
 
         @Override
         public Answer<Of> compute(Db db) {
             Layout.Of layout = db.ask(new Layout()).value();
             ModulePath path = db.ask(new Path()).value();
             if (layout == null || path == null) {
-                return Answer.of(new Of(Map.of()));
+                return Answer.of(new Of(Map.of(), Set.of()));
             }
             // Read the graph, work out where each of its modules is reached from, and only then say
             // anything. Each of the three needs the one before it finished: a module is read once
@@ -468,7 +476,8 @@ public final class Front {
                                     new ModuleMessage.ItIsReachedFromHereToo())));
                 }
             }
-            return Answer.of(new Of(Ordered.map(found)), reports);
+            return Answer.of(new Of(Ordered.map(found), Ordered.set(refused.keySet())),
+                    reports);
         }
     }
 
@@ -935,7 +944,15 @@ public final class Front {
         }
     }
 
-    /** Every module name this compilation knows — declared by a source or read off the path. */
+    /**
+     * Every module name this compilation knows — declared by a source, or read off the path whether
+     * or not it may be used.
+     *
+     * <p>Knowing a name and being able to read what it declares are two questions, and this is the
+     * first. An import of a module the path holds and this compilation refuses is a mistake about
+     * what that module is called itself, not about whether there is any such thing; told the second
+     * as well, an author is left with two reports that cannot both be true.
+     */
     public record ModuleNames() implements Key<Set<String>> {
         @Override
         public Answer<Set<String>> compute(Db db) {
@@ -947,6 +964,7 @@ public final class Front {
             }
             if (path != null) {
                 names.addAll(path.modules().keySet());
+                names.addAll(path.refused());
             }
             return Answer.of(Ordered.set(names));
         }

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -357,7 +357,16 @@ public final class Front {
          */
         public record OnThePath(Ast.Module module, Set<String> injectedBehaviors,
                                 Map<String, ValueName.Stdlib> libraryNames,
-                                List<SourcePos> reachedFrom) {}
+                                List<SourcePos> reachedFrom) {
+
+            /** Copied, for the reason {@link Exposing.Checked} is: this is remembered, and what is
+             *  remembered is a value. */
+            public OnThePath {
+                injectedBehaviors = Ordered.set(injectedBehaviors);
+                libraryNames = Ordered.map(libraryNames);
+                reachedFrom = List.copyOf(reachedFrom);
+            }
+        }
 
         public record Of(Map<String, OnThePath> modules) {}
 
@@ -381,6 +390,9 @@ public final class Front {
             // module off the path reaches in turn.
             Map<String, List<SourcePos>> named = new LinkedHashMap<>();
             Map<String, List<String>> edges = new LinkedHashMap<>();
+            // The ones this compilation will not have, whatever the path holds: a module that took a
+            // name no module may take. On the path and refused, which is not the same as absent.
+            Map<String, Diagnostic> refused = new LinkedHashMap<>();
             Deque<String> pending = new ArrayDeque<>();
             for (String declared : layout.idOfModule().keySet()) {
                 Ast.Module m = db.ask(new Exposed(declared)).value();
@@ -403,10 +415,13 @@ public final class Front {
                 if (published == null) {
                     continue;   // absent; which of its importers minds is worked out below
                 }
-                Report reserved = reservedNamespace(published.module().name(),
+                Diagnostic reserved = reservedNamespaceTaken(published.module().name(),
                         published.module().pos());
                 if (reserved != null) {
-                    reports.add(reserved);
+                    // Refused, and said once the graph is known — like anything else found about a
+                    // module off the path, and for the same reason: this is the only producer here
+                    // whose report was left where the module wrote it, which is a file nobody holds.
+                    refused.put(name, reserved);
                     continue;
                 }
                 Exposing.Checked checked = Exposing.check(published.module());
@@ -426,10 +441,19 @@ public final class Front {
             // things to be told: they are missing from two places, an author reaching one of them
             // has not reached the other, and a report saying the first while pointing at an import
             // that arrives at the second says where the code is and is wrong about it.
+            for (Map.Entry<String, Diagnostic> taken : refused.entrySet()) {
+                List<SourcePos> here = reachedFrom.getOrDefault(taken.getKey(), List.of());
+                reports.add(Report.of(here.isEmpty() ? taken.getValue()
+                        : taken.getValue().reachedFrom(here, taken.getKey(),
+                                new ModuleMessage.ItIsReachedFromHereToo())));
+            }
             for (Map.Entry<String, List<String>> reaching : edges.entrySet()) {
                 List<SourcePos> here = reachedFrom.getOrDefault(reaching.getKey(), List.of());
                 for (String needed : reaching.getValue()) {
-                    if (read.containsKey(needed) || layout.idOfModule().containsKey(needed)
+                    // Refused is not absent: a module that took a name no module may take is on the
+                    // path, and has been told so.
+                    if (read.containsKey(needed) || refused.containsKey(needed)
+                            || layout.idOfModule().containsKey(needed)
                             || Prelude.isQualifier(needed)) {
                         continue;
                     }
@@ -986,16 +1010,30 @@ public final class Front {
     /** A module in the reserved namespace, or one named like a standard-library qualifier — or null
      * when the name is the module's to take. */
     static Report reservedNamespace(String name, SourcePos pos) {
+        Diagnostic said = reservedNamespaceTaken(name, pos);
+        return said == null ? null : Report.raised(said);
+    }
+
+    /**
+     * The same, as the diagnostic rather than the report — for a reader that has to say it somewhere
+     * other than where it was found.
+     *
+     * <p>A module off the class path is written where this compile has no file, so what it is told
+     * about is settled here and where it is said is settled once the graph is known. Read as a
+     * report it would carry the English it would have been thrown with, coordinate and all, which is
+     * the wrong text the moment the caret moves.
+     */
+    static Diagnostic reservedNamespaceTaken(String name, SourcePos pos) {
         if (name.equals(RESERVED) || name.startsWith(RESERVED + ".")) {
-            return Report.raised(Diagnostic.say(new ModuleMessage.TheModuleIsInTheReservedNamespace(name))
-                            .at(pos).build());
+            return Diagnostic.say(new ModuleMessage.TheModuleIsInTheReservedNamespace(name))
+                    .at(pos).build();
         }
         // The short qualifiers are how the standard library is reached (`List.map`, `import
         // String`); a user module by one of these names would shadow the library and could not be
         // imported.
         if (Prelude.isQualifier(name)) {
-            return Report.raised(Diagnostic.say(new ModuleMessage.TheModuleTakesTheStandardLibraryQualifier(name))
-                            .at(pos).build());
+            return Diagnostic.say(new ModuleMessage.TheModuleTakesTheStandardLibraryQualifier(name))
+                    .at(pos).build();
         }
         return null;
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -368,23 +368,27 @@ public final class Front {
             if (layout == null || path == null) {
                 return Answer.of(new Of(Map.of()));
             }
+            // Read the graph, work out where each of its modules is reached from, and only then say
+            // anything. Each of the three needs the one before it finished: a module is read once
+            // and a route to it may turn up long after, so a place written down as it was read is
+            // the places it had by then — with two dependencies of a project both reaching a third,
+            // which of them was read first decided whether the second's importer was told anything.
             PublishedModule.Classes classes = path.declarations();
-            Map<String, OnThePath> found = new LinkedHashMap<>();
+            Map<String, Exposing.Checked> read = new LinkedHashMap<>();
+            Map<String, Set<String>> injected = new LinkedHashMap<>();
             List<Report> reports = new ArrayList<>();
-            // What is waiting to be read, and — for one a module off the path needs — which module
-            // needs it, so an incomplete path is reported as that rather than as an import nobody
-            // wrote.
+            // Where a source of this compile names each module it reaches, and which modules each
+            // module off the path reaches in turn.
+            Map<String, List<SourcePos>> named = new LinkedHashMap<>();
+            Map<String, List<String>> edges = new LinkedHashMap<>();
             Deque<String> pending = new ArrayDeque<>();
-            Map<String, String> neededBy = new LinkedHashMap<>();
-            // Where a source of this compile named each of them. A module reached only through
-            // another off the path inherits that one's place: the import line naming the dependency
-            // is the nearest thing a reader here holds, and there is no line naming the rest.
-            Map<String, List<SourcePos>> reachedFrom = new LinkedHashMap<>();
             for (String declared : layout.idOfModule().keySet()) {
                 Ast.Module m = db.ask(new Exposed(declared)).value();
                 if (m != null) {
                     reaches(m).forEach((reach, where) -> {
-                        alsoReachedFrom(reachedFrom, reach, where == null ? List.of() : List.of(where));
+                        if (where != null) {
+                            named.computeIfAbsent(reach, k -> new ArrayList<>()).add(where);
+                        }
                         pending.add(reach);
                     });
                 }
@@ -392,26 +396,12 @@ public final class Front {
             Set<String> tried = new HashSet<>();
             while (!pending.isEmpty()) {
                 String name = pending.poll();
-                if (layout.idOfModule().containsKey(name) || found.containsKey(name)
-                        || !tried.add(name)) {
+                if (layout.idOfModule().containsKey(name) || !tried.add(name)) {
                     continue;
                 }
                 PublishedModule published = PublishedModule.read(name, classes);
                 if (published == null) {
-                    if (neededBy.containsKey(name) && !Prelude.isQualifier(name)) {
-                        // Said where the module that needs it was reached from, the same as anything
-                        // else found about a module off the path. This walk is one question about
-                        // the whole compilation, so it cannot name the module each of its reports is
-                        // about the way a question about one module does — it says so itself
-                        // instead, and a report that said neither reached no file at all.
-                        List<SourcePos> here = reachedFrom.getOrDefault(name, List.of());
-                        reports.add(Report.of(here.isEmpty()
-                                ? needs(name, neededBy.get(name))
-                                : needs(name, neededBy.get(name)).reachedFrom(here,
-                                        neededBy.get(name),
-                                        new ModuleMessage.ItIsReachedFromHereToo())));
-                    }
-                    continue;   // written in a source being compiled: still that import's own error
+                    continue;   // absent; which of its importers minds is worked out below
                 }
                 Report reserved = reservedNamespace(published.module().name(),
                         published.module().pos());
@@ -420,13 +410,38 @@ public final class Front {
                     continue;
                 }
                 Exposing.Checked checked = Exposing.check(published.module());
-                List<SourcePos> here = reachedFrom.getOrDefault(name, List.of());
-                found.put(name, new OnThePath(checked.module(), published.injectedBehaviors(),
-                        checked.exposed(), here));
-                for (String reach : reaches(checked.module()).keySet()) {
-                    neededBy.putIfAbsent(reach, name);
-                    alsoReachedFrom(reachedFrom, reach, here);
-                    pending.add(reach);
+                read.put(name, checked);
+                injected.put(name, published.injectedBehaviors());
+                List<String> reaches = List.copyOf(reaches(checked.module()).keySet());
+                edges.put(name, reaches);
+                pending.addAll(reaches);
+            }
+            Map<String, List<SourcePos>> reachedFrom = reachedFrom(named, edges);
+            Map<String, OnThePath> found = new LinkedHashMap<>();
+            read.forEach((name, checked) -> found.put(name, new OnThePath(checked.module(),
+                    injected.get(name), checked.exposed(),
+                    reachedFrom.getOrDefault(name, List.of()))));
+            // An incomplete path is one module needing another, and not a module being absent. Two
+            // dependencies of a project may each need a third that is not there, and those are two
+            // things to be told: they are missing from two places, an author reaching one of them
+            // has not reached the other, and a report saying the first while pointing at an import
+            // that arrives at the second says where the code is and is wrong about it.
+            for (Map.Entry<String, List<String>> reaching : edges.entrySet()) {
+                List<SourcePos> here = reachedFrom.getOrDefault(reaching.getKey(), List.of());
+                for (String needed : reaching.getValue()) {
+                    if (read.containsKey(needed) || layout.idOfModule().containsKey(needed)
+                            || Prelude.isQualifier(needed)) {
+                        continue;
+                    }
+                    // Said where the module that needs it was reached from — that being where the
+                    // import nobody here wrote is written. This walk is one question about the whole
+                    // compilation and cannot name the module each of its reports is about the way a
+                    // question about one module does, so it says so itself; a report that said
+                    // neither reached no file at all.
+                    reports.add(Report.of(here.isEmpty()
+                            ? needs(needed, reaching.getKey())
+                            : needs(needed, reaching.getKey()).reachedFrom(here, reaching.getKey(),
+                                    new ModuleMessage.ItIsReachedFromHereToo())));
                 }
             }
             return Answer.of(new Of(Ordered.map(found)), reports);
@@ -519,25 +534,53 @@ public final class Front {
     }
 
     /**
-     * {@code where} added to the places a source of this compilation reaches {@code module} from,
-     * each place once.
+     * Every place a source of this compilation reaches each module from: the lines that name it,
+     * and — for one no line here names — the lines naming whichever module off the path led there.
      *
-     * <p>A module reached through another off the path inherits that one's places: there is no line
-     * naming it anywhere a reader here can look, and the lines naming the dependency that led there
-     * are the nearest there are. Reached again by a different route, it keeps both — the two routes
-     * are two files whose authors each wrote an import that arrives at it.
+     * <p>Worked out over the whole graph rather than as it is walked. A module is read once and a
+     * route to it may be found after that, so a place written down when it was read is the places
+     * it had by then; where two dependencies of a project both reach a third, which of them was
+     * read first would decide whether the second's importer is told anything. The walk gathers what
+     * names what, and this answers.
+     *
+     * <p>A closure and not a step, for the same reason. What reaches a module reaches everything
+     * that module reaches, however far down, and each place is kept once — the answer grows and
+     * stops growing, whatever order the edges arrive in.
      */
-    private static void alsoReachedFrom(Map<String, List<SourcePos>> reachedFrom, String module,
-                                        List<SourcePos> where) {
-        if (where.isEmpty()) {
-            return;
-        }
-        List<SourcePos> places = reachedFrom.computeIfAbsent(module, k -> new ArrayList<>());
-        for (SourcePos one : where) {
-            if (!places.contains(one)) {
-                places.add(one);
+    private static Map<String, List<SourcePos>> reachedFrom(Map<String, List<SourcePos>> named,
+                                                            Map<String, List<String>> edges) {
+        Map<String, List<SourcePos>> places = new LinkedHashMap<>();
+        Deque<String> pending = new ArrayDeque<>();
+        named.forEach((module, where) -> {
+            if (alsoReachedFrom(places, module, where)) {
+                pending.add(module);
+            }
+        });
+        while (!pending.isEmpty()) {
+            String module = pending.poll();
+            List<SourcePos> here = List.copyOf(places.get(module));
+            for (String reach : edges.getOrDefault(module, List.of())) {
+                if (!reach.equals(module) && alsoReachedFrom(places, reach, here)) {
+                    pending.add(reach);
+                }
             }
         }
+        return places;
+    }
+
+    /** {@code where} added to the places {@code module} is reached from, each place once. Whether
+     *  any of them was new, which is what says there is anything further to carry on. */
+    private static boolean alsoReachedFrom(Map<String, List<SourcePos>> places, String module,
+                                           List<SourcePos> where) {
+        List<SourcePos> held = places.computeIfAbsent(module, k -> new ArrayList<>());
+        boolean added = false;
+        for (SourcePos one : where) {
+            if (!held.contains(one)) {
+                held.add(one);
+                added = true;
+            }
+        }
+        return added;
     }
 
     /** A module off the path needing one that is not there. */
@@ -910,6 +953,9 @@ public final class Front {
                 aliases.put(imp.alias(), imp.module());
             }
         }
+        // A type reference a pass wrote before resolution names nothing written anywhere, and has
+        // no name to read a qualifier off. A `>->` stage and a `depends on` are always names the
+        // author wrote, which is what an `Ast.Var` is.
         List<WrittenName> written = new ArrayList<>();
         for (Ast.TypeRef ref : Names.typeRefs(m)) {
             if (ref.written() != null) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -347,12 +347,17 @@ public final class Front {
          * second place to remember to fill, and the one that was not filled is what left an
          * invariant's bare names denoting nothing.
          *
-         * @param reachedFrom the nearest place in a source of this compilation on the way to this
-         *        module: the import line that names it, or the one naming whichever module off the
-         *        path led here. Null only where nothing this compile can quote reached it.
+         * @param reachedFrom every nearest place in a source of this compilation on the way to
+         *        this module: each {@code import} line that names it, or that names whichever
+         *        module off the path led here. Every one of them and not the first, because a
+         *        dependency two files import is reached by both and a report about it is one an
+         *        author editing either has to be told — an editor marking one file leaves the other
+         *        looking clean while the build fails. Empty only where nothing this compile can
+         *        quote reached it.
          */
         public record OnThePath(Ast.Module module, Set<String> injectedBehaviors,
-                                Map<String, ValueName.Stdlib> libraryNames, SourcePos reachedFrom) {}
+                                Map<String, ValueName.Stdlib> libraryNames,
+                                List<SourcePos> reachedFrom) {}
 
         public record Of(Map<String, OnThePath> modules) {}
 
@@ -374,12 +379,12 @@ public final class Front {
             // Where a source of this compile named each of them. A module reached only through
             // another off the path inherits that one's place: the import line naming the dependency
             // is the nearest thing a reader here holds, and there is no line naming the rest.
-            Map<String, SourcePos> reachedFrom = new LinkedHashMap<>();
+            Map<String, List<SourcePos>> reachedFrom = new LinkedHashMap<>();
             for (String declared : layout.idOfModule().keySet()) {
                 Ast.Module m = db.ask(new Exposed(declared)).value();
                 if (m != null) {
                     reaches(m).forEach((reach, where) -> {
-                        reachedFrom.putIfAbsent(reach, where);
+                        alsoReachedFrom(reachedFrom, reach, where == null ? List.of() : List.of(where));
                         pending.add(reach);
                     });
                 }
@@ -394,8 +399,17 @@ public final class Front {
                 PublishedModule published = PublishedModule.read(name, classes);
                 if (published == null) {
                     if (neededBy.containsKey(name) && !Prelude.isQualifier(name)) {
-                        reports.add(Report.of(Diagnostic.say(new ModuleMessage.AModuleItNeedsIsNotOnThePath(name, neededBy.get(name)))
-                                .hint(new ModuleMessage.AddItToThisProjectsDependencies(name)).build()));
+                        // Said where the module that needs it was reached from, the same as anything
+                        // else found about a module off the path. This walk is one question about
+                        // the whole compilation, so it cannot name the module each of its reports is
+                        // about the way a question about one module does — it says so itself
+                        // instead, and a report that said neither reached no file at all.
+                        List<SourcePos> here = reachedFrom.getOrDefault(name, List.of());
+                        reports.add(Report.of(here.isEmpty()
+                                ? needs(name, neededBy.get(name))
+                                : needs(name, neededBy.get(name)).reachedFrom(here,
+                                        neededBy.get(name),
+                                        new ModuleMessage.ItIsReachedFromHereToo())));
                     }
                     continue;   // written in a source being compiled: still that import's own error
                 }
@@ -406,14 +420,12 @@ public final class Front {
                     continue;
                 }
                 Exposing.Checked checked = Exposing.check(published.module());
-                SourcePos here = reachedFrom.get(name);
+                List<SourcePos> here = reachedFrom.getOrDefault(name, List.of());
                 found.put(name, new OnThePath(checked.module(), published.injectedBehaviors(),
                         checked.exposed(), here));
                 for (String reach : reaches(checked.module()).keySet()) {
                     neededBy.putIfAbsent(reach, name);
-                    if (here != null) {
-                        reachedFrom.putIfAbsent(reach, here);
-                    }
+                    alsoReachedFrom(reachedFrom, reach, here);
                     pending.add(reach);
                 }
             }
@@ -504,6 +516,35 @@ public final class Front {
             return onThePath == null ? Answer.absent()
                     : Answer.of(Ordered.map(onThePath.libraryNames()));
         }
+    }
+
+    /**
+     * {@code where} added to the places a source of this compilation reaches {@code module} from,
+     * each place once.
+     *
+     * <p>A module reached through another off the path inherits that one's places: there is no line
+     * naming it anywhere a reader here can look, and the lines naming the dependency that led there
+     * are the nearest there are. Reached again by a different route, it keeps both — the two routes
+     * are two files whose authors each wrote an import that arrives at it.
+     */
+    private static void alsoReachedFrom(Map<String, List<SourcePos>> reachedFrom, String module,
+                                        List<SourcePos> where) {
+        if (where.isEmpty()) {
+            return;
+        }
+        List<SourcePos> places = reachedFrom.computeIfAbsent(module, k -> new ArrayList<>());
+        for (SourcePos one : where) {
+            if (!places.contains(one)) {
+                places.add(one);
+            }
+        }
+    }
+
+    /** A module off the path needing one that is not there. */
+    private static Diagnostic needs(String needed, String module) {
+        return Diagnostic.say(new ModuleMessage.AModuleItNeedsIsNotOnThePath(needed, module))
+                .hint(new ModuleMessage.AddItToThisProjectsDependencies(needed))
+                .build();
     }
 
     /** What the path carries for {@code name}, or null when no module of that name came off it. */

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -954,8 +954,9 @@ public final class Front {
             }
         }
         // A type reference a pass wrote before resolution names nothing written anywhere, and has
-        // no name to read a qualifier off. A `>->` stage and a `depends on` are always names the
-        // author wrote, which is what an `Ast.Var` is.
+        // no name to read a qualifier off. A `>->` stage and a `depends on` have one whatever wrote
+        // them: `Ast.Var`'s constructor reads its name, so there is no such thing as one without —
+        // the two are asked differently because the two answer differently, not by oversight.
         List<WrittenName> written = new ArrayList<>();
         for (Ast.TypeRef ref : Names.typeRefs(m)) {
             if (ref.written() != null) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -853,7 +853,7 @@ public final class Names {
          *
          * <p>Read off the parsed source rather than off {@link Front.Available}, because the module
          * that arrives from there has had its standard-library import lines taken out
-         * ({@link souther.compiler.check.Exposing#withoutLibraryImports}) — an unused
+         * ({@link souther.compiler.check.Exposing#check}) — an unused
          * {@code import List ( fold )} would be invisible to a check that read the module. An
          * attached {@code examples for} file writes no imports, so the declaring source's lines are
          * all of them.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -423,6 +423,7 @@ module.the-module-takes-the-standard-library-qualifier=module `{module}` uses a 
 module.duplicate-module=Duplicate module `{module}`.
 module.a-module-it-needs-is-not-on-the-path=Module `{module}` needs `{needed}`, which is not on the path either.
 module.add-it-to-this-projects-dependencies=`{module}` is a dependency of a module you depend on. Add it to this project's dependencies.
+module.it-is-reached-from-here-too=This import reaches it too.
 module.the-module-is-compiled-here-and-on-the-path=Module `{module}` is compiled here and is also on the path.
 module.rename-it-or-drop-the-dependency=One name cannot stand for two modules. Rename this one, or drop the dependency that also provides `{module}`.
 module.the-module-was-compiled-by-another-souther=Module `{module}` was compiled by Souther {by}, which does not agree with this compiler about what an importing module may reach.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -418,6 +418,7 @@ module.the-module-takes-the-standard-library-qualifier=module `{module}` は標�
 module.duplicate-module=モジュール `{module}` が重複しています。
 module.a-module-it-needs-is-not-on-the-path=モジュール `{module}` は `{needed}` を必要としていますが、`{needed}` もパス上にありません。
 module.add-it-to-this-projects-dependencies=`{module}` は、依存しているモジュールがさらに依存しているものです。このプロジェクトの依存に足してください。
+module.it-is-reached-from-here-too=この import も同じところに到達しています。
 module.the-module-is-compiled-here-and-on-the-path=モジュール `{module}` はここでコンパイルされ、同時にパス上にもあります。
 module.rename-it-or-drop-the-dependency=1つの名前が2つのモジュールを指すことはできません。こちらをリネームするか、`{module}` を提供している依存を外してください。
 module.the-module-was-compiled-by-another-souther=モジュール `{module}` は Souther {by} でコンパイルされていて、import する側が何に触れてよいかについて、このコンパイラと一致していません。

--- a/souther-compiler/src/test/java/souther/compiler/ADependencyOnThePathIsCountedLikeAnyOtherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ADependencyOnThePathIsCountedLikeAnyOtherTest.java
@@ -182,7 +182,7 @@ class ADependencyOnThePathIsCountedLikeAnyOtherTest {
                 """), name -> null);
         compilation.answerEverything();
 
-        assertNull(compilation.failure(compilation.db().allReports()));
+        assertNull(compilation.failure());
         assertTrue(compilation.db()
                         .ask(new Output.EvaluationLinked("app.alone", Output.CoverageMode.NONE))
                         .value() != null,

--- a/souther-compiler/src/test/java/souther/compiler/AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest.java
@@ -148,6 +148,100 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
                 "a compile that emitted nothing said nothing about why");
     }
 
+    /**
+     * Every error reaches a file. What the command line stops for and what an editor marks are the
+     * same set, and a report that reached neither is one the author is never told about — the
+     * walk over the path is one question about the whole compilation and names no module of its
+     * own, so what it finds has to say where it is said.
+     *
+     * <p>Measured on the reports rather than on the classes. A compile that emits nothing and says
+     * nothing is what this looked like, but which of those is the defect is the second one: what a
+     * build produces is its own question, and one that legitimately produces no classes would make
+     * the first reading say this had been fixed.
+     */
+    @Test
+    void noErrorIsLeftWithNowhereToBeSaid() {
+        Compilation compilation = reading("""
+                module app.uses
+                import lib.held ( Held )
+
+                data Page = { held: Held }
+                """, held());
+
+        List<String> unreachable = new ArrayList<>();
+        for (Db.Found found : compilation.reports()) {
+            if (found.report().isError() && compilation.publishSourceIdsOf(found).isEmpty()) {
+                unreachable.add(found.report().diagnostic().code() + " about " + found.module());
+            }
+        }
+        assertEquals(List.of(), unreachable, "an error the author is never shown");
+    }
+
+    /**
+     * A dependency two files import is reached by both, and both authors are told.
+     *
+     * <p>Neither import is the premise the other is measured by, and neither author has anything
+     * different to do about it. Marking one of them leaves the other looking at a file that is fine
+     * while the build fails — and which of the two it would be is the order the sources happened to
+     * arrive in.
+     */
+    @Test
+    void everySourceThatReachesItIsTold() {
+        Compilation compilation = Compilation.ofSources(List.of("""
+                module app.a exposing ( A )
+                import lib.held ( Held )
+
+                data A = { held: Held }
+                """, """
+                module app.b exposing ( B )
+                import lib.held ( Held )
+
+                data B = { held: Held }
+                """), held()::get);
+        compilation.answerEverything();
+
+        Map<String, List<Located>> byId = compilation.diagnostics();
+        assertFalse(byId.get("0").isEmpty(), "the source that was reached first");
+        assertFalse(byId.get("1").isEmpty(), "the one that reaches it just as much");
+    }
+
+    /**
+     * Two findings that differed only in where they were written are said once.
+     *
+     * <p>Reading a report for where it may be said is what makes them one. Their coordinates are in
+     * a text nobody holds and are what told them apart; said at the place the module was reached
+     * from, they are one sentence at one caret, and an author shown it twice has nothing to tell
+     * them apart by either.
+     */
+    @Test
+    void twoFindingsInOnePublishedModuleAreSaidOnce() {
+        Map<String, byte[]> withDeep = Compiler.compile("""
+                module lib.deep exposing ( Deep )
+                data Deep = String
+                """);
+        Map<String, byte[]> twice = built("""
+                module lib.twice exposing ( Twice )
+                data Twice = { a: lib.deep.Deep, b: lib.deep.Deep }
+                """, withDeep);
+        // the dependency is rebuilt without the type, so both field types fail to resolve
+        Map<String, byte[]> withoutDeep = Compiler.compile("""
+                module lib.deep exposing ( Other )
+                data Other = String
+                """);
+
+        Compilation compilation = reading("""
+                module app.uses
+                import lib.twice ( Twice )
+
+                data Page = { twice: Twice }
+                """, and(withoutDeep, twice));
+
+        assertEquals(2, compilation.db().allReports().size(),
+                "two findings, at the two places the module writes the name");
+        assertEquals(1, compilation.diagnostics().get("0").size(),
+                "one thing to be told, said once");
+    }
+
     /** Where the report about {@code module} is said. */
     private static SourcePos whereTheReportAboutIsSaid(Compilation compilation, String module) {
         List<SourcePos> said = new ArrayList<>();

--- a/souther-compiler/src/test/java/souther/compiler/AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A module read off the class path is read from text this compile put back together out of what the
@@ -378,9 +377,11 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
 
         List<Located> onTheSource = compilation.diagnostics().get("0");
         assertNotNull(onTheSource);
-        assertTrue(onTheSource.stream().anyMatch(said ->
-                        "E1502".equals(said.diagnostic().code())),
-                "the refusal reached no file at all: " + onTheSource);
+        // That one, and only that one. A module the path holds and this compilation refuses is
+        // still a module it has heard of, so an importer of it is not also told there is no such
+        // thing — two reports that cannot both be true.
+        assertEquals(List.of("E1502"),
+                onTheSource.stream().map(said -> said.diagnostic().code()).toList());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest.java
@@ -1,0 +1,162 @@
+package souther.compiler;
+
+import souther.compiler.diag.Citation;
+import souther.compiler.diag.Located;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Db;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * A module read off the class path is read from text this compile put back together out of what the
+ * module published, so a coordinate in it is a line and a column of a file nobody holds. A report
+ * found there is said at the nearest place on the way to that module a source of this compilation
+ * writes, and names where the code is rather than pointing at it.
+ *
+ * <p>Both halves matter. Quoted as it stands, the coordinate lands wherever those numbers happen to
+ * fall in the file the author is looking at — a compile of one source has no way to tell an untagged
+ * report from one about no file at all — and filed as it stands it lands nowhere, which left a
+ * failing compile answering no classes and no diagnostics.
+ */
+class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
+
+    /** A module compiled against {@code path}, as its own project's build produced it. */
+    private static Map<String, byte[]> built(String source, Map<String, byte[]> path) {
+        return Compiler.compileModules(List.of(source), path::get);
+    }
+
+    private static Map<String, byte[]> and(Map<String, byte[]> one, Map<String, byte[]> other) {
+        Map<String, byte[]> both = new java.util.LinkedHashMap<>(one);
+        both.putAll(other);
+        return both;
+    }
+
+    private static Compilation reading(String source, Map<String, byte[]> path) {
+        Compilation compilation = Compilation.ofSources(List.of(source), path::get);
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    /** The classes of {@code lib.deep}, which every path here leaves out. */
+    private static Map<String, byte[]> deep() {
+        return Compiler.compile("""
+                module lib.deep exposing ( Deep )
+                data Deep = String
+                """);
+    }
+
+    /** The declaring project's build of {@code lib.held}, which needs {@code lib.deep}. */
+    private static Map<String, byte[]> held() {
+        return built("""
+                module lib.held exposing ( Held )
+                import lib.deep ( Deep )
+
+                data Held = { deep: Deep }
+                """, deep());
+    }
+
+    @Test
+    void itIsSaidAtTheImportThatNamedTheModule() {
+        // `lib.held` is on the path and the module it needs is not, so reading it back has something
+        // to report about a declaration written where this compile has no file.
+        Compilation compilation = reading("""
+                module app.uses
+
+
+
+
+                import lib.held ( Held )
+
+                data Page = { held: Held }
+                """, held());
+
+        SourcePos said = whereTheReportAboutIsSaid(compilation, "lib.held");
+        assertEquals("0", said.sourceId(), "a reader can only be sent to a file this compile holds");
+        assertEquals(6, said.line(), "the import line naming the module, not a line of the module");
+        assertEquals(1, said.column());
+    }
+
+    /** The coordinate says the code is elsewhere, so no surface reads it as the place. */
+    @Test
+    void theCoordinateStandsInForCodeWrittenInThatModule() {
+        Compilation compilation = reading("""
+                module app.uses
+                import lib.held ( Held )
+
+                data Page = { held: Held }
+                """, held());
+
+        Citation citation = Citation.of(whereTheReportAboutIsSaid(compilation, "lib.held"));
+
+        assertEquals("lib.held",
+                assertInstanceOf(Citation.OutOfSight.class, citation).declaration());
+    }
+
+    /**
+     * A module reached only through another off the path inherits that one's place. There is no
+     * import line naming it anywhere a reader here can look, and the one naming the dependency that
+     * led there is the nearest thing there is.
+     */
+    @Test
+    void oneReachedThroughAnotherIsSaidAtTheImportThatLedThere() {
+        Map<String, byte[]> held = held();
+        Map<String, byte[]> front = built("""
+                module lib.front exposing ( Front )
+                import lib.held ( Held )
+
+                data Front = { held: Held }
+                """, and(held, deep()));
+
+        Compilation compilation = reading("""
+                module app.uses
+
+
+                import lib.front ( Front )
+
+                data Page = { front: Front }
+                """, and(held, front));
+
+        SourcePos said = whereTheReportAboutIsSaid(compilation, "lib.held");
+        assertEquals("0", said.sourceId());
+        assertEquals(4, said.line(), "the import of the dependency that led to it");
+    }
+
+    /** The route this was found on. The report is about a module the caller has no file for, and it
+     *  still reaches the file the caller does have. */
+    @Test
+    void itIsPublishedOnTheSourceThatReachedIt() {
+        Compilation compilation = reading("""
+                module app.uses
+                import lib.held ( Held )
+
+                data Page = { held: Held }
+                """, held());
+
+        List<Located> onTheSource = compilation.diagnostics().get("0");
+        assertNotNull(onTheSource);
+        assertFalse(onTheSource.isEmpty(),
+                "a compile that emitted nothing said nothing about why");
+    }
+
+    /** Where the report about {@code module} is said. */
+    private static SourcePos whereTheReportAboutIsSaid(Compilation compilation, String module) {
+        List<SourcePos> said = new ArrayList<>();
+        for (Db.Found found : compilation.reports()) {
+            if (module.equals(found.module()) && found.report().diagnostic().pos() != null) {
+                said.add(found.report().diagnostic().pos());
+            }
+        }
+        assertFalse(said.isEmpty(), "nothing was reported about " + module);
+        return said.get(0);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest.java
@@ -1,6 +1,10 @@
 package souther.compiler;
 
 import souther.compiler.diag.Citation;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Region;
+import souther.compiler.diag.msg.ModuleMessage;
+import souther.compiler.diag.msg.NameMessage;
 import souther.compiler.diag.Located;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.query.Compilation;
@@ -45,6 +49,17 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
         Compilation compilation = Compilation.ofSources(List.of(source), path::get);
         compilation.answerEverything();
         return compilation;
+    }
+
+    /** A module holding one thing out of another, as its own project's build produced it. */
+    private static Map<String, byte[]> holding(String name, String type, String from,
+                                               String imported, Map<String, byte[]> path) {
+        return built("""
+                module %s exposing ( %s )
+                import %s ( %s )
+
+                data %s = { x: %s }
+                """.formatted(name, type, from, imported, type, imported), path);
     }
 
     /** The classes of {@code lib.deep}, which every path here leaves out. */
@@ -206,6 +221,129 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
     }
 
     /**
+     * A route found after the module it leads to was read counts as much as the one found before.
+     *
+     * <p>The walk reads each module once, and a place written down when it was read is the places it
+     * had by then. Here one source names the shared dependency outright and the other reaches it
+     * through a dependency of its own, so the second route arrives after the shared module has been
+     * read and everything under it settled — and the author of the second file was told nothing
+     * about a missing dependency their import reaches. Which file that is comes down to nothing
+     * either author wrote.
+     */
+    @Test
+    void aRouteFoundAfterTheModuleWasReadCountsToo() {
+        Map<String, byte[]> shared = built("""
+                module lib.shared exposing ( Shared )
+                import lib.deep ( Deep )
+
+                data Shared = { deep: Deep }
+                """, deep());
+        Map<String, byte[]> between = built("""
+                module lib.between exposing ( Between )
+                import lib.shared ( Shared )
+
+                data Between = { shared: Shared }
+                """, and(shared, deep()));
+
+        Compilation compilation = Compilation.ofSources(List.of("""
+                module app.a exposing ( A )
+                import lib.shared ( Shared )
+
+                data A = { shared: Shared }
+                """, """
+                module app.b exposing ( B )
+                import lib.between ( Between )
+
+                data B = { between: Between }
+                """), and(shared, between)::get);
+        compilation.answerEverything();
+
+        Map<String, List<Located>> byId = compilation.diagnostics();
+        assertEquals(byId.get("0").size(), byId.get("1").size(),
+                "the file that reaches it the long way round is told the same things");
+    }
+
+    /**
+     * Two routes of different lengths meeting at one module carry both origins on down.
+     *
+     * <p>{@code app.a} reaches the meeting point through one module and {@code app.b} through two,
+     * so the meeting point is read while only the short route is known and everything under it is
+     * settled from that. What the long route adds arrives afterwards and has to travel the rest of
+     * the way — reaching a module is reaching everything it reaches, and where the two routes happen
+     * to be the same length is not what decides it.
+     */
+    @Test
+    void routesOfDifferentLengthsBothReachWhatTheyMeetOver() {
+        Map<String, byte[]> leaf = Compiler.compile("""
+                module lib.leaf exposing ( Leaf )
+                data Leaf = String
+                """);
+        Map<String, byte[]> meeting = holding("lib.meeting", "Meeting", "lib.leaf", "Leaf", leaf);
+        Map<String, byte[]> shortWay = holding("lib.short", "Short", "lib.meeting", "Meeting",
+                and(meeting, leaf));
+        Map<String, byte[]> middle = holding("lib.middle", "Middle", "lib.meeting", "Meeting",
+                and(meeting, leaf));
+        Map<String, byte[]> longWay = holding("lib.long", "Long", "lib.middle", "Middle",
+                and(middle, and(meeting, leaf)));
+
+        // everything but the leaf, so what is missing is under the module the two routes meet at
+        Compilation compilation = Compilation.ofSources(List.of("""
+                module app.a exposing ( A )
+                import lib.short ( Short )
+
+                data A = { x: Short }
+                """, """
+                module app.b exposing ( B )
+                import lib.long ( Long )
+
+                data B = { x: Long }
+                """), and(and(meeting, shortWay), and(middle, longWay))::get);
+        compilation.answerEverything();
+
+        Map<String, List<Located>> byId = compilation.diagnostics();
+        assertEquals(byId.get("0").size(), byId.get("1").size(),
+                "the file that reaches the meeting point the long way round is told the same things");
+    }
+
+    /**
+     * Two modules each needing the same absent one are two things to be told.
+     *
+     * <p>They are missing from two places. An author who reaches one of them has not reached the
+     * other, so one report pointing at both imports would say the code is written in a module that
+     * import never arrives at — a statement about a place, and false. What is absent is the edge and
+     * not the module.
+     */
+    @Test
+    void twoModulesNeedingTheSameAbsentOneAreTwoFindings() {
+        Map<String, byte[]> left = holding("lib.left", "Left", "lib.deep", "Deep", deep());
+        Map<String, byte[]> right = holding("lib.right", "Right", "lib.deep", "Deep", deep());
+
+        Compilation compilation = Compilation.ofSources(List.of("""
+                module app.a exposing ( A )
+                import lib.left ( Left )
+
+                data A = { x: Left }
+                """, """
+                module app.b exposing ( B )
+                import lib.right ( Right )
+
+                data B = { x: Right }
+                """), and(left, right)::get);
+        compilation.answerEverything();
+
+        for (Db.Found found : compilation.reports()) {
+            SourcePos at = found.report().diagnostic().pos();
+            if (at == null || !at.isOutOfSight()) {
+                continue;
+            }
+            String stands = ((Citation.OutOfSight) Citation.of(at)).declaration();
+            String reachedIn = at.sourceId();
+            assertEquals("lib.left".equals(stands) ? "0" : "1", reachedIn,
+                    "`" + stands + "` is not reached from the other file at all");
+        }
+    }
+
+    /**
      * Two findings that differed only in where they were written are said once.
      *
      * <p>Reading a report for where it may be said is what makes them one. Their coordinates are in
@@ -240,6 +378,34 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
                 "two findings, at the two places the module writes the name");
         assertEquals(1, compilation.diagnostics().get("0").size(),
                 "one thing to be told, said once");
+    }
+
+    /**
+     * A report whose caret stays put keeps every label it had.
+     *
+     * <p>A label naming no source of its own is read in the diagnostic's, which is what a hand-made
+     * position is for and is a contract older than any of this. Only moving the caret takes that
+     * away — the file the label would be read in stops being the file it was built against — so a
+     * reading that dropped such a label from every report would be reading "no file of its own" as
+     * "no file at all", which is a different thing and is already answered.
+     */
+    @Test
+    void anOrdinaryReportKeepsALabelThatNamesNoSourceOfItsOwn() {
+        Diagnostic said = Diagnostic.say(new NameMessage.NoValueOfThatNameInScope("x"))
+                .at(new SourcePos(1, 1, "0"))
+                .secondary(Region.ofWidth(new SourcePos(3, 3), 4),
+                        new NameMessage.WriteItOnItsOwn("x"))
+                .build();
+
+        assertEquals(1, said.secondary().size(), "the label is there to begin with");
+        assertEquals("0", said.secondary().get(0).sourceIdOr("0"),
+                "and is read in the file the diagnostic is in");
+
+        Diagnostic moved = said.reachedFrom(List.of(new SourcePos(2, 1, "0")), "lib.held",
+                new ModuleMessage.ItIsReachedFromHereToo());
+
+        assertEquals(List.of(), moved.secondary(),
+                "moving the caret is what takes the label's file away");
     }
 
     /** Where the report about {@code module} is said. */

--- a/souther-compiler/src/test/java/souther/compiler/AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest.java
@@ -13,13 +13,16 @@ import souther.compiler.query.Db;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A module read off the class path is read from text this compile put back together out of what the
@@ -331,16 +334,53 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
                 """), and(left, right)::get);
         compilation.answerEverything();
 
+        Set<String> saidAbout = new LinkedHashSet<>();
         for (Db.Found found : compilation.reports()) {
             SourcePos at = found.report().diagnostic().pos();
             if (at == null || !at.isOutOfSight()) {
                 continue;
             }
             String stands = ((Citation.OutOfSight) Citation.of(at)).declaration();
-            String reachedIn = at.sourceId();
-            assertEquals("lib.left".equals(stands) ? "0" : "1", reachedIn,
+            saidAbout.add(stands);
+            // Every file it is said in, and not only the one the caret is in: a second place is
+            // said as a labelled region, and claiming a file that never reaches this module is
+            // exactly what putting both imports on one report would do.
+            assertEquals(List.of("lib.left".equals(stands) ? "0" : "1"),
+                    compilation.publishSourceIdsOf(found),
                     "`" + stands + "` is not reached from the other file at all");
         }
+        assertEquals(Set.of("lib.left", "lib.right"), saidAbout,
+                "each of them needs it, and each of them is a thing to be told");
+    }
+
+    /**
+     * A module on the path that took a name no module may take is refused, and the refusal is said
+     * where the module was reached from.
+     *
+     * <p>The other thing this walk finds on its own. It is refused rather than read, so it has no
+     * declarations for anything else to trip over and nothing later says it again — which is what
+     * left it as the one report here still carrying a coordinate in a file nobody holds.
+     */
+    @Test
+    void aModuleOnThePathThatTookAReservedNameIsRefusedWhereItWasReached() {
+        Compilation core = Compilation.ofCoreSource("""
+                module souther.taken exposing ( X )
+                data X = Int
+                """);
+        core.answerEverything();
+
+        Compilation compilation = reading("""
+                module app.uses
+                import souther.taken ( X )
+
+                data A = { x: X }
+                """, core.classes());
+
+        List<Located> onTheSource = compilation.diagnostics().get("0");
+        assertNotNull(onTheSource);
+        assertTrue(onTheSource.stream().anyMatch(said ->
+                        "E1502".equals(said.diagnostic().code())),
+                "the refusal reached no file at all: " + onTheSource);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/AnEvaluationRunsTheClassesThisCompileGeneratedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEvaluationRunsTheClassesThisCompileGeneratedTest.java
@@ -73,7 +73,7 @@ class AnEvaluationRunsTheClassesThisCompileGeneratedTest {
         Compilation compilation = Compilation.ofSources(List.of(NOW), leftOverClassFiles());
         compilation.answerEverything();
 
-        assertNull(compilation.failure(compilation.db().allReports()),
+        assertNull(compilation.failure(),
                 "the model is correct, so nothing is wrong with it");
 
         String sourceId = compilation.exampleSourcesOf("example.stale").get(0);

--- a/souther-compiler/src/test/java/souther/compiler/AnImportedNameSurvivesPublicationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnImportedNameSurvivesPublicationTest.java
@@ -1,0 +1,166 @@
+package souther.compiler;
+
+import souther.compiler.check.Resolve;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Names;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A module may import the names it wants and then write them bare, and a module is published as the
+ * source that declared it. So an invariant that calls a bare imported name has to mean the same
+ * thing read back out of a jar as it does in the project that wrote it: what the import brought in
+ * is part of what the declaration says, and travels with it.
+ *
+ * <p>Whether the module was compiled here or read off the class path does not enter into it — the
+ * specification says as much of a construction's discharge, and it is the same reading.
+ */
+class AnImportedNameSurvivesPublicationTest {
+
+    private static final String BARE = """
+            module lib.text exposing ( Title )
+            import String ( length )
+
+            data Title = String
+                invariant length(value) > 0
+            """;
+
+    private static final String QUALIFIED = """
+            module lib.text exposing ( Title )
+
+            data Title = String
+                invariant String.length(value) > 0
+            """;
+
+    private static final String IMPORTING = """
+            module app.uses
+            import lib.text ( Title )
+
+            data Note = { title: Title }
+            """;
+
+    private static ModulePath published(String source) {
+        Map<String, byte[]> classes = Compiler.compile(source);
+        return classes::get;
+    }
+
+    @Test
+    void anInvariantCallingABareImportedNameReadsBack() {
+        assertTrue(Compiler.compileModules(List.of(IMPORTING), published(BARE))
+                .containsKey("app.uses.Note"));
+    }
+
+    /** The helpers an invariant calls travel with it, and are read back under the same imports. */
+    @Test
+    void aPublishedHelperCallingABareImportedNameReadsBack() {
+        ModulePath path = published("""
+                module lib.text exposing ( Title )
+                import String ( length )
+
+                data Title = String
+                    invariant nonEmpty(value)
+
+                let nonEmpty (s: String) = length(s) > 0
+                """);
+
+        assertTrue(Compiler.compileModules(List.of(IMPORTING), path)
+                .containsKey("app.uses.Note"));
+    }
+
+    /** The import line writes both halves of a library name, and the alias is the half a published
+     *  module is read back under. */
+    @Test
+    void anAliasedLibraryImportReadsBack() {
+        ModulePath path = published("""
+                module lib.text exposing ( Title )
+                import String as S ( length )
+
+                data Title = String
+                    invariant length(value) > 0
+                """);
+
+        assertTrue(Compiler.compileModules(List.of(IMPORTING), path)
+                .containsKey("app.uses.Note"));
+    }
+
+    /** A module off the path brings its own reaches with it, and each of them is read back the same
+     *  way — a dependency of a dependency is not read under weaker rules. */
+    @Test
+    void aModuleReachedThroughAnotherOnThePathReadsBack() {
+        Map<String, byte[]> base = Compiler.compile(BARE);
+        Map<String, byte[]> mid = Compiler.compileModules(List.of("""
+                module lib.doc exposing ( Doc )
+                import lib.text ( Title )
+
+                data Doc = { title: Title }
+                """), base::get);
+
+        Map<String, byte[]> app = Compiler.compileModules(List.of("""
+                module app.uses
+                import lib.doc ( Doc )
+
+                data Page = { doc: Doc }
+                """), name -> mid.containsKey(name) ? mid.get(name) : base.get(name));
+
+        assertTrue(app.containsKey("app.uses.Page"));
+    }
+
+    /**
+     * The two spellings are one declaration, so they are read back as one.
+     *
+     * <p>Measured on what the name denotes and not on the tree it was written as: the import line
+     * lets a name be written without its qualifier and says nothing else, so the two differ in their
+     * text and in nothing a reader of the declaration is answered.
+     */
+    @Test
+    void theTwoSpellingsDenoteTheSameLibraryOperation() {
+        assertEquals(Set.of(new ValueName.Stdlib("String", "length")), libraryNamesDenotedBy(BARE));
+        assertEquals(libraryNamesDenotedBy(QUALIFIED), libraryNamesDenotedBy(BARE),
+                "an import line changes how a name is written and not what it means");
+    }
+
+    /** What the invariant of {@code lib.text} denotes, read back off the classes {@code source}
+     *  compiled to, in a project that has no source for it. */
+    private static Set<ValueName.Stdlib> libraryNamesDenotedBy(String source) {
+        Compilation compilation = Compilation.ofSources(List.of(IMPORTING), published(source));
+        compilation.answerEverything();
+        Resolve.ResolutionIndex facts =
+                compilation.db().ask(new Names.Facts("lib.text")).value();
+        Set<ValueName.Stdlib> denoted = new LinkedHashSet<>();
+        for (Resolve.ValueUse use : facts.values()) {
+            if (use.denotes() instanceof ValueName.Stdlib operation
+                    && !operation.isNamespace()) {
+                denoted.add(operation);
+            }
+        }
+        return denoted;
+    }
+
+    /**
+     * The failing route this was found on. A compile driven through the query API answered no
+     * classes and no diagnostics at all: the report was about a module no source of the compile
+     * declared, and was dropped for having nowhere to go.
+     */
+    @Test
+    void theQueryApiEmitsTheSameClassesForEitherSpelling() {
+        assertEquals(classesFor(QUALIFIED), classesFor(BARE));
+        assertFalse(classesFor(BARE).isEmpty(), "nothing was emitted and nothing was said");
+    }
+
+    private static Set<String> classesFor(String source) {
+        Compilation compilation = Compilation.ofSources(List.of(IMPORTING), published(source));
+        compilation.answerEverything();
+        return compilation.classes().keySet();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileDeepExpressionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileDeepExpressionTest.java
@@ -197,7 +197,7 @@ class CompileDeepExpressionTest {
             return thrown.getClass().getName();
         }
         if (handedBack instanceof Compilation compilation
-                && !compilation.errors(compilation.db().allReports()).isEmpty()) {
+                && !compilation.errors().isEmpty()) {
             return null;
         }
         return "compiled";

--- a/souther-compiler/src/test/java/souther/compiler/CompileTypeVariableTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileTypeVariableTest.java
@@ -27,7 +27,7 @@ class CompileTypeVariableTest {
     private static Map<String, byte[]> compileCore(String src) {
         Compilation compilation = Compilation.ofCoreSource(src);
         compilation.answerEverything();
-        CompileException failed = compilation.failure(compilation.db().allReports());
+        CompileException failed = compilation.failure();
         if (failed != null) {
             throw failed;
         }

--- a/souther-compiler/src/test/java/souther/compiler/EveryPositionOfADeclaredTypeIsReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryPositionOfADeclaredTypeIsReadTest.java
@@ -80,7 +80,7 @@ class EveryPositionOfADeclaredTypeIsReadTest {
     private static CompileException failure(String source) {
         Compilation compilation = Compilation.ofCoreSource(source);
         compilation.answerEverything();
-        return compilation.failure(compilation.db().allReports());
+        return compilation.failure();
     }
 
     @ParameterizedTest(name = "{0}")

--- a/souther-compiler/src/test/java/souther/compiler/TheStepBudgetHasRoomOverWhatModelsActuallySpendTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/TheStepBudgetHasRoomOverWhatModelsActuallySpendTest.java
@@ -79,7 +79,7 @@ class TheStepBudgetHasRoomOverWhatModelsActuallySpendTest {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         souther.compiler.diag.CompileException wrong =
-                compilation.failure(compilation.db().allReports());
+                compilation.failure();
         if (wrong != null) {
             throw new IllegalStateException("the census model has to compile: " + wrong.getMessage());
         }

--- a/souther-compiler/src/test/java/souther/compiler/query/EverySurfaceReadsTheSameReportsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EverySurfaceReadsTheSameReportsTest.java
@@ -14,6 +14,7 @@ import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * What the command line stops for and what an editor marks are the same problems, read once.
@@ -36,10 +37,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  */
 class EverySurfaceReadsTheSameReportsTest {
 
-    /** Where the raw collection belongs: the store that answers it, and the one reading of it. */
-    private static final Set<String> READS_IT = Set.of(
-            "souther/compiler/query/Db.java",
-            "souther/compiler/query/Compilation.java");
+    /** The store that answers the raw collection. */
+    private static final String ANSWERS_IT = "souther/compiler/query/Db.java";
+
+    /** The one reading of it. */
+    private static final String READS_IT = "souther/compiler/query/Compilation.java";
 
     @Test
     void nothingOutsideTheOneReadingCollectsTheRawReports() throws IOException {
@@ -49,7 +51,7 @@ class EverySurfaceReadsTheSameReportsTest {
         Set<String> reading = new TreeSet<>();
         for (Path source : sources) {
             String within = source.toString().replace('\\', '/').replaceAll(".*/src/main/java/", "");
-            if (READS_IT.contains(within)) {
+            if (within.equals(ANSWERS_IT) || within.equals(READS_IT)) {
                 continue;
             }
             // A call and not a mention: a reference in prose writes `Db#allReports()`, and saying
@@ -62,5 +64,32 @@ class EverySurfaceReadsTheSameReportsTest {
                 "the reports a reader is shown are the ones Compilation.reports() answers, read for"
                         + " where a reader can be sent to them; ask through failure, errors,"
                         + " warnings or diagnostics");
+    }
+
+    /**
+     * The one reading is one call.
+     *
+     * <p>Naming a file as the place the raw collection is read leaves every other method in it able
+     * to read it too, which is the arrangement this exists to end — the two outputs were two
+     * readings inside one class before they were two classes.
+     */
+    @Test
+    void theOneReadingReadsItOnce() throws IOException {
+        Path reading = null;
+        for (Path source : EveryShippedMessageCatalogIsCompleteAndValidTest.mainSources()) {
+            if (source.toString().replace('\\', '/').endsWith(READS_IT)) {
+                reading = source;
+            }
+        }
+        assertNotNull(reading, "the one reading is not where this test looks for it");
+
+        String text = Files.readString(reading, StandardCharsets.UTF_8);
+        int read = 0;
+        for (int at = text.indexOf(".allReports("); at >= 0;
+                at = text.indexOf(".allReports(", at + 1)) {
+            read++;
+        }
+        assertEquals(1, read, "every surface reads what Compilation.reports() answers, and that"
+                + " reads the raw collection once");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/EverySurfaceReadsTheSameReportsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EverySurfaceReadsTheSameReportsTest.java
@@ -1,0 +1,66 @@
+package souther.compiler.query;
+
+import souther.compiler.diag.EveryShippedMessageCatalogIsCompleteAndValidTest;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * What the command line stops for and what an editor marks are the same problems, read once.
+ *
+ * <p>{@link Db#allReports()} is what the memo store collected, before anything asked where a reader
+ * could be sent to any of it. A report about a module off the class path carries a coordinate in
+ * text this compile reassembled: read from there, a run with one source quotes whatever sits at
+ * those numbers in the file the author is looking at, and a run with several files it nowhere.
+ * {@link Compilation#reports()} is that set read for where it may be said, and every surface reads
+ * it — through {@code failure}, {@code errors}, {@code warnings} or {@code diagnostics}.
+ *
+ * <p>The two outputs were two readings, and the difference was invisible: a compile stopped on the
+ * command line and left an editor showing a clean file with nothing generated. So the rule is that
+ * there is one reading, and a surface added later does not get to pick.
+ *
+ * <p>A tripwire and not a proof. It reads the sources for the raw collection being asked for, and a
+ * helper in between defeats it — the call that would have to be written first is the one this fails
+ * on. Tests read the raw set freely: what they are usually about is the store itself, and a test
+ * that wants what a reader is told asks for it the way a reader does.
+ */
+class EverySurfaceReadsTheSameReportsTest {
+
+    /** Where the raw collection belongs: the store that answers it, and the one reading of it. */
+    private static final Set<String> READS_IT = Set.of(
+            "souther/compiler/query/Db.java",
+            "souther/compiler/query/Compilation.java");
+
+    @Test
+    void nothingOutsideTheOneReadingCollectsTheRawReports() throws IOException {
+        List<Path> sources = EveryShippedMessageCatalogIsCompleteAndValidTest.mainSources();
+        assertFalse(sources.isEmpty(), "found no sources at all — the scan missed the tree");
+
+        Set<String> reading = new TreeSet<>();
+        for (Path source : sources) {
+            String within = source.toString().replace('\\', '/').replaceAll(".*/src/main/java/", "");
+            if (READS_IT.contains(within)) {
+                continue;
+            }
+            // A call and not a mention: a reference in prose writes `Db#allReports()`, and saying
+            // where the raw collection lives is what those references are for.
+            if (Files.readString(source, StandardCharsets.UTF_8).contains(".allReports(")) {
+                reading.add(within);
+            }
+        }
+        assertEquals(Set.of(), reading,
+                "the reports a reader is shown are the ones Compilation.reports() answers, read for"
+                        + " where a reader can be sent to them; ask through failure, errors,"
+                        + " warnings or diagnostics");
+    }
+}

--- a/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
@@ -1,6 +1,7 @@
 package souther.compiler.diag;
 
 
+import souther.compiler.diag.msg.FindingRegion;
 import souther.compiler.diag.msg.Supporting;
 import souther.compiler.diag.msg.Reported;
 import souther.compiler.diag.msg.MessageCodes;
@@ -126,21 +127,63 @@ public final class Diagnostic {
      *
      * <p>The one way to move a caret. Everything else about the finding is what it was, so the rule
      * it reports and the values it says it about do not change with how far away the code turned out
-     * to be. A second region is kept only where it too is somewhere a reader can be sent: a label is
-     * a sentence about the place it points at, and one pointing into the same unheld text says it of
-     * a line the author did not write.
+     * to be.
+     *
+     * <p>Every place, not the first. Two files may reach one declaration, and the problem is not
+     * readable from either of them alone — neither import is the premise the other is measured by,
+     * and an author editing the second is looking at a file that is fine while the build fails. So
+     * the rest are labelled {@code alsoHere}, which says they are part of what is found wrong
+     * ({@link souther.compiler.diag.msg.FindingRegion}) and is what puts the report in front of each
+     * of those authors.
+     *
+     * @throws IllegalArgumentException where {@code where} is empty. There is no such thing as
+     *         reaching code from nowhere: a caller with no place to send a reader has a report to
+     *         leave as it is, not one to move
      */
-    public Diagnostic reachedFrom(SourcePos where, String declaration) {
-        SourcePos stands = where.standingInFor(WrittenAt.outOfSight(declaration));
+    public <M extends Message & FindingRegion> Diagnostic reachedFrom(List<SourcePos> where,
+                                                                     String declaration,
+                                                                     M alsoHere) {
+        if (where.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "code out of sight is reached from somewhere or the report stays where it is");
+        }
+        WrittenAt out = WrittenAt.outOfSight(declaration);
+        List<LabeledRegion> also = new ArrayList<>(citableSecondary());
+        for (SourcePos other : where.subList(1, where.size())) {
+            also.add(new LabeledRegion(Region.point(other.standingInFor(out)), null, alsoHere));
+        }
+        return new Diagnostic(severity, code,
+                Region.point(where.get(0).standingInFor(out)), List.copyOf(also),
+                literalMessage, diff, notes, suggestion, said);
+    }
+
+    /**
+     * The same finding with any second region a reader cannot be sent to left off.
+     *
+     * <p>A label is a sentence about the place it points at, so one read from text this compile has
+     * no file for says it of whatever sits at those numbers in the file the report is filed under —
+     * a line the author did write and that the label says nothing about. It is the defect
+     * {@link #reachedFrom} moves a caret for, one region over, and it reaches a report whose own
+     * caret is fine: a body spliced in from out of sight is given the call site, and a label built
+     * over the body it came from is not.
+     */
+    public Diagnostic saidOnlyWhereAReaderCanBeSent() {
+        List<LabeledRegion> kept = citableSecondary();
+        return kept.size() == secondary.size() ? this
+                : new Diagnostic(severity, code, region, List.copyOf(kept), literalMessage, diff,
+                        notes, suggestion, said);
+    }
+
+    /** The second regions read from a source, which are the ones a reader can be shown. */
+    private List<LabeledRegion> citableSecondary() {
         List<LabeledRegion> kept = new ArrayList<>();
         for (LabeledRegion label : secondary) {
-            if (label.region() != null && label.region().start() != null
-                    && label.region().start().sourceId() != null) {
+            if (label.region() == null || label.region().start() == null
+                    || label.region().start().sourceId() != null) {
                 kept.add(label);
             }
         }
-        return new Diagnostic(severity, code, Region.point(stands), List.copyOf(kept),
-                literalMessage, diff, notes, suggestion, said);
+        return kept;
     }
 
     /**

--- a/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
@@ -148,7 +148,7 @@ public final class Diagnostic {
                     "code out of sight is reached from somewhere or the report stays where it is");
         }
         WrittenAt out = WrittenAt.outOfSight(declaration);
-        List<LabeledRegion> also = new ArrayList<>(citableSecondary());
+        List<LabeledRegion> also = new ArrayList<>(secondaryThatSurvivesTheMove());
         for (SourcePos other : where.subList(1, where.size())) {
             also.add(new LabeledRegion(Region.point(other.standingInFor(out)), null, alsoHere));
         }
@@ -158,28 +158,19 @@ public final class Diagnostic {
     }
 
     /**
-     * The same finding with any second region a reader cannot be sent to left off.
+     * The second regions that survive the caret moving.
      *
-     * <p>A label is a sentence about the place it points at, so one read from text this compile has
-     * no file for says it of whatever sits at those numbers in the file the report is filed under —
-     * a line the author did write and that the label says nothing about. It is the defect
-     * {@link #reachedFrom} moves a caret for, one region over, and it reaches a report whose own
-     * caret is fine: a body spliced in from out of sight is given the call site, and a label built
-     * over the body it came from is not.
+     * <p>A label naming no source of its own is read in the diagnostic's
+     * ({@link LabeledRegion#sourceIdOr}), and that is what a hand-made position is for. It stops
+     * being true when the caret moves: the file it would be read in is no longer the file it was
+     * built against, and the label would say what it says of whatever sits at those numbers in a
+     * file the author wrote. So it is dropped here and nowhere else — a report whose caret stays put
+     * keeps every label it had, whatever any of them names.
      */
-    public Diagnostic saidOnlyWhereAReaderCanBeSent() {
-        List<LabeledRegion> kept = citableSecondary();
-        return kept.size() == secondary.size() ? this
-                : new Diagnostic(severity, code, region, List.copyOf(kept), literalMessage, diff,
-                        notes, suggestion, said);
-    }
-
-    /** The second regions read from a source, which are the ones a reader can be shown. */
-    private List<LabeledRegion> citableSecondary() {
+    private List<LabeledRegion> secondaryThatSurvivesTheMove() {
         List<LabeledRegion> kept = new ArrayList<>();
         for (LabeledRegion label : secondary) {
-            if (label.region() == null || label.region().start() == null
-                    || label.region().start().sourceId() != null) {
+            if (label.sourceId() != null) {
                 kept.add(label);
             }
         }

--- a/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
@@ -113,6 +113,37 @@ public final class Diagnostic {
     }
 
     /**
+     * The same finding, said at {@code where} instead — for one about code this compile has no
+     * source for.
+     *
+     * <p>A coordinate read from a text nobody holds is not a place a reader can be sent, and every
+     * surface that quotes a line quotes it from a file: given one, a run with a single source quotes
+     * whatever happens to sit at those numbers in the file the author is looking at, and one with
+     * several drops the report for having nowhere to file it. Both are worse than saying where the
+     * code is in words, which is what this does — {@code where} is where this compile met the
+     * declaration, and the coordinate it is given says it stands in for code written in
+     * {@code declaration} ({@link Citation}).
+     *
+     * <p>The one way to move a caret. Everything else about the finding is what it was, so the rule
+     * it reports and the values it says it about do not change with how far away the code turned out
+     * to be. A second region is kept only where it too is somewhere a reader can be sent: a label is
+     * a sentence about the place it points at, and one pointing into the same unheld text says it of
+     * a line the author did not write.
+     */
+    public Diagnostic reachedFrom(SourcePos where, String declaration) {
+        SourcePos stands = where.standingInFor(WrittenAt.outOfSight(declaration));
+        List<LabeledRegion> kept = new ArrayList<>();
+        for (LabeledRegion label : secondary) {
+            if (label.region() != null && label.region().start() != null
+                    && label.region().start().sourceId() != null) {
+                kept.add(label);
+            }
+        }
+        return new Diagnostic(severity, code, Region.point(stands), List.copyOf(kept),
+                literalMessage, diff, notes, suggestion, said);
+    }
+
+    /**
      * What makes two diagnostics one problem: everything this one says, compared by what it says.
      *
      * <p>{@code said} is in here because it is what carries the values. Two diagnostics of one rule

--- a/souther-syntax/src/main/java/souther/compiler/diag/WrittenAt.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/WrittenAt.java
@@ -81,7 +81,9 @@ public sealed abstract class WrittenAt permits AtItsPlace, StoodInFor {
      *        from out of sight is qualified, so it is already enough to look the code up by, and the
      *        declaring module is a second value a report would have to show and has nothing to add
      *        ({@code List.map} is declared in {@code souther.list}, which is not how anyone reaches
-     *        it)
+     *        it). Where the code out of sight is a whole module rather than something in one, the
+     *        module's name is how it is reached — {@code lib.text} is what a reader here imports —
+     *        and the two answers coincide
      */
     public static WrittenAt outOfSight(String declaration) {
         return new StoodInFor(declaration);

--- a/souther-syntax/src/main/java/souther/compiler/diag/msg/ModuleMessage.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/msg/ModuleMessage.java
@@ -80,6 +80,11 @@ public sealed interface ModuleMessage extends Message {
 
     record AddItToThisProjectsDependencies(String module) implements ModuleMessage, Supporting {}
 
+    /** Another import of this compilation that arrives at the same declaration. A finding and not an
+     * explanation: the two imports are not measured against each other, and the author of either
+     * file has the same thing to do about it. */
+    record ItIsReachedFromHereToo() implements ModuleMessage, FindingRegion {}
+
     @Code(DiagnosticCode.E1504)
     record TheClassCarryingTheDeclarationIsNotOnThePath(String name, String module) implements ModuleMessage, Reported {}
 


### PR DESCRIPTION
Towards #755 — acceptance 1, 2, 3, and 4 as far as a primary coordinate goes.

Whether it closes #755 is a decision about the issue's wording, not about this branch. Acceptance 4 says "a diagnostic raised while reading a module back does not carry a coordinate into a file that does not have one", and does not say primary. A second region built over a body spliced in from out of sight is the same sentence about a different region — #760 — and cannot be answered where reports are read: a label naming no source of its own already means "read in the diagnostic's file", so nothing there tells one apart from a hand-made label. It wants provenance where the splice happens. Either #755 waits for #760, or its acceptance 4 is narrowed to the primary coordinate on purpose.

## What was wrong

`import String ( length )` and then `length(value) > 0` in an invariant. The import line is published on the class, and `Front.FromPath` dropped it and threw away the table saying what it had brought in. `Front.LibraryNames` was asked of the source layout — which a module off the class path is not in — and answered an empty table, so every bare name in a published invariant denoted nothing in every project but the one that wrote it.

Measured before the change, all four fail with `E1025`:

| | |
|---|---|
| an invariant calling a bare imported name | ✗ |
| a published helper an invariant calls, calling one | ✗ |
| `import String as S ( length )` | ✗ |
| a module reached only through another off the path | ✗ |

## The two failures this issue names are two failures

Acceptance 1–3 are a semantic loss. Acceptance 4 is a separate observable defect, and it is worse than a wrong caret.

The coordinate in a report about a published module is a line and a column of text this compile reassembled out of what the module published. Every surface quotes a line from a file, and a run with one source has no way to tell an untagged report from a report about no file at all:

```
-- NAMING ERROR  E1025 -------------------------app.sou:5:15

5|
   ^
```

`app.sou` has four lines; `5:15` is where `length` sits in `lib.sou`.

A run with several sources drops the report instead — `Compilation.diagnostics()` files by source, and a module off the path has none. Through the query API the editor reads, the same input answered **no classes and no diagnostics**:

```
bare       diagnostics: {0=[]}   classes: []
qualified  diagnostics: {0=[]}   classes: [app.uses.Note, … 6 classes]
```

`Compiler.compileModules` threw, because `failure()` read `db.allReports()` without filtering by source. Two readings of one set.

## What changed

**The table travels with the module.** `Exposing.check` answers the module without its library import lines *and* what those lines brought in, as one value — there is no longer a way to take the second and leave the first. A module off the path carries the table beside its injected behaviors, the other fact about it this compile cannot work out again. `LibraryNames` is asked of every module this compilation has, and reads the same reading `Front.Exposed` does, so a value an attached `examples for` file declares collides with an import of that spelling in one place instead of two.

**A compilation reads its reports once.** `Compilation.reports()` is the one set; `failure`, `errors`, `warnings` and `diagnostics` all project from it, and `failure(List)` is package-private so nothing outside can go around it. A report about a module off the path is said at the nearest place on the way to it that a source of this compilation writes — the `import` line naming it, or the one naming whichever dependency led there — and the coordinate says it stands in for code written in that module. That is a `Citation.OutOfSight`, which every renderer already reads, so the sentence comes for free on the terminal, in the JSON, and in the editor.

Before and after, on a dependency of a dependency missing from the path:

```
-- MODULE ERROR  E1504 -------------------------app2.sou:2:1     ← before

2|
   ^

Unknown module `lib.deep`.
```

```
-- MODULE ERROR  E1504 -------------------------app2.sou:6:1     ← after

6| import lib.held ( Held )
   ^

Unknown module `lib.deep`. The code is written in `lib.held`, which this
compile has no source for, so this is where it was reached from and not
where it is.
```

## Tests

`AnImportedNameSurvivesPublicationTest` — the four cases above, plus: the two spellings denote the same `ValueName.Stdlib` when read back, measured on resolution facts rather than on the tree, since an import line changes how a name is written and nothing else; and the query-API route emits the same classes for either spelling. All six fail on `develop` and pass here.

`AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest` — where such a report is said, that the coordinate stands in for the module rather than pointing at it, that a module reached only through another inherits the place, and that it reaches the source the caller does hold. On `develop` that source got zero diagnostics for a compile that emitted nothing.

Full reactor green.

## Not in this change

`Exposing` throws on a jar this compiler disagrees with about the standard library, and that throw escapes `FromPath` and takes the compilation with it. Reading a well-formed module back is this change; what to say about one that cannot be read back at all is artifact-boundary robustness — #757.

A second region built over a body spliced in from out of sight is read in the file the body was spliced into — #760. It reaches the standard library's bodies as much as a published module's, so it is about splice provenance rather than about reading a module back, and it cannot be told from a hand-made label by anything a reader of finished reports can see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
