### PR TITLE
Ask the compile what may be written here, and keep what it said

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -54,6 +54,9 @@ public final class Resolve {
 
     private final SyntaxSymbols symbols;
     private final Reachable reachable;
+    /** {@link Reachable#byName()}, worked out once: a bare name is looked up for every name this
+     * pass reads, and the table does not change while it reads. */
+    private final Map<String, ValueName> reaches;
     private final Elsewhere elsewhere;
     /** Every name this pass answered, in the order it met them. */
     private final List<TypeUse> denotations = new ArrayList<>();
@@ -105,6 +108,7 @@ public final class Resolve {
     private Resolve(SyntaxSymbols symbols, Values values) {
         this.symbols = symbols;
         this.reachable = values.reachable();
+        this.reaches = reachable.byName();
         this.elsewhere = values.elsewhere();
     }
 
@@ -176,6 +180,27 @@ public final class Resolve {
             helpers = Collections.unmodifiableMap(new LinkedHashMap<>(helpers));
             behaviors = Collections.unmodifiableMap(new LinkedHashMap<>(behaviors));
             exposed = Collections.unmodifiableMap(new LinkedHashMap<>(exposed));
+        }
+
+        /**
+         * Every bare spelling this reaches something by, and what writing it would mean.
+         *
+         * <p>The order the three tables are consulted in is a rule, and it is written once — here.
+         * An import brings a library name in, and everything the module already has is what that
+         * spelling means instead. Resolving a bare name reads this, so a reader listing what may be
+         * written here reads the answer resolution reads rather than a second assembly of the same
+         * three tables: two of those would agree until one of them moved, and nothing would say
+         * which had.
+         *
+         * <p>A binding in force and a type written as a value are not here. Both are answered before
+         * this table is consulted — the first from the bindings that hold at the position, the
+         * second from the type scope — so neither is a fact about the module.
+         */
+        public Map<String, ValueName> byName() {
+            Map<String, ValueName> reached = new LinkedHashMap<>(helpers);
+            behaviors.forEach(reached::putIfAbsent);
+            exposed.forEach(reached::putIfAbsent);
+            return Collections.unmodifiableMap(reached);
         }
 
         /**
@@ -1260,20 +1285,10 @@ public final class Resolve {
             return new ValueName.OfType(written, d.type(),
                     applied ? null : ConstructionOrigin.own());
         }
-        // a helper or a behavior, applied or handed over by name — which the inliner expands into a
-        // block that applies it
-        ValueName.Helper helper = reachable.helpers().get(written);
-        if (helper != null) {
-            return helper;
-        }
-        ValueName.Behavior behavior = reachable.behaviors().get(written);
-        if (behavior != null) {
-            return behavior;
-        }
-        // A name an import let this module write without its qualifier. Asked last: an import brings
-        // a name in, and everything the module already has — a binding in force, its own
-        // declarations — is what that name means here instead.
-        return reachable.exposed().get(written);
+        // A helper or a value of this module, a behavior it reaches, or a name an import let it
+        // write without a qualifier — asked of the one table that says which, so that a reader
+        // listing what may be written here reads the same answer this does.
+        return reaches.get(written);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
@@ -3,20 +3,19 @@ package souther.compiler.check;
 import souther.compiler.ast.Hir;
 import souther.compiler.types.Denotation;
 import souther.compiler.types.TypeKey;
-import souther.compiler.types.TypeSymbol;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
  * A {@link Scope} and a {@link Declarations} together, for the readers that have both to hand.
  *
  * <p>Not a thing of its own. It answers nothing itself except the one question that genuinely needs
- * both — {@link #visible} takes the identities a bare name reaches here and asks what each is — and
- * hands over its two parts otherwise. The two answer different questions and fail in different ways:
+ * both — {@link #reachable} takes the identities a bare name reaches here and asks what each is —
+ * and hands over its two parts otherwise. The two answer different questions and fail in different ways:
  * a spelling nothing here writes is not a declaration that did not come out, and while one object
  * answered both, which of them a reader was holding was something it worked out for itself.
  */
@@ -90,20 +89,32 @@ public final class Symbols implements NameSense {
     }
 
     /**
-     * The definitions reachable here by a bare name: this module\'s own plus the imported ones.
+     * Every bare spelling that reaches a definition here, and the definition it reaches — this
+     * module\'s own plus the imported ones.
      *
      * <p>The one question that is both. What is reachable is the scope\'s to say and what each of
      * them is a declaration of is not, so this is written where both are to hand rather than in
      * either of them.
+     *
+     * <p>The pair and not either half. Which declaration a bare name denotes is what resolving it
+     * answers, and a reader given only the declarations has to pair each back with a spelling of its
+     * own — the same guess about which module declares what, made outside the only place that knows.
+     * A spelling that reaches nothing is absent here and present in
+     * {@code scope().namesInScope()}, those being two questions.
      */
-    public Collection<Hir.Def> visible() {
-        List<Hir.Def> defs = new ArrayList<>();
-        for (TypeSymbol name : scope.visibleNames()) {
+    public Map<String, Hir.Def> reachable() {
+        Map<String, Hir.Def> reached = new LinkedHashMap<>();
+        scope.denotedNames().forEach((spelling, name) -> {
             Hir.Def def = declarations.declaration(name.key());
             if (def != null) {
-                defs.add(def);
+                reached.put(spelling, def);
             }
-        }
-        return defs;
+        });
+        return reached;
+    }
+
+    /** The definitions reachable here by a bare name, without the spellings they are reached by. */
+    public Collection<Hir.Def> visible() {
+        return new ArrayList<>(reachable().values());
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
@@ -4,8 +4,6 @@ import souther.compiler.ast.Hir;
 import souther.compiler.types.Denotation;
 import souther.compiler.types.TypeKey;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -111,10 +109,5 @@ public final class Symbols implements NameSense {
             }
         });
         return reached;
-    }
-
-    /** The definitions reachable here by a bare name, without the spellings they are reached by. */
-    public Collection<Hir.Def> visible() {
-        return new ArrayList<>(reachable().values());
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeScope.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeScope.java
@@ -7,6 +7,7 @@ import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.TypeReachName;
 
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -233,16 +234,28 @@ public final class TypeScope {
         return scope.keySet();
     }
 
+    /**
+     * Every bare spelling that reaches a name here, and the name it reaches.
+     *
+     * <p>The pair, which is what resolving a name answers. A spelling in scope standing for nothing
+     * is not here — it reaches no name — and it is still reachable, which {@link #namesInScope}
+     * answers. Two absences, two questions: whether a spelling may be written is the second, and
+     * what writing it would mean is this one.
+     */
+    public Map<String, TypeSymbol> denotedNames() {
+        Map<String, TypeSymbol> named = new LinkedHashMap<>();
+        scope.forEach((spelling, denotation) -> {
+            if (denotation instanceof Denotation.Denotes d) {
+                named.put(spelling, d.type());
+            }
+        });
+        return named;
+    }
+
     /** The names reachable here, canonical. A name in scope standing for nothing names no
      * declaration, so it is reachable and not among these. */
     public Collection<TypeSymbol> visibleNames() {
-        Set<TypeSymbol> named = new LinkedHashSet<>();
-        for (Denotation denotation : scope.values()) {
-            if (denotation instanceof Denotation.Denotes d) {
-                named.add(d.type());
-            }
-        }
-        return named;
+        return new LinkedHashSet<>(denotedNames().values());
     }
 
     /** Whether the module that declares {@code name} exposes it — its own names always count. */

--- a/souther-compiler/src/test/java/souther/compiler/query/ABareNameIsLookedUpInTheTableThatListsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ABareNameIsLookedUpInTheTableThatListsItTest.java
@@ -1,0 +1,102 @@
+package souther.compiler.query;
+
+import souther.compiler.check.Resolve;
+import souther.compiler.check.Scoping;
+import souther.compiler.types.ValueName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Resolving a bare name and listing what may be written here are one question, and both read
+ * {@link Resolve.Reachable#byName()}.
+ *
+ * <p>Written as agreement between the two answers rather than as the order the three tables are
+ * consulted in. Within a legal module they are disjoint — a definition spelled like a name an import
+ * brings in is refused where the import is written (E1508) — so an order is a rule no program
+ * exercises, and a test that asserted one would pass over two readers that had already gone apart.
+ * What can go apart is what each answers about a spelling, and that is what is held here.
+ */
+class ABareNameIsLookedUpInTheTableThatListsItTest {
+
+    private static final String UP = """
+            module up exposing ( price )
+
+            let price = 100
+            """;
+
+    private static final String DOWN = """
+            module down
+
+            import up ( price )
+            import String ( length )
+
+            let own (n) = n + price
+
+            behavior sizes : (s: String) -> Int
+            let sizes (s) = own(length(s))
+
+            behavior twice : (s: String) -> Int
+            let twice (s) = sizes(s) + sizes(s)
+
+            behavior double : (n: Int) -> Int
+            let double (n) = n + n
+            """;
+
+    private static Compilation compiled() {
+        return Compilation.ofDocuments(
+                Map.of("file:///up.sou", UP, "file:///down.sou", DOWN), Set.of(),
+                souther.compiler.meta.ModulePath.EMPTY);
+    }
+
+    private static Resolve.Reachable reachable(Compilation compilation) {
+        Scoping.Scoped scoped = compilation.db().ask(new Names.ModuleScope("down")).value();
+        assertTrue(scoped != null, "the module's scope is assembled");
+        return scoped.reachable();
+    }
+
+    @Test
+    void everyBareNameResolvesToWhatTheTableSaysItReaches() {
+        Compilation compilation = compiled();
+        Map<String, ValueName> byName = reachable(compilation).byName();
+        Resolve.ResolutionIndex facts = compilation.db().ask(new Names.Facts("down")).value();
+        assertTrue(facts != null, "the module resolves");
+
+        List<String> checked = new ArrayList<>();
+        for (Resolve.ValueUse use : facts.values()) {
+            String written = use.written().canonical();
+            ValueName listed = byName.get(written);
+            if (listed == null) {
+                continue;   // a binding in force, or a name written through its module
+            }
+            assertEquals(listed, use.denotes(),
+                    "`" + written + "` is listed as reaching " + listed
+                            + " and resolved to " + use.denotes());
+            checked.add(written);
+        }
+        assertTrue(checked.containsAll(List.of("own", "price", "length", "sizes")),
+                "a helper of this module, a value another module publishes, a library name an "
+                        + "import brought in, and a behavior — each was resolved: " + checked);
+    }
+
+    /** Every way into the namespace arrives in the one table, so a reader listing what may be
+     * written here does not have to know how many ways there are. */
+    @Test
+    void theTableHoldsWhatEachKindOfNameReaches() {
+        Map<String, ValueName> byName = reachable(compiled()).byName();
+
+        assertEquals(new ValueName.Helper("down", "own"), byName.get("own"));
+        assertEquals(new ValueName.Helper("up", "price"), byName.get("price"),
+                "a published value is reached bare, under the module that wrote it");
+        assertEquals(new ValueName.Behavior("down", "sizes"), byName.get("sizes"));
+        assertEquals(new ValueName.Stdlib("String", "length"), byName.get("length"));
+        assertFalse(byName.containsKey("s"), "a binding in force is not in a module's table");
+    }
+}

--- a/souther-lsp/src/main/java/souther/lsp/LspServer.java
+++ b/souther-lsp/src/main/java/souther/lsp/LspServer.java
@@ -306,16 +306,32 @@ public final class LspServer {
 
     // --- completion ---
 
+    /**
+     * The names that may be written at the cursor.
+     *
+     * <p>Answered from the workspace snapshot, as every other question about a position is: what a
+     * bare name reaches here is settled by this document's imports and by the modules around it, and
+     * one document cannot say what its own import lines brought in without reading them a second
+     * time — which is the rule that decides it, written twice.
+     */
     private Object completion(JsonNode params) {
         Params.PositionParams p = InboundDecoders.decode(InboundDecoders.POSITION_PARAMS, params)
                 .orElse(null);
-        String text = p == null ? null : documents.get(p.uri());
-        if (text == null) {
+        if (p == null || documents.get(p.uri()) == null) {
             return List.of();
         }
+        ModuleGraph graph = workspace.snapshot(documents.openDocuments());
         List<Object> items = new ArrayList<>();
-        for (CompletionItem item : analyzer.completions(text, p.position())) {
-            items.add(Map.of("label", item.label(), "kind", item.kind()));
+        for (CompletionItem item : analyzer.completions(p.uri(), p.position(), graph)) {
+            Map<String, Object> sent = new LinkedHashMap<>();
+            sent.put("label", item.label());
+            sent.put("kind", item.kind());
+            // Omitted rather than sent as null for a name with no origin: a client renders an empty
+            // detail as an empty line beside the label.
+            if (item.detail() != null) {
+                sent.put("detail", item.detail());
+            }
+            items.add(sent);
         }
         return items;
     }

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -48,6 +48,7 @@ import souther.lsp.protocol.Range;
 import souther.lsp.protocol.TextEdit;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -229,7 +230,7 @@ public final class Analyzer {
 
         Map<String, List<Located>> byUri;
         try {
-            byUri = compileOf(path, compileSet, brokenModules).diagnostics();
+            byUri = compileOf(graph, path, compileSet, brokenModules).diagnostics();
         } catch (RuntimeException | StackOverflowError e) {
             // Which file broke the walk is not known here, so every file that entered the compile is
             // marked. Silence would leave the whole workspace looking clean.
@@ -263,9 +264,25 @@ public final class Analyzer {
         return out;
     }
 
-    /** The workspace's compile, brought up to date with what the documents now say. */
-    private Compilation compileOf(souther.compiler.meta.ModulePath path,
+    /**
+     * The workspace's compile, brought up to date with what the documents now say.
+     *
+     * <p>Where this analyzer is told which documents the workspace holds, and so where what it
+     * remembers about a document it no longer holds is dropped. {@code sources} is not that set —
+     * it is the documents that could join the compile — and a document held out for its syntax
+     * errors is one this still has. The graph is, which is why it is taken rather than worked out
+     * from the two maps.
+     *
+     * <p>A document is named by its URI and a URI can be used again, so what was remembered has to
+     * be dropped while the document is gone rather than when the next one arrives — by then the two
+     * are both "the document at this URI" and nothing tells them apart. Every request that arrives
+     * with a workspace comes through here, and a file created or deleted on disk reaches it as a
+     * diagnose, so the gap is observed wherever there is one.
+     */
+    private Compilation compileOf(ModuleGraph graph, souther.compiler.meta.ModulePath path,
                                   Map<String, String> sources, Set<String> broken) {
+        elsewhere.forgetAllBut(graph.uris());
+        readings.keySet().retainAll(Set.copyOf(graph.uris()));
         if (workspaceCompile == null || !path.equals(compiledAgainst)) {
             workspaceCompile = Compilation.ofDocuments(sources, broken, path);
             workspaceCompile.measure(measure);
@@ -287,23 +304,50 @@ public final class Analyzer {
         Set<String> broken = new HashSet<>();
         for (String uri : graph.uris()) {
             String text = graph.text(uri);
-            boolean readable;
-            try {
-                readable = CstParser.parse(text).errors().isEmpty();
-            } catch (RuntimeException | StackOverflowError e) {
-                readable = false;
-            }
-            if (readable) {
+            Reading reading = readingOf(uri, text);
+            if (reading.parses()) {
                 clean.put(uri, text);
-            } else {
-                String name = Compiler.moduleNameFromHeader(text);
-                if (name != null) {
-                    broken.add(name);
-                }
+            } else if (reading.declares() != null) {
+                broken.add(reading.declares());
             }
         }
-        return compileOf(compiledAgainst == null ? souther.compiler.meta.ModulePath.EMPTY
+        return compileOf(graph, compiledAgainst == null ? souther.compiler.meta.ModulePath.EMPTY
                 : compiledAgainst, clean, broken);
+    }
+
+    /**
+     * What one document was found to be: whether it can join a compile, and — where it cannot — the
+     * module its header names, which is what keeps an importer from being told the module is
+     * unknown.
+     *
+     * <p>Kept with the text it was read from. Every request that arrives with the workspace sorts it
+     * into what can be compiled and what cannot, and a request arrives for each keystroke while
+     * completion is open; reading every file in the workspace again on each of them is work whose
+     * answer cannot have changed, since one text parses one way. On the crm example — seven sources,
+     * 3898 lines — it was 7.3 of the 9.3 milliseconds a completion took, and it grows with the
+     * workspace rather than with the edit.
+     */
+    private record Reading(String text, boolean parses, String declares) {}
+
+    /** Documents this analyzer has already read, by URI. Dropped along with everything else it
+     * remembers about a document the workspace no longer holds. */
+    private final Map<String, Reading> readings = new HashMap<>();
+
+    private Reading readingOf(String uri, String text) {
+        Reading had = readings.get(uri);
+        if (had != null && had.text().equals(text)) {
+            return had;
+        }
+        boolean parses;
+        try {
+            parses = CstParser.parse(text).errors().isEmpty();
+        } catch (RuntimeException | StackOverflowError e) {
+            parses = false;
+        }
+        Reading now = new Reading(text, parses,
+                parses ? null : Compiler.moduleNameFromHeader(text));
+        readings.put(uri, now);
+        return now;
     }
 
     /** Where the cursor is, in the terms the compiler answers about: a place in a file, not a line
@@ -1160,15 +1204,14 @@ public final class Analyzer {
         Compilation compilation = compileOf(graph);
         String module = moduleOf(compilation, graph, uri);
         List<CompletionItem> declared = declaredIn(root, module);
-        elsewhere.forgetAllBut(graph.uris());
         List<CompletionItem> fromElsewhere =
                 elsewhere.of(compilation, uri, module, labelsOf(declared));
 
         LinkedHashMap<String, CompletionItem> byLabel = new LinkedHashMap<>();
-        SyntaxNode enclosing =
-                enclosingDef(root, new LineIndex(text).offsetOf(pos.line(), pos.character()));
+        int cursor = new LineIndex(text).offsetOf(pos.line(), pos.character());
+        SyntaxNode enclosing = enclosingDef(root, cursor);
         if (enclosing != null) {
-            collectLocalBindings(enclosing, byLabel);
+            collectLocalBindings(enclosing, cursor, byLabel);
         }
         for (CompletionItem item : declared) {
             byLabel.putIfAbsent(item.label(), item);
@@ -1231,11 +1274,33 @@ public final class Analyzer {
         return null;
     }
 
-    /** Adds every param and {@code let} name bound anywhere inside {@code node} as a variable candidate. */
-    private void collectLocalBindings(SyntaxNode node, Map<String, CompletionItem> out) {
+    /**
+     * Adds the params and {@code let} names in force at {@code offset} as variable candidates.
+     *
+     * <p>In force, and not every name bound anywhere in the definition. A binding is what its
+     * spelling denotes where it holds, which is what lets a candidate offered from here stand ahead
+     * of one an import brought in — so the two have to be the same set. A name bound in an arm of a
+     * {@code match} the cursor is not in denotes nothing where the cursor is, and offering it there
+     * both says something untrue and takes the place of the name that spelling does denote.
+     *
+     * <p>A construct that confines what it binds is walked into only when the cursor is inside it,
+     * and what it binds is offered only then. Everything else is walked through: a pattern is not a
+     * scope of its own, and the names it binds hold over the arm that holds the cursor.
+     *
+     * <p>A binding written after the cursor is not in force yet either. That is read off where it
+     * starts, so the {@code let} on the line below is not offered as though it had already been
+     * written.
+     */
+    private void collectLocalBindings(SyntaxNode node, int offset,
+                                      Map<String, CompletionItem> out) {
         for (SyntaxElement e : node.children()) {
             if (e instanceof SyntaxNode child) {
-                if (VALUE_BINDINGS.contains(child.kind())) {
+                boolean holds = !BINDING_SCOPES.contains(child.kind())
+                        || (offset >= child.start() && offset <= child.end());
+                if (!holds) {
+                    continue;
+                }
+                if (VALUE_BINDINGS.contains(child.kind()) && child.start() <= offset) {
                     SyntaxToken bound = firstIdent(child);
                     if (bound != null) {
                         // A binding comes from nowhere else, so it has no origin to show.
@@ -1243,10 +1308,15 @@ public final class Analyzer {
                                 new CompletionItem(nameOf(bound), CompletionItem.VARIABLE, null));
                     }
                 }
-                collectLocalBindings(child, out);
+                collectLocalBindings(child, offset, out);
             }
         }
     }
+
+    /** Node kinds that confine what they bind: a name bound in one holds inside it and nowhere else.
+     * A pattern is not among them — it binds over the arm that holds it, not over itself. */
+    private static final java.util.Set<SyntaxKind> BINDING_SCOPES = java.util.Set.of(
+            SyntaxKind.BLOCK_EXPR, SyntaxKind.MATCH_CASE, SyntaxKind.LAMBDA_EXPR);
 
     /** Whether {@code name} is a legal rename target: a single identifier token, not a keyword. The
      * lexer decides, so a non-ASCII name (Souther identifiers may be Japanese) is judged correctly. */

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -88,6 +88,11 @@ public final class Analyzer {
      * set of modules to resolve an import against, so the compile is started again. */
     private souther.compiler.meta.ModulePath compiledAgainst;
 
+    /** What each open document reaches from outside itself, as the last compile that could answer
+     * said. Held across edits so completion has something to offer while the document being typed in
+     * is held out of the compile for its syntax errors. */
+    private final NamesFromElsewhere elsewhere = new NamesFromElsewhere();
+
     /**
      * How much of what the rows cover this editor was told to measure. Off by default.
      *
@@ -1128,47 +1133,90 @@ public final class Analyzer {
     }
 
     /**
-     * Completion candidates at the cursor: the language keywords, the top-level names defined in this
-     * file (types, behaviors, functions), the names its imports bring in, and the params and
-     * {@code let} bindings of the definition the cursor sits in. Deduplicated by label, in that order.
-     * This is name completion, not context-sensitive member completion — a {@code .} field list is
-     * ADR-deferred, so every visible name is offered regardless of the position's expected type.
+     * Completion candidates at the cursor, nearest scope first: the params and {@code let} bindings
+     * of the definition the cursor sits in, the top-level names this document declares, the names
+     * that reach it from elsewhere, and the language keywords. One item per label, the nearest
+     * winning — which is what shadowing means, a binding in force being what its spelling denotes
+     * however many imports also spell it.
+     *
+     * <p>The first two are read off this document's syntax tree every time, so a definition being
+     * written now is offered before it compiles. The third is the compiler's answer about the module
+     * this document belongs to, kept while the compiler cannot answer (see
+     * {@link NamesFromElsewhere}) — a document that does not parse is held out of the compile, and
+     * that is the document being typed in.
+     *
+     * <p>This is name completion, not context-sensitive member completion — a {@code .} field list is
+     * ADR-deferred, so every reachable name is offered regardless of the position's expected type.
+     * One item per label follows from that: which namespace a position is in is not being read, so
+     * two entities of one spelling cannot be told apart by anything but the label, and the nearest is
+     * offered. That is a limit of this list, not a property of the language.
      */
-    public List<CompletionItem> completions(String text, Position pos) {
-        LinkedHashMap<String, CompletionItem> byLabel = new LinkedHashMap<>();
-        for (String keyword : CstLexer.keywords()) {
-            byLabel.putIfAbsent(keyword, new CompletionItem(keyword, CompletionItem.KEYWORD));
+    public List<CompletionItem> completions(String uri, Position pos, ModuleGraph graph) {
+        String text = graph.text(uri);
+        if (text == null) {
+            return List.of();
         }
         SyntaxNode root = CstParser.parse(text).root();
-        for (SyntaxNode def : root.childNodes()) {
-            switch (def.kind()) {
-                case DATA_DEF -> addName(byLabel, def, CompletionItem.CLASS);
-                case BEHAVIOR_DEF -> addName(byLabel, def, CompletionItem.INTERFACE);
-                case FN_DEF -> addName(byLabel, def, CompletionItem.FUNCTION);
-                default -> { /* header, imports, error nodes contribute no completion name */ }
-            }
-        }
-        try {
-            for (Ast.Import imp : CstFrontend.parse(text, "Main").imports()) {
-                for (String name : imp.names()) {
-                    byLabel.putIfAbsent(name, new CompletionItem(name, CompletionItem.FUNCTION));
-                }
-            }
-        } catch (RuntimeException | StackOverflowError _) {
-            // a file that does not parse cleanly exposes no imports; the rest of the list still stands
-        }
-        SyntaxNode enclosing = enclosingDef(root, new LineIndex(text).offsetOf(pos.line(), pos.character()));
+        Compilation compilation = compileOf(graph);
+        String module = moduleOf(compilation, graph, uri);
+        List<CompletionItem> declared = declaredIn(root, module);
+        elsewhere.forgetAllBut(graph.uris());
+        List<CompletionItem> fromElsewhere =
+                elsewhere.of(compilation, uri, module, labelsOf(declared));
+
+        LinkedHashMap<String, CompletionItem> byLabel = new LinkedHashMap<>();
+        SyntaxNode enclosing =
+                enclosingDef(root, new LineIndex(text).offsetOf(pos.line(), pos.character()));
         if (enclosing != null) {
             collectLocalBindings(enclosing, byLabel);
+        }
+        for (CompletionItem item : declared) {
+            byLabel.putIfAbsent(item.label(), item);
+        }
+        for (CompletionItem item : fromElsewhere) {
+            byLabel.putIfAbsent(item.label(), item);
+        }
+        for (String keyword : CstLexer.keywords()) {
+            byLabel.putIfAbsent(keyword, new CompletionItem(keyword, CompletionItem.KEYWORD, null));
         }
         return new ArrayList<>(byLabel.values());
     }
 
-    private void addName(Map<String, CompletionItem> out, SyntaxNode def, int kind) {
-        SyntaxToken name = nameToken(def);
-        if (name != null) {
-            out.putIfAbsent(nameOf(name), new CompletionItem(nameOf(name), kind));
+    /**
+     * The top-level names this document declares, read off its tree.
+     *
+     * <p>Off the tree and not off the compile, because the compile does not have a document that
+     * will not parse and this is the one it is being asked about. A {@code data} written as a sum is
+     * offered as one, so a declaration reads the same here as it does from another document, where
+     * the compiler answers what it is.
+     */
+    private List<CompletionItem> declaredIn(SyntaxNode root, String module) {
+        List<CompletionItem> declared = new ArrayList<>();
+        for (SyntaxNode def : root.childNodes()) {
+            SyntaxToken name = nameToken(def);
+            if (name == null) {
+                continue;
+            }
+            Integer kind = switch (def.kind()) {
+                case DATA_DEF -> def.child(SyntaxKind.SUM_BODY).isPresent()
+                        ? CompletionItem.ENUM : CompletionItem.CLASS;
+                case BEHAVIOR_DEF -> CompletionItem.INTERFACE;
+                case FN_DEF -> CompletionItem.FUNCTION;
+                default -> null;   // header, imports, error nodes declare no completion name
+            };
+            if (kind != null) {
+                declared.add(new CompletionItem(nameOf(name), kind, module));
+            }
         }
+        return declared;
+    }
+
+    private static Set<String> labelsOf(List<CompletionItem> items) {
+        Set<String> labels = new HashSet<>();
+        for (CompletionItem item : items) {
+            labels.add(item.label());
+        }
+        return labels;
     }
 
     /** The top-level definition whose span contains {@code offset}, or {@code null} at the file level. */
@@ -1190,8 +1238,9 @@ public final class Analyzer {
                 if (VALUE_BINDINGS.contains(child.kind())) {
                     SyntaxToken bound = firstIdent(child);
                     if (bound != null) {
+                        // A binding comes from nowhere else, so it has no origin to show.
                         out.putIfAbsent(nameOf(bound),
-                                new CompletionItem(nameOf(bound), CompletionItem.VARIABLE));
+                                new CompletionItem(nameOf(bound), CompletionItem.VARIABLE, null));
                     }
                 }
                 collectLocalBindings(child, out);

--- a/souther-lsp/src/main/java/souther/lsp/analysis/NamesFromElsewhere.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/NamesFromElsewhere.java
@@ -1,0 +1,137 @@
+package souther.lsp.analysis;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Scoping;
+import souther.compiler.check.Symbols;
+import souther.compiler.query.Answer;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Names;
+import souther.compiler.types.ValueName;
+import souther.lsp.protocol.CompletionItem;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What a document may write that it does not declare itself, as the compiler last answered it.
+ *
+ * <p>Which bare spelling reaches what is the compiler's, and both namespaces are asked of it every
+ * time it can answer: {@link Names.NameScope} for the declarations a name reaches, which carry what
+ * kind of declaration each is, and {@link Names.ModuleScope} for the value namespace. Nothing here
+ * reads an import line. What one brings in is {@code Scoping}'s to say, and a second reader of those
+ * lines would be that rule written twice, to go out of agreement the first time either moved.
+ *
+ * <p>The compiler cannot answer about a module whose source will not parse — that file is held out
+ * of the compile, which is exactly the file being typed in — and what is kept here is the last
+ * answer it gave, so an editor goes on offering names while the compiler has nothing to say about
+ * the file in front of the author.
+ *
+ * <p>An availability fallback and not a second source of names. It is written only where the
+ * compiler answered and read only where it did not; the two are never merged, so a name that is
+ * offered is either what the current compile says or what the last one did, and deleting an import
+ * from a document that parses takes its names away at once.
+ *
+ * <p>Kept per document rather than per module, because a module is not one file. Seen from an
+ * attached {@code examples for} file, the declarations of its module's own source are from
+ * elsewhere — that document does not declare them and cannot read them off its own text — and a
+ * partition drawn at the module would drop exactly those while the other file is the one being
+ * edited. What is from elsewhere is settled against the spellings the document itself declares,
+ * which is exact: one spelling reaches one thing in a scope.
+ */
+final class NamesFromElsewhere {
+
+    /** Document URI → what the last compile that could answer said reaches it from elsewhere. */
+    private final Map<String, List<CompletionItem>> byDocument = new LinkedHashMap<>();
+
+    /**
+     * The candidates {@code uri} reaches from outside itself.
+     *
+     * <p>{@code declaredHere} is what the document's own text declares, read from its syntax tree.
+     * Those are the document's to answer for, every time, so that a definition being written now is
+     * offered before it compiles; they are kept out of what is remembered rather than filtered on
+     * the way out, so a name deleted while the file will not parse does not come back.
+     */
+    List<CompletionItem> of(Compilation compilation, String uri, String module,
+                            Set<String> declaredHere) {
+        List<CompletionItem> answered = ask(compilation, module, declaredHere);
+        if (answered == null) {
+            return byDocument.getOrDefault(uri, List.of());
+        }
+        byDocument.put(uri, answered);
+        return answered;
+    }
+
+    /**
+     * What the compile says reaches this document from elsewhere, or null where it cannot say.
+     *
+     * <p>Null for a document whose module cannot be named as well as for one whose module the
+     * compile does not have. Which module an attached {@code examples for} file belongs to is the
+     * compile's answer — its text declares no module of its own — so a file held out of the compile
+     * for its own syntax errors, or one whose module's other source was, has no module to be asked
+     * about. That is the same absence and takes the same answer.
+     */
+    private static List<CompletionItem> ask(Compilation compilation, String module,
+                                            Set<String> declaredHere) {
+        if (module == null) {
+            return null;
+        }
+        Answer<Symbols> types = compilation.db().ask(new Names.NameScope(module));
+        Answer<Scoping.Scoped> scope = compilation.db().ask(new Names.ModuleScope(module));
+        if (!types.present() || !scope.present()) {
+            return null;
+        }
+        List<CompletionItem> found = new ArrayList<>();
+        // The type namespace first, as a bare name in a value position is answered: a data written
+        // as a value is its construction, and the value table is read after that.
+        types.value().reachable().forEach((spelling, def) -> {
+            if (!declaredHere.contains(spelling)) {
+                found.add(new CompletionItem(spelling, kindOf(def), def.declaredIn()));
+            }
+        });
+        scope.value().reachable().byName().forEach((spelling, name) -> {
+            CompletionItem item = itemOf(spelling, name);
+            if (item != null && !declaredHere.contains(spelling)) {
+                found.add(item);
+            }
+        });
+        return List.copyOf(found);
+    }
+
+    /** Forgets every document the workspace no longer holds, so a file that was deleted or renamed
+     * leaves no names behind. */
+    void forgetAllBut(Collection<String> uris) {
+        byDocument.keySet().retainAll(Set.copyOf(uris));
+    }
+
+    /** What kind of declaration an editor is being offered. Read off the declaration, so a sum is
+     * not offered as a product because the two are both {@code data}. */
+    private static int kindOf(Hir.Def def) {
+        return switch (def) {
+            case Hir.SumData _ -> CompletionItem.ENUM;
+            case Hir.Data _, Hir.UnitData _ -> CompletionItem.CLASS;
+        };
+    }
+
+    /**
+     * One value-namespace candidate, or null where the spelling names nothing to offer.
+     *
+     * <p>A library namespace applied ({@code Date} in {@code Date(...)}) is not a member of
+     * anything, and a local is not reachable from a table — the bindings in force at the cursor are
+     * the document's to read.
+     */
+    private static CompletionItem itemOf(String spelling, ValueName name) {
+        return switch (name) {
+            case ValueName.Behavior behavior ->
+                    new CompletionItem(spelling, CompletionItem.INTERFACE, behavior.module());
+            case ValueName.Helper helper ->
+                    new CompletionItem(spelling, CompletionItem.FUNCTION, helper.module());
+            case ValueName.Stdlib stdlib when !stdlib.isNamespace() ->
+                    new CompletionItem(spelling, CompletionItem.FUNCTION, stdlib.alias());
+            default -> null;
+        };
+    }
+}

--- a/souther-lsp/src/main/java/souther/lsp/protocol/CompletionItem.java
+++ b/souther-lsp/src/main/java/souther/lsp/protocol/CompletionItem.java
@@ -1,10 +1,18 @@
 package souther.lsp.protocol;
 
 /**
- * An LSP completion item: the text to insert and its {@code kind} (an LSP CompletionItemKind number,
- * which the client renders as an icon).
+ * An LSP completion item: the text to insert, its {@code kind} (an LSP CompletionItemKind number,
+ * which the client renders as an icon), and the {@code detail} shown beside the label.
+ *
+ * <p>{@code detail} is where the name comes from — the module that declares it, or the library
+ * qualifier it is published under — and is null for a name that comes from nowhere else: a binding
+ * in force at the cursor, or a keyword. Two candidates spelled the same are told apart by it, and a
+ * list of bare names with no origins is a list an author has to already know to read.
+ *
+ * <p>There is no two-argument form. Whether a name has an origin is something each place that builds
+ * an item has to answer, and a default would let the question go unasked.
  */
-public record CompletionItem(String label, int kind) {
+public record CompletionItem(String label, int kind, String detail) {
 
     // The LSP CompletionItemKind numbers this server uses.
     public static final int FUNCTION = 3;
@@ -12,5 +20,6 @@ public record CompletionItem(String label, int kind) {
     public static final int VARIABLE = 6;
     public static final int CLASS = 7;
     public static final int INTERFACE = 8;
+    public static final int ENUM = 13;
     public static final int KEYWORD = 14;
 }

--- a/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
@@ -617,7 +617,8 @@ class AnalyzerTest {
                 + "behavior f : (x: Thing) -> Thing\n"
                 + "let f (x) = x\n";
         // cursor in the body of `let f (x) = x` (line 4, on the trailing `x`)
-        List<CompletionItem> items = analyzer.completions(text, new Position(4, 12));
+        List<CompletionItem> items = analyzer.completions("file:///demo.sou", new Position(4, 12),
+                ModuleGraph.of(java.util.Map.of("file:///demo.sou", text)));
 
         java.util.Set<String> labels = new java.util.HashSet<>();
         for (CompletionItem i : items) {

--- a/souther-lsp/src/test/java/souther/lsp/analysis/WhatMayBeWrittenHereIsAskedOfTheCompileTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/WhatMayBeWrittenHereIsAskedOfTheCompileTest.java
@@ -1,0 +1,289 @@
+package souther.lsp.analysis;
+
+import souther.lsp.protocol.CompletionItem;
+import souther.lsp.protocol.Position;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Completion asks the workspace compile which bare spelling reaches what, and goes on offering the
+ * names that came from elsewhere while the document being typed in will not parse.
+ *
+ * <p>The two halves are asymmetric on purpose. What the document declares is read off its own tree
+ * every time, so a definition being written is offered before it compiles; what reaches it from
+ * elsewhere is the compiler's answer, kept per document because a module is not one file.
+ */
+class WhatMayBeWrittenHereIsAskedOfTheCompileTest {
+
+    private static final String UP = """
+            module up exposing ( Amount, Colour, price )
+
+            data Amount = { v: Int }
+
+            data Colour = Red | Green
+
+            let price = 100
+            """;
+
+    private static final String DOWN = """
+            module down
+
+            import up ( Amount, Colour, price )
+            import String ( length )
+
+            data Own = { n: Int }
+
+            behavior f : (x: Int) -> Int
+            let f (x) = x
+            """;
+
+    private static final String UP_URI = "file:///up.sou";
+    private static final String DOWN_URI = "file:///down.sou";
+
+    /** The cursor in the body of `let f (x) = x`, which is the last line of {@link #DOWN}. */
+    private static final Position IN_THE_BODY = new Position(8, 12);
+
+    private static ModuleGraph graphOf(String... uriThenText) {
+        Map<String, String> sources = new LinkedHashMap<>();
+        for (int i = 0; i < uriThenText.length; i += 2) {
+            sources.put(uriThenText[i], uriThenText[i + 1]);
+        }
+        return ModuleGraph.of(sources);
+    }
+
+    private static Map<String, CompletionItem> byLabel(List<CompletionItem> items) {
+        Map<String, CompletionItem> out = new LinkedHashMap<>();
+        for (CompletionItem item : items) {
+            out.put(item.label(), item);
+        }
+        return out;
+    }
+
+    /** The candidates that came from another module or from the library — everything carrying an
+     * origin that is not this document's own module, plus what the standard library published. */
+    private static List<String> fromElsewhere(List<CompletionItem> items, String ownModule) {
+        List<String> out = new ArrayList<>();
+        for (CompletionItem item : items) {
+            if (item.detail() != null && !item.detail().equals(ownModule)) {
+                out.add(item.label());
+            }
+        }
+        return out;
+    }
+
+    /** {@link #DOWN} with a line of nonsense inserted before the body, which no recovery makes into
+     * a module: the file is held out of the compile, and the compiler has nothing to say about it. */
+    private static String broken(String source) {
+        return source.replace("let f (x) = x", "let f (x) = ((((\nlet f (x) = x");
+    }
+
+    @Test
+    void aNameAnImportBringsInIsOfferedAsWhatItIsDeclaredToBe() {
+        Analyzer analyzer = new Analyzer();
+        Map<String, CompletionItem> items = byLabel(analyzer.completions(
+                DOWN_URI, IN_THE_BODY, graphOf(UP_URI, UP, DOWN_URI, DOWN)));
+
+        assertEquals(new CompletionItem("Amount", CompletionItem.CLASS, "up"), items.get("Amount"),
+                "an imported product data, as a data and as coming from up: " + items.keySet());
+        assertEquals(new CompletionItem("Colour", CompletionItem.ENUM, "up"), items.get("Colour"),
+                "an imported sum is offered as a sum, not as a product");
+        assertEquals(new CompletionItem("price", CompletionItem.FUNCTION, "up"), items.get("price"),
+                "a value another module publishes");
+        assertEquals(new CompletionItem("length", CompletionItem.FUNCTION, "String"),
+                items.get("length"), "a library name an import let this module write bare");
+        assertEquals(new CompletionItem("Own", CompletionItem.CLASS, "down"), items.get("Own"),
+                "this document's own declaration, under its own module");
+        assertEquals(CompletionItem.VARIABLE, items.get("x").kind(), "the param in scope");
+        assertEquals(CompletionItem.KEYWORD, items.get("behavior").kind(), "a language keyword");
+    }
+
+    @Test
+    void namesFromElsewhereAreOfferedWhileTheDocumentWillNotParse() {
+        Analyzer analyzer = new Analyzer();
+        List<CompletionItem> clean = analyzer.completions(
+                DOWN_URI, IN_THE_BODY, graphOf(UP_URI, UP, DOWN_URI, DOWN));
+        assertFalse(fromElsewhere(clean, "down").isEmpty(), "the clean document reaches names");
+
+        List<CompletionItem> whileBroken = analyzer.completions(
+                DOWN_URI, IN_THE_BODY, graphOf(UP_URI, UP, DOWN_URI, broken(DOWN)));
+
+        List<String> elsewhere = fromElsewhere(whileBroken, "down");
+        assertFalse(elsewhere.isEmpty(),
+                "a document that will not parse still reaches what it reached: " + elsewhere);
+        assertTrue(elsewhere.containsAll(List.of("Amount", "Colour", "price", "length")),
+                "each of them, whichever namespace it came from: " + elsewhere);
+    }
+
+    /**
+     * The negative control for the test above: it is the remembered answer doing the work, and
+     * nothing else. Asked about a document that has never parsed since this server started, there is
+     * nothing from elsewhere to offer — which is what the state was for every document before.
+     */
+    @Test
+    void withNoCompileThatEverAnsweredThereIsNothingFromElsewhere() {
+        Analyzer analyzer = new Analyzer();
+        List<CompletionItem> items = analyzer.completions(
+                DOWN_URI, IN_THE_BODY, graphOf(UP_URI, UP, DOWN_URI, broken(DOWN)));
+
+        assertEquals(List.of(), fromElsewhere(items, "down"),
+                "nothing answered about this document, so nothing is remembered about it");
+        assertTrue(byLabel(items).containsKey("Own"),
+                "what the document declares is still read off its own tree");
+    }
+
+    @Test
+    void aDefinitionBeingTypedIsOfferedBeforeItCompiles() {
+        Analyzer analyzer = new Analyzer();
+        analyzer.completions(DOWN_URI, IN_THE_BODY, graphOf(UP_URI, UP, DOWN_URI, DOWN));
+
+        String beingTyped = broken(DOWN).replace("data Own", "data Fresh = { m: Int }\n\ndata Own");
+        Map<String, CompletionItem> items = byLabel(analyzer.completions(
+                DOWN_URI, IN_THE_BODY, graphOf(UP_URI, UP, DOWN_URI, beingTyped)));
+
+        assertTrue(items.containsKey("Fresh"),
+                "written into a document that will not parse, and offered: " + items.keySet());
+        assertTrue(items.containsKey("Amount"), "and the remembered names are still there");
+    }
+
+    /**
+     * What this document declares is kept out of what is remembered about it, rather than filtered
+     * on the way out. A name it no longer writes is in neither place, so renaming a definition while
+     * the file will not parse does not go on offering the name it had.
+     */
+    @Test
+    void aDeclarationRenamedWhileTheDocumentWillNotParseIsNotOfferedUnderItsOldName() {
+        Analyzer analyzer = new Analyzer();
+        analyzer.completions(DOWN_URI, IN_THE_BODY, graphOf(UP_URI, UP, DOWN_URI, DOWN));
+
+        String renamed = broken(DOWN).replace("data Own", "data Owned");
+        Map<String, CompletionItem> items = byLabel(analyzer.completions(
+                DOWN_URI, IN_THE_BODY, graphOf(UP_URI, UP, DOWN_URI, renamed)));
+
+        assertTrue(items.containsKey("Owned"), "under what it is called now: " + items.keySet());
+        assertFalse(items.containsKey("Own"), "and not under what it was called");
+        assertTrue(items.containsKey("Amount"), "the names from elsewhere are unaffected");
+    }
+
+    /**
+     * The remembered answer is never consulted while the compiler can answer, so an import taken out
+     * of a document that parses takes its names with it at once.
+     */
+    @Test
+    void anImportRemovedFromADocumentThatParsesStopsBeingOffered() {
+        Analyzer analyzer = new Analyzer();
+        analyzer.completions(DOWN_URI, IN_THE_BODY, graphOf(UP_URI, UP, DOWN_URI, DOWN));
+
+        String withoutTheImport = DOWN.replace("import up ( Amount, Colour, price )\n", "");
+        Map<String, CompletionItem> items = byLabel(analyzer.completions(
+                DOWN_URI, IN_THE_BODY, graphOf(UP_URI, UP, DOWN_URI, withoutTheImport)));
+
+        assertFalse(items.containsKey("Amount"), "the import is gone: " + items.keySet());
+        assertTrue(items.containsKey("length"), "the import that is still written is not");
+    }
+
+    @Test
+    void aDocumentTheWorkspaceNoLongerHoldsIsForgotten() {
+        Analyzer analyzer = new Analyzer();
+        analyzer.completions(DOWN_URI, IN_THE_BODY, graphOf(UP_URI, UP, DOWN_URI, DOWN));
+        analyzer.completions(UP_URI, new Position(2, 0), graphOf(UP_URI, UP));
+
+        // down.sou is asked about again after the workspace stopped holding it: nothing of it is
+        // remembered, so the answer is what a document this server has never seen would get.
+        List<CompletionItem> items = analyzer.completions(
+                DOWN_URI, IN_THE_BODY, graphOf(UP_URI, UP, DOWN_URI, broken(DOWN)));
+        assertEquals(List.of(), fromElsewhere(items, "down"));
+    }
+
+    @Test
+    void aBindingInForceShadowsAnImportOfTheSameSpelling() {
+        String shadowing = DOWN.replace("let f (x) = x", "let f (length) = length");
+        Analyzer analyzer = new Analyzer();
+        Map<String, CompletionItem> items = byLabel(analyzer.completions(
+                DOWN_URI, new Position(8, 20), graphOf(UP_URI, UP, DOWN_URI, shadowing)));
+
+        assertEquals(CompletionItem.VARIABLE, items.get("length").kind(),
+                "the param is what `length` means in this body, so it is what is offered");
+        assertEquals(1, items.values().stream().filter(i -> i.label().equals("length")).count(),
+                "and only once");
+    }
+
+    // --- a module written across two documents ---
+
+    private static final String CRM = """
+            module crm exposing ( Customer )
+
+            data Customer = { id: Int }
+
+            behavior g : (c: Customer) -> Int
+            let g (c) = c.id
+            """;
+
+    private static final String CRM_ROWS = """
+            examples for crm
+
+            let someone = Customer { id = 1 }
+            """;
+
+    private static final String CRM_URI = "file:///crm.sou";
+    private static final String ROWS_URI = "file:///crm.examples.sou";
+
+    /** An attached file writes no import line, and its module's declarations are in scope bare. */
+    @Test
+    void anAttachedFileIsOfferedItsModulesDeclarations() {
+        Analyzer analyzer = new Analyzer();
+        Map<String, CompletionItem> items = byLabel(analyzer.completions(
+                ROWS_URI, new Position(2, 30), graphOf(CRM_URI, CRM, ROWS_URI, CRM_ROWS)));
+
+        assertEquals(new CompletionItem("Customer", CompletionItem.CLASS, "crm"),
+                items.get("Customer"),
+                "declared in the module's own source, reached bare here: " + items.keySet());
+        assertTrue(items.containsKey("someone"), "and what this document itself declares");
+    }
+
+    /**
+     * The module goes out of the compile when either of its documents will not parse, so the
+     * partition has to be the document. A sibling's declarations are from elsewhere seen from here,
+     * and are what is kept.
+     */
+    @Test
+    void aSiblingsDeclarationsAreKeptWhileTheSiblingWillNotParse() {
+        Analyzer analyzer = new Analyzer();
+        analyzer.completions(ROWS_URI, new Position(2, 30), graphOf(CRM_URI, CRM, ROWS_URI, CRM_ROWS));
+
+        String brokenCrm = CRM.replace("let g (c) = c.id", "let g (c) = ((((\nlet g (c) = c.id");
+        Map<String, CompletionItem> items = byLabel(analyzer.completions(
+                ROWS_URI, new Position(2, 30), graphOf(CRM_URI, brokenCrm, ROWS_URI, CRM_ROWS)));
+
+        assertEquals("crm", items.get("Customer").detail(),
+                "the sibling will not parse and its declarations are still offered here");
+    }
+
+    /**
+     * The other direction, which is the case the per-document partition exists for: one answer holds
+     * a sibling's remembered declarations and a declaration typed into this document since it
+     * stopped parsing.
+     */
+    @Test
+    void aDocumentThatWillNotParseOffersItsSiblingAndWhatIsBeingTypedInIt() {
+        Analyzer analyzer = new Analyzer();
+        analyzer.completions(ROWS_URI, new Position(2, 30), graphOf(CRM_URI, CRM, ROWS_URI, CRM_ROWS));
+
+        String beingTyped = CRM_ROWS + "\nlet another = Customer { id = 2\nlet third = 3\n";
+        Set<String> labels = byLabel(analyzer.completions(
+                ROWS_URI, new Position(2, 30), graphOf(CRM_URI, CRM, ROWS_URI, beingTyped)))
+                .keySet().stream().collect(Collectors.toSet());
+
+        assertTrue(labels.contains("Customer"), "remembered from the sibling: " + labels);
+        assertTrue(labels.contains("third"), "read off this document as it now is: " + labels);
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/analysis/WhatMayBeWrittenHereIsAskedOfTheCompileTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/WhatMayBeWrittenHereIsAskedOfTheCompileTest.java
@@ -191,6 +191,40 @@ class WhatMayBeWrittenHereIsAskedOfTheCompileTest {
         assertTrue(items.containsKey("length"), "the import that is still written is not");
     }
 
+    /**
+     * The fallback lasts exactly as long as the compiler cannot answer, in both directions.
+     *
+     * <p>Whether a document can join the compile is read from its text, and a document is read once
+     * per text rather than once per request — so what is held here is that the reading follows the
+     * text. A document first seen while it will not parse rejoins the compile the moment it does,
+     * and one edited into a state that will not parse leaves it.
+     */
+    @Test
+    void whetherTheCompilerCanAnswerFollowsWhatTheDocumentNowSays() {
+        Analyzer analyzer = new Analyzer();
+
+        List<CompletionItem> whileBroken = analyzer.completions(
+                DOWN_URI, IN_THE_BODY, graphOf(UP_URI, UP, DOWN_URI, broken(DOWN)));
+        assertEquals(List.of(), fromElsewhere(whileBroken, "down"),
+                "seen first in a state it cannot be compiled in, and never answered about");
+
+        Map<String, CompletionItem> mended = byLabel(analyzer.completions(
+                DOWN_URI, IN_THE_BODY, graphOf(UP_URI, UP, DOWN_URI, DOWN)));
+        assertTrue(mended.containsKey("Amount"),
+                "it parses now, so the compile answers about it: " + mended.keySet());
+
+        String withoutTheImport = DOWN.replace("import up ( Amount, Colour, price )\n", "");
+        Map<String, CompletionItem> brokenAgain = byLabel(analyzer.completions(
+                DOWN_URI, IN_THE_BODY, graphOf(UP_URI, UP, DOWN_URI, broken(withoutTheImport))));
+        assertTrue(brokenAgain.containsKey("Amount"),
+                "an import taken out while it will not parse is what goes stale, by design");
+
+        Map<String, CompletionItem> mendedAgain = byLabel(analyzer.completions(
+                DOWN_URI, IN_THE_BODY, graphOf(UP_URI, UP, DOWN_URI, withoutTheImport)));
+        assertFalse(mendedAgain.containsKey("Amount"),
+                "and it stops being stale the moment the document parses: " + mendedAgain.keySet());
+    }
+
     @Test
     void aDocumentTheWorkspaceNoLongerHoldsIsForgotten() {
         Analyzer analyzer = new Analyzer();
@@ -204,6 +238,30 @@ class WhatMayBeWrittenHereIsAskedOfTheCompileTest {
         assertEquals(List.of(), fromElsewhere(items, "down"));
     }
 
+    /**
+     * A URI names a document and can be used again, so what is remembered has to go while the
+     * document is gone. By the time another one arrives at the same URI, the two are both "the
+     * document at this URI" and nothing tells them apart.
+     *
+     * <p>Nothing here asks for completion while the file is missing, which is the case the eviction
+     * has to survive: it is not completion that observes a workspace losing a file. A file created
+     * or deleted on disk reaches this server as a diagnose, so that is what stands here for the gap.
+     */
+    @Test
+    void aDocumentRemovedAndWrittenAgainAtTheSameUriDoesNotInheritTheOldOnesNames() {
+        Analyzer analyzer = new Analyzer();
+        analyzer.completions(DOWN_URI, IN_THE_BODY, graphOf(UP_URI, UP, DOWN_URI, DOWN));
+
+        analyzer.diagnostics(graphOf(UP_URI, UP));   // down.sou is deleted; the server diagnoses
+
+        String different = "module other\n\nlet f (x) = ((((\n";
+        List<CompletionItem> items = analyzer.completions(
+                DOWN_URI, new Position(2, 12), graphOf(UP_URI, UP, DOWN_URI, different));
+
+        assertEquals(List.of(), fromElsewhere(items, "other"),
+                "a different document is now at that URI, and it has never compiled");
+    }
+
     @Test
     void aBindingInForceShadowsAnImportOfTheSameSpelling() {
         String shadowing = DOWN.replace("let f (x) = x", "let f (length) = length");
@@ -215,6 +273,65 @@ class WhatMayBeWrittenHereIsAskedOfTheCompileTest {
                 "the param is what `length` means in this body, so it is what is offered");
         assertEquals(1, items.values().stream().filter(i -> i.label().equals("length")).count(),
                 "and only once");
+    }
+
+    /**
+     * A binding is offered ahead of an import of the same spelling because it is what that spelling
+     * denotes where the cursor is. So the two have to be the same set: a name bound somewhere the
+     * cursor is not denotes nothing there, and offering it would both say something untrue and take
+     * the place of the name that spelling does denote.
+     */
+    @Test
+    void aBindingInAnotherArmIsNotInForceAndDoesNotDisplaceTheImport() {
+        String twoArms = """
+                module down
+
+                import up ( Amount, Colour, price )
+                import String ( length )
+
+                behavior f : (c: Colour) -> Int
+                let f (c) = match c with
+                    | Red -> {
+                        let price = 0
+                        price
+                      }
+                    | Green -> 1
+                """;
+        Analyzer analyzer = new Analyzer();
+        // the cursor is on the `1` of the Green arm, outside the block the Red arm binds in
+        Map<String, CompletionItem> items = byLabel(analyzer.completions(
+                DOWN_URI, new Position(10, 15), graphOf(UP_URI, UP, DOWN_URI, twoArms)));
+
+        assertEquals(new CompletionItem("price", CompletionItem.FUNCTION, "up"), items.get("price"),
+                "the import is what `price` denotes here: " + items.get("price"));
+        assertEquals(CompletionItem.VARIABLE, items.get("c").kind(),
+                "the param is in force over the whole body");
+    }
+
+    /** The other direction, so the test above is not passed by never offering a binding at all. */
+    @Test
+    void aBindingIsOfferedWhereItIsInForce() {
+        String shadowingInsideTheArm = """
+                module down
+
+                import up ( Amount, Colour, price )
+                import String ( length )
+
+                behavior f : (c: Colour) -> Int
+                let f (c) = match c with
+                    | Red -> {
+                        let price = 0
+                        price
+                      }
+                    | Green -> 1
+                """;
+        Analyzer analyzer = new Analyzer();
+        // the cursor is on the `price` that reads the binding, inside the block that made it
+        Map<String, CompletionItem> items = byLabel(analyzer.completions(
+                DOWN_URI, new Position(9, 12), graphOf(UP_URI, UP, DOWN_URI, shadowingInsideTheArm)));
+
+        assertEquals(CompletionItem.VARIABLE, items.get("price").kind(),
+                "inside the block, `price` is the binding: " + items.get("price"));
     }
 
     // --- a module written across two documents ---


### PR DESCRIPTION
Closes #765.

Completion was the one question the language server answered from the
document alone. Everything else — hover, definition, references, code
actions, rename — takes a position and the workspace; this took a text, so
it had no module to ask about and read the import lines itself to work out
what they brought in. That is the scope assembly's rule written a second
time, and it was also read through a parse that throws on the first syntax
error anywhere in the file, so it contributed nothing whenever the
document did not parse.

## What #767 had already settled

Most of the compiler side of this was in place. `Resolve.Values` is
already split into `Reachable` — a value — and `Elsewhere`, the lookup a
pass makes while it reads, and `Names.ModuleScope` already answers a
module's assembled scope with `Scoped.reachable()` on it, whose javadoc
says it is what a reader wanting to know what may be written here asks
for. So this adds no query. The server asks `Names.NameScope` for the type
namespace, because kinds are read off declarations, and
`Names.ModuleScope(...).reachable()` for the value namespace.

Two things were left, and they are the first two commits.

Resolving a bare value name read the three tables in turn, so the order
they are consulted in lived in the reader. An enumeration would have to
state it again, and two statements of one rule agree until either moves —
so it is written once, on the table, and the reader asks it.

The type scope handed over the declarations a bare name reaches and
dropped the spellings each is reached by. The value namespace already
answers the pair; this is the other half of the same question.

## Answering while the document will not parse

The names that came from elsewhere are what the last compile that could
answer said they were, kept and offered while the current one cannot. It
is an availability fallback and not a second source of names: written only
where the compiler answered, read only where it did not, never merged. So
deleting an import from a document that parses takes its names away at
once.

Kept per document rather than per module, because a module is not one
file. Seen from an attached `examples for` file, the declarations of its
module's own source are from elsewhere — that document does not declare
them and cannot read them off its own text — and a partition drawn at the
module would drop exactly those while the other file is the one being
edited. That file is also where reading import lines was least of an
answer: it writes none, and its module's data and behaviors are in scope
bare there.

What the document declares is read off its tree every time, so a
definition being written is offered before it compiles. Those spellings
are kept out of what is remembered rather than filtered on the way out,
which is what stops a name lingering under the one it was renamed from.

An item now carries where it came from and the server sends it, a kind is
read off the declaration rather than assumed, and the bindings in force at
the cursor are offered ahead of an import that spells the same name.

## Measured

Over the sixteen sources of the crm, account and hr examples, inserting a
two-character line after every line gives 7603 edits, none of which parse.
Before, the number of candidates from anywhere but the document itself was
zero on every one of them; now it is non-zero on every one, and constant
per file — what the compiler last said does not move while the document
does not parse. `account.sou`, which writes no import line at all, offers
one: `NoAccount`, an implicit unit data synthesized from
`-> Balance | NoAccount` that no `data` line spells. `org.sou` offers
four, which is exactly `UserId` plus `fold, length, isEmpty`.

`CI=1 mvn -Plint clean verify` is green (syntax 98, fmt 2224, compiler
4713, lsp 215, cli 333), and each of the first two commits is green on its
own. The `examples --format json` output of five example projects is
byte-identical to develop's.

Six mutations were run to check the tests fail for the reasons they state.
Never reading the remembered answer kills five; remembering what the
document declares kills the rename test; never forgetting a dropped
document kills the eviction test; offering bindings last kills the
shadowing test; assuming a kind kills the kind test; leaving the library
names out of the one table kills the two compiler tests. Nothing else
moves in any of them.

## A correction to the issue

The issue argued from a line written `exposing (..)` contributing the
declarations it brings in. There is no such form: an import's name list is
an explicit list of identifiers, and so is a module header's `exposing`
clause. The issue has been rewritten to argue from the attached
`examples for` file instead, which shows the same thing in the language as
it stands — the set of imports written in a document is not the set of
names it reaches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
