### PR TITLE
Derive what a reading can reach, not everything the naming has seen

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/DerivedBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DerivedBounds.java
@@ -64,12 +64,16 @@ final class DerivedBounds {
      * outside both sets is one no question asked of this domain can reach
      * ({@link NumericDomain#atomsSpokenOf}).
      *
-     * <p>One pass, and not because the roots happen not to grow. Every derivation reads {@code
-     * base} — {@link #derive} is handed it at every level — so what is derived for an atom is a
-     * function of {@code base} and the recipes alone. A bound derived here is an answer of this
-     * reading and never a premise another recipe is derived from, which is the interval reasoning
-     * that tightens under its own answers that this declines to be. So the recipes reachable from
-     * the roots are all of them, whatever order they are walked in.
+     * <p>One pass, and not because the roots happen not to grow. The recipe graph's own edges do
+     * carry: a recipe's operands are derived first and read where its form is read, which is how
+     * {@code a * b / 100} reads what the product was derived to. What does not happen is the other
+     * direction — the reading is never rebuilt from what was derived and the recipes put through
+     * again against it. Every derivation is handed {@code base} ({@link #derive} at every level), so
+     * what is derived for an atom is a function of {@code base} and the recipe graph alone: an
+     * evaluation over a graph with no way back to where it started, in whatever order the roots are
+     * walked, with no fixed point to reach. A derived bound reaches another recipe only where the
+     * graph names it, and never through a relation this domain holds between the two — which is the
+     * interval reasoning that tightens under its own answers that this declines to be.
      */
     static NumericDomain<Term> refine(NumericDomain<Term> base, Terms terms, Set<Term> asked) {
         Map<Term, Derivation> recipes = terms.derivations();
@@ -197,6 +201,11 @@ final class DerivedBounds {
      * an atom out of itself, which is the check disagreeing with itself about which value an atom is
      * — so it is refused rather than swallowed, for the reason
      * {@link TheCheckDisagreesWithItself} gives.
+     *
+     * <p>Asked of what a reading walks, and so of the recipes its question reaches rather than of
+     * every recipe the naming recorded. A cycle among recipes no reading reaches goes unremarked,
+     * which is a narrowing of where an assertion about this check's own naming can fire and not of
+     * what any program is told: what such a recipe would have derived is read by nothing.
      */
     static final class AnAtomComputedFromItself extends TheCheckDisagreesWithItself {
 

--- a/souther-compiler/src/main/java/souther/compiler/check/DerivedBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DerivedBounds.java
@@ -9,8 +9,9 @@ import souther.compiler.numeric.NumericDomain.Bounds;
 import souther.compiler.numeric.NumericDomain.LinearForm;
 import souther.compiler.numeric.NumericDomain.Rel;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -38,23 +39,81 @@ final class DerivedBounds {
     private DerivedBounds() {}
 
     /**
-     * {@code base} with what follows about every atom {@code terms} recorded a derivation for taken
-     * as holding.
+     * The atoms whose recipe each reading evaluated, one entry per reading, where a test in this
+     * package is watching — and null everywhere else.
+     *
+     * <p>Beside {@link InvariantChecker#WATCHING} and for a reason of its own. What this states is
+     * that a reading does no work the question it was asked cannot reach, and that is not something
+     * any diagnostic says: a reading that derived every recipe in the behavior answers exactly what
+     * a reading that derived three of them answers. So the property has nowhere else to be read,
+     * and one that nothing reads stops being true without anything failing.
      */
-    static NumericDomain<Term> refine(NumericDomain<Term> base, Terms terms) {
+    static List<List<Term>> WATCHING;
+
+    /**
+     * {@code base} with what follows about the arithmetic outside the affine fragment that this
+     * reading can reach, taken as holding.
+     *
+     * <p>What it can reach is the two together: the atoms the clauses are decided by, and the atoms
+     * {@code base} says anything about. Neither alone is it. A clause naming a product needs that
+     * product derived though no guard mentions it; and a clause naming no product at all reaches
+     * one through a guard that equated the two, since what a bound on the product gives {@code
+     * total} it gives through the difference the domain recorded. Everything else {@code terms}
+     * named is arithmetic somewhere else in this behavior: {@code terms} is a memo of what the
+     * naming has seen, which is a longer-lived thing than the question asked here, and an atom
+     * outside both sets is one no question asked of this domain can reach
+     * ({@link NumericDomain#atomsSpokenOf}).
+     *
+     * <p>One pass, and not because the roots happen not to grow. Every derivation reads {@code
+     * base} — {@link #derive} is handed it at every level — so what is derived for an atom is a
+     * function of {@code base} and the recipes alone. A bound derived here is an answer of this
+     * reading and never a premise another recipe is derived from, which is the interval reasoning
+     * that tightens under its own answers that this declines to be. So the recipes reachable from
+     * the roots are all of them, whatever order they are walked in.
+     */
+    static NumericDomain<Term> refine(NumericDomain<Term> base, Terms terms, Set<Term> asked) {
         Map<Term, Derivation> recipes = terms.derivations();
-        if (recipes.isEmpty() || base.isBottom()) {
-            return base;
+        Map<Term, Bounds> derived = new LinkedHashMap<>();
+        if (!recipes.isEmpty() && !base.isBottom()) {
+            for (Term atom : roots(recipes, base, asked)) {
+                derive(atom, base, terms, derived, new LinkedHashSet<>());
+            }
         }
-        Map<Term, Bounds> derived = new HashMap<>();
-        for (Term atom : recipes.keySet()) {
-            derive(atom, base, terms, derived, new LinkedHashSet<>());
-        }
+        watched(derived.keySet());
         NumericDomain<Term> out = base;
         for (Map.Entry<Term, Bounds> one : derived.entrySet()) {
             out = taking(out, one.getKey(), one.getValue(), terms);
         }
         return out;
+    }
+
+    /** The atoms this reading is to derive from: the ones it can reach that were recorded as
+     * arithmetic. Walked from the reaching side rather than from {@code recipes}, so what it costs
+     * is what the question is about and not how much arithmetic the behavior contains. */
+    private static Set<Term> roots(Map<Term, Derivation> recipes, NumericDomain<Term> base,
+                                   Set<Term> asked) {
+        Set<Term> out = new LinkedHashSet<>();
+        for (Term atom : asked) {
+            if (recipes.containsKey(atom)) {
+                out.add(atom);
+            }
+        }
+        for (Term atom : base.atomsSpokenOf()) {
+            if (recipes.containsKey(atom)) {
+                out.add(atom);
+            }
+        }
+        return out;
+    }
+
+    /** Records the recipes this reading evaluated, where a test is reading them. Every atom here
+     * had its recipe put through {@link Intervals}: {@link #derive} answers a second ask from what
+     * it remembered, so an atom is written once however many forms name it. */
+    private static void watched(Set<Term> evaluated) {
+        List<List<Term>> watching = WATCHING;
+        if (watching != null) {
+            watching.add(List.copyOf(evaluated));
+        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Combinators.Handed;
-import souther.compiler.numeric.Granularity;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.core.Core;
@@ -1096,26 +1095,11 @@ public final class InvariantChecker {
         if (owed.isEmpty()) {
             return new Judgment(unreadable ? Verdict.UNREPRESENTABLE : Verdict.PROVED, found);
         }
-        NumericDomain<Term> dom = k.numbers();
+        NumericDomain<Term> dom = readingOf(k.numbers(), owed);
         // The same clauses read against the same site, under what would be known here had no
         // condition on the path settled anything. What each clause states of the sizes it names holds
         // either way, so both readings take it.
-        NumericDomain<Term> alone = k.unguarded().numbers();
-        for (Owing owing : owed) {
-            for (Predicates.Constraint known : owing.owed().known()) {
-                Map<Term, Granularity> kinds = terms.kindsOf(known.form());
-                dom = dom.assume(known.form(), known.rel(), kinds);
-                alone = alone.assume(known.form(), known.rel(), kinds);
-            }
-        }
-        // What follows about the arithmetic the domain cannot carry — a product of two values, a
-        // truncating quotient — read off what each reading proves of the values it was computed
-        // from. Both readings are refined, and each answers with its own: a bound derived here is
-        // derived from what the reading assumed, so it belongs to that reading and not to the value.
-        // Asked once the clauses' own statements are in, so a size a clause bounds is one the
-        // arithmetic over it can be read against.
-        dom = DerivedBounds.refine(dom, terms);
-        alone = DerivedBounds.refine(alone, terms);
+        NumericDomain<Term> alone = readingOf(k.unguarded().numbers(), owed);
         // An invariant is the conjunction of its clauses, so every one of them is read before what
         // the invariant came out as is decided. A clause the values alone refute is the whole
         // invariant refuted on the values alone, whatever another clause needed to be refuted —
@@ -1146,6 +1130,37 @@ public final class InvariantChecker {
         // Every clause that could be read is discharged. One that could not be read still stands, so
         // this is not the whole invariant proven.
         return new Judgment(unreadable ? Verdict.UNREPRESENTABLE : Verdict.PROVED, found);
+    }
+
+    /**
+     * The domain {@code owed} is read against, built from what {@code base} holds.
+     *
+     * <p>Two steps that are one operation. What each clause states of the sizes it names is taken
+     * as holding, and then what follows about the arithmetic the domain cannot carry — a product of
+     * two values, a truncating quotient — is derived from what the reading proves of the values it
+     * was computed from. The second reads the first: a size a clause bounds is one the arithmetic
+     * over it can be read against, so the derivation has to come after, and a clause added to the
+     * first step without the second being asked again is a construction judged against arithmetic
+     * nothing was derived for. Written as one step so there is no order for a caller to keep.
+     *
+     * <p>Each reading answers with its own. A bound derived here is derived from what this reading
+     * assumed, so it belongs to the reading and not to the value — which is why the construction's
+     * two readings are built by two calls rather than sharing one domain.
+     */
+    private NumericDomain<Term> readingOf(NumericDomain<Term> base, List<Owing> owed) {
+        NumericDomain<Term> out = base;
+        // What the clauses are decided by, which is one half of what the derivation can reach. The
+        // other half is what the domain speaks of, and that is the domain's own to answer — asked
+        // after this loop, since assuming a clause's statements is what puts its atoms there.
+        Set<Term> asked = new LinkedHashSet<>();
+        for (Owing owing : owed) {
+            Predicates.Clause c = owing.owed();
+            for (Predicates.Constraint known : c.known()) {
+                out = out.assume(known.form(), known.rel(), terms.kindsOf(known.form()));
+            }
+            asked.addAll(c.atomsItIsDecidedBy());
+        }
+        return DerivedBounds.refine(out, terms, asked);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -24,6 +24,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -138,7 +139,13 @@ final class Predicates {
         return found[0];
     }
 
-    record Constraint(LinearForm<Term> form, Rel rel) {}
+    record Constraint(LinearForm<Term> form, Rel rel) {
+
+        /** The atoms this relation is written over. */
+        Set<Term> atoms() {
+            return form.coefs().keySet();
+        }
+    }
 
     /**
      * A predicate stated of a term. {@code keys} is the term as written first, then each container it
@@ -171,6 +178,20 @@ final class Predicates {
      *              be taken into a domain without asking anything further of the caller
      */
     record Case(Constraint numeric, List<Constraint> given, Map<Term, Granularity> kinds) {
+
+        /**
+         * Every atom this case is decided by.
+         *
+         * <p>Read off {@code kinds}, which is where the atoms of this case are registered as its
+         * forms are built — the substituted clause, the equality saying the call answered this
+         * argument, and each condition on the arguments. A reader listing those three would be a
+         * second answer to keep in step with the building, and the one that would fall behind: what
+         * a condition names and never answers is an atom of this case all the same, and today no
+         * operation in the table has such an argument.
+         */
+        Set<Term> atomsItIsDecidedBy() {
+            return kinds.keySet();
+        }
 
         /** {@code d} with this case's conditions on the arguments taken as holding. */
         private NumericDomain<Term> in(NumericDomain<Term> d) {
@@ -208,6 +229,17 @@ final class Predicates {
      * which proves less and states nothing false.
      */
     record Piecewise(List<Case> cases) {
+
+        /** Every atom any case of this is decided by. A case that is never reached is one the
+         * conditions rule out, and which those are is what the domain answers — so every case is
+         * counted here, including the ones a reading will drop. */
+        Set<Term> atomsItIsDecidedBy() {
+            Set<Term> out = new LinkedHashSet<>();
+            for (Case one : cases) {
+                out.addAll(one.atomsItIsDecidedBy());
+            }
+            return out;
+        }
 
         boolean entailedBy(NumericDomain<Term> d) {
             boolean reached = false;
@@ -252,6 +284,38 @@ final class Predicates {
      * another, and which of the two routes carries it is not the author's concern.
      */
     record Clause(Constraint numeric, Fact fact, List<Constraint> known, Piecewise piecewise) {
+
+        /**
+         * Every atom a numeric domain could decide this clause differently by.
+         *
+         * <p>The question a reading asks before it decides what to prove about the arithmetic it
+         * cannot carry: a bound derived for an atom no clause is decided by, and that the domain
+         * does not speak of either, changes nothing here ({@link NumericDomain#atomsSpokenOf}).
+         *
+         * <p>What a guard settled by name is not this. {@link Fact} is answered by
+         * {@link PredicateFacts} and never by the domain, so its keys are not atoms a bound could
+         * reach — and counting them would put terms into a derivation's roots that no arithmetic is
+         * read off.
+         *
+         * <p>{@code known} is here though a reading that takes it as holding first would reach those
+         * atoms anyway. This says what the clause is decided by, which is a fact about the clause;
+         * that a caller happens to have put the same atoms into its domain a line earlier is a fact
+         * about the caller, and answering by what some caller does is how the answer comes to be
+         * wrong for the next one.
+         */
+        Set<Term> atomsItIsDecidedBy() {
+            Set<Term> out = new LinkedHashSet<>();
+            if (numeric != null) {
+                out.addAll(numeric.atoms());
+            }
+            for (Constraint one : known) {
+                out.addAll(one.atoms());
+            }
+            if (piecewise != null) {
+                out.addAll(piecewise.atomsItIsDecidedBy());
+            }
+            return out;
+        }
 
         boolean dischargedBy(NumericDomain<Term> d, PredicateFacts facts) {
             return numeric != null && d.entails(numeric.form(), numeric.rel())

--- a/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
@@ -509,6 +509,26 @@ public final class NumericDomain<A> {
     }
 
     /**
+     * Every atom this domain says anything about.
+     *
+     * <p>What it is for is the other side of it: an atom outside this is one no question asked here
+     * can reach. A question is asked of a form, and the answer reads the form's own atoms' ends and
+     * then leaves them by two routes only — the differences, which {@link #closedDiff} carries a
+     * bound through, and the relations kept as written, which {@link #proveLe} subtracts from a
+     * goal. Every atom on either route arrived through {@link #assume} and so is here. So asserting
+     * something about an atom this does not speak of cannot change what it proves about anything
+     * else, which is what lets a caller deriving bounds decide whose bounds are worth deriving.
+     *
+     * <p>Generous where it is uncertain. An atom named in an assertion this could not record — a
+     * disequality, a form kept as written — is here, because what was dropped is a narrowing and the
+     * atom is still one a relation was written about. Answering with the atoms of the bounds alone
+     * would be reading back what was stored rather than saying what can be reached.
+     */
+    public Set<A> atomsSpokenOf() {
+        return kinds.keySet();
+    }
+
+    /**
      * How the values of {@code atom} are spaced here, or null where nothing said.
      *
      * <p>Asked by a reader counting the values between two ends, which only a spacing makes a number:

--- a/souther-compiler/src/test/java/souther/compiler/check/AProductIsHeldToWhatThePathKnowsOfItsFactorsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AProductIsHeldToWhatThePathKnowsOfItsFactorsTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -89,7 +90,7 @@ class AProductIsHeldToWhatThePathKnowsOfItsFactorsTest {
         assertTrue(guarded.boundsOf(atom).isEmpty(),
                 "nothing was said about the product itself");
 
-        NumericDomain<Term> derived = DerivedBounds.refine(guarded, terms);
+        NumericDomain<Term> derived = DerivedBounds.refine(guarded, terms, Set.of(atom));
 
         assertEquals(Endpoint.inclusive(Count.of(0)), derived.boundsOf(atom).min());
         assertNull(derived.boundsOf(atom).max(), "nothing bounds either factor above");
@@ -114,7 +115,7 @@ class AProductIsHeldToWhatThePathKnowsOfItsFactorsTest {
                 arithmetic(Hir.BinOp.MUL, read("a", a), read("b", b)), at);
         Term atom = product.coefs().keySet().iterator().next();
 
-        NumericDomain<Term> derived = DerivedBounds.refine(NumericDomain.top(), terms);
+        NumericDomain<Term> derived = DerivedBounds.refine(NumericDomain.top(), terms, Set.of(atom));
 
         assertTrue(derived.boundsOf(atom).isEmpty());
     }
@@ -141,7 +142,7 @@ class AProductIsHeldToWhatThePathKnowsOfItsFactorsTest {
         Term atom = form.coefs().keySet().iterator().next();
         NumericDomain<Term> guarded = atOrAboveZero(terms, terms.bodyKey(read("x", x), at));
 
-        NumericDomain<Term> derived = DerivedBounds.refine(guarded, terms);
+        NumericDomain<Term> derived = DerivedBounds.refine(guarded, terms, Set.of(atom));
 
         assertEquals(Endpoint.inclusive(Count.of(0)), derived.boundsOf(atom).min());
     }
@@ -173,7 +174,7 @@ class AProductIsHeldToWhatThePathKnowsOfItsFactorsTest {
                 .assume(LinearForm.atom(factorB).minus(num(1000)), Rel.LE,
                         terms.kindsOf(LinearForm.atom(factorB)));
 
-        NumericDomain<Term> derived = DerivedBounds.refine(guarded, terms);
+        NumericDomain<Term> derived = DerivedBounds.refine(guarded, terms, Set.of(atom));
 
         assertEquals(Endpoint.inclusive(Count.of(0)), derived.boundsOf(atom).min());
         assertEquals(Endpoint.inclusive(Count.of(100)), derived.boundsOf(atom).max(),

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAReadingDerivesIsWhatItsQuestionReachesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAReadingDerivesIsWhatItsQuestionReachesTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * What a construction's reading derives about the arithmetic the domain cannot carry, and what it
@@ -72,9 +71,15 @@ class WhatAReadingDerivesIsWhatItsQuestionReachesTest {
      */
     @Test
     void whatOneConstructionDerivesDoesNotGrowWithArithmeticItIsNotAbout() {
+        Set<String> theProduct = Set.of("(demo.total.0 MUL demo.total.1)");
         List<Set<String>> none = derivedWhileCompiling(behaviorWith(0));
 
-        assertFalse(none.isEmpty(), "the construction is over a product, so something was derived");
+        // Said as what was derived and not as how much. Asked only whether the readings agree with
+        // each other, a reading that derived nothing at all would agree with itself at every count
+        // and this would come out green while saying that no work grew — which is true of a check
+        // that does no work, and is not what this is for.
+        assertEquals(List.of(theProduct, theProduct), none,
+                "each of the construction's two readings derived the product it is over");
         assertEquals(none, derivedWhileCompiling(behaviorWith(10)));
         assertEquals(none, derivedWhileCompiling(behaviorWith(100)));
     }
@@ -97,22 +102,27 @@ class WhatAReadingDerivesIsWhatItsQuestionReachesTest {
     }
 
     /**
-     * A bound derived for one recipe is an answer of the reading and not a premise the next recipe is
-     * derived from.
+     * A bound derived for one recipe reaches another only where the recipe graph names it, and not
+     * through a relation the domain holds between the two.
+     *
+     * <p>Not the graph's own edges, which do carry: a recipe's operands are derived and read where
+     * its form is read, which is what
+     * {@link AProductIsHeldToWhatThePathKnowsOfItsFactorsTest#aQuotientOverAProductReadsWhatTheProductWasDerivedTo}
+     * holds of {@code a * b / 100}. What is asked here is the sideways route.
      *
      * <p>{@code q == a * b} relates {@code q} to the product through a difference, and
      * {@code NonNeg(q)} is discharged by it — the product's derived bound reaches {@code q} through
-     * that difference once it is in. {@code q * c} is a second recipe over {@code q}, and it is
-     * derived against the domain the reading was given, in which {@code q} is bounded by nothing. So
-     * the clause stands.
+     * that difference once the results are taken in. {@code q * c} is a second recipe over
+     * {@code q}, and it is derived against the domain the reading was given, in which {@code q} is
+     * bounded by nothing. So that clause stands.
      *
-     * <p>Held to because it is what makes one pass enough. Were a derived bound readable by another
-     * derivation, the answers would depend on the order the recipes were walked in, and deriving from
-     * a fixed set of roots would be short of what deriving everything reaches. The control below is
-     * the same construction with {@code q} bounded by a guard instead, which is the one difference.
+     * <p>Held to because it is what makes one pass enough. Were what a reading derived readable by
+     * the next derivation, the answers would depend on the order the recipes were walked in and a
+     * fixed set of roots would be short of what walking everything reaches. The control below is the
+     * same second recipe over a {@code q} a guard bounds outright, which is the one difference.
      */
     @Test
-    void aBoundDerivedForOneRecipeIsNotReadWhenAnotherIsDerived() {
+    void aDerivedBoundDoesNotReachAnotherRecipeThroughADomainRelation() {
         assertEquals(List.of(), warningsOf(TYPES + """
                 behavior f : (a: Int, b: Int, q: Int) -> NonNeg | Bad constructs NonNeg, Bad
                 let f (a, b, q) = {
@@ -154,6 +164,64 @@ class WhatAReadingDerivesIsWhatItsQuestionReachesTest {
                     guard q >= 0
                         else Bad
                     NonNeg(q * c)
+                }
+                """));
+    }
+
+    /**
+     * A derived bound reaches a clause through a relation the domain kept as written.
+     *
+     * <p>The second of the two routes out of a form's own atoms that
+     * {@link souther.compiler.numeric.NumericDomain#atomsSpokenOf} names. {@code q <= a * b + z} is
+     * three atoms, which is neither an interval nor a difference, so it is kept as written and
+     * proves things as a premise: the goal {@code q <= 0} leaves the residual {@code a * b + z},
+     * and the product's derived upper end together with {@code z}'s own puts that at or below zero.
+     *
+     * <p>The other route is a difference, and
+     * {@link AProductIsBoundedByWhatThePathBoundsItsFactorsToTest#aClauseReachesAProductThroughAGuardThatEquatesTheTwo}
+     * is that one. Both are here because the roots a reading derives from are what the domain says
+     * anything about, and a reading of that narrowed to the atoms it holds bounds and differences on
+     * would answer the same for every witness but this.
+     *
+     * <p>The control is the same relation with nothing bounding the factors, where the residual is
+     * unbounded above and the clause stands — so what carries the first is the derivation and not
+     * the shape of the guard.
+     */
+    @Test
+    void aDerivedBoundReachesAClauseThroughARelationKeptAsWritten() {
+        assertEquals(List.of(), warningsOf("""
+                module demo
+                data NonPos = Int
+                    invariant value <= 0
+                data Bad
+                behavior f : (a: Int, b: Int, z: Int, q: Int) -> NonPos | Bad
+                    constructs NonPos, Bad
+                let f (a, b, z, q) = {
+                    guard a >= 0
+                        else Bad
+                    guard b <= 0
+                        else Bad
+                    guard z <= 0
+                        else Bad
+                    guard q <= a * b + z
+                        else Bad
+                    NonPos(q)
+                }
+                """));
+
+        assertEquals(List.of("E2011"), warningsOf("""
+                module demo
+                data NonPos = Int
+                    invariant value <= 0
+                data Bad
+                behavior f : (a: Int, b: Int, z: Int, q: Int) -> NonPos | Bad
+                    constructs NonPos, Bad
+                let f (a, b, z, q) = {
+                    guard z <= 0
+                        else Bad
+                    guard q <= a * b + z
+                        else Bad
+                    NonPos(q)
                 }
                 """));
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAReadingDerivesIsWhatItsQuestionReachesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAReadingDerivesIsWhatItsQuestionReachesTest.java
@@ -1,0 +1,183 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * What a construction's reading derives about the arithmetic the domain cannot carry, and what it
+ * leaves alone.
+ *
+ * <p>A recipe — how a product or a truncating quotient was computed — is recorded where the atom is
+ * named, and the naming lasts as long as the behavior body being read. What is derived from a recipe
+ * depends on what the path assumed, and is answered where a construction is judged. The two are not
+ * the same unit, and reading the first as the work list for the second is what made a behavior with
+ * many non-linear expressions pay for every one of them at every construction in it.
+ *
+ * <p>So a reading derives what its own question can reach: the atoms its clauses are decided by, and
+ * the atoms the domain it was built from says anything about. The second half is not an optimisation
+ * to be tidied away — {@link AProductIsBoundedByWhatThePathBoundsItsFactorsToTest#
+ * aClauseReachesAProductThroughAGuardThatEquatesTheTwo} is a clause that names no product and
+ * reaches one through a guard that related the two.
+ */
+class WhatAReadingDerivesIsWhatItsQuestionReachesTest {
+
+    private static final String TYPES = """
+            module demo
+            data NonNeg = Int
+                invariant value >= 0
+            data Bad
+            """;
+
+    private static List<String> warningsOf(String module) {
+        return Compiler.compileWithWarnings(module).warnings().stream()
+                .filter(d -> d.severity() == Severity.WARNING)
+                .map(Diagnostic::code)
+                .toList();
+    }
+
+    /** The recipes each reading of the module evaluated, by the name each atom renders as. */
+    private static List<Set<String>> derivedWhileCompiling(String module) {
+        List<List<Term>> watching = new ArrayList<>();
+        DerivedBounds.WATCHING = watching;
+        try {
+            Compiler.compileWithWarnings(module);
+        } finally {
+            DerivedBounds.WATCHING = null;
+        }
+        return watching.stream()
+                .map(one -> one.stream().map(Term::rendered)
+                        .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new)))
+                .map(one -> (Set<String>) one)
+                .toList();
+    }
+
+    /**
+     * One construction, and a behavior around it holding however many products nothing on the path
+     * relates to it. What the construction's readings evaluate is the same set every time.
+     *
+     * <p>The set and not how big it is. A count says the work did not grow; the set says the work is
+     * the arithmetic this construction is about, which is the property that stops the growth coming
+     * back by another route.
+     */
+    @Test
+    void whatOneConstructionDerivesDoesNotGrowWithArithmeticItIsNotAbout() {
+        List<Set<String>> none = derivedWhileCompiling(behaviorWith(0));
+
+        assertFalse(none.isEmpty(), "the construction is over a product, so something was derived");
+        assertEquals(none, derivedWhileCompiling(behaviorWith(10)));
+        assertEquals(none, derivedWhileCompiling(behaviorWith(100)));
+    }
+
+    /** A behavior whose construction is over {@code a * b}, with {@code unrelated} further products
+     * bound to names nothing reads. Each is arithmetic the naming records a recipe for, and none of
+     * them is a value the clause or the guards reach. */
+    private static String behaviorWith(int unrelated) {
+        StringBuilder b = new StringBuilder(TYPES);
+        b.append("behavior total : (a: Int, b: Int) -> NonNeg | Bad constructs NonNeg, Bad\n");
+        b.append("let total (a, b) = {\n");
+        b.append("    guard a >= 0\n        else Bad\n");
+        b.append("    guard b >= 0\n        else Bad\n");
+        for (int i = 0; i < unrelated; i++) {
+            b.append("    let n").append(i).append(" = (a + ").append(i)
+                    .append(") * (b + ").append(i).append(")\n");
+        }
+        b.append("    NonNeg(a * b)\n}\n");
+        return b.toString();
+    }
+
+    /**
+     * A bound derived for one recipe is an answer of the reading and not a premise the next recipe is
+     * derived from.
+     *
+     * <p>{@code q == a * b} relates {@code q} to the product through a difference, and
+     * {@code NonNeg(q)} is discharged by it — the product's derived bound reaches {@code q} through
+     * that difference once it is in. {@code q * c} is a second recipe over {@code q}, and it is
+     * derived against the domain the reading was given, in which {@code q} is bounded by nothing. So
+     * the clause stands.
+     *
+     * <p>Held to because it is what makes one pass enough. Were a derived bound readable by another
+     * derivation, the answers would depend on the order the recipes were walked in, and deriving from
+     * a fixed set of roots would be short of what deriving everything reaches. The control below is
+     * the same construction with {@code q} bounded by a guard instead, which is the one difference.
+     */
+    @Test
+    void aBoundDerivedForOneRecipeIsNotReadWhenAnotherIsDerived() {
+        assertEquals(List.of(), warningsOf(TYPES + """
+                behavior f : (a: Int, b: Int, q: Int) -> NonNeg | Bad constructs NonNeg, Bad
+                let f (a, b, q) = {
+                    guard a >= 0
+                        else Bad
+                    guard b >= 0
+                        else Bad
+                    guard q == a * b
+                        else Bad
+                    NonNeg(q)
+                }
+                """));
+
+        assertEquals(List.of("E2011"), warningsOf(TYPES + """
+                behavior f : (a: Int, b: Int, c: Int, q: Int) -> NonNeg | Bad constructs NonNeg, Bad
+                let f (a, b, c, q) = {
+                    guard a >= 0
+                        else Bad
+                    guard b >= 0
+                        else Bad
+                    guard c >= 0
+                        else Bad
+                    guard q == a * b
+                        else Bad
+                    NonNeg(q * c)
+                }
+                """));
+    }
+
+    /** The control: the same second recipe over a {@code q} a guard bounds directly, so the only
+     * difference from the case above is where {@code q}'s bound came from. */
+    @Test
+    void theSameSecondRecipeIsDerivedWhereTheGuardBoundsItsFactorOutright() {
+        assertEquals(List.of(), warningsOf(TYPES + """
+                behavior f : (c: Int, q: Int) -> NonNeg | Bad constructs NonNeg, Bad
+                let f (c, q) = {
+                    guard c >= 0
+                        else Bad
+                    guard q >= 0
+                        else Bad
+                    NonNeg(q * c)
+                }
+                """));
+    }
+
+    /**
+     * A clause read as the cases of an operation that answers one of its arguments reaches a product
+     * standing in one of those cases.
+     *
+     * <p>Nothing bounds what {@code Int.min} answers, so the clause is not settled as written and is
+     * read case by case. The case that answers the product is where the product's derived bound is
+     * needed, and the atoms of a case are the case's own to say — a reading that asked only what the
+     * clause names as written would leave this construction owed a guard the author has written.
+     */
+    @Test
+    void aClauseReadCaseByCaseReachesAProductStandingInACase() {
+        assertEquals(List.of(), warningsOf(TYPES + """
+                behavior f : (a: Int, b: Int) -> NonNeg | Bad constructs NonNeg, Bad
+                let f (a, b) = {
+                    guard a >= 0
+                        else Bad
+                    guard b >= 0
+                        else Bad
+                    NonNeg(Int.min(a * b, 100))
+                }
+                """));
+    }
+}


### PR DESCRIPTION
Closes #759.

## What was wrong

`Terms.derivations()` is a memo of every product and truncating quotient named while one behavior body is read. `DerivedBounds.refine` was walking all of it at every construction, once for the guarded reading and once for the values alone.

Those are two units. What was named is a fact about the body; what has to be derived is a question about one construction on one path. Reading the first as the work list for the second made the work their product, and worse than their product — each derived bound is asserted one at a time, and every assertion recomputes the difference closure.

| unrelated products | constructions | before | after |
|---|---|---|---|
| 0 | 20 | 7ms | 10ms |
| 40 | 20 | 68ms | 10ms |
| 80 | 20 | 107ms | 9ms |
| 160 | 20 | 392ms | 14ms |

## What it derives now

The roots are the atoms its clauses are decided by, together with the atoms the domain it was built from says anything about. Both halves carry — the second is what `AProductIsBoundedByWhatThePathBoundsItsFactorsToTest.aClauseReachesAProductThroughAGuardThatEquatesTheTwo` needs, where the clause names `total` and reaches `a * b` only through the guard that equated them.

`NumericDomain.atomsSpokenOf` answers the second half. What it guarantees runs one way: **an atom outside it cannot be reached by any question asked here.** A question is asked of a form, and the answer leaves that form's atoms by two routes only — the differences, and the relations kept as written — and every atom on either route arrived through `assume`. It is a safe superset and not the exact reachable set: `assume` records an atom's spacing before it decides whether it can hold the relation, so an atom named in a dropped disequality is in it too. Generous is the sound direction, and the doc says so.

`readingOf` owns both the clause assumptions and the derivation. The second reads the first, and a caller that added to the first without asking the second again would judge a construction against arithmetic nothing was derived for — so there is no order left for a caller to keep.

The atoms of a piecewise case are read off the `kinds` its forms register into, not listed from `numeric` and `given`. A condition naming an argument no case answers is an atom of that case all the same; no operation in `CHOOSES` has one today, which is exactly why a list would fall behind.

## What one pass rules out

Not the recipe graph's own edges — those carry. `boundsOf` derives an operand that is itself a recipe and reads it where the recipe's form is read, which is how `a * b / 100` reads what the product was bounded to (`aQuotientOverAProductReadsWhatTheProductWasDerivedTo`).

What does not happen is the reading being rebuilt from what was derived and the recipes put through again against it. Every derivation is handed the domain `refine` was given, so what is derived for an atom is a function of that domain and the recipe graph alone — an evaluation over a graph with no way back to where it started, no fixed point, no dependence on the order the roots are walked. A derived bound reaches another recipe only where the graph names it, never through a relation the domain holds between the two.

Measured, not assumed: `q == a * b` discharges a clause about `q`, and the same relation leaves a clause about `q * c` owed, with the same second recipe over a `q` a guard bounds outright as the control.

## Acceptance criteria

1. **Verdicts unchanged.** souther-examples built with the compiler before and after; the full logs differ only in PIDs, ports and jOOQ's tip of the day. No diagnostic moved. (todomvc is red in both, at the same place, as it was before this branch.) Full suite green.
2. **The relational-indirection witness passes, and fails when the derivation is removed.** Removing the `atomsSpokenOf` half of the roots puts it back to E2011.
3. **The work is bounded by the question.** `WhatAReadingDerivesIsWhatItsQuestionReachesTest` grows the unrelated products 0 → 10 → 100 and holds the visited recipe set equal — the set, and named: each reading evaluated the one product the construction is over.

## Controls run

Each part was removed to check the tests say something:

| removed | result |
|---|---|
| the root narrowing | visited set grows to every recipe; the growth test fails |
| the roots entirely | all five tests in the new class fail |
| `atomsSpokenOf` half of the roots | relational-indirection and `q == a * b` go to E2011 |
| `piecewise` from `Clause` | `Int.min(a * b, 100)` goes to E2011; the 14 existing piecewise tests do not catch it |
| `numeric` from `Clause` | 12 failures |

Both routes `atomsSpokenOf` names now have a witness. The differences had one; the relations kept as written did not, so a later reading of that API as the atoms it holds bounds and differences on would have left every test green. `q <= a * b + z` is three atoms and is kept, and the product's derived end together with `z`'s puts the residual at or below zero; with nothing bounding the factors the same guard leaves the clause owed.

`known` is the one part nothing catches — a reading that assumes it first reaches those atoms anyway. It is kept because what a clause is decided by is a fact about the clause, not about what some caller did a line earlier. Said so in its doc.

## One narrowing worth naming

`AnAtomComputedFromItself` now fires only for recipes a reading reaches. It asserts about this check's own naming, nothing a program can write reaches it, and a recipe no reading reaches derives what nothing reads — so no diagnostic changes. Said where it is thrown rather than left for a reader to notice.

## Not in this change

Batching the assertions inside `NumericDomain` so the difference closure is not recomputed per bound. That is a constant factor, it needs its own argument that closing once is the same as closing after each, and with the roots narrowed it no longer shows up in the numbers.

specification.adoc is unchanged. §invariant-discharge's "What is derived is derived once, from what is known where the clause is read" still holds word for word, and which products a reading walks is below the level it describes — which is what the unchanged diagnostics say.