### PR TITLE
Make declaration indexing a value during module construction

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/DeclarationRefusals.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclarationRefusals.java
@@ -1,7 +1,10 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.ast.Hir;
 import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Region;
+import souther.compiler.diag.SourcePos;
 import souther.compiler.diag.msg.BehaviorMessage;
 import souther.compiler.diag.msg.DataMessage;
 
@@ -15,24 +18,40 @@ import souther.compiler.diag.msg.DataMessage;
  * artifact has no such reader, and what a refusal means there is a fact about the artifact
  * ({@link souther.compiler.meta.Readback.Failure}) said to whoever put it on the path.
  *
- * <p>One place for each rule's sentence, and a switch with nothing to fall through to: a rule added
- * to the indexing is one this has to have a sentence for.
+ * <p>Two doors and one sentence per rule. Which representation the declarations are in decides
+ * nothing about what is said — the rule is the same rule on both sides of {@code Resolve} — so the
+ * two entries read the name and the place off their own form and meet at one switch.
  */
 public final class DeclarationRefusals {
 
     private DeclarationRefusals() {
     }
 
-    /** How {@code refusal} is said to the author of the module that wrote it. */
-    public static Diagnostic reported(DeclaredNames.Refusal<Ast.Def> refusal) {
+    /** How {@code refusal} is said, of a module as it was written. */
+    public static Diagnostic reportedAsWritten(DeclaredNames.Refusal<Ast.Def> refusal) {
         Ast.Def def = refusal.refused();
+        return said(refusal, def.name(), def.pos(), def.written().reportedAt());
+    }
+
+    /** How {@code refusal} is said, of a module something has resolved. */
+    public static Diagnostic reportedAsResolved(DeclaredNames.Refusal<Hir.Def> refusal) {
+        Hir.Def def = refusal.refused();
+        return said(refusal, def.name(), def.pos(), def.written().reportedAt());
+    }
+
+    /**
+     * The sentence for each rule there is, and a switch with nothing to fall through to: a rule
+     * added to the indexing is one this has to have a sentence for.
+     */
+    private static <D> Diagnostic said(DeclaredNames.Refusal<D> refusal, String name,
+                                       SourcePos pos, Region reportedAt) {
         return switch (refusal) {
-            case DeclaredNames.Refusal.DeclaredTwice<Ast.Def> _ -> Diagnostic
-                    .at(def.pos())
-                    .say(new DataMessage.ADataIsAlreadyDefined(def.name())).build();
-            case DeclaredNames.Refusal.ABuiltInOptionCaseIsDeclared<Ast.Def> _ -> Diagnostic
-                    .at(def.written().reportedAt())
-                    .say(new BehaviorMessage.ABuiltInOptionCaseCannotBeDeclared(def.name())).build();
+            case DeclaredNames.Refusal.DeclaredTwice<D> _ -> Diagnostic
+                    .at(pos)
+                    .say(new DataMessage.ADataIsAlreadyDefined(name)).build();
+            case DeclaredNames.Refusal.ABuiltInOptionCaseIsDeclared<D> _ -> Diagnostic
+                    .at(reportedAt)
+                    .say(new BehaviorMessage.ABuiltInOptionCaseCannotBeDeclared(name)).build();
         };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclarationRefusals.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclarationRefusals.java
@@ -1,0 +1,38 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.msg.BehaviorMessage;
+import souther.compiler.diag.msg.DataMessage;
+
+/**
+ * What the author of a module is told about a declaration it may not have.
+ *
+ * <p>The other side of {@link DeclaredNames}, and deliberately not part of it. Indexing answers
+ * which declarations a module has and which rule refused the rest; that answer is the same wherever
+ * the module came from. Saying it to somebody is not: this is written for a module of this
+ * compilation, whose author holds the file and can be sent to the line. A module read back off an
+ * artifact has no such reader, and what a refusal means there is a fact about the artifact
+ * ({@link souther.compiler.meta.Readback.Failure}) said to whoever put it on the path.
+ *
+ * <p>One place for each rule's sentence, and a switch with nothing to fall through to: a rule added
+ * to the indexing is one this has to have a sentence for.
+ */
+public final class DeclarationRefusals {
+
+    private DeclarationRefusals() {
+    }
+
+    /** How {@code refusal} is said to the author of the module that wrote it. */
+    public static Diagnostic reported(DeclaredNames.Refusal<Ast.Def> refusal) {
+        Ast.Def def = refusal.refused();
+        return switch (refusal) {
+            case DeclaredNames.Refusal.DeclaredTwice<Ast.Def> _ -> Diagnostic
+                    .at(def.pos())
+                    .say(new DataMessage.ADataIsAlreadyDefined(def.name())).build();
+            case DeclaredNames.Refusal.ABuiltInOptionCaseIsDeclared<Ast.Def> _ -> Diagnostic
+                    .at(def.written().reportedAt())
+                    .say(new BehaviorMessage.ABuiltInOptionCaseCannotBeDeclared(def.name())).build();
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredNames.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredNames.java
@@ -1,63 +1,95 @@
 package souther.compiler.check;
 
-import souther.compiler.ast.WrittenName;
-import souther.compiler.diag.CompileException;
-import souther.compiler.diag.Diagnostic;
-import souther.compiler.diag.SourcePos;
-import souther.compiler.diag.msg.BehaviorMessage;
-import souther.compiler.diag.msg.DataMessage;
-
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
 /**
- * Which of the declarations a module writes it actually has, and one error per declaration it may
+ * Which of the declarations a module writes it actually has, and one refusal per declaration it may
  * not.
  *
- * <p>A name declared twice keeps the first: the second is reported and left out, so the rest of the
+ * <p>A name declared twice keeps the first: the second is refused and left out, so the rest of the
  * module still means what it means. Writing a declaration twice is what copying one looks like
  * halfway through, and taking every name in the file away until it is finished is the opposite of
  * useful.
  *
- * <p>Written over the names and positions rather than over a tree, because the rule is the same one
- * on both sides of {@code Resolve}: which declarations a module has is settled by what it wrote, and
- * nothing about it is a question resolution answers. Both representations ask it here so that the
- * two cannot come to differ about what a module declares.
+ * <p>Written over the names rather than over a tree, because the rule is the same one on both sides
+ * of {@code Resolve}: which declarations a module has is settled by what it wrote, and nothing about
+ * it is a question resolution answers. Both representations ask it here so that the two cannot come
+ * to differ about what a module declares.
+ *
+ * <p>What comes back is a fact and not a report. A refusal says which declaration is refused and
+ * which rule refused it, and that is all it says — where to complain about it, and whether there is
+ * anyone to complain to, depend on where the declarations came from. A module of this compilation
+ * has an author holding the file; a module read back off an artifact has nobody, and a rule broken
+ * inside one is a fact about what the artifact carries. Minting a diagnostic here made those one
+ * answer, and the second was reached by catching an exception type.
  */
 public final class DeclaredNames {
 
     private DeclaredNames() {
     }
 
-    /** What a module declares, keyed by the name written there, and the errors for the rest. */
-    public record Of<D>(Map<String, D> defs, List<CompileException> rejected) {}
+    /**
+     * What a module declares, keyed by the name written there, and the declarations it may not have.
+     *
+     * <p>Partial on purpose. The declarations are what is left after the refusals are taken out, so
+     * a reader that has a source to report against goes on with them and reports the rest. A reader
+     * with nowhere to report has an index it may not use at all unless {@link #refusals()} is empty,
+     * and that is the reader's own rule rather than something read off this.
+     */
+    public record Index<D>(Map<String, D> declarations, List<Refusal<D>> refusals) {
 
-    public static <D> Of<D> of(List<D> defs, Function<D, String> name, Function<D, WrittenName> written,
-                        Function<D, SourcePos> pos) {
+        public Index {
+            declarations = Collections.unmodifiableMap(new LinkedHashMap<>(declarations));
+            refusals = List.copyOf(refusals);
+        }
+    }
+
+    /**
+     * One declaration a module writes and does not have, as which rule refused it.
+     *
+     * <p>Closed, so that a reader turning these into something else — a report, a fact about an
+     * artifact, a fault — says what it does about each. A rule added here is one every such reader
+     * has to have an answer for, and the compiler asks them for it.
+     */
+    public sealed interface Refusal<D> {
+
+        /** The declaration this is about. */
+        D refused();
+
+        /** The name is already declared by this module, and the first one keeps it. */
+        record DeclaredTwice<D>(D refused) implements Refusal<D> {}
+
+        /**
+         * It is named after a built-in {@code Option} case.
+         *
+         * <p>{@code Some} and {@code None} are the built-in cases (ADR-0011); a user data of the
+         * same name would make a {@code | Some v} pattern ambiguous between {@code Option} and the
+         * user case, so the declaration is refused rather than allowed to collide (ADR-0035).
+         */
+        record ABuiltInOptionCaseIsDeclared<D>(D refused) implements Refusal<D> {}
+    }
+
+    /** What {@code defs} declares, by the name each is written under. */
+    public static <D> Index<D> index(List<D> defs, Function<D, String> name) {
         Map<String, D> declared = new LinkedHashMap<>();
-        List<CompileException> rejected = new ArrayList<>();
+        List<Refusal<D>> refused = new ArrayList<>();
         for (D def : defs) {
             String bare = name.apply(def);
             if (bare.equals("Some") || bare.equals("None")) {
-                // Some/None are the built-in Option cases (ADR-0011); a user data of the same name
-                // would make a `| Some v` pattern ambiguous between Option and the user case, so the
-                // declaration is rejected here rather than allowed to collide (ADR-0035).
-                rejected.add(CompileException.of(Diagnostic
-                        .at(written.apply(def).reportedAt())
-                        .say(new BehaviorMessage.ABuiltInOptionCaseCannotBeDeclared(bare)).build()));
+                refused.add(new Refusal.ABuiltInOptionCaseIsDeclared<>(def));
                 continue;
             }
             if (declared.containsKey(bare)) {
-                rejected.add(CompileException.of(Diagnostic
-                        .at(pos.apply(def))
-                        .say(new DataMessage.ADataIsAlreadyDefined(bare)).build()));
+                refused.add(new Refusal.DeclaredTwice<>(def));
                 continue;
             }
             declared.put(bare, def);
         }
-        return new Of<>(declared, List.copyOf(rejected));
+        return new Index<>(declared, refused);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Prelude.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Prelude.java
@@ -368,9 +368,9 @@ public final class Prelude {
             // The standard library is this compiler's own source. A declaration it may not have is
             // nobody's mistake to be told about: it is a resource shipped in the jar being wrong,
             // which is refused where it is loaded like the rest of what is checked here.
-            throw new IllegalStateException("prelude resource " + resource + " declares `"
-                    + indexed.refusals().get(0).refused().name() + "`, which is a declaration no"
-                    + " module may have");
+            throw new IllegalStateException("prelude resource " + resource + " carries a"
+                    + " declaration the indexing refused: `"
+                    + indexed.refusals().get(0).refused().name() + "`");
         }
         Map<String, Ast.Def> declared = indexed.declarations();
         if (declared.isEmpty()) {
@@ -394,8 +394,8 @@ public final class Prelude {
             scope.put(name, new Denotation.Denotes(TypeSymbol.runtime(name)));
         }
         return SyntaxSymbols.of(TypeSymbol.RUNTIME,
-                Registry.ofRead(Map.of(TypeSymbol.RUNTIME, declared),
-                        Map.of(TypeSymbol.RUNTIME, Registry.baseNames(m.exposing()))),
+                Registry.ofRead(Map.of(TypeSymbol.RUNTIME, new Registry.Declared<>(
+                        declared, Registry.baseNames(m.exposing())))),
                 scope, Map.of());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Prelude.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Prelude.java
@@ -363,7 +363,16 @@ public final class Prelude {
      * A case of a registered sum is registered with it.
      */
     private static SyntaxSymbols symbolsOf(Ast.Module m, String resource) {
-        Map<String, Ast.Def> declared = Registry.ownDefs(m);
+        DeclaredNames.Index<Ast.Def> indexed = Registry.indexed(m);
+        if (!indexed.refusals().isEmpty()) {
+            // The standard library is this compiler's own source. A declaration it may not have is
+            // nobody's mistake to be told about: it is a resource shipped in the jar being wrong,
+            // which is refused where it is loaded like the rest of what is checked here.
+            throw new IllegalStateException("prelude resource " + resource + " declares `"
+                    + indexed.refusals().get(0).refused().name() + "`, which is a declaration no"
+                    + " module may have");
+        }
+        Map<String, Ast.Def> declared = indexed.declarations();
         if (declared.isEmpty()) {
             return SyntaxSymbols.none();   // signatures over primitives and type variables only
         }
@@ -385,7 +394,9 @@ public final class Prelude {
             scope.put(name, new Denotation.Denotes(TypeSymbol.runtime(name)));
         }
         return SyntaxSymbols.of(TypeSymbol.RUNTIME,
-                Registry.ofWritten(Map.of(TypeSymbol.RUNTIME, m)), scope, Map.of());
+                Registry.ofRead(Map.of(TypeSymbol.RUNTIME, declared),
+                        Map.of(TypeSymbol.RUNTIME, Registry.baseNames(m.exposing()))),
+                scope, Map.of());
     }
 
     /** The runtime-backed declaration {@code name} denotes, or null when there is none. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Registry.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Registry.java
@@ -65,7 +65,29 @@ public interface Registry<D> {
 
     /** Nothing is declared anywhere — for signatures written over primitives and type variables. */
     static <D> Registry<D> empty() {
-        return ofRead(Map.of(), Map.of());
+        return ofRead(Map.of());
+    }
+
+    /**
+     * One module as a registry has it: what it declares, and the base type names it exposes.
+     *
+     * <p>One value, because having a module is one fact and the three questions a registry answers
+     * are answered from it. Handed over as two maps, a caller could fill one and not the other, and
+     * what came back said a declaration was there under a name the registry did not have.
+     *
+     * @param declarations what it declares, by the name written there
+     * @param exposed      the base type names it exposes ({@link #baseNames})
+     */
+    record Declared<D>(Map<String, D> declarations, Set<String> exposed) {
+
+        /** Copied in the order the module wrote them. What a module declares is read out in that
+         *  order — a reader rebuilding a module from what a registry has puts its declarations back
+         *  in the order it finds them, so a copy that does not keep it moves them. */
+        public Declared {
+            declarations =
+                    java.util.Collections.unmodifiableMap(new java.util.LinkedHashMap<>(declarations));
+            exposed = Set.copyOf(exposed);
+        }
     }
 
     /**
@@ -77,18 +99,12 @@ public interface Registry<D> {
      * the compiler ships is a fault in the compiler. Each of those is said where the module is
      * obtained, and what arrives here is what was left standing.
      *
-     * <p>A module that had nothing to give is not among {@code declarations}, and is answered the
-     * way a module nobody has is answered. Which of the two it was is not this registry's to say:
-     * that is what the reader settled, and it says it where it says what it has.
-     *
-     * @param declarations what each module declares, by the name written there
-     * @param exposed      the base type names each module exposes ({@link #baseNames}), whose names
-     *                     are the modules this registry has
+     * <p>A module that had nothing to give is not among {@code modules}, and is answered the way a
+     * module nobody has is answered. Which of the two it was is not this registry's to say: that is
+     * what the reader settled, and it says it where it says what it has.
      */
-    static <D> Registry<D> ofRead(Map<String, Map<String, D>> declarations,
-                                  Map<String, Set<String>> exposed) {
-        Map<String, Map<String, D>> declared = Map.copyOf(declarations);
-        Map<String, Set<String>> exposes = Map.copyOf(exposed);
+    static <D> Registry<D> ofRead(Map<String, Declared<D>> modules) {
+        Map<String, Declared<D>> has = Map.copyOf(modules);
         return new Registry<D>() {
 
             @Override
@@ -98,17 +114,19 @@ public interface Registry<D> {
 
             @Override
             public Map<String, D> declaredIn(String moduleName) {
-                return declared.getOrDefault(moduleName, Map.of());
+                Declared<D> module = has.get(moduleName);
+                return module == null ? Map.of() : module.declarations();
             }
 
             @Override
             public Set<String> exposedBy(String moduleName) {
-                return exposes.getOrDefault(moduleName, Set.of());
+                Declared<D> module = has.get(moduleName);
+                return module == null ? Set.of() : module.exposed();
             }
 
             @Override
             public Set<String> moduleNames() {
-                return exposes.keySet();
+                return has.keySet();
             }
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Registry.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Registry.java
@@ -6,7 +6,6 @@ import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.TypeSymbols;
 
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -19,6 +18,13 @@ import java.util.Set;
  * are. Keeping it to that is the point — a registry that handed out {@code Hir.Module} would let a
  * caller reach a module's behaviors, examples or fns and so depend on which pass had last rewritten
  * it, which is how a definition's meaning came to depend on the whole compile.
+ *
+ * <p>Every question here is a lookup, and no lookup refuses. A registry is built out of declarations
+ * that have already been indexed, so whether a module's declarations can be indexed at all is
+ * settled by whoever built it, once, where there is still somebody to answer — and every asker
+ * afterwards gets the same answer. Working them out on first use is what put a refusal behind a
+ * lookup: the reader that caught the first ask was caught by the second, because a module named with
+ * a qualifier is asked for again while some other module is being resolved.
  */
 public interface Registry<D> {
 
@@ -58,127 +64,63 @@ public interface Registry<D> {
     Set<String> moduleNames();
 
     /** Nothing is declared anywhere — for signatures written over primitives and type variables. */
-    static Registry<Hir.Def> empty() {
-        return of(Map.of());
-    }
-
-    /** The declarations of a fixed set of modules. Each module's definitions are worked out on
-     * first use, so a compilation that never reaches a module never reads it. */
-    static Registry<Hir.Def> of(Map<String, Hir.Module> modules) {
-        return new Registry<Hir.Def>() {
-            private final Map<String, Map<String, Hir.Def>> defs = new HashMap<>();
-            private final Map<String, Set<String>> exposed = new HashMap<>();
-
-            @Override
-            public Hir.Def declaration(TypeKey address) {
-                return declaredIn(address.module()).get(address.name());
-            }
-
-            @Override
-            public Map<String, Hir.Def> declaredIn(String moduleName) {
-                return defs.computeIfAbsent(moduleName, name -> {
-                    Hir.Module m = modules.get(name);
-                    return m == null ? Map.of() : TypeChecker.ownDefs(m);
-                });
-            }
-
-            @Override
-            public Set<String> exposedBy(String moduleName) {
-                return exposed.computeIfAbsent(moduleName, name -> {
-                    Hir.Module m = modules.get(name);
-                    return m == null ? Set.of() : baseNames(m.exposing());
-                });
-            }
-
-            @Override
-            public Set<String> moduleNames() {
-                return modules.keySet();
-            }
-        };
-    }
-
-    /** A module's own definitions as it wrote them, keyed by the name written there. */
-    static Map<String, Ast.Def> ownDefs(Ast.Module module) {
-        DeclaredNames.Of<Ast.Def> declared = DeclaredNames.of(module.defs(), Ast.Def::name,
-                Ast.Def::written, Ast.Def::pos);
-        if (!declared.rejected().isEmpty()) {
-            throw declared.rejected().get(0);
-        }
-        return declared.defs();
-    }
-
-    /** The declarations of a fixed set of modules, as they were written — what {@code Resolve}
-     * reads other modules by. */
-    static Registry<Ast.Def> ofWritten(Map<String, Ast.Module> modules) {
-        return new Registry<Ast.Def>() {
-            private final Map<String, Map<String, Ast.Def>> defs = new HashMap<>();
-
-            @Override
-            public Ast.Def declaration(TypeKey address) {
-                return declaredIn(address.module()).get(address.name());
-            }
-
-            @Override
-            public Map<String, Ast.Def> declaredIn(String moduleName) {
-                return defs.computeIfAbsent(moduleName, name -> {
-                    Ast.Module m = modules.get(name);
-                    return m == null ? Map.of() : ownDefs(m);
-                });
-            }
-
-            @Override
-            public Set<String> exposedBy(String moduleName) {
-                Ast.Module m = modules.get(moduleName);
-                return m == null ? Set.of() : baseNames(m.exposing());
-            }
-
-            @Override
-            public Set<String> moduleNames() {
-                return modules.keySet();
-            }
-        };
+    static <D> Registry<D> empty() {
+        return ofRead(Map.of(), Map.of());
     }
 
     /**
-     * The declarations of a set of modules already indexed, for a reader that settled which of them
-     * could be indexed at all.
+     * The declarations of a set of modules already indexed.
      *
-     * <p>{@link #ofWritten} works a module's definitions out on first use and raises where they
-     * cannot be indexed, which is what a compilation wants: the raise is the report, said against
-     * the source that carries the second declaration. A reader of what another build published has
-     * nobody to say it to — the source is not this compile's, and a module it cannot index is one
-     * it cannot read rather than one anybody here got wrong. So it indexes each module once, keeps
-     * what that settled, and reads by this.
+     * <p>Indexed by the caller, because what a refusal means depends on where the declarations came
+     * from and this cannot know: a module of this compilation has an author to report it to, one
+     * read back off an artifact has nobody and is an artifact this compiler will not read, and one
+     * the compiler ships is a fault in the compiler. Each of those is said where the module is
+     * obtained, and what arrives here is what was left standing.
      *
      * <p>A module that had nothing to give is not among {@code declarations}, and is answered the
      * way a module nobody has is answered. Which of the two it was is not this registry's to say:
      * that is what the reader settled, and it says it where it says what it has.
+     *
+     * @param declarations what each module declares, by the name written there
+     * @param exposed      the base type names each module exposes ({@link #baseNames}), whose names
+     *                     are the modules this registry has
      */
-    static Registry<Ast.Def> ofRead(Map<String, Ast.Module> modules,
-                                    Map<String, Map<String, Ast.Def>> declarations) {
-        return new Registry<Ast.Def>() {
+    static <D> Registry<D> ofRead(Map<String, Map<String, D>> declarations,
+                                  Map<String, Set<String>> exposed) {
+        Map<String, Map<String, D>> declared = Map.copyOf(declarations);
+        Map<String, Set<String>> exposes = Map.copyOf(exposed);
+        return new Registry<D>() {
 
             @Override
-            public Ast.Def declaration(TypeKey address) {
+            public D declaration(TypeKey address) {
                 return declaredIn(address.module()).get(address.name());
             }
 
             @Override
-            public Map<String, Ast.Def> declaredIn(String moduleName) {
-                return declarations.getOrDefault(moduleName, Map.of());
+            public Map<String, D> declaredIn(String moduleName) {
+                return declared.getOrDefault(moduleName, Map.of());
             }
 
             @Override
             public Set<String> exposedBy(String moduleName) {
-                Ast.Module m = modules.get(moduleName);
-                return m == null ? Set.of() : baseNames(m.exposing());
+                return exposes.getOrDefault(moduleName, Set.of());
             }
 
             @Override
             public Set<String> moduleNames() {
-                return modules.keySet();
+                return exposes.keySet();
             }
         };
+    }
+
+    /** What one module declares as it was written, and the declarations it may not have. */
+    static DeclaredNames.Index<Ast.Def> indexed(Ast.Module module) {
+        return DeclaredNames.index(module.defs(), Ast.Def::name);
+    }
+
+    /** What one resolved module declares, and the declarations it may not have. */
+    static DeclaredNames.Index<Hir.Def> indexed(Hir.Module module) {
+        return DeclaredNames.index(module.defs(), Hir.Def::name);
     }
 
     /** An {@code exposing} list as the type names it names: {@code Amount.decoder} exposes

--- a/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Hir;
+import souther.compiler.diag.CompileException;
 import souther.compiler.types.Denotation;
 import souther.compiler.types.TypeKey;
 
@@ -36,26 +37,26 @@ public final class Symbols implements NameSense {
     /**
      * A lone module, compiled with nothing else in sight: bare names are its own definitions.
      *
-     * <p>Indexed here, so that what comes back is a symbol table over declarations this module has.
-     * A declaration it may not have is refused where the module is read — reported against the
-     * source that wrote it, or answered as an artifact this compiler will not read — so one that
-     * survived as far as a resolved module is a module nothing read, which is a fault here rather
-     * than something to say to anybody.
+     * <p>Indexed here, so that what comes back is a symbol table over declarations this module has,
+     * and refused here where it may not have one. Refused as the report and not as a fault: a module
+     * of this compilation reaches this stage carrying a declaration it may not have, because
+     * {@code Names} reports that one and goes on with the rest, and resolution resolves the module
+     * as it was written. So the author holds the file, and what to do about it is the same thing
+     * {@link SyntaxSymbols#of(souther.compiler.ast.Ast.Module)} says one representation earlier.
      */
     public static Symbols of(Hir.Module m) {
         DeclaredNames.Index<Hir.Def> declared = Registry.indexed(m);
         if (!declared.refusals().isEmpty()) {
-            throw new IllegalStateException("`"
-                    + declared.refusals().get(0).refused().name() + "` is a declaration "
-                    + m.name() + " may not have, and a module still carrying one was never read");
+            throw CompileException.of(
+                    DeclarationRefusals.reportedAsResolved(declared.refusals().get(0)));
         }
         Map<String, Denotation> names = new HashMap<>();
         for (Hir.Def def : declared.declarations().values()) {
             names.put(def.name(), new Denotation.Denotes(def.declares()));
         }
         return new Symbols(m.name(),
-                Registry.ofRead(Map.of(m.name(), declared.declarations()),
-                        Map.of(m.name(), Registry.baseNames(m.exposing()))),
+                Registry.ofRead(Map.of(m.name(), new Registry.Declared<>(
+                        declared.declarations(), Registry.baseNames(m.exposing())))),
                 names, Map.of());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
@@ -33,23 +33,33 @@ public final class Symbols implements NameSense {
         return new Symbols("", Registry.empty(), Map.of(), Map.of());
     }
 
-    /** A lone module, compiled with nothing else in sight: bare names are its own definitions. */
+    /**
+     * A lone module, compiled with nothing else in sight: bare names are its own definitions.
+     *
+     * <p>Indexed here, so that what comes back is a symbol table over declarations this module has.
+     * A declaration it may not have is refused where the module is read — reported against the
+     * source that wrote it, or answered as an artifact this compiler will not read — so one that
+     * survived as far as a resolved module is a module nothing read, which is a fault here rather
+     * than something to say to anybody.
+     */
     public static Symbols of(Hir.Module m) {
+        DeclaredNames.Index<Hir.Def> declared = Registry.indexed(m);
+        if (!declared.refusals().isEmpty()) {
+            throw new IllegalStateException("`"
+                    + declared.refusals().get(0).refused().name() + "` is a declaration "
+                    + m.name() + " may not have, and a module still carrying one was never read");
+        }
         Map<String, Denotation> names = new HashMap<>();
-        for (Hir.Def def : TypeChecker.ownDefs(m).values()) {
+        for (Hir.Def def : declared.declarations().values()) {
             names.put(def.name(), new Denotation.Denotes(def.declares()));
         }
-        return new Symbols(m.name(), Registry.of(Map.of(m.name(), m)), names, Map.of());
+        return new Symbols(m.name(),
+                Registry.ofRead(Map.of(m.name(), declared.declarations()),
+                        Map.of(m.name(), Registry.baseNames(m.exposing()))),
+                names, Map.of());
     }
 
-    /** A module compiled against a registry: {@code names} is what its bare names mean (own plus
-     * imported) and {@code aliases} maps each {@code import ... as} alias to its module. */
-    public static Symbols of(Hir.Module m, Map<String, Hir.Module> registry,
-                             Map<String, Denotation> names, Map<String, String> aliases) {
-        return of(m.name(), Registry.of(registry), names, aliases);
-    }
-
-    /** As {@link #of(Hir.Module, Map, Map, Map)}, over a registry that reads its declarations
+    /** A module compiled over a registry that reads its declarations
      * however it likes — the form a query-backed compilation uses, where a module's definitions are
      * asked for one at a time rather than held in a map.
      *

--- a/souther-compiler/src/main/java/souther/compiler/check/SyntaxSymbols.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SyntaxSymbols.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.diag.CompileException;
 import souther.compiler.types.Denotation;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
@@ -40,17 +41,32 @@ public final class SyntaxSymbols implements NameSense {
 
     /** No module at all — for signatures written over primitives and type variables only. */
     public static SyntaxSymbols none() {
-        return new SyntaxSymbols("", Registry.ofWritten(Map.of()), Map.of(), Map.of());
+        return new SyntaxSymbols("", Registry.empty(), Map.of(), Map.of());
     }
 
-    /** A lone module, resolved with nothing else in sight: bare names are its own definitions. */
+    /**
+     * A lone module, resolved with nothing else in sight: bare names are its own definitions.
+     *
+     * <p>The module is indexed here and refused here. This is the door a source comes in at with
+     * nowhere for a report to be collected, so a declaration the module may not have is raised as
+     * the report — which is what a compilation wants of its own source. What it is not is a lookup
+     * that refuses: the raise is at the one statement that builds the table, and what comes out
+     * answers every later question about what the module declares.
+     */
     public static SyntaxSymbols of(Ast.Module m) {
+        DeclaredNames.Index<Ast.Def> declared = Registry.indexed(m);
+        if (!declared.refusals().isEmpty()) {
+            throw CompileException.of(DeclarationRefusals.reported(declared.refusals().get(0)));
+        }
         Map<String, Denotation> names = new HashMap<>();
-        for (Ast.Def def : Registry.ownDefs(m).values()) {
+        for (Ast.Def def : declared.declarations().values()) {
             names.put(def.name(),
                     new Denotation.Denotes(TypeSymbols.declared(def.declaredKey())));
         }
-        return new SyntaxSymbols(m.name(), Registry.ofWritten(Map.of(m.name(), m)), names, Map.of());
+        return new SyntaxSymbols(m.name(),
+                Registry.ofRead(Map.of(m.name(), declared.declarations()),
+                        Map.of(m.name(), Registry.baseNames(m.exposing()))),
+                names, Map.of());
     }
 
     /** A module resolved against a registry that reads its declarations however it likes — the form

--- a/souther-compiler/src/main/java/souther/compiler/check/SyntaxSymbols.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SyntaxSymbols.java
@@ -56,7 +56,8 @@ public final class SyntaxSymbols implements NameSense {
     public static SyntaxSymbols of(Ast.Module m) {
         DeclaredNames.Index<Ast.Def> declared = Registry.indexed(m);
         if (!declared.refusals().isEmpty()) {
-            throw CompileException.of(DeclarationRefusals.reported(declared.refusals().get(0)));
+            throw CompileException.of(
+                    DeclarationRefusals.reportedAsWritten(declared.refusals().get(0)));
         }
         Map<String, Denotation> names = new HashMap<>();
         for (Ast.Def def : declared.declarations().values()) {
@@ -64,8 +65,8 @@ public final class SyntaxSymbols implements NameSense {
                     new Denotation.Denotes(TypeSymbols.declared(def.declaredKey())));
         }
         return new SyntaxSymbols(m.name(),
-                Registry.ofRead(Map.of(m.name(), declared.declarations()),
-                        Map.of(m.name(), Registry.baseNames(m.exposing()))),
+                Registry.ofRead(Map.of(m.name(), new Registry.Declared<>(
+                        declared.declarations(), Registry.baseNames(m.exposing())))),
                 names, Map.of());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -452,30 +452,4 @@ public final class TypeChecker {
         return Symbols.of(module);
     }
 
-    /** A module's own definitions, keyed by the name written there. */
-    public static Map<String, Hir.Def> ownDefs(Hir.Module module) {
-        Declared declared = declared(module);
-        if (!declared.rejected().isEmpty()) {
-            throw declared.rejected().get(0);
-        }
-        return declared.defs();
-    }
-
-    /** What a module declares, and the declarations it cannot have. */
-    public record Declared(Map<String, Hir.Def> defs, List<CompileException> rejected) {}
-
-    /**
-     * Every declaration a module may have, by name, and one error per declaration it may not.
-     *
-     * <p>A name declared twice keeps the first: the second is reported and left out, so the rest of
-     * the module still means what it means. Writing a declaration twice is what copying one looks
-     * like halfway through, and taking every name in the file away until it is finished is the
-     * opposite of useful.
-     */
-    public static Declared declared(Hir.Module module) {
-        DeclaredNames.Of<Hir.Def> declared = DeclaredNames.of(module.defs(), Hir.Def::name,
-                Hir.Def::written, Hir.Def::pos);
-        return new Declared(declared.defs(), declared.rejected());
-    }
-
 }

--- a/souther-compiler/src/main/java/souther/compiler/meta/ModuleReadback.java
+++ b/souther-compiler/src/main/java/souther/compiler/meta/ModuleReadback.java
@@ -240,19 +240,6 @@ public final class ModuleReadback {
     }
 
     /**
-     * A refusal the check found, as a fact about the artifact it was found in.
-     *
-     * <p>The place goes here and nowhere else. A refusal carries the {@code import} line it was
-     * written on, which is what lets a reader holding that source quote it; this side has no source
-     * to quote and the line is in a text nobody holds, so what crosses is what happened. Left on,
-     * the position this whole type exists to keep out would have arrived as an AST node instead of
-     * as a diagnostic.
-     *
-     * <p>A switch over every refusal there is, with nothing to fall through to: a rule added to the
-     * check is one this boundary has to say something about, and one that reached here with nothing
-     * to say would be an artifact refused for a reason nobody can name.
-     */
-    /**
      * A declaration the indexing refused, as a fact about the artifact it was found in.
      *
      * <p>The declaration goes and the node stays behind, for the reason a refused import line's
@@ -274,6 +261,19 @@ public final class ModuleReadback {
         };
     }
 
+    /**
+     * A refusal the check found, as a fact about the artifact it was found in.
+     *
+     * <p>The place goes here and nowhere else. A refusal carries the {@code import} line it was
+     * written on, which is what lets a reader holding that source quote it; this side has no source
+     * to quote and the line is in a text nobody holds, so what crosses is what happened. Left on,
+     * the position this whole type exists to keep out would have arrived as an AST node instead of
+     * as a diagnostic.
+     *
+     * <p>A switch over every refusal there is, with nothing to fall through to: a rule added to the
+     * check is one this boundary has to say something about, and one that reached here with nothing
+     * to say would be an artifact refused for a reason nobody can name.
+     */
     private static Readback.Exposure asAnArtifactsFailure(Exposing.Refusal refusal) {
         return switch (refusal) {
             case Exposing.Refusal.NoSuchLibraryFunction r ->

--- a/souther-compiler/src/main/java/souther/compiler/meta/ModuleReadback.java
+++ b/souther-compiler/src/main/java/souther/compiler/meta/ModuleReadback.java
@@ -1,7 +1,9 @@
 package souther.compiler.meta;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.check.DeclaredNames;
 import souther.compiler.check.Exposing;
+import souther.compiler.check.Registry;
 import souther.compiler.codegen.Backend;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.SourceProvenance;
@@ -33,11 +35,12 @@ import java.util.Set;
  * arrives with no types written and is settled again here — including one that names what a value is
  * and leaves what it holds open, which is why no type variable has to be written for it to cross.
  *
- * <p>Reading the import lines is part of reading the module and not a step after it. A module comes
- * out of here with its library names already answered ({@link ReadableModule}), because the lines
- * that carried them are dropped once read and nothing else says what its bare names mean. Split in
- * two, a caller did the first and not the second, and an invariant that called a name its module
- * imported bare then resolved against nothing in every project but the one that wrote it.
+ * <p>Reading the import lines is part of reading the module and not a step after it, and so is
+ * indexing what it declares. A module comes out of here with its library names already answered and
+ * its declarations already indexed ({@link ReadableModule}), because both can fail and both used to
+ * be left to whoever wanted them: a caller that read the module and not the import lines held one
+ * whose bare names resolved against nothing in every project but the one that wrote it, and a
+ * caller that indexed afterwards had a known failure arriving as a raise from inside a lookup.
  *
  * <p>Nothing here raises for an artifact this compiler will not read. Every such failure is a
  * {@link Readback.Failure}, named where it is found by the code that knows its shape, so what
@@ -187,6 +190,17 @@ public final class ModuleReadback {
             // of this module here, whatever the class carries.
             return unreadable(moduleName, new Readback.Failure.AnotherModule(parsed.name()));
         }
+        // Indexed before the import lines are read, because that is the order the two questions
+        // depend on each other in: what the module declares is settled by what it wrote, and
+        // whether a line may bring a name in is asked against the declarations. Read the other way
+        // round, a line is held against a set of declarations this compiler has already refused.
+        DeclaredNames.Index<Ast.Def> declared = Registry.indexed(parsed);
+        if (!declared.refusals().isEmpty()) {
+            List<Readback.DeclarationRejection> refused = declared.refusals().stream()
+                    .map(ModuleReadback::asAnArtifactsRejection).toList();
+            return unreadable(moduleName, new Readback.Failure.InvalidDeclarations(
+                    refused.get(0), refused.subList(1, refused.size())));
+        }
         // Which imports are needed is asked of the header and the declarations — everything that was
         // published except the import lines themselves.
         Exposing.Checked checked =
@@ -198,7 +212,7 @@ public final class ModuleReadback {
                     crossed.get(0), crossed.subList(1, crossed.size())));
         }
         return new Readback.Ready(
-                new AsRead(checked.module(), injected, checked.exposed()));
+                new AsRead(checked.module(), declared.declarations(), injected, checked.exposed()));
     }
 
     /**
@@ -208,12 +222,14 @@ public final class ModuleReadback {
      * can make one, and nothing inside it does — so a value of this type is a reading that got to
      * the end, rather than a value somebody assembled that looks like one.
      */
-    record AsRead(Ast.Module module, Set<String> injectedBehaviors,
+    record AsRead(Ast.Module module, Map<String, Ast.Def> declarations,
+                  Set<String> injectedBehaviors,
                   Map<String, ValueName.Stdlib> libraryNames) implements ReadableModule {
 
         /** Copied, because this is an answer a compilation remembers and an answer it remembers is
          *  a value. */
         AsRead {
+            declarations = Collections.unmodifiableMap(new LinkedHashMap<>(declarations));
             injectedBehaviors = Collections.unmodifiableSet(new LinkedHashSet<>(injectedBehaviors));
             libraryNames = Collections.unmodifiableMap(new LinkedHashMap<>(libraryNames));
         }
@@ -236,6 +252,28 @@ public final class ModuleReadback {
      * check is one this boundary has to say something about, and one that reached here with nothing
      * to say would be an artifact refused for a reason nobody can name.
      */
+    /**
+     * A declaration the indexing refused, as a fact about the artifact it was found in.
+     *
+     * <p>The declaration goes and the node stays behind, for the reason a refused import line's
+     * does: what the indexing hands back is the form it refused, and every place in that form is a
+     * place in a text this reading assembled. What crosses is which declaration and which rule.
+     *
+     * <p>A switch over every rule there is, with nothing to fall through to. A rule added to the
+     * indexing is one this boundary has to say something about, and one that reached here with
+     * nothing to say would be an artifact refused for a reason nobody can name.
+     */
+    private static Readback.DeclarationRejection asAnArtifactsRejection(
+            DeclaredNames.Refusal<Ast.Def> refusal) {
+        String declaration = refusal.refused().name();
+        return switch (refusal) {
+            case DeclaredNames.Refusal.DeclaredTwice<Ast.Def> _ ->
+                    new Readback.DeclarationRejection.DeclaredTwice(declaration);
+            case DeclaredNames.Refusal.ABuiltInOptionCaseIsDeclared<Ast.Def> _ ->
+                    new Readback.DeclarationRejection.BuiltInOptionCaseDeclared(declaration);
+        };
+    }
+
     private static Readback.Exposure asAnArtifactsFailure(Exposing.Refusal refusal) {
         return switch (refusal) {
             case Exposing.Refusal.NoSuchLibraryFunction r ->

--- a/souther-compiler/src/main/java/souther/compiler/meta/PublishedUniverse.java
+++ b/souther-compiler/src/main/java/souther/compiler/meta/PublishedUniverse.java
@@ -176,13 +176,12 @@ public final class PublishedUniverse {
      * declares and what resolution finds there are one answer rather than two that happen to agree.
      */
     private Registry<Ast.Def> declaredBy() {
-        Map<String, Map<String, Ast.Def>> declared = new LinkedHashMap<>();
-        Map<String, Set<String>> exposed = new LinkedHashMap<>();
+        Map<String, Registry.Declared<Ast.Def>> declared = new LinkedHashMap<>();
         for (Map.Entry<String, ReadableModule> each : read.entrySet()) {
-            declared.put(each.getKey(), each.getValue().declarations());
-            exposed.put(each.getKey(), Registry.baseNames(each.getValue().module().exposing()));
+            declared.put(each.getKey(), new Registry.Declared<>(each.getValue().declarations(),
+                    Registry.baseNames(each.getValue().module().exposing())));
         }
-        return Registry.ofRead(declared, exposed);
+        return Registry.ofRead(declared);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/meta/PublishedUniverse.java
+++ b/souther-compiler/src/main/java/souther/compiler/meta/PublishedUniverse.java
@@ -7,8 +7,6 @@ import souther.compiler.check.ModuleUniverse;
 import souther.compiler.check.Registry;
 import souther.compiler.check.Resolve;
 import souther.compiler.check.Scoping;
-import souther.compiler.diag.CompileException;
-import souther.compiler.types.ValueName;
 import souther.compiler.query.Front;
 
 import java.util.ArrayDeque;
@@ -40,9 +38,10 @@ import java.util.Set;
 public final class PublishedUniverse {
 
     private final PublishedClasses classes;
-    private final Map<String, Ast.Module> written = new LinkedHashMap<>();
-    private final Map<String, Map<String, ValueName.Stdlib>> libraryNames = new LinkedHashMap<>();
-    private final Map<String, Set<String>> injected = new LinkedHashMap<>();
+    // What each module gave, as the one value a reading answers with. Three maps filled at one
+    // statement apiece is three places to remember, and the fact they hold is one fact: this is
+    // what reading that module came back with.
+    private final Map<String, ReadableModule> read = new LinkedHashMap<>();
     private final Map<String, Read> resolved = new LinkedHashMap<>();
     private final Set<String> unreadable = new LinkedHashSet<>();
     // What was reached and gave no reading, told apart the way a universe tells them apart: a name
@@ -73,13 +72,13 @@ public final class PublishedUniverse {
             return already;
         }
         readReaching(module);
-        if (!written.containsKey(module)) {
+        if (!read.containsKey(module)) {
             unreadable.add(module);
             return null;
         }
         ModuleUniverse universe = universe();
-        Registry<Ast.Def> registry = declaredBy(universe);
-        for (String name : Set.copyOf(written.keySet())) {
+        Registry<Ast.Def> registry = declaredBy();
+        for (String name : Set.copyOf(read.keySet())) {
             if (resolved.containsKey(name)) {
                 continue;
             }
@@ -87,7 +86,7 @@ public final class PublishedUniverse {
             if (hir == null) {
                 unreadable.add(name);
             } else {
-                resolved.put(name, new Read(hir, injected.getOrDefault(name, Set.of())));
+                resolved.put(name, new Read(hir, read.get(name).injectedBehaviors()));
             }
         }
         return resolved.get(module);
@@ -116,25 +115,23 @@ public final class PublishedUniverse {
         Set<String> tried = new LinkedHashSet<>(Set.of(module));
         while (!toRead.isEmpty()) {
             String name = toRead.removeFirst();
-            if (written.containsKey(name) || unreadable.contains(name)) {
+            if (read.containsKey(name) || unreadable.contains(name)) {
                 continue;
             }
             // Which of the two a name is comes off the reading itself. It used to be asked again of
             // the classes afterwards, because a reading that failed answered null however it failed.
             Readback readback = ModuleReadback.read(name, classes);
-            if (!(readback instanceof Readback.Ready(ReadableModule read))) {
+            if (!(readback instanceof Readback.Ready(ReadableModule readable))) {
                 unreadable.add(name);
                 beyondReading.put(name, readback instanceof Readback.Unreadable
                         ? ModuleUniverse.InSight.UNREADABLE : ModuleUniverse.InSight.UNKNOWN);
                 continue;
             }
-            written.put(name, read.module());
-            libraryNames.put(name, read.libraryNames());
-            injected.put(name, read.injectedBehaviors());
+            read.put(name, readable);
             // Which modules a module's declarations name, answered where the compiler answers it:
             // an import line names one, and so does a type or a behavior written with a qualifier,
             // which needs no import at all.
-            for (String reaches : Front.reaches(read.module()).keySet()) {
+            for (String reaches : Front.reaches(readable.module()).keySet()) {
                 if (tried.add(reaches)) {
                     toRead.addLast(reaches);
                 }
@@ -156,45 +153,36 @@ public final class PublishedUniverse {
     /**
      * What was read, as the universe a module is resolved against.
      *
-     * <p>Every module is indexed here, once, and this is the only place indexing one can fail. A
-     * registry that works a module's declarations out when it is first asked raises wherever it is
-     * asked from, and a reader that caught the first ask was caught by the second: a module named
-     * with a qualifier is asked for again while some other module is being resolved, and the raise
-     * came back out of a reading that answers absences.
+     * <p>Nothing is worked out here. A module that came back readable came back indexed — which
+     * declarations it has is settled while it is read, and a set of declarations one module may not
+     * have is an artifact this compiler will not read, said as that. So a module is in sight with
+     * what it declares, or it is one of the two kinds of absence, and there is no third thing that
+     * can go wrong at the moment a universe is assembled.
      */
     private ModuleUniverse universe() {
         Map<String, ModuleUniverse.InSight> modules = new LinkedHashMap<>(beyondReading);
-        for (Map.Entry<String, Ast.Module> each : written.entrySet()) {
-            modules.put(each.getKey(), sighted(each.getValue()));
+        for (Map.Entry<String, ReadableModule> each : read.entrySet()) {
+            modules.put(each.getKey(), new ModuleUniverse.InSight.Read(
+                    each.getValue().module(), each.getValue().declarations()));
         }
         return new ModuleUniverse.OfWhatIsRead(modules);
     }
 
-    /** One module of that universe: what it wrote and what it declares, or nothing to be built on. */
-    private static ModuleUniverse.InSight sighted(Ast.Module module) {
-        try {
-            return new ModuleUniverse.InSight.Read(module, Registry.ownDefs(module));
-        } catch (CompileException | IllegalArgumentException _) {
-            return ModuleUniverse.InSight.UNREADABLE;
-        }
-    }
-
     /**
-     * What resolution reads other modules by: the declarations this universe settled, and nothing
+     * What resolution reads other modules by: the declarations each reading settled, and nothing
      * worked out again.
      *
-     * <p>Built from the universe rather than beside it, so what a scope says a module declares and
-     * what resolution finds there are one answer. A module the universe has nothing to give for is
-     * not among them, and is read the way a module nobody has is read.
+     * <p>Built from the same readings the universe is built from, so what a scope says a module
+     * declares and what resolution finds there are one answer rather than two that happen to agree.
      */
-    private Registry<Ast.Def> declaredBy(ModuleUniverse universe) {
+    private Registry<Ast.Def> declaredBy() {
         Map<String, Map<String, Ast.Def>> declared = new LinkedHashMap<>();
-        for (String name : written.keySet()) {
-            if (universe.module(name) instanceof ModuleUniverse.InSight.Read read) {
-                declared.put(name, read.declarations());
-            }
+        Map<String, Set<String>> exposed = new LinkedHashMap<>();
+        for (Map.Entry<String, ReadableModule> each : read.entrySet()) {
+            declared.put(each.getKey(), each.getValue().declarations());
+            exposed.put(each.getKey(), Registry.baseNames(each.getValue().module().exposing()));
         }
-        return Registry.ofRead(Map.copyOf(written), declared);
+        return Registry.ofRead(declared, exposed);
     }
 
     /**
@@ -215,8 +203,8 @@ public final class PublishedUniverse {
         if (!(universe.module(module) instanceof ModuleUniverse.InSight.Read read)) {
             return null;
         }
-        Scoping.Scoped scoped =
-                Scoping.of(universe, new Scoping.Subject(read, libraryNames.get(module)));
+        Scoping.Scoped scoped = Scoping.of(universe,
+                new Scoping.Subject(read, this.read.get(module).libraryNames()));
         if (!scoped.refused().isEmpty()) {
             return null;
         }

--- a/souther-compiler/src/main/java/souther/compiler/meta/ReadableModule.java
+++ b/souther-compiler/src/main/java/souther/compiler/meta/ReadableModule.java
@@ -35,6 +35,18 @@ public sealed interface ReadableModule permits ModuleReadback.AsRead {
     /** The module as the front end read it, with its library import lines dropped. */
     Ast.Module module();
 
+    /**
+     * What it declares, by the name written there — indexed once, where it was read.
+     *
+     * <p>Here rather than worked out by whoever needs it, because indexing is a step of the reading
+     * and can refuse: a set of declarations one module may not have is an artifact this compiler
+     * will not read ({@link Readback.Failure.InvalidDeclarations}). A reader that indexed for itself
+     * would be asking, after the fact, a question the reading has already answered — and would have
+     * to decide what to do when the answer is no, which is how a known failure came to travel as a
+     * raise out of a lookup.
+     */
+    Map<String, Ast.Def> declarations();
+
     /** The behaviors this module publishes no implementation for. */
     Set<String> injectedBehaviors();
 

--- a/souther-compiler/src/main/java/souther/compiler/meta/Readback.java
+++ b/souther-compiler/src/main/java/souther/compiler/meta/Readback.java
@@ -110,6 +110,55 @@ public sealed interface Readback {
                 rest = List.copyOf(rest);
             }
         }
+
+        /**
+         * Its declarations are not a set of declarations one module may have.
+         *
+         * <p>A published module can carry such a set: it was published under the rules of the
+         * compiler that built it, and a rule this one has that that one did not is broken by an
+         * artifact nobody here can edit. Which is what makes it a fact about the artifact rather
+         * than a report — indexing this module's declarations is refused, so there is no module
+         * here to have declarations at all.
+         *
+         * <p>At least one, and the type says so, for the reason {@link InvalidExposure} says it.
+         */
+        record InvalidDeclarations(DeclarationRejection first, List<DeclarationRejection> rest)
+                implements Failure {
+
+            public InvalidDeclarations {
+                java.util.Objects.requireNonNull(first,
+                        "a declarations failure is at least one declaration");
+                rest = List.copyOf(rest);
+            }
+        }
+    }
+
+    /**
+     * One declaration of an artifact that this compiler will not index, as a fact about the
+     * artifact.
+     *
+     * <p>The same shape as {@link Exposure}, and here for the same reason. What the indexing finds
+     * is a refusal carrying the declaration it refused — an AST node, with the place in the
+     * published text it was parsed from — and the place is in a text nobody holds. So the refusal is
+     * projected here, and what crosses is which declaration and which rule.
+     *
+     * <p>Told apart from the reasons a readback fails, because the two are at different
+     * granularities and about different things: a {@link Failure} says which part of reading an
+     * artifact did not hold, and this says what is wrong with the declarations it carries. Flattened
+     * into {@code Failure}, the reasons a set of declarations can be refused would be arms of the
+     * type that says how far a reading got.
+     */
+    sealed interface DeclarationRejection {
+
+        /** The declaration this is about. */
+        String declaration();
+
+        /** The module declares the name twice. */
+        record DeclaredTwice(String declaration) implements DeclarationRejection {}
+
+        /** It is named after a built-in {@code Option} case, which no module may declare
+         *  (ADR-0035). */
+        record BuiltInOptionCaseDeclared(String declaration) implements DeclarationRejection {}
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -376,6 +376,11 @@ public final class Front {
                 return read.module();
             }
 
+            /** What it declares, indexed where it was read back. */
+            public Map<String, Ast.Def> declarations() {
+                return read.declarations();
+            }
+
             public Set<String> injectedBehaviors() {
                 return read.injectedBehaviors();
             }
@@ -696,6 +701,10 @@ public final class Front {
             case Readback.Failure.InvalidExposure(Readback.Exposure line, List<Readback.Exposure> _) ->
                     said.hint(new ModuleMessage.AnImportLineOfItsCannotBeReadHere(
                             line.name(), line.from()));
+            case Readback.Failure.InvalidDeclarations(
+                    Readback.DeclarationRejection first, List<Readback.DeclarationRejection> _) ->
+                    said.hint(new ModuleMessage.ADeclarationOfItsCannotBeReadHere(
+                            first.declaration()));
         };
         return because.hint(new ModuleMessage.RebuildItOrCompileAgainstWhatBuiltIt(module)).build();
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -226,7 +226,7 @@ public final class Names {
                 DeclaredNames.Index<Ast.Def> declared = Registry.indexed(mine.value());
                 List<Report> reports = new ArrayList<>();
                 for (DeclaredNames.Refusal<Ast.Def> refused : declared.refusals()) {
-                    reports.add(Report.of(DeclarationRefusals.reported(refused)));
+                    reports.add(Report.of(DeclarationRefusals.reportedAsWritten(refused)));
                 }
                 return Answer.of(declared.declarations(), reports);
             }

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -6,6 +6,7 @@ import souther.compiler.check.Prelude;
 import souther.compiler.ast.Ast;
 import souther.compiler.ast.Hir;
 import souther.compiler.ast.WrittenName;
+import souther.compiler.check.DeclarationRefusals;
 import souther.compiler.check.DeclaredNames;
 import souther.compiler.check.ModuleUniverse;
 import souther.compiler.check.Scoping;
@@ -186,8 +187,23 @@ public final class Names {
         };
     }
 
-    /** What a module declares, by the name written there — checked once, here, because the names
-     * are the same at every stage and every later registry reads them through this. */
+    /**
+     * What a module declares, by the name written there — asked once, here, because the names are
+     * the same at every stage and every later registry reads them through this.
+     *
+     * <p>Where the answer is worked out depends on where the module came from, and nothing above
+     * has to know which: a source of this compilation is indexed here and a declaration it may not
+     * have is reported against the file its author holds; a module off the class path was indexed
+     * where it was read back, and one whose declarations could not be indexed never became a module
+     * this compilation has. So the two are one question with one answer, and a caller holding the
+     * answer cannot tell — which is the point, since a caller that could would be a second place the
+     * rule is written.
+     *
+     * <p>Indexing an artifact here is what this replaces. The declarations came back as source, so
+     * they were indexed like source, and a name a published module declared twice was reported to
+     * the author of the project importing it — {@code E1011}, under the caret of their own
+     * {@code import} line, about a file they do not have and did not write.
+     */
     public record Declarations(String name) implements Key<Map<String, Ast.Def>> {
         @Override
         public String module() {
@@ -202,20 +218,20 @@ public final class Names {
                 // ask a question that is answering itself.
                 return Answer.absent();
             }
-            Answer<Ast.Module> m = db.ask(new Front.Available(name));
-            if (!m.present()) {
-                return Answer.absent();
+            Answer<Ast.Module> mine = db.ask(new Front.Exposed(name));
+            if (mine.present()) {
+                // A declaration the module may not have is reported and left out; the ones it may
+                // have are what it declares. So a name written twice does not take every other name
+                // in the file with it.
+                DeclaredNames.Index<Ast.Def> declared = Registry.indexed(mine.value());
+                List<Report> reports = new ArrayList<>();
+                for (DeclaredNames.Refusal<Ast.Def> refused : declared.refusals()) {
+                    reports.add(Report.of(DeclarationRefusals.reported(refused)));
+                }
+                return Answer.of(declared.declarations(), reports);
             }
-            // A declaration the module may not have is reported and left out; the ones it may have
-            // are what it declares. So a name written twice does not take every other name in the
-            // file with it.
-            DeclaredNames.Of<Ast.Def> declared = DeclaredNames.of(m.value().defs(),
-                    Ast.Def::name, Ast.Def::written, Ast.Def::pos);
-            List<Report> reports = new ArrayList<>();
-            for (CompileException rejected : declared.rejected()) {
-                reports.addAll(Report.of(rejected));
-            }
-            return Answer.of(declared.defs(), reports);
+            Front.FromPath.OnThePath fromPath = Front.onThePath(db, name);
+            return fromPath == null ? Answer.absent() : Answer.of(fromPath.declarations());
         }
     }
 

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -442,6 +442,7 @@ module.its-metadata-cannot-be-read-here=One of its classes carries metadata this
 module.it-declares-another-module=What it carries declares `{named}`, not the module it was found under.
 module.what-it-published-is-not-source-this-compiler-parses=What it published is not source this compiler parses.
 module.an-import-line-of-its-cannot-be-read-here=Its `import {from} ( {name} )` is not a line this compiler can read.
+module.a-declaration-of-its-cannot-be-read-here=Its `{declaration}` is not a declaration this compiler can read there.
 module.rebuild-it-or-compile-against-what-built-it=Rebuild `{module}` with this compiler, or compile against the version that built it.
 module.unknown-module=Unknown module `{module}`.
 module.the-module-does-not-expose-it=`{name}` is not exposed by `{module}`.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -437,6 +437,7 @@ module.its-metadata-cannot-be-read-here=そのクラスの1つが、このコン
 module.it-declares-another-module=クラスが運んでいる宣言は `{named}` のもので、それが置かれていたモジュールのものではありません。
 module.what-it-published-is-not-source-this-compiler-parses=公開された内容が、このコンパイラの読めるソースになっていません。
 module.an-import-line-of-its-cannot-be-read-here=その `import {from} ( {name} )` は、このコンパイラが読める行ではありません。
+module.a-declaration-of-its-cannot-be-read-here=その `{declaration}` は、このコンパイラがそこで読める宣言ではありません。
 module.rebuild-it-or-compile-against-what-built-it=`{module}` をこのコンパイラでビルドし直すか、それをビルドしたバージョンでコンパイルしてください。
 module.unknown-module=未知のモジュール `{module}` です。
 module.the-module-does-not-expose-it=`{name}` は `{module}` から公開されていません。

--- a/souther-compiler/src/test/java/souther/compiler/AnArtifactThisCompilerCannotReadIsSaidWhereItWasReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnArtifactThisCompilerCannotReadIsSaidWhereItWasReachedTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -244,6 +245,53 @@ class AnArtifactThisCompilerCannotReadIsSaidWhereItWasReachedTest {
 
         assertEquals(Set.of("E1023"), codes,
                 "the author's own mistake, and nothing about a line nothing published names");
+    }
+
+    /**
+     * What it declares is not a set of declarations one module may have.
+     *
+     * <p>The declarations came back as source, so they were indexed like source — and a name a
+     * published module declared twice was reported to the author of the project importing it. What
+     * they saw was {@code E1011}, "data `Held` is already defined", under the caret of their own
+     * {@code import} line: a rule about a file they do not have, quoted at a line of theirs that
+     * does not break it. Reading an artifact is one question with one answer, and this is one of the
+     * ways the answer is no.
+     */
+    @Test
+    void oneThatDeclaresANameTwice() {
+        Fabricated path = new Fabricated(Map.of(
+                "lib.pub.$Module", new PublishedClasses.Declarations(
+                        new PublishedClasses.SoutherModuleView(Backend.BOUNDARY_VERSION,
+                                "0.0.1-other", "module lib.pub exposing ( Held )",
+                                List.of(), List.of("Held", "Twice"), List.of(), List.of()),
+                        null, null, null),
+                "lib.pub.Held", dataClass("data Held = String"),
+                "lib.pub.Twice", dataClass("data Held = Int")));
+
+        bothAreSaidOnTheSource(path);
+        assertFalse(saidAboutTheSource(path).contains("E1011"),
+                "and not as a rule about declarations, said to somebody who declared none of them");
+    }
+
+    /**
+     * And a declaration named after a built-in {@code Option} case, which is the other rule the
+     * indexing has.
+     *
+     * <p>Here because the two rules are two arms of what crosses, and an arm nothing reaches is an
+     * arm nothing holds to anything. A module that declares {@code Some} was published under rules
+     * that allowed it (ADR-0035 is this compiler's), which is exactly the case an artifact carries
+     * and a source of this compile cannot.
+     */
+    @Test
+    void oneThatDeclaresABuiltInOptionCase() {
+        bothAreSaidOnTheSource(new Fabricated(Map.of(
+                "lib.pub.$Module", new PublishedClasses.Declarations(
+                        new PublishedClasses.SoutherModuleView(Backend.BOUNDARY_VERSION,
+                                "0.0.1-other", "module lib.pub exposing ( Held )",
+                                List.of(), List.of("Held", "Some"), List.of(), List.of()),
+                        null, null, null),
+                "lib.pub.Held", dataClass("data Held = String"),
+                "lib.pub.Some", dataClass("data Some = String"))));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatANameMeansDoesNotDependOnWhichUniverseAnsweredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatANameMeansDoesNotDependOnWhichUniverseAnsweredTest.java
@@ -102,15 +102,14 @@ class WhatANameMeansDoesNotDependOnWhichUniverseAnsweredTest {
 
     /** What resolution reads other modules by: what each reading of them settled. */
     private static Registry<Ast.Def> declaredBy(Map<String, ModuleUniverse.InSight> readings) {
-        Map<String, Map<String, Ast.Def>> declared = new LinkedHashMap<>();
-        Map<String, java.util.Set<String>> exposed = new LinkedHashMap<>();
+        Map<String, Registry.Declared<Ast.Def>> declared = new LinkedHashMap<>();
         readings.forEach((name, sighted) -> {
             if (sighted instanceof ModuleUniverse.InSight.Read there) {
-                declared.put(name, there.declarations());
-                exposed.put(name, Registry.baseNames(there.module().exposing()));
+                declared.put(name, new Registry.Declared<>(there.declarations(),
+                        Registry.baseNames(there.module().exposing())));
             }
         });
-        return Registry.ofRead(declared, exposed);
+        return Registry.ofRead(declared);
     }
 
     /** {@code module} resolved against {@code universe}, by the one assembly there is. */

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatANameMeansDoesNotDependOnWhichUniverseAnsweredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatANameMeansDoesNotDependOnWhichUniverseAnsweredTest.java
@@ -100,20 +100,27 @@ class WhatANameMeansDoesNotDependOnWhichUniverseAnsweredTest {
         return subject;
     }
 
+    /** What resolution reads other modules by: what each reading of them settled. */
+    private static Registry<Ast.Def> declaredBy(Map<String, ModuleUniverse.InSight> readings) {
+        Map<String, Map<String, Ast.Def>> declared = new LinkedHashMap<>();
+        Map<String, java.util.Set<String>> exposed = new LinkedHashMap<>();
+        readings.forEach((name, sighted) -> {
+            if (sighted instanceof ModuleUniverse.InSight.Read there) {
+                declared.put(name, there.declarations());
+                exposed.put(name, Registry.baseNames(there.module().exposing()));
+            }
+        });
+        return Registry.ofRead(declared, exposed);
+    }
+
     /** {@code module} resolved against {@code universe}, by the one assembly there is. */
     private static Hir.Module resolvedAgainst(ModuleUniverse universe, Scoping.Subject subject,
                                               Map<String, ModuleUniverse.InSight> readings) {
-        Map<String, Ast.Module> written = new LinkedHashMap<>();
-        readings.forEach((name, sighted) -> {
-            if (sighted instanceof ModuleUniverse.InSight.Read there) {
-                written.put(name, there.module());
-            }
-        });
         Scoping.Scoped scoped = Scoping.of(universe, subject);
         assertEquals(java.util.List.of(), scoped.refused(),
                 "nothing about this model is refused");
         Resolve.Resolution answered = Resolve.resolving(subject.read().module(),
-                scoped.writtenSymbols(Registry.ofWritten(written)), scoped.values());
+                scoped.writtenSymbols(declaredBy(readings)), scoped.values());
         assertEquals(java.util.List.of(), answered.unresolved(),
                 () -> "every name was answered: " + answered.unresolved());
         return answered.module();
@@ -180,16 +187,10 @@ class WhatANameMeansDoesNotDependOnWhichUniverseAnsweredTest {
         Scoping.Subject withoutTheTable =
                 new Scoping.Subject(read(readings, "scope.down"), Map.of());
 
-        Map<String, Ast.Module> written = new LinkedHashMap<>();
-        readings.forEach((name, sighted) -> {
-            if (sighted instanceof ModuleUniverse.InSight.Read there) {
-                written.put(name, there.module());
-            }
-        });
         Scoping.Scoped scoped =
                 Scoping.of(new ModuleUniverse.OfWhatIsRead(readings), withoutTheTable);
         Resolve.Resolution answered = Resolve.resolving(withoutTheTable.read().module(),
-                scoped.writtenSymbols(Registry.ofWritten(written)), scoped.values());
+                scoped.writtenSymbols(declaredBy(readings)), scoped.values());
 
         assertTrue(answered.unresolved().stream()
                         .anyMatch(e -> e.getMessage().contains("length")),

--- a/souther-compiler/src/test/java/souther/compiler/meta/APublishedModuleIsReadAsTheCompilerReadsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/APublishedModuleIsReadAsTheCompilerReadsItTest.java
@@ -163,10 +163,13 @@ class APublishedModuleIsReadAsTheCompilerReadsItTest {
      * <p>Indexing refuses a name written twice, and a module read back from another build can carry
      * one: it was published under the rules of the compiler that built it. There is nobody to tell —
      * the source is not this compile's — so it is a module this reader cannot read, and a reader of
-     * <em>that</em> is what this holds. The second ask is the one that matters. A registry that works
-     * a module's declarations out when it is first asked raises again for the next asker, and the
-     * next asker is a module naming it with a qualifier while it is being resolved, which is past
-     * everything that answers absences.
+     * <em>that</em> is what this holds.
+     *
+     * <p>The second ask is the one that matters. This was settled at the moment a universe was
+     * assembled, by catching what the indexing raised; a module named with a qualifier is asked for
+     * again while some other module is being resolved, and the raise came back from a lookup, past
+     * everything that answers absences. It is settled where the module is read now, and what a
+     * lookup answers is what that reading left.
      */
     @Test
     void aModuleWhoseDeclarationsCannotBeIndexedIsAnAbsenceWhereverItIsReachedFrom() {

--- a/souther-compiler/src/test/java/souther/compiler/meta/ModuleReadbackTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/ModuleReadbackTest.java
@@ -2,6 +2,7 @@ package souther.compiler.meta;
 
 import souther.compiler.Compiler;
 import souther.compiler.ast.Ast;
+import souther.compiler.codegen.Backend;
 import souther.compiler.frontend.CstFrontend;
 
 import org.junit.jupiter.api.Test;
@@ -315,6 +316,41 @@ class ModuleReadbackTest {
 
         assertEquals("shared.other", why.named(),
                 "the name the artifact gave itself, which is not the one it was filed under");
+    }
+
+    /**
+     * Every declaration the indexing refused crosses, and not only the first.
+     *
+     * <p>The indexing reads the whole module and answers with every refusal it saw, so keeping one
+     * would be this boundary deciding to lose the others — a rule about what an artifact is, made
+     * where an artifact is being described. What is shown to an author is one sentence, and that is
+     * a question about a report rather than about the facts a report is written from.
+     */
+    @Test
+    void everyDeclarationItRefusesCrosses() {
+        Map<String, PublishedClasses.Declarations> published = Map.of(
+                "lib.two.$Module", new PublishedClasses.Declarations(
+                        new PublishedClasses.SoutherModuleView(Backend.BOUNDARY_VERSION,
+                                "another build", "module lib.two exposing ( Held )", List.of(),
+                                List.of("Held", "Twice", "Some"), List.of(), List.of()),
+                        null, null, null),
+                "lib.two.Held", declaring("data Held = String"),
+                "lib.two.Twice", declaring("data Held = Int"),
+                "lib.two.Some", declaring("data Some = String"));
+
+        Readback.Failure why =
+                refusalOf("lib.two", name -> PublishedClasses.carrying(published.get(name)));
+
+        Readback.Failure.InvalidDeclarations refused =
+                assertInstanceOf(Readback.Failure.InvalidDeclarations.class, why);
+        assertEquals(new Readback.DeclarationRejection.DeclaredTwice("Held"), refused.first());
+        assertEquals(List.of(new Readback.DeclarationRejection.BuiltInOptionCaseDeclared("Some")),
+                refused.rest(), "the rest of what the indexing saw, in the order it saw them");
+    }
+
+    /** The class one declaration was stamped on. */
+    private static PublishedClasses.Declarations declaring(String declaration) {
+        return new PublishedClasses.Declarations(null, declaration, null, null);
     }
 
     /** {@code classes}, with whatever their `$Module` annotation says rewritten by {@code as}. */

--- a/souther-syntax/src/main/java/souther/compiler/diag/msg/ModuleMessage.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/msg/ModuleMessage.java
@@ -106,6 +106,10 @@ public sealed interface ModuleMessage extends Message {
      *  fail is the publishing project's to see in its own build; here they come to the same thing. */
     record AnImportLineOfItsCannotBeReadHere(String name, String from) implements ModuleMessage, Supporting {}
 
+    /** Why: what it declares is not a set of declarations one module may have. Which rule it breaks
+     *  is the publishing project's to see in its own build; here they come to the same thing. */
+    record ADeclarationOfItsCannotBeReadHere(String declaration) implements ModuleMessage, Supporting {}
+
     record RebuildItOrCompileAgainstWhatBuiltIt(String module) implements ModuleMessage, Supporting {}
 
     @Code(DiagnosticCode.E1504)


### PR DESCRIPTION
Closes #783.

Declaration indexing becomes part of constructing or reading back a module, rather than a lookup that raises.

## What was measured first

A published module that declares one name twice, imported by a project of this compile:

```
source=0 code=E1011 pos=2:1 msg=ADataIsAlreadyDefined[data=Held]
```

Not a position in a text nobody holds — a position in the *importing* author's own file, on the `import lib.pub ( Held )` line, telling them a rule about declarations they did not write. `E1509` was not said at all.

The issue named `PublishedUniverse.sighted`, which catches the raise and answers `UNREADABLE`. Its twin on the compile side was not named and had no catch: `Front.Available` answers with a module whether it came from a source of this compile or off the class path, so `CompilationUniverse.module` asked `Names.Declarations` for a published module and got it indexed like source.

## What changed

`DeclaredNames` no longer knows what a diagnostic is. It answers `Index<D>(declarations, refusals)`, with `Refusal<D>` a closed sum of the rules it has — `DeclaredTwice` and `ABuiltInOptionCaseIsDeclared` — each carrying the declaration it refused. Turning one into a sentence for the author who wrote it is `DeclarationRefusals.reported`, on the source side only.

`ReadableModule` owns its declaration index. Indexing runs inside `ModuleReadback.read`, before the import lines are read — which is the order the two questions depend on each other in, since whether a line may bring a name in is asked against the declarations. A refusal there is `Readback.Failure.InvalidDeclarations(first, rest)`, over a `DeclarationRejection` hierarchy of its own: what a `Failure` says is which part of a reading did not hold, and what a rejection says is what is wrong with the declarations. Every refusal the indexing saw crosses; showing one sentence is a decision about a report, not about the facts.

So holding a `ReadableModule` is holding a module whose declarations have been indexed and not refused, and `PublishedUniverse.sighted` is gone along with the three parallel maps it filled.

`Names.Declarations` is the one place the two provenances are told apart: a source of this compile is indexed there and its refusals become reports, and a module off the path hands back the index its readback settled. No consumer of `Front.Available` changed.

The lazy `Registry` constructors are gone — `ofWritten`, and `of(Map<String, Hir.Module>)` on the other representation. A registry is built from declarations already indexed, so no lookup refuses and no caller decides how wide to catch. `TypeChecker.ownDefs` / `declared` / `Declared` went with them, having no callers left.

Three invariants hold together, which is why this is one commit:

- a consumer of `ReadableModule` does not index
- a `Registry` lookup does not refuse
- only the construction boundary over raw declarations interprets a refusal

## Every indexing call site

| caller | input | what a refusal means |
| --- | --- | --- |
| `Names.Declarations` (source branch) | a source of this compile | a report |
| `ModuleReadback.read` | an artifact | `InvalidDeclarations` |
| `Prelude.symbolsOf` | source the compiler ships | `IllegalStateException` |
| `SyntaxSymbols.of(Ast.Module)` | a lone module, no report to collect | `CompileException` |
| `Symbols.of(Hir.Module)` | a lone resolved module | `IllegalStateException` |

## Controls

Removing one arm of the refusal-to-rejection switch fails the build at that switch and nowhere else. Raising an `IllegalArgumentException` from inside the indexing leaves it as a fault: the artifact tests error with it rather than answering that the module is unreadable, which is what the catch this removes used to do.

`mvn -o verify` is green across the reactor (4895 tests in `souther-compiler`), `CI=1 mvn -Plint verify` is green, and `souther-examples` builds 12 of 13 modules — `todomvc` is red before this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
