### PR TITLE
Refuse a type whose equalities admit no value, whatever carries it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
@@ -1,0 +1,194 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.core.Core;
+import souther.compiler.types.Type;
+import souther.compiler.values.AdmissibleValues;
+import souther.compiler.values.Value;
+import souther.compiler.values.ValueSet;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The clauses reaching a value, read for which values each of its positions may hold.
+ *
+ * <p>Beside the reading that turns those same clauses into bounds, over the same list and at the
+ * same moment. Which clauses reach a value is settled once, by the walk that gathers them, so the
+ * two readings cannot come to disagree about what they were given; what each of them makes of a
+ * clause is its own.
+ *
+ * <p>Apart from what a construction owes ({@link Predicates}), which is a different question and
+ * has a different answer for the same clause. A clause stated as one of two alternatives owes a
+ * construction nothing that a guard could discharge, and it says something here — so reading it
+ * through the obligations would turn "some reading took this in" into "a construction may be held
+ * to it", and a row would be offered at an edge promised by nothing.
+ *
+ * <p>Everything this cannot read is {@link AdmissibleValues#unreadable}, which widens and never
+ * narrows. That is the whole discipline: a reading that answered "no value" from a clause it did
+ * not read would refuse a model somebody can write. A denial is turned into what it leaves where
+ * the values can be written out ({@link ValueUniverse}) and is kept as a denial where they cannot,
+ * so nothing reaches emptiness except through values this had in hand.
+ */
+final class AdmissibleReading {
+
+    private final Terms terms;
+    private final Denotations at;
+    /** What each position of the value is called, and what type stands there. A position is here
+     * whether or not it is a number: which values a boolean has is as much an answer as which
+     * values an integer has, and the reading that asked the carrier had no word for the first. */
+    private final Map<Term, Type> byName;
+    private final Symbols symbols;
+
+    private AdmissibleReading(Terms terms, Denotations at, Map<Term, Type> byName,
+                              Symbols symbols) {
+        this.terms = terms;
+        this.at = at;
+        this.byName = byName;
+        this.symbols = symbols;
+    }
+
+    /**
+     * What {@code clauses} leave each position able to hold, all of them holding at once.
+     *
+     * @param byName the type at each position, keyed by what that position is called
+     */
+    static AdmissibleValues<Term> of(List<Core> clauses, Terms terms, Denotations at,
+                                     Map<Term, Type> byName, Symbols symbols) {
+        AdmissibleReading reading = new AdmissibleReading(terms, at, byName, symbols);
+        AdmissibleValues<Term> out = AdmissibleValues.top();
+        for (Core clause : clauses) {
+            out = out.meet(reading.read(clause, true));
+        }
+        return out;
+    }
+
+    /**
+     * What {@code e} says, stated where {@code positive} and denied where it is not.
+     *
+     * <p>A denial is carried to the leaves rather than applied to what a branch came to. What a
+     * state says is a value per position, and the denial of that is not one — the values a
+     * conjunction rules out are a choice between the positions it named, which no map of positions
+     * holds. Carried down, every denial meets a comparison, where it is one.
+     */
+    private AdmissibleValues<Term> read(Core e, boolean positive) {
+        Core under = Predicates.negated(e);
+        if (under != null) {
+            return read(under, !positive);
+        }
+        if (e instanceof Core.Binary b) {
+            // Stated, a conjunction gives both sides; denied, it gives the choice between their
+            // denials. And the same the other way round, which is the whole of what a denial does
+            // to a connective.
+            if (b.op() == Hir.BinOp.AND) {
+                return positive ? read(b.left(), true).meet(read(b.right(), true))
+                        : read(b.left(), false).join(read(b.right(), false));
+            }
+            if (b.op() == Hir.BinOp.OR) {
+                return positive ? read(b.left(), true).join(read(b.right(), true))
+                        : read(b.left(), false).meet(read(b.right(), false));
+            }
+            if (b.op() == Hir.BinOp.EQ || b.op() == Hir.BinOp.NE) {
+                // Which of the two it states, once the denials above have been counted: `/=` denied
+                // states the equality, and `==` denied denies it.
+                return comparison(b, (b.op() == Hir.BinOp.EQ) == positive);
+            }
+        }
+        return AdmissibleValues.unreadable(names(e));
+    }
+
+    /** What one comparison of a position with a value says, or nothing where it is not one. */
+    private AdmissibleValues<Term> comparison(Core.Binary b, boolean states) {
+        AdmissibleValues<Term> read = sided(b.left(), b.right(), states);
+        if (read == null) {
+            // `"A" == value` says what `value == "A"` says.
+            read = sided(b.right(), b.left(), states);
+        }
+        return read != null ? read : AdmissibleValues.unreadable(names(b));
+    }
+
+    /** The same, with {@code where} read as the position and {@code what} as the value, or null
+     * where they are not those. */
+    private AdmissibleValues<Term> sided(Core where, Core what, boolean states) {
+        Term position = terms.atomOf(where, at);
+        if (position == null) {
+            position = terms.bodyKey(where, at);
+        }
+        Type type = position == null ? null : byName.get(position);
+        Value value = type == null ? null : valueOf(what);
+        return value == null ? null : AdmissibleValues.at(position, admits(value, states, type));
+    }
+
+    /**
+     * The values a position of {@code type} is left by naming {@code value}, or by denying it.
+     *
+     * <p>A denial over a type whose values can be written out is the rest of them, which is how
+     * {@code /= true} beside {@code /= false} comes to leave nothing. Over a type whose values
+     * cannot be, it stays a denial and leaves no end of values, which is how {@code /= "A"} beside
+     * {@code /= "B"} comes to leave almost everything.
+     */
+    private ValueSet admits(Value value, boolean states, Type type) {
+        if (states) {
+            return ValueSet.just(value);
+        }
+        List<Value> every = ValueUniverse.of(type, symbols);
+        if (every == null) {
+            return ValueSet.allBut(value);
+        }
+        Set<Value> left = new LinkedHashSet<>(every);
+        left.remove(value);
+        return ValueSet.oneOf(left);
+    }
+
+    /**
+     * The value {@code e} is, or null where it is not one written out.
+     *
+     * <p>Read through the one fold there is, so a value written as an expression of values — two
+     * strings joined — is the value it comes to. A case of an enumeration holds nothing and is not
+     * folded to anything; what it is is which declaration it is.
+     */
+    private Value valueOf(Core e) {
+        if (e instanceof Core.UnitValue unit) {
+            return Value.of(unit.data());
+        }
+        Object folded = Terms.folded(e);
+        if (folded instanceof String text) {
+            return Value.text(text);
+        }
+        if (folded instanceof Boolean truth) {
+            return Value.truth(truth);
+        }
+        if (folded instanceof Long whole) {
+            return Value.number(whole);
+        }
+        return folded instanceof BigDecimal number ? Value.number(number) : null;
+    }
+
+    /**
+     * The positions {@code e} names.
+     *
+     * <p>What a clause this could not read costs. It cannot cost a position it does not name:
+     * nothing here relates one position to another, so a rule narrowing a position names it — and a
+     * rule relating two of them names both and is itself one of these.
+     */
+    private Set<Term> names(Core e) {
+        Set<Term> found = new LinkedHashSet<>();
+        gather(e, found);
+        return found;
+    }
+
+    private void gather(Core e, Set<Term> found) {
+        Term here = terms.atomOf(e, at);
+        if (here == null) {
+            here = terms.bodyKey(e, at);
+        }
+        if (here != null && byName.containsKey(here)) {
+            found.add(here);
+            return;   // a position names itself, and nothing under it is a position of its own
+        }
+        Core.forEachChild(e, child -> gather(child, found));
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/CardinalityTransfer.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CardinalityTransfer.java
@@ -3,6 +3,7 @@ package souther.compiler.check;
 import souther.compiler.ast.Hir;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
+import souther.compiler.values.Value;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -157,6 +158,19 @@ final class CardinalityTransfer {
                 : Cardinality.none(new Emptiness.AtAField(emptiestAt, emptiest));
     }
 
+    /**
+     * How many values {@code type} has, where they are something that can be written out.
+     *
+     * <p>Nothing proven where they cannot be, which is the answer every shape this does not read
+     * gets. A type whose values can be written out has at least one of them: a list with nothing in
+     * it is not a type, and the count of none is a claim that carries a proof.
+     */
+    private static Cardinality howManyValues(Type type, Symbols symbols) {
+        List<Value> every = ValueUniverse.of(type, symbols);
+        return every == null || every.isEmpty() ? Cardinality.UNKNOWN
+                : Cardinality.atMost(every.size());
+    }
+
     /** {@code count} as it stands at {@code path}, which is where a proof of none says it sits. */
     private static Cardinality at(String path, Cardinality count) {
         return count instanceof Cardinality.None it
@@ -177,7 +191,10 @@ final class CardinalityTransfer {
                                Set<TypeSymbol> worn) {
         return switch (type) {
             case Type.Prim prim -> switch (prim) {
-                case BOOL -> Cardinality.atMost(2);
+                // As many as it has values, which is a question with an answer of its own. Written
+                // here as a number, the count and the values would be two records of one fact with
+                // nothing holding them together.
+                case BOOL -> howManyValues(type, symbols);
                 case INT -> values.wholeValuesAt(path);
                 // Spaced too finely to count between two ends, or not spaced at all. A string bounded
                 // in length and a date bounded at both ends are finite and are not counted here: what

--- a/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
@@ -131,15 +131,37 @@ final class Clauses {
      * it owes where one is being built are the same clauses read the same way, and they differ only
      * in what the fields are given — a read of each field, or the value each is being handed.
      */
-    List<Stated> statedAt(TypeSymbol named, Hir.Data data, Map<BindingId, Core> given) {
+    StatedClauses statedAt(TypeSymbol named, Hir.Data data, Map<BindingId, Core> given) {
         List<Stated> stated = new ArrayList<>();
+        int declared = 0;
         for (TypeOps.Declared inv : declared(named, data)) {
+            declared++;
             Core one = statedAt(inv.clause().expr(), named, data, given);
             if (one != null) {
                 stated.add(new Stated(clauseOf(inv), one));
             }
         }
-        return stated;
+        return new StatedClauses(List.copyOf(stated), stated.size() == declared);
+    }
+
+    /**
+     * The clauses of one declaration as they read here, and whether they are all of them.
+     *
+     * <p>The second because leaving one out is not visible in the first. A clause that states
+     * nothing this can read is dropped, and a caller handed the rest has no way to tell a
+     * declaration whose every clause was read from one whose clauses it is holding some of — the
+     * two are the same list with different things missing from it. Said here, where the dropping
+     * happens, rather than counted again by whoever needs to know.
+     *
+     * @param everyClauseStated whether every clause the declaration writes is in {@code clauses}.
+     *                          A caller that asked for none of them was not asked to lose any and
+     *                          is told so
+     */
+    record StatedClauses(List<Stated> clauses, boolean everyClauseStated) {
+
+        /** What a reading told to leave a declaration's clauses out gets: none of them, and nothing
+         * lost. */
+        static final StatedClauses NONE_ASKED_FOR = new StatedClauses(List.of(), true);
     }
 
     /** What a diagnostic can say about the clause {@code inv} is, and what tells it apart from the

--- a/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
@@ -1,0 +1,54 @@
+package souther.compiler.check;
+
+import souther.compiler.numeric.Granularity;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.numeric.NumericDomain.LinearForm;
+import souther.compiler.numeric.NumericDomain.Rel;
+
+import java.util.Map;
+
+/**
+ * What the rules say, in each of the languages this reading has for saying it.
+ *
+ * <p>Several domains and one state. A clause relates numbers, or settles a predicate that relates to
+ * nothing, and each of those is written where something can be reasoned about it — but what a caller
+ * asks of them together is one question, and it is whether anything at all satisfies what has been
+ * taken in. That is {@link #isBottom}, and it is asked of the whole because a reader that asked one
+ * domain would answer that a value exists whenever the domain it happened to ask had nothing to say.
+ * {@code value == "A"} beside {@code value /= "A"} reaches no number and leaves the predicates
+ * contradictory, and a count taken from the numbers alone called that type inhabited.
+ *
+ * <p>The parts are readable, and only in one direction. A reader wanting the numbers may have them —
+ * an interval is what a bound is read off, and nothing else answers that — but a reader asking
+ * whether a value exists asks here and never assembles the answer out of the parts. A domain added
+ * later is a component of this and an arm of {@link #isBottom}, and every such reader has it without
+ * being touched.
+ */
+record ConstraintState(NumericDomain<Term> numbers, PredicateFacts facts) {
+
+    /** Nothing taken in, so nothing ruled out. */
+    static ConstraintState top() {
+        return new ConstraintState(NumericDomain.top(), PredicateFacts.none());
+    }
+
+    /**
+     * Whether nothing satisfies what has been taken in.
+     *
+     * <p>Every domain, because each of them can hold the whole state's contradiction on its own: what
+     * one of them cannot express it leaves alone, so a contradiction found anywhere is a
+     * contradiction, and one found nowhere is only what these readings were able to show.
+     */
+    boolean isBottom() {
+        return numbers.isBottom() || facts.isBottom();
+    }
+
+    /** This, with {@code f rel 0} taken as holding. */
+    ConstraintState taking(LinearForm<Term> f, Rel rel, Map<Term, Granularity> kinds) {
+        return new ConstraintState(numbers.assume(f, rel, kinds), facts);
+    }
+
+    /** This, with the predicate {@code key} taken as holding, or as failing. */
+    ConstraintState taking(Term key, boolean positive) {
+        return new ConstraintState(numbers, facts.assume(key, positive));
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
@@ -4,6 +4,7 @@ import souther.compiler.numeric.Granularity;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.NumericDomain.LinearForm;
 import souther.compiler.numeric.NumericDomain.Rel;
+import souther.compiler.values.AdmissibleValues;
 
 import java.util.Map;
 
@@ -24,11 +25,13 @@ import java.util.Map;
  * later is a component of this and an arm of {@link #isBottom}, and every such reader has it without
  * being touched.
  */
-record ConstraintState(NumericDomain<Term> numbers, PredicateFacts facts) {
+record ConstraintState(NumericDomain<Term> numbers, PredicateFacts facts,
+                       AdmissibleValues<Term> values) {
 
     /** Nothing taken in, so nothing ruled out. */
     static ConstraintState top() {
-        return new ConstraintState(NumericDomain.top(), PredicateFacts.none());
+        return new ConstraintState(NumericDomain.top(), PredicateFacts.none(),
+                AdmissibleValues.top());
     }
 
     /**
@@ -39,16 +42,21 @@ record ConstraintState(NumericDomain<Term> numbers, PredicateFacts facts) {
      * contradiction, and one found nowhere is only what these readings were able to show.
      */
     boolean isBottom() {
-        return numbers.isBottom() || facts.isBottom();
+        return numbers.isBottom() || facts.isBottom() || values.isBottom();
     }
 
     /** This, with {@code f rel 0} taken as holding. */
     ConstraintState taking(LinearForm<Term> f, Rel rel, Map<Term, Granularity> kinds) {
-        return new ConstraintState(numbers.assume(f, rel, kinds), facts);
+        return new ConstraintState(numbers.assume(f, rel, kinds), facts, values);
     }
 
     /** This, with the predicate {@code key} taken as holding, or as failing. */
     ConstraintState taking(Term key, boolean positive) {
-        return new ConstraintState(numbers, facts.assume(key, positive));
+        return new ConstraintState(numbers, facts.assume(key, positive), values);
+    }
+
+    /** This, with {@code admitted} taken as holding of the positions it speaks about. */
+    ConstraintState taking(AdmissibleValues<Term> admitted) {
+        return new ConstraintState(numbers, facts, values.meet(admitted));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
@@ -24,6 +24,13 @@ import java.util.Map;
  * whether a value exists asks here and never assembles the answer out of the parts. A domain added
  * later is a component of this and an arm of {@link #isBottom}, and every such reader has it without
  * being touched.
+ *
+ * <p>One reader still asks the numbers alone, and it is the other question. Whether a path is
+ * reached — whether the conditions guarding a construction can all hold — is asked of
+ * {@code numbers} where the walk reads a branch, so a path made impossible by predicates alone is
+ * walked and what stands on it is reported. That is a mistake of the same shape as the one above,
+ * and it is not this one: what it moves is which constructions are reported at, and a change to
+ * that is its own change with its own reason to make.
  */
 record ConstraintState(NumericDomain<Term> numbers, PredicateFacts facts,
                        AdmissibleValues<Term> values) {

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -10,8 +10,10 @@ import souther.compiler.values.ValueSet;
 import souther.compiler.numeric.Count;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * What a record leaves each of its fields able to hold.
@@ -187,7 +189,14 @@ public final class FieldDomains {
         // and it is the position a reader of a newtype asks about.
         Map<String, ValueSet> admitted = new LinkedHashMap<>();
         Map<String, Boolean> spokenFor = new LinkedHashMap<>();
-        seeded.keys().keySet().forEach(field -> {
+        // Every position that answers to either name. A number is called one thing by the interval
+        // algebra and another by everything else, and the two are filed as they are found — so a
+        // reading keyed by one of the maps would leave a position held only by the other answering
+        // from a default, which is the widest thing there is to say and is said about a position a
+        // clause may well have narrowed.
+        Set<String> positions = new LinkedHashSet<>(seeded.keys().keySet());
+        positions.addAll(seeded.atoms().keySet());
+        positions.forEach(field -> {
             AdmissibleValues<Term> values = seeded.constraints().values();
             // Both names of the position, since a number has one of each and a clause reaching it
             // is filed under whichever the reading recognised. Both are about the same values, so

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -39,10 +39,17 @@ public final class FieldDomains {
      */
     public static final String THE_VALUE = "";
 
-    /** Nothing known of any field. */
+    /**
+     * Nothing known of any field.
+     *
+     * <p>Which is not the same as a value with nothing written about it, and answers as the first:
+     * no clause of anything was gathered here, so {@link #admits} says of every position that a
+     * rule about it may be unread. A caller holding this holds it because it chose not to read a
+     * declaration or had none to read, and neither of those is a reading that found no rules.
+     */
     public static final FieldDomains NONE =
             new FieldDomains(Map.of(), Map.of(), Map.of(), Map.of(), List.of(), Map.of(), true,
-                    ConstraintState.top(), null, null, null, Map.of(), () -> true);
+                    false, ConstraintState.top(), null, null, null, Map.of(), () -> true);
 
     private final Map<String, NumericDomain.Bounds> byField;
     /** The ends the record's own clauses place, which is a different question from the range they
@@ -62,6 +69,8 @@ public final class FieldDomains {
      * reading knows about itself: a walk that fell over produces the same empty domain as a value
      * with no rules, and a second reading asked afterwards does not take the same path. */
     private final boolean seeded;
+    /** Whether every clause of this value reached the readings at all — see {@link #admits}. */
+    private final boolean everyClauseGathered;
     /** Everything the clauses were read as, kept whole. Whether any value of this exists is a
      * question about all of it and is asked of it; the numbers are read out of it where a bound is
      * what a caller is after. */
@@ -80,7 +89,8 @@ public final class FieldDomains {
                          Map<String, Boolean> spokenForByField,
                          List<InvariantChecker.Direct> directs,
                          Map<String, List<TypeSymbol>> narrowers,
-                         boolean seeded, ConstraintState constraints, TypeSymbol named,
+                         boolean seeded, boolean everyClauseGathered,
+                         ConstraintState constraints, TypeSymbol named,
                          Hir.Data data, Symbols symbols, Map<String, Count> settled,
                          java.util.function.BooleanSupplier reading) {
         this.byField = byField;
@@ -90,6 +100,7 @@ public final class FieldDomains {
         this.directs = directs;
         this.narrowers = narrowers;
         this.seeded = seeded;
+        this.everyClauseGathered = everyClauseGathered;
         this.constraints = constraints;
         this.named = named;
         this.data = data;
@@ -208,7 +219,8 @@ public final class FieldDomains {
         return new FieldDomains(Map.copyOf(out), Map.copyOf(holds), Map.copyOf(admitted),
                 Map.copyOf(spokenFor), seeded.reading().directs(),
                 seeded.reading().narrowers(),
-                seeded.everyClauseRead(), seeded.constraints(), named, data, symbols, settled,
+                seeded.everyClauseRead(), seeded.everyClauseGathered(),
+                seeded.constraints(), named, data, symbols, settled,
                 // Classifying the rules is a second reading of every one of them. Asked when the
                 // answer is, and not before: a caller filling a row wants the bounds and nothing
                 // else.
@@ -379,32 +391,59 @@ public final class FieldDomains {
     }
 
     /**
+     * Which values a position may hold, and whether that is the whole of what its rules leave it.
+     *
+     * <p>One answer and not two, because the two are read together or read wrongly. A set of two
+     * values is a division the model draws at that position; the same set beside a rule this
+     * reading could not take in is a division the model may draw more finely; and both are the same
+     * set. Handed over as a set with a second answer beside it, a caller may take the set and leave
+     * the answer — which is what {@link Held} is here to stop happening to a bound, one question
+     * earlier.
+     */
+    public sealed interface Admits {
+
+        /** The whole of what the rules leave the position. */
+        record EveryRuleRead(ValueSet values) implements Admits {}
+
+        /**
+         * These values, and the rules may leave fewer.
+         *
+         * <p>A rule reaching the position was not read as a set, or the reading never reached the
+         * position at all. Which of those it was is not said, because what a reader does about it
+         * is the same: the values hold — everything they exclude is excluded — and they are not a
+         * division of the position.
+         */
+        record SomeRuleUnread(ValueSet values) implements Admits {}
+
+        /** The values, which bound the position from above whichever of the two this is. */
+        ValueSet values();
+    }
+
+    /**
      * Which values the position at {@code path} may hold.
      *
      * <p>{@link ValueSet#ANY} where the rules leave it open, which is also what a position nothing
-     * was written about comes to. Whether the answer is the whole of what the rules leave is
-     * {@link #speaksFor}, and the two have to be read together: a set of two values is a division
-     * the model draws, and the same set beside a rule this could not read is a division the model
-     * may draw more finely.
+     * was written about comes to — told apart from a position this could not read by which of the
+     * two answers carries it.
      *
      * <p>{@code path} is read from the value these are of, as {@link #at} is, and what a name wraps
      * is at {@link #THE_VALUE}. A range is not handed back there and this is: a newtype's value is
      * the position the newtype is, so it is the position a reader of one asks about.
      */
-    public ValueSet admits(String path) {
-        return admittedByField.getOrDefault(path, ValueSet.ANY);
-    }
-
-    /**
-     * Whether {@link #admits} is the whole of what the rules leave the position at {@code path}.
-     *
-     * <p>False where a rule reaching it could not be read as a set. The values are still true of
-     * the position — every value they exclude is excluded — but they are wider than the rules, so a
-     * reader dividing the position into classes would be dividing it more coarsely than the model
-     * does, and a reader saying the model divides it in no way at all would be wrong outright.
-     */
-    public boolean speaksFor(String path) {
-        return spokenForByField.getOrDefault(path, true);
+    public Admits admits(String path) {
+        ValueSet values = admittedByField.getOrDefault(path, ValueSet.ANY);
+        // A clause that never reached the readings cannot have spoiled the position it was about,
+        // because no reading here ever saw which position that was. A walk that fell over and a
+        // clause nothing could type are both that, and both leave maps that read exactly like a
+        // value with no rules — so what the gathering knows about itself is asked, rather than
+        // guessed from the maps being empty.
+        //
+        // Not `allRulesRead`, and not the flag under it. That one is one reading's account of the
+        // clauses it was handed, and a clause it could not turn into an obligation is one this
+        // reading may have taken in whole; borrowing it would settle this reading's completeness by
+        // a fragment that is not this reading's.
+        return everyClauseGathered && spokenForByField.getOrDefault(path, true)
+                ? new Admits.EveryRuleRead(values) : new Admits.SomeRuleUnread(values);
     }
 
     /** Both names the position at {@code path} answers to. A number has one of each and everything

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -4,6 +4,8 @@ import souther.compiler.ast.Hir;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.types.TypeSymbol;
+import souther.compiler.values.AdmissibleValues;
+import souther.compiler.values.ValueSet;
 
 import souther.compiler.numeric.Count;
 import java.util.ArrayList;
@@ -39,7 +41,7 @@ public final class FieldDomains {
 
     /** Nothing known of any field. */
     public static final FieldDomains NONE =
-            new FieldDomains(Map.of(), Map.of(), List.of(), Map.of(), true,
+            new FieldDomains(Map.of(), Map.of(), Map.of(), Map.of(), List.of(), Map.of(), true,
                     ConstraintState.top(), null, null, null, Map.of(), () -> true);
 
     private final Map<String, NumericDomain.Bounds> byField;
@@ -52,6 +54,10 @@ public final class FieldDomains {
     /** What each field has to hold, kept apart from what each field is. Same numbers, different
      * question — see {@link Held}. */
     private final Map<String, NumericDomain.Bounds> heldByField;
+    /** Which values each position may hold — see {@link #admits}. */
+    private final Map<String, ValueSet> admittedByField;
+    /** Whether that is the whole of what the rules leave each of them — see {@link #speaksFor}. */
+    private final Map<String, Boolean> spokenForByField;
     /** Whether the reading that produced these bounds ran to the end. Kept because it is what that
      * reading knows about itself: a walk that fell over produces the same empty domain as a value
      * with no rules, and a second reading asked afterwards does not take the same path. */
@@ -70,6 +76,8 @@ public final class FieldDomains {
 
     private FieldDomains(Map<String, NumericDomain.Bounds> byField,
                          Map<String, NumericDomain.Bounds> heldByField,
+                         Map<String, ValueSet> admittedByField,
+                         Map<String, Boolean> spokenForByField,
                          List<InvariantChecker.Direct> directs,
                          Map<String, List<TypeSymbol>> narrowers,
                          boolean seeded, ConstraintState constraints, TypeSymbol named,
@@ -77,6 +85,8 @@ public final class FieldDomains {
                          java.util.function.BooleanSupplier reading) {
         this.byField = byField;
         this.heldByField = heldByField;
+        this.admittedByField = admittedByField;
+        this.spokenForByField = spokenForByField;
         this.directs = directs;
         this.narrowers = narrowers;
         this.seeded = seeded;
@@ -161,6 +171,25 @@ public final class FieldDomains {
                 out.put(field, bounds);
             }
         });
+        // Which values each position may hold, resolved onto paths for the same reason the bounds
+        // are. Every position and not only the fields: what a name wraps is at no path of its own,
+        // and it is the position a reader of a newtype asks about.
+        Map<String, ValueSet> admitted = new LinkedHashMap<>();
+        Map<String, Boolean> spokenFor = new LinkedHashMap<>();
+        seeded.keys().keySet().forEach(field -> {
+            AdmissibleValues<Term> values = seeded.constraints().values();
+            // Both names of the position, since a number has one of each and a clause reaching it
+            // is filed under whichever the reading recognised. Both are about the same values, so
+            // what holds of it is what both leave.
+            ValueSet here = ValueSet.ANY;
+            boolean spoken = true;
+            for (Term name : named(seeded, field)) {
+                here = here.meet(values.at(name));
+                spoken &= values.speaksFor(name);
+            }
+            admitted.put(field, here);
+            spokenFor.put(field, spoken);
+        });
         // Resolved here rather than handed over as atoms. An atom is a name the seeding gave a shape
         // and means nothing once the reading that named it is gone, so a caller holding one could
         // only ask the domain it came from — which is this one, while it is still here.
@@ -176,7 +205,8 @@ public final class FieldDomains {
         });
         // Classifying the rules is a second reading of every one of them, and the bounds are the
         // whole of what a caller filling a row needs. Asked when the answer is, and not before.
-        return new FieldDomains(Map.copyOf(out), Map.copyOf(holds), seeded.reading().directs(),
+        return new FieldDomains(Map.copyOf(out), Map.copyOf(holds), Map.copyOf(admitted),
+                Map.copyOf(spokenFor), seeded.reading().directs(),
                 seeded.reading().narrowers(),
                 seeded.everyClauseRead(), seeded.constraints(), named, data, symbols, settled,
                 // Classifying the rules is a second reading of every one of them. Asked when the
@@ -346,6 +376,50 @@ public final class FieldDomains {
     public Held heldAt(String path) {
         NumericDomain.Bounds bounds = heldByField.get(path);
         return bounds == null ? null : new Held(bounds);
+    }
+
+    /**
+     * Which values the position at {@code path} may hold.
+     *
+     * <p>{@link ValueSet#ANY} where the rules leave it open, which is also what a position nothing
+     * was written about comes to. Whether the answer is the whole of what the rules leave is
+     * {@link #speaksFor}, and the two have to be read together: a set of two values is a division
+     * the model draws, and the same set beside a rule this could not read is a division the model
+     * may draw more finely.
+     *
+     * <p>{@code path} is read from the value these are of, as {@link #at} is, and what a name wraps
+     * is at {@link #THE_VALUE}. A range is not handed back there and this is: a newtype's value is
+     * the position the newtype is, so it is the position a reader of one asks about.
+     */
+    public ValueSet admits(String path) {
+        return admittedByField.getOrDefault(path, ValueSet.ANY);
+    }
+
+    /**
+     * Whether {@link #admits} is the whole of what the rules leave the position at {@code path}.
+     *
+     * <p>False where a rule reaching it could not be read as a set. The values are still true of
+     * the position — every value they exclude is excluded — but they are wider than the rules, so a
+     * reader dividing the position into classes would be dividing it more coarsely than the model
+     * does, and a reader saying the model divides it in no way at all would be wrong outright.
+     */
+    public boolean speaksFor(String path) {
+        return spokenForByField.getOrDefault(path, true);
+    }
+
+    /** Both names the position at {@code path} answers to. A number has one of each and everything
+     * else has the second, and a clause is filed under whichever the reading recognised. */
+    private static List<Term> named(InvariantChecker.Seeded seeded, String path) {
+        List<Term> names = new ArrayList<>();
+        Term atom = seeded.atoms().get(path);
+        if (atom != null) {
+            names.add(atom);
+        }
+        Term key = seeded.keys().get(path);
+        if (key != null) {
+            names.add(key);
+        }
+        return names;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -39,8 +39,8 @@ public final class FieldDomains {
 
     /** Nothing known of any field. */
     public static final FieldDomains NONE =
-            new FieldDomains(Map.of(), Map.of(), List.of(), Map.of(), false, true,
-                    NumericDomain.top(), null, null, null, Map.of(), () -> true);
+            new FieldDomains(Map.of(), Map.of(), List.of(), Map.of(), true,
+                    ConstraintState.top(), null, null, null, Map.of(), () -> true);
 
     private final Map<String, NumericDomain.Bounds> byField;
     /** The ends the record's own clauses place, which is a different question from the range they
@@ -52,12 +52,14 @@ public final class FieldDomains {
     /** What each field has to hold, kept apart from what each field is. Same numbers, different
      * question — see {@link Held}. */
     private final Map<String, NumericDomain.Bounds> heldByField;
-    private final boolean infeasible;
     /** Whether the reading that produced these bounds ran to the end. Kept because it is what that
      * reading knows about itself: a walk that fell over produces the same empty domain as a value
      * with no rules, and a second reading asked afterwards does not take the same path. */
     private final boolean seeded;
-    private final NumericDomain numbers;
+    /** Everything the clauses were read as, kept whole. Whether any value of this exists is a
+     * question about all of it and is asked of it; the numbers are read out of it where a bound is
+     * what a caller is after. */
+    private final ConstraintState constraints;
     /** What this was read from, so that it can be read again without one declaration's clauses. */
     private final TypeSymbol named;
     private final Hir.Data data;
@@ -69,17 +71,16 @@ public final class FieldDomains {
     private FieldDomains(Map<String, NumericDomain.Bounds> byField,
                          Map<String, NumericDomain.Bounds> heldByField,
                          List<InvariantChecker.Direct> directs,
-                         Map<String, List<TypeSymbol>> narrowers, boolean infeasible,
-                         boolean seeded, NumericDomain numbers, TypeSymbol named, Hir.Data data,
-                         Symbols symbols, Map<String, Count> settled,
+                         Map<String, List<TypeSymbol>> narrowers,
+                         boolean seeded, ConstraintState constraints, TypeSymbol named,
+                         Hir.Data data, Symbols symbols, Map<String, Count> settled,
                          java.util.function.BooleanSupplier reading) {
         this.byField = byField;
         this.heldByField = heldByField;
         this.directs = directs;
         this.narrowers = narrowers;
-        this.infeasible = infeasible;
         this.seeded = seeded;
-        this.numbers = numbers;
+        this.constraints = constraints;
         this.named = named;
         this.data = data;
         this.symbols = symbols;
@@ -94,9 +95,14 @@ public final class FieldDomains {
      * means every position here holds anything while the other means none of them holds anything: a
      * report that took the second for the first would ask for rows at edges of a value nobody can
      * build.
+     *
+     * <p>Asked of the whole state and not of the numbers in it. A rule reaches whichever domain has
+     * a word for it, so a contradiction can be held entirely by a domain that has nothing to do with
+     * intervals — and a reading that asked the numbers alone answered that a value exists because
+     * the domain it asked had never heard of the rules.
      */
     public boolean infeasible() {
-        return infeasible;
+        return constraints.isBottom();
     }
 
     /** What {@code data}, declared as {@code named}, leaves its fields able to hold. */
@@ -171,8 +177,8 @@ public final class FieldDomains {
         // Classifying the rules is a second reading of every one of them, and the bounds are the
         // whole of what a caller filling a row needs. Asked when the answer is, and not before.
         return new FieldDomains(Map.copyOf(out), Map.copyOf(holds), seeded.reading().directs(),
-                seeded.reading().narrowers(), seeded.numbers().isBottom(),
-                seeded.everyClauseRead(), seeded.numbers(), named, data, symbols, settled,
+                seeded.reading().narrowers(),
+                seeded.everyClauseRead(), seeded.constraints(), named, data, symbols, settled,
                 // Classifying the rules is a second reading of every one of them. Asked when the
                 // answer is, and not before: a caller filling a row wants the bounds and nothing
                 // else.
@@ -374,7 +380,7 @@ public final class FieldDomains {
         // What the reading that made these bounds knows about itself comes first. A second reading
         // asked afterwards walks the declarations and not the same path, so it can come back clean
         // about a projection that was never computed.
-        if (!seeded || !numbers.projectionIsLossless()) {
+        if (!seeded || !constraints.numbers().projectionIsLossless()) {
             return false;
         }
         Boolean read = everyRuleRead;

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -251,11 +251,15 @@ public final class InvariantChecker {
      * What the invariants reaching a value of {@code data} leave each of its fields able to hold, and
      * the atom each field is named by.
      *
-     * <p>The same seeding a parameter of that type gets ({@link #seedAt}), read for its numbers
-     * instead of for what it discharges. A record's own clause relates its fields; each field's type
-     * bounds that field on its own; and both land in one domain over the same atoms, which is what
-     * lets a bound reach one field through another.
+     * <p>The same seeding a parameter of that type gets ({@link #seedAt}), read for what it says of
+     * the values instead of for what it discharges. A record's own clause relates its fields; each
+     * field's type bounds that field on its own; and both land in one state over the same atoms,
+     * which is what lets a bound reach one field through another.
      *
+     * @param constraints everything the clauses were read as, whichever domain each of them reached.
+     *                    The whole state and not one domain of it: what a caller asks of a
+     *                    declaration is whether any value of it exists, and that is a question about
+     *                    all of them at once ({@link ConstraintState#isBottom})
      * @param atoms the atom each field's own value is, for the fields that are numbers
      * @param held the atom the count of each field is, for the fields whose values are counted by
      *             something. A field is in one of these two or in neither, never in both: what
@@ -265,8 +269,15 @@ public final class InvariantChecker {
      *                        then weaker than what the declaration actually says, and a caller
      *                        turning one into an obligation has to know that
      */
-    record Seeded(NumericDomain<Term> numbers, Map<String, Term> atoms, Map<String, Term> held,
-                  Reading reading, boolean everyClauseRead) {}
+    record Seeded(ConstraintState constraints, Map<String, Term> atoms, Map<String, Term> held,
+                  Reading reading, boolean everyClauseRead) {
+
+        /** The numbers alone, for the readers that are about intervals. Whether a value exists is
+         * asked of {@link #constraints} and is never read off this. */
+        NumericDomain<Term> numbers() {
+            return constraints.numbers();
+        }
+    }
 
     /** {@link Seeded} for one declaration. A declaration this cannot read is one whose fields it says
      * nothing about, which is the same answer as a declaration with no rules — so nothing about the
@@ -371,7 +382,7 @@ public final class InvariantChecker {
             }
         } catch (RuntimeException why) {
             gaveUp("seedFields " + named.name(), why);
-            return new Seeded(NumericDomain.top(), Map.of(), Map.of(),
+            return new Seeded(ConstraintState.top(), Map.of(), Map.of(),
                     new Reading(List.of(), Map.of()), false);
         }
         Map<String, Term> atoms = new LinkedHashMap<>();
@@ -392,20 +403,20 @@ public final class InvariantChecker {
         // Which of the clauses place an edge, asked once the positions have names to be recognised
         // by.
         Reading reading = c.directsIn(written, at, atoms, keys, held, typeAt);
-        NumericDomain<Term> numbers = k.numbers();
+        ConstraintState constraints = k.constraints();
         for (Map.Entry<String, Count> each : settled.entrySet()) {
             Term atom = atoms.get(each.getKey());
             Type type = typeAt.get(each.getKey());
             if (atom == null || type == null) {
                 continue;
             }
-            numbers = numbers.assume(
+            constraints = constraints.taking(
                     NumericDomain.LinearForm.atom(atom)
                             .minus(NumericDomain.LinearForm.constant(each.getValue().at())),
                     NumericDomain.Rel.EQ,
                     Map.of(atom, c.terms.granularityOf(type)));
         }
-        return new Seeded(numbers, atoms, held, reading, read);
+        return new Seeded(constraints, atoms, held, reading, read);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -261,6 +261,9 @@ public final class InvariantChecker {
      *                    declaration is whether any value of it exists, and that is a question about
      *                    all of them at once ({@link ConstraintState#isBottom})
      * @param atoms the atom each field's own value is, for the fields that are numbers
+     * @param keys what each field is called where it is not a number — which every named position
+     *             has, and which a number has as well. A position is looked up by both, since a
+     *             clause reaching it may be recognised by either
      * @param held the atom the count of each field is, for the fields whose values are counted by
      *             something. A field is in one of these two or in neither, never in both: what
      *             names a number is its own value and what names a list is how much of it there is
@@ -269,8 +272,8 @@ public final class InvariantChecker {
      *                        then weaker than what the declaration actually says, and a caller
      *                        turning one into an obligation has to know that
      */
-    record Seeded(ConstraintState constraints, Map<String, Term> atoms, Map<String, Term> held,
-                  Reading reading, boolean everyClauseRead) {
+    record Seeded(ConstraintState constraints, Map<String, Term> atoms, Map<String, Term> keys,
+                  Map<String, Term> held, Reading reading, boolean everyClauseRead) {
 
         /** The numbers alone, for the readers that are about intervals. Whether a value exists is
          * asked of {@link #constraints} and is never read off this. */
@@ -382,7 +385,7 @@ public final class InvariantChecker {
             }
         } catch (RuntimeException why) {
             gaveUp("seedFields " + named.name(), why);
-            return new Seeded(ConstraintState.top(), Map.of(), Map.of(),
+            return new Seeded(ConstraintState.top(), Map.of(), Map.of(), Map.of(),
                     new Reading(List.of(), Map.of()), false);
         }
         Map<String, Term> atoms = new LinkedHashMap<>();
@@ -421,7 +424,7 @@ public final class InvariantChecker {
                     NumericDomain.Rel.EQ,
                     Map.of(atom, c.terms.granularityOf(type)));
         }
-        return new Seeded(constraints, atoms, held, reading, read);
+        return new Seeded(constraints, atoms, keys, held, reading, read);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -403,7 +403,12 @@ public final class InvariantChecker {
         // Which of the clauses place an edge, asked once the positions have names to be recognised
         // by.
         Reading reading = c.directsIn(written, at, atoms, keys, held, typeAt);
-        ConstraintState constraints = k.constraints();
+        // And which values each position is left, off the same clauses and at the same moment. What
+        // reached this value is the walk's answer and is given to both readings; what each of them
+        // makes of a clause is its own, so neither can widen the other's idea of what it was handed.
+        ConstraintState constraints = k.constraints().taking(AdmissibleReading.of(
+                written.stream().map(Written::clause).toList(), c.terms, at,
+                positions(atoms, keys, typeAt), symbols));
         for (Map.Entry<String, Count> each : settled.entrySet()) {
             Term atom = atoms.get(each.getKey());
             Type type = typeAt.get(each.getKey());
@@ -481,6 +486,31 @@ public final class InvariantChecker {
                     under(path, field.getKey()), field.getValue(), at, symbols, depth + 1,
                     atoms, typeAt, held, keys);
         }
+    }
+
+    /**
+     * The type at each position of a value, keyed by what that position is called.
+     *
+     * <p>Every position that has a name, and not only the ones that are numbers. Which values a
+     * boolean or an enumeration has is as much an answer as which values an integer has, and a
+     * reading keyed by the numeric atoms alone had no word for the first two. Where a position has
+     * both names — a number is called one thing by the interval algebra and another by everything
+     * else — both are filed, since a clause reaching it may be recognised by either.
+     */
+    private static Map<Term, Type> positions(Map<String, Term> atoms, Map<String, Term> keys,
+                                             Map<String, Type> typeAt) {
+        Map<Term, Type> out = new LinkedHashMap<>();
+        typeAt.forEach((path, type) -> {
+            Term key = keys.get(path);
+            if (key != null) {
+                out.put(key, type);
+            }
+            Term atom = atoms.get(path);
+            if (atom != null) {
+                out.put(atom, type);
+            }
+        });
+        return out;
     }
 
     /** A field of the value at {@code path}. The root of a newtype's own reading is the value it

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -373,8 +373,20 @@ public final class InvariantChecker {
         // A clause nothing could type never reaches `written`, so no reading below sees it and none
         // of them can spoil a position for it. That is a fact about what was handed over rather
         // than about any one reading, and it is recorded here where the handing over happens.
-        boolean gathered = true;
+        boolean[] gathered = {true};
         List<Written> written = new ArrayList<>();
+        Gathering gathering = new Gathering() {
+
+            @Override
+            public void gathered(TypeSymbol from, Core clause) {
+                written.add(new Written(from, clause));
+            }
+
+            @Override
+            public void missed(TypeSymbol from) {
+                gathered[0] = false;
+            }
+        };
         try {
             for (Hir.InvariantClause clause :
                     reach.withoutClauses().test(named) || reach.stopAt().test(named)
@@ -382,7 +394,7 @@ public final class InvariantChecker {
                 Core stated = c.clauses.typed(clause.expr(), named, data);
                 if (stated == null) {
                     read = false;
-                    gathered = false;
+                    gathered[0] = false;
                     continue;
                 }
                 written.add(new Written(named, stated));
@@ -399,8 +411,7 @@ public final class InvariantChecker {
                     // No depth limit here: this is the reading a boundary is derived from, and a
                     // rule the construction must satisfy is a rule wherever in the value it sits.
                     k = c.seedAt(new Core.Read(field.getKey(), field.getValue(), type, NOWHERE),
-                            k, at, 1, Integer.MAX_VALUE, new HashSet<>(),
-                            (from, clause) -> written.add(new Written(from, clause)), reach);
+                            k, at, 1, Integer.MAX_VALUE, new HashSet<>(), gathering, reach);
                 }
             }
         } catch (RuntimeException why) {
@@ -443,7 +454,7 @@ public final class InvariantChecker {
                     NumericDomain.Rel.EQ,
                     Map.of(atom, c.terms.granularityOf(type)));
         }
-        return new Seeded(constraints, atoms, keys, held, reading, read, gathered);
+        return new Seeded(constraints, atoms, keys, held, reading, read, gathered[0]);
     }
 
     /**
@@ -558,6 +569,24 @@ public final class InvariantChecker {
     /** One clause reaching a value, rebased onto the positions of that value, and the declaration it
      * is written on. */
     private record Written(TypeSymbol from, Core clause) {}
+
+    /**
+     * Told what a walk over a value gathers, as it gathers it.
+     *
+     * <p>What it found and what it lost, because the second is not visible in the first. A clause
+     * that states nothing the check can read is dropped before any reading sees it, and which
+     * position it governed is what is not known about it — so a collector told only of the clauses
+     * that arrived would take them for every clause there is, and answer for a declaration on the
+     * strength of rules it never saw.
+     */
+    interface Gathering {
+
+        /** A clause of {@code from}, rebased onto the positions of the value being read. */
+        void gathered(TypeSymbol from, Core clause);
+
+        /** A clause of {@code from} that could not be stated here, and so reached no reading. */
+        void missed(TypeSymbol from);
+    }
 
     /** A coordinate a clause reaching this value could be about. */
     private record Coordinate(String path, boolean measured, Carrier carrier) {}
@@ -1148,7 +1177,10 @@ public final class InvariantChecker {
         // A newtype construction from a value written out is the constant check's to report: it names
         // the clause that failed. It reads the construction as written, so a name given the value is
         // not one it sees, and this check says it instead — which is what `decidesFalse` carries.
-        for (Clauses.Stated stated : clauses.statedAt(named, type, given)) {
+        // The clauses that state something here, and not whether they are all of them: a clause
+        // stating nothing readable at this construction is one the run-time check stands for, which
+        // is what `unreadable` below already carries for the ones that were read.
+        for (Clauses.Stated stated : clauses.statedAt(named, type, given).clauses()) {
             Predicates.Owed o = predicates.obligations(stated.expr(), k, at, unnamed, decidesFalse);
             unreadable |= o.unreadable();
             for (Predicates.Clause one : o.clauses()) {
@@ -2016,16 +2048,15 @@ public final class InvariantChecker {
      * own kind stops rather than descending for ever. Kept per path and not for the whole walk: two
      * fields of one type are two positions and both are seeded.
      *
-     * @param onClause told each clause as it is reached, with the declaration it is written on, or
-     *                 null where nobody is collecting. A clause governs a position from wherever it
-     *                 is written — the record the position is a field of, and the declarations under
-     *                 that record it sits inside — and this walk is where it is rebased onto the
-     *                 position it governs. A reader wanting that list has to be told here or walk the
-     *                 same descent again and rebase it a second way.
+     * @param gathering told what this walk gathers, or null where nobody is collecting. A clause
+     *                  governs a position from wherever it is written — the record the position is a
+     *                  field of, and the declarations under that record it sits inside — and this
+     *                  walk is where it is rebased onto the position it governs. A reader wanting
+     *                  that list has to be told here or walk the same descent again and rebase it a
+     *                  second way.
      */
     private Known seedAt(Core root, Known k, Denotations at, int depth, int limit,
-                         Set<TypeSymbol> onPath,
-                         java.util.function.BiConsumer<TypeSymbol, Core> onClause, Reach reach) {
+                         Set<TypeSymbol> onPath, Gathering gathering, Reach reach) {
         // Read before the path is entered, so that the one name and the other stay paired: a stop
         // taken after entering would leave the name on the path with nothing to take it off, and the
         // next field of the same type would be passed over as one already read. Supposed to hold
@@ -2049,13 +2080,21 @@ public final class InvariantChecker {
         });
         Known out = k;
         List<Quantified> quantified = new ArrayList<>();
-        for (Clauses.Stated stated : reach.withoutClauses().test(ref.name())
-                ? List.<Clauses.Stated>of() : clauses.statedAt(ref.name(), data, given)) {
-            if (onClause != null) {
-                onClause.accept(ref.name(), stated.expr());
+        Clauses.StatedClauses stated = reach.withoutClauses().test(ref.name())
+                ? Clauses.StatedClauses.NONE_ASKED_FOR : clauses.statedAt(ref.name(), data, given);
+        // A clause of a declaration under here that states nothing this can read is gone before any
+        // reading sees it, and which position it was about goes with it. Said as it happens: a
+        // reader collecting the clauses would otherwise take the ones it was handed for every
+        // clause there is, and answer for a rule it never saw.
+        if (gathering != null && !stated.everyClauseStated()) {
+            gathering.missed(ref.name());
+        }
+        for (Clauses.Stated one : stated.clauses()) {
+            if (gathering != null) {
+                gathering.gathered(ref.name(), one.expr());
             }
-            predicates.quantifiedBy(stated.expr(), at, true, quantified);
-            out = predicates.assume(predicates.obligations(stated.expr(), out, at, false), out,
+            predicates.quantifiedBy(one.expr(), at, true, quantified);
+            out = predicates.assume(predicates.obligations(one.expr(), out, at, false), out,
                     Known.Held.OF_THE_VALUE);
         }
         out = out.and(quantified);
@@ -2064,10 +2103,10 @@ public final class InvariantChecker {
             // guaranteed of this very atom: `data Outer = Inner` carries Inner's invariant.
             Core value = given.get(bindings.get("value"));
             out = value == null ? out
-                    : seedAt(value, out, at, depth + 1, limit, onPath, onClause, reach);
+                    : seedAt(value, out, at, depth + 1, limit, onPath, gathering, reach);
         } else {
             for (Core value : given.values()) {
-                out = seedAt(value, out, at, depth + 1, limit, onPath, onClause, reach);
+                out = seedAt(value, out, at, depth + 1, limit, onPath, gathering, reach);
             }
         }
         onPath.remove(ref.name());

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -383,14 +383,19 @@ public final class InvariantChecker {
             }
 
             @Override
-            public void missed(TypeSymbol from) {
+            public void missed() {
                 gathered[0] = false;
             }
         };
         try {
+            boolean own = !reach.withoutClauses().test(named) && !reach.stopAt().test(named);
+            if (!own && !c.clauses.of(named, data).isEmpty()) {
+                // Left out because this reading was asked to leave them out, which is still a rule
+                // of the value that no reading here took in.
+                gathering.missed();
+            }
             for (Hir.InvariantClause clause :
-                    reach.withoutClauses().test(named) || reach.stopAt().test(named)
-                            ? List.<Hir.InvariantClause>of() : c.clauses.of(named, data)) {
+                    own ? c.clauses.of(named, data) : List.<Hir.InvariantClause>of()) {
                 Core stated = c.clauses.typed(clause.expr(), named, data);
                 if (stated == null) {
                     read = false;
@@ -584,8 +589,16 @@ public final class InvariantChecker {
         /** A clause of {@code from}, rebased onto the positions of the value being read. */
         void gathered(TypeSymbol from, Core clause);
 
-        /** A clause of {@code from} that could not be stated here, and so reached no reading. */
-        void missed(TypeSymbol from);
+        /**
+         * A rule of this value that reached no reading, either because it could not be stated or
+         * because the walk did not go where it is written.
+         *
+         * <p>Which rule is not said, and there is nothing to say: a clause that could not be stated
+         * is one whose position is exactly what is unknown about it, and a subtree that was not
+         * entered holds rules nobody here has read. What a collector does with it is the same
+         * either way.
+         */
+        void missed();
     }
 
     /** A coordinate a clause reaching this value could be about. */
@@ -2055,6 +2068,56 @@ public final class InvariantChecker {
      *                  that list has to be told here or walk the same descent again and rebase it a
      *                  second way.
      */
+    /**
+     * {@code k} as it stands, with the reading told where it is leaving rules unread.
+     *
+     * <p>Every way this walk stops short comes here: past the depth it reads to, at a value the
+     * caller supposed holds values, at a type it has no declaration for, and at a name already on
+     * the path. What a stop costs is not the same at each of them — most of them stop where there
+     * was nothing to read — so what is asked is whether any rule stands under what is being left,
+     * and only then is anything said. A walk that reported every stop would have a record with one
+     * plain string field speaking for none of its positions.
+     */
+    private Known declining(Type type, Gathering gathering, Known k) {
+        if (gathering != null && type != null && anyRuleUnder(type, new HashSet<>())) {
+            gathering.missed();
+        }
+        return k;
+    }
+
+    /**
+     * Whether any rule is written anywhere under {@code type}.
+     *
+     * <p>A question about the model and not about the walk, which is what makes it the right one to
+     * ask at a stop: the walk's own reach is what is being decided, so reading it would answer that
+     * whatever was not read had nothing in it.
+     *
+     * <p>{@code seen} stops a type that holds its own kind. A name met on the way here was read
+     * where it was met, so what it holds is accounted for and reaching it again adds nothing.
+     */
+    private boolean anyRuleUnder(Type type, Set<TypeSymbol> seen) {
+        if (type instanceof Type.Ref ref) {
+            if (!seen.add(ref.name())) {
+                return false;
+            }
+            return switch (symbols.declarations().declaration(ref.name().key())) {
+                // A unit data holds nothing and may write no rule about it (spec §unit-data), so a
+                // sum of them is a type nothing is written under — which is what makes an
+                // enumeration a position this still speaks for.
+                case Hir.UnitData _ -> false;
+                case Hir.SumData sum -> TypeOps.leafCases(sum, symbols).stream()
+                        .anyMatch(each -> anyRuleUnder(Type.ref(each), seen));
+                case Hir.Data data -> !clauses.declared(ref.name(), data).isEmpty()
+                        || TypeOps.fieldTypes(data, symbols).values().stream()
+                                .anyMatch(each -> anyRuleUnder(each, seen));
+                case null, default -> false;
+            };
+        }
+        boolean[] found = {false};
+        Type.forEachChild(type, child -> found[0] |= anyRuleUnder(child, seen));
+        return found[0];
+    }
+
     private Known seedAt(Core root, Known k, Denotations at, int depth, int limit,
                          Set<TypeSymbol> onPath, Gathering gathering, Reach reach) {
         // Read before the path is entered, so that the one name and the other stay paired: a stop
@@ -2064,10 +2127,10 @@ public final class InvariantChecker {
         // none, and reading it here is the supposing undone one step in.
         if (depth > limit || !(root.type() instanceof Type.Ref ref)
                 || reach.stopAt().test(ref.name())) {
-            return k;
+            return declining(root.type(), gathering, k);
         }
         if (!(symbols.declarations().declaration(ref.name().key()) instanceof Hir.Data data) || !onPath.add(ref.name())) {
-            return k;
+            return declining(root.type(), gathering, k);
         }
         Map<String, Type> fields = clauses.fieldsOf(data);
         Map<String, BindingId> bindings = clauses.bindingsOf(ref.name(), data);
@@ -2087,7 +2150,7 @@ public final class InvariantChecker {
         // reader collecting the clauses would otherwise take the ones it was handed for every
         // clause there is, and answer for a rule it never saw.
         if (gathering != null && !stated.everyClauseStated()) {
-            gathering.missed(ref.name());
+            gathering.missed();
         }
         for (Clauses.Stated one : stated.clauses()) {
             if (gathering != null) {
@@ -2102,7 +2165,7 @@ public final class InvariantChecker {
             // A newtype's `.value` is the same location as the newtype, so what its base guarantees is
             // guaranteed of this very atom: `data Outer = Inner` carries Inner's invariant.
             Core value = given.get(bindings.get("value"));
-            out = value == null ? out
+            out = value == null ? declining(fields.get("value"), gathering, out)
                     : seedAt(value, out, at, depth + 1, limit, onPath, gathering, reach);
         } else {
             for (Core value : given.values()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -271,9 +271,24 @@ public final class InvariantChecker {
      *                        where one could not be typed or held nothing this reads — the bounds are
      *                        then weaker than what the declaration actually says, and a caller
      *                        turning one into an obligation has to know that
+     * @param everyClauseGathered whether every clause of the value reached the readings at all.
+     *                 False where the walk fell over, and false where a clause could not be typed —
+     *                 in both, a rule of the declaration is one no reading here ever saw, so no
+     *                 reading can say it took the declaration in. A different question from
+     *                 {@code everyClauseRead}, which is one reading's account of the clauses it was
+     *                 handed: a clause that reading could not turn into an obligation is one
+     *                 another reading may have taken in whole, and borrowing that answer would
+     *                 settle each reading's completeness by a fragment that is not its own
      */
     record Seeded(ConstraintState constraints, Map<String, Term> atoms, Map<String, Term> keys,
-                  Map<String, Term> held, Reading reading, boolean everyClauseRead) {
+                  Map<String, Term> held, Reading reading, boolean everyClauseRead,
+                  boolean everyClauseGathered) {
+
+        /** What a walk that fell over comes to: no position named, no rule read, and saying so. */
+        static Seeded nothingRead() {
+            return new Seeded(ConstraintState.top(), Map.of(), Map.of(), Map.of(),
+                    new Reading(List.of(), Map.of()), false, false);
+        }
 
         /** The numbers alone, for the readers that are about intervals. Whether a value exists is
          * asked of {@link #constraints} and is never read off this. */
@@ -355,6 +370,10 @@ public final class InvariantChecker {
         Denotations at = Denotations.none().locations(bindings.values());
         Known k = Known.top();
         boolean read = true;
+        // A clause nothing could type never reaches `written`, so no reading below sees it and none
+        // of them can spoil a position for it. That is a fact about what was handed over rather
+        // than about any one reading, and it is recorded here where the handing over happens.
+        boolean gathered = true;
         List<Written> written = new ArrayList<>();
         try {
             for (Hir.InvariantClause clause :
@@ -363,6 +382,7 @@ public final class InvariantChecker {
                 Core stated = c.clauses.typed(clause.expr(), named, data);
                 if (stated == null) {
                     read = false;
+                    gathered = false;
                     continue;
                 }
                 written.add(new Written(named, stated));
@@ -385,8 +405,7 @@ public final class InvariantChecker {
             }
         } catch (RuntimeException why) {
             gaveUp("seedFields " + named.name(), why);
-            return new Seeded(ConstraintState.top(), Map.of(), Map.of(), Map.of(),
-                    new Reading(List.of(), Map.of()), false);
+            return Seeded.nothingRead();
         }
         Map<String, Term> atoms = new LinkedHashMap<>();
         Map<String, Type> typeAt = new LinkedHashMap<>();
@@ -424,7 +443,7 @@ public final class InvariantChecker {
                     NumericDomain.Rel.EQ,
                     Map.of(atom, c.terms.granularityOf(type)));
         }
-        return new Seeded(constraints, atoms, keys, held, reading, read);
+        return new Seeded(constraints, atoms, keys, held, reading, read, gathered);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Known.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Known.java
@@ -25,21 +25,41 @@ import java.util.Set;
  * reading refutes took something more than the values to settle. Which something is not recorded, so
  * it is not claimed either.
  */
-record Known(NumericDomain<Term> numbers, PredicateFacts facts, List<Quantified> quantified,
+record Known(ConstraintState constraints, List<Quantified> quantified,
                      Set<Term> spoken, Unguarded unguarded) {
 
     /** What holds of the values here whatever the path did — what a type guarantees of a value and
      * what a name was given. It carries no quantifiers and no spoken terms: those decide which
      * clauses are read at all, and both readings are asked about the same clauses. */
-    record Unguarded(NumericDomain<Term> numbers, PredicateFacts facts) {
+    record Unguarded(ConstraintState constraints) {
 
         Unguarded taking(LinearForm<Term> f, Rel rel, Map<Term, Granularity> kinds) {
-            return new Unguarded(numbers.assume(f, rel, kinds), facts);
+            return new Unguarded(constraints.taking(f, rel, kinds));
         }
 
         Unguarded taking(Term key, boolean positive) {
-            return new Unguarded(numbers, facts.assume(key, positive));
+            return new Unguarded(constraints.taking(key, positive));
         }
+
+        NumericDomain<Term> numbers() {
+            return constraints.numbers();
+        }
+
+        PredicateFacts facts() {
+            return constraints.facts();
+        }
+    }
+
+    /** The relations between numbers this state holds. Handed out because a bound is read off an
+     * interval and off nothing else; whether anything satisfies the state at all is
+     * {@link ConstraintState#isBottom} and is not assembled from this. */
+    NumericDomain<Term> numbers() {
+        return constraints.numbers();
+    }
+
+    /** The predicates this state has settled, read the same way and for the same reason. */
+    PredicateFacts facts() {
+        return constraints.facts();
     }
 
     /** How far a fact reaches: a value's type and a name's binding say something wherever that value
@@ -47,20 +67,20 @@ record Known(NumericDomain<Term> numbers, PredicateFacts facts, List<Quantified>
     enum Held { OF_THE_VALUE, ON_THE_PATH }
 
     static Known top() {
-        return new Known(NumericDomain.top(), PredicateFacts.none(), List.of(), Set.of(),
-                new Unguarded(NumericDomain.top(), PredicateFacts.none()));
+        return new Known(ConstraintState.top(), List.of(), Set.of(),
+                new Unguarded(ConstraintState.top()));
     }
 
     /** This, with {@code f rel 0} taken as holding as far as {@code held} reaches. */
     Known taking(LinearForm<Term> f, Rel rel, Held held, Map<Term, Granularity> kinds) {
-        return new Known(numbers.assume(f, rel, kinds), facts, quantified, spoken,
+        return new Known(constraints.taking(f, rel, kinds), quantified, spoken,
                 held == Held.OF_THE_VALUE ? unguarded.taking(f, rel, kinds) : unguarded);
     }
 
     /** This, with the predicate {@code key} taken as holding — or as failing, where {@code positive}
      * is false — as far as {@code held} reaches. */
     Known taking(Term key, boolean positive, Held held) {
-        return new Known(numbers, facts.assume(key, positive), quantified, spoken,
+        return new Known(constraints.taking(key, positive), quantified, spoken,
                 held == Held.OF_THE_VALUE ? unguarded.taking(key, positive) : unguarded);
     }
 
@@ -89,7 +109,7 @@ record Known(NumericDomain<Term> numbers, PredicateFacts facts, List<Quantified>
         }
         Set<Term> all = new HashSet<>(spoken);
         all.addAll(terms);
-        return new Known(numbers, facts, quantified, all, unguarded);
+        return new Known(constraints, quantified, all, unguarded);
     }
 
     /** Whether an assumption on this path named {@code term}. */
@@ -103,6 +123,6 @@ record Known(NumericDomain<Term> numbers, PredicateFacts facts, List<Quantified>
         }
         List<Quantified> all = new ArrayList<>(quantified);
         all.addAll(more);
-        return new Known(numbers, facts, List.copyOf(all), spoken, unguarded);
+        return new Known(constraints, List.copyOf(all), spoken, unguarded);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/PredicateFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PredicateFacts.java
@@ -33,6 +33,19 @@ final class PredicateFacts {
         return NONE;
     }
 
+    /**
+     * Whether the predicates settled here cannot all hold.
+     *
+     * <p>A claim about the values and not about the reading: what it takes to reach it is one key
+     * settled both ways, which is a contradiction whatever the predicate says. So it is read where a
+     * value is asked for as well as where a path is — a declaration stating a predicate of its value
+     * and denying the same predicate of the same value has no value, and nothing about that answer
+     * needs the numbers.
+     */
+    boolean isBottom() {
+        return bottom;
+    }
+
     /** The facts with {@code key} settled. Settling it both ways makes the path infeasible. */
     PredicateFacts assume(Term key, boolean positive) {
         if (bottom) {

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueUniverse.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueUniverse.java
@@ -1,5 +1,6 @@
 package souther.compiler.check;
 
+import souther.compiler.ast.Hir;
 import souther.compiler.types.Type;
 import souther.compiler.values.Value;
 
@@ -15,8 +16,8 @@ import java.util.List;
  *
  * <p>Not {@link Carrier}, which answers whether a position has an order-preserving count. The two
  * questions come apart at both ends: a boolean has no order and has two values, a string has an
- * order and has no end of them. Answered with the carrier, a boolean was a position nothing could
- * be counted of.
+ * order and has no end of them. They are asked apart here as well as answered apart — nothing below
+ * reads that one — so a change to which types carry an order leaves this where it was.
  *
  * <p>Exhaustive over the primitives, so one added to the language is answered here rather than
  * falling to whichever arm this happened to end with. Where the values cannot be counted out the
@@ -45,14 +46,19 @@ final class ValueUniverse {
                 case INT, DECIMAL, STRING, DATE, TIME, DATETIME, INSTANT, RAW -> null;
             };
         }
-        // An enumeration's cases, taken from the one reading that decides which sums are
-        // enumerations and in which order their cases stand. A second reading of that here would be
-        // a second answer to keep in step with it.
-        if (!(Carrier.ofValue(base, symbols) instanceof Carrier.Ordinal ordinal)) {
+        // An enumeration's cases, in the order the sum declares them. Asked of the sum directly and
+        // not through {@link Carrier}: that one answers whether a position has an order-preserving
+        // count, which is a different question that happens to hold of the same declarations today.
+        // Read through it, a change to which types carry an order would silently change which types
+        // have values that can be written out. Both go to `TypeOps` for what an enumeration is, so
+        // this is one reading of that and not two.
+        if (!(base instanceof Type.Ref ref)
+                || !(symbols.declarations().declaration(ref.name().key()) instanceof Hir.SumData sum)
+                || !TypeOps.isUnitOnlySum(base, symbols)) {
             return null;
         }
         List<Value> values = new ArrayList<>();
-        ordinal.cases().forEach(each -> values.add(Value.of(each)));
-        return List.copyOf(values);
+        TypeOps.leafCases(sum, symbols).forEach(each -> values.add(Value.of(each)));
+        return values.isEmpty() ? null : List.copyOf(values);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueUniverse.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueUniverse.java
@@ -1,0 +1,58 @@
+package souther.compiler.check;
+
+import souther.compiler.types.Type;
+import souther.compiler.values.Value;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Every value a type has, where they can be counted out at all.
+ *
+ * <p>Asked so that a rule saying which values a position may not hold can be read as the values it
+ * may. {@code /= true} beside {@code /= false} leaves nothing where the values are two and leaves
+ * almost everything where they are strings, and the whole of that difference is this answer.
+ *
+ * <p>Not {@link Carrier}, which answers whether a position has an order-preserving count. The two
+ * questions come apart at both ends: a boolean has no order and has two values, a string has an
+ * order and has no end of them. Answered with the carrier, a boolean was a position nothing could
+ * be counted of.
+ *
+ * <p>Exhaustive over the primitives, so one added to the language is answered here rather than
+ * falling to whichever arm this happened to end with. Where the values cannot be counted out the
+ * answer is nothing at all, which is what leaves a rule about them saying only what it excludes.
+ */
+final class ValueUniverse {
+
+    private ValueUniverse() {}
+
+    /**
+     * The values of {@code type} in the order the model writes them, or null where they are not
+     * something this counts out.
+     *
+     * <p>Read through whatever names the type wears: a name wrapped round a boolean is two values
+     * like the boolean it wraps.
+     */
+    static List<Value> of(Type type, Symbols symbols) {
+        Type base = TypeOps.base(type, symbols);
+        if (base instanceof Type.Prim prim) {
+            return switch (prim) {
+                case BOOL -> List.of(Value.truth(false), Value.truth(true));
+                // Counted out by nobody here. An `Int` and a `Date` have ends rather than a list of
+                // values, and what a rule leaves between two of them is read as an interval; a
+                // `String`, a `Decimal` and the rest have no end of values between any two. Both
+                // are the same answer to this question, which is about writing the values down.
+                case INT, DECIMAL, STRING, DATE, TIME, DATETIME, INSTANT, RAW -> null;
+            };
+        }
+        // An enumeration's cases, taken from the one reading that decides which sums are
+        // enumerations and in which order their cases stand. A second reading of that here would be
+        // a second answer to keep in step with it.
+        if (!(Carrier.ofValue(base, symbols) instanceof Carrier.Ordinal ordinal)) {
+            return null;
+        }
+        List<Value> values = new ArrayList<>();
+        ordinal.cases().forEach(each -> values.add(Value.of(each)));
+        return List.copyOf(values);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -1,0 +1,151 @@
+package souther.compiler.values;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Which values each position may hold, over all the rules a reading took in.
+ *
+ * <p>A state and not a set. A rule is written about a whole value and may name several of its
+ * positions, and the connectives join whole readings rather than the answer at one position — so
+ * what a conjunction and a disjunction are applied to is this, and the arithmetic at one position
+ * is {@link ValueSet}.
+ *
+ * <p><b>A position not held here is at {@link ValueSet#ANY}.</b> That is what makes the two
+ * connectives what they are below, and it is the one thing to hold on to while reading them.
+ *
+ * <pre>
+ *     meet             the keys of both, each side missing one standing at ANY
+ *     join             the keys of both, each side missing one standing at ANY
+ * </pre>
+ *
+ * <p>Which reads the same and is not: joining at a key one side does not hold is joining with ANY,
+ * and that is ANY — so a join keeps only what both sides spoke about, and a meet keeps everything
+ * either did. {@code value == "A" || something-this-cannot-read} has to come out saying nothing
+ * about {@code value}, and a join written as a merge of the two maps says {@code "A"}.
+ *
+ * <h2>What the reading knows about itself</h2>
+ *
+ * <p>Beside the values, which positions this can speak for. A reading that could not take a rule in
+ * leaves the values wider than the rules are, which is the safe direction for refusing a
+ * declaration — nothing is admitted that the rules exclude — and the wrong direction for saying
+ * that a model divides a position into these classes and no others. The two answers are different
+ * questions and are kept apart: {@link #at} says which values, {@link #speaksFor} says whether that
+ * is the whole of what the rules leave.
+ *
+ * <p>Two things spoil it, and the second is the one that is easy to miss.
+ *
+ * <p>A rule this could not read spoils the positions it names. It cannot spoil a position it does
+ * not name: nothing here relates one position to another, so a rule that narrows a position names
+ * it — a rule relating two of them names both, and is itself a rule this cannot read.
+ *
+ * <p>A rule this could not read spoils, under a disjunction, every position the other branch spoke
+ * about, whether or not it names them. {@code value == "A" || opaque()} leaves {@code value} at ANY
+ * because a value satisfying the second branch is under no obligation from the first — and ANY
+ * arrived at that way is not the ANY of a position nothing was written about. Without this a
+ * position would be reported as one the model draws no distinction at, when what happened is that
+ * this reading could not follow the distinction the model draws.
+ */
+public record AdmissibleValues<A>(Map<A, ValueSet> values, Set<A> unread, boolean dropped) {
+
+    /**
+     * @param values  what each position admits. A position at {@link ValueSet#ANY} is left out, so
+     *                that what is held is what was said
+     * @param unread  the positions this reading cannot speak for
+     * @param dropped whether any rule at all was left unread, which is what a disjunction needs in
+     *                order to know that a branch widened it
+     */
+    public AdmissibleValues {
+        Map<A, ValueSet> said = new LinkedHashMap<>();
+        values.forEach((atom, set) -> {
+            if (!set.isAny()) {
+                said.put(atom, set);
+            }
+        });
+        values = Map.copyOf(said);
+        unread = Set.copyOf(unread);
+    }
+
+    /** Nothing read and nothing missed, which is what a reading starts from. */
+    public static <A> AdmissibleValues<A> top() {
+        return new AdmissibleValues<>(Map.of(), Set.of(), false);
+    }
+
+    /** One position said to admit {@code set}, and nothing missed. */
+    public static <A> AdmissibleValues<A> at(A atom, ValueSet set) {
+        return new AdmissibleValues<>(Map.of(atom, set), Set.of(), false);
+    }
+
+    /**
+     * A rule this could not read, which says nothing about any position and spoils the ones it
+     * names.
+     *
+     * <p>{@code named} may be empty — a rule reaching no position this can name is still a rule that
+     * was not read, and what that costs is settled where it is joined rather than here.
+     */
+    public static <A> AdmissibleValues<A> unreadable(Set<A> named) {
+        return new AdmissibleValues<>(Map.of(), named, true);
+    }
+
+    /** What {@code atom} may hold, everything being admitted where nothing was said. */
+    public ValueSet at(A atom) {
+        return values.getOrDefault(atom, ValueSet.ANY);
+    }
+
+    /**
+     * Whether {@link #at} is the whole of what the rules leave {@code atom}, rather than a wider
+     * answer this reading could not narrow.
+     */
+    public boolean speaksFor(A atom) {
+        return !unread.contains(atom);
+    }
+
+    /** Whether some position admits no value, so that nothing satisfies these rules. */
+    public boolean isBottom() {
+        return values.values().stream().anyMatch(ValueSet::isEmpty);
+    }
+
+    /** Both readings holding at once. */
+    public AdmissibleValues<A> meet(AdmissibleValues<A> other) {
+        Map<A, ValueSet> out = new LinkedHashMap<>(values);
+        other.values.forEach((atom, set) -> out.merge(atom, set, ValueSet::meet));
+        return new AdmissibleValues<>(out, union(unread, other.unread), dropped || other.dropped);
+    }
+
+    /**
+     * Either reading holding.
+     *
+     * <p>Over the positions both spoke about, since a position one of them left open is one the two
+     * of them together leave open. And over the positions the other spoke about, where this branch
+     * had something it could not read: those are open too, and open because of the reading rather
+     * than because of the model.
+     */
+    public AdmissibleValues<A> join(AdmissibleValues<A> other) {
+        Map<A, ValueSet> out = new LinkedHashMap<>();
+        values.forEach((atom, set) -> {
+            ValueSet there = other.values.get(atom);
+            if (there != null) {
+                out.put(atom, set.join(there));
+            }
+        });
+        Set<A> spoiled = union(unread, other.unread);
+        if (other.dropped) {
+            spoiled = union(spoiled, values.keySet());
+        }
+        if (dropped) {
+            spoiled = union(spoiled, other.values.keySet());
+        }
+        return new AdmissibleValues<>(out, spoiled, dropped || other.dropped);
+    }
+
+    private static <A> Set<A> union(Set<A> these, Set<A> those) {
+        if (those.isEmpty()) {
+            return these;
+        }
+        Set<A> out = new LinkedHashSet<>(these);
+        out.addAll(those);
+        return out;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/AdmissibleValues.java
@@ -1,5 +1,6 @@
 package souther.compiler.values;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -64,8 +65,11 @@ public record AdmissibleValues<A>(Map<A, ValueSet> values, Set<A> unread, boolea
                 said.put(atom, set);
             }
         });
-        values = Map.copyOf(said);
-        unread = Set.copyOf(unread);
+        // Kept in the order the positions were read, as {@link ValueSet} keeps its values: what is
+        // written out of these has to come out the same on two runs of the compiler, and the
+        // iteration order of an immutable copy does not.
+        values = Collections.unmodifiableMap(said);
+        unread = Collections.unmodifiableSet(new LinkedHashSet<>(unread));
     }
 
     /** Nothing read and nothing missed, which is what a reading starts from. */

--- a/souther-compiler/src/main/java/souther/compiler/values/Value.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/Value.java
@@ -1,0 +1,97 @@
+package souther.compiler.values;
+
+import souther.compiler.types.TypeSymbol;
+
+import java.math.BigDecimal;
+
+/**
+ * One value a model can write out, as the thing it denotes rather than as the text it was written
+ * with.
+ *
+ * <p>What this is for is deciding whether two rules name the same value. {@code == "A"} beside
+ * {@code == "B"} admits nothing and {@code == "A"} beside {@code == "A"} admits one thing, and the
+ * whole of the difference is an equality between two of these.
+ *
+ * <p>Sealed, so a kind of value added to the language is a build failure at every reader rather
+ * than a literal quietly answering that it is unlike everything including itself.
+ *
+ * <p>What is not here is as much of the design as what is. A date, a time and an instant are
+ * ordered and each has a count that stands for it, so what two of them admit together is a question
+ * the interval algebra answers over that count; putting them here as well would give one position
+ * two ways of being told which values it has, and the two would have to be kept agreeing. The line
+ * is not that a date is unlike a string — it is that a date already has a domain and a string has
+ * none.
+ */
+public sealed interface Value {
+
+    /** A string, standing for itself. */
+    record Text(String value) implements Value {
+
+        public Text {
+            if (value == null) {
+                throw new IllegalArgumentException("a written string is not absent");
+            }
+        }
+    }
+
+    /**
+     * A number, kept in the one form that makes two writings of it one value.
+     *
+     * <p>{@code 1.0m} and {@code 1.00m} are the same value where they are written, and the interval
+     * algebra already reads them as one: a declaration bounded at both by equality is admitted,
+     * where the same declaration bounded at {@code 1.0m} and {@code 2.0m} is refused. Two domains
+     * disagreeing about which numbers are the same number would leave one position with two sets of
+     * values it may hold, so this holds the same identity that one does. Nothing here decides what
+     * the language compares equal; it follows what the reading beside it already does.
+     *
+     * <p>An {@code Int} and a {@code Decimal} cannot be compared with each other, so a position is
+     * written about in one of them and never in both.
+     */
+    record Number(BigDecimal value) implements Value {
+
+        public Number {
+            if (value == null) {
+                throw new IllegalArgumentException("a written number is not absent");
+            }
+            value = value.stripTrailingZeros();
+        }
+    }
+
+    /** A boolean. */
+    record Truth(boolean value) implements Value {}
+
+    /**
+     * One case of an enumeration, named by the declaration it is.
+     *
+     * <p>A case holds nothing, so what tells two of them apart is which declaration each is, which
+     * is what a name is for. Read the same way wherever an enumeration is written out.
+     */
+    record Case(TypeSymbol data) implements Value {
+
+        public Case {
+            if (data == null) {
+                throw new IllegalArgumentException("a case is named by a declaration");
+            }
+        }
+    }
+
+    static Value text(String value) {
+        return new Text(value);
+    }
+
+    static Value number(BigDecimal value) {
+        return new Number(value);
+    }
+
+    static Value number(long value) {
+        return new Number(BigDecimal.valueOf(value));
+    }
+
+    static Value truth(boolean value) {
+        return new Truth(value);
+    }
+
+    static Value of(TypeSymbol data) {
+        return new Case(data);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/ValueSet.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/ValueSet.java
@@ -1,0 +1,124 @@
+package souther.compiler.values;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Which values one position may hold, as far as the rules about it were read.
+ *
+ * <p>Two shapes and not one, because {@code /=} does not leave a finite answer. {@code == "A"}
+ * admits one value and {@code /= "A"} admits every value but one, and a reading with only the first
+ * shape would have to answer the second with "anything" — which is true and is the answer that
+ * loses {@code /= true} beside {@code /= false}. Written as the pair, the two are closed under
+ * everything the connectives do to them.
+ *
+ * <p>{@link Cofinite} is over a carrier whose values are not counted out here. Where they can be
+ * counted out — a boolean, an enumeration — what is excluded is taken away from them where the rule
+ * is read, and what is left is a {@link Finite}. So a set that admits nothing is {@code Finite} with
+ * nothing in it, and that is the only shape emptiness has: every reading that could reach it went
+ * through values it had in hand.
+ *
+ * <p>{@link #ANY} is what a position nothing was read about holds, which is every value there is. It
+ * is not "unread": whether a reading could take in the rules about a position is a separate answer
+ * and is held separately ({@link AdmissibleValues}), because a position the model says nothing about
+ * and a position this could not read say the same thing here and mean opposite things to a reader.
+ */
+public sealed interface ValueSet {
+
+    /** These values and no others. */
+    record Finite(Set<Value> values) implements ValueSet {
+
+        public Finite {
+            values = Set.copyOf(values);
+        }
+    }
+
+    /** Every value of the carrier except these. */
+    record Cofinite(Set<Value> excluded) implements ValueSet {
+
+        public Cofinite {
+            excluded = Set.copyOf(excluded);
+        }
+    }
+
+    /** Every value there is, which is what the rules leave where they say nothing. */
+    ValueSet ANY = new Cofinite(Set.of());
+
+    /** Nothing at all. */
+    ValueSet NONE = new Finite(Set.of());
+
+    /** Just this one value. */
+    static ValueSet just(Value value) {
+        return new Finite(Set.of(value));
+    }
+
+    /** Everything but this one value. */
+    static ValueSet allBut(Value value) {
+        return new Cofinite(Set.of(value));
+    }
+
+    /** These values and no others. */
+    static ValueSet oneOf(Set<Value> values) {
+        return new Finite(values);
+    }
+
+    /** Whether no value is admitted, which is what refuses a declaration. */
+    default boolean isEmpty() {
+        return this instanceof Finite it && it.values().isEmpty();
+    }
+
+    /** Whether every value is admitted, so that nothing has been said. */
+    default boolean isAny() {
+        return this instanceof Cofinite it && it.excluded().isEmpty();
+    }
+
+    /** The values both admit — what two rules stated together leave. */
+    default ValueSet meet(ValueSet other) {
+        return switch (this) {
+            case Finite here -> switch (other) {
+                case Finite there -> new Finite(kept(here.values(), there.values()::contains));
+                case Cofinite there -> new Finite(kept(here.values(),
+                        each -> !there.excluded().contains(each)));
+            };
+            case Cofinite here -> switch (other) {
+                case Finite _ -> other.meet(this);
+                case Cofinite there -> new Cofinite(both(here.excluded(), there.excluded()));
+            };
+        };
+    }
+
+    /** The values either admits — what a rule stated as one of two alternatives leaves. */
+    default ValueSet join(ValueSet other) {
+        return switch (this) {
+            case Finite here -> switch (other) {
+                case Finite there -> new Finite(both(here.values(), there.values()));
+                // Everything the other admits, less what it excludes and this does not have: a value
+                // it excludes is admitted here where this names it, so it is no longer excluded from
+                // the two of them together.
+                case Cofinite there -> new Cofinite(kept(there.excluded(),
+                        each -> !here.values().contains(each)));
+            };
+            case Cofinite here -> switch (other) {
+                case Finite _ -> other.join(this);
+                case Cofinite there -> new Cofinite(kept(here.excluded(),
+                        there.excluded()::contains));
+            };
+        };
+    }
+
+    private static Set<Value> kept(Set<Value> these, java.util.function.Predicate<Value> keep) {
+        Set<Value> out = new LinkedHashSet<>();
+        these.forEach(each -> {
+            if (keep.test(each)) {
+                out.add(each);
+            }
+        });
+        return out;
+    }
+
+    private static Set<Value> both(Set<Value> these, Set<Value> those) {
+        Set<Value> out = new LinkedHashSet<>(these);
+        out.addAll(those);
+        return out;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/ValueSet.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/ValueSet.java
@@ -1,5 +1,6 @@
 package souther.compiler.values;
 
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -29,7 +30,7 @@ public sealed interface ValueSet {
     record Finite(Set<Value> values) implements ValueSet {
 
         public Finite {
-            values = Set.copyOf(values);
+            values = held(values);
         }
     }
 
@@ -37,8 +38,22 @@ public sealed interface ValueSet {
     record Cofinite(Set<Value> excluded) implements ValueSet {
 
         public Cofinite {
-            excluded = Set.copyOf(excluded);
+            excluded = held(excluded);
         }
+    }
+
+    /**
+     * A set kept as it was given, and unable to be changed after.
+     *
+     * <p>The order is the order the model writes the values in, and it is kept because something
+     * will be written out of one of these: a position admitting three cases of an enumeration is
+     * three classes, and which order a reader lists them in is not a thing to leave to how a set
+     * happened to store them. {@code Set.copyOf} is what this is not — its iteration order is
+     * settled per run of the compiler, so the same model would list them one way today and another
+     * way tomorrow.
+     */
+    private static Set<Value> held(Set<Value> values) {
+        return Collections.unmodifiableSet(new LinkedHashSet<>(values));
     }
 
     /** Every value there is, which is what the rules leave where they say nothing. */

--- a/souther-compiler/src/test/java/souther/compiler/check/ATypeWithNoValueIsRefusedHoweverItCameToHaveNoneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ATypeWithNoValueIsRefusedHoweverItCameToHaveNoneTest.java
@@ -249,6 +249,196 @@ class ATypeWithNoValueIsRefusedHoweverItCameToHaveNoneTest {
                 """);
     }
 
+    /**
+     * Equalities that name two values, over a carrier no interval is read of.
+     *
+     * <p>An invariant written with {@code ==} says which values the type admits, and two of them
+     * stated together admit what both do. Where they name different values that is nothing, and the
+     * carrier has no part in it: what a reading of the numbers could show about {@code Int} is what
+     * a reading of the values shows about anything whose values can be compared at all.
+     */
+    @Test
+    void twoEqualitiesNamingDifferentValuesAreRefused() {
+        refuses("Gender", """
+                module demo
+
+                data Gender = String
+                    invariant value == "A" && value == "B"
+                """);
+    }
+
+    /** And where they are written as two clauses rather than as one. */
+    @Test
+    void twoEqualitiesWrittenAsSeparateClausesAreRefused() {
+        refuses("Gender", """
+                module demo
+
+                data Gender = String
+                    invariant a = value == "A"
+                    invariant b = value == "B"
+                """);
+    }
+
+    /** And over a boolean, which has two values and no order to read them by. */
+    @Test
+    void twoEqualitiesOverABooleanAreRefused() {
+        refuses("Flag", """
+                module demo
+
+                data Flag = Bool
+                    invariant no = value == true && value == false
+                """);
+    }
+
+    /**
+     * And denying both of a boolean's values, which leaves it none.
+     *
+     * <p>What makes this a refusal is that the values can be written out. The same two denials over
+     * a string leave every string but two, which is the test below.
+     */
+    @Test
+    void denyingEveryValueABooleanHasIsRefused() {
+        refuses("Flag", """
+                module demo
+
+                data Flag = Bool
+                    invariant no = value /= true && value /= false
+                """);
+    }
+
+    /** And over an enumeration, whose values are its cases. */
+    @Test
+    void twoEqualitiesOverAnEnumerationAreRefused() {
+        refuses("Painted", """
+                module demo
+
+                data Red
+                data Green
+                data Blue
+                data Colour = Red | Green | Blue
+
+                data Painted = { colour: Colour }
+                    invariant no = colour == Red && colour == Green
+                """);
+    }
+
+    /** And denying every case of one. */
+    @Test
+    void denyingEveryCaseAnEnumerationHasIsRefused() {
+        refuses("Painted", """
+                module demo
+
+                data Red
+                data Green
+                data Blue
+                data Colour = Red | Green | Blue
+
+                data Painted = { colour: Colour }
+                    invariant no = colour /= Red && colour /= Green && colour /= Blue
+                """);
+    }
+
+    /** Denying all but one of them leaves that one, and refuses nothing. */
+    @Test
+    void denyingAllButOneCaseIsAdmitted() {
+        admits("""
+                module demo
+
+                data Red
+                data Green
+                data Blue
+                data Colour = Red | Green | Blue
+
+                data Painted = { colour: Colour }
+                    invariant blue = colour /= Red && colour /= Green
+                """);
+    }
+
+    /**
+     * Two denials over a carrier whose values are not written out refuse nothing.
+     *
+     * <p>The other side of the reading above. What made the boolean a refusal was having its values
+     * in hand to take away from; a string has no end of values, and a reading that answered the two
+     * shapes alike would refuse this one.
+     */
+    @Test
+    void twoDenialsOverAStringAreAdmitted() {
+        admits("""
+                module demo
+
+                data Gender = String
+                    invariant no = value /= "A" && value /= "B"
+                """);
+    }
+
+    /** Equalities stated as alternatives admit both values. */
+    @Test
+    void twoEqualitiesAsAlternativesAreAdmitted() {
+        admits("""
+                module demo
+
+                data Gender = String
+                    invariant either = value == "A" || value == "B"
+                """);
+    }
+
+    /**
+     * And an alternative to a rule this cannot read admits everything.
+     *
+     * <p>The place a reading of values goes wrong. A value satisfying the rule that was not read is
+     * under no obligation from the one that was, so nothing narrows here at all — and a reading that
+     * kept what the readable side said would refuse whatever the unreadable side would have
+     * allowed.
+     */
+    @Test
+    void anAlternativeToARuleThatCannotBeReadIsAdmitted() {
+        admits("""
+                module demo
+
+                data Gender = String
+                    invariant either = value == "A" || String.matches("[0-9]+", value)
+                """);
+    }
+
+    /** And a rule this cannot read stated beside one it can narrows nothing further. */
+    @Test
+    void aRuleThatCannotBeReadBesideOneThatCanIsAdmitted() {
+        admits("""
+                module demo
+
+                data Gender = String
+                    invariant both = value == "A" && String.matches("[A-Z]", value)
+                """);
+    }
+
+    /** Two positions named one value each contradict nothing. */
+    @Test
+    void twoPositionsNamedOneValueEachAreAdmitted() {
+        admits("""
+                module demo
+
+                data Pair = { left: String, right: String }
+                    invariant both = left == "A" && right == "B"
+                """);
+    }
+
+    /** A value written as an expression is the value it comes to, on both sides of the reading. */
+    @Test
+    void aValueWrittenAsAnExpressionIsTheValueItComesTo() {
+        refuses("Joined", """
+                module demo
+
+                data Joined = String
+                    invariant no = value == "A" ++ "B" && value == "AC"
+                """);
+        admits("""
+                module demo
+
+                data Joined = String
+                    invariant fine = value == "A" ++ "B" && value == "AB"
+                """);
+    }
+
     @Test
     void aNumberWithOneValueLeftIsAdmitted() {
         admits("""
@@ -399,6 +589,25 @@ class ATypeWithNoValueIsRefusedHoweverItCameToHaveNoneTest {
 
                 data Bad = Int
                     invariant no = value >= 2 && value <= 1
+                """));
+    }
+
+    /**
+     * A declaration whose equalities admit no value is told the same thing, and told it once.
+     *
+     * <p>The sentence is about the rules and not about the carrier, since neither is the count.
+     * What holds the record beside it out of the report is that granting the name a value leaves
+     * the record with one: the record is not what the author has to change.
+     */
+    @Test
+    void aDeclarationWhoseEqualitiesAdmitNoValueIsToldItsRulesCannotAllHold() {
+        assertEquals(List.of("ItsRulesCannotAllHold"), saidBy("""
+                module demo
+
+                data Gender = String
+                    invariant no = value == "A" && value == "B"
+
+                data Person = { gender: Gender }
                 """));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/ATypeWithNoValueIsRefusedHoweverItCameToHaveNoneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ATypeWithNoValueIsRefusedHoweverItCameToHaveNoneTest.java
@@ -212,6 +212,43 @@ class ATypeWithNoValueIsRefusedHoweverItCameToHaveNoneTest {
                 """);
     }
 
+    /**
+     * A predicate stated and denied of one value, which reaches no number anywhere.
+     *
+     * <p>The reading settles this where it stands: a predicate settled both ways leaves nothing for
+     * a value to be, and it has left it that way all along. What the count read was the numbers
+     * alone, so a contradiction held entirely by another domain was a type this said could be
+     * built.
+     */
+    @Test
+    void aPredicateStatedAndDeniedOfOneValueIsRefused() {
+        refuses("Shouted", """
+                module demo
+
+                data Shouted = String
+                    invariant no = String.matches("[A-Z]+", value)
+                        && Bool.not(String.matches("[A-Z]+", value))
+                """);
+    }
+
+    /**
+     * And the same two predicates about two positions, which contradict nothing.
+     *
+     * <p>What tells them apart is the value each is stated of and not the words either is written
+     * with. A reading that settled a predicate by how it reads would have this record refused for
+     * saying two things that hold together in every value of it.
+     */
+    @Test
+    void twoPositionsStatingOppositePredicatesAreAdmitted() {
+        admits("""
+                module demo
+
+                data Pair = { shouted: String, quiet: String }
+                    invariant here = String.matches("[A-Z]+", shouted)
+                        && Bool.not(String.matches("[A-Z]+", quiet))
+                """);
+    }
+
     @Test
     void aNumberWithOneValueLeftIsAdmitted() {
         admits("""

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
@@ -58,8 +58,31 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
         return read(source, named).domains();
     }
 
+    /** The same, for a model the compiler refuses: what this hands over afterwards is still read by
+     * whatever ran before the refusal reached the caller. */
+    private static FieldDomains ofRefused(String source, String named) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        assertFalse(compilation.diagnostics().values().stream().flatMap(List::stream).toList()
+                .isEmpty(), "this model is meant to be refused");
+        Symbols symbols = compilation.symbols("demo");
+        TypeSymbol name = TypeSymbols.declared(new TypeKey(symbols.module(), named));
+        return FieldDomains.of(name,
+                (Hir.Data) symbols.declarations().declaration(name.key()), symbols);
+    }
+
     private static final Value A = Value.text("A");
     private static final Value B = Value.text("B");
+
+    /** {@code values} are what the position holds, and are the whole of what its rules leave it. */
+    private static void wholly(ValueSet values, FieldDomains read, String path) {
+        assertEquals(new FieldDomains.Admits.EveryRuleRead(values), read.admits(path));
+    }
+
+    /** {@code values} are what the position holds, and the rules may leave fewer. */
+    private static void asFarAsRead(ValueSet values, FieldDomains read, String path) {
+        assertEquals(new FieldDomains.Admits.SomeRuleUnread(values), read.admits(path));
+    }
 
     /** An equality names the one value the position may hold. */
     @Test
@@ -70,8 +93,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
                 data Gender = String
                     invariant only = value == "A"
                 """, "Gender");
-        assertEquals(ValueSet.just(A), read.admits(FieldDomains.THE_VALUE));
-        assertTrue(read.speaksFor(FieldDomains.THE_VALUE));
+        wholly(ValueSet.just(A), read, FieldDomains.THE_VALUE);
     }
 
     /** Alternatives name both, which is the distinction a model writes this way. */
@@ -83,8 +105,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
                 data Gender = String
                     invariant either = value == "A" || value == "B"
                 """, "Gender");
-        assertEquals(ValueSet.oneOf(Set.of(A, B)), read.admits(FieldDomains.THE_VALUE));
-        assertTrue(read.speaksFor(FieldDomains.THE_VALUE));
+        wholly(ValueSet.oneOf(Set.of(A, B)), read, FieldDomains.THE_VALUE);
     }
 
     /**
@@ -102,8 +123,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
                 data Gender = String
                     invariant either = value == "A" || String.matches("[0-9]+", value)
                 """, "Gender");
-        assertTrue(read.admits(FieldDomains.THE_VALUE).isAny());
-        assertFalse(read.speaksFor(FieldDomains.THE_VALUE));
+        asFarAsRead(ValueSet.ANY, read, FieldDomains.THE_VALUE);
     }
 
     /**
@@ -124,8 +144,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
                 data Pair = { left: String, right: String }
                     invariant either = left == "A" || String.matches("[0-9]+", right)
                 """, "Pair");
-        assertTrue(read.admits("left").isAny());
-        assertFalse(read.speaksFor("left"));
+        asFarAsRead(ValueSet.ANY, read, "left");
     }
 
     /**
@@ -146,8 +165,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
                 data Gender = String
                     invariant both = value == "A" && String.matches("[A-Z]", value)
                 """, "Gender");
-        assertEquals(ValueSet.just(A), read.admits(FieldDomains.THE_VALUE));
-        assertFalse(read.speaksFor(FieldDomains.THE_VALUE));
+        asFarAsRead(ValueSet.just(A), read, FieldDomains.THE_VALUE);
     }
 
     /** And a rule it cannot read that names another position costs this one nothing at all.
@@ -163,9 +181,8 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
                 data Pair = { left: String, right: String }
                     invariant both = left == "A" && String.matches("[A-Z]", right)
                 """, "Pair");
-        assertEquals(ValueSet.just(A), read.admits("left"));
-        assertTrue(read.speaksFor("left"));
-        assertFalse(read.speaksFor("right"));
+        wholly(ValueSet.just(A), read, "left");
+        asFarAsRead(ValueSet.ANY, read, "right");
     }
 
     /** A rule this cannot read on its own leaves the position open, and says that it did. */
@@ -177,8 +194,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
                 data Gender = String
                     invariant shape = String.matches("[A-Z]", value)
                 """, "Gender");
-        assertTrue(read.admits(FieldDomains.THE_VALUE).isAny());
-        assertFalse(read.speaksFor(FieldDomains.THE_VALUE));
+        asFarAsRead(ValueSet.ANY, read, FieldDomains.THE_VALUE);
     }
 
     /** A position with no rules at all is open, and this can say so: the model divides it in no
@@ -190,8 +206,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
 
                 data Gender = String
                 """, "Gender");
-        assertTrue(read.admits(FieldDomains.THE_VALUE).isAny());
-        assertTrue(read.speaksFor(FieldDomains.THE_VALUE));
+        wholly(ValueSet.ANY, read, FieldDomains.THE_VALUE);
     }
 
     /** A denial over an enumeration leaves the cases it did not deny. */
@@ -208,9 +223,48 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
                 data Painted = { colour: Colour }
                     invariant notRed = colour /= Red
                 """, "Painted");
-        assertEquals(ValueSet.oneOf(Set.of(read.caseNamed("Green"), read.caseNamed("Blue"))),
-                read.domains().admits("colour"));
-        assertTrue(read.domains().speaksFor("colour"));
+        wholly(ValueSet.oneOf(Set.of(read.caseNamed("Green"), read.caseNamed("Blue"))),
+                read.domains(), "colour");
+        // And in the order the model declares them. What is written out of these is a class per
+        // value, and a reader listing them takes the order it is given — so the order has to be one
+        // the model settled rather than one a set happened to store them in, which for an immutable
+        // copy is settled afresh on every run of the compiler.
+        assertEquals(List.of(read.caseNamed("Green"), read.caseNamed("Blue")),
+                List.copyOf(((ValueSet.Finite) read.domains().admits("colour").values()).values()));
+    }
+
+    /**
+     * A reading that never ran says of every position that a rule about it may be unread.
+     *
+     * <p>Which is the answer that costs something to get wrong. A reading that fell over, and one a
+     * caller never asked for, leave the same empty maps a value with no rules leaves — and the
+     * empty answer read as "the model divides this position in no way at all" is the widest claim
+     * there is, made where nothing was read.
+     */
+    @Test
+    void aReadingOfNothingSpeaksForNoPosition() {
+        asFarAsRead(ValueSet.ANY, FieldDomains.NONE, FieldDomains.THE_VALUE);
+        asFarAsRead(ValueSet.ANY, FieldDomains.NONE, "anything");
+    }
+
+    /**
+     * And a clause nothing could type leaves every position of its declaration the same way.
+     *
+     * <p>Such a clause reaches no reading at all, so no reading here knows which position it was
+     * about — and a position it might have divided is one this cannot claim to have read. The
+     * declaration is refused where the clause is written; what is asserted here is that a reader
+     * asking this one afterwards is not told something untrue.
+     */
+    @Test
+    void aClauseNothingCouldTypeLeavesNoPositionSpokenFor() {
+        FieldDomains read = ofRefused("""
+                module demo
+
+                data Pair = { left: String, right: Int }
+                    invariant no = left == "A" && right == "B"
+                """, "Pair");
+        asFarAsRead(ValueSet.ANY, read, "left");
+        asFarAsRead(ValueSet.ANY, read, "right");
     }
 
     /** And the rules of one field say nothing about another. */
@@ -222,8 +276,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
                 data Pair = { left: String, right: String }
                     invariant one = left == "A"
                 """, "Pair");
-        assertEquals(ValueSet.just(A), read.admits("left"));
-        assertTrue(read.admits("right").isAny());
-        assertTrue(read.speaksFor("right"));
+        wholly(ValueSet.just(A), read, "left");
+        wholly(ValueSet.ANY, read, "right");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
@@ -288,6 +288,70 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
         asFarAsRead(ValueSet.ANY, read, "inner");
     }
 
+    /**
+     * A type the walk does not enter leaves its rules unread, and that is said too.
+     *
+     * <p>The walk goes through a field's own type and stops at what wraps one — an optional, a
+     * collection, a sum of records — so a rule written inside one of those reaches no reading here.
+     * A position whose values those rules narrow is not one this can speak for, however plainly the
+     * clauses it did read were read.
+     */
+    @Test
+    void aRuleUnderSomethingTheWalkDoesNotEnterIsARuleUnread() {
+        asFarAsRead(ValueSet.ANY, of("""
+                module demo
+
+                data Inner = String
+                    invariant only = value == "A"
+
+                data Outer = { inner: Inner? }
+                """, "Outer"), "inner");
+        asFarAsRead(ValueSet.ANY, of("""
+                module demo
+
+                data Inner = String
+                    invariant only = value == "A"
+
+                data Outer = { inners: List<Inner> }
+                """, "Outer"), "inners");
+        asFarAsRead(ValueSet.ANY, of("""
+                module demo
+
+                data Yes = { n: Int }
+                    invariant only = n == 1
+                data No = { n: Int }
+                data Answer = Yes | No
+
+                data Outer = { answer: Answer }
+                """, "Outer"), "answer");
+    }
+
+    /**
+     * And a type it does not enter that no rule is written under costs nothing.
+     *
+     * <p>Which is what keeps the answer worth having. A record with a plain field, or with a field
+     * of an enumeration, is a record the walk stops at twice and loses nothing at either stop — a
+     * unit data may write no rule (spec §unit-data), and a primitive has none to write. A reading
+     * that said so at every stop would speak for no position of any record that has a field.
+     */
+    @Test
+    void aTypeTheWalkDoesNotEnterCostsNothingWhereNoRuleIsWrittenUnderIt() {
+        wholly(ValueSet.ANY, of("""
+                module demo
+
+                data Outer = { plain: String }
+                """, "Outer"), "plain");
+        wholly(ValueSet.ANY, of("""
+                module demo
+
+                data Red
+                data Green
+                data Colour = Red | Green
+
+                data Outer = { colour: Colour }
+                """, "Outer"), "colour");
+    }
+
     /** And the rules of one field say nothing about another. */
     @Test
     void whatOneFieldMayHoldIsNotWhatTheFieldBesideItMayHold() {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
@@ -1,0 +1,229 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.query.Compilation;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+import souther.compiler.values.Value;
+import souther.compiler.values.ValueSet;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Which values a position is left, and whether that is the whole of what its rules leave it.
+ *
+ * <p>Two answers, and a reader needs both. A set of two values is a distinction the model draws at
+ * that position, and the same set beside a rule this could not read is a distinction the model may
+ * draw more finely. Told apart, a position nothing narrowed and a position this could not follow
+ * are different reports; run together, the second is told the model divides it no way at all.
+ *
+ * <p>What refuses a declaration reads only the first, and reaching nothing is sound whatever the
+ * second says: everything a set excludes is excluded by the rules, whether or not the rules say
+ * more. So the answers below are held for the reader that divides a position rather than for the
+ * one that refuses it.
+ */
+class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
+
+    /** One declaration read, and the module it was read in, so that a case of an enumeration can be
+     * named the way the reading names it. */
+    private record Read(FieldDomains domains, Symbols symbols) {
+
+        Value caseNamed(String data) {
+            return Value.of(TypeSymbols.declared(new TypeKey(symbols.module(), data)));
+        }
+    }
+
+    private static Read read(String source, String named) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.diagnostics().values().stream()
+                .flatMap(List::stream)
+                .map(each -> each.diagnostic().code())
+                .toList(), "the model this reads has to be one somebody could write");
+        Symbols symbols = compilation.symbols("demo");
+        TypeSymbol name = TypeSymbols.declared(new TypeKey(symbols.module(), named));
+        return new Read(FieldDomains.of(name,
+                (Hir.Data) symbols.declarations().declaration(name.key()), symbols), symbols);
+    }
+
+    private static FieldDomains of(String source, String named) {
+        return read(source, named).domains();
+    }
+
+    private static final Value A = Value.text("A");
+    private static final Value B = Value.text("B");
+
+    /** An equality names the one value the position may hold. */
+    @Test
+    void anEqualityLeavesTheValueItNames() {
+        FieldDomains read = of("""
+                module demo
+
+                data Gender = String
+                    invariant only = value == "A"
+                """, "Gender");
+        assertEquals(ValueSet.just(A), read.admits(FieldDomains.THE_VALUE));
+        assertTrue(read.speaksFor(FieldDomains.THE_VALUE));
+    }
+
+    /** Alternatives name both, which is the distinction a model writes this way. */
+    @Test
+    void alternativesLeaveEveryValueTheyName() {
+        FieldDomains read = of("""
+                module demo
+
+                data Gender = String
+                    invariant either = value == "A" || value == "B"
+                """, "Gender");
+        assertEquals(ValueSet.oneOf(Set.of(A, B)), read.admits(FieldDomains.THE_VALUE));
+        assertTrue(read.speaksFor(FieldDomains.THE_VALUE));
+    }
+
+    /**
+     * An alternative to a rule this cannot read leaves the position open, and says so.
+     *
+     * <p>Both halves matter and neither is the other. The values are open because a value
+     * satisfying the second alternative is under no obligation from the first — and they are open
+     * because of this reading, not because the model is silent about the position.
+     */
+    @Test
+    void anAlternativeThatCannotBeReadLeavesThePositionOpenAndSaysWhy() {
+        FieldDomains read = of("""
+                module demo
+
+                data Gender = String
+                    invariant either = value == "A" || String.matches("[0-9]+", value)
+                """, "Gender");
+        assertTrue(read.admits(FieldDomains.THE_VALUE).isAny());
+        assertFalse(read.speaksFor(FieldDomains.THE_VALUE));
+    }
+
+    /**
+     * And where the alternative this cannot read never mentions the position at all.
+     *
+     * <p>The case the rule above is written for, and the one the case above does not reach: there
+     * the unreadable alternative names {@code value}, so the position is spoiled by being named and
+     * nothing about the alternative's being an alternative is asserted. Here nothing names
+     * {@code left} but the branch that was read, and it is still a position this cannot speak for —
+     * a value satisfying the other branch is under no obligation from this one, so what
+     * {@code left} holds is open however plainly the first branch was read.
+     */
+    @Test
+    void anAlternativeThatCannotBeReadSpoilsAPositionItNeverMentions() {
+        FieldDomains read = of("""
+                module demo
+
+                data Pair = { left: String, right: String }
+                    invariant either = left == "A" || String.matches("[0-9]+", right)
+                """, "Pair");
+        assertTrue(read.admits("left").isAny());
+        assertFalse(read.speaksFor("left"));
+    }
+
+    /**
+     * A rule this cannot read stated beside one it can takes nothing away from what the read one
+     * says, and leaves the position one this cannot speak for.
+     *
+     * <p>Both halves again, and the second is not the first being cautious. What is left is every
+     * value the rules admit and may be more: the same shape with {@code "[0-9]"} in it admits
+     * nothing at all, and this reading answers {@code "A"} to both. Sound for refusing — nothing is
+     * excluded that the rules allow — and not a division of the position, which is what saying so
+     * is for.
+     */
+    @Test
+    void aRuleThatCannotBeReadBesideOneThatCanCostsTheValuesNothingAndTheDivisionEverything() {
+        FieldDomains read = of("""
+                module demo
+
+                data Gender = String
+                    invariant both = value == "A" && String.matches("[A-Z]", value)
+                """, "Gender");
+        assertEquals(ValueSet.just(A), read.admits(FieldDomains.THE_VALUE));
+        assertFalse(read.speaksFor(FieldDomains.THE_VALUE));
+    }
+
+    /** And a rule it cannot read that names another position costs this one nothing at all.
+     *
+     * <p>Nothing here relates one position to another, so a rule that narrows a position names it —
+     * which is what makes the answer above local rather than a whole declaration's worth of
+     * caution. */
+    @Test
+    void aRuleThatCannotBeReadAboutAnotherPositionCostsThisOneNothing() {
+        FieldDomains read = of("""
+                module demo
+
+                data Pair = { left: String, right: String }
+                    invariant both = left == "A" && String.matches("[A-Z]", right)
+                """, "Pair");
+        assertEquals(ValueSet.just(A), read.admits("left"));
+        assertTrue(read.speaksFor("left"));
+        assertFalse(read.speaksFor("right"));
+    }
+
+    /** A rule this cannot read on its own leaves the position open, and says that it did. */
+    @Test
+    void aRuleThatCannotBeReadAtAllLeavesThePositionOpenAndSaysWhy() {
+        FieldDomains read = of("""
+                module demo
+
+                data Gender = String
+                    invariant shape = String.matches("[A-Z]", value)
+                """, "Gender");
+        assertTrue(read.admits(FieldDomains.THE_VALUE).isAny());
+        assertFalse(read.speaksFor(FieldDomains.THE_VALUE));
+    }
+
+    /** A position with no rules at all is open, and this can say so: the model divides it in no
+     * way, which is a different answer from the one above and reads the same here. */
+    @Test
+    void aPositionWithNoRulesIsOpenAndSpokenFor() {
+        FieldDomains read = of("""
+                module demo
+
+                data Gender = String
+                """, "Gender");
+        assertTrue(read.admits(FieldDomains.THE_VALUE).isAny());
+        assertTrue(read.speaksFor(FieldDomains.THE_VALUE));
+    }
+
+    /** A denial over an enumeration leaves the cases it did not deny. */
+    @Test
+    void aDenialOverAnEnumerationLeavesTheCasesItDidNotDeny() {
+        Read read = read("""
+                module demo
+
+                data Red
+                data Green
+                data Blue
+                data Colour = Red | Green | Blue
+
+                data Painted = { colour: Colour }
+                    invariant notRed = colour /= Red
+                """, "Painted");
+        assertEquals(ValueSet.oneOf(Set.of(read.caseNamed("Green"), read.caseNamed("Blue"))),
+                read.domains().admits("colour"));
+        assertTrue(read.domains().speaksFor("colour"));
+    }
+
+    /** And the rules of one field say nothing about another. */
+    @Test
+    void whatOneFieldMayHoldIsNotWhatTheFieldBesideItMayHold() {
+        FieldDomains read = of("""
+                module demo
+
+                data Pair = { left: String, right: String }
+                    invariant one = left == "A"
+                """, "Pair");
+        assertEquals(ValueSet.just(A), read.admits("left"));
+        assertTrue(read.admits("right").isAny());
+        assertTrue(read.speaksFor("right"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
@@ -267,6 +267,27 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
         asFarAsRead(ValueSet.ANY, read, "right");
     }
 
+    /**
+     * And a clause nothing could type inside a field's own type leaves that field the same way.
+     *
+     * <p>A rule reaches a position from wherever it is written — the record the position is a field
+     * of, and the declarations under that record it sits inside — so a clause lost anywhere on that
+     * descent is a clause no reading here saw. Which position it was about is exactly what is not
+     * known, so the field it was lost under is one this cannot speak for.
+     */
+    @Test
+    void aClauseNothingCouldTypeInsideAFieldsTypeLeavesThatFieldSpokenForByNothing() {
+        FieldDomains read = ofRefused("""
+                module demo
+
+                data Inner = String
+                    invariant no = value == 1
+
+                data Outer = { inner: Inner }
+                """, "Outer");
+        asFarAsRead(ValueSet.ANY, read, "inner");
+    }
+
     /** And the rules of one field say nothing about another. */
     @Test
     void whatOneFieldMayHoldIsNotWhatTheFieldBesideItMayHold() {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhetherAValueExistsIsAskedOfEveryDomainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhetherAValueExistsIsAskedOfEveryDomainTest.java
@@ -1,0 +1,87 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.numeric.NumericDomain.LinearForm;
+import souther.compiler.numeric.NumericDomain.Rel;
+
+import java.lang.reflect.RecordComponent;
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A state holding nothing, whichever of its domains is the one that holds nothing.
+ *
+ * <p>A clause reaches whatever domain has a word for it, and the domains do not overlap: a relation
+ * between numbers reaches the interval algebra and says nothing to the facts, and a predicate about
+ * a string reaches the facts and says nothing to the numbers. So a contradiction can be held
+ * entirely by one of them while every other one is untouched, and a reader asking a single domain
+ * whether a value exists answers yes whenever it asked the domain that had never heard of the rules.
+ *
+ * <p>Each domain is put at its own bottom on its own here, because that is the shape of the mistake:
+ * not that the answer was wrong about a state where everything contradicts, but that it was wrong
+ * about a state where one thing does.
+ */
+class WhetherAValueExistsIsAskedOfEveryDomainTest {
+
+    private static final Term A_PREDICATE = new Term.Interner().written("some predicate");
+
+    /** Nothing taken in leaves every value there was. */
+    @Test
+    void aStateNothingWasTakenIntoHoldsWhateverItHeld() {
+        assertFalse(ConstraintState.top().isBottom());
+    }
+
+    /** Numbers that cannot both hold, which is the one the reading always asked. */
+    @Test
+    void numbersThatCannotBothHoldLeaveNothing() {
+        assertTrue(numbersAtBottom().isBottom());
+        assertFalse(numbersAtBottom().facts().isBottom(), "and the other domain is untouched");
+    }
+
+    /** A predicate settled both ways, which reaches no number at all. */
+    @Test
+    void aPredicateSettledBothWaysLeavesNothing() {
+        assertTrue(factsAtBottom().isBottom());
+        assertFalse(factsAtBottom().numbers().isBottom(), "and the other domain is untouched");
+    }
+
+    private static ConstraintState numbersAtBottom() {
+        // `1 <= 0`, which is how a reading already says that what it stands in is never reached.
+        return ConstraintState.top()
+                .taking(LinearForm.constant(BigDecimal.ONE), Rel.LE, Map.of());
+    }
+
+    private static ConstraintState factsAtBottom() {
+        return ConstraintState.top().taking(A_PREDICATE, true).taking(A_PREDICATE, false);
+    }
+
+    /**
+     * A tripwire and not the proof above it.
+     *
+     * <p>What the tests above establish is that {@link ConstraintState#isBottom} reads each domain
+     * this state has today. They cannot establish it of a domain added tomorrow, and the failure
+     * they would leave is the silent one: the new domain reaches its own bottom, nothing asks it,
+     * and every type whose rules only that domain can read is built. So the count is pinned here.
+     * A domain added to the state fails this until it is added to the table above as well.
+     */
+    @Test
+    void everyDomainOfTheStateIsOneThisTestPutAtItsOwnBottom() {
+        RecordComponent[] domains = ConstraintState.class.getRecordComponents();
+        assertEquals(2, domains.length,
+                "each domain of the state needs a case above putting that one, and only that one, "
+                        + "at its bottom");
+    }
+
+    /** And the interval algebra's own answer is left as it was: a state is not bottom because some
+     * domain in it has nothing to say. */
+    @Test
+    void aDomainWithNothingToSayIsNotADomainThatHoldsNothing() {
+        assertFalse(NumericDomain.<Term>top().isBottom());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhetherAValueExistsIsAskedOfEveryDomainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhetherAValueExistsIsAskedOfEveryDomainTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.NumericDomain.LinearForm;
 import souther.compiler.numeric.NumericDomain.Rel;
+import souther.compiler.values.AdmissibleValues;
+import souther.compiler.values.Value;
+import souther.compiler.values.ValueSet;
 
 import java.lang.reflect.RecordComponent;
 import java.math.BigDecimal;
@@ -29,7 +32,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class WhetherAValueExistsIsAskedOfEveryDomainTest {
 
-    private static final Term A_PREDICATE = new Term.Interner().written("some predicate");
+    private static final Term.Interner NAMES = new Term.Interner();
+    private static final Term A_PREDICATE = NAMES.written("some predicate");
+    private static final Term A_POSITION = NAMES.written("some position");
 
     /** Nothing taken in leaves every value there was. */
     @Test
@@ -51,6 +56,14 @@ class WhetherAValueExistsIsAskedOfEveryDomainTest {
         assertFalse(factsAtBottom().numbers().isBottom(), "and the other domain is untouched");
     }
 
+    /** A position left no value it may hold, which no number and no predicate has a word for. */
+    @Test
+    void aPositionWithNoValueLeftLeavesNothing() {
+        assertTrue(valuesAtBottom().isBottom());
+        assertFalse(valuesAtBottom().numbers().isBottom(), "and the other domains are untouched");
+        assertFalse(valuesAtBottom().facts().isBottom());
+    }
+
     private static ConstraintState numbersAtBottom() {
         // `1 <= 0`, which is how a reading already says that what it stands in is never reached.
         return ConstraintState.top()
@@ -59,6 +72,12 @@ class WhetherAValueExistsIsAskedOfEveryDomainTest {
 
     private static ConstraintState factsAtBottom() {
         return ConstraintState.top().taking(A_PREDICATE, true).taking(A_PREDICATE, false);
+    }
+
+    private static ConstraintState valuesAtBottom() {
+        return ConstraintState.top()
+                .taking(AdmissibleValues.at(A_POSITION, ValueSet.just(Value.text("A"))))
+                .taking(AdmissibleValues.at(A_POSITION, ValueSet.just(Value.text("B"))));
     }
 
     /**
@@ -73,7 +92,7 @@ class WhetherAValueExistsIsAskedOfEveryDomainTest {
     @Test
     void everyDomainOfTheStateIsOneThisTestPutAtItsOwnBottom() {
         RecordComponent[] domains = ConstraintState.class.getRecordComponents();
-        assertEquals(2, domains.length,
+        assertEquals(3, domains.length,
                 "each domain of the state needs a case above putting that one, and only that one, "
                         + "at its bottom");
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhichTypesHaveValuesThatCanBeWrittenOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhichTypesHaveValuesThatCanBeWrittenOutTest.java
@@ -1,0 +1,124 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Compilation;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
+import souther.compiler.values.Value;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The types whose values can be written out, which is what makes a rule saying what a position is
+ * not into a rule saying what it is.
+ *
+ * <p>{@code /= true} beside {@code /= false} leaves nothing, and {@code /= "A"} beside
+ * {@code /= "B"} leaves nearly everything. The difference is not the shape of the rules — it is
+ * whether the values are something this can count out and take away from.
+ *
+ * <p>Asked of the type and not of what carries it. Two questions come apart here: a boolean has two
+ * values and no order, an enumeration has both, and a string has an order and no end of values. A
+ * reading that answered this with the carrier said a boolean was a position nothing could be
+ * counted of.
+ */
+class WhichTypesHaveValuesThatCanBeWrittenOutTest {
+
+    private static Symbols symbolsOf(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.diagnostics().values().stream()
+                .flatMap(List::stream)
+                .map(each -> each.diagnostic().code())
+                .toList(), "the model this reads has to be one somebody could write");
+        return compilation.symbols("demo");
+    }
+
+    private static List<Value> of(String source, String named) {
+        Symbols symbols = symbolsOf(source);
+        return ValueUniverse.of(
+                Type.ref(TypeSymbols.declared(new TypeKey(symbols.module(), named))), symbols);
+    }
+
+    @Test
+    void aBooleanIsTwoValues() {
+        assertEquals(List.of(Value.truth(false), Value.truth(true)),
+                ValueUniverse.of(Type.BOOL, symbolsOf("module demo\n\ndata U\n")));
+    }
+
+    /** And a name wrapped round one is the same two: wearing a name is not being another type. */
+    @Test
+    void aNameWrappedRoundABooleanIsTheSameTwo() {
+        assertEquals(List.of(Value.truth(false), Value.truth(true)), of("""
+                module demo
+
+                data Flag = Bool
+                """, "Flag"));
+    }
+
+    /** An enumeration is its cases, in the order the model writes them. */
+    @Test
+    void anEnumerationIsItsCasesInTheOrderTheyAreWritten() {
+        Symbols symbols = symbolsOf("""
+                module demo
+
+                data Red
+                data Green
+                data Blue
+
+                data Colour = Red | Green | Blue
+                """);
+        assertEquals(
+                List.of(named(symbols, "Red"), named(symbols, "Green"), named(symbols, "Blue")),
+                ValueUniverse.of(
+                        Type.ref(TypeSymbols.declared(new TypeKey(symbols.module(), "Colour"))),
+                        symbols));
+    }
+
+    private static Value named(Symbols symbols, String data) {
+        return Value.of(TypeSymbols.declared(new TypeKey(symbols.module(), data)));
+    }
+
+    /**
+     * A string is not written out, and neither is a number.
+     *
+     * <p>An {@code Int} between two ends is finitely many values and is still not this: what a rule
+     * leaves it is read as an interval, and writing the values out as well would give one position
+     * two readings to be kept agreeing.
+     */
+    @Test
+    void thePositionsWithNoValuesToWriteOutAreAnsweredNothing() {
+        Symbols symbols = symbolsOf("module demo\n\ndata U\n");
+        assertNull(ValueUniverse.of(Type.STRING, symbols));
+        assertNull(ValueUniverse.of(Type.INT, symbols));
+        assertNull(ValueUniverse.of(Type.DECIMAL, symbols));
+        assertNull(ValueUniverse.of(Type.DATE, symbols));
+    }
+
+    /** A sum whose cases hold something is not an enumeration, so its values are not written out. */
+    @Test
+    void aSumOfCasesThatHoldSomethingIsNotWrittenOut() {
+        assertNull(of("""
+                module demo
+
+                data Leaf = { n: Int }
+                data Stop
+
+                data Shape = Leaf | Stop
+                """, "Shape"));
+    }
+
+    /** And a record is not one either. */
+    @Test
+    void aRecordIsNotWrittenOut() {
+        assertNull(of("""
+                module demo
+
+                data Point = { x: Int, y: Int }
+                """, "Point"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/AnUnreadRuleWidensAndSaysThatItDidTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/AnUnreadRuleWidensAndSaysThatItDidTest.java
@@ -1,0 +1,142 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a reading that could not take a rule in leaves, and what it says about having left it.
+ *
+ * <p>The whole risk of reading values out of rules is here. A reading that answers "no value" from a
+ * rule it did not read refuses a model somebody can write, so a rule left unread has to widen and
+ * never narrow; and a position left wide because a rule was unread is not a position the model says
+ * nothing about, so the two have to be told apart.
+ *
+ * <p>The connectives do not treat an unread rule alike, which is what these are written around. A
+ * rule stated beside others only narrows, so one that went unread costs precision at the positions
+ * it named. A rule stated as an alternative to others widens, so one that went unread takes back
+ * everything the other alternative said — including at positions it never mentions.
+ */
+class AnUnreadRuleWidensAndSaysThatItDidTest {
+
+    private static final String VALUE = "value";
+    private static final String OTHER = "other";
+    private static final Value A = Value.text("A");
+    private static final Value B = Value.text("B");
+
+    private static AdmissibleValues<String> says(String atom, Value value) {
+        return AdmissibleValues.at(atom, ValueSet.just(value));
+    }
+
+    /** A rule read and nothing else is what it says, and this can speak for the position. */
+    @Test
+    void aRuleReadIsWhatItSays() {
+        AdmissibleValues<String> read = says(VALUE, A);
+        assertEquals(ValueSet.just(A), read.at(VALUE));
+        assertTrue(read.speaksFor(VALUE));
+        assertFalse(read.isBottom());
+    }
+
+    /** Two of them stated together leave nothing, and that is a refusal. */
+    @Test
+    void twoRulesStatedTogetherCanLeaveNothing() {
+        assertTrue(says(VALUE, A).meet(says(VALUE, B)).isBottom());
+    }
+
+    /** Stated as alternatives the same two leave both values, and refuse nothing. */
+    @Test
+    void theSameTwoAsAlternativesLeaveBoth() {
+        AdmissibleValues<String> either = says(VALUE, A).join(says(VALUE, B));
+        assertEquals(ValueSet.oneOf(Set.of(A, B)), either.at(VALUE));
+        assertFalse(either.isBottom());
+        assertTrue(either.speaksFor(VALUE));
+    }
+
+    /**
+     * A rule this could not read, stated beside one it could, narrows nothing and refuses nothing.
+     *
+     * <p>And leaves the position it does not name spoken for. Nothing here relates one position to
+     * another, so a rule that narrows a position names it — which is what makes this safe rather
+     * than merely convenient.
+     */
+    @Test
+    void anUnreadRuleStatedBesideAnotherNarrowsNothing() {
+        AdmissibleValues<String> both = says(VALUE, A).meet(AdmissibleValues.unreadable(Set.of()));
+        assertEquals(ValueSet.just(A), both.at(VALUE));
+        assertFalse(both.isBottom());
+        assertTrue(both.speaksFor(VALUE));
+    }
+
+    /** And where it names a position, that position is one this can no longer speak for. */
+    @Test
+    void anUnreadRuleNamingAPositionLeavesItSpokenForByNothing() {
+        AdmissibleValues<String> both =
+                says(VALUE, A).meet(AdmissibleValues.unreadable(Set.of(OTHER)));
+        assertTrue(both.speaksFor(VALUE));
+        assertFalse(both.speaksFor(OTHER));
+        assertEquals(ValueSet.ANY, both.at(OTHER));
+    }
+
+    /**
+     * A rule this could not read, stated as an alternative, takes back what the other alternative
+     * said.
+     *
+     * <p>Even where it names nothing. A value satisfying the branch this could not read is under no
+     * obligation from the branch it could, so the position is open — and a reading that merged the
+     * two maps would answer that the model admits one value there.
+     */
+    @Test
+    void anUnreadAlternativeTakesBackWhatTheOtherSaid() {
+        AdmissibleValues<String> either =
+                says(VALUE, A).join(AdmissibleValues.unreadable(Set.of()));
+        assertEquals(ValueSet.ANY, either.at(VALUE));
+        assertFalse(either.isBottom());
+    }
+
+    /**
+     * And says so: the position is open because of this reading and not because of the model.
+     *
+     * <p>The two are the same answer about the values and opposite answers to a reader asking what
+     * the model divides. Whichever side the unread alternative is written on.
+     */
+    @Test
+    void aPositionLeftOpenByAnUnreadAlternativeIsNotOneNothingWasSaidAbout() {
+        assertFalse(says(VALUE, A).join(AdmissibleValues.unreadable(Set.of())).speaksFor(VALUE));
+        assertFalse(AdmissibleValues.<String>unreadable(Set.of()).join(says(VALUE, A))
+                .speaksFor(VALUE));
+    }
+
+    /** A position neither alternative spoke about is open because neither said anything, which this
+     * can speak for. */
+    @Test
+    void aPositionNeitherAlternativeSpokeAboutIsOpenAndSpokenFor() {
+        AdmissibleValues<String> either = says(VALUE, A).join(says(VALUE, B));
+        assertEquals(ValueSet.ANY, either.at(OTHER));
+        assertTrue(either.speaksFor(OTHER));
+    }
+
+    /**
+     * A position only one alternative spoke about is open, and open because of the model.
+     *
+     * <p>The other branch admits every value there, so every value is admitted — and nothing about
+     * that answer was lost by this reading.
+     */
+    @Test
+    void aPositionOneAlternativeLeftOpenIsOpenBecauseTheModelLeavesItSo() {
+        AdmissibleValues<String> either = says(VALUE, A).join(AdmissibleValues.top());
+        assertEquals(ValueSet.ANY, either.at(VALUE));
+        assertTrue(either.speaksFor(VALUE));
+    }
+
+    /** Nothing read at all says nothing about anything and speaks for all of it. */
+    @Test
+    void aReadingOfNoRulesSaysNothingAndMissedNothing() {
+        assertEquals(ValueSet.ANY, AdmissibleValues.<String>top().at(VALUE));
+        assertTrue(AdmissibleValues.<String>top().speaksFor(VALUE));
+        assertFalse(AdmissibleValues.<String>top().isBottom());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/values/WhatTwoRulesAboutOnePositionLeaveItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/values/WhatTwoRulesAboutOnePositionLeaveItTest.java
@@ -1,0 +1,124 @@
+package souther.compiler.values;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The values one position is left, rule by rule.
+ *
+ * <p>Two shapes carry every answer: the values a rule names, and the values it takes away. What is
+ * asserted here is that the connectives keep them closed — no pair of rules leaves an answer neither
+ * shape can hold — and that emptiness is reached only where values were counted.
+ */
+class WhatTwoRulesAboutOnePositionLeaveItTest {
+
+    private static final Value A = Value.text("A");
+    private static final Value B = Value.text("B");
+    private static final Value C = Value.text("C");
+
+    /** Two equalities naming different values leave nothing, which is the whole of the refusal. */
+    @Test
+    void twoEqualitiesNamingDifferentValuesLeaveNothing() {
+        assertTrue(ValueSet.just(A).meet(ValueSet.just(B)).isEmpty());
+    }
+
+    /** And naming the same value they leave it. */
+    @Test
+    void twoEqualitiesNamingOneValueLeaveIt() {
+        assertEquals(ValueSet.just(A), ValueSet.just(A).meet(ValueSet.just(A)));
+    }
+
+    /** An equality and its denial leave nothing. */
+    @Test
+    void anEqualityAndItsDenialLeaveNothing() {
+        assertTrue(ValueSet.just(A).meet(ValueSet.allBut(A)).isEmpty());
+    }
+
+    /** A denial takes its value out of what an equality named, and leaves the rest. */
+    @Test
+    void aDenialTakesItsValueOutOfWhatWasNamed() {
+        assertEquals(ValueSet.just(A),
+                ValueSet.oneOf(Set.of(A, B)).meet(ValueSet.allBut(B)));
+    }
+
+    /**
+     * Two denials over a carrier whose values are not counted out leave everything but the two.
+     *
+     * <p>Never nothing. What it would take to reach nothing is the values of the carrier in hand,
+     * and where they are in hand the denial was turned into what it leaves before it got here.
+     */
+    @Test
+    void twoDenialsLeaveEverythingButBoth() {
+        ValueSet left = ValueSet.allBut(A).meet(ValueSet.allBut(B));
+        assertEquals(new ValueSet.Cofinite(Set.of(A, B)), left);
+        assertFalse(left.isEmpty());
+    }
+
+    /** Alternatives are the values either names. */
+    @Test
+    void twoEqualitiesAsAlternativesLeaveBoth() {
+        assertEquals(ValueSet.oneOf(Set.of(A, B)), ValueSet.just(A).join(ValueSet.just(B)));
+    }
+
+    /** An alternative to a denial no longer denies what the other side names. */
+    @Test
+    void anAlternativeToADenialTakesBackWhatItNames() {
+        assertEquals(ValueSet.ANY, ValueSet.just(A).join(ValueSet.allBut(A)));
+        assertEquals(ValueSet.allBut(B), ValueSet.just(A).join(ValueSet.allBut(B)),
+                "and leaves the denial of a value neither side names standing");
+    }
+
+    /** Two denials as alternatives deny only what both deny. */
+    @Test
+    void twoDenialsAsAlternativesDenyOnlyWhatBothDeny() {
+        assertEquals(ValueSet.allBut(A),
+                new ValueSet.Cofinite(Set.of(A, B)).join(new ValueSet.Cofinite(Set.of(A, C))));
+    }
+
+    /** Anything is what a position nothing was said about holds, and saying nothing twice says
+     * nothing. */
+    @Test
+    void sayingNothingLeavesEverything() {
+        assertTrue(ValueSet.ANY.isAny());
+        assertTrue(ValueSet.ANY.meet(ValueSet.ANY).isAny());
+        assertTrue(ValueSet.ANY.join(ValueSet.just(A)).isAny());
+        assertEquals(ValueSet.just(A), ValueSet.ANY.meet(ValueSet.just(A)));
+    }
+
+    /** Nothing admitted stays nothing under a further rule, and takes an alternative's values. */
+    @Test
+    void nothingAdmittedIsNotWidenedByAFurtherRule() {
+        assertTrue(ValueSet.NONE.meet(ValueSet.just(A)).isEmpty());
+        assertEquals(ValueSet.just(A), ValueSet.NONE.join(ValueSet.just(A)));
+    }
+
+    /**
+     * Two writings of one number are one value.
+     *
+     * <p>Which is what the interval algebra beside this already does with them: a declaration whose
+     * rules name {@code 1.0m} and {@code 1.00m} is admitted, and one naming {@code 1.0m} and
+     * {@code 2.0m} is refused. Two domains disagreeing here would leave one position holding two
+     * sets of values.
+     */
+    @Test
+    void twoWritingsOfOneNumberAreOneValue() {
+        Value once = Value.number(new BigDecimal("1.0"));
+        Value again = Value.number(new BigDecimal("1.00"));
+        assertEquals(once, again);
+        assertEquals(ValueSet.just(once), ValueSet.just(once).meet(ValueSet.just(again)));
+        assertTrue(ValueSet.just(once).meet(ValueSet.just(Value.number(2))).isEmpty());
+    }
+
+    /** And a whole number written as one is the same value as the decimal it equals, so that a
+     * position read through either spelling holds one set of values. */
+    @Test
+    void aWholeNumberIsTheNumberItEquals() {
+        assertEquals(Value.number(1), Value.number(new BigDecimal("1.000")));
+    }
+}


### PR DESCRIPTION
Closes #771.

## What was wrong

Two things, and either one alone leaves the other standing.

The seeding of a declaration builds a state over several domains and handed back one of them. A
clause relating numbers reaches the interval algebra; a predicate that relates to nothing reaches
the facts, which already record that a key settled both ways is a contradiction. The count that
decides whether a type has any value read `numbers.isBottom()`, so a state holding nothing was read
as a state holding anything whenever the domain that held the contradiction was not the one asked.
Measured before the change: `String.matches("[A-Z]+", value) && Bool.not(String.matches("[A-Z]+",
value))` compiled, with the facts at bottom by the end of the same seeding that answered for it.

And no domain held which values a position may take, so an equality over a carrier with no numeric
atom said nothing at all. `data Gender = String invariant value == "A" && value == "B"` compiled,
emitted classes, and aborted at run time on every construction.

## What the change is

`ConstraintState` is the state, and `isBottom` is the one question asked of it. `Known`, its
unguarded reading and `Seeded` carry it, and `FieldDomains.infeasible` asks it rather than
assembling the answer out of parts. A domain added later is a component here and an arm of that one
question.

`AdmissibleValues` is the new domain: which values each position may hold, as a finite set or as a
carrier less a finite set, closed under intersection, union and the connectives. Two shapes and not
one, because `/=` does not leave a finite answer — a domain with only the first has to answer a
denial with "anything", which is true and loses `/= true` beside `/= false`. Emptiness has one
shape, the finite set with nothing in it, so every reading that reaches it went through values it
had in hand.

The clauses reaching a value are read for it beside the reading that turns those same clauses into
bounds — over the same list, at the same moment. Which clauses reach a value is settled once, by the
walk that gathers them; what each reading makes of a clause is its own.

It is deliberately not read through `Predicates.obligations`. A clause stated as one of two
alternatives owes a construction nothing a guard could discharge and it says something here, so
reading it there would have turned "some reading took this in" into "a construction may be held to
it" — `Owed.unreadable` feeds `everyClauseRead`, which is what licenses writing a row at an edge.

`FieldDomains` hands the sets over per position, with a second answer beside them: whether that is
the whole of what the rules leave. Either alone is read wrongly — a set of two values is a
distinction the model draws, the same set beside a rule this could not read is a distinction the
model may draw more finely, and a position this could not follow reads exactly like a position the
model says nothing about. This is what #772 was promised.

## What is refused now, and what is not

Refused: two equalities naming different values over a `String`, a `Bool` or an enumeration, written
as one clause or as two, through a record field or through a name wrapped round one; denying every
value a `Bool` or an enumeration has; a value written as an expression that comes to a different one;
and a predicate stated and denied of one value.

Not refused, and each of these is a test: alternatives; an alternative to a rule this cannot read; a
rule it cannot read stated beside one it can; two denials over a `String`; denying all but one case
of an enumeration; two positions named one value each; two positions stating opposite predicates;
and a record holding a name whose own rules leave it nothing, which is reported at the name alone.

## Discipline

Everything unread widens. Under a conjunction an unread rule costs the positions it names; under a
disjunction it costs every position the other branch spoke about, named or not, because a value
satisfying the branch that was not read is under no obligation from the branch that was. That second
rule is why the join keeps the positions both sides spoke about rather than merging the two maps.

A denial is turned into what it leaves only where the values can be written out, and the values of a
type are asked apart from its order: a boolean has two values and no order, a string has an order and
no end of values. Dates, times and instants are left out on purpose — each is ordered and has a count
that stands for it, so what two rules about one admit is the interval algebra's question over that
count, and writing them out here as well would leave one position with two readings to keep agreeing.

## What was measured

- `souther-compiler` 4852 tests, all modules 7904, green.
- `souther-examples`: 12 of 13 modules verify. `todomvc` fails at `testCompile` on missing generated
  classes, which it did before this branch.
- No declaration in the examples became refused, which is the check that the two new ways of reaching
  "no value" do not refuse a model somebody wrote.

Four negative controls, each run to see that it fails for the stated reason and that nothing else
moves:

| put wrong | what went red |
|---|---|
| `infeasible()` back to the numbers alone | the predicate stated and denied of one value |
| alternatives read as a conjunction | `== "A" \|\| == "B"` refused |
| no carrier's values ever written out | the two denials over a `Bool` and over an enumeration |
| the join's widening-branch rule removed | the position an unread alternative never mentions |

The last one found the end-to-end test of that rule passing for the wrong reason: `value == "A" ||
String.matches("...", value)` spoils `value` by naming it, so nothing about the alternative was being
asserted. Written across two fields, where the unreadable branch mentions only the other one, it
fails as it should. Both readings are kept.

`ConstraintState`'s component count is pinned by a test, so a domain added without a case of its own
is a build failure rather than a domain nothing asks about. It fired once during this branch, which
is what it is for.

No spec change. `<<a-data-can-be-constructed>>` already says that rules which cannot all hold leave
nothing satisfying them; the reading caught up to the rule rather than the rule changing.

## Filed while measuring

#780: a contradictory ordering over an enumeration is not refused, where the same shape over an `Int`
is. That is where the values stop rather than which values are named, so it belongs to the interval
algebra over the carrier's count and not to this domain — the same shape as #773.

🤖 Generated with [Claude Code](https://claude.com/claude-code)