### PR TITLE
Offer the declaration a signature already described

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -257,12 +257,13 @@ public final class SpecChecker {
                 throw new Unanswerable(required.pos());
             }
         }
+        // What this fn has to take, asked of the behavior rather than added up here (§fn-declaration).
+        List<SpecImplementation.Parameter> shape = SpecImplementation.parameters(spec);
         int nBusiness = spec.params().size();
-        int nReq = spec.dependsOn().size();
-        if (fn.params().size() != nBusiness + nReq) {
+        if (fn.params().size() != shape.size()) {
             throw CompileException.of(Diagnostic
                             .at(fn.pos())
-                            .say(new BehaviorMessage.TheImplementationTakesAnotherNumberOfParameters(fn.name(), String.valueOf(fn.params().size()), spec.name(), String.valueOf(nBusiness), String.valueOf(nReq))).build());
+                            .say(new BehaviorMessage.TheImplementationTakesAnotherNumberOfParameters(fn.name(), String.valueOf(fn.params().size()), spec.name(), String.valueOf(nBusiness), String.valueOf(shape.size() - nBusiness))).build());
         }
         for (Hir.FnParam p : fn.params()) {
             // a pattern in parameter position names a type, but it is not an annotation: it opens
@@ -272,18 +273,20 @@ public final class SpecChecker {
                                 .at(p.pos()).say(new BehaviorMessage.AnImplementationsParametersTakeTheirTypesFromIt(fn.name(), spec.name(), p.name())).build());
             }
         }
-        for (int i = 0; i < nReq; i++) {
-            // A clause naming nothing names no parameter for this one to be out of order against;
-            // it is reported where it is written, and the parameters beside it are still held to
-            // the ones that do.
-            if (!(spec.dependsOn().get(i).answered() instanceof Hir.Var.Denoting named)) {
-                continue;
-            }
-            String got = fn.params().get(nBusiness + i).name();
-            String want = named.bare();
-            if (!got.equals(want)) {
-                throw CompileException.of(Diagnostic
-                                .at(fn.pos()).say(new BehaviorMessage.AnInjectedParameterIsOutOfOrder(fn.name(), got, want)).build());
+        for (int i = 0; i < shape.size(); i++) {
+            switch (shape.get(i)) {
+                // An input's name is the implementation's to choose.
+                case SpecImplementation.Parameter.Input _ -> { }
+                // A clause naming nothing names no parameter for this one to be out of order
+                // against, and it was refused above, at the clause rather than at this list.
+                case SpecImplementation.Parameter.Unanswered _ -> { }
+                case SpecImplementation.Parameter.Injected injected -> {
+                    String got = fn.params().get(i).name();
+                    if (!got.equals(injected.name())) {
+                        throw CompileException.of(Diagnostic
+                                        .at(fn.pos()).say(new BehaviorMessage.AnInjectedParameterIsOutOfOrder(fn.name(), got, injected.name())).build());
+                    }
+                }
             }
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecImplementation.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecImplementation.java
@@ -1,0 +1,70 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Hir;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The formal parameters the {@code let} implementing a behavior is required to take (spec
+ * §fn-declaration, §depends-on).
+ *
+ * <p>The behavior's inputs, then the behaviors it depends on in the order they were declared. The
+ * order is not a matter of layout: it is what {@link SpecChecker} holds an implementation to, and
+ * writing an injected parameter out of that order is E1615. Said here once so that a reader wanting
+ * to know the shape — the checker that refuses one, an editor offering to write one — asks rather
+ * than works it out again from the signature. Two readings of one rule agree until either moves.
+ *
+ * <p>Nothing here is about how a parameter is written. Where it goes in a line, and whether the line
+ * breaks, is the formatter's.
+ */
+public final class SpecImplementation {
+
+    private SpecImplementation() {}
+
+    /**
+     * One position of the parameter list, told apart by what settles its name.
+     *
+     * <p>A reader has to do something different with each, which is why they are three and not one
+     * name and a flag. What an editor may offer as a hole is exactly what nothing here settles.
+     */
+    public sealed interface Parameter {
+
+        /**
+         * An input. Its position and its type come from the behavior; its name does not — the
+         * implementation may call it what it likes — so the behavior's own spelling is a suggestion.
+         */
+        record Input(String nameSuggestion) implements Parameter {}
+
+        /**
+         * An injected behavior. Its position and its name are both settled: it names the behavior it
+         * injects, and an implementation that spells it otherwise is refused.
+         */
+        record Injected(String name) implements Parameter {}
+
+        /**
+         * A {@code depends on} entry that reaches no declaration.
+         *
+         * <p>It takes a position — an implementation still has to have a parameter there — and
+         * settles no name for it, since the name it would be held to is the one that was not found.
+         * That the clause names nothing is reported where the clause is written, so nothing here
+         * says it again.
+         */
+        record Unanswered() implements Parameter {}
+    }
+
+    /** What an implementation of {@code spec} is required to take, in order. */
+    public static List<Parameter> parameters(Hir.SpecBehavior spec) {
+        List<Parameter> required = new ArrayList<>(spec.params().size() + spec.dependsOn().size());
+        for (Hir.Param input : spec.params()) {
+            required.add(new Parameter.Input(input.name()));
+        }
+        for (Hir.Var dependency : spec.dependsOn()) {
+            Hir.Var.Denoting named = dependency.answered();
+            required.add(named == null
+                    ? new Parameter.Unanswered()
+                    : new Parameter.Injected(named.bare()));
+        }
+        return List.copyOf(required);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleProvisioning.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleProvisioning.java
@@ -1,0 +1,73 @@
+package souther.compiler.examples;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * What stands in for a behavior's requirement while an example runs (spec §example-fakes).
+ *
+ * <p>Two things may: a {@code with} written on the row, and a {@code fake} table written beside it.
+ * The row is looked at first, so a row that answers a dependency itself answers it whatever the
+ * module says. A requirement neither of them answers is one nothing can run against, which is
+ * E1908.
+ *
+ * <p>Said here rather than inside the verifier that reports it, because the question is asked twice
+ * over: once by a run about to build a stand-in, and once by a reader that only wants to know what a
+ * row still owes and has no values to build. What was written and where is handed back rather than a
+ * yes or no, since those two do different things with it.
+ *
+ * <p>What a row contributes is the {@code with}s on it, taken as a list rather than as the row, so
+ * that a row nobody has written yet can be asked the same question by contributing none.
+ */
+public final class ExampleProvisioning {
+
+    private ExampleProvisioning() {}
+
+    /** What was found to stand in, and where it was written. */
+    public sealed interface Standin {
+
+        /** The row answers this one itself, with a value that ignores what it is asked. */
+        record OnTheRow(Hir.With written) implements Standin {}
+
+        /** A table beside the rows answers it. */
+        record InTheModule(Prepared.FakeTable table) implements Standin {}
+
+        /** Nothing answers it, and a row whose target requires it cannot be run. */
+        record Nothing() implements Standin {}
+    }
+
+    /**
+     * What stands in for {@code dependency}, given what the row supplies of its own.
+     *
+     * @param onTheRow the {@code with}s written on the row; empty for a row not written yet
+     */
+    public static Standin standingIn(List<Hir.With> onTheRow, String dependency,
+                                     Prepared.ExampleExecution module) {
+        for (Hir.With written : onTheRow) {
+            if (written.dep().equals(dependency)) {
+                return new Standin.OnTheRow(written);
+            }
+        }
+        for (Prepared.FakeTable table : module.fakes()) {
+            if (table.target().equals(dependency)) {
+                return new Standin.InTheModule(table);
+            }
+        }
+        return new Standin.Nothing();
+    }
+
+    /** Of {@code required}, the ones nothing stands in for, in the order they were required. */
+    public static List<String> unsupplied(List<Hir.With> onTheRow, List<String> required,
+                                          Prepared.ExampleExecution module) {
+        List<String> owed = new ArrayList<>();
+        for (String dependency : required) {
+            if (standingIn(onTheRow, dependency, module) instanceof Standin.Nothing) {
+                owed.add(dependency);
+            }
+        }
+        return List.copyOf(owed);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -1087,13 +1087,15 @@ public final class ExampleVerifier {
             return null;
         }
         BoundaryOutput outType = depSig.out();
-        // a value fake given inline on the row: `with dep = value`
-        for (Hir.With w : row.withs()) {
-            if (w.dep().equals(depName)) {
+        // What stands in, and where it was written, is ExampleProvisioning's; building the value it
+        // answers with is this reader's.
+        return switch (ExampleProvisioning.standingIn(row.withs(), depName, module)) {
+            case ExampleProvisioning.Standin.OnTheRow onTheRow -> {
+                Hir.With w = onTheRow.written();
                 try {
                     Object value = fixtures.buildFixture(w.value(), outType).value();
                     // a constant: it ignores its inputs
-                    return new DependencyStandin(depName, dep.params().size(), _ -> value);
+                    yield new DependencyStandin(depName, dep.params().size(), _ -> value);
                 } catch (FixtureException fe) {
                     // The row does supply a fake. What failed is building its value, which is a
                     // different problem from a dependency nothing stands in for.
@@ -1101,20 +1103,17 @@ public final class ExampleVerifier {
                             .say(new ExampleMessage.TheFakeValueCouldNotBeBuilt(depName,
                                     fe.getMessage()))
                             .build());
-                    return null;
+                    yield null;
                 }
             }
-        }
-        // a function fake given as a `fake dep | table` declaration
-        for (souther.compiler.check.Prepared.FakeTable table : module.fakes()) {
-            Hir.Fake fk = table.read();
-            if (fk.target().equals(depName)) {
-                return tableStandin(fixtures, fk, dep, depSig);
+            case ExampleProvisioning.Standin.InTheModule inTheModule ->
+                    tableStandin(fixtures, inTheModule.table().read(), dep, depSig);
+            case ExampleProvisioning.Standin.Nothing _ -> {
+                out.add(fakeMissingDiag(target, req, row, "add `with " + depName
+                        + " = ...` on the row, or a `fake " + depName + "` table"));
+                yield null;
             }
-        }
-        out.add(fakeMissingDiag(target, req, row, "add `with " + depName
-                + " = ...` on the row, or a `fake " + depName + "` table"));
-        return null;
+        };
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/AnImplementationsParametersAreStatedOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnImplementationsParametersAreStatedOnceTest.java
@@ -1,0 +1,148 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.ast.Hir;
+import souther.compiler.diag.CompileException;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Shapes;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * What a behavior's implementation is required to take, said as a list.
+ *
+ * <p>The rule is the language's: the {@code let} that implements a behavior takes the behavior's
+ * inputs and then the behaviors it depends on, in the order they were declared, and the trailing
+ * ones are named by what they inject rather than by whatever the author felt like. That is what
+ * E1615 is about, and until now it lived only inside the check that reports it — as two counts added
+ * together and an index walked twice — so anything else wanting to know the shape had to work it out
+ * again from the signature.
+ *
+ * <p>The three arms are told apart because a reader has to do something different with each. An
+ * input is a position whose name is the author's, so it is a suggestion; an injected one is a
+ * position whose name is settled, so it is a name; and a {@code depends on} entry that reaches
+ * nothing settles neither, which is reported where it is written and is not a shape anything can be
+ * held to.
+ */
+class AnImplementationsParametersAreStatedOnceTest {
+
+    private static final String TWO_OF_EACH = """
+            module example.shape
+
+            data MemberId = String
+            data Found = { id: MemberId }
+            data Missing = { why: String }
+
+            behavior findMember : (id: MemberId) -> Found | Missing
+
+            behavior logLookup : (id: MemberId) -> Found | Missing
+
+            behavior place : (id: MemberId, other: MemberId) -> Found | Missing
+                depends on findMember, logLookup
+
+            let place (id, other, findMember, logLookup) = match findMember(id) with
+                | Found   -> logLookup(other)
+                | Missing -> findMember(other)
+            """;
+
+    private static final String NO_DEPENDENCIES = """
+            module example.plain
+
+            data MemberId = String
+            data Found = { id: MemberId }
+
+            behavior name : (id: MemberId, fallback: MemberId) -> Found
+                constructs Found
+
+            let name (id, fallback) = Found { id = id }
+            """;
+
+    /** The inputs first, in declared order, then what is injected, in declared order. */
+    @Test
+    void theInputsComeFirstAndTheInjectedOnesFollowInDeclaredOrder() {
+        assertEquals(List.of(
+                        new SpecImplementation.Parameter.Input("id"),
+                        new SpecImplementation.Parameter.Input("other"),
+                        new SpecImplementation.Parameter.Injected("findMember"),
+                        new SpecImplementation.Parameter.Injected("logLookup")),
+                SpecImplementation.parameters(behaviorOf(TWO_OF_EACH, "place")));
+    }
+
+    /** A behavior that depends on nothing is its inputs and nothing else. */
+    @Test
+    void aBehaviorThatDependsOnNothingIsItsInputs() {
+        assertEquals(List.of(
+                        new SpecImplementation.Parameter.Input("id"),
+                        new SpecImplementation.Parameter.Input("fallback")),
+                SpecImplementation.parameters(behaviorOf(NO_DEPENDENCIES, "name")));
+    }
+
+    /**
+     * And it is the same list the implementation was accepted against.
+     *
+     * <p>Both of these models compile, so their {@code let}s satisfied E1615. Holding the list to
+     * what those {@code let}s were written with is what says this states the rule the checker
+     * applies rather than a second reading of the signature that happens to agree today.
+     */
+    @Test
+    void theListIsWhatAnAcceptedImplementationWasWrittenWith() {
+        assertEquals(List.of("id", "other", "findMember", "logLookup"),
+                writtenParametersOf(TWO_OF_EACH, "place"));
+        assertEquals(List.of("id", "fallback"), writtenParametersOf(NO_DEPENDENCIES, "name"));
+    }
+
+    /**
+     * An implementation that does not take the list is refused, and refused for taking the wrong
+     * number of parameters.
+     *
+     * <p>Here because nothing else asserted it. The rule the list states is the rule E1615 enforces,
+     * and a list that stopped counting the injected positions would leave every implementation
+     * accepted with too few parameters — which the models above, all of which compile, cannot show.
+     */
+    @Test
+    void anImplementationThatDoesNotTakeTheListIsRefused() {
+        CompileException tooFew = assertThrows(CompileException.class,
+                () -> Compiler.compile(TWO_OF_EACH.replace(
+                        "let place (id, other, findMember, logLookup)", "let place (id, other)")));
+        assertEquals("E1615", tooFew.code(), "an implementation short of its injected parameters");
+    }
+
+    /** And one that takes them in another order is refused for that. */
+    @Test
+    void anInjectedParameterOutOfOrderIsRefused() {
+        CompileException swapped = assertThrows(CompileException.class,
+                () -> Compiler.compile(TWO_OF_EACH.replace(
+                        "let place (id, other, findMember, logLookup)",
+                        "let place (id, other, logLookup, findMember)")));
+        assertEquals("E1615", swapped.code(), "the injected parameters are named in declared order");
+    }
+
+    private static Hir.SpecBehavior behaviorOf(String source, String name) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        assertNotNull(prepared, "the model under test compiles");
+        return (Hir.SpecBehavior) prepared.behaviors().stream()
+                .filter(behavior -> behavior.name().equals(name))
+                .findFirst().orElseThrow();
+    }
+
+    /** What the accepted implementation of {@code name} was actually written with. */
+    private static List<String> writtenParametersOf(String source, String name) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        assertNotNull(prepared, "the model under test compiles");
+        return prepared.fns().stream()
+                .filter(fn -> fn.read().name().equals(name))
+                .findFirst().orElseThrow()
+                .read().params().stream().map(Hir.FnParam::name).toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/examples/WhatStandsInForARequirementIsAskedInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/WhatStandsInForARequirementIsAskedInOnePlaceTest.java
@@ -1,0 +1,136 @@
+package souther.compiler.examples;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Shapes;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * What stands in for a behavior's requirement while an example runs, and where that was found.
+ *
+ * <p>Two things may stand in — a {@code with} written on the row, and a {@code fake} table written
+ * beside it — and the row is looked at first. That order, and the fact that there are two of them at
+ * all, is what E1908 is about: a row whose target depends on something neither supplies cannot run,
+ * and the message says both ways to answer it.
+ *
+ * <p>It lived inside the verifier, wound together with building the value each stand-in answers
+ * with. A reader that only wants to know whether a requirement is still owed — an editor offering to
+ * write a row, which cannot build a value because it has none yet — had nowhere to ask, and asking
+ * by looking for a {@code with} and then a {@code fake} itself would be this rule written a second
+ * time.
+ *
+ * <p>The answer carries what it found rather than a yes or no, because the two callers do different
+ * things with it: one builds a stand-in out of it, the other counts what is left.
+ */
+class WhatStandsInForARequirementIsAskedInOnePlaceTest {
+
+    private static final String FAKED = """
+            module example.faked
+
+            data MemberId = String
+            data Found = { id: MemberId }
+            data Missing = { why: String }
+
+            behavior findMember : (id: MemberId) -> Found | Missing
+
+            behavior place : (id: MemberId) -> Found | Missing
+                depends on findMember
+
+            let place (id, findMember) = findMember(id)
+
+            fake findMember
+                | _ -> Missing { why = "none" }
+
+            example place
+                | (MemberId("m-1")) -> Missing { why = "none" }
+            """;
+
+    private static final String WITH_ON_THE_ROW = """
+            module example.withrow
+
+            data MemberId = String
+            data Found = { id: MemberId }
+            data Missing = { why: String }
+
+            behavior findMember : (id: MemberId) -> Found | Missing
+
+            behavior place : (id: MemberId) -> Found | Missing
+                depends on findMember
+
+            let place (id, findMember) = findMember(id)
+
+            fake findMember
+                | _ -> Missing { why = "none" }
+
+            example place
+                | (MemberId("m-1")) with findMember = Found { id = MemberId("m-1") }
+                    -> Found { id = MemberId("m-1") }
+            """;
+
+    /** A table beside the rows stands in where the row says nothing. */
+    @Test
+    void aTableStandsInWhereTheRowSaysNothing() {
+        Model model = modelOf(FAKED);
+        assertInstanceOf(ExampleProvisioning.Standin.InTheModule.class,
+                ExampleProvisioning.standingIn(model.row().withs(), "findMember", model.execution()));
+    }
+
+    /** And the row is looked at first, so what it writes stands in over the table beside it. */
+    @Test
+    void theRowIsLookedAtBeforeTheTableBesideIt() {
+        Model model = modelOf(WITH_ON_THE_ROW);
+        ExampleProvisioning.Standin found =
+                ExampleProvisioning.standingIn(model.row().withs(), "findMember", model.execution());
+        assertInstanceOf(ExampleProvisioning.Standin.OnTheRow.class, found,
+                "the `with` on the row was passed over for the table beside it");
+    }
+
+    /** Something neither supplies is owed, which is what E1908 is said about. */
+    @Test
+    void aRequirementNeitherSuppliesIsOwed() {
+        Model model = modelOf(FAKED);
+        assertInstanceOf(ExampleProvisioning.Standin.Nothing.class,
+                ExampleProvisioning.standingIn(model.row().withs(), "somethingElse",
+                        model.execution()));
+    }
+
+    /**
+     * A row that is not written yet supplies nothing, and is asked the same question.
+     *
+     * <p>What a row contributes is its {@code with}s, so a row nobody has written contributes an
+     * empty list rather than a stand-in row built to be asked with. Its target's requirements are
+     * then owed exactly where nothing else answers them, which is what an editor has to know before
+     * it can offer a row that will run.
+     */
+    @Test
+    void aRowNotWrittenYetSuppliesNothingOfItsOwn() {
+        Model model = modelOf(WITH_ON_THE_ROW);
+        assertInstanceOf(ExampleProvisioning.Standin.InTheModule.class,
+                ExampleProvisioning.standingIn(List.of(), "findMember", model.execution()),
+                "the table beside the rows answers a row that has not been written");
+        assertEquals(List.of(),
+                ExampleProvisioning.unsupplied(List.of(), List.of("findMember"), model.execution()));
+        assertEquals(List.of("somethingElse"),
+                ExampleProvisioning.unsupplied(List.of(), List.of("findMember", "somethingElse"),
+                        model.execution()));
+    }
+
+    private record Model(Hir.ExampleRow row, Prepared.ExampleExecution execution) {}
+
+    private static Model modelOf(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        assertNotNull(prepared, "the model under test compiles");
+        Hir.ExampleRow row = prepared.examples().get(0).read().rows().get(0);
+        return new Model(row, prepared.forExamples());
+    }
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Skeleton.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Skeleton.java
@@ -1,0 +1,146 @@
+package souther.compiler.fmt;
+
+import souther.compiler.cst.CstLexer;
+import souther.compiler.cst.CstParser;
+import souther.compiler.cst.GreenToken;
+import souther.compiler.cst.SyntaxKind;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A declaration written out as tokens, laid out by the formatter, with the places a person still has
+ * to fill in marked.
+ *
+ * <p>Nothing here decides what a skeleton says. What tokens to write is the caller's, and where they
+ * go on the page is {@link Formatter}'s: the tokens are joined, parsed, and formatted, so a skeleton
+ * is the canonical form of what it was built from and is left alone the next time the file it lands
+ * in is formatted. That holds because of how it is made rather than because something checks it
+ * afterwards.
+ *
+ * <p>The holes carry their own text — whatever a caller offers as the thing to replace — so the
+ * layout is worked out over exactly the characters that will be in the buffer if they are left as
+ * they stand. Nothing is padded, and no stand-in of a chosen width is needed.
+ *
+ * <p>Where a hole ends up is counted, not searched for. Its position among the tokens is fixed when
+ * the skeleton is built, and the formatted text is held to those tokens one for one, so a hole is
+ * where it was written even when its text is spelled the same as something else in the same
+ * skeleton. A formatter that added, dropped or rewrote a token would break the count, and that is
+ * refused rather than answered with a hole in the wrong place.
+ */
+public final class Skeleton {
+
+    private Skeleton() {}
+
+    /** Raised where the tokens do not make a declaration, or where the formatted text is not them. */
+    public static final class Mismatch extends RuntimeException {
+        Mismatch(String message) {
+            super(message);
+        }
+    }
+
+    /** What a hole stands for, which is what a caller has to be able to offer for it. */
+    public enum Category {
+        /** A name the author chooses. */
+        IDENTIFIER,
+        /** An expression, which nothing here can propose. */
+        EXPRESSION
+    }
+
+    /** One token to write: its kind, and how it is spelled. */
+    public record Word(SyntaxKind kind, String text) {}
+
+    /** A run of tokens, either written as they are or left to be replaced. */
+    public sealed interface Part {
+
+        List<Word> words();
+
+        /** Tokens the skeleton states. */
+        record Literal(List<Word> words) implements Part {}
+
+        /**
+         * Tokens a person replaces.
+         *
+         * <p>A run rather than one token: what stands in for an expression may be spelled with
+         * several, and a hole that could only ever be one token would have to be taken apart the
+         * first time one was.
+         */
+        record Hole(Category category, List<Word> words) implements Part {}
+    }
+
+    /** Where a hole ended up: the stretch of the formatted text it covers. */
+    public record Placed(Category category, int start, int end) {}
+
+    /** A skeleton as it is written, and where its holes are in it. */
+    public record Built(String text, List<Placed> holes) {}
+
+    /** The token indices a hole covers, {@code from} up to but not including {@code to}. */
+    record Range(Category category, int from, int to) {}
+
+    /** {@code parts} laid out, with the holes among them placed in the result. */
+    public static Built of(List<Part> parts) {
+        List<Word> composed = new ArrayList<>();
+        List<Range> ranges = new ArrayList<>();
+        for (Part part : parts) {
+            if (part.words().isEmpty()) {
+                throw new Mismatch("a part of a skeleton writes no tokens");
+            }
+            int from = composed.size();
+            composed.addAll(part.words());
+            if (part instanceof Part.Hole hole) {
+                ranges.add(new Range(hole.category(), from, composed.size()));
+            }
+        }
+        // A space between every pair, which is the one join that cannot glue two tokens into a
+        // third. What the source looks like here is not what comes out: the formatter derives the
+        // layout from the tree, so this text is read and then thrown away.
+        String source = String.join(" ", composed.stream().map(Word::text).toList());
+        CstParser.Result parsed = CstParser.parse(source);
+        if (!parsed.errors().isEmpty()) {
+            throw new Mismatch("these tokens do not make a declaration: " + source);
+        }
+        String formatted = Formatter.format(parsed.root());
+        return new Built(formatted, placedIn(composed, formatted, ranges));
+    }
+
+    /**
+     * Where each range lands in {@code formatted}, having held it to {@code composed}.
+     *
+     * <p>The text is read back into tokens and matched against the ones it was built from, in order
+     * and including how each is spelled. A difference anywhere means the text is not those tokens,
+     * and there is then no answer to give about where a hole is in it.
+     */
+    static List<Placed> placedIn(List<Word> composed, String formatted, List<Range> ranges) {
+        List<Placed> holes = new ArrayList<>();
+        int[] starts = new int[composed.size()];
+        int[] ends = new int[composed.size()];
+        int seen = 0;
+        int at = 0;
+        for (GreenToken token : CstLexer.lex(formatted).tokens()) {
+            if (token.kind().isTrivia() || token.kind() == SyntaxKind.EOF) {
+                at += token.text().length();
+                continue;
+            }
+            if (seen == composed.size()) {
+                throw new Mismatch("the formatted text writes more tokens than the skeleton did");
+            }
+            Word word = composed.get(seen);
+            if (word.kind() != token.kind() || !word.text().equals(token.text())) {
+                throw new Mismatch("token " + seen + " was written as `" + word.text()
+                        + "` and read back as `" + token.text() + "`");
+            }
+            starts[seen] = at;
+            ends[seen] = at + token.text().length();
+            seen++;
+            at += token.text().length();
+        }
+        if (seen != composed.size()) {
+            throw new Mismatch("the formatted text writes " + seen + " of the skeleton's "
+                    + composed.size() + " tokens");
+        }
+        for (Range range : ranges) {
+            holes.add(new Placed(range.category(), starts[range.from()], ends[range.to() - 1]));
+        }
+        return List.copyOf(holes);
+    }
+}

--- a/souther-fmt/src/test/java/souther/compiler/fmt/ASkeletonKeepsEveryTokenItWasBuiltFromTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/ASkeletonKeepsEveryTokenItWasBuiltFromTest.java
@@ -1,0 +1,132 @@
+package souther.compiler.fmt;
+
+import souther.compiler.cst.SyntaxKind;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A skeleton is laid out by the formatter, and where its holes are is read back through the tokens
+ * it was built from.
+ *
+ * <p>Nothing here spells a space or a line break. The tokens are written down, the formatter is
+ * given them, and what comes back is the canonical form of exactly those tokens — so a skeleton
+ * whose placeholders are left as they stand is already formatted, and stays that way when the file
+ * it was written into is next formatted. That is a property of how it is built rather than something
+ * to check afterwards.
+ *
+ * <p>The holes are found by counting tokens, not by looking for their text. A hole's default may be
+ * spelled the same as something else in the same skeleton — a parameter named for the behavior it
+ * injects, an expected value named for a parameter — and a search for the text would find whichever
+ * came first. The count is decided when the skeleton is built and is checked against the formatted
+ * text token by token, so a formatter that ever moved, added or rewrote one is refused rather than
+ * quietly given a hole in the wrong place.
+ */
+class ASkeletonKeepsEveryTokenItWasBuiltFromTest {
+
+    /** {@code let f (a, b) = c}, with the parameters and the body as holes. */
+    private static List<Skeleton.Part> aLet() {
+        return List.of(
+                literal(word(SyntaxKind.LET_KW, "let"), word(SyntaxKind.IDENT, "f"),
+                        word(SyntaxKind.LPAREN, "(")),
+                hole(Skeleton.Category.IDENTIFIER, word(SyntaxKind.IDENT, "a")),
+                literal(word(SyntaxKind.COMMA, ",")),
+                hole(Skeleton.Category.IDENTIFIER, word(SyntaxKind.IDENT, "b")),
+                literal(word(SyntaxKind.RPAREN, ")"), word(SyntaxKind.ASSIGN, "=")),
+                hole(Skeleton.Category.EXPRESSION, word(SyntaxKind.IDENT, "c")));
+    }
+
+    @Test
+    void itIsLaidOutTheWayTheFormatterLaysOutThoseTokens() {
+        Skeleton.Built built = Skeleton.of(aLet());
+        assertEquals(Formatter.format("let f (a, b) = c"), built.text());
+    }
+
+    /** And so formatting it again moves nothing. */
+    @Test
+    void formattingItAgainChangesNothing() {
+        Skeleton.Built built = Skeleton.of(aLet());
+        assertEquals(built.text(), Formatter.format(built.text()));
+    }
+
+    /** Each hole covers the text it was built from, and carries what kind of hole it is. */
+    @Test
+    void aHoleCoversTheTokensItWasBuiltFrom() {
+        Skeleton.Built built = Skeleton.of(aLet());
+        assertEquals(List.of("a", "b", "c"), built.holes().stream()
+                .map(hole -> built.text().substring(hole.start(), hole.end())).toList());
+        assertEquals(List.of(Skeleton.Category.IDENTIFIER, Skeleton.Category.IDENTIFIER,
+                        Skeleton.Category.EXPRESSION),
+                built.holes().stream().map(Skeleton.Placed::category).toList());
+    }
+
+    /**
+     * A hole is where it was built, not where its text next appears.
+     *
+     * <p>Here the body is spelled the same as the first parameter, which is legal and says nothing
+     * about the two being the same thing. A skeleton that looked for its holes would put the third
+     * one on the first parameter.
+     */
+    @Test
+    void aHoleIsNotFoundByLookingForItsText() {
+        Skeleton.Built built = Skeleton.of(List.of(
+                literal(word(SyntaxKind.LET_KW, "let"), word(SyntaxKind.IDENT, "f"),
+                        word(SyntaxKind.LPAREN, "(")),
+                hole(Skeleton.Category.IDENTIFIER, word(SyntaxKind.IDENT, "a")),
+                literal(word(SyntaxKind.RPAREN, ")"), word(SyntaxKind.ASSIGN, "=")),
+                hole(Skeleton.Category.EXPRESSION, word(SyntaxKind.IDENT, "a"))));
+        assertEquals(2, built.holes().size());
+        assertTrue(built.holes().get(0).start() < built.holes().get(1).start(),
+                "both holes landed on the same `a`");
+        assertEquals("let f (a) = a\n", built.text());
+    }
+
+    /** Tokens that do not parse are not a skeleton, and are refused rather than laid out. */
+    @Test
+    void tokensThatDoNotParseAreRefused() {
+        assertThrows(Skeleton.Mismatch.class, () -> Skeleton.of(List.of(
+                literal(word(SyntaxKind.LET_KW, "let"), word(SyntaxKind.LPAREN, "(")))));
+    }
+
+    /**
+     * And a formatted text that is not the tokens it was built from is refused.
+     *
+     * <p>The correspondence is asked directly here, with a token taken out of the list it is held
+     * against, because a formatter that rewrites a skeleton's tokens is the thing this refuses and
+     * the formatter does not do it. Without this the refusal would never be exercised, and a
+     * correspondence that accepted anything would read as a passing test.
+     */
+    @Test
+    void aFormattedTextThatIsNotThoseTokensIsRefused() {
+        List<Skeleton.Word> composed = List.of(word(SyntaxKind.LET_KW, "let"),
+                word(SyntaxKind.IDENT, "f"), word(SyntaxKind.ASSIGN, "="),
+                word(SyntaxKind.IDENT, "c"));
+        assertThrows(Skeleton.Mismatch.class,
+                () -> Skeleton.placedIn(composed, "let f =\n", List.of()),
+                "a text short of a token was taken for the tokens it was built from");
+        assertThrows(Skeleton.Mismatch.class,
+                () -> Skeleton.placedIn(composed, "let f = c d\n", List.of()),
+                "a text with a token over was taken for the tokens it was built from");
+        assertThrows(Skeleton.Mismatch.class,
+                () -> Skeleton.placedIn(composed, "let g = c\n", List.of()),
+                "a text spelling a token otherwise was taken for the tokens it was built from");
+        assertEquals(List.of(), Skeleton.placedIn(composed, "let f = c\n", List.of()),
+                "the text that is those tokens was refused");
+    }
+
+    private static Skeleton.Word word(SyntaxKind kind, String text) {
+        return new Skeleton.Word(kind, text);
+    }
+
+    private static Skeleton.Part literal(Skeleton.Word... words) {
+        return new Skeleton.Part.Literal(List.of(words));
+    }
+
+    private static Skeleton.Part hole(Skeleton.Category category, Skeleton.Word... words) {
+        return new Skeleton.Part.Hole(category, List.of(words));
+    }
+}

--- a/souther-lsp/src/main/java/souther/lsp/LspServer.java
+++ b/souther-lsp/src/main/java/souther/lsp/LspServer.java
@@ -11,6 +11,7 @@ import souther.lsp.protocol.CodeLens;
 import souther.lsp.protocol.CompletionItem;
 import souther.lsp.protocol.DocumentSymbol;
 import souther.lsp.protocol.Hover;
+import souther.lsp.protocol.Insertion;
 import souther.lsp.protocol.Location;
 import souther.lsp.protocol.LspDiagnostic;
 import souther.lsp.protocol.Position;
@@ -39,6 +40,9 @@ public final class LspServer {
     private final MessageConnection conn;
     private final DocumentStore documents = new DocumentStore();
     private final Analyzer analyzer = new Analyzer();
+
+    /** Whether this client said it reads completion placeholders. False until it says so. */
+    private boolean readsSnippets;
     private final Workspace workspace = new Workspace();
     private int nextRequestId = 1;
 
@@ -180,6 +184,28 @@ public final class LspServer {
         }
         workspace.setRoots(roots);
         analyzer.measure(adequacyAsked(params));
+        readsSnippets = snippetSupportAsked(params);
+    }
+
+    /**
+     * Whether the client said it reads completion placeholders, from
+     * {@code capabilities.textDocument.completion.completionItem.snippetSupport}.
+     *
+     * <p>False unless it said so, which is the protocol's default and not a guess: a client sent a
+     * snippet it did not ask for gets the placeholders in its buffer as characters. Nothing else the
+     * client declares is read — what this server answers does not depend on it — so this is the one
+     * thing asked of the handshake beyond where the workspace is.
+     */
+    private static boolean snippetSupportAsked(JsonNode params) {
+        JsonNode at = params == null ? null : params.get("capabilities");
+        for (String field : List.of("textDocument", "completion", "completionItem",
+                "snippetSupport")) {
+            if (at == null || at.isNull()) {
+                return false;
+            }
+            at = at.get(field);
+        }
+        return at != null && at.isBoolean() && at.asBoolean();
     }
 
     /**
@@ -330,6 +356,14 @@ public final class LspServer {
             // detail as an empty line beside the label.
             if (item.detail() != null) {
                 sent.put("detail", item.detail());
+            }
+            if (item.writes() != null) {
+                sent.put("insertText", readsSnippets
+                        ? Insertion.snippet(item.writes())
+                        : Insertion.plain(item.writes()));
+                if (readsSnippets) {
+                    sent.put("insertTextFormat", Insertion.SNIPPET_FORMAT);
+                }
             }
             items.add(sent);
         }

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -1271,7 +1271,11 @@ public final class Analyzer {
                         DeclarationSkeletons.fixed(form)).ifPresent(out::add);
             }
         }
-        out.addAll(behaviorsToWrite(uri, compilation, module));
+        // Through the same gate. A declaration written from a signature stands where a declaration
+        // stands, and knowing which one it is does not make it writable anywhere else.
+        if (here.contains(TopLevelForm.Region.BODY)) {
+            out.addAll(behaviorsToWrite(uri, compilation, module));
+        }
         return List.copyOf(out);
     }
 
@@ -1287,7 +1291,7 @@ public final class Analyzer {
     private List<CompletionItem> behaviorsToWrite(String uri, Compilation compilation,
                                                   String module) {
         List<CompletionItem> answered =
-                behaviorsOwed.of(uri, () -> askBehaviorsToWrite(compilation, module));
+                behaviorsOwed.of(uri, module, () -> askBehaviorsToWrite(compilation, module));
         return answered == null ? List.of() : answered;
     }
 
@@ -1343,8 +1347,11 @@ public final class Analyzer {
      * {@link Bodies.Requirements} carries a composition's stages' requirements as its own, so a row
      * for one supplies what the stages want.
      *
-     * <p>A behavior that is itself injected requires nothing and is not a key there, which is
-     * absence meaning what it says rather than the question going unanswered.
+     * <p>A behavior that is itself injected requires nothing and is not a key there — the one place
+     * a name being missing says something rather than being something missing. Which of the two it
+     * is, is asked of the behavior rather than read off the absence: a name that is not there for
+     * any other reason is an answer that does not hold together, and a row written as though it
+     * required nothing would state no stand-in for what it depends on.
      */
     private static Optional<CompletionItem> rowToWrite(
             Prepared prepared, Hir.BehaviorDef declared, Map<String, Sig> signatures,
@@ -1353,9 +1360,15 @@ public final class Analyzer {
         if (sig == null) {
             return Optional.empty();
         }
+        List<BehaviorRequirement> required = List.of();
+        if (!prepared.injected(declared)) {
+            required = requirements.get(declared.name());
+            if (required == null) {
+                return Optional.empty();
+            }
+        }
         List<String> unsupplied = ExampleProvisioning.unsupplied(List.of(),
-                Requirements.names(requirements.getOrDefault(declared.name(), List.of())),
-                prepared.forExamples());
+                Requirements.names(required), prepared.forExamples());
         return built(TopLevelForm.EXAMPLE.starter() + " " + declared.name(),
                 CompletionItem.SNIPPET, module,
                 DeclarationSkeletons.exampleFor(declared.name(), argumentsOf(declared, sig),

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -1270,9 +1270,6 @@ public final class Analyzer {
                         DeclarationSkeletons.fixed(form)).ifPresent(out::add);
             }
         }
-        if (!here.contains(TopLevelForm.Region.BODY)) {
-            return List.copyOf(out);
-        }
         out.addAll(behaviorsToWrite(uri, compilation, module));
         return List.copyOf(out);
     }
@@ -1334,9 +1331,17 @@ public final class Analyzer {
     /**
      * An item writing {@code parts}, or nothing where they do not make a declaration.
      *
-     * <p>A skeleton is refused where the tokens do not parse or where the formatter did not write
-     * back what it was given. Neither should happen, and where one does the answer is to offer one
-     * candidate fewer rather than to fail the request that asked for all of them.
+     * <p>Fail-open, deliberately. A skeleton is refused where the tokens do not parse or where the
+     * formatter did not write back what it was given, and neither is about what an author typed:
+     * every name in one comes from a declaration the compiler read, so both mean a defect in the
+     * formatter or the grammar. What that costs here is one candidate fewer, which nothing says out
+     * loud — this server has no channel to say it on, since its output is the protocol.
+     *
+     * <p>Taken over the alternative, which is to let it out and lose the whole list: an editor would
+     * be left with no completion at all, for every request against that document, over a candidate
+     * that was never the one being asked for. What guards against it going unnoticed is that every
+     * form is built in a test, and a behavior's is built over each model those tests are written
+     * against.
      */
     private static Optional<CompletionItem> built(String label, int kind, String detail,
                                                   List<Skeleton.Part> parts) {
@@ -1419,6 +1424,11 @@ public final class Analyzer {
         return labels;
     }
 
+    /** The top-level definitions, each of which is written as one thing and holds what it binds. */
+    private static final Set<SyntaxKind> DEFINITIONS = Set.of(
+            SyntaxKind.DATA_DEF, SyntaxKind.BEHAVIOR_DEF, SyntaxKind.FN_DEF,
+            SyntaxKind.EXAMPLE_DEF, SyntaxKind.FAKE_DEF);
+
     /**
      * The top-level definition whose text contains {@code offset}, or {@code null} at the file level.
      *
@@ -1427,11 +1437,16 @@ public final class Analyzer {
      * empty line above a definition is inside its span while being nowhere near it. That line is
      * where the next declaration is written, and what is bound inside the definition below is bound
      * nowhere there.
+     *
+     * <p>The rows of an {@code example} and of a {@code fake} are definitions here as much as a
+     * {@code let} is. What is written in one is an expression — a row's inputs, what it expects, what
+     * a table answers with — so a declaration offered inside one would be offered inside an
+     * expression, and a binding written in a row's block holds there and is in force at a cursor in
+     * it.
      */
     private SyntaxNode enclosingDef(SyntaxNode root, int offset) {
         for (SyntaxNode def : root.childNodes()) {
-            if (def.kind() != SyntaxKind.DATA_DEF && def.kind() != SyntaxKind.BEHAVIOR_DEF
-                    && def.kind() != SyntaxKind.FN_DEF) {
+            if (!DEFINITIONS.contains(def.kind())) {
                 continue;
             }
             int written = writtenFrom(def);

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -4,6 +4,7 @@ import souther.compiler.Compiler;
 import souther.compiler.check.BehaviorRequirement;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Requirements;
+import souther.compiler.check.Sig;
 import souther.compiler.check.Resolve;
 import souther.compiler.check.SpecImplementation;
 import souther.compiler.examples.ExampleProvisioning;
@@ -1277,10 +1278,11 @@ public final class Analyzer {
     /**
      * What the behaviors of {@code module} are still owed, as declarations to write.
      *
-     * <p>Which behaviors have no implementation is {@link Requirements#injected} — the same question
-     * the emitter asks about which names it has to be given — so an editor and a compile cannot
-     * disagree about whether a behavior is written. A behavior written as a composition is already
-     * its own implementation and is not among them.
+     * <p>Two sets, not one. An implementation is owed by a behavior written as a signature with
+     * nothing implementing it, which is {@link Requirements#injected} — the same question the
+     * emitter asks about what it has to be given. A row may be written for any behavior at all: a
+     * composition has no implementation to offer, since it is its own, and has rows like anything
+     * else.
      */
     private List<CompletionItem> behaviorsToWrite(String uri, Compilation compilation,
                                                   String module) {
@@ -1289,43 +1291,99 @@ public final class Analyzer {
         return answered == null ? List.of() : answered;
     }
 
-    /** The same, asked of the compile — null where it cannot say what this module declares. */
+    /**
+     * The same, asked of the compile — null where it cannot say what this module declares.
+     *
+     * <p>Null for each of the three questions going unanswered, and not only for the first. A
+     * module's requirements not being answered is not that module requiring nothing: a row written
+     * from that would leave out the stand-in its target needs, which is E1908 the moment it is
+     * completed. Answering nothing is what lets the last answer that was given stand.
+     */
     private List<CompletionItem> askBehaviorsToWrite(Compilation compilation, String module) {
         if (module == null) {
             return null;
         }
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        if (prepared == null) {
-            return null;
-        }
         Map<String, List<BehaviorRequirement>> requirements =
                 compilation.db().ask(new Bodies.Requirements(module)).value();
+        Map<String, Sig> signatures = compilation.db().ask(new Bodies.Signatures(module)).value();
+        if (prepared == null || requirements == null || signatures == null) {
+            return null;
+        }
         List<CompletionItem> out = new ArrayList<>();
         for (Hir.BehaviorDef declared : prepared.behaviors()) {
-            if (!(declared instanceof Hir.SpecBehavior behavior)) {
-                continue;
-            }
-            List<SpecImplementation.Parameter> parameters =
-                    SpecImplementation.parameters(behavior);
-            if (parameters.contains(new SpecImplementation.Parameter.Unanswered())) {
-                // A dependency naming nothing settles no parameter, and a skeleton stating one it
-                // did not read would be this server inventing it.
-                continue;
-            }
-            if (prepared.injected(behavior)) {
-                built(TopLevelForm.FN.starter() + " " + behavior.name(), CompletionItem.SNIPPET,
-                        module, DeclarationSkeletons.implementing(behavior.name(), parameters))
-                        .ifPresent(out::add);
-            }
-            List<String> unsupplied = requirements == null ? List.of()
-                    : ExampleProvisioning.unsupplied(List.of(),
-                            Requirements.names(requirements.getOrDefault(behavior.name(), List.of())),
-                            prepared.forExamples());
-            built(TopLevelForm.EXAMPLE.starter() + " " + behavior.name(), CompletionItem.SNIPPET,
-                    module, DeclarationSkeletons.exampleFor(behavior.name(), parameters, unsupplied))
-                    .ifPresent(out::add);
+            implementationToWrite(prepared, declared, module).ifPresent(out::add);
+            rowToWrite(prepared, declared, signatures, requirements, module).ifPresent(out::add);
         }
         return out;
+    }
+
+    /** The {@code let} a behavior is owed, where it is owed one. */
+    private static Optional<CompletionItem> implementationToWrite(
+            Prepared prepared, Hir.BehaviorDef declared, String module) {
+        if (!(declared instanceof Hir.SpecBehavior behavior) || !prepared.injected(behavior)) {
+            return Optional.empty();
+        }
+        List<SpecImplementation.Parameter> parameters = SpecImplementation.parameters(behavior);
+        if (parameters.contains(new SpecImplementation.Parameter.Unanswered())) {
+            // A dependency naming nothing settles no parameter, and a skeleton stating one it did
+            // not read would be this server inventing it.
+            return Optional.empty();
+        }
+        return built(TopLevelForm.FN.starter() + " " + behavior.name(), CompletionItem.SNIPPET,
+                module, DeclarationSkeletons.implementing(behavior.name(), parameters));
+    }
+
+    /**
+     * A row for a behavior: as many arguments as it takes, and what nothing stands in for.
+     *
+     * <p>How many it takes is the signature's, which is what a row is held to whether the behavior
+     * is written as one or composed out of others — a composition takes what its first stage takes,
+     * and nothing here works that out a second time. What it depends on is the same:
+     * {@link Bodies.Requirements} carries a composition's stages' requirements as its own, so a row
+     * for one supplies what the stages want.
+     *
+     * <p>A behavior that is itself injected requires nothing and is not a key there, which is
+     * absence meaning what it says rather than the question going unanswered.
+     */
+    private static Optional<CompletionItem> rowToWrite(
+            Prepared prepared, Hir.BehaviorDef declared, Map<String, Sig> signatures,
+            Map<String, List<BehaviorRequirement>> requirements, String module) {
+        Sig sig = signatures.get(declared.name());
+        if (sig == null) {
+            return Optional.empty();
+        }
+        List<String> unsupplied = ExampleProvisioning.unsupplied(List.of(),
+                Requirements.names(requirements.getOrDefault(declared.name(), List.of())),
+                prepared.forExamples());
+        return built(TopLevelForm.EXAMPLE.starter() + " " + declared.name(),
+                CompletionItem.SNIPPET, module,
+                DeclarationSkeletons.exampleFor(declared.name(), argumentsOf(declared, sig),
+                        unsupplied));
+    }
+
+    /**
+     * What to write in each of a row's argument places.
+     *
+     * <p>How many there are is the signature's. What each is called is a label and nothing more —
+     * what stands there is a value, not the parameter — so it is taken from the declaration where
+     * there is one to take it from, and held to the count rather than deciding it. A composition
+     * names no parameters of its own, and a row for one says what it takes without saying what its
+     * first stage happened to call them.
+     */
+    private static List<String> argumentsOf(Hir.BehaviorDef declared, Sig sig) {
+        List<String> labels = new ArrayList<>();
+        if (declared instanceof Hir.SpecBehavior behavior
+                && behavior.params().size() == sig.ins().size()) {
+            for (Hir.Param param : behavior.params()) {
+                labels.add(param.name());
+            }
+            return labels;
+        }
+        for (int i = 0; i < sig.ins().size(); i++) {
+            labels.add("arg");
+        }
+        return labels;
     }
 
     /**
@@ -1353,36 +1411,51 @@ public final class Analyzer {
     }
 
     /**
-     * The places in a file the cursor is still in.
+     * The places in a file the cursor is in.
      *
-     * <p>A file is read as a header, then its imports, then its body, so where the cursor stands
-     * against what is already written says which of those it is still in front of. A body item may
-     * be written wherever a declaration may.
+     * <p>A file is read as a header, then its imports, then its body, and a form may be written at
+     * the cursor when writing it there leaves the file still in that order. So both sides of the
+     * cursor are read: what stands before it says what it is past, and what stands after it says
+     * what it may not be written in front of. An import offered above one already written is an
+     * offer to write a file whose imports are not together, and a definition offered above one is an
+     * offer to write a definition the imports come after.
+     *
+     * <p>A header is offered only to a file with none. There is one, it opens the file, and a second
+     * is not something to write.
      */
     private static Set<TopLevelForm.Region> regionsAt(SyntaxNode root, int cursor) {
-        Set<TopLevelForm.Region> here = new LinkedHashSet<>();
-        here.add(TopLevelForm.Region.BODY);
-        boolean beforeEveryItem = true;
-        boolean beforeEveryDefinition = true;
+        int headerEnds = -1;
+        boolean hasHeader = false;
+        int lastImportEnds = -1;
+        int firstDefinition = Integer.MAX_VALUE;
+        boolean anythingBefore = false;
         for (SyntaxNode item : root.childNodes()) {
             // Where the item is written, not where its node begins: a node reaches back over the
             // blank line in front of it, and a cursor on that line is in front of the item.
             int written = writtenFrom(item);
-            if (written < 0 || written >= cursor) {
+            if (written < 0) {
                 continue;
             }
-            beforeEveryItem = false;
-            if (item.kind() != SyntaxKind.MODULE_HEADER
-                    && item.kind() != SyntaxKind.EXAMPLES_FILE_HEADER
-                    && item.kind() != SyntaxKind.IMPORT_DECL) {
-                beforeEveryDefinition = false;
+            anythingBefore |= written < cursor;
+            switch (item.kind()) {
+                case MODULE_HEADER, EXAMPLES_FILE_HEADER -> {
+                    hasHeader = true;
+                    headerEnds = Math.max(headerEnds, item.end());
+                }
+                case IMPORT_DECL -> lastImportEnds = Math.max(lastImportEnds, item.end());
+                default -> firstDefinition = Math.min(firstDefinition, written);
             }
         }
-        if (beforeEveryItem) {
+        Set<TopLevelForm.Region> here = new LinkedHashSet<>();
+        if (!hasHeader && !anythingBefore) {
             here.add(TopLevelForm.Region.FILE_HEADER);
         }
-        if (beforeEveryDefinition) {
+        boolean pastTheHeader = cursor >= headerEnds;
+        if (pastTheHeader && cursor <= firstDefinition) {
             here.add(TopLevelForm.Region.PRELUDE);
+        }
+        if (pastTheHeader && cursor >= lastImportEnds) {
+            here.add(TopLevelForm.Region.BODY);
         }
         return here;
     }

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -1,8 +1,14 @@
 package souther.lsp.analysis;
 
 import souther.compiler.Compiler;
+import souther.compiler.check.BehaviorRequirement;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Requirements;
 import souther.compiler.check.Resolve;
+import souther.compiler.check.SpecImplementation;
+import souther.compiler.examples.ExampleProvisioning;
 import souther.compiler.query.Adequacy;
+import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Names;
 import souther.compiler.query.Shapes;
@@ -34,7 +40,9 @@ import souther.compiler.cst.SyntaxElement;
 import souther.compiler.cst.SyntaxKind;
 import souther.compiler.cst.SyntaxNode;
 import souther.compiler.cst.SyntaxToken;
+import souther.compiler.cst.TopLevelForm;
 import souther.compiler.fmt.Formatter;
+import souther.compiler.fmt.Skeleton;
 import souther.compiler.frontend.CstFrontend;
 import souther.lsp.protocol.CodeAction;
 import souther.lsp.protocol.CodeLens;
@@ -51,6 +59,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -93,6 +102,9 @@ public final class Analyzer {
      * said. Held across edits so completion has something to offer while the document being typed in
      * is held out of the compile for its syntax errors. */
     private final NamesFromElsewhere elsewhere = new NamesFromElsewhere();
+
+    /** What the last compile that could answer said each document owes a declaration for. */
+    private final LastAnswered<List<CompletionItem>> behaviorsOwed = new LastAnswered<>();
 
     /**
      * How much of what the rows cover this editor was told to measure. Off by default.
@@ -282,6 +294,7 @@ public final class Analyzer {
     private Compilation compileOf(ModuleGraph graph, souther.compiler.meta.ModulePath path,
                                   Map<String, String> sources, Set<String> broken) {
         elsewhere.forgetAllBut(graph.uris());
+        behaviorsOwed.forgetAllBut(graph.uris());
         readings.keySet().retainAll(Set.copyOf(graph.uris()));
         if (workspaceCompile == null || !path.equals(compiledAgainst)) {
             workspaceCompile = Compilation.ofDocuments(sources, broken, path);
@@ -1219,10 +1232,154 @@ public final class Analyzer {
         for (CompletionItem item : fromElsewhere) {
             byLabel.putIfAbsent(item.label(), item);
         }
+        // Ahead of the keywords, so where a declaration may be written the offer is the declaration
+        // rather than the word it starts with. Inside a definition none of these are offered and the
+        // word stands, which is what a `let` binding in a block is written with.
+        for (CompletionItem item : declarationsToWrite(uri, root, cursor, compilation, module)) {
+            byLabel.putIfAbsent(item.label(), item);
+        }
         for (String keyword : CstLexer.keywords()) {
             byLabel.putIfAbsent(keyword, new CompletionItem(keyword, CompletionItem.KEYWORD, null));
         }
         return new ArrayList<>(byLabel.values());
+    }
+
+    /**
+     * The declarations that may be written at the cursor.
+     *
+     * <p>Nothing where the cursor is inside a definition: what may be written there is an
+     * expression, and a declaration offered inside one is an offer to write a syntax error. At the
+     * file level, the forms whose place in a file the cursor is still in — a header opens a file, an
+     * import follows it, and a body item may be written wherever one may.
+     *
+     * <p>Where the compile can say what this module declares, a behavior with no implementation is
+     * offered the {@code let} its signature describes, and every behavior is offered a row. Where it
+     * cannot — which is every keystroke that leaves the document unparseable — the forms are still
+     * offered, stating what they are and nothing that was not read.
+     */
+    private List<CompletionItem> declarationsToWrite(String uri, SyntaxNode root, int cursor,
+                                                     Compilation compilation, String module) {
+        if (enclosingDef(root, cursor) != null) {
+            return List.of();
+        }
+        List<CompletionItem> out = new ArrayList<>();
+        Set<TopLevelForm.Region> here = regionsAt(root, cursor);
+        for (TopLevelForm form : TopLevelForm.values()) {
+            if (here.contains(form.region())) {
+                built(form.starter(), CompletionItem.SNIPPET, null,
+                        DeclarationSkeletons.fixed(form)).ifPresent(out::add);
+            }
+        }
+        if (!here.contains(TopLevelForm.Region.BODY)) {
+            return List.copyOf(out);
+        }
+        out.addAll(behaviorsToWrite(uri, compilation, module));
+        return List.copyOf(out);
+    }
+
+    /**
+     * What the behaviors of {@code module} are still owed, as declarations to write.
+     *
+     * <p>Which behaviors have no implementation is {@link Requirements#injected} — the same question
+     * the emitter asks about which names it has to be given — so an editor and a compile cannot
+     * disagree about whether a behavior is written. A behavior written as a composition is already
+     * its own implementation and is not among them.
+     */
+    private List<CompletionItem> behaviorsToWrite(String uri, Compilation compilation,
+                                                  String module) {
+        List<CompletionItem> answered =
+                behaviorsOwed.of(uri, () -> askBehaviorsToWrite(compilation, module));
+        return answered == null ? List.of() : answered;
+    }
+
+    /** The same, asked of the compile — null where it cannot say what this module declares. */
+    private List<CompletionItem> askBehaviorsToWrite(Compilation compilation, String module) {
+        if (module == null) {
+            return null;
+        }
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        if (prepared == null) {
+            return null;
+        }
+        Map<String, List<BehaviorRequirement>> requirements =
+                compilation.db().ask(new Bodies.Requirements(module)).value();
+        List<CompletionItem> out = new ArrayList<>();
+        for (Hir.BehaviorDef declared : prepared.behaviors()) {
+            if (!(declared instanceof Hir.SpecBehavior behavior)) {
+                continue;
+            }
+            List<SpecImplementation.Parameter> parameters =
+                    SpecImplementation.parameters(behavior);
+            if (parameters.contains(new SpecImplementation.Parameter.Unanswered())) {
+                // A dependency naming nothing settles no parameter, and a skeleton stating one it
+                // did not read would be this server inventing it.
+                continue;
+            }
+            if (prepared.injected(behavior)) {
+                built(TopLevelForm.FN.starter() + " " + behavior.name(), CompletionItem.SNIPPET,
+                        module, DeclarationSkeletons.implementing(behavior.name(), parameters))
+                        .ifPresent(out::add);
+            }
+            List<String> unsupplied = requirements == null ? List.of()
+                    : ExampleProvisioning.unsupplied(List.of(),
+                            Requirements.names(requirements.getOrDefault(behavior.name(), List.of())),
+                            prepared.forExamples());
+            built(TopLevelForm.EXAMPLE.starter() + " " + behavior.name(), CompletionItem.SNIPPET,
+                    module, DeclarationSkeletons.exampleFor(behavior.name(), parameters, unsupplied))
+                    .ifPresent(out::add);
+        }
+        return out;
+    }
+
+    /**
+     * An item writing {@code parts}, or nothing where they do not make a declaration.
+     *
+     * <p>A skeleton is refused where the tokens do not parse or where the formatter did not write
+     * back what it was given. Neither should happen, and where one does the answer is to offer one
+     * candidate fewer rather than to fail the request that asked for all of them.
+     */
+    private static Optional<CompletionItem> built(String label, int kind, String detail,
+                                                  List<Skeleton.Part> parts) {
+        try {
+            return Optional.of(new CompletionItem(label, kind, detail, Skeleton.of(parts)));
+        } catch (Skeleton.Mismatch _) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * The places in a file the cursor is still in.
+     *
+     * <p>A file is read as a header, then its imports, then its body, so where the cursor stands
+     * against what is already written says which of those it is still in front of. A body item may
+     * be written wherever a declaration may.
+     */
+    private static Set<TopLevelForm.Region> regionsAt(SyntaxNode root, int cursor) {
+        Set<TopLevelForm.Region> here = new LinkedHashSet<>();
+        here.add(TopLevelForm.Region.BODY);
+        boolean beforeEveryItem = true;
+        boolean beforeEveryDefinition = true;
+        for (SyntaxNode item : root.childNodes()) {
+            // Where the item is written, not where its node begins: a node reaches back over the
+            // blank line in front of it, and a cursor on that line is in front of the item.
+            int written = writtenFrom(item);
+            if (written < 0 || written >= cursor) {
+                continue;
+            }
+            beforeEveryItem = false;
+            if (item.kind() != SyntaxKind.MODULE_HEADER
+                    && item.kind() != SyntaxKind.EXAMPLES_FILE_HEADER
+                    && item.kind() != SyntaxKind.IMPORT_DECL) {
+                beforeEveryDefinition = false;
+            }
+        }
+        if (beforeEveryItem) {
+            here.add(TopLevelForm.Region.FILE_HEADER);
+        }
+        if (beforeEveryDefinition) {
+            here.add(TopLevelForm.Region.PRELUDE);
+        }
+        return here;
     }
 
     /**
@@ -1262,16 +1419,44 @@ public final class Analyzer {
         return labels;
     }
 
-    /** The top-level definition whose span contains {@code offset}, or {@code null} at the file level. */
+    /**
+     * The top-level definition whose text contains {@code offset}, or {@code null} at the file level.
+     *
+     * <p>Its text, and not its span. A node reaches back over the blank lines and comments in front
+     * of it — the tree covers every character, and they belong to something — so a cursor on the
+     * empty line above a definition is inside its span while being nowhere near it. That line is
+     * where the next declaration is written, and what is bound inside the definition below is bound
+     * nowhere there.
+     */
     private SyntaxNode enclosingDef(SyntaxNode root, int offset) {
         for (SyntaxNode def : root.childNodes()) {
-            if ((def.kind() == SyntaxKind.DATA_DEF || def.kind() == SyntaxKind.BEHAVIOR_DEF
-                    || def.kind() == SyntaxKind.FN_DEF)
-                    && offset >= def.start() && offset <= def.end()) {
+            if (def.kind() != SyntaxKind.DATA_DEF && def.kind() != SyntaxKind.BEHAVIOR_DEF
+                    && def.kind() != SyntaxKind.FN_DEF) {
+                continue;
+            }
+            int written = writtenFrom(def);
+            if (written >= 0 && offset >= written && offset <= def.end()) {
                 return def;
             }
         }
         return null;
+    }
+
+    /** Where {@code node}'s own text begins: its first code token, past the trivia in front of it. */
+    private static int writtenFrom(SyntaxNode node) {
+        for (SyntaxElement e : node.children()) {
+            if (e instanceof SyntaxToken token) {
+                if (!token.kind().isTrivia()) {
+                    return token.start();
+                }
+            } else if (e instanceof SyntaxNode child) {
+                int written = writtenFrom(child);
+                if (written >= 0) {
+                    return written;
+                }
+            }
+        }
+        return -1;
     }
 
     /**

--- a/souther-lsp/src/main/java/souther/lsp/analysis/DeclarationSkeletons.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/DeclarationSkeletons.java
@@ -43,27 +43,36 @@ final class DeclarationSkeletons {
      * <p>An input is a hole standing in with the behavior's own spelling, which is a suggestion; an
      * injected parameter is written out, because its name is the behavior it injects and any other
      * spelling is refused.
+     *
+     * <p>A behavior with nothing to take is written without parentheses. They are what makes a
+     * {@code let} a function, and one written without them defines a value — an empty pair is
+     * refused (E2301), so writing one would be offering a declaration nothing accepts.
      */
     static List<Skeleton.Part> implementing(String behavior,
                                             List<SpecImplementation.Parameter> parameters) {
         List<Skeleton.Part> parts = new ArrayList<>();
-        parts.add(literal(starterOf(TopLevelForm.FN), name(behavior), spelt(SyntaxKind.LPAREN)));
-        for (int i = 0; i < parameters.size(); i++) {
-            if (i > 0) {
-                parts.add(literal(spelt(SyntaxKind.COMMA)));
+        parts.add(literal(starterOf(TopLevelForm.FN), name(behavior)));
+        if (!parameters.isEmpty()) {
+            parts.add(literal(spelt(SyntaxKind.LPAREN)));
+            for (int i = 0; i < parameters.size(); i++) {
+                if (i > 0) {
+                    parts.add(literal(spelt(SyntaxKind.COMMA)));
+                }
+                switch (parameters.get(i)) {
+                    case SpecImplementation.Parameter.Input input ->
+                            parts.add(hole(Skeleton.Category.IDENTIFIER, input.nameSuggestion()));
+                    case SpecImplementation.Parameter.Injected injected ->
+                            parts.add(literal(name(injected.name())));
+                    // A dependency naming nothing settles no parameter to write. Nothing is offered
+                    // for a behavior holding one, so this is unreachable through what offers a
+                    // skeleton.
+                    case SpecImplementation.Parameter.Unanswered _ ->
+                            parts.add(hole(Skeleton.Category.IDENTIFIER, A_PARAMETER));
+                }
             }
-            switch (parameters.get(i)) {
-                case SpecImplementation.Parameter.Input input ->
-                        parts.add(hole(Skeleton.Category.IDENTIFIER, input.nameSuggestion()));
-                case SpecImplementation.Parameter.Injected injected ->
-                        parts.add(literal(name(injected.name())));
-                // A dependency naming nothing settles no parameter to write. Nothing is offered for
-                // a behavior holding one, so this is unreachable through what offers a skeleton.
-                case SpecImplementation.Parameter.Unanswered _ ->
-                        parts.add(hole(Skeleton.Category.IDENTIFIER, A_PARAMETER));
-            }
+            parts.add(literal(spelt(SyntaxKind.RPAREN)));
         }
-        parts.add(literal(spelt(SyntaxKind.RPAREN), spelt(SyntaxKind.ASSIGN)));
+        parts.add(literal(spelt(SyntaxKind.ASSIGN)));
         parts.add(hole(Skeleton.Category.EXPRESSION, A_BODY));
         return List.copyOf(parts);
     }

--- a/souther-lsp/src/main/java/souther/lsp/analysis/DeclarationSkeletons.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/DeclarationSkeletons.java
@@ -69,28 +69,24 @@ final class DeclarationSkeletons {
     }
 
     /**
-     * An {@code example} for a behavior: one row, stating as many arguments as the behavior takes
-     * inputs, supplying what nothing already stands in for, and expecting something.
+     * An {@code example} for a behavior: one row, stating an argument apiece, supplying what nothing
+     * already stands in for, and expecting something.
      *
-     * <p>The row states the inputs alone. What a behavior depends on is not passed to it — a row
-     * supplies that through {@code with}, or a {@code fake} table beside the rows does — so a row
-     * with a place for every parameter would have one place too many for each dependency.
+     * <p>{@code arguments} is one label per place the row states, which is what the behavior takes
+     * at its boundary. What it depends on is not among them — a row supplies that through
+     * {@code with}, or a {@code fake} table beside the rows does — so a row with a place per
+     * dependency as well would have one place too many for each.
      */
-    static List<Skeleton.Part> exampleFor(String target,
-                                          List<SpecImplementation.Parameter> parameters,
+    static List<Skeleton.Part> exampleFor(String target, List<String> arguments,
                                           List<String> unsupplied) {
         List<Skeleton.Part> parts = new ArrayList<>();
         parts.add(literal(starterOf(TopLevelForm.EXAMPLE), name(target), spelt(SyntaxKind.PIPE),
                 spelt(SyntaxKind.LPAREN)));
-        int written = 0;
-        for (SpecImplementation.Parameter parameter : parameters) {
-            if (parameter instanceof SpecImplementation.Parameter.Input input) {
-                if (written > 0) {
-                    parts.add(literal(spelt(SyntaxKind.COMMA)));
-                }
-                parts.add(hole(Skeleton.Category.EXPRESSION, input.nameSuggestion()));
-                written++;
+        for (int i = 0; i < arguments.size(); i++) {
+            if (i > 0) {
+                parts.add(literal(spelt(SyntaxKind.COMMA)));
             }
+            parts.add(hole(Skeleton.Category.EXPRESSION, arguments.get(i)));
         }
         parts.add(literal(spelt(SyntaxKind.RPAREN)));
         for (int i = 0; i < unsupplied.size(); i++) {

--- a/souther-lsp/src/main/java/souther/lsp/analysis/DeclarationSkeletons.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/DeclarationSkeletons.java
@@ -1,0 +1,198 @@
+package souther.lsp.analysis;
+
+import souther.compiler.check.SpecImplementation;
+import souther.compiler.cst.SyntaxKind;
+import souther.compiler.cst.TopLevelForm;
+import souther.compiler.fmt.Skeleton;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The declarations an editor offers to write, as tokens.
+ *
+ * <p>Nothing here spells a keyword or a bracket. A form's own words come from {@link TopLevelForm},
+ * which is what recognises them, and everything else from {@link SyntaxKind#fixedSpelling()}, which
+ * is what the language writes them as. What is left to choose is which of the forms the grammar
+ * allows to offer — a {@code behavior} may be written as a signature or as a composition, and only
+ * one of those can be offered — and that choice is this server's, since it is about what helps
+ * someone writing rather than about what the language admits.
+ *
+ * <p>Where a declaration can be read, the skeleton is built from it and holds a hole exactly where
+ * the compiler settles nothing. Where one cannot, the skeleton states what a form is and no more:
+ * three parameter holes because behaviors often take three would be this server inventing a
+ * signature it did not read.
+ */
+final class DeclarationSkeletons {
+
+    private DeclarationSkeletons() {}
+
+    /** What a hole stands in with until the author replaces it. */
+    private static final String A_NAME = "name";
+    private static final String A_PARAMETER = "param";
+    private static final String A_BODY = "body";
+    private static final String A_TYPE = "Type";
+    private static final String AN_ARGUMENT = "arg";
+    private static final String AN_EXPECTED = "expected";
+    private static final String A_VALUE = "value";
+
+    /**
+     * The {@code let} implementing a behavior: its name, the parameters it is required to take, and
+     * a body.
+     *
+     * <p>An input is a hole standing in with the behavior's own spelling, which is a suggestion; an
+     * injected parameter is written out, because its name is the behavior it injects and any other
+     * spelling is refused.
+     */
+    static List<Skeleton.Part> implementing(String behavior,
+                                            List<SpecImplementation.Parameter> parameters) {
+        List<Skeleton.Part> parts = new ArrayList<>();
+        parts.add(literal(starterOf(TopLevelForm.FN), name(behavior), spelt(SyntaxKind.LPAREN)));
+        for (int i = 0; i < parameters.size(); i++) {
+            if (i > 0) {
+                parts.add(literal(spelt(SyntaxKind.COMMA)));
+            }
+            switch (parameters.get(i)) {
+                case SpecImplementation.Parameter.Input input ->
+                        parts.add(hole(Skeleton.Category.IDENTIFIER, input.nameSuggestion()));
+                case SpecImplementation.Parameter.Injected injected ->
+                        parts.add(literal(name(injected.name())));
+                // A dependency naming nothing settles no parameter to write. Nothing is offered for
+                // a behavior holding one, so this is unreachable through what offers a skeleton.
+                case SpecImplementation.Parameter.Unanswered _ ->
+                        parts.add(hole(Skeleton.Category.IDENTIFIER, A_PARAMETER));
+            }
+        }
+        parts.add(literal(spelt(SyntaxKind.RPAREN), spelt(SyntaxKind.ASSIGN)));
+        parts.add(hole(Skeleton.Category.EXPRESSION, A_BODY));
+        return List.copyOf(parts);
+    }
+
+    /**
+     * An {@code example} for a behavior: one row, stating as many arguments as the behavior takes
+     * inputs, supplying what nothing already stands in for, and expecting something.
+     *
+     * <p>The row states the inputs alone. What a behavior depends on is not passed to it — a row
+     * supplies that through {@code with}, or a {@code fake} table beside the rows does — so a row
+     * with a place for every parameter would have one place too many for each dependency.
+     */
+    static List<Skeleton.Part> exampleFor(String target,
+                                          List<SpecImplementation.Parameter> parameters,
+                                          List<String> unsupplied) {
+        List<Skeleton.Part> parts = new ArrayList<>();
+        parts.add(literal(starterOf(TopLevelForm.EXAMPLE), name(target), spelt(SyntaxKind.PIPE),
+                spelt(SyntaxKind.LPAREN)));
+        int written = 0;
+        for (SpecImplementation.Parameter parameter : parameters) {
+            if (parameter instanceof SpecImplementation.Parameter.Input input) {
+                if (written > 0) {
+                    parts.add(literal(spelt(SyntaxKind.COMMA)));
+                }
+                parts.add(hole(Skeleton.Category.EXPRESSION, input.nameSuggestion()));
+                written++;
+            }
+        }
+        parts.add(literal(spelt(SyntaxKind.RPAREN)));
+        for (int i = 0; i < unsupplied.size(); i++) {
+            parts.add(literal(i == 0 ? spelt(SyntaxKind.WITH_KW) : spelt(SyntaxKind.COMMA),
+                    name(unsupplied.get(i)), spelt(SyntaxKind.ASSIGN)));
+            parts.add(hole(Skeleton.Category.EXPRESSION, A_VALUE));
+        }
+        parts.add(literal(spelt(SyntaxKind.ARROW)));
+        parts.add(hole(Skeleton.Category.EXPRESSION, AN_EXPECTED));
+        return List.copyOf(parts);
+    }
+
+    /**
+     * The skeleton for a form where no declaration was read, which states what the form is and
+     * nothing it was not told.
+     *
+     * <p>A switch over the forms, so a form added to the catalog does not compile until there is
+     * something to offer for it.
+     */
+    static List<Skeleton.Part> fixed(TopLevelForm form) {
+        return switch (form) {
+            case MODULE_HEADER -> List.of(
+                    literal(starterOf(form)),
+                    hole(Skeleton.Category.IDENTIFIER, A_NAME));
+            case EXAMPLES_FILE_HEADER -> List.of(
+                    literal(starterOf(form)),
+                    hole(Skeleton.Category.IDENTIFIER, A_NAME));
+            case IMPORT -> List.of(
+                    literal(starterOf(form)),
+                    hole(Skeleton.Category.IDENTIFIER, A_NAME),
+                    literal(spelt(SyntaxKind.LPAREN)),
+                    hole(Skeleton.Category.IDENTIFIER, A_NAME),
+                    literal(spelt(SyntaxKind.RPAREN)));
+            case DATA -> List.of(
+                    literal(starterOf(form)),
+                    hole(Skeleton.Category.IDENTIFIER, A_TYPE),
+                    literal(spelt(SyntaxKind.ASSIGN), spelt(SyntaxKind.LBRACE)),
+                    hole(Skeleton.Category.IDENTIFIER, A_NAME),
+                    literal(spelt(SyntaxKind.COLON)),
+                    hole(Skeleton.Category.IDENTIFIER, A_TYPE),
+                    literal(spelt(SyntaxKind.RBRACE)));
+            case BEHAVIOR -> List.of(
+                    literal(starterOf(form)),
+                    hole(Skeleton.Category.IDENTIFIER, A_NAME),
+                    literal(spelt(SyntaxKind.COLON), spelt(SyntaxKind.LPAREN)),
+                    hole(Skeleton.Category.IDENTIFIER, A_PARAMETER),
+                    literal(spelt(SyntaxKind.COLON)),
+                    hole(Skeleton.Category.IDENTIFIER, A_TYPE),
+                    literal(spelt(SyntaxKind.RPAREN), spelt(SyntaxKind.ARROW)),
+                    hole(Skeleton.Category.IDENTIFIER, A_TYPE));
+            case FN -> List.of(
+                    literal(starterOf(form)),
+                    hole(Skeleton.Category.IDENTIFIER, A_NAME),
+                    literal(spelt(SyntaxKind.LPAREN)),
+                    hole(Skeleton.Category.IDENTIFIER, A_PARAMETER),
+                    literal(spelt(SyntaxKind.RPAREN), spelt(SyntaxKind.ASSIGN)),
+                    hole(Skeleton.Category.EXPRESSION, A_BODY));
+            case EXAMPLE -> List.of(
+                    literal(starterOf(form)),
+                    hole(Skeleton.Category.IDENTIFIER, A_NAME),
+                    literal(spelt(SyntaxKind.PIPE), spelt(SyntaxKind.LPAREN)),
+                    hole(Skeleton.Category.EXPRESSION, AN_ARGUMENT),
+                    literal(spelt(SyntaxKind.RPAREN), spelt(SyntaxKind.ARROW)),
+                    hole(Skeleton.Category.EXPRESSION, AN_EXPECTED));
+            case FAKE -> List.of(
+                    literal(starterOf(form)),
+                    hole(Skeleton.Category.IDENTIFIER, A_NAME),
+                    literal(spelt(SyntaxKind.PIPE), spelt(SyntaxKind.LPAREN)),
+                    hole(Skeleton.Category.EXPRESSION, AN_ARGUMENT),
+                    literal(spelt(SyntaxKind.RPAREN), spelt(SyntaxKind.ARROW)),
+                    hole(Skeleton.Category.EXPRESSION, A_VALUE));
+        };
+    }
+
+    /** The words a form is opened with, as tokens to write. */
+    private static List<Skeleton.Word> starterOf(TopLevelForm form) {
+        return form.words().stream()
+                .map(word -> new Skeleton.Word(word.kind(), word.spelling()))
+                .toList();
+    }
+
+    /** A token the language spells for itself. */
+    private static Skeleton.Word spelt(SyntaxKind kind) {
+        return new Skeleton.Word(kind, kind.fixedSpelling().orElseThrow(
+                () -> new IllegalArgumentException(kind + " does not spell itself")));
+    }
+
+    private static Skeleton.Word name(String spelling) {
+        return new Skeleton.Word(SyntaxKind.IDENT, spelling);
+    }
+
+    private static Skeleton.Part literal(Skeleton.Word... words) {
+        return new Skeleton.Part.Literal(List.of(words));
+    }
+
+    private static Skeleton.Part literal(List<Skeleton.Word> opening, Skeleton.Word... rest) {
+        List<Skeleton.Word> words = new ArrayList<>(opening);
+        words.addAll(List.of(rest));
+        return new Skeleton.Part.Literal(List.copyOf(words));
+    }
+
+    private static Skeleton.Part hole(Skeleton.Category category, String spelling) {
+        return new Skeleton.Part.Hole(category, List.of(name(spelling)));
+    }
+}

--- a/souther-lsp/src/main/java/souther/lsp/analysis/LastAnswered.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/LastAnswered.java
@@ -29,22 +29,43 @@ import java.util.function.Supplier;
  */
 final class LastAnswered<T> {
 
-    private final Map<String, T> byDocument = new LinkedHashMap<>();
+    /** An answer, and what it was an answer about. */
+    private record Answered<V>(String subject, V value) {}
+
+    private final Map<String, Answered<T>> byDocument = new LinkedHashMap<>();
 
     /**
      * What {@code ask} answers about {@code uri}, or what it last answered where it answers nothing
-     * now.
+     * now and was answering about the same thing.
      *
-     * <p>Null where it has never answered about this document: there is nothing to fall back to, and
-     * a reader with nothing to say says nothing rather than something it did not read.
+     * <p>{@code subject} is what the answer is about — the module a document belongs to — and null
+     * where that is not known either. A document is edited while it is a document of one module, and
+     * what is kept is an answer about that module; a document that has become another module's has
+     * no last answer, since the one being kept was never about what is being asked. Falling back
+     * without asking would be handing over a declaration of a module this file no longer has
+     * anything to do with.
+     *
+     * <p>An unknown subject falls back. Which module a document belongs to is itself the compile's
+     * answer and goes absent with everything else, so refusing there would refuse in exactly the
+     * case this is for.
+     *
+     * <p>Null where nothing has been answered about this document that this asking may have: there
+     * is nothing to fall back to, and a reader with nothing to say says nothing rather than
+     * something it did not read.
      */
-    T of(String uri, Supplier<T> ask) {
+    T of(String uri, String subject, Supplier<T> ask) {
         T answered = ask.get();
-        if (answered == null) {
-            return byDocument.get(uri);
+        if (answered != null) {
+            byDocument.put(uri, new Answered<>(subject, answered));
+            return answered;
         }
-        byDocument.put(uri, answered);
-        return answered;
+        Answered<T> kept = byDocument.get(uri);
+        if (kept == null) {
+            return null;
+        }
+        boolean aboutTheSame =
+                subject == null || kept.subject() == null || subject.equals(kept.subject());
+        return aboutTheSame ? kept.value() : null;
     }
 
     /** Forgets every document the workspace no longer holds, so a file that was deleted or renamed

--- a/souther-lsp/src/main/java/souther/lsp/analysis/LastAnswered.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/LastAnswered.java
@@ -1,0 +1,55 @@
+package souther.lsp.analysis;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * What the compiler last said about a document, kept for while it cannot say anything about it.
+ *
+ * <p>A document that will not parse is held out of the compile, and that is the document being typed
+ * in — so every question answered from the compile goes unanswerable at the keystroke that starts
+ * the edit it was there to help with. What is kept here is the last answer, offered until there is a
+ * new one.
+ *
+ * <p>An availability fallback and not a second source. It is written only where the compiler
+ * answered and read only where it did not, and the two are never merged, so what a reader gets is
+ * either what this compile says or what the last one did — never half of each. That is what makes a
+ * deletion take effect the moment the document parses again.
+ *
+ * <p>Per document rather than per module, because a module is not one file. Seen from an attached
+ * {@code examples for} file, what its module's own source declares is from elsewhere, and a
+ * partition drawn at the module would drop exactly that while the other file is the one being
+ * edited.
+ *
+ * <p>The mechanism only. What is worth remembering, and what counts as the compiler having nothing
+ * to say, is each reader's own — they answer it by what they hand over and by handing over nothing.
+ */
+final class LastAnswered<T> {
+
+    private final Map<String, T> byDocument = new LinkedHashMap<>();
+
+    /**
+     * What {@code ask} answers about {@code uri}, or what it last answered where it answers nothing
+     * now.
+     *
+     * <p>Null where it has never answered about this document: there is nothing to fall back to, and
+     * a reader with nothing to say says nothing rather than something it did not read.
+     */
+    T of(String uri, Supplier<T> ask) {
+        T answered = ask.get();
+        if (answered == null) {
+            return byDocument.get(uri);
+        }
+        byDocument.put(uri, answered);
+        return answered;
+    }
+
+    /** Forgets every document the workspace no longer holds, so a file that was deleted or renamed
+     * leaves nothing behind. */
+    void forgetAllBut(Collection<String> uris) {
+        byDocument.keySet().retainAll(Set.copyOf(uris));
+    }
+}

--- a/souther-lsp/src/main/java/souther/lsp/analysis/NamesFromElsewhere.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/NamesFromElsewhere.java
@@ -56,7 +56,7 @@ final class NamesFromElsewhere {
     List<CompletionItem> of(Compilation compilation, String uri, String module,
                             Set<String> declaredHere) {
         List<CompletionItem> answered =
-                byDocument.of(uri, () -> ask(compilation, module, declaredHere));
+                byDocument.of(uri, module, () -> ask(compilation, module, declaredHere));
         return answered == null ? List.of() : answered;
     }
 

--- a/souther-lsp/src/main/java/souther/lsp/analysis/NamesFromElsewhere.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/NamesFromElsewhere.java
@@ -11,9 +11,7 @@ import souther.lsp.protocol.CompletionItem;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -44,8 +42,8 @@ import java.util.Set;
  */
 final class NamesFromElsewhere {
 
-    /** Document URI → what the last compile that could answer said reaches it from elsewhere. */
-    private final Map<String, List<CompletionItem>> byDocument = new LinkedHashMap<>();
+    /** What the last compile that could answer said reaches each document from elsewhere. */
+    private final LastAnswered<List<CompletionItem>> byDocument = new LastAnswered<>();
 
     /**
      * The candidates {@code uri} reaches from outside itself.
@@ -57,12 +55,9 @@ final class NamesFromElsewhere {
      */
     List<CompletionItem> of(Compilation compilation, String uri, String module,
                             Set<String> declaredHere) {
-        List<CompletionItem> answered = ask(compilation, module, declaredHere);
-        if (answered == null) {
-            return byDocument.getOrDefault(uri, List.of());
-        }
-        byDocument.put(uri, answered);
-        return answered;
+        List<CompletionItem> answered =
+                byDocument.of(uri, () -> ask(compilation, module, declaredHere));
+        return answered == null ? List.of() : answered;
     }
 
     /**
@@ -104,7 +99,7 @@ final class NamesFromElsewhere {
     /** Forgets every document the workspace no longer holds, so a file that was deleted or renamed
      * leaves no names behind. */
     void forgetAllBut(Collection<String> uris) {
-        byDocument.keySet().retainAll(Set.copyOf(uris));
+        byDocument.forgetAllBut(uris);
     }
 
     /** What kind of declaration an editor is being offered. Read off the declaration, so a sum is

--- a/souther-lsp/src/main/java/souther/lsp/protocol/CompletionItem.java
+++ b/souther-lsp/src/main/java/souther/lsp/protocol/CompletionItem.java
@@ -1,5 +1,7 @@
 package souther.lsp.protocol;
 
+import souther.compiler.fmt.Skeleton;
+
 /**
  * An LSP completion item: the text to insert, its {@code kind} (an LSP CompletionItemKind number,
  * which the client renders as an icon), and the {@code detail} shown beside the label.
@@ -11,8 +13,25 @@ package souther.lsp.protocol;
  *
  * <p>There is no two-argument form. Whether a name has an origin is something each place that builds
  * an item has to answer, and a default would let the question go unasked.
+ *
+ * <p>{@code writes} is the declaration this item writes, for an item that writes more than its own
+ * label — where the holes in it are is part of it, and how those reach a client is settled where the
+ * client's capabilities are read. It is null for an item that inserts what it says.
  */
-public record CompletionItem(String label, int kind, String detail) {
+public record CompletionItem(String label, int kind, String detail, Skeleton.Built writes) {
+
+    /**
+     * An item that writes what it says.
+     *
+     * <p>A default here and not for {@code detail}, because the two questions are not alike. An item
+     * with no origin and one whose origin was not filled in read the same to whoever is choosing
+     * between two candidates spelled alike, so that has to be answered. What an item inserts has an
+     * answer already — a completion with nothing else to say inserts its own label, which is what
+     * the protocol does with an item carrying no insertion — so saying nothing here says that.
+     */
+    public CompletionItem(String label, int kind, String detail) {
+        this(label, kind, detail, null);
+    }
 
     // The LSP CompletionItemKind numbers this server uses.
     public static final int FUNCTION = 3;
@@ -22,4 +41,5 @@ public record CompletionItem(String label, int kind, String detail) {
     public static final int INTERFACE = 8;
     public static final int ENUM = 13;
     public static final int KEYWORD = 14;
+    public static final int SNIPPET = 15;
 }

--- a/souther-lsp/src/main/java/souther/lsp/protocol/Insertion.java
+++ b/souther-lsp/src/main/java/souther/lsp/protocol/Insertion.java
@@ -1,0 +1,62 @@
+package souther.lsp.protocol;
+
+import souther.compiler.fmt.Skeleton;
+
+/**
+ * A declaration written for a client, either way it can read one.
+ *
+ * <p>Both are written from the one skeleton the analyzer built, so what a client without
+ * placeholders inserts is exactly what a client with them inserts if every placeholder is left as it
+ * stands. Two spellings of one declaration would agree until either moved.
+ *
+ * <p>A client says whether it reads placeholders, and one that says nothing has said no — the
+ * protocol's own default, and the reason this cannot be assumed. What such a client is sent has no
+ * {@code insertTextFormat} at all: the field is what says the text is to be read as a snippet, and a
+ * text with {@code ${1:name}} in it and nothing saying so lands in the buffer as those characters.
+ */
+public final class Insertion {
+
+    private Insertion() {}
+
+    /** The LSP {@code InsertTextFormat} for a snippet. */
+    public static final int SNIPPET_FORMAT = 2;
+
+    /** The declaration as it stands, holes and all — for a client that does not read placeholders. */
+    public static String plain(Skeleton.Built written) {
+        return written.text();
+    }
+
+    /**
+     * The same, with each hole marked as a place to tab to, numbered in the order they are written.
+     *
+     * <p>The characters the snippet grammar reads — {@code $}, {@code }} and the backslash that
+     * escapes them — are escaped wherever they stand in the declaration, inside a hole as much as
+     * outside one. None of them can be written by a skeleton today; escaping them anyway is what
+     * makes that a fact about this text rather than something to remember when the next hole is
+     * filled from something an author wrote.
+     */
+    public static String snippet(Skeleton.Built written) {
+        StringBuilder out = new StringBuilder();
+        int at = 0;
+        int number = 0;
+        for (Skeleton.Placed hole : written.holes()) {
+            escaped(out, written.text().substring(at, hole.start()));
+            out.append("${").append(++number).append(':');
+            escaped(out, written.text().substring(hole.start(), hole.end()));
+            out.append('}');
+            at = hole.end();
+        }
+        escaped(out, written.text().substring(at));
+        return out.toString();
+    }
+
+    private static void escaped(StringBuilder out, String text) {
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (c == '$' || c == '}' || c == '\\') {
+                out.append('\\');
+            }
+            out.append(c);
+        }
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/NoSnippetReachesAClientThatDidNotAskForOneTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/NoSnippetReachesAClientThatDidNotAskForOneTest.java
@@ -1,0 +1,177 @@
+package souther.lsp;
+
+import souther.lsp.transport.MessageConnection;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A skeleton is sent as one only to a client that said it reads them.
+ *
+ * <p>Placeholders are not text a client falls back to reading: one that was not told the insertion
+ * is a snippet puts {@code ${1:name}} in the buffer as it stands. The protocol says a client
+ * declares {@code snippetSupport} and that the default is false, and this server read nothing the
+ * client sent at the handshake — it answered with its own capabilities and looked at none of theirs.
+ *
+ * <p>So the same declaration goes out two ways, and both are written from the one value the analyzer
+ * built: with its holes marked for a client that reads them, and with the holes standing as their
+ * own text for a client that does not. What the second inserts is what the first inserts if every
+ * placeholder is left alone.
+ */
+class NoSnippetReachesAClientThatDidNotAskForOneTest {
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    private static final String MODULE = """
+            module m
+
+            data MemberId = String
+
+            behavior findMember : (id: MemberId) -> MemberId
+            """;
+
+    @Test
+    void aClientThatSaidNothingIsSentNoSnippet() {
+        List<JsonNode> items = completionsFor(null);
+        assertFalse(items.isEmpty(), "the server offered nothing to check");
+        for (JsonNode item : items) {
+            assertFalse(item.has("insertTextFormat"),
+                    "a snippet format reached a client that did not ask for one: " + item);
+            if (item.has("insertText")) {
+                assertFalse(item.get("insertText").asString().contains("${"),
+                        "a placeholder reached a client that reads it as text: " + item);
+            }
+        }
+    }
+
+    /** And what it is sent instead is the declaration with its holes standing as their own text. */
+    @Test
+    void aClientThatSaidNothingIsSentTheDeclarationAsText() {
+        JsonNode offered = itemLabelled(completionsFor(null), "let findMember");
+        assertEquals("let findMember (id) = body\n", offered.get("insertText").asString());
+    }
+
+    /**
+     * A client that said it reads them is sent the holes as placeholders, numbered in order.
+     *
+     * <p>The name is not among them. What implements a behavior is the {@code let} of the same name,
+     * so the one thing about this declaration that is not the author's is what it is called.
+     */
+    @Test
+    void aClientThatAskedIsSentTheHolesAsPlaceholders() {
+        JsonNode offered = itemLabelled(completionsFor(true), "let findMember");
+        assertEquals(2, offered.get("insertTextFormat").asInt(), "the snippet format");
+        assertEquals("let findMember (${1:id}) = ${2:body}\n",
+                offered.get("insertText").asString());
+    }
+
+    /** A name is a name to either of them: it inserts what it says, and says so by carrying nothing. */
+    @Test
+    void anItemThatWritesWhatItSaysCarriesNoInsertion() {
+        JsonNode offered = itemLabelled(completionsFor(true), "MemberId");
+        assertFalse(offered.has("insertText"), "a name was sent an insertion: " + offered);
+        assertFalse(offered.has("insertTextFormat"), "a name was sent a format: " + offered);
+    }
+
+    /**
+     * The client's own words, or nothing at all.
+     *
+     * <p>{@code snippetSupport} is written at
+     * {@code capabilities.textDocument.completion.completionItem}, and a client that declares
+     * nothing along that path has declared false — which the protocol says, and which is the
+     * difference between reading what a client sent and assuming it.
+     */
+    private static List<JsonNode> completionsFor(Boolean snippetSupport) {
+        Map<String, Object> initialize = new LinkedHashMap<>();
+        if (snippetSupport != null) {
+            initialize.put("capabilities", Map.of("textDocument", Map.of("completion",
+                    Map.of("completionItem", Map.of("snippetSupport", snippetSupport)))));
+        }
+        byte[] input = frames(
+                message(1, "initialize", initialize),
+                message(null, "initialized", Map.of()),
+                message(null, "textDocument/didOpen", Map.of(
+                        "textDocument", Map.of("uri", "file:///m.sou", "text", MODULE))),
+                message(2, "textDocument/completion", Map.of(
+                        "textDocument", Map.of("uri", "file:///m.sou"),
+                        "position", Map.of("line", (int) MODULE.lines().count(), "character", 0))));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new LspServer(new MessageConnection(new ByteArrayInputStream(input), out)).run();
+
+        JsonNode response = readFrames(out.toByteArray()).stream()
+                // The server asks the client things of its own, under an id of its own spelling.
+                .filter(m -> m.has("id") && m.get("id").isNumber() && m.get("id").asInt() == 2)
+                .findFirst().orElseThrow(() -> new AssertionError("no completion response"));
+        List<JsonNode> items = new ArrayList<>();
+        response.get("result").forEach(items::add);
+        return items;
+    }
+
+    private static JsonNode itemLabelled(List<JsonNode> items, String label) {
+        for (JsonNode item : items) {
+            if (item.get("label").asString().equals(label)) {
+                return item;
+            }
+        }
+        throw new AssertionError("nothing labelled " + label + " among "
+                + items.stream().map(i -> i.get("label").asString()).toList());
+    }
+
+    private static String message(Integer id, String method, Map<String, Object> params) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("jsonrpc", "2.0");
+        if (id != null) {
+            m.put("id", id);
+        }
+        m.put("method", method);
+        m.put("params", params);
+        return JSON.writeValueAsString(m);
+    }
+
+    private static byte[] frames(String... messages) {
+        StringBuilder sb = new StringBuilder();
+        for (String body : messages) {
+            byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+            sb.append("Content-Length: ").append(bytes.length).append("\r\n\r\n").append(body);
+        }
+        return sb.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static List<JsonNode> readFrames(byte[] bytes) {
+        List<JsonNode> out = new ArrayList<>();
+        String all = new String(bytes, StandardCharsets.UTF_8);
+        int at = 0;
+        while (true) {
+            int header = all.indexOf("Content-Length: ", at);
+            if (header < 0) {
+                return out;
+            }
+            int eol = all.indexOf("\r\n", header);
+            int length = Integer.parseInt(all.substring(header + 16, eol).trim());
+            int body = all.indexOf("\r\n\r\n", eol) + 4;
+            out.add(JSON.readTree(all.substring(body, body + length)));
+            at = body + length;
+        }
+    }
+
+    /** Asserts the harness itself found something, so an empty response cannot pass as agreement. */
+    @Test
+    void theHarnessReachesTheServer() {
+        assertNotNull(itemLabelled(completionsFor(true), "let"));
+        assertTrue(completionsFor(null).size() > 5, "the server answered with almost nothing");
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationIsOfferedWhereOneMayBeWrittenTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationIsOfferedWhereOneMayBeWrittenTest.java
@@ -157,6 +157,88 @@ class ADeclarationIsOfferedWhereOneMayBeWrittenTest {
                 "an import was offered after a definition, where it will not parse");
     }
 
+    /**
+     * And a definition may not be written above an import, which is the same fact read forwards.
+     *
+     * <p>Where a form may stand is not settled by what is behind the cursor alone. A definition
+     * written above an import leaves a file whose imports come after a definition, which is the
+     * order the parse refuses — the same refusal, met from the other side.
+     */
+    @Test
+    void aDefinitionIsNotOfferedAboveAnImport() {
+        String withImports = """
+                module m
+
+                import up ( A )
+
+                data B = { v: Int }
+                """;
+        List<String> lines = withImports.lines().toList();
+        Map<String, CompletionItem> aboveTheImport =
+                at(withImports, lines.indexOf("import up ( A )"), 0);
+        assertNull(aboveTheImport.get("data").writes(),
+                "a definition was offered above an import, where the imports would follow it");
+        assertNotNull(aboveTheImport.get("import").writes(),
+                "an import was not offered beside the imports");
+
+        Map<String, CompletionItem> belowIt =
+                at(withImports, (int) withImports.lines().count(), 0);
+        assertNotNull(belowIt.get("data").writes(), "a definition was not offered below the imports");
+        assertNull(belowIt.get("import").writes(),
+                "an import was offered below a definition");
+    }
+
+    /** A file that has a header is not offered another, above it or anywhere else. */
+    @Test
+    void aFileThatHasAHeaderIsNotOfferedAnother() {
+        assertNull(at(MODULE, 0, 0).get("module").writes(),
+                "a second header was offered to a file that has one");
+        assertNull(atEndOfFile().get("module").writes(),
+                "a header was offered halfway down a file");
+    }
+
+    /**
+     * A composition has rows like anything else, and is offered them.
+     *
+     * <p>It has no implementation to be offered — it is its own — but a row for one takes what it
+     * takes and depends on what its stages depend on, which is the answer a composition made worth
+     * asking for in the first place. A candidate set drawn from what may be implemented would leave
+     * exactly the case that reading was for.
+     */
+    @Test
+    void aCompositionIsOfferedARowAndNoImplementation() {
+        String composed = """
+                module m
+
+                data A = { v: Int }
+                data B = { v: Int }
+                data C = { v: Int }
+
+                behavior first : (a: A) -> B
+                    constructs B
+
+                let first (a) = B { v = a.v }
+
+                behavior second : (b: B) -> C
+                    constructs C
+                    depends on store
+
+                behavior store : (c: C) -> C
+
+                let second (b, store) = store(C { v = b.v })
+
+                behavior both = first >-> second
+                """;
+        Map<String, CompletionItem> items = at(composed, (int) composed.lines().count(), 0);
+
+        CompletionItem row = items.get("example both");
+        assertNotNull(row, "a composition was offered no row: " + items.keySet());
+        assertTrue(row.writes().text().contains("with store = value"),
+                "the row does not supply what the stages depend on: " + row.writes().text());
+        assertFalse(items.containsKey("let both"),
+                "a composition was offered an implementation, which it already is");
+    }
+
     private static Map<String, CompletionItem> atEndOfFile() {
         return at((int) MODULE.lines().count(), 0);
     }

--- a/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationIsOfferedWhereOneMayBeWrittenTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationIsOfferedWhereOneMayBeWrittenTest.java
@@ -171,6 +171,8 @@ class ADeclarationIsOfferedWhereOneMayBeWrittenTest {
 
                 import up ( A )
 
+                behavior findMember : (id: A) -> A
+
                 data B = { v: Int }
                 """;
         List<String> lines = withImports.lines().toList();
@@ -178,6 +180,12 @@ class ADeclarationIsOfferedWhereOneMayBeWrittenTest {
                 at(withImports, lines.indexOf("import up ( A )"), 0);
         assertNull(aboveTheImport.get("data").writes(),
                 "a definition was offered above an import, where the imports would follow it");
+        // The same gate, for a declaration written from a signature: knowing which one it is does
+        // not make it writable where a declaration is not.
+        assertFalse(aboveTheImport.containsKey("let findMember"),
+                "an implementation was offered above an import");
+        assertFalse(aboveTheImport.containsKey("example findMember"),
+                "a row was offered above an import");
         assertNotNull(aboveTheImport.get("import").writes(),
                 "an import was not offered beside the imports");
 
@@ -237,6 +245,36 @@ class ADeclarationIsOfferedWhereOneMayBeWrittenTest {
                 "the row does not supply what the stages depend on: " + row.writes().text());
         assertFalse(items.containsKey("let both"),
                 "a composition was offered an implementation, which it already is");
+    }
+
+    /**
+     * A behavior that takes nothing is offered both, and both are accepted where they are offered.
+     *
+     * <p>A skeleton that does not parse is dropped rather than offered, so a form the language
+     * writes differently is not a candidate that comes out wrong — it is a candidate that quietly
+     * stops being there. Asking for it by name is what tells the two apart.
+     */
+    @Test
+    void aBehaviorThatTakesNothingIsOfferedBoth() {
+        String nothingToTake = """
+                module m
+
+                data A = { v: Int }
+
+                behavior make : () -> A
+                    constructs A
+                """;
+        Map<String, CompletionItem> items =
+                at(nothingToTake, (int) nothingToTake.lines().count(), 0);
+
+        CompletionItem implementation = items.get("let make");
+        assertNotNull(implementation,
+                "a behavior taking nothing was offered no implementation: " + items.keySet());
+        assertEquals("let make = body\n", implementation.writes().text());
+
+        CompletionItem row = items.get("example make");
+        assertNotNull(row, "a behavior taking nothing was offered no row");
+        assertEquals("example make\n    | () -> expected\n", row.writes().text());
     }
 
     private static Map<String, CompletionItem> atEndOfFile() {

--- a/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationIsOfferedWhereOneMayBeWrittenTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationIsOfferedWhereOneMayBeWrittenTest.java
@@ -1,0 +1,150 @@
+package souther.lsp.analysis;
+
+import souther.lsp.protocol.CompletionItem;
+import souther.lsp.protocol.Position;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Where a declaration may be written, an editor is offered the declaration and not only the word it
+ * starts with.
+ *
+ * <p>What may be written is the grammar's, and where in a file each of those may stand is the same
+ * answer: a header opens a file, an import follows it, and everything else is a body item. An
+ * {@code import} offered after the first definition would be an offer to write a syntax error.
+ *
+ * <p>Where a behavior can be read, what is offered for it is what it said. The parameters of the
+ * {@code let} that implements it are the behavior's, and a row for it takes as many arguments as it
+ * has inputs and supplies what nothing else stands in for. A behavior that already has an
+ * implementation is not offered a second one.
+ */
+class ADeclarationIsOfferedWhereOneMayBeWrittenTest {
+
+    private static final String URI = "file:///m.sou";
+
+    private static final String MODULE = """
+            module m
+
+            data MemberId = String
+            data Found = { id: MemberId }
+            data Missing = { why: String }
+
+            behavior findMember : (id: MemberId) -> Found | Missing
+
+            behavior place : (id: MemberId) -> Found | Missing
+                depends on findMember
+
+            let place (id, findMember) = findMember(id)
+            """;
+
+    @Test
+    void aBehaviorWithNoImplementationIsOfferedTheOneItsSignatureDescribes() {
+        Map<String, CompletionItem> items = atEndOfFile();
+
+        CompletionItem offered = items.get("let findMember");
+        assertNotNull(offered, "nothing offers to implement findMember: " + items.keySet());
+        assertEquals("let findMember (id) = body\n", offered.writes().text());
+        assertEquals(CompletionItem.SNIPPET, offered.kind());
+        assertEquals("m", offered.detail());
+    }
+
+    /** A behavior that has one is not offered another, which would be declaring its name twice. */
+    @Test
+    void aBehaviorThatHasAnImplementationIsNotOfferedAnother() {
+        assertFalse(atEndOfFile().containsKey("let place"),
+                "an implementation was offered for a behavior that has one");
+    }
+
+    /**
+     * A row states the inputs and supplies what nothing stands in for.
+     *
+     * <p>{@code place} depends on {@code findMember} and nothing in this module fakes it, so a row
+     * written without a stand-in could not run — which is E1908, reported the moment the row is
+     * completed.
+     */
+    @Test
+    void aRowSuppliesWhatNothingElseStandsInFor() {
+        CompletionItem offered = atEndOfFile().get("example place");
+        assertNotNull(offered, "nothing offers to write a row for place");
+        assertTrue(offered.writes().text().contains("with findMember = value"),
+                "the row does not supply findMember: " + offered.writes().text());
+    }
+
+    /** With no signature to read, the form is still offered — stating no parameters it did not read. */
+    @Test
+    void aFormIsOfferedWithNothingItDidNotRead() {
+        Map<String, CompletionItem> items = atEndOfFile();
+        assertEquals("let name (param) = body\n", items.get("let").writes().text());
+        assertEquals(CompletionItem.SNIPPET, items.get("let").kind());
+        assertNotNull(items.get("example"), "`example` is not a keyword and was never offered");
+        assertNotNull(items.get("fake"), "`fake` is not a keyword and was never offered");
+    }
+
+    /** Inside a definition no declaration is offered, and the words are words again. */
+    @Test
+    void insideADefinitionTheWordsAreOfferedAndNotTheDeclarations() {
+        Map<String, CompletionItem> items = at(lineOf("let place (id, findMember)"), 30);
+        assertEquals(CompletionItem.KEYWORD, items.get("let").kind(),
+                "a declaration was offered inside a definition");
+        assertNull(items.get("let").writes(), "a keyword writes what it says");
+        assertFalse(items.containsKey("let findMember"),
+                "an implementation was offered from inside another definition");
+    }
+
+    /**
+     * An import may follow the header, and may not follow a definition.
+     *
+     * <p>Both are the same fact about where the form stands, read from the catalog rather than from
+     * a list kept here.
+     *
+     * <p>The word is still offered in both places. Which words may be written where is not something
+     * this list answers — every keyword is offered at every position, as {@code then} and {@code
+     * else} are at the top level — and nothing here made it answer it. What is offered where is the
+     * declaration.
+     */
+    @Test
+    void anImportIsOfferedWhereOneMayStand() {
+        CompletionItem afterTheHeader = at(lineOf("module m") + 1, 0).get("import");
+        assertNotNull(afterTheHeader.writes(),
+                "an import declaration was not offered where one may be written");
+        assertEquals(CompletionItem.SNIPPET, afterTheHeader.kind());
+        assertNull(atEndOfFile().get("import").writes(),
+                "an import was offered after a definition, where it will not parse");
+    }
+
+    private static Map<String, CompletionItem> atEndOfFile() {
+        return at((int) MODULE.lines().count(), 0);
+    }
+
+    private static Map<String, CompletionItem> at(int line, int character) {
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put(URI, MODULE);
+        List<CompletionItem> items = new Analyzer()
+                .completions(URI, new Position(line, character), ModuleGraph.of(sources));
+        Map<String, CompletionItem> byLabel = new LinkedHashMap<>();
+        for (CompletionItem item : items) {
+            byLabel.put(item.label(), item);
+        }
+        return byLabel;
+    }
+
+    /** The line {@code marker} is written on. */
+    private static int lineOf(String marker) {
+        List<String> lines = MODULE.lines().toList();
+        for (int i = 0; i < lines.size(); i++) {
+            if (lines.get(i).startsWith(marker)) {
+                return i;
+            }
+        }
+        throw new IllegalArgumentException("no line starts with " + marker);
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationIsOfferedWhereOneMayBeWrittenTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationIsOfferedWhereOneMayBeWrittenTest.java
@@ -46,6 +46,16 @@ class ADeclarationIsOfferedWhereOneMayBeWrittenTest {
             let place (id, findMember) = findMember(id)
             """;
 
+    /** The same with a table and a row written under it, for asking about a cursor inside one. */
+    private static final String WITH_ROWS = MODULE + """
+
+            fake findMember
+                | _ -> Missing { why = "none" }
+
+            example place
+                | "the author" : (MemberId("m-1")) -> Missing { why = "none" }
+            """;
+
     @Test
     void aBehaviorWithNoImplementationIsOfferedTheOneItsSignatureDescribes() {
         Map<String, CompletionItem> items = atEndOfFile();
@@ -89,6 +99,32 @@ class ADeclarationIsOfferedWhereOneMayBeWrittenTest {
         assertNotNull(items.get("fake"), "`fake` is not a keyword and was never offered");
     }
 
+    /**
+     * A row is a definition too, and what is written in one is an expression.
+     *
+     * <p>An {@code example} and a {@code fake} are read as one thing each, the way a {@code let} is,
+     * and what stands in their rows is what a row states and what it expects. A declaration offered
+     * at a cursor in one is offered inside an expression, and taking it up writes a whole definition
+     * into the middle of a row.
+     */
+    @Test
+    void insideARowNoDeclarationIsOffered() {
+        List<String> lines = WITH_ROWS.lines().toList();
+        int row = lines.indexOf("    | \"the author\" : (MemberId(\"m-1\")) -> Missing { why = \"none\" }");
+        assertTrue(row > 0, "the row this asks about is not written: " + lines);
+
+        Map<String, CompletionItem> items = at(WITH_ROWS, row, 30);
+        assertNull(items.get("let").writes(), "a declaration was offered inside a row");
+        assertFalse(items.containsKey("let findMember"),
+                "an implementation was offered from inside a row");
+        assertFalse(items.containsKey("example place"),
+                "a row was offered from inside a row");
+
+        int table = lines.indexOf("    | _ -> Missing { why = \"none\" }");
+        assertNull(at(WITH_ROWS, table, 12).get("let").writes(),
+                "a declaration was offered inside a table");
+    }
+
     /** Inside a definition no declaration is offered, and the words are words again. */
     @Test
     void insideADefinitionTheWordsAreOfferedAndNotTheDeclarations() {
@@ -126,8 +162,12 @@ class ADeclarationIsOfferedWhereOneMayBeWrittenTest {
     }
 
     private static Map<String, CompletionItem> at(int line, int character) {
+        return at(MODULE, line, character);
+    }
+
+    private static Map<String, CompletionItem> at(String source, int line, int character) {
         Map<String, String> sources = new LinkedHashMap<>();
-        sources.put(URI, MODULE);
+        sources.put(URI, source);
         List<CompletionItem> items = new Analyzer()
                 .completions(URI, new Position(line, character), ModuleGraph.of(sources));
         Map<String, CompletionItem> byLabel = new LinkedHashMap<>();

--- a/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationSkeletonRepeatsNothingTheSignatureSaidTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationSkeletonRepeatsNothingTheSignatureSaidTest.java
@@ -1,0 +1,123 @@
+package souther.lsp.analysis;
+
+import souther.compiler.check.SpecImplementation.Parameter;
+import souther.compiler.cst.TopLevelForm;
+import souther.compiler.fmt.Skeleton;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a skeleton leaves for the author to write, and what it writes itself.
+ *
+ * <p>A hole is a place the compiler cannot settle. The name of an input is one: the implementation
+ * may call it what it likes, and the behavior's own spelling is only a suggestion. The name of an
+ * injected parameter is not — it names the behavior it injects, in the order they were declared, and
+ * an implementation spelling it otherwise is refused — so it is written out. A skeleton that offered
+ * it as a hole would be offering the author a choice the language does not give them, and the first
+ * thing they did with it would be E1615.
+ *
+ * <p>The same rule settles the rest. An example row states as many arguments as the behavior takes
+ * inputs, since what it depends on is supplied through {@code with} rather than passed, and it
+ * writes a {@code with} for each dependency nothing already stands in for — a row that left one out
+ * would be a row that cannot run, which is E1908.
+ */
+class ADeclarationSkeletonRepeatsNothingTheSignatureSaidTest {
+
+    @Test
+    void anInjectedParameterIsWrittenOutAndAnInputIsLeftToTheAuthor() {
+        Skeleton.Built built = Skeleton.of(DeclarationSkeletons.implementing("place", List.of(
+                new Parameter.Input("id"),
+                new Parameter.Input("other"),
+                new Parameter.Injected("findMember"))));
+        assertEquals("let place (id, other, findMember) = body\n", built.text());
+        assertEquals(List.of("id", "other", "body"), holeTextsOf(built));
+    }
+
+    /** A behavior that depends on nothing leaves every parameter to the author. */
+    @Test
+    void aBehaviorThatDependsOnNothingLeavesEveryParameterOpen() {
+        Skeleton.Built built = Skeleton.of(DeclarationSkeletons.implementing("name",
+                List.of(new Parameter.Input("id"), new Parameter.Input("fallback"))));
+        assertEquals("let name (id, fallback) = body\n", built.text());
+        assertEquals(List.of("id", "fallback", "body"), holeTextsOf(built));
+    }
+
+    /** A row takes the inputs and not what is injected, and says so with as many arguments. */
+    @Test
+    void aRowStatesAsManyArgumentsAsTheBehaviorTakesInputs() {
+        Skeleton.Built built = Skeleton.of(DeclarationSkeletons.exampleFor("place", List.of(
+                new Parameter.Input("id"),
+                new Parameter.Input("other"),
+                new Parameter.Injected("findMember")), List.of()));
+        assertEquals("example place\n    | (id, other) -> expected\n", built.text());
+        assertEquals(List.of("id", "other", "expected"), holeTextsOf(built));
+    }
+
+    /** And writes a {@code with} for each dependency nothing already stands in for. */
+    @Test
+    void aRowSuppliesWhatNothingElseStandsInFor() {
+        Skeleton.Built built = Skeleton.of(DeclarationSkeletons.exampleFor("place",
+                List.of(new Parameter.Input("id"), new Parameter.Injected("findMember")),
+                List.of("findMember")));
+        assertTrue(built.text().contains("with findMember = value"),
+                "the row does not supply what nothing stands in for: " + built.text());
+        assertEquals(List.of("id", "value", "expected"), holeTextsOf(built));
+    }
+
+    /**
+     * A dependency something already stands in for is not asked for again.
+     *
+     * <p>A {@code with} written where a {@code fake} already answers is read first, so it would take
+     * the table's place for that row alone. Offering one is offering to change what the row runs
+     * against, which is not what completing a row is for.
+     */
+    @Test
+    void aDependencySomethingAlreadyStandsInForIsNotAskedForAgain() {
+        Skeleton.Built built = Skeleton.of(DeclarationSkeletons.exampleFor("place",
+                List.of(new Parameter.Input("id"), new Parameter.Injected("findMember")),
+                List.of()));
+        assertTrue(!built.text().contains("with"),
+                "a row was offered a stand-in for a dependency that has one: " + built.text());
+    }
+
+    /**
+     * Every form has a skeleton, and every one of them is a declaration.
+     *
+     * <p>{@link Skeleton#of} refuses tokens that do not parse, so building each of these is the
+     * check. A form added to the catalog with no skeleton does not compile, since the answer is a
+     * switch over the forms; one added with a skeleton that is not a declaration fails here.
+     */
+    @Test
+    void everyFormCanBeWrittenWithoutADeclarationToRead() {
+        List<String> refused = new ArrayList<>();
+        for (TopLevelForm form : TopLevelForm.values()) {
+            try {
+                Skeleton.Built built = Skeleton.of(DeclarationSkeletons.fixed(form));
+                if (built.holes().isEmpty()) {
+                    refused.add(form + " offers nothing to fill in");
+                }
+            } catch (Skeleton.Mismatch e) {
+                refused.add(form + ": " + e.getMessage());
+            }
+        }
+        assertEquals(List.of(), refused, "a form whose skeleton is not a declaration");
+    }
+
+    /** The one for a {@code let} states no parameters, having read no signature. */
+    @Test
+    void aSkeletonWithNoSignatureToReadStatesNoParametersItDidNotRead() {
+        Skeleton.Built built = Skeleton.of(DeclarationSkeletons.fixed(TopLevelForm.FN));
+        assertEquals("let name (param) = body\n", built.text());
+        assertEquals(List.of("name", "param", "body"), holeTextsOf(built));
+    }
+
+    private static List<String> holeTextsOf(Skeleton.Built built) {
+        return built.holes().stream()
+                .map(hole -> built.text().substring(hole.start(), hole.end())).toList();
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationSkeletonRepeatsNothingTheSignatureSaidTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationSkeletonRepeatsNothingTheSignatureSaidTest.java
@@ -47,13 +47,12 @@ class ADeclarationSkeletonRepeatsNothingTheSignatureSaidTest {
         assertEquals(List.of("id", "fallback", "body"), holeTextsOf(built));
     }
 
-    /** A row takes the inputs and not what is injected, and says so with as many arguments. */
+    /** A row states an argument apiece for what the behavior takes. */
     @Test
-    void aRowStatesAsManyArgumentsAsTheBehaviorTakesInputs() {
-        Skeleton.Built built = Skeleton.of(DeclarationSkeletons.exampleFor("place", List.of(
-                new Parameter.Input("id"),
-                new Parameter.Input("other"),
-                new Parameter.Injected("findMember")), List.of()));
+    void aRowStatesAnArgumentApiece() {
+        Skeleton.Built built =
+                Skeleton.of(DeclarationSkeletons.exampleFor("place", List.of("id", "other"),
+                        List.of()));
         assertEquals("example place\n    | (id, other) -> expected\n", built.text());
         assertEquals(List.of("id", "other", "expected"), holeTextsOf(built));
     }
@@ -62,8 +61,7 @@ class ADeclarationSkeletonRepeatsNothingTheSignatureSaidTest {
     @Test
     void aRowSuppliesWhatNothingElseStandsInFor() {
         Skeleton.Built built = Skeleton.of(DeclarationSkeletons.exampleFor("place",
-                List.of(new Parameter.Input("id"), new Parameter.Injected("findMember")),
-                List.of("findMember")));
+                List.of("id"), List.of("findMember")));
         assertTrue(built.text().contains("with findMember = value"),
                 "the row does not supply what nothing stands in for: " + built.text());
         assertEquals(List.of("id", "value", "expected"), holeTextsOf(built));
@@ -79,8 +77,7 @@ class ADeclarationSkeletonRepeatsNothingTheSignatureSaidTest {
     @Test
     void aDependencySomethingAlreadyStandsInForIsNotAskedForAgain() {
         Skeleton.Built built = Skeleton.of(DeclarationSkeletons.exampleFor("place",
-                List.of(new Parameter.Input("id"), new Parameter.Injected("findMember")),
-                List.of()));
+                List.of("id"), List.of()));
         assertTrue(!built.text().contains("with"),
                 "a row was offered a stand-in for a dependency that has one: " + built.text());
     }

--- a/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationSkeletonRepeatsNothingTheSignatureSaidTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationSkeletonRepeatsNothingTheSignatureSaidTest.java
@@ -47,6 +47,31 @@ class ADeclarationSkeletonRepeatsNothingTheSignatureSaidTest {
         assertEquals(List.of("id", "fallback", "body"), holeTextsOf(built));
     }
 
+    /**
+     * A behavior that takes nothing is implemented by a {@code let} written without parentheses.
+     *
+     * <p>The parentheses are what makes a {@code let} a function; one written without them defines a
+     * value, and the language refuses an empty pair (E2301). So a skeleton that wrote them for a
+     * behavior with nothing to take would be a skeleton nothing accepts — and, since a skeleton that
+     * does not parse is dropped rather than offered, a behavior taking nothing would quietly be
+     * offered no implementation at all.
+     */
+    @Test
+    void aBehaviorThatTakesNothingIsWrittenWithoutParentheses() {
+        Skeleton.Built built = Skeleton.of(DeclarationSkeletons.implementing("make", List.of()));
+        assertEquals("let make = body\n", built.text());
+        assertEquals(List.of("body"), holeTextsOf(built));
+    }
+
+    /** A row for one still states its argument list, which is where an empty pair is written. */
+    @Test
+    void aRowForABehaviorThatTakesNothingStatesAnEmptyList() {
+        Skeleton.Built built =
+                Skeleton.of(DeclarationSkeletons.exampleFor("make", List.of(), List.of()));
+        assertEquals("example make\n    | () -> expected\n", built.text());
+        assertEquals(List.of("expected"), holeTextsOf(built));
+    }
+
     /** A row states an argument apiece for what the behavior takes. */
     @Test
     void aRowStatesAnArgumentApiece() {

--- a/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationSurvivesTheKeystrokeThatBrokeTheFileTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationSurvivesTheKeystrokeThatBrokeTheFileTest.java
@@ -125,6 +125,30 @@ class ADeclarationSurvivesTheKeystrokeThatBrokeTheFileTest {
     /** A composition that reaches itself: what this module requires has no answer while it stands. */
     private static final String CYCLE = "\nbehavior loop = loop >-> place\n";
 
+    /**
+     * What was kept is about a module, and a document that has become another module's is not owed
+     * it.
+     *
+     * <p>Keeping an answer is for a document being edited while the compiler cannot say what it
+     * declares. It is not for a document that now says it belongs somewhere else: the behaviors of
+     * the module it used to be are not what may be written here, and offering them is offering a
+     * declaration of something this file has nothing to do with. The compiler has not said nothing
+     * about this module — it has never been asked about it.
+     */
+    @Test
+    void aDocumentThatBecameAnotherModulesIsNotOfferedTheOnesItWas() {
+        Analyzer analyzer = new Analyzer();
+        assertNotNull(offered(analyzer, DEPENDING).get("example place"),
+                "nothing was offered while the compiler could answer");
+
+        String elsewhere = DEPENDING.replace("module m", "module n") + CYCLE;
+        Map<String, CompletionItem> items = offered(analyzer, elsewhere);
+        assertNull(items.get("example place"),
+                "a row was offered for a module this document is no longer part of");
+        assertNotNull(items.get("let").writes(),
+                "the forms themselves stopped being offered, which is not what changed");
+    }
+
     private static Map<String, CompletionItem> offered(Analyzer analyzer, String source) {
         Map<String, String> sources = new LinkedHashMap<>();
         sources.put(URI, source);

--- a/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationSurvivesTheKeystrokeThatBrokeTheFileTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationSurvivesTheKeystrokeThatBrokeTheFileTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
@@ -78,6 +79,51 @@ class ADeclarationSurvivesTheKeystrokeThatBrokeTheFileTest {
                         .containsKey("let findMember"),
                 "a behavior that is no longer written was offered from what was remembered");
     }
+
+    /**
+     * A question the compiler did not answer is not an answer of nothing.
+     *
+     * <p>A document may parse and still leave the compiler unable to say what a behavior depends on
+     * or what it takes. A row written from that would state no stand-in for what its target depends
+     * on, which is E1908 the moment it is completed — so what those questions going unanswered
+     * means is that nothing is answered here either, and the last answer that was given stands.
+     *
+     * <p>The module is made unanswerable by a composition that composes with itself, which is a
+     * mistake reported where it is written and leaves what every behavior in the module requires
+     * with no answer. The rows already offered are about behaviors that composition says nothing
+     * about, and none of them stop needing what they needed.
+     */
+    @Test
+    void aQuestionTheCompilerDidNotAnswerIsNotAnAnswerOfNothing() {
+        Analyzer analyzer = new Analyzer();
+        CompletionItem whole = offered(analyzer, DEPENDING).get("example place");
+        assertNotNull(whole, "nothing offered a row while the compiler could answer");
+        assertTrue(whole.writes().text().contains("with findMember = value"),
+                "the row does not supply what nothing stands in for: " + whole.writes().text());
+
+        CompletionItem afterTheCycle = offered(analyzer, DEPENDING + CYCLE).get("example place");
+        assertNotNull(afterTheCycle,
+                "the offer went away when a question about the module went unanswered");
+        assertTrue(afterTheCycle.writes().text().contains("with findMember = value"),
+                "a row was offered with nothing standing in for what it depends on: "
+                        + afterTheCycle.writes().text());
+    }
+
+    private static final String DEPENDING = """
+            module m
+
+            data MemberId = String
+
+            behavior findMember : (id: MemberId) -> MemberId
+
+            behavior place : (id: MemberId) -> MemberId
+                depends on findMember
+
+            let place (id, findMember) = findMember(id)
+            """;
+
+    /** A composition that reaches itself: what this module requires has no answer while it stands. */
+    private static final String CYCLE = "\nbehavior loop = loop >-> place\n";
 
     private static Map<String, CompletionItem> offered(Analyzer analyzer, String source) {
         Map<String, String> sources = new LinkedHashMap<>();

--- a/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationSurvivesTheKeystrokeThatBrokeTheFileTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/ADeclarationSurvivesTheKeystrokeThatBrokeTheFileTest.java
@@ -1,0 +1,94 @@
+package souther.lsp.analysis;
+
+import souther.lsp.protocol.CompletionItem;
+import souther.lsp.protocol.Position;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The declarations a document is owed go on being offered while the compiler cannot say what it
+ * declares.
+ *
+ * <p>Which behaviors have no implementation is the compile's answer, and a document that will not
+ * parse is held out of the compile — which is the document being typed in. Writing the first two
+ * letters of {@code let} is enough to break it, so a list that could only answer from the current
+ * compile would go empty at the keystroke that started the declaration it is there to offer.
+ *
+ * <p>What is offered is then the last answer the compiler gave about this document, and never a
+ * blend of that and this one: written only where the compile answered, read only where it did not.
+ * So a behavior deleted from a document that still parses stops being offered at once, and one
+ * deleted while the document will not parse comes back to being offered until it parses again — the
+ * compiler has said nothing about that document since, and this says what it last said rather than
+ * guessing past it.
+ */
+class ADeclarationSurvivesTheKeystrokeThatBrokeTheFileTest {
+
+    private static final String URI = "file:///m.sou";
+
+    private static final String MODULE = """
+            module m
+
+            data MemberId = String
+
+            behavior findMember : (id: MemberId) -> MemberId
+
+            let place (id) = id
+            """;
+
+    /** The same document with a line no recovery makes into a module. */
+    private static final String BROKEN = MODULE.replace("let place (id) = id",
+            "let place (id) = ((((\nlet place (id) = id");
+
+    @Test
+    void aDeclarationOfferedWhileTheDocumentParsesIsStillOfferedWhenItDoesNot() {
+        Analyzer analyzer = new Analyzer();
+        assertNotNull(offered(analyzer, MODULE).get("let findMember"),
+                "nothing was offered while the document parses");
+
+        CompletionItem afterTheKeystroke = offered(analyzer, BROKEN).get("let findMember");
+        assertNotNull(afterTheKeystroke, "the offer went away when the document stopped parsing");
+        assertEquals("let findMember (id) = body\n", afterTheKeystroke.writes().text());
+    }
+
+    /** An analyzer that never saw the document parse offers the forms and nothing it did not read. */
+    @Test
+    void aDocumentThatNeverParsedIsOfferedNothingItDidNotRead() {
+        Map<String, CompletionItem> items = offered(new Analyzer(), BROKEN);
+        assertNull(items.get("let findMember"),
+                "a signature nothing ever read was offered anyway");
+        assertEquals("let name (param) = body\n", items.get("let").writes().text(),
+                "the form itself is still offered, stating nothing it did not read");
+    }
+
+    /** What the compile can answer is taken from it, so a deletion that parses takes the offer away. */
+    @Test
+    void aBehaviorDeletedFromADocumentThatParsesStopsBeingOffered() {
+        Analyzer analyzer = new Analyzer();
+        offered(analyzer, MODULE);
+        assertFalse(offered(analyzer, MODULE.replace(
+                        "behavior findMember : (id: MemberId) -> MemberId\n", ""))
+                        .containsKey("let findMember"),
+                "a behavior that is no longer written was offered from what was remembered");
+    }
+
+    private static Map<String, CompletionItem> offered(Analyzer analyzer, String source) {
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put(URI, source);
+        int line = (int) source.lines().count();
+        List<CompletionItem> items = analyzer.completions(URI, new Position(line, 0),
+                ModuleGraph.of(sources));
+        Map<String, CompletionItem> byLabel = new LinkedHashMap<>();
+        for (CompletionItem item : items) {
+            byLabel.put(item.label(), item);
+        }
+        return byLabel;
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/analysis/WhatIsOfferedIsAcceptedWhereItIsOfferedTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/WhatIsOfferedIsAcceptedWhereItIsOfferedTest.java
@@ -1,0 +1,142 @@
+package souther.lsp.analysis;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.CompileException;
+import souther.compiler.fmt.Skeleton;
+import souther.lsp.protocol.CompletionItem;
+import souther.lsp.protocol.Position;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * What is offered, written where it was offered, is accepted there.
+ *
+ * <p>The claim is about what the skeleton settles and nothing else: how many parameters an
+ * implementation takes and what the injected ones are called, and what a row has to supply before it
+ * can run. Those are E1615 and E1908, and they are what is asserted. What a body computes and what a
+ * row expects are not the skeleton's to know — it leaves holes exactly there — so the holes are
+ * filled from the model this is written against rather than from something invented to fill them.
+ *
+ * <p>Filling is done through the hole positions the skeleton hands back, from the last to the first,
+ * which is what a client does with them. A test that rebuilt the text itself would be asserting
+ * against its own idea of the declaration rather than against the one that was offered.
+ */
+class WhatIsOfferedIsAcceptedWhereItIsOfferedTest {
+
+    private static final String URI = "file:///m.sou";
+
+    /** A model that compiles, whose one behavior depends on another and has a row that runs. */
+    private static final String WHOLE = """
+            module m
+
+            data MemberId = String
+            data Found = { id: MemberId }
+
+            behavior findMember : (id: MemberId) -> Found
+
+            behavior place : (id: MemberId) -> Found
+                depends on findMember
+
+            let place (id, findMember) = findMember(id)
+            """;
+
+    /** The same with the implementation taken away, which is where one is offered. */
+    private static final String WITHOUT_THE_IMPLEMENTATION =
+            WHOLE.replace("let place (id, findMember) = findMember(id)\n", "");
+
+    @Test
+    void theModelThisIsWrittenAgainstCompiles() {
+        Compiler.compile(WHOLE);
+    }
+
+    /**
+     * The implementation offered for a behavior takes what the checker holds one to.
+     *
+     * <p>Its body is the one the model had, since a body is what the skeleton does not know.
+     */
+    @Test
+    void anOfferedImplementationIsAccepted() {
+        String written = filled(offered(WITHOUT_THE_IMPLEMENTATION, "let place"),
+                "id", "findMember(id)");
+        assertEquals("let place (id, findMember) = findMember(id)\n", written);
+        Compiler.compile(WITHOUT_THE_IMPLEMENTATION + "\n" + written);
+    }
+
+    /**
+     * And an implementation that does not is refused, which is what makes the above an assertion.
+     *
+     * <p>The injected parameter is moved in front of the input it follows. Nothing else changes: the
+     * same names, the same count, the same body.
+     */
+    @Test
+    void anImplementationWrittenAnotherWayIsRefused() {
+        String swapped = "let place (findMember, id) = findMember(id)\n";
+        CompileException refused = assertThrows(CompileException.class,
+                () -> Compiler.compile(WITHOUT_THE_IMPLEMENTATION + "\n" + swapped));
+        assertEquals("E1615", refused.code());
+    }
+
+    /** A row offered for a behavior supplies what the run needs of it. */
+    @Test
+    void anOfferedRowIsAccepted() {
+        String written = filled(offered(WHOLE, "example place"),
+                "MemberId(\"m-1\")", "Found { id = MemberId(\"m-1\") }",
+                "Found { id = MemberId(\"m-1\") }");
+        Compiler.compile(WHOLE + "\n" + written);
+    }
+
+    /**
+     * And a row without it is refused for want of a stand-in.
+     *
+     * <p>The {@code with} the skeleton wrote is taken back out of the row it was offered in, so what
+     * is being asserted is that writing it is what stopped E1908 rather than something else about
+     * the row.
+     */
+    @Test
+    void aRowWithoutWhatItSuppliesIsRefused() {
+        String written = filled(offered(WHOLE, "example place"),
+                "MemberId(\"m-1\")", "Found { id = MemberId(\"m-1\") }",
+                "Found { id = MemberId(\"m-1\") }");
+        String withoutTheStandin =
+                written.replaceAll("\\s*with findMember = Found \\{ id = MemberId\\(\"m-1\"\\) \\}", "");
+        CompileException refused = assertThrows(CompileException.class,
+                () -> Compiler.compile(WHOLE + "\n" + withoutTheStandin));
+        assertEquals("E1908", refused.code());
+    }
+
+    /** The skeleton offered under {@code label} where {@code source} is the document. */
+    private static Skeleton.Built offered(String source, String label) {
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put(URI, source);
+        List<CompletionItem> items = new Analyzer().completions(URI,
+                new Position((int) source.lines().count(), 0), ModuleGraph.of(sources));
+        for (CompletionItem item : items) {
+            if (item.label().equals(label)) {
+                assertNotNull(item.writes(), label + " offered nothing to write");
+                return item.writes();
+            }
+        }
+        throw new AssertionError("nothing labelled " + label + " was offered");
+    }
+
+    /** {@code written} with each hole replaced, in the order the holes are written. */
+    private static String filled(Skeleton.Built written, String... answers) {
+        List<Skeleton.Placed> holes = new ArrayList<>(written.holes());
+        assertEquals(answers.length, holes.size(),
+                "the skeleton has " + holes.size() + " holes and " + answers.length
+                        + " were answered: " + written.text());
+        StringBuilder out = new StringBuilder(written.text());
+        for (int i = holes.size() - 1; i >= 0; i--) {
+            out.replace(holes.get(i).start(), holes.get(i).end(), answers[i]);
+        }
+        return out.toString();
+    }
+}

--- a/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
+++ b/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
@@ -155,25 +155,32 @@ public final class CstParser {
         }
     }
 
+    /**
+     * A file: its header, then its imports, then everything else.
+     *
+     * <p>Which words open which form is {@link TopLevelForm}'s, so the conditions here are asked of
+     * it rather than spelled again. What each form is read by is this parser's, and it is the one
+     * thing said here.
+     */
     private void topLevelItems() {
-        if (atContextual("examples")) {
+        if (starts(TopLevelForm.EXAMPLES_FILE_HEADER)) {
             examplesFileHeader();
-        } else if (at(SyntaxKind.MODULE_KW)) {
+        } else if (starts(TopLevelForm.MODULE_HEADER)) {
             moduleHeader();
         }
-        while (at(SyntaxKind.IMPORT_KW)) {
+        while (starts(TopLevelForm.IMPORT)) {
             importDecl();
         }
         while (!at(SyntaxKind.EOF)) {
-            if (at(SyntaxKind.DATA_KW)) {
+            if (starts(TopLevelForm.DATA)) {
                 dataDef();
-            } else if (at(SyntaxKind.BEHAVIOR_KW)) {
+            } else if (starts(TopLevelForm.BEHAVIOR)) {
                 behaviorDef();
-            } else if (at(SyntaxKind.LET_KW) || atModifiedLet()) {
+            } else if (starts(TopLevelForm.FN)) {
                 fnDef();
-            } else if (atContextual("example")) {
+            } else if (starts(TopLevelForm.EXAMPLE)) {
                 exampleDef();
-            } else if (atContextual("fake")) {
+            } else if (starts(TopLevelForm.FAKE)) {
                 fakeDef();
             } else {
                 recoverTopLevel();
@@ -182,18 +189,47 @@ public final class CstParser {
         bumpEof();
     }
 
-    /** Wraps stray tokens (until the next top-level starter) in an ERROR node so the tree stays
-     * whole even when the source is malformed. */
+    /**
+     * Wraps stray tokens in an ERROR node so the tree stays whole even when the source is malformed,
+     * up to the point the parse can pick itself up again.
+     *
+     * <p>Where that is, is this parser's answer about a mistake rather than a fact about the
+     * language, so it is written here as a rule over the catalog: at anything that may open
+     * something after the header. A header form does not stop it — a file has one header and it is
+     * at the top, so a {@code module} line further down is not a beginning to resume at.
+     */
     private void recoverTopLevel() {
         error(new ParseMessage.ATopLevelDefinitionStartsWithAKeyword());
         start(SyntaxKind.ERROR_TOKEN);
         do {
             bump();
-        } while (!at(SyntaxKind.EOF) && !at(SyntaxKind.DATA_KW) && !at(SyntaxKind.BEHAVIOR_KW)
-                && !at(SyntaxKind.LET_KW) && !atModifiedLet() && !at(SyntaxKind.IMPORT_KW)
-                && !atContextual("example") && !atContextual("fake"));
+        } while (!at(SyntaxKind.EOF) && !atResumePoint());
         finish();
     }
+
+    /** Whether something that may follow a file's header opens here. */
+    private boolean atResumePoint() {
+        return TopLevelForm.at(ahead)
+                .filter(form -> form.region() != TopLevelForm.Region.FILE_HEADER)
+                .isPresent();
+    }
+
+    private boolean starts(TopLevelForm form) {
+        return form.startsAt(ahead);
+    }
+
+    /** The meaningful tokens ahead of the cursor, as the catalog reads them. */
+    private final TopLevelForm.Lookahead ahead = new TopLevelForm.Lookahead() {
+        @Override
+        public SyntaxKind kindAt(int i) {
+            return nth(i);
+        }
+
+        @Override
+        public String textAt(int i) {
+            return tokenText(mi(i));
+        }
+    };
 
     private void moduleHeader() {
         start(SyntaxKind.MODULE_HEADER);
@@ -501,14 +537,6 @@ public final class CstParser {
      * {@code private partial let}. Both are contextual soft-keywords, so a parameter or field may
      * still be named {@code private} or {@code partial} — only the word directly before a
      * {@code let} (or before the other modifier and then a {@code let}) is read as one. */
-    private boolean atModifiedLet() {
-        if (atContextual("private")) {
-            return nth(1) == SyntaxKind.LET_KW
-                    || (contextualAt(1, "partial") && nth(2) == SyntaxKind.LET_KW);
-        }
-        return atContextual("partial") && nth(1) == SyntaxKind.LET_KW;
-    }
-
     private void fnDef() {
         start(SyntaxKind.FN_DEF);
         if (atContextual("private")) {

--- a/souther-syntax/src/main/java/souther/compiler/cst/TopLevelForm.java
+++ b/souther-syntax/src/main/java/souther/compiler/cst/TopLevelForm.java
@@ -110,7 +110,18 @@ public enum TopLevelForm {
         return words;
     }
 
-    /** Whether the tokens ahead open this form, past any modifiers written in front of it. */
+    /**
+     * Whether the tokens ahead open this form, past any modifiers written in front of it.
+     *
+     * <p>The first word, and not all of them. What opens a form and what it is written with are the
+     * same everywhere but one: an {@code examples for} header is two words, and a file whose first
+     * line is {@code examples m} has opened one and left a word out. Reading it as opening nothing
+     * takes the line away from the routine that would say which word is missing, and takes the
+     * header off the file with it — so what is read here is enough to say which form it is, and
+     * saying what is wrong with the rest of it belongs to whatever reads the form.
+     *
+     * <p>Enough because the opening words differ: no two forms begin with the same one.
+     */
     public boolean startsAt(Lookahead ahead) {
         int i = 0;
         for (Word modifier : modifiers) {
@@ -118,12 +129,7 @@ public enum TopLevelForm {
                 i++;
             }
         }
-        for (Word word : words) {
-            if (!word.matchesAt(ahead, i++)) {
-                return false;
-            }
-        }
-        return true;
+        return words.getFirst().matchesAt(ahead, i);
     }
 
     /** The form the tokens ahead open, or empty where they open none. */

--- a/souther-syntax/src/main/java/souther/compiler/cst/TopLevelForm.java
+++ b/souther-syntax/src/main/java/souther/compiler/cst/TopLevelForm.java
@@ -1,0 +1,138 @@
+package souther.compiler.cst;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * What may be written at the top level of a file, and the words each of those is opened with.
+ *
+ * <p>A fact about the language and not about any one reader of it. The parser dispatches on this, a
+ * recovery works out from it where a parse may pick itself up again, and an editor offering to write
+ * a declaration asks it what there is to offer. Those three asked the same question of three lists
+ * of words before, and the one that was written for the editor could only ever have been a fourth.
+ *
+ * <p>The words are not the reserved keywords. {@code example}, {@code fake} and the {@code for} of
+ * an {@code examples for} header are ordinary identifiers everywhere else, and a reader that took
+ * {@link CstLexer#keywords()} for the set of things a declaration may start with would be short by
+ * two whole forms of definition. Nor is a keyword enough to name one: a {@code let} may have
+ * modifiers written in front of it, and it is the same form with or without them.
+ *
+ * <p>Nothing here says how a form is read past its first words. Which routine reads which form is
+ * the parser's, where the grammar is.
+ */
+public enum TopLevelForm {
+
+    MODULE_HEADER(Region.FILE_HEADER, Word.of(SyntaxKind.MODULE_KW)),
+    EXAMPLES_FILE_HEADER(Region.FILE_HEADER, Word.of("examples"), Word.of("for")),
+    IMPORT(Region.PRELUDE, Word.of(SyntaxKind.IMPORT_KW)),
+    DATA(Region.BODY, Word.of(SyntaxKind.DATA_KW)),
+    BEHAVIOR(Region.BODY, Word.of(SyntaxKind.BEHAVIOR_KW)),
+    FN(Region.BODY, List.of(Word.of("private"), Word.of("partial")), Word.of(SyntaxKind.LET_KW)),
+    EXAMPLE(Region.BODY, Word.of("example")),
+    FAKE(Region.BODY, Word.of("fake"));
+
+    /**
+     * Where in a file a form may open something.
+     *
+     * <p>A file is read as a header, then the imports, then everything else, and this says which of
+     * those three a form belongs to. It is what the parse reads in order and what an editor asks
+     * about a cursor: a {@code module} line is not something to offer halfway down a file.
+     */
+    public enum Region { FILE_HEADER, PRELUDE, BODY }
+
+    /** A reader of the meaningful tokens ahead of a point, counted from it. */
+    public interface Lookahead {
+
+        /** The kind of the {@code i}th meaningful token from here, or {@link SyntaxKind#EOF}. */
+        SyntaxKind kindAt(int i);
+
+        /** Its exact text. */
+        String textAt(int i);
+    }
+
+    /**
+     * One word a form is opened with, however the lexer happens to treat it.
+     *
+     * <p>A reserved word is matched by its kind and spells itself through {@link
+     * SyntaxKind#fixedSpelling()}; a contextual one lexes as an identifier and is matched by its
+     * text. Either way the spelling is held once, so what recognises a form and what an editor shows
+     * for it cannot come apart.
+     */
+    public record Word(SyntaxKind kind, String spelling) {
+
+        public static Word of(SyntaxKind kind) {
+            return new Word(kind, kind.fixedSpelling().orElseThrow(
+                    () -> new IllegalArgumentException(kind + " does not spell itself")));
+        }
+
+        /** A contextual word: an ordinary identifier that opens a form only where it stands. */
+        public static Word of(String contextual) {
+            return new Word(SyntaxKind.IDENT, contextual);
+        }
+
+        private boolean matchesAt(Lookahead ahead, int i) {
+            return ahead.kindAt(i) == kind
+                    && (kind != SyntaxKind.IDENT || spelling.equals(ahead.textAt(i)));
+        }
+    }
+
+    private final Region region;
+    private final List<Word> modifiers;
+    private final List<Word> words;
+
+    TopLevelForm(Region region, Word... words) {
+        this(region, List.of(), words);
+    }
+
+    TopLevelForm(Region region, List<Word> modifiers, Word... words) {
+        this.region = region;
+        this.modifiers = modifiers;
+        this.words = List.of(words);
+    }
+
+    public Region region() {
+        return region;
+    }
+
+    /**
+     * How this form is written, for a reader being offered it.
+     *
+     * <p>The words it is recognised by, so the two cannot disagree. The modifiers are left out: they
+     * may be written in front of a form but they do not open one, and a reader offered
+     * {@code private let} would be shown a choice the language does not make for them.
+     */
+    public String starter() {
+        return String.join(" ", words.stream().map(Word::spelling).toList());
+    }
+
+    /** The same, as the tokens they are — for a reader writing the form out rather than showing it. */
+    public List<Word> words() {
+        return words;
+    }
+
+    /** Whether the tokens ahead open this form, past any modifiers written in front of it. */
+    public boolean startsAt(Lookahead ahead) {
+        int i = 0;
+        for (Word modifier : modifiers) {
+            if (modifier.matchesAt(ahead, i)) {
+                i++;
+            }
+        }
+        for (Word word : words) {
+            if (!word.matchesAt(ahead, i++)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** The form the tokens ahead open, or empty where they open none. */
+    public static Optional<TopLevelForm> at(Lookahead ahead) {
+        for (TopLevelForm form : values()) {
+            if (form.startsAt(ahead)) {
+                return Optional.of(form);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/souther-syntax/src/test/java/souther/compiler/cst/ATopLevelFormIsParsedByTheEntryThatListsItTest.java
+++ b/souther-syntax/src/test/java/souther/compiler/cst/ATopLevelFormIsParsedByTheEntryThatListsItTest.java
@@ -116,6 +116,26 @@ class ATopLevelFormIsParsedByTheEntryThatListsItTest {
         assertEquals(Optional.empty(), TopLevelForm.at(lookahead("partial")));
     }
 
+    /**
+     * A form whose opening is two words is opened by the first of them.
+     *
+     * <p>{@code examples m} is a file that opened a header and left a word out, and the routine that
+     * reads the form is what says so. A file where nothing opened is a file with no header at all —
+     * the line is taken as a mistake of no particular kind, and every other file that names this one
+     * stops being about a module.
+     */
+    @Test
+    void aHeaderMissingItsSecondWordStillOpensTheHeader() {
+        assertEquals(Optional.of(TopLevelForm.EXAMPLES_FILE_HEADER),
+                TopLevelForm.at(lookahead("examples m")));
+
+        CstParser.Result parsed = CstParser.parse("examples m\n");
+        assertEquals(List.of(SyntaxKind.EXAMPLES_FILE_HEADER),
+                parsed.root().childNodes().stream().map(SyntaxNode::kind).toList(),
+                "the header was taken as a mistake of no particular kind");
+        assertEquals(1, parsed.errors().size(), "and said to be one thing wrong: " + parsed.errors());
+    }
+
     /** The meaningful tokens of {@code source}, as a reader ahead of them. */
     private static TopLevelForm.Lookahead lookahead(String source) {
         List<GreenToken> tokens = CstLexer.lex(source).tokens().stream()

--- a/souther-syntax/src/test/java/souther/compiler/cst/ATopLevelFormIsParsedByTheEntryThatListsItTest.java
+++ b/souther-syntax/src/test/java/souther/compiler/cst/ATopLevelFormIsParsedByTheEntryThatListsItTest.java
@@ -1,0 +1,135 @@
+package souther.compiler.cst;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Each {@link TopLevelForm} is recognised by the words it lists and read by the routine that reads
+ * that form, and here the two are held to one source apiece.
+ *
+ * <p>The catalog is what the parser dispatches on, so asking whether the parser accepts what the
+ * catalog lists would be asking the catalog about itself. What can still go wrong is a form whose
+ * words and whose routine are not about the same construct: an entry added with a starter nothing
+ * reads falls through to recovery, and one whose words match a construct the routine does not read
+ * produces the wrong node. A source per form catches both, and a form added with no source here
+ * fails for want of one.
+ *
+ * <p>The sources and the node kinds are written out rather than derived. Deriving either from the
+ * catalog would make the agreement hold by construction, which is a check that cannot fail.
+ */
+class ATopLevelFormIsParsedByTheEntryThatListsItTest {
+
+    /** One source per form, each holding that form and nothing else that could stand for it. */
+    private static final Map<TopLevelForm, String> WITNESSES = witnesses();
+
+    /** The node each form's routine builds. */
+    private static final Map<TopLevelForm, SyntaxKind> PRODUCES = produces();
+
+    private static Map<TopLevelForm, String> witnesses() {
+        Map<TopLevelForm, String> sources = new LinkedHashMap<>();
+        sources.put(TopLevelForm.MODULE_HEADER, "module m\n");
+        sources.put(TopLevelForm.EXAMPLES_FILE_HEADER, "examples for m\n");
+        sources.put(TopLevelForm.IMPORT, "import up ( a )\n");
+        sources.put(TopLevelForm.DATA, "data A = { v: Int }\n");
+        sources.put(TopLevelForm.BEHAVIOR, "behavior f : (x: Int) -> Int\n");
+        sources.put(TopLevelForm.FN, "let f (x) = x\n");
+        sources.put(TopLevelForm.EXAMPLE, "example f\n    | (1) -> 1\n");
+        sources.put(TopLevelForm.FAKE, "fake f\n    | _ -> 1\n");
+        return sources;
+    }
+
+    private static Map<TopLevelForm, SyntaxKind> produces() {
+        Map<TopLevelForm, SyntaxKind> kinds = new LinkedHashMap<>();
+        kinds.put(TopLevelForm.MODULE_HEADER, SyntaxKind.MODULE_HEADER);
+        kinds.put(TopLevelForm.EXAMPLES_FILE_HEADER, SyntaxKind.EXAMPLES_FILE_HEADER);
+        kinds.put(TopLevelForm.IMPORT, SyntaxKind.IMPORT_DECL);
+        kinds.put(TopLevelForm.DATA, SyntaxKind.DATA_DEF);
+        kinds.put(TopLevelForm.BEHAVIOR, SyntaxKind.BEHAVIOR_DEF);
+        kinds.put(TopLevelForm.FN, SyntaxKind.FN_DEF);
+        kinds.put(TopLevelForm.EXAMPLE, SyntaxKind.EXAMPLE_DEF);
+        kinds.put(TopLevelForm.FAKE, SyntaxKind.FAKE_DEF);
+        return kinds;
+    }
+
+    @Test
+    void everyFormHasASourceHere() {
+        List<TopLevelForm> unwitnessed = new ArrayList<>();
+        for (TopLevelForm form : TopLevelForm.values()) {
+            if (!WITNESSES.containsKey(form) || !PRODUCES.containsKey(form)) {
+                unwitnessed.add(form);
+            }
+        }
+        assertEquals(List.of(), unwitnessed, "a form nothing here is written for");
+    }
+
+    /** The words a form lists reach that form and no other. */
+    @Test
+    void aSourceStartsWithTheFormThatListsIt() {
+        List<String> wrong = new ArrayList<>();
+        WITNESSES.forEach((form, source) -> {
+            Optional<TopLevelForm> found = TopLevelForm.at(lookahead(source));
+            if (found.isEmpty() || found.get() != form) {
+                wrong.add(source.lines().findFirst().orElse("") + " reached " + found);
+            }
+        });
+        assertEquals(List.of(), wrong, "a source does not reach the form that lists its words");
+    }
+
+    /** And the routine that reads the form builds the node the form is about. */
+    @Test
+    void aSourceIsReadIntoTheNodeItsFormIsAbout() {
+        List<String> wrong = new ArrayList<>();
+        WITNESSES.forEach((form, source) -> {
+            CstParser.Result parsed = CstParser.parse(source);
+            List<SyntaxKind> children = parsed.root().childNodes().stream()
+                    .map(SyntaxNode::kind).toList();
+            if (!parsed.errors().isEmpty()) {
+                wrong.add(form + " does not parse: " + parsed.errors());
+            } else if (!children.contains(PRODUCES.get(form))) {
+                wrong.add(form + " was read as " + children);
+            }
+        });
+        assertEquals(List.of(), wrong, "a form's words and its routine are about different things");
+    }
+
+    /**
+     * A modifier in front of {@code let} is still the same form.
+     *
+     * <p>The words a form is recognised by are not all of what may stand in front of it, and the
+     * modifiers are the one place that is so. Read the other way, a bare {@code private} opens
+     * nothing, so an identifier spelled that way at the top level is not half a definition.
+     */
+    @Test
+    void aModifierInFrontOfLetOpensTheSameForm() {
+        assertEquals(Optional.of(TopLevelForm.FN), TopLevelForm.at(lookahead("private let f (x) = x")));
+        assertEquals(Optional.of(TopLevelForm.FN), TopLevelForm.at(lookahead("partial let f (x) = x")));
+        assertEquals(Optional.of(TopLevelForm.FN),
+                TopLevelForm.at(lookahead("private partial let f (x) = x")));
+        assertEquals(Optional.empty(), TopLevelForm.at(lookahead("private f (x) = x")));
+        assertEquals(Optional.empty(), TopLevelForm.at(lookahead("partial")));
+    }
+
+    /** The meaningful tokens of {@code source}, as a reader ahead of them. */
+    private static TopLevelForm.Lookahead lookahead(String source) {
+        List<GreenToken> tokens = CstLexer.lex(source).tokens().stream()
+                .filter(token -> !token.kind().isTrivia()).toList();
+        return new TopLevelForm.Lookahead() {
+            @Override
+            public SyntaxKind kindAt(int i) {
+                return i < tokens.size() ? tokens.get(i).kind() : SyntaxKind.EOF;
+            }
+
+            @Override
+            public String textAt(int i) {
+                return i < tokens.size() ? tokens.get(i).text() : "";
+            }
+        };
+    }
+}

--- a/souther-syntax/src/test/java/souther/compiler/cst/RecoveryStopsAtWhatMayFollowTheHeaderTest.java
+++ b/souther-syntax/src/test/java/souther/compiler/cst/RecoveryStopsAtWhatMayFollowTheHeaderTest.java
@@ -1,0 +1,76 @@
+package souther.compiler.cst;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Where a parse that has lost its place picks itself up again.
+ *
+ * <p>Which words open a construct is a fact about the language, and {@link TopLevelForm} has it.
+ * Where to resume after a run of tokens nothing could read is not: it is what this parser does about
+ * a mistake, and it is stated once, here in the parser, as a rule over the catalog rather than as a
+ * second list of words.
+ *
+ * <p>The rule is that a header form does not stop a recovery. A file has one header and it is
+ * written at the top; a {@code module} line further down is not the beginning of a file, so resuming
+ * there would be resuming at something the parse is already past.
+ */
+class RecoveryStopsAtWhatMayFollowTheHeaderTest {
+
+    @Test
+    void aDefinitionAfterTheMistakeIsStillRead() {
+        CstParser.Result parsed = CstParser.parse("""
+                module m
+
+                ???
+
+                data A = { v: Int }
+                """);
+        assertTrue(kindsOf(parsed).contains(SyntaxKind.DATA_DEF),
+                "the definition after the mistake was swallowed by it");
+    }
+
+    /**
+     * An import may follow the header, so a recovery stops at one. It is read no further here — the
+     * imports have been read by the time a body item is being looked for — and it becomes a mistake
+     * of its own, which is what leaves two of them rather than one.
+     */
+    @Test
+    void anImportStopsARecovery() {
+        CstParser.Result parsed = CstParser.parse("""
+                data A = { v: Int }
+
+                ???
+
+                import up ( a )
+                """);
+        assertEquals(2, count(parsed, SyntaxKind.ERROR_TOKEN),
+                "the import was taken as more of the mistake in front of it");
+    }
+
+    /** A header form does not, so it is taken as more of the mistake it is written after. */
+    @Test
+    void aHeaderDoesNotStopARecovery() {
+        CstParser.Result parsed = CstParser.parse("""
+                data A = { v: Int }
+
+                ???
+
+                module m
+                """);
+        assertEquals(1, count(parsed, SyntaxKind.ERROR_TOKEN),
+                "the parse resumed at a header, which is not where a file begins");
+    }
+
+    private static List<SyntaxKind> kindsOf(CstParser.Result parsed) {
+        return parsed.root().childNodes().stream().map(SyntaxNode::kind).toList();
+    }
+
+    private static long count(CstParser.Result parsed, SyntaxKind kind) {
+        return kindsOf(parsed).stream().filter(k -> k == kind).count();
+    }
+}


### PR DESCRIPTION
Closes #766.

A behavior is written twice, once as a signature and once as the `let`
that implements it, and the second's name and the number and spelling of
its parameters are the first's. Completion offered the word `let` and
left an author to type the rest of what the declaration already said.

What is offered now is the declaration. That took four questions being
answered where each is decided rather than a fifth place spelling
Souther's concrete syntax.

## What may open a file

The words a top-level form starts with were written in three places: the
parser's dispatch, the stop set a recovery resynchronizes on, and the
lookahead that reads a modifier in front of a `let`. One catalog holds
them now, and where a parse picks itself up again is derived from it as a
rule — a header does not stop a recovery, because a file has one and it
is at the top — rather than being a fourth list with an unexplained
asymmetry.

`example` and `fake` lex as identifiers, so a completion list built from
the reserved keywords was short by two whole forms of definition. They
have never been offered until now.

## What an implementation must take

The parameters of the `let` implementing a behavior — the inputs, then
what it depends on in declared order, the trailing ones named by what
they inject — lived inside the check that refuses one, as two counts
added together and an index walked twice. It is a list now, `SpecChecker`
is held to it, and a skeleton is written from it.

That decides which parts of the offer are holes. An input's name is the
author's, so it is a hole standing in with the behavior's own spelling; an
injected parameter's name is settled, so it is written out. A hole there
would be offering a choice the language does not give, and the first use
of it is E1615.

Nothing in the repository asserted E1615, so a rewrite of that check that
stopped refusing would have been green. Two tests now hold it.

## What a row still owes

E1908 accepts a `with` on the row or a `fake` table beside it, and the
row is looked at first. That search was inside the verifier, wound
together with building the value each answers with. It answers with what
was found and where now, so a reader that only wants to know what a row
still owes can ask without having values to build.

A row is offered a `with` for what nothing already stands in for, and
not for what does — a `with` written where a `fake` answers takes the
table's place for that row alone, which is not what completing a row is
for. In `souther-examples`, no row writes a `with` at all and 31 `fake`
tables are written.

## How it is laid out

A declaration spelled by hand goes out of agreement with the formatter
and is rewritten on the next save. So the tokens are written down,
parsed, and formatted, and the holes carry their own text — the layout is
worked out over the characters that will be in the buffer if they are
left as they stand.

Where a hole ended up is counted rather than searched for: the formatted
text is read back into tokens and held to the ones it was built from, one
for one. A hole is then where it was written even when its text is
spelled the same as something beside it, and a formatter that added,
dropped or rewrote a token is refused instead of answered with a hole in
the wrong place.

## What reaches a client

The server answered the handshake with its own capabilities and read
nothing the client sent. A client that did not declare `snippetSupport`
and is sent a snippet gets `${1:name}` in its buffer as characters. It is
read now, and the same skeleton is written both ways, so what a client
without placeholders inserts is what the other inserts with every
placeholder left alone.

## Also

A definition's node reaches back over the blank line above it, so a
cursor there counted as inside it — no declaration was offered on the one
line where one is most likely written, and bindings were offered where
they hold nothing. It is the definition's own text that decides now.

## What this does not do

Every keyword is still offered at every position; only declarations are
offered where they may stand. An `example` is offered for a behavior and
not for a pure helper, which the grammar also admits as a target. No
`fake` skeleton for a particular dependency is offered — that `fake` was
unofferable is a fact about where completion candidates came from, and
building one is a separate question.

Verified with `mvn verify` and `CI=1 mvn -Plint verify` over the whole
reactor, on this branch rebased onto develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
