### PR TITLE
A diagnostic says what it points at, and a surface says what it is reading

### DIFF
--- a/souther-bench/src/main/java/souther/bench/Corpus.java
+++ b/souther-bench/src/main/java/souther/bench/Corpus.java
@@ -86,7 +86,7 @@ public record Corpus(String name, List<String> sources, int lines) {
             for (Diagnostic diagnostic : found.getValue()) {
                 if (diagnostic.severity() == Severity.ERROR) {
                     errors.add(name + " source " + found.getKey() + ": " + diagnostic.code()
-                            + " at " + diagnostic.pos());
+                            + " at " + diagnostic.primary());
                 }
             }
         }

--- a/souther-cli/src/main/java/souther/cli/Main.java
+++ b/souther-cli/src/main/java/souther/cli/Main.java
@@ -716,14 +716,14 @@ public final class Main {
     /**
      * Which of the files handed over a source id names, or -1 when it names none of them.
      *
-     * <p>For a diagnostic, which may name no source — a report this compile could pin on none — so
-     * the single file is the answer whatever the id reads. Not for a reason in a report, which
-     * always names one: {@link #namesOf} matches on the id alone.
+     * <p>On the id and nothing else. The one file handed over used to be the answer for whatever it
+     * was asked, including for no id at all, because a report could arrive here without one and the
+     * single file was the only guess to be had. A report says which source it points into now, so
+     * there is nothing left to guess — and the guess was answering for reports it had no business
+     * answering for: handed one file and a report about another, it quoted that file at the
+     * report's numbers, which put a caret past the end of a line the author never wrote.
      */
     private static int indexOf(List<Path> sources, SourceId sourceId) {
-        if (sources.size() == 1) {
-            return 0;
-        }
         for (int i = 0; i < sources.size(); i++) {
             if (Compilation.idOfSourceIndex(i).equals(sourceId)) {
                 return i;

--- a/souther-cli/src/main/java/souther/cli/Main.java
+++ b/souther-cli/src/main/java/souther/cli/Main.java
@@ -662,9 +662,9 @@ public final class Main {
     /**
      * Which of the files handed over a source id names, or null when it names none of them.
      *
-     * <p>One file handed over is the answer however the diagnostic is tagged — which is why one
-     * item is not read as "the source called 0, or nothing". A compile of one source names it like
-     * any other now, so this is for the report that could be pinned on none.
+     * <p>Matched on the id, like everything else this command resolves. A report says which source
+     * it points into, so a caller with one file to hand has nothing to guess at and a caller with
+     * several has nothing to work out.
      */
     private static Path pathOf(List<Path> sources, SourceId sourceId) {
         int at = indexOf(sources, sourceId);
@@ -689,12 +689,10 @@ public final class Main {
      * front of the reader. Both renderings go through {@link #displayNames}, so a run cannot quote a
      * line from {@code a/model.sou} and then say the rows of {@code model.sou} were not read.
      *
-     * <p>Matched on the id and nothing else, which is where this parts from {@link #indexOf}. That
-     * answers for a diagnostic, which may name no source at all — a report this compile could pin on
-     * none — and the one file handed over is then the answer. A reason in a report always names one,
-     * so an id that is none of these files is an id
-     * about a source this command did not hand over, and answering with the only file would be
-     * inventing the very correspondence this is here to stop being guessed at.
+     * <p>Matched on the id and nothing else, as {@link #indexOf} is. An id that is none of these
+     * files is an id about a source this command did not hand over, and answering with the only file
+     * there happens to be would be inventing the very correspondence this is here to stop being
+     * guessed at.
      */
     static SourceNameResolver namesOf(List<Path> sources) {
         List<String> names = displayNames(sources);

--- a/souther-cli/src/test/java/souther/cli/HowManyFilesWereHandedOverDoesNotDecideWhatIsQuotedTest.java
+++ b/souther-cli/src/test/java/souther/cli/HowManyFilesWereHandedOverDoesNotDecideWhatIsQuotedTest.java
@@ -1,0 +1,138 @@
+package souther.cli;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.DiagnosticRenderer;
+import souther.compiler.diag.HumanRenderer;
+import souther.compiler.diag.Located;
+import souther.compiler.diag.ReportContext;
+import souther.compiler.diag.SourceContextResolver;
+
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a report quotes does not depend on how many files the command line was handed.
+ *
+ * <p>It did. A report reaches this command as a diagnostic and a list of sources, and the list used
+ * to answer the only file it had for any id at all — including for no id. That made two rules hold
+ * each other up: a report that arrived without a source was quoted correctly whenever exactly one
+ * file had been handed over, and lost its file name and its line the moment a second one was. The
+ * numbers were never in doubt; the report said which source they were of and nothing on the way
+ * carried it.
+ *
+ * <p>So this renders one report twice, against one file and against two, and holds the two outputs
+ * to being the same string. The report is the same report and the file it points into is the same
+ * file; a second file the report says nothing about is not a fact about it.
+ */
+class HowManyFilesWereHandedOverDoesNotDecideWhatIsQuotedTest {
+
+    private static final String BROKEN = """
+            module a
+
+            let f (x: Int): Int = x + "no"
+            """;
+
+    private static final String UNRELATED = """
+            module b
+
+            let g (x: Int): Int = x
+            """;
+
+    /** The command line's own resolver over {@code files} — the thing that used to answer the one
+     *  file it had for whatever it was asked. */
+    private static SourceContextResolver resolverOf(List<Path> files) throws Exception {
+        Method sourcesOf = Main.class.getDeclaredMethod("sourcesOf", List.class);
+        sourcesOf.setAccessible(true);
+        return (SourceContextResolver) sourcesOf.invoke(null, files);
+    }
+
+    private static String rendered(List<Path> files, CompileException e) throws Exception {
+        return DiagnosticRenderer.renderAll(e.locatedDiagnostics(), resolverOf(files),
+                new HumanRenderer(false), Locale.ENGLISH).get(0);
+    }
+
+    @Test
+    void oneFileAndTwoQuoteTheSameThing(@TempDir Path dir) throws Exception {
+        Path a = dir.resolve("a.sou");
+        Path b = dir.resolve("b.sou");
+        Files.writeString(a, BROKEN);
+        Files.writeString(b, UNRELATED);
+
+        CompileException e = assertThrows(CompileException.class,
+                () -> Main.compileToDir(List.of(a), dir.resolve("out")));
+
+        String alone = rendered(List.of(a), e);
+        String beside = rendered(List.of(a, b), e);
+
+        assertTrue(alone.contains("a.sou:3:"), alone);
+        assertTrue(alone.contains("let f (x: Int): Int = x + \"no\""), alone);
+        assertEquals(alone, beside,
+                "a second file the report says nothing about is not a fact about the report");
+    }
+
+    /**
+     * And the same of a report the command line was told nothing about.
+     *
+     * <p>The route that used to lose it: a report raised without a source list at all. Where it
+     * points is on the report, so both renderings quote it, and neither reads the file count as an
+     * answer to a question the report had already answered.
+     */
+    @Test
+    void aReportCarryingNoSourceListQuotesItsOwnFileEitherWay(@TempDir Path dir) throws Exception {
+        Path a = dir.resolve("a.sou");
+        Path b = dir.resolve("b.sou");
+        Files.writeString(a, BROKEN);
+        Files.writeString(b, UNRELATED);
+
+        CompileException tagged = assertThrows(CompileException.class,
+                () -> Main.compileToDir(List.of(a), dir.resolve("out")));
+        CompileException untagged = CompileException.of(tagged.diagnostic());
+
+        String alone = new HumanRenderer(false).render(
+                new Located(untagged.diagnostic(), ReportContext.NONE),
+                resolverOf(List.of(a)), Locale.ENGLISH);
+        String beside = new HumanRenderer(false).render(
+                new Located(untagged.diagnostic(), ReportContext.NONE),
+                resolverOf(List.of(a, b)), Locale.ENGLISH);
+
+        assertTrue(alone.contains("a.sou:3:"), alone);
+        assertTrue(alone.contains("let f (x: Int): Int = x + \"no\""), alone);
+        assertEquals(alone, beside, "the report names its own file, told or not");
+    }
+
+    /**
+     * A report this command cannot place is not quoted from the only file to hand.
+     *
+     * <p>What the single-file answer was for, and the one thing losing it changes. A report that
+     * points at nothing and is listed under no file has said, twice, that it is not about a line of
+     * anybody's source; naming the only file handed over is this command deciding otherwise, and it
+     * is a decision it has nothing to make it on.
+     */
+    @Test
+    void aReportThisCommandCannotPlaceIsNotQuotedFromTheOnlyFileToHand(@TempDir Path dir)
+            throws Exception {
+        Path a = dir.resolve("a.sou");
+        Files.writeString(a, BROKEN);
+
+        String out = new HumanRenderer(false).render(
+                new Located(Diagnostic.literal(null, "boom"), ReportContext.NONE),
+                resolverOf(List.of(a)), Locale.ENGLISH);
+
+        assertTrue(out.contains("boom"), out);
+        assertFalse(out.contains("a.sou"),
+                "one file to hand is not a reason to say the report is about it: " + out);
+        assertFalse(out.contains("let f"), out);
+    }
+}

--- a/souther-cli/src/test/java/souther/cli/WarningReportingTest.java
+++ b/souther-cli/src/test/java/souther/cli/WarningReportingTest.java
@@ -104,7 +104,7 @@ class WarningReportingTest {
                 List.of(), warnings);
 
         assertEquals(1, warnings.size(), warnings.toString());
-        assertEquals(new SourceId("0"), warnings.get(0).primarySourceId(),
+        assertEquals(new SourceId("0"), warnings.get(0).context().filedUnder().orElse(null),
                 "the one source is a source, and a warning in it says so");
         assertTrue(compile(file, "--lang", "en").contains("probe.sou:8:5"));
     }

--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -119,7 +119,7 @@ public final class Compiler {
      * <p>No position is claimed: where the stack ended is not a fact about the source.
      */
     private static CompileException tooDeep() {
-        return CompileException.of(Diagnostic.say(new DeclarationMessage.TheCompilerRanOutOfRoom()).build());
+        return CompileException.of(Diagnostic.say(new DeclarationMessage.TheCompilerRanOutOfRoom()).nowhere().build());
     }
 
     /**
@@ -452,8 +452,9 @@ public final class Compiler {
         // Every module's classes are now present, so a constant construction and an example can
         // resolve a cross-module reference — including into a dependency, whose classes come off the
         // same path its declarations were read from.
-        List<Diagnostic> exampleFailures = new ArrayList<>();
-        List<SourceId> exampleSources = new ArrayList<>();
+        // Each failing row with the file it is listed under: a row from an `examples for` file is
+        // written in that file, not in the module it contributes to.
+        List<Located> exampleFailures = new ArrayList<>();
         for (String module : compilation.modules()) {
             if (!db.ask(new Output.ConstConstructions(module)).present()) {
                 CompileException bad = compilation.failure();
@@ -464,9 +465,8 @@ public final class Compiler {
             }
             for (SourceId id : compilation.exampleSourcesOf(module)) {
                 for (Report failure : Report.errorsIn(db.ask(Output.Examples.asked(db, module, id)).reports())) {
-                    exampleFailures.add(failure.diagnostic());
-                    // a row from an `examples for` file is positioned in that file, not this one
-                    exampleSources.add(id);
+                    exampleFailures.add(new Located(failure.diagnostic(),
+                            souther.compiler.diag.ReportContext.inFile(id)));
                 }
             }
             db.ask(new Output.SaidDisagreements(module));
@@ -476,8 +476,8 @@ public final class Compiler {
         }
         warningsOut.addAll(compilation.warnings());
         if (!exampleFailures.isEmpty()) {
-            throw CompileException.ofAllInSources(exampleFailures, exampleSources,
-                    ExampleVerifier.legacySummary(exampleFailures));
+            throw CompileException.ofAllReported(exampleFailures,
+                    ExampleVerifier.legacySummary(Located.diagnosticsOf(exampleFailures)));
         }
         return compilation;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -467,8 +467,14 @@ public final class CallElaborator {
             }
             Diagnostic.Builder b = Diagnostic
                     .at(args.get(seed).reportedAt());
-            if (stepError.diagnostic() != null && stepError.diagnostic().region() != null) {
-                b.secondary(stepError.diagnostic().region(), new NameMessage.TheAccumulatorsTypeStaysUnknown());
+            // The step's own place, where it has one a reader can be sent to. A report about code
+            // out of sight, or one in a text this compile cannot name, has no place to lend: the
+            // region it holds is not one this label could be read at.
+            if (stepError.diagnostic() != null
+                    && stepError.diagnostic().primary()
+                            instanceof souther.compiler.diag.Primary.InSource(
+                                    souther.compiler.diag.DiagnosticPlace.InSource place)) {
+                b.secondary(place, new NameMessage.TheAccumulatorsTypeStaysUnknown());
             }
             throw CompileException.of(b.say(new NameMessage.TheElementTypeCannotBeInferredHere()).build());
         }

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -13,6 +13,7 @@ import souther.compiler.diag.Located;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.diag.Citation;
 import souther.compiler.diag.Primary;
+import souther.compiler.diag.ReportContext;
 import souther.compiler.diag.Region;
 import souther.compiler.diag.SourceProvenance;
 import souther.compiler.diag.WhereCodeIsWritten;
@@ -460,11 +461,15 @@ public final class Compilation {
             byId.put(id, new ArrayList<>());
         }
         for (Db.Found found : reports()) {
-            SourceId primary = locatedSourceIdOf(found);
+            SourceId primary = filedUnderOf(found);
             for (SourceId id : publishSourceIdsOf(found)) {
                 List<Located> on = byId.get(id);
                 if (on != null) {
-                    on.add(new Located(found.report().diagnostic(), primary));
+                    // Listed under the file the report claims, and read from the file this entry
+                    // is for. A problem written in two files is one report said in both, and on
+                    // the second of them the text being read is that second file.
+                    on.add(new Located(found.report().diagnostic(),
+                            ReportContext.of(primary, id)));
                 }
             }
         }
@@ -499,7 +504,7 @@ public final class Compilation {
         Map<Repeat, Db.Found> reports = new LinkedHashMap<>();
         for (Db.Found found : db.allReports()) {
             Db.Found said = citable(found);
-            reports.putIfAbsent(new Repeat(said.module(), locatedSourceIdOf(said),
+            reports.putIfAbsent(new Repeat(said.module(), filedUnderOf(said),
                     said.report().problem()), said);
         }
         return new ArrayList<>(reports.values());
@@ -559,18 +564,15 @@ public final class Compilation {
      * <p>A report in a text this compilation cannot name is left where it is. Its position is one
      * whoever handed the text over can use and this is not being read by them — but nothing about it
      * says where its code came from, and moving it would mean answering that from the module, which
-     * is the inference again. Whether such a position is a place at all is the open question about a
-     * primary region, and this does not decide it.
+     * is the inference again.
      */
     static SourceProvenance whatToMove(Diagnostic said, String module) {
         if (module == null) {
             return null;
         }
         boolean nowhereToSendAReader = switch (said.primary()) {
-            case null -> true;
-            case Primary.Unavailable _ -> true;
-            case Primary.AtARegion(Region region) ->
-                    Citation.of(region.start()) instanceof Citation.OutOfSight;
+            case Primary.Unavailable _, Primary.Nowhere _ -> true;
+            case Primary.InSource _, Primary.InAnUnnamedText _ -> false;
         };
         if (!nowhereToSendAReader) {
             return null;
@@ -657,15 +659,14 @@ public final class Compilation {
                 .thenComparingInt(f -> lineOf(f.report().diagnostic()))
                 .thenComparingInt(f -> columnOf(f.report().diagnostic())));
         Db.Found first = errors.get(0);
-        List<Diagnostic> rest = new ArrayList<>();
-        List<SourceId> restSources = new ArrayList<>();
+        List<Located> rest = new ArrayList<>();
         for (Db.Found f : errors.subList(1, errors.size())) {
-            rest.add(f.report().diagnostic());
-            restSources.add(sourceIdOf(f));
+            rest.add(new Located(f.report().diagnostic(),
+                    ReportContext.inFile(filedUnderOf(f))));
         }
         return first.report().asException()
-                .alsoReporting(rest, restSources)
-                .inSource(sourceIdOf(first));
+                .alsoReporting(rest)
+                .inSource(filedUnderOf(first));
     }
 
     /** Where a report sits among the sources for ordering, with the one naming none before them all. */
@@ -674,32 +675,56 @@ public final class Compilation {
         return index < 0 ? -1 : index;
     }
 
-    /** A report with no position comes before the ones in its source that have one: it is about the
-     *  source rather than about a line of it. */
+    /**
+     * Where in its file a report sits, for ordering — and before every line of it where it points at
+     * no part of the file.
+     *
+     * <p>A report about the file rather than about a line of it comes first, and so does one whose
+     * numbers are of a text this compile could not name: those numbers are not of the file it is
+     * listed under, so ordering by them would interleave it with the lines of a file it says nothing
+     * about.
+     */
+    private static SourcePos orderingPositionOf(Diagnostic diagnostic) {
+        return diagnostic == null ? null : switch (diagnostic.primary()) {
+            case Primary.InSource(souther.compiler.diag.DiagnosticPlace.InSource place) ->
+                    place.region().start();
+            case Primary.InAnUnnamedText _, Primary.Unavailable _, Primary.Nowhere _ -> null;
+        };
+    }
+
     private static int lineOf(Diagnostic diagnostic) {
-        SourcePos pos = diagnostic == null ? null : diagnostic.pos();
+        SourcePos pos = orderingPositionOf(diagnostic);
         return pos == null ? -1 : pos.line();
     }
 
     private static int columnOf(Diagnostic diagnostic) {
-        SourcePos pos = diagnostic == null ? null : diagnostic.pos();
+        SourcePos pos = orderingPositionOf(diagnostic);
         return pos == null ? -1 : pos.column();
     }
 
     /**
-     * Which of the sources this compilation holds a report's primary region is in: the one the report
-     * claims ({@link Db.Found#claimedSourceId()}), or — where it claims none, or claims one this
-     * compile was not handed — the one that declares the module it was about.
+     * Which of this compilation's sources a report is listed under: the one it claims
+     * ({@link Db.Found#claimedSourceId()}), or — where it claims none, or claims one this compile
+     * was not handed — the one that declares the module it was about.
      *
-     * <p>The second half of that is a guard, and it guards availability as much as attribution. A
-     * position may have been read from a source this compile does not have: the prelude, or a module
-     * read back off the module path. Filing a report under a name {@link #diagnostics()} has no entry
-     * for would drop it silently, and a report the author never sees is worse than one on the wrong
-     * file.
+     * <p>Listed under, and not "the source its primary region is in". Those were one method and one
+     * word for two questions, and the second of them has no answer here any more: a report that
+     * points into a source says which one, on the place itself
+     * ({@link souther.compiler.diag.Primary.InSource}), and nothing needs to be told. What is left
+     * is this one, which the report cannot answer — a report about a module, one whose code is out
+     * of sight, one in a text this compile could not name, all have to be listed somewhere for an
+     * author to be shown them, and only a caller holding the files can say where.
      *
-     * <p>Always answered, whatever the compile tells a caller about its sources. What a source is
-     * called here is how a report is filed and how its regions are quoted; what a caller is told is
-     * {@link #sourceIdOf(Db.Found)}, and the two are not the same question.
+     * <p>So the fallback below is not a place. It is where the report is listed, and nothing reads
+     * it as a caret: a renderer quotes from the place the report points at and names the file it is
+     * listed under, which for a report pointing nowhere is the whole of what it says. Read as a
+     * place — which it was, while one field answered both — it put a line and a column from one
+     * source against the text of another.
+     *
+     * <p>The fallback guards availability as much as attribution. A position may have been read
+     * from a source this compile does not have: the prelude, or a module read back off the module
+     * path. Filing a report under a name {@link #diagnostics()} has no entry for would drop it
+     * silently, and a report the author never sees is worse than one listed on the wrong file.
      *
      * <p>Which module the report is a failure of is a third question and not this one. A report
      * points into another module wherever the code it is about was written there — an invariant of
@@ -707,28 +732,12 @@ public final class Compilation {
      * on that code, because that is what the report is about. Where it is said is
      * {@link #publishSourceIdsOf(Db.Found)}.
      */
-    private SourceId locatedSourceIdOf(Db.Found found) {
+    public SourceId filedUnderOf(Db.Found found) {
         SourceId claimed = found.claimedSourceId();
         if (claimed != null && sourceIds().contains(claimed)) {
             return claimed;
         }
         return found.module() == null ? null : sourceIdOf(found.module());
-    }
-
-    /**
-     * Which source a report's primary region is in, as a caller holding its own list of files is
-     * told — none where nothing says.
-     *
-     * <p>The same answer whatever the caller handed over. A compile of one source used to answer
-     * none here, on the grounds that the caller knows the file it gave: what that did was leave the
-     * primary naming nothing while every secondary named the one source there was, so a renderer
-     * comparing the two read them as two files and printed a file name over a note in the file it
-     * was already quoting. Whether to print a name is the renderer's question, and it already
-     * answers it by comparing the anchor with the place; whether a caller wants to see ids at all is
-     * answered by the names it gives them.
-     */
-    public SourceId sourceIdOf(Db.Found found) {
-        return locatedSourceIdOf(found);
     }
 
     /**
@@ -753,7 +762,7 @@ public final class Compilation {
      * not the other for a difference neither of them wrote.
      */
     public List<SourceId> publishSourceIdsOf(Db.Found found) {
-        SourceId primary = locatedSourceIdOf(found);
+        SourceId primary = filedUnderOf(found);
         List<SourceId> saidAt = new ArrayList<>();
         if (primary != null) {
             saidAt.add(primary);
@@ -779,9 +788,9 @@ public final class Compilation {
     }
 
     /** Where a report sits in the order the sources were given, or -1 when it names none. Only for
-     * ordering: which file a reader is sent to is {@link #sourceIdOf(Db.Found)}. */
+     * ordering: which file a report is listed under is {@link #filedUnderOf(Db.Found)}. */
     private int indexOf(Db.Found found) {
-        SourceId id = locatedSourceIdOf(found);
+        SourceId id = filedUnderOf(found);
         if (id == null) {
             return -1;
         }
@@ -802,7 +811,7 @@ public final class Compilation {
         List<Db.Found> found = reports();
         for (Db.Found f : found) {
             if (!f.report().isError()) {
-                warnings.add(new Located(f.report().diagnostic(), sourceIdOf(f)));
+                warnings.add(new Located(f.report().diagnostic(), ReportContext.inFile(filedUnderOf(f))));
             }
         }
         return warnings;
@@ -821,7 +830,7 @@ public final class Compilation {
         List<Db.Found> found = reports();
         for (Db.Found f : found) {
             if (f.report().isError()) {
-                errors.add(new Located(f.report().diagnostic(), sourceIdOf(f)));
+                errors.add(new Located(f.report().diagnostic(), ReportContext.inFile(filedUnderOf(f))));
             }
         }
         return errors;

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -4,8 +4,8 @@ import souther.compiler.source.SourceId;
 
 import java.util.ArrayDeque;
 import souther.compiler.diag.Diagnostic;
-import souther.compiler.diag.QuotedFrom;
-import souther.compiler.diag.SourcePos;
+import souther.compiler.diag.DiagnosticPlace;
+import souther.compiler.diag.Primary;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -294,16 +294,14 @@ public final class Db {
          * regions it points at, and is asked of them.
          */
         public SourceId claimedSourceId() {
-            SourcePos at = report.diagnostic().pos();
-            if (at == null) {
-                return sourceId;
-            }
-            return switch (at.quotedFrom()) {
-                case QuotedFrom.ASourceThisCompileHolds(SourceId named) -> named;
-                // A place with no file of its own is filed under the one this answer was being read
-                // for. Which is a choice this makes and not something the place said: it is the only
-                // file in hand, and a report has to be filed somewhere for anybody to be shown it.
-                case QuotedFrom.TextItCannotShow _, QuotedFrom.TextItCannotName _ -> sourceId;
+            return switch (report.diagnostic().primary()) {
+                case Primary.InSource(DiagnosticPlace.InSource place) -> place.source();
+                // Everything else is filed under the source this answer was being read for. Which is
+                // a choice this makes and not something the report said: a place in a text nobody
+                // named, a report about code out of sight and one about no stretch of text at all
+                // have no file of their own, and a report has to be filed somewhere for anybody to
+                // be shown it.
+                case Primary.InAnUnnamedText _, Primary.Unavailable _, Primary.Nowhere _ -> sourceId;
             };
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -1036,7 +1036,7 @@ public final class Front {
                 return Answer.of(Boolean.FALSE);
             }
             return Answer.absent(Report.raised(Diagnostic.say(new ModuleMessage.TheModuleIsCompiledHereAndOnThePath(name))
-                            .hint(new ModuleMessage.RenameItOrDropTheDependency(name)).build()));
+                            .hint(new ModuleMessage.RenameItOrDropTheDependency(name)).nowhere().build()));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -7,6 +7,7 @@ import souther.compiler.ast.Ast;
 import souther.compiler.ast.WrittenName;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Primary;
 import souther.compiler.diag.msg.ModuleMessage;
 import souther.compiler.diag.msg.ExampleMessage;
 import souther.compiler.diag.msg.ImportMessage;
@@ -456,7 +457,11 @@ public final class Front {
                 // brought the other out. Both are said.
                 Diagnostic.Builder reserved = reservedNamespaceTaken(name);
                 if (reserved != null) {
-                    refused.put(name, reserved.build());
+                    // The same as the two below: the name was taken by a module this compile has no
+                    // file for, so the report says which module and points nowhere.
+                    refused.put(name,
+                            reserved.atCodeWrittenOutOfSight(ModuleReadback.provenanceOf(name))
+                                    .build());
                 }
                 if (readback instanceof Readback.Unreadable(String about, Readback.Failure why)) {
                     unreadable.put(about, why);
@@ -683,7 +688,7 @@ public final class Front {
      * added later is a failure this has to have something to say about, and one that reached here
      * with nothing to say would be a module quietly missing from the compile.
      */
-    private static Diagnostic cannotBeReadBack(String module, Readback.Failure why) {
+    static Diagnostic cannotBeReadBack(String module, Readback.Failure why) {
         Diagnostic.Builder said = Diagnostic
                 .say(new ModuleMessage.TheModuleCannotBeReadBack(module));
         Diagnostic.Builder because = switch (why) {
@@ -706,7 +711,9 @@ public final class Front {
                     said.hint(new ModuleMessage.ADeclarationOfItsCannotBeReadHere(
                             first.declaration()));
         };
-        return because.hint(new ModuleMessage.RebuildItOrCompileAgainstWhatBuiltIt(module)).build();
+        return because.hint(new ModuleMessage.RebuildItOrCompileAgainstWhatBuiltIt(module))
+                .atCodeWrittenOutOfSight(ModuleReadback.provenanceOf(module))
+                .build();
     }
 
     /**
@@ -731,10 +738,24 @@ public final class Front {
         };
     }
 
-    /** A module off the path needing one that is not there. */
-    private static Diagnostic needs(String needed, String module) {
+    /**
+     * A module off the path needing one that is not there.
+     *
+     * <p>The code is written in {@code module}, which this compile has no file for, so there is
+     * nowhere to send a reader and the module is what a reader is told instead
+     * ({@link Primary.Unavailable}). Said here rather than left for {@link #saidAbout} to work out:
+     * a report that says nothing about where its code is may be moved anywhere, and one that says
+     * refuses a move that would put it somewhere else
+     * ({@link Diagnostic.MovedSomewhereElsesCode}).
+     *
+     * <p>Package-private for the reason {@link #cannotBeReadBack} is: what it answers is which
+     * provenance this compilation is reporting about, which is a fact this package states rather
+     * than a fragment of one method.
+     */
+    static Diagnostic needs(String needed, String module) {
         return Diagnostic.say(new ModuleMessage.AModuleItNeedsIsNotOnThePath(needed, module))
                 .hint(new ModuleMessage.AddItToThisProjectsDependencies(needed))
+                .atCodeWrittenOutOfSight(ModuleReadback.provenanceOf(module))
                 .build();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/AGeneratedMethodStaysWithinTheJvmParameterSlotLimitTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGeneratedMethodStaysWithinTheJvmParameterSlotLimitTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.HumanRenderer;
 import souther.compiler.diag.Region;
@@ -125,7 +127,7 @@ class AGeneratedMethodStaysWithinTheJvmParameterSlotLimitTest {
         CompileException e = assertThrows(CompileException.class,
                 () -> Compiler.compile(dataOf(128, "Int")));
 
-        Region region = e.diagnostic().region();
+        Region region = ((Primary.InSource) e.diagnostic().primary()).place().region();
         assertEquals(3, region.start().line(), "the `data Wide` line");
         assertEquals("module demo\n\ndata ".length()
                 - "module demo\n\n".length() + 1, region.start().column(),

--- a/souther-compiler/src/test/java/souther/compiler/ALabelSaysWhereItIsWithoutBeingToldWhereItIsShownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ALabelSaysWhereItIsWithoutBeingToldWhereItIsShownTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.ReportContext;
+
 import souther.compiler.source.SourceId;
 
 import souther.compiler.diag.Diagnostic;
@@ -216,7 +218,7 @@ class ALabelSaysWhereItIsWithoutBeingToldWhereItIsShownTest {
     }
 
     private static String rendered(Compilation c, String source) {
-        return new HumanRenderer(false).render(new Located(theWarning(c), new SourceId("0")),
+        return new HumanRenderer(false).render(new Located(theWarning(c), ReportContext.inFile(new SourceId("0"))),
                 id -> new SourceContext("m.sou", source), Locale.ENGLISH);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/AMistakeInAnAttachedFileIsSaidOnThatFileTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMistakeInAnAttachedFileIsSaidOnThatFileTest.java
@@ -1,5 +1,9 @@
 package souther.compiler;
 
+import souther.compiler.diag.ReportContext;
+
+import souther.compiler.diag.Primary;
+
 import souther.compiler.source.SourceId;
 import souther.compiler.diag.QuotedFrom;
 
@@ -62,7 +66,7 @@ class AMistakeInAnAttachedFileIsSaidOnThatFileTest {
 
     /** Where the compile says the problem is, as `sourceId line:column`. */
     private static String saidAt(CompileException e) {
-        return e.sourceId() + " " + e.diagnostic().pos();
+        return e.sourceId() + " " + ((Primary.InSource) e.diagnostic().primary()).place().region().start();
     }
 
     // --- one method per way of getting it wrong -------------------------------------------------
@@ -111,7 +115,7 @@ class AMistakeInAnAttachedFileIsSaidOnThatFileTest {
                 """);
 
         assertEquals(new SourceId("1"), e.sourceId(), "the field is given its value in the attached file");
-        assertEquals(3, e.diagnostic().pos().line());
+        assertEquals(3, ((Primary.InSource) e.diagnostic().primary()).place().region().start().line());
     }
 
     /**
@@ -129,7 +133,7 @@ class AMistakeInAnAttachedFileIsSaidOnThatFileTest {
 
         assertEquals(new SourceId("1"), e.sourceId());
         assertEquals(new QuotedFrom.ASourceThisCompileHolds(new SourceId("1")),
-                e.diagnostic().pos().quotedFrom(),
+                ((Primary.InSource) e.diagnostic().primary()).place().region().start().quotedFrom(),
                 "the position itself says which file, which is what the id is read off");
     }
 
@@ -153,7 +157,7 @@ class AMistakeInAnAttachedFileIsSaidOnThatFileTest {
         };
 
         String out = new HumanRenderer(false).render(
-                new Located(e.diagnostic(), e.sourceId()), sources, Locale.ENGLISH);
+                new Located(e.diagnostic(), ReportContext.inFile(e.sourceId())), sources, Locale.ENGLISH);
 
         assertTrue(out.contains("shippingfee.examples.sou:4:"), out);
         assertTrue(out.contains("北海道沖縄"), "the line quoted is the row that names it: " + out);

--- a/souther-compiler/src/test/java/souther/compiler/AModuleIsNotJudgedForWhatAnotherModulesRowWritesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AModuleIsNotJudgedForWhatAnotherModulesRowWritesTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.source.SourceId;
 
 import souther.compiler.diag.CompileException;
@@ -72,7 +74,7 @@ class AModuleIsNotJudgedForWhatAnotherModulesRowWritesTest {
 
         assertEquals("E1903", e.diagnostic().code(),
                 "a supply position with no value to supply is the row's own fixture error");
-        assertEquals(8, e.diagnostic().pos().line(), "the row");
+        assertEquals(8, ((Primary.InSource) e.diagnostic().primary()).place().region().start().line(), "the row");
     }
 
     @Test
@@ -84,7 +86,7 @@ class AModuleIsNotJudgedForWhatAnotherModulesRowWritesTest {
 
         assertEquals(declared.diagnostic().code(), bare.diagnostic().code());
         assertEquals(declared.sourceId(), bare.sourceId());
-        assertEquals(declared.diagnostic().pos().line(), bare.diagnostic().pos().line());
+        assertEquals(((Primary.InSource) declared.diagnostic().primary()).place().region().start().line(), ((Primary.InSource) bare.diagnostic().primary()).place().region().start().line());
     }
 
     @Test
@@ -105,6 +107,6 @@ class AModuleIsNotJudgedForWhatAnotherModulesRowWritesTest {
                         """)));
 
         assertEquals("E1903", e.diagnostic().code());
-        assertEquals(8, e.diagnostic().pos().line(), "the row, not the helper on line 5");
+        assertEquals(8, ((Primary.InSource) e.diagnostic().primary()).place().region().start().line(), "the row, not the helper on line 5");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/ANameAFailedImportStandsInForIsReportedOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ANameAFailedImportStandsInForIsReportedOnceTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.diag.Diagnostic;
@@ -74,7 +76,7 @@ class ANameAFailedImportStandsInForIsReportedOnceTest {
     private static List<Integer> lines(String... sources) {
         List<Integer> found = new ArrayList<>();
         for (Diagnostic d : diagnostics(sources)) {
-            found.add(d.pos().line());
+            found.add(((Primary.InSource) d.primary()).place().region().start().line());
         }
         return found;
     }

--- a/souther-compiler/src/test/java/souther/compiler/AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest.java
@@ -14,6 +14,9 @@ import souther.compiler.diag.SourcePos;
 import souther.compiler.diag.SourceProvenance;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Db;
+import souther.compiler.diag.Primary;
+import souther.compiler.diag.WhereCodeIsWritten;
+import souther.compiler.meta.ModuleReadback;
 
 import org.junit.jupiter.api.Test;
 
@@ -347,7 +350,7 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
 
         Set<String> saidAbout = new LinkedHashSet<>();
         for (Db.Found found : compilation.reports()) {
-            SourcePos at = found.report().diagnostic().pos();
+            SourcePos at = ((Primary.InSource) found.report().diagnostic().primary()).place().region().start();
             if (at == null || !(Citation.of(at) instanceof Citation.Elsewhere elsewhere)) {
                 continue;
             }
@@ -397,40 +400,92 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
     }
 
     /**
-     * Two findings that differed only in where they were written are said once.
+     * The same unavailable problem is told once.
      *
-     * <p>Reading a report for where it may be said is what makes them one. Their coordinates are in
-     * a text nobody holds and are what told them apart; said at the place the module was reached
-     * from, they are one sentence at one caret, and an author shown it twice has nothing to tell
-     * them apart by either.
+     * <p>A finding inside a module's published text has nowhere to point ({@link Primary.Unavailable}),
+     * so what told two of them apart was a line of a text nobody holds. Two findings agreeing on the
+     * rule, on the values and on the module are then the same diagnostic, and the store keeps one:
+     * there is nothing left for an author to tell them apart by, at the caret or in the sentence.
+     *
+     * <p>Which is a claim about identity and not about the walk. That both fields were read is a
+     * separate question with a fixture of its own
+     * ({@link #everyFieldOfAPublishedModuleIsRead}), because a walk that stopped at the first field
+     * would leave this one green.
      */
     @Test
-    void twoFindingsInOnePublishedModuleAreSaidOnce() {
-        Map<String, byte[]> withDeep = Compiler.compile("""
-                module lib.deep exposing ( Deep )
-                data Deep = String
-                """);
-        Map<String, byte[]> twice = built("""
-                module lib.twice exposing ( Twice )
-                data Twice = { a: lib.deep.Deep, b: lib.deep.Deep }
-                """, withDeep);
-        // the dependency is rebuilt without the type, so both field types fail to resolve
-        Map<String, byte[]> withoutDeep = Compiler.compile("""
-                module lib.deep exposing ( Other )
-                data Other = String
-                """);
-
+    void theSameUnavailableProblemIsToldOnce() {
         Compilation compilation = reading("""
                 module app.uses
                 import lib.twice ( Twice )
 
                 data Page = { twice: Twice }
-                """, and(withoutDeep, twice));
+                """, twiceNaming("lib.deep.Deep", "lib.deep.Deep"));
 
-        assertEquals(2, compilation.db().allReports().size(),
-                "two findings, at the two places the module writes the name");
+        List<Db.Found> found = compilation.db().allReports();
+        assertEquals(List.of("E1506"),
+                found.stream().map(f -> f.report().diagnostic().code()).toList(),
+                "one problem, however many places the module writes the name");
+
+        Diagnostic asFound = found.get(0).report().diagnostic();
+        assertInstanceOf(Primary.Unavailable.class, asFound.primary(),
+                "found inside the module's own text, so there is nowhere to send a reader");
+        assertEquals(new WhereCodeIsWritten.Elsewhere(ModuleReadback.provenanceOf("lib.twice")),
+                asFound.whereItsCodeIsWritten(),
+                "the code is in the module that was read back, not in the file it is said on");
+
+        Diagnostic said = whereTheReportAboutIsSaidIn(compilation, "lib.twice");
+        Citation.Reached reached = assertInstanceOf(Citation.Reached.class,
+                Citation.of(((Primary.InSource) said.primary()).place().region().start()), "read for where it may be said, the caret is the import");
+        assertEquals(2, reached.at().line(), "the import line naming it");
+
         assertEquals(1, compilation.diagnostics().get(new SourceId("0")).size(),
                 "one thing to be told, said once");
+    }
+
+    /**
+     * Every field of a published module is read, not the first.
+     *
+     * <p>The other half of what {@link #theSameUnavailableProblemIsToldOnce} used to assert, with a
+     * fixture that can carry it: the two fields name two missing types, so the two findings differ
+     * in the values they are about. Nothing downstream may merge them — the store tells reports
+     * apart by what they say — so this stays a claim about the walk however identity is decided.
+     */
+    @Test
+    void everyFieldOfAPublishedModuleIsRead() {
+        Compilation compilation = reading("""
+                module app.uses
+                import lib.twice ( Twice )
+
+                data Page = { twice: Twice }
+                """, twiceNaming("lib.deep.Deep", "lib.deep.Other"));
+
+        assertEquals(List.of("Deep", "Other"),
+                compilation.db().allReports().stream()
+                        .map(f -> String.valueOf(f.report().diagnostic().values().get("name")))
+                        .toList(),
+                "both fields were read, and each says which name it could not find");
+    }
+
+    /**
+     * A published module whose two fields name {@code first} and {@code second}, built against a
+     * dependency that had them and put on the path beside one that no longer does.
+     */
+    private static Map<String, byte[]> twiceNaming(String first, String second) {
+        Map<String, byte[]> withThem = Compiler.compile("""
+                module lib.deep exposing ( Deep, Other )
+                data Deep = String
+                data Other = String
+                """);
+        Map<String, byte[]> twice = built("""
+                module lib.twice exposing ( Twice )
+                data Twice = { a: %s, b: %s }
+                """.formatted(first, second), withThem);
+        // the dependency is rebuilt without either, so both field types fail to resolve
+        Map<String, byte[]> withoutThem = Compiler.compile("""
+                module lib.deep exposing ( Gone )
+                data Gone = String
+                """);
+        return and(withoutThem, twice);
     }
 
     /**
@@ -478,11 +533,21 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
     }
 
     /** Where the report about {@code module} is said. */
+    /** The report about {@code module}, read for where it may be said. */
+    private static Diagnostic whereTheReportAboutIsSaidIn(Compilation compilation, String module) {
+        for (Db.Found found : compilation.reports()) {
+            if (module.equals(found.module())) {
+                return found.report().diagnostic();
+            }
+        }
+        throw new AssertionError("nothing was reported about " + module);
+    }
+
     private static SourcePos whereTheReportAboutIsSaid(Compilation compilation, String module) {
         List<SourcePos> said = new ArrayList<>();
         for (Db.Found found : compilation.reports()) {
-            if (module.equals(found.module()) && found.report().diagnostic().pos() != null) {
-                said.add(found.report().diagnostic().pos());
+            if (module.equals(found.module()) && ((Primary.InSource) found.report().diagnostic().primary()).place().region().start() != null) {
+                said.add(((Primary.InSource) found.report().diagnostic().primary()).place().region().start());
             }
         }
         assertFalse(said.isEmpty(), "nothing was reported about " + module);

--- a/souther-compiler/src/test/java/souther/compiler/AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest.java
@@ -14,6 +14,7 @@ import souther.compiler.diag.SourcePos;
 import souther.compiler.diag.SourceProvenance;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Db;
+import souther.compiler.diag.DiagnosticPlace;
 import souther.compiler.diag.Primary;
 import souther.compiler.diag.WhereCodeIsWritten;
 import souther.compiler.meta.ModuleReadback;
@@ -532,7 +533,6 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
                         new NameMessage.WriteItOnItsOwn("x")));
     }
 
-    /** Where the report about {@code module} is said. */
     /** The report about {@code module}, read for where it may be said. */
     private static Diagnostic whereTheReportAboutIsSaidIn(Compilation compilation, String module) {
         for (Db.Found found : compilation.reports()) {
@@ -543,11 +543,16 @@ class AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest {
         throw new AssertionError("nothing was reported about " + module);
     }
 
+    /** Where the report about {@code module} sends a reader, of the reports that send one at all.
+     *  A report about a module off the path is anchored before it is read back here, so a run in
+     *  which none of them points anywhere is a fixture that stopped reaching the module. */
     private static SourcePos whereTheReportAboutIsSaid(Compilation compilation, String module) {
         List<SourcePos> said = new ArrayList<>();
         for (Db.Found found : compilation.reports()) {
-            if (module.equals(found.module()) && ((Primary.InSource) found.report().diagnostic().primary()).place().region().start() != null) {
-                said.add(((Primary.InSource) found.report().diagnostic().primary()).place().region().start());
+            if (module.equals(found.module())
+                    && found.report().diagnostic().primary()
+                            instanceof Primary.InSource(DiagnosticPlace.InSource place)) {
+                said.add(place.region().start());
             }
         }
         assertFalse(said.isEmpty(), "nothing was reported about " + module);

--- a/souther-compiler/src/test/java/souther/compiler/ARowAFakeCannotAnswerWithIsRefusedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowAFakeCannotAnswerWithIsRefusedTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.source.SourceId;
 
 import org.junit.jupiter.api.Test;
@@ -135,7 +137,7 @@ class ARowAFakeCannotAnswerWithIsRefusedTest {
         List<Diagnostic> said = unanswerable(source);
 
         assertEquals(1, said.size(), "one row of the two answers nothing");
-        assertEquals(lineOf(source, "\"second\""), said.get(0).pos().line(),
+        assertEquals(lineOf(source, "\"second\""), ((Primary.InSource) said.get(0).primary()).place().region().start().line(),
                 "and it is the later one, since the first match is what answers");
         assertEquals(lineOf(source, "Found { id = MemberId(\"m-1\") }"),
                 ((souther.compiler.diag.DiagnosticPlace.InSource) said.get(0).secondary().get(0).place()).region().start().line(),
@@ -153,7 +155,7 @@ class ARowAFakeCannotAnswerWithIsRefusedTest {
         List<Diagnostic> said = unanswerable(source);
 
         assertEquals(1, said.size(), "one of the two `_` rows answers nothing");
-        assertEquals(lineOf(source, "\"first\""), said.get(0).pos().line(),
+        assertEquals(lineOf(source, "\"first\""), ((Primary.InSource) said.get(0).primary()).place().region().start().line(),
                 "and it is the earlier one, since a table falls through to the last `_`");
         assertEquals(lineOf(source, "\"second\""),
                 ((souther.compiler.diag.DiagnosticPlace.InSource) said.get(0).secondary().get(0).place()).region().start().line(),
@@ -172,7 +174,7 @@ class ARowAFakeCannotAnswerWithIsRefusedTest {
         List<Diagnostic> said = unanswerable(source);
 
         assertEquals(List.of(lineOf(source, "\"first\""), lineOf(source, "\"second\"")),
-                said.stream().map(d -> d.pos().line()).sorted().toList(),
+                said.stream().map(d -> ((Primary.InSource) d.primary()).place().region().start().line()).sorted().toList(),
                 "two rows answer nothing, and each is said at itself");
         assertTrue(said.stream().allMatch(d -> ((souther.compiler.diag.DiagnosticPlace.InSource) d.secondary().get(0).place()).region().start().line()
                         == lineOf(source, "\"third\"")),

--- a/souther-compiler/src/test/java/souther/compiler/ARowAndItsStandInAreUnderlinedOverWhatTheyStateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowAndItsStandInAreUnderlinedOverWhatTheyStateTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.LabeledRegion;
 import souther.compiler.diag.Located;
@@ -95,7 +97,7 @@ class ARowAndItsStandInAreUnderlinedOverWhatTheyStateTest {
 
     /** The primary region of the one disagreement {@code source} is warned about. */
     private static Region primary(String source) {
-        return disagreement(source).region();
+        return ((Primary.InSource) disagreement(source).primary()).place().region();
     }
 
     /** The region said beside it — where the stand-in is written. */

--- a/souther-compiler/src/test/java/souther/compiler/ARowNameIsUniqueWithinItsBehaviorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowNameIsUniqueWithinItsBehaviorTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.source.SourceId;
 
 import org.junit.jupiter.api.Test;
@@ -113,7 +115,7 @@ class ARowNameIsUniqueWithinItsBehaviorTest {
 
         assertEquals(2, said.size(), "both rows carry the name, so both are told");
         assertEquals(List.of(lineOf(source, "Amount(200)"), lineOf(source, "Amount(300)")),
-                said.stream().map(d -> d.pos().line()).sorted().toList(),
+                said.stream().map(d -> ((Primary.InSource) d.primary()).place().region().start().line()).sorted().toList(),
                 "each is said at the row it is about");
         ExampleMessage.TheNameIsOnMoreThanOneRow first =
                 assertInstanceOf(ExampleMessage.TheNameIsOnMoreThanOneRow.class, said.get(0).said());
@@ -139,7 +141,7 @@ class ARowNameIsUniqueWithinItsBehaviorTest {
         assertEquals(1, collisions(said.get(new SourceId("0"))).size(), "the module's own row is told, on the module");
         assertEquals(1, collisions(said.get(new SourceId("1"))).size(),
                 "the attached file's row is told, on the attached file");
-        assertEquals(lineOf(attached, "Amount(300)"), collisions(said.get(new SourceId("1"))).get(0).pos().line(),
+        assertEquals(lineOf(attached, "Amount(300)"), ((Primary.InSource) collisions(said.get(new SourceId("1"))).get(0).primary()).place().region().start().line(),
                 "a position is a line of the file the row is written in");
     }
 
@@ -170,7 +172,7 @@ class ARowNameIsUniqueWithinItsBehaviorTest {
                 .toList();
 
         assertEquals(1, said.size(), "a name was written and it names nothing");
-        assertEquals(lineOf(source, "Amount(200)"), said.get(0).pos().line());
+        assertEquals(lineOf(source, "Amount(200)"), ((Primary.InSource) said.get(0).primary()).place().region().start().line());
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/AnArtifactThisCompilerCannotReadIsSaidWhereItWasReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnArtifactThisCompilerCannotReadIsSaidWhereItWasReachedTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.codegen.Backend;
 import souther.compiler.diag.Located;
 import souther.compiler.meta.ModulePath;
@@ -182,8 +184,8 @@ class AnArtifactThisCompilerCannotReadIsSaidWhereItWasReachedTest {
         Located said = compilation.diagnostics().get(new SourceId("0")).stream()
                 .filter(d -> d.diagnostic().code().equals("E1509")).findFirst().orElseThrow();
 
-        assertEquals(6, said.diagnostic().pos().line(), "the import line naming the module");
-        assertEquals(1, said.diagnostic().pos().column());
+        assertEquals(6, ((Primary.InSource) said.diagnostic().primary()).place().region().start().line(), "the import line naming the module");
+        assertEquals(1, ((Primary.InSource) said.diagnostic().primary()).place().region().start().column());
     }
 
     /** The boundary revision does not agree. */

--- a/souther-compiler/src/test/java/souther/compiler/CompileConstructionInInvariantTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileConstructionInInvariantTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.source.SourceId;
 
 import souther.compiler.diag.msg.InvariantMessage;
@@ -49,7 +51,7 @@ class CompileConstructionInInvariantTest {
                     invariant ok = List.all(x -> Yen(0).value <= x, value)
                 """);
         assertInstanceOf(InvariantMessage.TheNamedClauseConstructsAData.class, e.diagnostic().said());
-        assertEquals(4, e.diagnostic().region().start().line());
+        assertEquals(4, ((Primary.InSource) e.diagnostic().primary()).place().region().start().line());
     }
 
     @Test
@@ -61,7 +63,7 @@ class CompileConstructionInInvariantTest {
                     invariant ok = List.all(x -> Yen { value = 0 }.value <= x, value)
                 """);
         assertInstanceOf(InvariantMessage.TheNamedClauseConstructsAData.class, e.diagnostic().said());
-        assertEquals(4, e.diagnostic().region().start().line());
+        assertEquals(4, ((Primary.InSource) e.diagnostic().primary()).place().region().start().line());
     }
 
     @Test
@@ -74,7 +76,7 @@ class CompileConstructionInInvariantTest {
                     invariant ok = atLeastZero(value)
                 """);
         assertInstanceOf(InvariantMessage.TheNamedClauseConstructsAData.class, e.diagnostic().said());
-        assertEquals(3, e.diagnostic().region().start().line(),
+        assertEquals(3, ((Primary.InSource) e.diagnostic().primary()).place().region().start().line(),
                 "the error is at the construction, which is in the helper");
     }
 
@@ -88,7 +90,7 @@ class CompileConstructionInInvariantTest {
                     invariant ok = atLeastZero(value)
                 """);
         assertInstanceOf(InvariantMessage.TheNamedClauseConstructsAData.class, e.diagnostic().said());
-        assertEquals(3, e.diagnostic().region().start().line());
+        assertEquals(3, ((Primary.InSource) e.diagnostic().primary()).place().region().start().line());
     }
 
     /** However many helpers away: the clause arrives at the check with all of them expanded into it,
@@ -104,7 +106,7 @@ class CompileConstructionInInvariantTest {
                     invariant ok = outer(value)
                 """);
         assertInstanceOf(InvariantMessage.TheNamedClauseConstructsAData.class, e.diagnostic().said());
-        assertEquals(3, e.diagnostic().region().start().line(),
+        assertEquals(3, ((Primary.InSource) e.diagnostic().primary()).place().region().start().line(),
                 "`inner` holds the construction; `outer` only passes through");
     }
 
@@ -201,8 +203,8 @@ class CompileConstructionInInvariantTest {
                     invariant ok = List.all(x -> atLeastZero(x), value)
                 """);
         assertInstanceOf(InvariantMessage.TheNamedClauseConstructsAData.class, e.diagnostic().said());
-        assertEquals(3, e.diagnostic().region().start().line());
-        assertEquals(34, e.diagnostic().region().start().column(),
+        assertEquals(3, ((Primary.InSource) e.diagnostic().primary()).place().region().start().line());
+        assertEquals(34, ((Primary.InSource) e.diagnostic().primary()).place().region().start().column(),
                 "the construction in the helper, not the combinator the clause calls");
     }
 
@@ -220,8 +222,8 @@ class CompileConstructionInInvariantTest {
                         value)
                 """);
         assertInstanceOf(InvariantMessage.TheNamedClauseConstructsAData.class, e.diagnostic().said());
-        assertEquals(5, e.diagnostic().region().start().line());
-        assertEquals(14, e.diagnostic().region().start().column());
+        assertEquals(5, ((Primary.InSource) e.diagnostic().primary()).place().region().start().line());
+        assertEquals(14, ((Primary.InSource) e.diagnostic().primary()).place().region().start().column());
     }
 
     /** Written in the clause itself there is one place, and labelling it twice says nothing. */

--- a/souther-compiler/src/test/java/souther/compiler/CompileDeriveDiagnosticTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileDeriveDiagnosticTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.HumanRenderer;
@@ -39,7 +41,7 @@ class CompileDeriveDiagnosticTest {
                 """;
         Diagnostic d = diagnosticOf(src);
 
-        assertEquals(4, d.pos().line());
+        assertEquals(4, ((Primary.InSource) d.primary()).place().region().start().line());
         String out = new HumanRenderer(false).render(d, new SourceContext("demo.sou", src),
                 Locale.ENGLISH);
         assertTrue(out.contains("`集計.entries`"), out);
@@ -64,7 +66,7 @@ class CompileDeriveDiagnosticTest {
                 """;
         Diagnostic d = diagnosticOf(src);
 
-        assertEquals(4, d.pos().line());
+        assertEquals(4, ((Primary.InSource) d.primary()).place().region().start().line());
         String out = new HumanRenderer(false).render(d, new SourceContext("demo.sou", src),
                 Locale.ENGLISH);
         assertTrue(out.contains("`座席.where`"), out);

--- a/souther-compiler/src/test/java/souther/compiler/CompileDestructuringTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileDestructuringTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.diag.msg.TypeMessage;
 import souther.compiler.diag.msg.BehaviorMessage;
 import souther.compiler.diag.CompileException;
@@ -416,8 +418,8 @@ class CompileDestructuringTest {
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
 
         String line = src.lines().toList().get(4);
-        assertEquals(5, e.diagnostic().pos().line(), e.getMessage());
-        assertEquals(line.indexOf("Line(") + 1, e.diagnostic().pos().column(),
+        assertEquals(5, ((Primary.InSource) e.diagnostic().primary()).place().region().start().line(), e.getMessage());
+        assertEquals(line.indexOf("Line(") + 1, ((Primary.InSource) e.diagnostic().primary()).place().region().start().column(),
                 "the caret is on the pattern: " + line);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.source.SourceId;
 import souther.compiler.diag.QuotedFrom;
 
@@ -91,10 +93,10 @@ class CompileFakeExampleDisagreementTest {
         // both are written statements, and which of them is right is not what this reports.
         assertEquals(1, found.size(), found.toString());
         Diagnostic one = found.get(0).diagnostic();
-        assertEquals(22, one.pos().line(), "anchored at the recorded row");
+        assertEquals(22, ((Primary.InSource) one.primary()).place().region().start().line(), "anchored at the recorded row");
         assertEquals(1, one.secondary().size(), one.secondary().toString());
         assertEquals(25, ((souther.compiler.diag.DiagnosticPlace.InSource) one.secondary().get(0).place()).region().start().line(), "pointing at the fake row");
-        assertEquals(new QuotedFrom.ASourceThisCompileHolds(((souther.compiler.diag.DiagnosticPlace.InSource) one.secondary().get(0).place()).source()), one.pos().quotedFrom(),
+        assertEquals(new QuotedFrom.ASourceThisCompileHolds(((souther.compiler.diag.DiagnosticPlace.InSource) one.secondary().get(0).place()).source()), ((Primary.InSource) one.primary()).place().region().start().quotedFrom(),
                 "both are in this source, and the second region says so rather than leaving a"
                         + " reader to work it out from where the diagnostic was filed");
     }
@@ -332,8 +334,8 @@ class CompileFakeExampleDisagreementTest {
 
         assertEquals(1, said.size(), said.toString());
         Diagnostic one = said.get(0).diagnostic();
-        assertEquals(17, one.pos().line(), "anchored where the fake names the behavior");
-        assertEquals(6, one.pos().column());
+        assertEquals(17, ((Primary.InSource) one.primary()).place().region().start().line(), "anchored where the fake names the behavior");
+        assertEquals(6, ((Primary.InSource) one.primary()).place().region().start().column());
         // What could not be done, then what stopped: the table is what did not answer, and the
         // comparison is what that cost. The number is read off the wait this compile was given
         // rather than written in, so the line still holds if that wait changes — and it is read as
@@ -822,7 +824,7 @@ class CompileFakeExampleDisagreementTest {
         assertEquals(1, found.size(), found.toString());
         Diagnostic one = found.get(0).diagnostic();
         assertEquals(1, one.secondary().size(), one.secondary().toString());
-        souther.compiler.source.SourceId primary = found.get(0).primarySourceId();
+        souther.compiler.source.SourceId primary = found.get(0).context().filedUnder().orElse(null);
         souther.compiler.source.SourceId other = ((souther.compiler.diag.DiagnosticPlace.InSource)
                 one.secondary().get(0).place()).source();
         assertNotNull(other, why + ": the second region names the file it is in");

--- a/souther-compiler/src/test/java/souther/compiler/CompileFakeTableWhereWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFakeTableWhereWrittenTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.source.SourceId;
 
 import souther.compiler.examples.EvaluationPolicy;
@@ -81,7 +83,7 @@ class CompileFakeTableWhereWrittenTest {
                 """);
 
         assertEquals("E1317", one.code());
-        assertEquals(16, one.pos().line(), "at the row that states no value");
+        assertEquals(16, ((Primary.InSource) one.primary()).place().region().start().line(), "at the row that states no value");
     }
 
     @Test
@@ -116,7 +118,7 @@ class CompileFakeTableWhereWrittenTest {
 
         assertEquals("E1908", one.code());
         assertInstanceOf(ExampleMessage.TheFakeCouldNotBeBuilt.class, one.said());
-        assertEquals(16, one.pos().line(), "at the row whose input count is wrong");
+        assertEquals(16, ((Primary.InSource) one.primary()).place().region().start().line(), "at the row whose input count is wrong");
     }
 
     /**
@@ -259,8 +261,8 @@ class CompileFakeTableWhereWrittenTest {
         assertEquals(List.of(), only("E1920", warnings),
                 "nothing records what `find` owes, so no comparison was missed");
         Diagnostic one = said.get(0).diagnostic();
-        assertEquals(14, one.pos().line(), "at the fake");
-        assertEquals(6, one.pos().column(), "on the behavior it names");
+        assertEquals(14, ((Primary.InSource) one.primary()).place().region().start().line(), "at the fake");
+        assertEquals(6, ((Primary.InSource) one.primary()).place().region().start().column(), "on the behavior it names");
         // The number is read off the wait this compile was given rather than written in, so the
         // line still holds if that wait changes. Ungrouped, which is how it is set.
         assertTrue(rendered(one).contains("Building the `fake find` table did not answer within "

--- a/souther-compiler/src/test/java/souther/compiler/CompileImportCollisionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileImportCollisionTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.source.SourceId;
 
 import souther.compiler.diag.msg.MessageKeys;
@@ -63,7 +65,7 @@ class CompileImportCollisionTest {
                         data Line = { a: Amount }
                         """)));
 
-        assertEquals(3, e.diagnostic().region().start().line(), "the caret is on the second import");
+        assertEquals(3, ((Primary.InSource) e.diagnostic().primary()).place().region().start().line(), "the caret is on the second import");
         assertEquals(1, e.diagnostic().secondary().size(), "the first import is labelled too");
         assertEquals(2, ((souther.compiler.diag.DiagnosticPlace.InSource) e.diagnostic().secondary().get(0).place()).region().start().line());
     }

--- a/souther-compiler/src/test/java/souther/compiler/CompileIncludeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileIncludeTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import net.unit8.raoh.Err;
 import net.unit8.raoh.Ok;
 import net.unit8.raoh.Result;
@@ -119,9 +121,9 @@ class CompileIncludeTest {
                 """));
 
         assertTrue(e.getMessage().contains("cannot find a type named `Common`"), e.getMessage());
-        assertEquals(2, e.diagnostic().region().start().line());
-        assertEquals(21, e.diagnostic().region().start().column(), "the caret is on the spread's name");
-        assertEquals(27, e.diagnostic().region().end().column());
+        assertEquals(2, ((Primary.InSource) e.diagnostic().primary()).place().region().start().line());
+        assertEquals(21, ((Primary.InSource) e.diagnostic().primary()).place().region().start().column(), "the caret is on the spread's name");
+        assertEquals(27, ((Primary.InSource) e.diagnostic().primary()).place().region().end().column());
     }
 
     // The same miss written as a field's type reports the same thing at the same kind of position —
@@ -134,7 +136,7 @@ class CompileIncludeTest {
                 """));
 
         assertTrue(e.getMessage().contains("cannot find a type named `Common`"), e.getMessage());
-        assertEquals(21, e.diagnostic().region().start().column());
+        assertEquals(21, ((Primary.InSource) e.diagnostic().primary()).place().region().start().column());
     }
 
     @Test
@@ -146,8 +148,8 @@ class CompileIncludeTest {
                 """));
 
         assertTrue(e.getMessage().contains("not a product data"), e.getMessage());
-        assertEquals(3, e.diagnostic().region().start().line());
-        assertEquals(21, e.diagnostic().region().start().column());
+        assertEquals(3, ((Primary.InSource) e.diagnostic().primary()).place().region().start().line());
+        assertEquals(21, ((Primary.InSource) e.diagnostic().primary()).place().region().start().column());
     }
 
     // Every reader of a spread goes through the same resolution, so none of them may reach a null

--- a/souther-compiler/src/test/java/souther/compiler/CompileNamedInvariantClauseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileNamedInvariantClauseTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.diag.msg.InvariantMessage;
 import org.junit.jupiter.api.Test;
 
@@ -243,7 +245,7 @@ class CompileNamedInvariantClauseTest {
                     invariant _ = value > 0
                 """));
         assertInstanceOf(InvariantMessage.UnderscoreCannotNameAClause.class, e.diagnostics().get(0).said());
-        assertEquals(3, e.diagnostics().get(0).pos().line(), "reported at the clause, not at a use");
+        assertEquals(3, ((Primary.InSource) e.diagnostics().get(0).primary()).place().region().start().line(), "reported at the clause, not at a use");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/CompilePathAgreementTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePathAgreementTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.diag.CompileException;
 
 import org.junit.jupiter.params.ParameterizedTest;
@@ -169,7 +171,7 @@ class CompilePathAgreementTest {
         CompileException linked = compileError(() -> Compiler.compileModules(List.of(source)));
         assertEquals(alone.diagnostic().said(), linked.diagnostic().said(),
                 "the two paths disagree on what is wrong with " + name);
-        assertEquals(alone.diagnostic().pos(), linked.diagnostic().pos(),
+        assertEquals(((Primary.InSource) alone.diagnostic().primary()).place().region().start(), ((Primary.InSource) linked.diagnostic().primary()).place().region().start(),
                 "the two paths disagree on where " + name + " is wrong");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileQualifiedCalleeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileQualifiedCalleeTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.diag.msg.NameMessage;
 import org.junit.jupiter.api.Test;
 import souther.compiler.diag.CompileException;
@@ -90,7 +92,7 @@ class CompileQualifiedCalleeTest {
 
         assertTrue(e.getMessage().contains("`up.defaults`"), e.getMessage());
         assertEquals("up.defaults".length(),
-                e.diagnostic().region().end().column() - e.diagnostic().region().start().column());
+                ((Primary.InSource) e.diagnostic().primary()).place().region().end().column() - ((Primary.InSource) e.diagnostic().primary()).place().region().start().column());
     }
 
     /** A chain rooted at a binding is field reads all the way down, however long it is: the root is
@@ -147,7 +149,7 @@ class CompileQualifiedCalleeTest {
 
         assertTrue(e.getMessage().contains("probe.a.NoSuch"), e.getMessage());
         assertEquals("probe.a.NoSuch".length(),
-                e.diagnostic().region().end().column() - e.diagnostic().region().start().column(),
+                ((Primary.InSource) e.diagnostic().primary()).place().region().end().column() - ((Primary.InSource) e.diagnostic().primary()).place().region().start().column(),
                 "the report underlines exactly the name that was written");
     }
 
@@ -166,7 +168,7 @@ class CompileQualifiedCalleeTest {
         assertInstanceOf(NameMessage.NoValueOfThatNameInScope.class, e.diagnostic().said());
         assertTrue(e.getMessage().contains("`unknown`"), e.getMessage());
         assertEquals("unknown".length(),
-                e.diagnostic().region().end().column() - e.diagnostic().region().start().column());
+                ((Primary.InSource) e.diagnostic().primary()).place().region().end().column() - ((Primary.InSource) e.diagnostic().primary()).place().region().start().column());
     }
 
     /**
@@ -191,7 +193,7 @@ class CompileQualifiedCalleeTest {
         assertInstanceOf(NameMessage.ItIsNotAFunctionHere.class, e.diagnostic().said());
         assertTrue(e.getMessage().contains("`d.count`"), e.getMessage());
         assertEquals("d.count".length(),
-                e.diagnostic().region().end().column() - e.diagnostic().region().start().column(),
+                ((Primary.InSource) e.diagnostic().primary()).place().region().end().column() - ((Primary.InSource) e.diagnostic().primary()).place().region().start().column(),
                 "the report underlines the read, not the binding the lowering introduced");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileSignatureApplicationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileSignatureApplicationTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 
@@ -70,6 +72,6 @@ class CompileSignatureApplicationTest {
                 }
                 """);
         assertEquals("check.fold.seed.title", d.titleKey());
-        assertEquals(5, d.pos().line());
+        assertEquals(5, ((Primary.InSource) d.primary()).place().region().start().line());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileUnitValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileUnitValueTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.HumanRenderer;
 import souther.compiler.diag.SourceContext;
@@ -131,7 +133,7 @@ class CompileUnitValueTest {
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
         assertTrue(e.getMessage().contains("empty body"), e.getMessage());
         assertEquals(2, e.pos().line(), "must point at the opening brace");
-        assertEquals(1, e.diagnostic().region().sourceSpan(), "a multi-line region draws one caret");
+        assertEquals(1, ((Primary.InSource) e.diagnostic().primary()).place().region().sourceSpan(), "a multi-line region draws one caret");
     }
 
     /** A spread body is a body: what it includes decides the fields, and an empty one cannot be

--- a/souther-compiler/src/test/java/souther/compiler/CompileUnusedImportWarningTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileUnusedImportWarningTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.diag.msg.MessageKeys;
 import org.junit.jupiter.api.Test;
 
@@ -59,7 +61,7 @@ class CompileUnusedImportWarningTest {
                 continue;
             }
             assertFalse(report.report().isError(), "an unused import does not stop a build");
-            SourcePos at = d.pos();
+            SourcePos at = ((Primary.InSource) d.primary()).place().region().start();
             found.add(d.values().get("name") + " at " + at.line() + ":" + at.column());
         }
         return found;

--- a/souther-compiler/src/test/java/souther/compiler/EveryPlaceDeliveredNamesASourceThisCompilationHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryPlaceDeliveredNamesASourceThisCompilationHoldsTest.java
@@ -269,8 +269,11 @@ class EveryPlaceDeliveredNamesASourceThisCompilationHoldsTest {
     private static List<Citation> citations(Compilation compilation) {
         List<Citation> citations = new ArrayList<>();
         for (Db.Found found : compilation.reports()) {
-            if (((Primary.InSource) found.report().diagnostic().primary()).place().region().start() != null) {
-                citations.add(Citation.of(((Primary.InSource) found.report().diagnostic().primary()).place().region().start()));
+            // Of the reports that point somewhere. One that points at nothing says where its code
+            // is on the primary itself, and has no position to project a citation from.
+            if (found.report().diagnostic().primary()
+                    instanceof Primary.InSource(DiagnosticPlace.InSource place)) {
+                citations.add(Citation.of(place.region().start()));
             }
         }
         return citations;

--- a/souther-compiler/src/test/java/souther/compiler/EveryPlaceDeliveredNamesASourceThisCompilationHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryPlaceDeliveredNamesASourceThisCompilationHoldsTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.diag.Citation;
@@ -248,7 +250,12 @@ class EveryPlaceDeliveredNamesASourceThisCompilationHoldsTest {
         List<Delivered> places = new ArrayList<>();
         for (Db.Found found : compilation.reports()) {
             Diagnostic said = found.report().diagnostic();
-            addPlace(places, "caret", said.region());
+            // Only a caret a reader can be sent to. A report pointing at nothing, or into a text
+            // this compilation cannot name, is offering nobody a place — which is what the arms
+            // say, so there is nothing here to test a region for.
+            if (said.primary() instanceof Primary.InSource(DiagnosticPlace.InSource place)) {
+                places.add(new Delivered("caret", place.region().start().quotedFrom()));
+            }
             for (LabeledRegion label : said.secondary()) {
                 if (label.place() instanceof DiagnosticPlace.InSource in) {
                     places.add(new Delivered("label", in.region().start().quotedFrom()));
@@ -258,21 +265,12 @@ class EveryPlaceDeliveredNamesASourceThisCompilationHoldsTest {
         return places;
     }
 
-    private static void addPlace(List<Delivered> places, String from, Region region) {
-        if (region == null || region.start() == null || region.end() == null) {
-            return;   // a report with nowhere to point is #769's, and is not a place being offered
-        }
-        if (DiagnosticPlace.of(region) instanceof DiagnosticPlace.InSource in) {
-            places.add(new Delivered(from, in.region().start().quotedFrom()));
-        }
-    }
-
     /** What every report says about where the code it is about is written. */
     private static List<Citation> citations(Compilation compilation) {
         List<Citation> citations = new ArrayList<>();
         for (Db.Found found : compilation.reports()) {
-            if (found.report().diagnostic().pos() != null) {
-                citations.add(Citation.of(found.report().diagnostic().pos()));
+            if (((Primary.InSource) found.report().diagnostic().primary()).place().region().start() != null) {
+                citations.add(Citation.of(((Primary.InSource) found.report().diagnostic().primary()).place().region().start()));
             }
         }
         return citations;

--- a/souther-compiler/src/test/java/souther/compiler/ExampleFileValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ExampleFileValuesTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.source.SourceId;
 
 import souther.compiler.diag.msg.ExampleMessage;
@@ -143,6 +145,6 @@ class ExampleFileValuesTest {
         assertEquals("E1906", e.diagnostic().code());
         assertInstanceOf(ExampleMessage.TheNameIsAlreadyDeclared.class, e.diagnostic().said());
         assertEquals(new SourceId("1"), e.sourceId(), "the declaration is in the attached file");
-        assertEquals(3, e.diagnostic().pos().line(), "and at its own line");
+        assertEquals(3, ((Primary.InSource) e.diagnostic().primary()).place().region().start().line(), "and at its own line");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/ExampleMultipleFailuresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ExampleMultipleFailuresTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.HumanRenderer;
@@ -54,7 +56,7 @@ class ExampleMultipleFailuresTest {
 
         List<Diagnostic> ds = e.diagnostics();
         assertEquals(2, ds.size(), "one diagnostic per failing row");
-        assertNotEquals(ds.get(0).region().start().line(), ds.get(1).region().start().line(),
+        assertNotEquals(((Primary.InSource) ds.get(0).primary()).place().region().start().line(), ((Primary.InSource) ds.get(1).primary()).place().region().start().line(),
                 "each points at its own row");
         assertEquals(ds.get(0), e.diagnostic(), "the first is still the one a single-diagnostic caller reads");
     }

--- a/souther-compiler/src/test/java/souther/compiler/HighValueDiagnosticTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/HighValueDiagnosticTest.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.diag.msg.DeclarationMessage;
 import souther.compiler.diag.CompileException;
 
@@ -92,7 +94,7 @@ class HighValueDiagnosticTest {
                 """);
         assertEquals("check.fold.seed.title", d.titleKey());
         // the primary caret is on the Map.empty seed (line 7), not the `+` inside upsert
-        assertEquals(7, d.pos().line());
+        assertEquals(7, ((Primary.InSource) d.primary()).place().region().start().line());
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/TheOneLineTextOfAFailingExampleIsNotAddressedToAReaderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/TheOneLineTextOfAFailingExampleIsNotAddressedToAReaderTest.java
@@ -32,7 +32,7 @@ class TheOneLineTextOfAFailingExampleIsNotAddressedToAReaderTest {
 
     @Test
     void aFailingExampleSaysWhatTheEnglishCatalogSays() {
-        Diagnostic failure = Diagnostic.say(SAID).build();
+        Diagnostic failure = Diagnostic.say(SAID).nowhere().build();
 
         String said = ExampleVerifier.legacySummary(List.of(failure));
 
@@ -45,7 +45,7 @@ class TheOneLineTextOfAFailingExampleIsNotAddressedToAReaderTest {
      */
     @Test
     void theCatalogWouldHaveSaidSomethingElseInJapanese() {
-        Diagnostic failure = Diagnostic.say(SAID).build();
+        Diagnostic failure = Diagnostic.say(SAID).nowhere().build();
 
         String said = ExampleVerifier.legacySummary(List.of(failure));
 

--- a/souther-compiler/src/test/java/souther/compiler/check/ADiagnosticPointsAtTheOperandThatSuppliedTheValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ADiagnosticPointsAtTheOperandThatSuppliedTheValueTest.java
@@ -1,5 +1,7 @@
 package souther.compiler.check;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.Compiler;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -40,7 +42,7 @@ class ADiagnosticPointsAtTheOperandThatSuppliedTheValueTest {
 
     private static Region regionOf(String source) {
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(source));
-        return e.diagnostic().region();
+        return ((Primary.InSource) e.diagnostic().primary()).place().region();
     }
 
     /** The argument is written three lines below the callee, so nothing but the argument's own

--- a/souther-compiler/src/test/java/souther/compiler/check/AHelperSaysTheSameThingWhereverItIsDeclaredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AHelperSaysTheSameThingWhereverItIsDeclaredTest.java
@@ -1,5 +1,7 @@
 package souther.compiler.check;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.source.SourceId;
 import souther.compiler.diag.QuotedFrom;
 
@@ -77,9 +79,9 @@ class AHelperSaysTheSameThingWhereverItIsDeclaredTest {
         Diagnostic one = only(diagnosticsOf(Map.of("m.sou", ONE_MODULE)), "m.sou");
 
         assertInstanceOf(InvariantMessage.TheNamedClauseConstructsAData.class, one.said());
-        assertEquals("Yen", quoted(ONE_MODULE, one.region()),
+        assertEquals("Yen", quoted(ONE_MODULE, ((Primary.InSource) one.primary()).place().region()),
                 "the caret is on the construction, which is what the rule is about");
-        assertFalse(one.pos().wasCopiedHere(),
+        assertFalse(((Primary.InSource) one.primary()).place().region().start().wasCopiedHere(),
                 "the construction is in a file this compile has, so the caret is at the code");
     }
 
@@ -93,11 +95,11 @@ class AHelperSaysTheSameThingWhereverItIsDeclaredTest {
                 "down.sou");
 
         assertInstanceOf(InvariantMessage.TheNamedClauseConstructsAData.class, one.said());
-        assertEquals("Yen", quoted(DECLARING, one.region()),
+        assertEquals("Yen", quoted(DECLARING, ((Primary.InSource) one.primary()).place().region()),
                 "the caret is on the construction, in the file the helper is written in");
         assertEquals(new QuotedFrom.ASourceThisCompileHolds(new SourceId("up.sou")),
-                one.pos().quotedFrom());
-        assertFalse(one.pos().wasCopiedHere());
+                ((Primary.InSource) one.primary()).place().region().start().quotedFrom());
+        assertFalse(((Primary.InSource) one.primary()).place().region().start().wasCopiedHere());
     }
 
     /**
@@ -133,7 +135,7 @@ class AHelperSaysTheSameThingWhereverItIsDeclaredTest {
 
         assertEquals(1, byFile.get(new SourceId("up.sou")).size(), () -> "" + byFile.get(new SourceId("up.sou")));
         assertEquals(1, byFile.get(new SourceId("down.sou")).size(), () -> "" + byFile.get(new SourceId("down.sou")));
-        assertEquals(new SourceId("up.sou"), byFile.get(new SourceId("down.sou")).get(0).primarySourceId(),
+        assertEquals(new SourceId("up.sou"), byFile.get(new SourceId("down.sou")).get(0).context().filedUnder().orElse(null),
                 "the caret is on the construction wherever the report is published");
         assertEquals(byFile.get(new SourceId("up.sou")).get(0).diagnostic().identity(),
                 byFile.get(new SourceId("down.sou")).get(0).diagnostic().identity(),
@@ -159,7 +161,7 @@ class AHelperSaysTheSameThingWhereverItIsDeclaredTest {
                         .standingInFor(new DeclaringCode(
                                 new SourceProvenance.APublishedModule("up", "up.atLeastZero")))
                         .placement(),
-                one.pos().placement(),
+                ((Primary.InSource) one.primary()).place().region().start().placement(),
                 "the caret is in the file the reader is compiling, since there is no other, and it"
                         + " says the code it names is written where that file cannot show");
     }
@@ -172,7 +174,7 @@ class AHelperSaysTheSameThingWhereverItIsDeclaredTest {
         Diagnostic one = only(diagnosticsOf(Map.of("down.sou", CALLING), published(DECLARING)),
                 "down.sou");
 
-        assertEquals(one.region().start(), one.region().end(),
+        assertEquals(((Primary.InSource) one.primary()).place().region().start(), ((Primary.InSource) one.primary()).place().region().end(),
                 "a stand-in points, it does not underline text it did not measure");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AKeptCallsFunctionArgumentIsRefusedWhereItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AKeptCallsFunctionArgumentIsRefusedWhereItIsWrittenTest.java
@@ -1,5 +1,9 @@
 package souther.compiler.check;
 
+import souther.compiler.source.SourceId;
+
+import souther.compiler.diag.Primary;
+
 import souther.compiler.ast.Hir;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.SourcePos;
@@ -28,8 +32,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class AKeptCallsFunctionArgumentIsRefusedWhereItIsWrittenTest {
 
-    private static final SourcePos CALL = new SourcePos(1, 1);
-    private static final SourcePos ARGUMENT = new SourcePos(3, 5);
+    /** Positions of a file this compile holds, as a parse of one makes them: what is being tested
+     *  is which of two lines the caret lands on, and a position naming no source would leave that
+     *  to whichever text the caller said it was reading. */
+    private static final SourceId SOURCE = new SourceId("0");
+    private static final SourcePos CALL = new SourcePos(1, 1, SOURCE);
+    private static final SourcePos ARGUMENT = new SourcePos(3, 5, SOURCE);
 
     /**
      * {@code List.flatMap : (('a) -> List<'b>, List<'a>) -> List<'b>} — the function argument is
@@ -51,7 +59,7 @@ class AKeptCallsFunctionArgumentIsRefusedWhereItIsWrittenTest {
                 () -> Elaborator.elaborate(call, Scope.NONE, CheckContext.of(Symbols.none())
                         .preserving(Preserved.byTheLanguagesOwnOperations())));
 
-        assertEquals(ARGUMENT.line(), e.diagnostic().region().start().line(),
+        assertEquals(ARGUMENT.line(), ((Primary.InSource) e.diagnostic().primary()).place().region().start().line(),
                 "the block is on line " + ARGUMENT.line() + " and the callee on line "
                         + CALL.line());
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/AWarningAboutAClauseSendsAReaderToItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AWarningAboutAClauseSendsAReaderToItTest.java
@@ -1,5 +1,7 @@
 package souther.compiler.check;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.source.SourceId;
 import souther.compiler.diag.QuotedFrom;
 
@@ -194,7 +196,7 @@ class AWarningAboutAClauseSendsAReaderToItTest {
 
         LabeledRegion one = warnings.get(0).secondary().get(0);
         assertEquals(new QuotedFrom.ASourceThisCompileHolds(new SourceId("1")),
-                warnings.get(0).pos().quotedFrom(),
+                ((Primary.InSource) warnings.get(0).primary()).place().region().start().quotedFrom(),
                 "the construction is in the second source");
         assertEquals(new SourceId("0"),
                 ((souther.compiler.diag.DiagnosticPlace.InSource) one.place()).source(),

--- a/souther-compiler/src/test/java/souther/compiler/check/AnExpansionOwnsWhatItWritesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnExpansionOwnsWhatItWritesTest.java
@@ -1,5 +1,7 @@
 package souther.compiler.check;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.Compiler;
 import souther.compiler.ast.Ast;
 import souther.compiler.ast.Hir;
@@ -135,7 +137,7 @@ class AnExpansionOwnsWhatItWritesTest {
                         """));
         assertTrue(e.getMessage().contains("takes 2 argument(s), but is written with 1"),
                 e.getMessage());
-        assertEquals(6, e.diagnostic().region().start().line(),
+        assertEquals(6, ((Primary.InSource) e.diagnostic().primary()).place().region().start().line(),
                 "the inner lambda's line, not the outer one's: " + e.getMessage());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AnExpansionRefusesAnArgumentWhereItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnExpansionRefusesAnArgumentWhereItIsWrittenTest.java
@@ -1,5 +1,7 @@
 package souther.compiler.check;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.Compiler;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -31,7 +33,7 @@ class AnExpansionRefusesAnArgumentWhereItIsWrittenTest {
 
     private static Region regionOf(String source) {
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(source));
-        return e.diagnostic().region();
+        return ((Primary.InSource) e.diagnostic().primary()).place().region();
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/diag/AJoinFailureNamesTheOperandItRefusedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/AJoinFailureNamesTheOperandItRefusedTest.java
@@ -203,12 +203,12 @@ class AJoinFailureNamesTheOperandItRefusedTest {
 
     /** The characters of {@code source} a report's primary region covers. */
     private static String underlined(String source, Diagnostic report) {
-        return at(source, report.region());
+        return at(source, ((Primary.InSource) report.primary()).place().region());
     }
 
     /** The whole source line a report's primary region begins on. */
     private static String line(String source, Diagnostic report) {
-        return source.lines().toList().get(report.region().start().line() - 1);
+        return source.lines().toList().get(((Primary.InSource) report.primary()).place().region().start().line() - 1);
     }
 
     /** The characters of {@code source} {@code region} covers. */

--- a/souther-compiler/src/test/java/souther/compiler/diag/AReportUnderlinesWhatTheAuthorTypedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/AReportUnderlinesWhatTheAuthorTypedTest.java
@@ -87,7 +87,7 @@ class AReportUnderlinesWhatTheAuthorTypedTest {
                 data Box = { v: %s . Missing }
                 """.formatted(NFD));
 
-        Region region = report.region();
+        Region region = ((Primary.InSource) report.primary()).place().region();
         assertEquals(region.start().line(), region.end().line());
         assertEquals((NFD + " . Missing").length(),
                 region.end().column() - region.start().column(),
@@ -105,7 +105,7 @@ class AReportUnderlinesWhatTheAuthorTypedTest {
 
     /** How many columns a report's primary region covers. */
     private static int width(Diagnostic report) {
-        Region region = report.region();
+        Region region = ((Primary.InSource) report.primary()).place().region();
         assertEquals(region.start().line(), region.end().line(), "a name is one line's worth");
         return region.end().column() - region.start().column();
     }

--- a/souther-compiler/src/test/java/souther/compiler/diag/AReportWithNowhereToPointStillSaysWhereItsCodeIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/AReportWithNowhereToPointStillSaysWhereItsCodeIsTest.java
@@ -153,4 +153,44 @@ class AReportWithNowhereToPointStillSaysWhereItsCodeIsTest {
         assertEquals(THE_CODE, reached.provenance(), "the same code");
         assertTrue(reached.at().isIn(new SourceId("app.sou")), "somewhere the reader holds");
     }
+
+    /**
+     * A label of its own does not become the place it points at.
+     *
+     * <p>A report with nowhere to point may still carry a label somewhere a reader can be sent — the
+     * guard a boundary finding was drawn by is in this compile's own source while the body the
+     * finding is about is not. Read as the thing to put the marker on, that label gives a report
+     * that says it points nowhere a line and a column that came from something else, which is the
+     * reading this family of types exists to stop: the header said the report was at the guard while
+     * the sentence under it said there was nowhere here to point at.
+     *
+     * <p>Which is not the rule that lets a label be the anchor. A problem written in two files is
+     * read from each of them, and on the second the label is what the marker goes on — but that is
+     * two places changing places, and a report with no place of its own has nothing to change with.
+     *
+     * <p>And the label keeps what it says. Anchored, its sentence is not written anywhere: an anchor
+     * is what the message is about, so nothing prints a note for it.
+     */
+    @Test
+    void aLabelOfItsOwnDoesNotBecomeThePlaceItPointsAt() {
+        Diagnostic said = Diagnostic.atCodeWrittenOutOfSight(THE_CODE)
+                .say(new ModuleMessage.CannotReadAFieldOnASum("x", "S"))
+                .secondary(Region.point(new SourcePos(2, 3, new SourceId("app.sou"))),
+                        new ModuleMessage.RenameItOrDropTheDependency("lib.rule"))
+                .build();
+        Located located = new Located(said, ReportContext.inFile(new SourceId("app.sou")));
+
+        DiagnosticView view = DiagnosticView.of(said, located.context());
+
+        assertTrue(view.anchor().isEmpty(),
+                () -> "nothing here is what the report is about: " + view.anchor());
+        assertEquals(1, view.others().size(), "and the label is still a label");
+
+        String out = new HumanRenderer(false).render(located,
+                _ -> new SourceContext("app.sou", "line one\nline two here\n"), Locale.ENGLISH);
+
+        assertFalse(out.lines().findFirst().orElseThrow().contains("2:3"),
+                () -> "the report is not at the guard's line: " + out);
+        assertTrue(out.contains("Rename"), () -> "and the label still says what it says: " + out);
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/diag/AReportWithNowhereToPointStillSaysWhereItsCodeIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/AReportWithNowhereToPointStillSaysWhereItsCodeIsTest.java
@@ -51,7 +51,7 @@ class AReportWithNowhereToPointStillSaysWhereItsCodeIsTest {
     @Test
     void whatABuildReadsSaysItAsAValue() {
         String json = new JsonRenderer().render(
-                new Located(nowhereToPoint(), new SourceId("app.sou")),
+                new Located(nowhereToPoint(), ReportContext.inFile(new SourceId("app.sou"))),
                 _ -> null, Locale.ENGLISH);
 
         assertTrue(json.contains("\"writtenAt\""),
@@ -133,9 +133,9 @@ class AReportWithNowhereToPointStillSaysWhereItsCodeIsTest {
 
         assertEquals(new WhereCodeIsWritten.Unstated(), said.whereItsCodeIsWritten(),
                 "nothing to point at, and nothing said through it");
-        assertEquals(THE_CODE, ((Citation.Reached) Citation.of(said.reachedFrom(
+        assertEquals(THE_CODE, ((Citation.Reached) Citation.of(((Primary.InSource) said.reachedFrom(
                         java.util.List.of(new SourcePos(2, 1, new SourceId("app.sou"))), THE_CODE,
-                        new ModuleMessage.ItIsReachedFromHereToo()).region().start()))
+                        new ModuleMessage.ItIsReachedFromHereToo()).primary()).place().region().start()))
                         .provenance(),
                 "so the caller says where the code is, and it is taken");
     }
@@ -149,7 +149,7 @@ class AReportWithNowhereToPointStillSaysWhereItsCodeIsTest {
                 new ModuleMessage.ItIsReachedFromHereToo());
 
         Citation.Reached reached =
-                (Citation.Reached) Citation.of(moved.region().start());
+                (Citation.Reached) Citation.of(((Primary.InSource) moved.primary()).place().region().start());
         assertEquals(THE_CODE, reached.provenance(), "the same code");
         assertTrue(reached.at().isIn(new SourceId("app.sou")), "somewhere the reader holds");
     }

--- a/souther-compiler/src/test/java/souther/compiler/diag/AResultReportUnderlinesWhatSuppliedTheValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/AResultReportUnderlinesWhatSuppliedTheValueTest.java
@@ -125,7 +125,7 @@ class AResultReportUnderlinesWhatSuppliedTheValueTest {
 
         Diagnostic report = only(source);
         assertEquals("if n > 0 then", lineUnderlined(source, report).trim());
-        assertEquals(1, report.region().sourceSpan(), "a construct is measured from its start");
+        assertEquals(1, ((Primary.InSource) report.primary()).place().region().sourceSpan(), "a construct is measured from its start");
     }
 
     /** A fold's step, written as a block, answers something the accumulator cannot hold. */
@@ -202,7 +202,7 @@ class AResultReportUnderlinesWhatSuppliedTheValueTest {
 
     /** The characters of {@code source} a report's primary region covers. */
     private static String underlined(String source, Diagnostic report) {
-        Region region = report.region();
+        Region region = ((Primary.InSource) report.primary()).place().region();
         assertEquals(region.start().line(), region.end().line(),
                 "an expression this test is about is one line's worth");
         int from = region.start().column() - 1;
@@ -211,6 +211,6 @@ class AResultReportUnderlinesWhatSuppliedTheValueTest {
 
     /** The whole source line a report's primary region begins on. */
     private static String lineUnderlined(String source, Diagnostic report) {
-        return source.lines().toList().get(report.region().start().line() - 1);
+        return source.lines().toList().get(((Primary.InSource) report.primary()).place().region().start().line() - 1);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/diag/ASecondaryRegionNamesItsFileTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/ASecondaryRegionNamesItsFileTest.java
@@ -61,13 +61,21 @@ class ASecondaryRegionNamesItsFileTest {
     }
 
     /** A diagnostic whose secondary is in {@code secondarySourceId} — which the region says, being
-     *  the only thing that says it. */
+     *  the only thing that says it. Its own place is in the row file, which its region says too:
+     *  what these are about is where a second region is read, and a primary that named no source
+     *  would leave the caller's answer doing that work as well. */
     private static Diagnostic withSecondary(String secondarySourceId) {
         return Diagnostic.say(new NameMessage.NoValueOfThatNameInScope("x"))
-                .at(new SourcePos(3, 3), 5)
+                .at(new SourcePos(3, 3, new SourceId("rows")), 5)
                 .secondary(Region.ofWidth(new SourcePos(3, 3, new SourceId(secondarySourceId)), 4),
                         new NameMessage.WriteItOnItsOwn("x"))
                 .build();
+    }
+
+    /** The source a spot shown here is in. Every one of them is in a source: what a text nobody
+     *  named looks like is {@link #aDiagnosticInATextTheCallerNamesIsQuotedFromIt}. */
+    private static SourceId sourceOf(Shown shown) {
+        return ((Spot.InSource) shown.spot()).place().source();
     }
 
     // --- what is quoted -------------------------------------------------------------------------
@@ -76,7 +84,7 @@ class ASecondaryRegionNamesItsFileTest {
     void aSecondaryInTheDiagnosticsOwnFileIsQuotedFromItAndNotNamed() {
         Asked asked = resolver();
         String out = new HumanRenderer(false).render(
-                new Located(withSecondary("rows"), new SourceId("rows")), asked.resolver(), Locale.ENGLISH);
+                new Located(withSecondary("rows"), ReportContext.inFile(new SourceId("rows"))), asked.resolver(), Locale.ENGLISH);
 
         assertEquals(2, count(out, "  | \"one\" : (1) -> 2"),
                 "the primary and the secondary both quote the row file: " + out);
@@ -88,21 +96,57 @@ class ASecondaryRegionNamesItsFileTest {
     void aSecondaryInAnotherFileIsQuotedFromThatFileAndNamed() {
         Asked asked = resolver();
         String out = new HumanRenderer(false).render(
-                new Located(withSecondary("fakes"), new SourceId("rows")), asked.resolver(), Locale.ENGLISH);
+                new Located(withSecondary("fakes"), ReportContext.inFile(new SourceId("rows"))), asked.resolver(), Locale.ENGLISH);
 
         assertTrue(out.contains("  | \"one\" : (1) -> 2"), "the primary quotes the row: " + out);
         assertTrue(out.contains("  | (1) -> 3"), "the secondary quotes the fake: " + out);
         assertTrue(out.contains("fakes.sou:3:3"), "and says where it is: " + out);
     }
 
+    /**
+     * A report in a text this compilation cannot name is quoted from the text the caller says it is
+     * reading.
+     *
+     * <p>Which the caller hands over, rather than answering for every id a resolver is asked about.
+     * The line and the column are real — somebody wrote that code and a parser read it — and which
+     * text they are of is the one thing the report cannot say, so the surface says it.
+     */
     @Test
-    void aDiagnosticThatNamesNoSourceIsQuotedFromWhateverTheCallerAnswersWith() {
+    void aDiagnosticInATextTheCallerNamesIsQuotedFromIt() {
+        Diagnostic inABufferNobodyNamed = Diagnostic
+                .say(new NameMessage.NoValueOfThatNameInScope("x"))
+                .at(new SourcePos(3, 3), 5)
+                .build();
+
         String out = new HumanRenderer(false).render(
-                new Located(withSecondary("rows"), Located.NO_SOURCE),
+                new Located(inABufferNobodyNamed, ReportContext.ofTheTextItself(rows())),
+                SourceContextResolver.none(), Locale.ENGLISH);
+
+        assertEquals(1, count(out, "  | \"one\" : (1) -> 2"), out);
+        assertFalse(out.contains("null"), out);
+    }
+
+    /**
+     * And where the caller says nothing, nothing is quoted rather than something guessed at.
+     *
+     * <p>The other half of the one above, and the reason the context is a value: a resolver that
+     * answered for whatever it was asked would quote this from the file the reader happened to have
+     * in mind, at numbers that are not of it.
+     */
+    @Test
+    void aDiagnosticInATextNobodyNamedIsNotQuotedFromWhateverIsToHand() {
+        Diagnostic inABufferNobodyNamed = Diagnostic
+                .say(new NameMessage.NoValueOfThatNameInScope("x"))
+                .at(new SourcePos(3, 3), 5)
+                .build();
+
+        String out = new HumanRenderer(false).render(
+                new Located(inABufferNobodyNamed, ReportContext.NONE),
                 id -> rows(), Locale.ENGLISH);
 
-        assertEquals(2, count(out, "  | \"one\" : (1) -> 2"), out);
-        assertFalse(out.contains("null"), out);
+        assertEquals(0, count(out, "  | \"one\" : (1) -> 2"),
+                "nothing to quote it from, so no line is quoted: " + out);
+        assertFalse(out.contains("3:3"), "and no numbers against a file nobody named: " + out);
     }
 
     @Test
@@ -116,7 +160,7 @@ class ASecondaryRegionNamesItsFileTest {
                         new NameMessage.WriteItOnItsOwn("x"))
                 .build();
 
-        new HumanRenderer(false).render(new Located(d, new SourceId("rows")), asked.resolver(), Locale.ENGLISH);
+        new HumanRenderer(false).render(new Located(d, ReportContext.inFile(new SourceId("rows"))), asked.resolver(), Locale.ENGLISH);
 
         assertEquals(1, count(asked.ids(), "fakes"),
                 "two regions in one file, one read: " + asked.ids());
@@ -128,7 +172,7 @@ class ASecondaryRegionNamesItsFileTest {
     void jsonNamesNoFileForASecondaryInTheDiagnosticsOwnFile() {
         Asked asked = resolver();
         String out = new JsonRenderer().render(
-                new Located(withSecondary("rows"), new SourceId("rows")), asked.resolver(), Locale.ENGLISH);
+                new Located(withSecondary("rows"), ReportContext.inFile(new SourceId("rows"))), asked.resolver(), Locale.ENGLISH);
 
         assertEquals(1, count(out, "\"file\""), "only the top-level file: " + out);
     }
@@ -137,7 +181,7 @@ class ASecondaryRegionNamesItsFileTest {
     void jsonNamesTheFileOfASecondaryWrittenInAnother() {
         Asked asked = resolver();
         String out = new JsonRenderer().render(
-                new Located(withSecondary("fakes"), new SourceId("rows")), asked.resolver(), Locale.ENGLISH);
+                new Located(withSecondary("fakes"), ReportContext.inFile(new SourceId("rows"))), asked.resolver(), Locale.ENGLISH);
 
         assertTrue(out.contains("\"file\":\"rows.sou\""), out);
         assertTrue(out.contains("\"file\":\"fakes.sou\""), out);
@@ -149,24 +193,29 @@ class ASecondaryRegionNamesItsFileTest {
     void theFileHoldingTheSecondaryReadsItAsTheAnchorAndThePrimaryAsElsewhere() {
         Diagnostic d = withSecondary("fakes");
 
-        DiagnosticView own = DiagnosticView.of(d, new SourceId("rows"), new SourceId("rows"));
-        assertEquals(new SourceId("rows"), own.anchor().sourceId());
-        assertFalse(own.anchor().labelled(), "the primary region carries no note of its own");
-        assertEquals(List.of(new SourceId("fakes")), own.others().stream().map(Spot::sourceId).toList());
+        DiagnosticView own = DiagnosticView.of(d, ReportContext.inFile(new SourceId("rows")));
+        assertEquals(new SourceId("rows"), sourceOf(own.anchor().orElseThrow()));
+        assertInstanceOf(Shown.ItsSubject.class, own.anchor().orElseThrow(),
+                "what the message is about carries no note of its own");
+        assertEquals(List.of(new SourceId("fakes")),
+                own.others().stream().map(ASecondaryRegionNamesItsFileTest::sourceOf).toList());
 
-        DiagnosticView other = DiagnosticView.of(d, new SourceId("rows"), new SourceId("fakes"));
-        assertEquals(new SourceId("fakes"), other.anchor().sourceId(), "the two change places");
-        assertTrue(other.anchor().labelled());
-        assertEquals(List.of(new SourceId("rows")), other.others().stream().map(Spot::sourceId).toList());
+        DiagnosticView other = DiagnosticView.of(d, ReportContext.of(new SourceId("rows"), new SourceId("fakes")));
+        assertEquals(new SourceId("fakes"), sourceOf(other.anchor().orElseThrow()),
+                "the two change places");
+        assertInstanceOf(Shown.ALabel.class, other.anchor().orElseThrow());
+        assertEquals(List.of(new SourceId("rows")),
+                other.others().stream().map(ASecondaryRegionNamesItsFileTest::sourceOf).toList());
     }
 
     /** A secondary in the diagnostic's own file is one spot among the others, named the same way
      *  every other is — by its region, not by being the one that said nothing. */
     @Test
     void aSecondaryInTheDiagnosticsOwnFileIsNamedLikeAnyOther() {
-        DiagnosticView view = DiagnosticView.of(withSecondary("rows"), new SourceId("rows"), new SourceId("rows"));
+        DiagnosticView view = DiagnosticView.of(withSecondary("rows"), ReportContext.inFile(new SourceId("rows")));
 
-        assertEquals(List.of(new SourceId("rows")), view.others().stream().map(Spot::sourceId).toList());
+        assertEquals(List.of(new SourceId("rows")),
+                view.others().stream().map(ASecondaryRegionNamesItsFileTest::sourceOf).toList());
         assertEquals(new SourceId("rows"), ((DiagnosticPlace.InSource)
                         withSecondary("rows").secondary().get(0).place()).source());
     }
@@ -176,7 +225,8 @@ class ASecondaryRegionNamesItsFileTest {
         Diagnostic d = withSecondary("fakes");
 
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
-                () -> DiagnosticView.of(d, new SourceId("rows"), new SourceId("elsewhere")));
+                () -> DiagnosticView.of(d,
+                        ReportContext.of(new SourceId("rows"), new SourceId("elsewhere"))));
 
         assertTrue(refused.getMessage().contains("elsewhere"), refused.getMessage());
     }
@@ -191,9 +241,9 @@ class ASecondaryRegionNamesItsFileTest {
                         new NameMessage.WriteItOnItsOwn("x"))
                 .build();
 
-        DiagnosticView view = DiagnosticView.of(d, new SourceId("rows"), new SourceId("fakes"));
+        DiagnosticView view = DiagnosticView.of(d, ReportContext.of(new SourceId("rows"), new SourceId("fakes")));
 
-        assertEquals(3, view.anchor().region().start().line(),
+        assertEquals(3, view.anchor().orElseThrow().spot().region().start().line(),
                 "declaration order, not the earlier line");
         assertEquals(2, view.others().size());
     }
@@ -242,7 +292,7 @@ class ASecondaryRegionNamesItsFileTest {
     void theSourceALabelNamesReachesTheRenderer() {
         Asked asked = resolver();
         new HumanRenderer(false).render(
-                new Located(withSecondary("fakes"), new SourceId("rows")), asked.resolver(), Locale.ENGLISH);
+                new Located(withSecondary("fakes"), ReportContext.inFile(new SourceId("rows"))), asked.resolver(), Locale.ENGLISH);
 
         assertTrue(asked.ids().contains(new SourceId("fakes")),
                 () -> "the label's own source is what was read: " + asked.ids());

--- a/souther-compiler/src/test/java/souther/compiler/diag/AnExpressionIsUnderlinedOverWhatWasWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/AnExpressionIsUnderlinedOverWhatWasWrittenTest.java
@@ -225,7 +225,7 @@ class AnExpressionIsUnderlinedOverWhatWasWrittenTest {
 
     /** The primary region of the one report compiling {@code source} produces. */
     private static Region primary(String source) {
-        return only(source).region();
+        return ((Primary.InSource) only(source).primary()).place().region();
     }
 
     /** The {@code n}th secondary region of the one report compiling {@code source} produces. */

--- a/souther-compiler/src/test/java/souther/compiler/diag/AskingForAMessageWithoutALanguageIsRefusedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/AskingForAMessageWithoutALanguageIsRefusedTest.java
@@ -34,7 +34,7 @@ class AskingForAMessageWithoutALanguageIsRefusedTest {
     @Test
     void renderingABodyWithNoLanguageIsRefused() {
         Diagnostic d = Diagnostic.say(
-                new ExampleMessage.TheRowReachedAnUnreachablePoint("why")).build();
+                new ExampleMessage.TheRowReachedAnUnreachablePoint("why")).nowhere().build();
 
         assertThrows(NullPointerException.class, () -> DiagnosticRenderer.body(d, null));
     }

--- a/souther-compiler/src/test/java/souther/compiler/diag/DiagnosticRenderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/DiagnosticRenderTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -116,7 +117,8 @@ class DiagnosticRenderTest {
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
         Diagnostic d = e.diagnostic();
         assertEquals("E1301", d.code());
-        assertEquals("E1301", ((Primary.InSource) d.primary()).place().region().start() == null ? null : d.code());
+        assertInstanceOf(Primary.InSource.class, d.primary(),
+                "a report from a compile of a source points into that source");
         String json = new JsonRenderer().render(d, null, Locale.JAPANESE);
         assertTrue(json.contains("\"code\":\"E1301\""), json);
     }

--- a/souther-compiler/src/test/java/souther/compiler/diag/DiagnosticRenderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/DiagnosticRenderTest.java
@@ -116,7 +116,7 @@ class DiagnosticRenderTest {
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
         Diagnostic d = e.diagnostic();
         assertEquals("E1301", d.code());
-        assertEquals("E1301", d.pos() == null ? null : d.code());
+        assertEquals("E1301", ((Primary.InSource) d.primary()).place().region().start() == null ? null : d.code());
         String json = new JsonRenderer().render(d, null, Locale.JAPANESE);
         assertTrue(json.contains("\"code\":\"E1301\""), json);
     }

--- a/souther-compiler/src/test/java/souther/compiler/diag/NoValueHoldsASourceBesideOneThatAnswersForItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/NoValueHoldsASourceBesideOneThatAnswersForItTest.java
@@ -75,27 +75,26 @@ class NoValueHoldsASourceBesideOneThatAnswersForItTest {
      * being written, one level down from the one it replaced.
      */
     private static final Set<Class<?>> ANSWERS_FOR_A_SOURCE = Set.of(
-            Region.class, SourcePos.class, DiagnosticPlace.InSource.class, Citation.class);
+            Region.class, SourcePos.class, DiagnosticPlace.InSource.class, Citation.class,
+            Diagnostic.class);
 
     /**
-     * The one value that holds both, and it is an open question rather than a shape this rule does
-     * not cover.
+     * Nothing. The one value that used to hold both was {@link Spot}, which paired a told source
+     * with a region because a primary region was not held to naming one — and what the told source
+     * meant depended on which of them it was beside: the source the region was in, or the file the
+     * report was being read from.
      *
-     * <p>{@link Spot} pairs a told source with a region, and the reason is not that a primary is a
-     * different kind of place. A secondary is built through {@link DiagnosticPlace}, so it names a
-     * source by construction; a primary is not held to that, and over one compile of this suite 53
-     * of 3545 diagnostics carried a primary region that names no source while saying the code is
-     * written at it, with another 22 carrying no region at all. Where the region does not answer,
-     * the told source is the only answer there is.
+     * <p>Both are values now and neither is told. A place a reader is sent to carries its source
+     * ({@link Spot.InSource}); a place in a text this compilation cannot name carries the text the
+     * surface says it is reading, which is not a second answer to a question its region answers,
+     * because that region answers nothing ({@link UnnamedRegion}). Which file a report is listed
+     * under is the third thing and is not a place at all — it is what a caller holding the files
+     * answers, and it is on the context rather than beside the report.
      *
-     * <p>So what is unsettled is not whether the pair may exist but what the second half means: the
-     * source the region is in, or the file this report is being read from. Deciding that means
-     * reading what those 53 diagnostics are about, across the fourteen codes they came from, and
-     * that is a question about the diagnostic model rather than about source identity. Named here so
-     * that it goes when that question is answered, rather than outliving it as a rule nobody
-     * remembers writing.
+     * <p>Kept as an empty set rather than deleted. An exception admitted here is a rule this test
+     * stops making, and one added later should look like what it is.
      */
-    private static final Set<Class<?>> OPEN = Set.of(Spot.class);
+    private static final Set<Class<?>> OPEN = Set.of();
 
     private static final List<Class<?>> COMPILED = compiled();
 
@@ -155,7 +154,9 @@ class NoValueHoldsASourceBesideOneThatAnswersForItTest {
     @Test
     void theScanReachesTheValuesThisRuleIsAbout() {
         assertTrue(COMPILED.size() > 500, "the compiler and its syntax, not a handful: " + COMPILED.size());
-        for (Class<?> named : List.of(SourcePos.class, Region.class, Citation.class, Spot.class,
+        for (Class<?> named : List.of(SourcePos.class, Region.class, Citation.class,
+                Spot.InSource.class, Spot.InTextBeingRead.class, Diagnostic.class, Located.class,
+                souther.compiler.query.Db.Found.class,
                 DiagnosticPlace.InSource.class, souther.compiler.observe.RowOutcome.class,
                 souther.compiler.observe.Incompleteness.class,
                 souther.compiler.query.Output.Examples.class)) {

--- a/souther-compiler/src/test/java/souther/compiler/query/ACompileAnswersWithEveryErrorItFoundTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ACompileAnswersWithEveryErrorItFoundTest.java
@@ -1,5 +1,7 @@
 package souther.compiler.query;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.source.SourceId;
 
 import souther.compiler.Compiler;
@@ -94,7 +96,7 @@ class ACompileAnswersWithEveryErrorItFoundTest {
 
         List<Integer> lines = new ArrayList<>();
         for (Diagnostic d : e.diagnostics()) {
-            lines.add(d.pos().line());
+            lines.add(((Primary.InSource) d.primary()).place().region().start().line());
         }
         List<Integer> ascending = new ArrayList<>(lines);
         ascending.sort(Integer::compareTo);

--- a/souther-compiler/src/test/java/souther/compiler/query/AFileThisCompileDoesNotHaveIsNotAFileToFileUnderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AFileThisCompileDoesNotHaveIsNotAFileToFileUnderTest.java
@@ -1,5 +1,7 @@
 package souther.compiler.query;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.source.SourceId;
 
 import souther.compiler.diag.msg.NameMessage;
@@ -53,7 +55,7 @@ class AFileThisCompileDoesNotHaveIsNotAFileToFileUnderTest {
         byId.put("m.sou", M);
         Compilation c = ofDocuments(byId);
 
-        assertEquals(new SourceId("m.sou"), c.sourceIdOf(about("m.sou")));
+        assertEquals(new SourceId("m.sou"), c.filedUnderOf(about("m.sou")));
     }
 
     @Test
@@ -62,7 +64,7 @@ class AFileThisCompileDoesNotHaveIsNotAFileToFileUnderTest {
         byId.put("m.sou", M);
         Compilation c = ofDocuments(byId);
 
-        assertEquals(new SourceId("m.sou"), c.sourceIdOf(about("somewhere-else.sou")),
+        assertEquals(new SourceId("m.sou"), c.filedUnderOf(about("somewhere-else.sou")),
                 "the position names a file this compile was never handed");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/query/AReportAboutAPathModuleSaysWhichModuleItIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AReportAboutAPathModuleSaysWhichModuleItIsAboutTest.java
@@ -1,0 +1,96 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.Citation;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Primary;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.diag.msg.ModuleMessage;
+import souther.compiler.meta.ModuleReadback;
+import souther.compiler.meta.Readback;
+import souther.compiler.source.SourceId;
+import souther.compiler.diag.Placement;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A report this compilation makes about a module off the class path says which module the code is
+ * in, before anything moves it.
+ *
+ * <p>Both of these used to be built with nothing said about where their code was, and the caret was
+ * put on an import line afterwards by the walk that found them ({@code Front.saidAbout}). A report
+ * that says nothing may be moved anywhere: {@link Diagnostic#reachedFrom} has one state where it
+ * takes the caller's word for where the code is, and that is the state where nothing contradicts it.
+ * So the walk was the only thing keeping the module a report is about and the module it is moved as
+ * belonging to the same module, and nothing said so.
+ *
+ * <p>Saying it at the producer puts the two under one check. What is measured here is that the
+ * producers say it — not that the walk still works, which the compile-level tests measure — because
+ * a producer that went back to saying nothing would leave those green.
+ */
+class AReportAboutAPathModuleSaysWhichModuleItIsAboutTest {
+
+    private static final List<SourcePos> AN_IMPORT_LINE =
+            List.of(Placement.aFileOfThisCompile(new SourceId("0")).at(2, 1));
+
+    @Test
+    void aMissingDependencyIsAboutTheModuleThatNeedsIt() {
+        Diagnostic said = Front.needs("lib.absent", "lib.held");
+
+        assertEquals(new Primary.Unavailable(ModuleReadback.provenanceOf("lib.held")),
+                said.primary(),
+                "the code that needs it is written in `lib.held`, which this compile has no file for");
+    }
+
+    @Test
+    void oneThisCompilerWillNotReadIsAboutThatModule() {
+        Diagnostic said = Front.cannotBeReadBack("lib.held",
+                new Readback.Failure.Incompatible("some other souther"));
+
+        assertEquals(new Primary.Unavailable(ModuleReadback.provenanceOf("lib.held")),
+                said.primary(),
+                "the module that cannot be read back is the one the report is about");
+    }
+
+    /**
+     * Moved to a place that reaches the module it is about, it points there and stays about the same
+     * code.
+     *
+     * <p>The positive control for the refusal below: a move that agrees is a move that happens, so
+     * the refusal is a claim about disagreement rather than about moving at all.
+     */
+    @Test
+    void aMoveToWhereThatModuleIsReachedIsTheOrdinaryCase() {
+        Diagnostic moved = Front.needs("lib.absent", "lib.held")
+                .reachedFrom(AN_IMPORT_LINE, ModuleReadback.provenanceOf("lib.held"),
+                        new ModuleMessage.ItIsReachedFromHereToo());
+
+        Citation.Reached reached = assertInstanceOf(Citation.Reached.class,
+                Citation.of(((Primary.InSource) moved.primary()).place().region().start()), "moved, it points at a file the reader holds");
+        assertEquals(2, reached.at().line());
+        assertEquals("lib.held", reached.provenance().reachedBy(),
+                "and is still about the code it was about");
+    }
+
+    /**
+     * Moved as though it were about another module, it is refused.
+     *
+     * <p>One of the two producers is enough: what is being checked is
+     * {@link Diagnostic#reachedFrom}'s comparison, which is one rule over whatever a report already
+     * says, and what the two producers differ in is only which provenance they say.
+     */
+    @Test
+    void aMoveToSomewhereElsesCodeIsRefused() {
+        Diagnostic said = Front.needs("lib.absent", "lib.held");
+
+        assertThrows(Diagnostic.MovedSomewhereElsesCode.class,
+                () -> said.reachedFrom(AN_IMPORT_LINE, ModuleReadback.provenanceOf("lib.other"),
+                        new ModuleMessage.ItIsReachedFromHereToo()),
+                "a report saying its code is in one module may not be moved as another's");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/AValueThatReachesItselfIsRefusedOnceAtItsNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AValueThatReachesItselfIsRefusedOnceAtItsNameTest.java
@@ -1,5 +1,7 @@
 package souther.compiler.query;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.source.SourceId;
 
 import souther.compiler.Compiler;
@@ -92,7 +94,7 @@ class AValueThatReachesItselfIsRefusedOnceAtItsNameTest {
 
         assertEquals(alone.said(), beside.said());
         assertEquals(List.copyOf(alone.values().values()), List.copyOf(beside.values().values()));
-        assertEquals(alone.region(), beside.region(),
+        assertEquals(((Primary.InSource) alone.primary()).place().region(), ((Primary.InSource) beside.primary()).place().region(),
                 "the refusal is about `step`, and where `step` is written did not move");
     }
 
@@ -123,7 +125,7 @@ class AValueThatReachesItselfIsRefusedOnceAtItsNameTest {
      */
     @Test
     void theRefusalUnderlinesTheNameAndNotTheKeywordInFrontOfIt() {
-        Region region = cycleIn(diagnose(CYCLE)).region();
+        Region region = ((Primary.InSource) cycleIn(diagnose(CYCLE)).primary()).place().region();
 
         assertEquals(region.start().line(), region.end().line(), "a name is one line's worth");
         assertEquals("let step = step".indexOf("step") + 1, region.start().column(),

--- a/souther-compiler/src/test/java/souther/compiler/query/DbTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/DbTest.java
@@ -163,7 +163,7 @@ class DbTest {
 
     @Test
     void raisesTheMessageAPassRaisedItWith() {
-        Diagnostic d = Diagnostic.say(new ModuleMessage.DuplicateModule("demo")).build();
+        Diagnostic d = Diagnostic.say(new ModuleMessage.DuplicateModule("demo")).nowhere().build();
         CompileException raised = CompileException.of(d);
         List<Report> reports = Report.of(raised);
         assertEquals(raised.getMessage(), reports.get(0).asException().getMessage());

--- a/souther-compiler/src/test/java/souther/compiler/query/UnresolvedNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/UnresolvedNamesTest.java
@@ -1,5 +1,7 @@
 package souther.compiler.query;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.source.SourceId;
 
 import souther.compiler.Compiler;
@@ -207,8 +209,8 @@ class UnresolvedNamesTest {
                 """);
 
         assertEquals(1, found.size(), found.toString());
-        assertEquals(6, found.get(0).region().start().line(), found.toString());
-        assertEquals(20, found.get(0).region().start().column(),
+        assertEquals(6, ((Primary.InSource) found.get(0).primary()).place().region().start().line(), found.toString());
+        assertEquals(20, ((Primary.InSource) found.get(0).primary()).place().region().start().column(),
                 "the stage, not the behavior it is in: " + found);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/query/WhereADiagnosticIsSaidTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhereADiagnosticIsSaidTest.java
@@ -1,5 +1,7 @@
 package souther.compiler.query;
 
+import souther.compiler.diag.Primary;
+
 import souther.compiler.source.SourceId;
 
 import org.junit.jupiter.api.Test;
@@ -41,7 +43,7 @@ class WhereADiagnosticIsSaidTest {
 
         Map<SourceId, List<Located>> found = c.diagnostics();
 
-        assertEquals(new SourceId("0"), found.get(new SourceId("0")).get(0).primarySourceId(),
+        assertEquals(new SourceId("0"), found.get(new SourceId("0")).get(0).context().filedUnder().orElse(null),
                 "the entry and the file it is filed under agree, or nothing can be quoted");
     }
 
@@ -61,7 +63,7 @@ class WhereADiagnosticIsSaidTest {
 
         Db.Found only = c.db().allReports().get(0);
 
-        assertEquals(new SourceId("0"), c.sourceIdOf(only),
+        assertEquals(new SourceId("0"), c.filedUnderOf(only),
                 "the one source is a source, and a report in it says so");
     }
 
@@ -77,7 +79,7 @@ class WhereADiagnosticIsSaidTest {
                 """), souther.compiler.meta.ModulePath.EMPTY);
         c.answerEverything();
 
-        List<SourceId> said = c.db().allReports().stream().map(c::sourceIdOf).toList();
+        List<SourceId> said = c.db().allReports().stream().map(c::filedUnderOf).toList();
 
         assertTrue(said.contains(new SourceId("1")), "the mistake is in the second source: " + said);
     }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -445,7 +445,7 @@ public final class Formatter {
      * it was reached wherever the stack happened to end, which is not a fact about the source.
      */
     private static CompileException tooDeep() {
-        return CompileException.of(Diagnostic.say(new DeclarationMessage.TheCompilerRanOutOfRoom()).build());
+        return CompileException.of(Diagnostic.say(new DeclarationMessage.TheCompilerRanOutOfRoom()).nowhere().build());
     }
 
     // --- layout ---

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -38,6 +38,11 @@ import souther.compiler.diag.Messages;
 import souther.compiler.diag.Located;
 import souther.compiler.diag.Spot;
 import souther.compiler.diag.Region;
+import souther.compiler.diag.Primary;
+import souther.compiler.diag.UnnamedRegion;
+import souther.compiler.diag.ReportContext;
+import souther.compiler.diag.SourceContext;
+import souther.compiler.diag.Shown;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.cst.SyntaxElement;
 import souther.compiler.cst.SyntaxKind;
@@ -160,10 +165,10 @@ public final class Analyzer {
             // A self-contained module compiles fully here, so its inline `example`s are evaluated
             // on save and a failing one (E1805) surfaces as an editor diagnostic.
             for (Located w : Compiler.compileWithWarnings(text, "Main").locatedWarnings()) {
-                out.add(fromDiagnostic(lines, w.diagnostic()));
+                out.add(fromDiagnostic(text, lines, w.diagnostic()));
             }
         } catch (CompileException e) {
-            out.addAll(fromCompile(lines, e));
+            out.addAll(fromCompile(text, lines, e));
         } catch (RuntimeException | StackOverflowError e) {
             out.add(internalError(lines, e));
         }
@@ -272,7 +277,13 @@ public final class Analyzer {
             for (Located loc : e.getValue()) {
                 // A workspace names its sources by document URI, so a source id is already the name
                 // the editor opens.
-                list.add(project(loc.diagnostic(), loc.primarySourceId(), e.getKey().value(),
+                // The document this marker is going in is what this route is reading, and the
+                // file the report is listed under is what the compile said. Both, because they
+                // are two answers: a problem written in two files is listed under one of them
+                // and read from each in turn.
+                list.add(project(loc.diagnostic(),
+                        ReportContext.of(loc.context().filedUnder().orElse(null),
+                                new SourceId(e.getKey().value())),
                         linesOf, uri -> graph.text(uri) == null ? null : uri));
             }
         }
@@ -618,10 +629,22 @@ public final class Analyzer {
             out.addAll(rowsToWrite(uri, text, requested, graph));
         }
         Diagnostic d = firstSemanticDiagnostic(text);
-        if (d == null || d.suggestion() == null || d.region() == null) {
+        if (d == null || d.suggestion() == null) {
             return out;
         }
-        Range diagRange = rangeOf(new LineIndex(text), d);
+        // The compile behind this read the document's own text and could not name it, so what it
+        // points at is a stretch of the text in front of the author. A report with nothing to point
+        // at has no edit to offer: an action needs a range, and a sentence about a module is not
+        // one.
+        Region diagnosed = switch (d.primary()) {
+            case Primary.InSource(DiagnosticPlace.InSource place) -> place.region();
+            case Primary.InAnUnnamedText(UnnamedRegion where) -> where.region();
+            case Primary.Unavailable _, Primary.Nowhere _ -> null;
+        };
+        if (diagnosed == null) {
+            return out;
+        }
+        Range diagRange = rangeOfRegion(diagnosed);
         if (overlaps(diagRange, requested)) {
             out.add(new CodeAction("Replace with '" + d.suggestion() + "'", uri, diagRange, d.suggestion()));
         }
@@ -2294,15 +2317,15 @@ public final class Analyzer {
     /** Every diagnostic the compile error carries, each as its own editor marker — a compile stops at
      * the first error, but a pass that finds several at once (each failing {@code example} row) is
      * squiggled row by row rather than collapsed onto the first. */
-    private List<LspDiagnostic> fromCompile(LineIndex lines, CompileException e) {
+    private List<LspDiagnostic> fromCompile(String text, LineIndex lines, CompileException e) {
         if (e.diagnostic() != null) {
             List<LspDiagnostic> out = new ArrayList<>();
             for (Diagnostic d : e.diagnostics()) {
-                out.add(fromDiagnostic(lines, d));
+                out.add(fromDiagnostic(text, lines, d));
             }
             return out;
         }
-        return List.of(new LspDiagnostic(rangeOf(lines, null), LspDiagnostic.ERROR, null,
+        return List.of(new LspDiagnostic(theHeadOfTheDocument(), LspDiagnostic.ERROR, null,
                 cleanMessage(e.getMessage())));
     }
 
@@ -2313,8 +2336,12 @@ public final class Analyzer {
      * <p>No linked locations. A link is a URI, and a document compiled from its text alone has none
      * to give — the workspace path is where a marker can point somewhere the editor can open.
      */
-    private LspDiagnostic fromDiagnostic(LineIndex lines, Diagnostic d) {
-        return project(d, null, null, id -> lines, id -> null);
+    private LspDiagnostic fromDiagnostic(String text, LineIndex lines, Diagnostic d) {
+        // The document itself is what this route is reading, and it is the only thing that knows:
+        // the compile behind it read this text without a name for it, so a report from that parse
+        // has real numbers and no file. Left unsaid, the marker fell to the head of the document.
+        return project(d, ReportContext.ofTheTextItself(new SourceContext(null, text)),
+                id -> lines, id -> null);
     }
 
     /**
@@ -2326,12 +2353,13 @@ public final class Analyzer {
      * the two change places rather than the second file getting a marker on a line that has nothing
      * to do with it.
      *
-     * @param primarySourceId the source the primary region is in, null when the compile named none
-     * @param publishedUri the file this marker is being put in, null for a single-document compile
+     * @param context what the editor answers for this report: the file it lists it under, and the
+     *        document it is reading — which is the one thing that knows which text a report parsed
+     *        out of an unsaved buffer is in
      * @param linesOf the line index of a source, for turning its positions into ranges
      * @param uriOf the editor's name for a source, null when it has none to link to
      */
-    private LspDiagnostic project(Diagnostic d, SourceId primarySourceId, String publishedUri,
+    private LspDiagnostic project(Diagnostic d, ReportContext context,
                                   java.util.function.Function<String, LineIndex> linesOf,
                                   java.util.function.Function<String, String> uriOf) {
         String message = DiagnosticRenderer.body(d, EDITOR_LANGUAGE);
@@ -2341,7 +2369,7 @@ public final class Analyzer {
         }
         int severity = d.severity() == souther.compiler.diag.Severity.WARNING
                 ? LspDiagnostic.WARNING : LspDiagnostic.ERROR;
-        DiagnosticView view = DiagnosticView.of(d, primarySourceId, SourceId.orNone(publishedUri));
+        DiagnosticView view = DiagnosticView.of(d, context);
         List<LspDiagnostic.Related> related = new ArrayList<>();
         // A label with nothing to point at joins the message. An editor's related information is a
         // location, and there is no location — the clause is in a module this workspace has no file
@@ -2355,28 +2383,23 @@ public final class Analyzer {
         for (DiagnosticView.Unquotable said : view.unquotable()) {
             message = message + " " + DiagnosticRenderer.saidAbout(said, EDITOR_LANGUAGE);
         }
-        for (Spot other : view.others()) {
-            // A spot naming no source can only be the primary now, and the primary's source is
-            // told rather than read off its region (`Spot.primary`) — a compile of one source names
-            // none, and the file this marker is being put in is that one. What used to reach here
-            // as well was a label, which is the defect: a label says where it is and no longer takes
-            // its file from where it is shown.
-            String uri = other.sourceId() == null
-                    ? publishedUri : uriOf.apply(other.sourceId().value());
-            LineIndex lines = linesOf.apply(uriOf(other.sourceId()));
-            if (uri == null || lines == null || other.region() == null) {
+        for (Shown other : view.others()) {
+            SourceId source = sourceOf(other.spot());
+            String uri = source == null ? null : uriOf.apply(source.value());
+            LineIndex lines = linesOf.apply(uriOf(source));
+            if (uri == null || lines == null) {
                 continue;   // nothing the editor could open, so nothing to link to
             }
-            related.add(new LspDiagnostic.Related(uri, rangeOfRegion(other.region()),
-                    other.labelled()
+            related.add(new LspDiagnostic.Related(uri, rangeOfRegion(other.spot().region()),
+                    other instanceof Shown.ALabel(Spot _, souther.compiler.diag.msg.Message said)
                             ? DiagnosticRenderer.qualified(
-                                    Messages.render(other.said(), EDITOR_LANGUAGE),
-                                    other.region().start(), EDITOR_LANGUAGE)
+                                    Messages.render(said, EDITOR_LANGUAGE),
+                                    other.spot().region().start(), EDITOR_LANGUAGE)
                             : aboutTheDiagnostic));
         }
-        Range range = view.anchor().region() != null
-                ? rangeOfRegion(view.anchor().region())
-                : rangeOf(linesOf.apply(uriOf(view.anchor().sourceId())), d);
+        Range range = view.anchor()
+                .map(shown -> rangeOfRegion(shown.spot().region()))
+                .orElseGet(Analyzer::theHeadOfTheDocument);
         return new LspDiagnostic(range, severity, d.code(), message, tagsOf(d), related);
     }
 
@@ -2386,19 +2409,22 @@ public final class Analyzer {
         return "E1922".equals(d.code()) ? List.of(LspDiagnostic.UNNECESSARY) : List.of();
     }
 
+    /** The document a spot is in, or none where it is in a text this workspace cannot name. */
+    private static SourceId sourceOf(Spot spot) {
+        return switch (spot) {
+            case Spot.InSource in -> in.place().source();
+            case Spot.InTextBeingRead(souther.compiler.diag.TextBeingRead text, UnnamedRegion _) ->
+                    text.identity().orElse(null);
+        };
+    }
+
     private Range rangeOfRegion(Region r) {
         return new Range(position(r.start()), position(r.end()));
     }
 
-    private Range rangeOf(LineIndex lines, Diagnostic d) {
-        if (d != null && d.region() != null) {
-            Region r = d.region();
-            return new Range(position(r.start()), position(r.end()));
-        }
-        if (d != null && d.pos() != null) {
-            Position p = position(d.pos());
-            return new Range(p, p);
-        }
+    /** Where an editor puts a marker for something with no place of its own: the head of the
+     *  document, which is where a reader looks when nothing points anywhere. */
+    private static Range theHeadOfTheDocument() {
         Position origin = new Position(0, 0);
         return new Range(origin, origin);
     }

--- a/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
@@ -73,6 +73,24 @@ class AnalyzerTest {
         assertTrue(diags.get(0).message().contains("type variable"), diags.get(0).message());
     }
 
+    /**
+     * And it is marked where it is written, not at the head of the document.
+     *
+     * <p>The compile behind this route reads the document without a name for it, so what it reports
+     * points into a text this compilation cannot name — real numbers, no file. Which document that
+     * is, is what this route knows and nothing else does; left unsaid, the marker has nowhere to go
+     * and falls to the first character.
+     */
+    @Test
+    void aSemanticErrorIsMarkedWhereItIsWritten() {
+        String src = "module demo\ndata X = { v: Int }\nlet f (x: 'a) = x\n";
+
+        List<LspDiagnostic> diags = analyzer.diagnostics(src);
+
+        assertEquals(2, diags.get(0).range().start().line(),
+                "the third line, which is where the type variable is written: " + diags.get(0));
+    }
+
     @Test
     void formatReturnsCanonicalTextForACleanDocument() {
         // a one-line product def is reflowed into the multi-line leading-comma block

--- a/souther-lsp/src/test/java/souther/lsp/analysis/DiagnosticPathAgreementTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/DiagnosticPathAgreementTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -162,8 +163,13 @@ class DiagnosticPathAgreementTest {
 
         // LSP positions are 0-based, the compiler's are 1-based; that offset is the only difference
         // allowed between them.
-        assertEquals(compiled.pos().line() - 1, seen.range().start().line(), "line");
-        assertEquals(compiled.pos().column() - 1, seen.range().start().character(), "column");
+        // The compile reads a document of its own, so what it reports points into a source of it.
+        souther.compiler.diag.SourcePos at = assertInstanceOf(
+                souther.compiler.diag.Primary.InSource.class, compiled.primary(),
+                "a report from a compile of a source points into that source")
+                .place().region().start();
+        assertEquals(at.line() - 1, seen.range().start().line(), "line");
+        assertEquals(at.column() - 1, seen.range().start().character(), "column");
     }
 
     @ParameterizedTest(name = "{0}")

--- a/souther-syntax/src/main/java/souther/compiler/diag/CompileException.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/CompileException.java
@@ -21,30 +21,24 @@ import java.util.List;
  */
 public class CompileException extends RuntimeException {
 
-    /** A position is a line and a column, so a compile that was handed several sources also has to
-     *  say which one — otherwise there is nothing to quote the line from. */
-    private static final SourceId NO_SOURCE = Located.NO_SOURCE;
-
-    private final transient List<Diagnostic> diagnostics;
-    /** One entry per diagnostic: which source it came from, or {@link #NO_SOURCE}. A compile that
-     *  reports several modules at once has a diagnostic per module, and each quotes its own file.
-     *  Parallel to {@link #diagnostics}, so the order here is that list's order and nothing else. */
-    private final transient List<SourceId> sources;
+    /**
+     * What this error found, each with what the compile can say about where it is listed.
+     *
+     * <p>One list and not two. It was a list of diagnostics beside a list of sources with one entry
+     * per diagnostic, which is a pair kept in step by hand: two builders checked the sizes matched
+     * and every reader indexed both by the same {@code i}. A diagnostic and the file it is listed
+     * under are one thing to carry, and {@link Located} is that thing.
+     */
+    private final transient List<Located> reported;
 
     /** Throws with a fully structured diagnostic (a migrated site). */
     public CompileException(Diagnostic diagnostic, String legacyMessage) {
-        this(List.of(diagnostic), legacyMessage, NO_SOURCE);
+        this(List.of(new Located(diagnostic, ReportContext.NONE)), legacyMessage);
     }
 
-    private CompileException(List<Diagnostic> diagnostics, String legacyMessage, SourceId sourceId) {
-        this(diagnostics, legacyMessage, java.util.Collections.nCopies(diagnostics.size(), sourceId));
-    }
-
-    private CompileException(List<Diagnostic> diagnostics, String legacyMessage, List<SourceId> sources) {
+    private CompileException(List<Located> reported, String legacyMessage) {
         super(legacyMessage);
-        this.diagnostics = diagnostics;
-        // Not List.copyOf: an entry is NO_SOURCE for a diagnostic that names none, and that is null.
-        this.sources = java.util.Collections.unmodifiableList(new java.util.ArrayList<>(sources));
+        this.reported = List.copyOf(reported);
     }
 
     /**
@@ -55,7 +49,7 @@ public class CompileException extends RuntimeException {
      * rule says is in the catalog, and this is where it is read.
      */
     public static CompileException of(Diagnostic diagnostic) {
-        return new CompileException(diagnostic, format(diagnostic.pos(), diagnostic.code(),
+        return new CompileException(diagnostic, format(positionOf(diagnostic), diagnostic.code(),
                 DiagnosticRenderer.legacyBody(diagnostic)));
     }
 
@@ -71,32 +65,42 @@ public class CompileException extends RuntimeException {
             throw new IllegalArgumentException("a compile error carries at least one diagnostic");
         }
         Diagnostic first = diagnostics.get(0);
-        return new CompileException(List.copyOf(diagnostics),
-                format(first.pos(), first.code(), legacyBody), NO_SOURCE);
+        return new CompileException(
+                diagnostics.stream().map(d -> new Located(d, ReportContext.NONE)).toList(),
+                format(positionOf(first), first.code(), legacyBody));
     }
 
     /**
-     * Several errors found across several sources, each tagged with the source it came from —
-     * a multi-module compile reporting every module's failing examples rather than the first
-     * module's. {@code sources} has one entry per diagnostic, {@link Located#NO_SOURCE} for one that
-     * names none.
+     * Several errors found across several sources, each carrying the file it is listed under — a
+     * multi-module compile reporting every module's failing examples rather than the first module's.
      */
-    public static CompileException ofAllInSources(List<Diagnostic> diagnostics, List<SourceId> sources,
-                                                  String legacyBody) {
-        if (diagnostics == null || diagnostics.isEmpty()) {
+    public static CompileException ofAllReported(List<Located> reported, String legacyBody) {
+        if (reported == null || reported.isEmpty()) {
             throw new IllegalArgumentException("a compile error carries at least one diagnostic");
         }
-        if (sources.size() != diagnostics.size()) {
-            throw new IllegalArgumentException("one source per diagnostic");
-        }
-        Diagnostic first = diagnostics.get(0);
-        return new CompileException(List.copyOf(diagnostics),
-                format(first.pos(), first.code(), legacyBody), sources);
+        Diagnostic first = reported.get(0).diagnostic();
+        return new CompileException(List.copyOf(reported),
+                format(positionOf(first), first.code(), legacyBody));
     }
 
+    /**
+     * Where the leading diagnostic points, as a single position, or none where it points nowhere.
+     *
+     * <p>Read off what it points at rather than off a region it might not have. A report about a
+     * module, and one whose code is out of sight, have no position at all; one in a text this
+     * compile could not name has numbers, and they are numbers of that text — which is what the
+     * one-line message below says them as, and is not a place anything sends a reader to.
+     */
     public SourcePos pos() {
-        Diagnostic d = diagnostic();
-        return d == null ? null : d.pos();
+        return positionOf(diagnostic());
+    }
+
+    private static SourcePos positionOf(Diagnostic d) {
+        return d == null ? null : switch (d.primary()) {
+            case Primary.InSource(DiagnosticPlace.InSource place) -> place.region().start();
+            case Primary.InAnUnnamedText(UnnamedRegion where) -> where.region().start();
+            case Primary.Unavailable _, Primary.Nowhere _ -> null;
+        };
     }
 
     public String code() {
@@ -115,7 +119,7 @@ public class CompileException extends RuntimeException {
      * several when a pass reports each of its independent failures. Empty when the structured form
      * did not survive (the field is transient, so a deserialized error has only its message). */
     public List<Diagnostic> diagnostics() {
-        return diagnostics == null ? List.of() : diagnostics;
+        return Located.diagnosticsOf(locatedDiagnostics());
     }
 
     /**
@@ -126,24 +130,21 @@ public class CompileException extends RuntimeException {
      * first source".
      */
     public SourceId sourceId() {
-        return sources.isEmpty() ? NO_SOURCE : sources.get(0);
+        return sourceIdOf(0);
     }
 
-    /** Which source the {@code i}-th of {@link #diagnostics()} came from, or null when it names
-     *  none. A renderer walking the list quotes each diagnostic's own file. */
+    /** Which source the {@code i}-th of {@link #diagnostics()} is listed under, or null when the
+     *  compile could name none. A renderer walking the list quotes each diagnostic's own file. */
     public SourceId sourceIdOf(int i) {
-        return sources == null || i >= sources.size() ? NO_SOURCE : sources.get(i);
+        List<Located> all = locatedDiagnostics();
+        return i >= all.size() ? null : all.get(i).context().filedUnder().orElse(null);
     }
 
-    /** Every diagnostic this error carries, each with the source it came from — what a renderer
-     *  walks, and the shape a warning arrives in too, so one loop renders both. */
+    /** Every diagnostic this error carries, each with what the compile can say about where it is
+     *  listed — what a renderer walks, and the shape a warning arrives in too, so one loop renders
+     *  both. */
     public List<Located> locatedDiagnostics() {
-        List<Diagnostic> ds = diagnostics();
-        List<Located> located = new java.util.ArrayList<>(ds.size());
-        for (int i = 0; i < ds.size(); i++) {
-            located.add(new Located(ds.get(i), sourceIdOf(i)));
-        }
-        return List.copyOf(located);
+        return reported == null ? List.of() : reported;
     }
 
     /**
@@ -155,21 +156,14 @@ public class CompileException extends RuntimeException {
      * {@code example} row — words it over what it found, and rendering the leading diagnostic again
      * here would answer with a sentence about one row instead.
      *
-     * @param moreSources one entry per added diagnostic, {@link Located#NO_SOURCE} for one that
-     *                    names no source
      */
-    public CompileException alsoReporting(List<Diagnostic> more, List<SourceId> moreSources) {
+    public CompileException alsoReporting(List<Located> more) {
         if (more.isEmpty()) {
             return this;
         }
-        if (more.size() != moreSources.size()) {
-            throw new IllegalArgumentException("one source per diagnostic");
-        }
-        List<Diagnostic> all = new java.util.ArrayList<>(diagnostics);
+        List<Located> all = new java.util.ArrayList<>(locatedDiagnostics());
         all.addAll(more);
-        List<SourceId> allSources = new java.util.ArrayList<>(sources);
-        allSources.addAll(moreSources);
-        CompileException joined = new CompileException(all, getMessage(), allSources);
+        CompileException joined = new CompileException(all, getMessage());
         joined.setStackTrace(getStackTrace());
         return joined;
     }
@@ -179,11 +173,14 @@ public class CompileException extends RuntimeException {
      * an inner phase that already named its source keeps it, so a surrounding loop may tag freely.
      */
     public CompileException inSource(SourceId sourceId) {
-        if (sourceId == null || sources.stream().allMatch(src -> src != NO_SOURCE)) {
+        List<Located> all = locatedDiagnostics();
+        if (sourceId == null || all.stream().allMatch(one -> one.context().filedUnder().isPresent())) {
             return this;   // already named, or nothing to name it with
         }
-        List<SourceId> filled = sources.stream().map(src -> src == NO_SOURCE ? sourceId : src).toList();
-        CompileException tagged = new CompileException(diagnostics, getMessage(), filled);
+        CompileException tagged = new CompileException(
+                all.stream().map(one -> one.context().filedUnder().isPresent() ? one
+                        : new Located(one.diagnostic(), ReportContext.inFile(sourceId))).toList(),
+                getMessage());
         tagged.setStackTrace(getStackTrace());
         return tagged;
     }

--- a/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
@@ -84,14 +84,16 @@ public final class Diagnostic {
         return code == null ? null : code.titleKey();
     }
 
-    /** Where this points, or null where it points nowhere. A report that has something to say
-     *  instead says it through {@link #primary()}; every surface that only wanted a region reads
-     *  this and is told the same nothing it was told before. */
-    public Region region() {
-        return Primary.regionOf(primary);
-    }
-
-    /** What this points at, which is a region or is nowhere and where the code is. */
+    /**
+     * What this points at.
+     *
+     * <p>There is no accessor beside this one answering "the region, if there is one". Four of the
+     * things a primary can be came back as a region or a null through such an accessor, and each
+     * reader read the null as whichever of them it had in mind: the editor as "put the marker at the
+     * top", the caller lending a place to a label as "there is no place", the renderer as "quote
+     * nothing". A reader that wants the region says which case it is in first, and having said so
+     * has seen that the others exist.
+     */
     public Primary primary() {
         return primary;
     }
@@ -111,14 +113,18 @@ public final class Diagnostic {
      */
     public WhereCodeIsWritten whereItsCodeIsWritten() {
         return switch (primary) {
-            case null -> WhereCodeIsWritten.Unstated.IT;
+            case Primary.Nowhere _ -> WhereCodeIsWritten.Unstated.IT;
             case Primary.Unavailable(SourceProvenance from) ->
                     new WhereCodeIsWritten.Elsewhere(from);
-            case Primary.AtARegion(Region region) ->
-                    Citation.of(region.start()) instanceof Citation.Elsewhere elsewhere
-                            ? new WhereCodeIsWritten.Elsewhere(elsewhere.provenance())
-                            : WhereCodeIsWritten.Here.IT;
+            case Primary.InSource(DiagnosticPlace.InSource place) -> writtenAt(place.region());
+            case Primary.InAnUnnamedText(UnnamedRegion where) -> writtenAt(where.region());
         };
+    }
+
+    private static WhereCodeIsWritten writtenAt(Region region) {
+        return Citation.of(region.start()) instanceof Citation.Elsewhere elsewhere
+                ? new WhereCodeIsWritten.Elsewhere(elsewhere.provenance())
+                : WhereCodeIsWritten.Here.IT;
     }
 
     public List<LabeledRegion> secondary() {
@@ -139,12 +145,6 @@ public final class Diagnostic {
 
     public String suggestion() {
         return suggestion;
-    }
-
-    /** The primary source position (the region's start). */
-    public SourcePos pos() {
-        Region region = region();
-        return region == null ? null : region.start();
     }
 
     /**
@@ -204,7 +204,7 @@ public final class Diagnostic {
             also.add(new LabeledRegion(Region.point(other.standingInFor(declaring)), alsoHere));
         }
         return new Diagnostic(severity, code,
-                new Primary.AtARegion(Region.point(where.get(0).standingInFor(declaring))),
+                Primary.at(Region.point(where.get(0).standingInFor(declaring))),
                 List.copyOf(also),
                 literalMessage, diff, notes, suggestion, said);
     }
@@ -259,7 +259,7 @@ public final class Diagnostic {
      * either of those has a catalog key by now. {@code pos} may be null for a position-less error. */
     public static Diagnostic literal(SourcePos pos, String message) {
         return new Diagnostic(Severity.ERROR, null,
-                pos == null ? null : new Primary.AtARegion(Region.point(pos)),
+                pos == null ? Primary.Nowhere.IT : Primary.at(Region.point(pos)),
                 List.of(), message, null, List.of(), null, null);
     }
 
@@ -325,7 +325,20 @@ public final class Diagnostic {
         }
 
         public Builder at(SourcePos pos) {
-            this.primary = pos == null ? null : new Primary.AtARegion(Region.point(pos));
+            this.primary = pos == null ? Primary.Nowhere.IT : Primary.at(Region.point(pos));
+            return this;
+        }
+
+        /**
+         * The report is not about a stretch of text.
+         *
+         * <p>Said outright, because it is a thing to say and not the absence of one. A module
+         * declared here and also on the path is wrong about neither line; a compile that ran out of
+         * room is not a fact about the source. Which file such a report is listed under is answered
+         * where it is shown, by a caller that holds the files.
+         */
+        public Builder nowhere() {
+            this.primary = Primary.Nowhere.IT;
             return this;
         }
 
@@ -357,16 +370,16 @@ public final class Diagnostic {
          */
         public Builder at(SourcePos pos, int width) {
             if (pos == null) {
-                this.primary = null;
+                this.primary = Primary.Nowhere.IT;
             } else {
-                this.primary = new Primary.AtARegion(
+                this.primary = Primary.at(
                         pos.wasCopiedHere() ? Region.point(pos) : Region.ofWidth(pos, width));
             }
             return this;
         }
 
         public Builder at(Region region) {
-            this.primary = region == null ? null : new Primary.AtARegion(region);
+            this.primary = region == null ? Primary.Nowhere.IT : Primary.at(region);
             return this;
         }
 
@@ -387,6 +400,15 @@ public final class Diagnostic {
          */
         public <M extends Message & Supporting> Builder secondary(Region region, M label) {
             this.secondary.add(new LabeledRegion(region, label));
+            return this;
+        }
+
+        /** A second thing to say, about a place already classified — what a site pointing at another
+         *  report's place has, that place having gone through {@link DiagnosticPlace#of} once
+         *  already. */
+        public <M extends Message & Supporting> Builder secondary(DiagnosticPlace.InSource place,
+                                                                  M label) {
+            this.secondary.add(new LabeledRegion(place, label));
             return this;
         }
 
@@ -412,6 +434,13 @@ public final class Diagnostic {
         public Diagnostic build() {
             if (code == null) {
                 throw new IllegalStateException("a diagnostic reports a rule; call `say`");
+            }
+            if (primary == null) {
+                // Not the same as pointing nowhere, which is `nowhere()` and is a thing to say. This
+                // is a site that has not said, and a report that reached a reader unsaid used to
+                // have its file worked out from wherever it was filed.
+                throw new IllegalStateException(
+                        "a diagnostic says where it points; call `at` or `nowhere`");
             }
             return new Diagnostic(code.severity(), code, primary, List.copyOf(secondary), null,
                     diff, List.copyOf(notes), suggestion, said);

--- a/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticPlace.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticPlace.java
@@ -52,7 +52,7 @@ public sealed interface DiagnosticPlace {
     record InSource(Region region) implements DiagnosticPlace {
 
         public InSource {
-            heldToOnePlace(region);
+            OnePlace.heldTo(region);
             if (!(region.start().quotedFrom() instanceof QuotedFrom.ASourceThisCompileHolds)) {
                 throw new NotAPlace("a place a reader is sent to names the source it is in: "
                         + region);
@@ -91,7 +91,7 @@ public sealed interface DiagnosticPlace {
      * @throws NotOnePlace where the ends are in two places
      */
     static DiagnosticPlace of(Region region) {
-        heldToOnePlace(region);
+        OnePlace.heldTo(region);
         return switch (Citation.of(region.start())) {
             case Citation.Written _, Citation.Reached _ -> new InSource(region);
             case Citation.OutOfSight out -> new Unavailable(out.provenance());
@@ -120,35 +120,6 @@ public sealed interface DiagnosticPlace {
 
         NotAPlace(String message) {
             super(message);
-        }
-    }
-
-    /**
-     * Refuses a region that is not one place before anything is asked of it.
-     *
-     * <p>The whole of where a position is, and not just the file. A region whose ends are in two
-     * places is a place that is two places, and a placement is what says which place one end is in —
-     * so this is one comparison rather than a file test and a provenance test that could be kept in
-     * step by hand. Read off the start alone, the second end's answer would go unrecorded: a region
-     * running from a copy of {@code A} to a copy of {@code B} would come back as a report about
-     * {@code A}, and nothing anywhere would say otherwise.
-     *
-     * <p>Held here rather than on {@link Region}, which is a pair of coordinates and is built by
-     * every pass; this is where a pair is asked to be a place. Measured before it was written: no
-     * region in the compiler's own corpus has ends that disagree about provenance.
-     */
-    private static void heldToOnePlace(Region region) {
-        if (region == null) {
-            throw new NotAPlace("a label is about a region and was given none");
-        }
-        SourcePos start = region.start();
-        SourcePos end = region.end();
-        if (start == null || end == null) {
-            throw new NotAPlace("a region a label is about has two ends: " + region);
-        }
-        if (!start.placement().equals(end.placement())) {
-            throw new NotOnePlace("a region runs from " + start.placement() + " to "
-                    + end.placement() + ", which is not one place");
         }
     }
 

--- a/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticRenderer.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticRenderer.java
@@ -22,7 +22,7 @@ public interface DiagnosticRenderer {
      * in that file, so there is nothing to resolve and nothing to name.
      */
     default String render(Diagnostic d, SourceContext src, Locale locale) {
-        return render(new Located(d, Located.NO_SOURCE), id -> src, locale);
+        return render(new Located(d, ReportContext.ofTheTextItself(src)), id -> src, locale);
     }
 
     /**
@@ -90,11 +90,18 @@ public interface DiagnosticRenderer {
         // is that there is no position and the code is written somewhere this compile cannot show.
         // Read off the position alone that came back as nothing to say, and a reader was left with a
         // sentence about a place, no place, and no account of why.
-        if (d.primary() instanceof Primary.Unavailable(SourceProvenance from)) {
-            return with(said, new WrittenAtMessage.TheCodeIsWrittenWhereThisCompileCannotShowIt(
-                    from.reachedBy()), locale);
-        }
-        return qualified(said, d.pos(), locale);
+        return switch (d.primary()) {
+            case Primary.Unavailable(SourceProvenance from) ->
+                    with(said, new WrittenAtMessage.TheCodeIsWrittenWhereThisCompileCannotShowIt(
+                            from.reachedBy()), locale);
+            case Primary.InSource(DiagnosticPlace.InSource place) ->
+                    qualified(said, place.region().start(), locale);
+            case Primary.InAnUnnamedText(UnnamedRegion where) ->
+                    qualified(said, where.region().start(), locale);
+            // Nothing pointed at is nothing to qualify: the sentence is about a file or about the
+            // compile, and a clause saying where the code is written would be about nothing.
+            case Primary.Nowhere _ -> said;
+        };
     }
 
     /**

--- a/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticView.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticView.java
@@ -98,8 +98,9 @@ public record DiagnosticView(SpotResolution primary, Optional<Shown> anchor,
                         unquotable.add(new Unquotable(out, label.said()));
             }
         }
-        int at = anchorAmong(shown, published);
-        if (at < 0 && !Objects.equals(context.filedUnder().orElse(null), published)) {
+        int at = anchorAmong(shown, published, primary instanceof SpotResolution.Found);
+        if (nothingIsIn(shown, published)
+                && !Objects.equals(context.filedUnder().orElse(null), published)) {
             throw new IllegalArgumentException(
                     "no place of this diagnostic is in " + published
                             + " and it is not listed under it either; it points into "
@@ -117,25 +118,49 @@ public record DiagnosticView(SpotResolution primary, Optional<Shown> anchor,
     }
 
     /**
-     * Which of {@code shown} is in {@code published}, or -1.
+     * Which of {@code shown} the marker goes on in {@code published}, or -1.
      *
-     * <p>Compared through {@link Spot#knownToBeOneText}, so a place is the anchor when it can be
-     * shown to be in that file and not when nothing rules it out. A place in a text the surface
-     * named answers here as readily as one in a source, which is what lets an editor anchor a report
-     * parsed out of the very document it is publishing.
+     * <p>Compared through {@link Spot#knownToBeIn}, so a place is the anchor when it can be shown to
+     * be in that file and not when nothing rules it out. A place in a text the surface named answers
+     * here as readily as one in a source, which is what lets an editor anchor a report parsed out of
+     * the very document it is publishing.
+     *
+     * <p>A label is the anchor only where the report has a place of its own somewhere else. That is
+     * what "the two change places" means: a problem written in two files is read from each of them,
+     * and on the second the label is what the marker goes on. A report that has no place at all is
+     * not in that case — it has nothing to change places with, and anchoring it on a label would
+     * give a report that says it points nowhere a line and a column that came from something else,
+     * which is the reading this whole family of types exists to stop. Its labels stay labels, each
+     * keeping the sentence that says why it is pointed at.
      */
-    private static int anchorAmong(List<Shown> shown, SourceId published) {
+    private static int anchorAmong(List<Shown> shown, SourceId published, boolean hasAPlaceOfItsOwn) {
         // A caller naming no file is not asking which of several it is reading: it has one text and
-        // everything is quoted from it, so the first place is the one the marker goes on. Read as
-        // "no place is in this file", it would leave a caller that holds the text with no caret.
+        // everything is quoted from it, so the report's own place is the one the marker goes on.
+        // Read as "no place is in this file", it would leave a caller that holds the text with no
+        // caret.
         if (published == null) {
-            return shown.isEmpty() ? -1 : 0;
+            return hasAPlaceOfItsOwn ? 0 : -1;
         }
         for (int i = 0; i < shown.size(); i++) {
-            if (Spot.knownToBeIn(shown.get(i).spot(), published)) {
+            boolean itsOwn = shown.get(i) instanceof Shown.ItsSubject;
+            if ((itsOwn || hasAPlaceOfItsOwn) && Spot.knownToBeIn(shown.get(i).spot(), published)) {
                 return i;
             }
         }
         return -1;
+    }
+
+    /**
+     * Whether the report points into no part of {@code published}.
+     *
+     * <p>Asked apart from which place the marker goes on, because the two differ for a report with
+     * no place of its own: it is said on the file a label of its is in — an author editing that file
+     * is told — while nothing there is the thing the report is about.
+     */
+    private static boolean nothingIsIn(List<Shown> shown, SourceId published) {
+        if (published == null) {
+            return false;   // a caller naming no file is not asking about one
+        }
+        return shown.stream().noneMatch(one -> Spot.knownToBeIn(one.spot(), published));
     }
 }

--- a/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticView.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticView.java
@@ -5,28 +5,41 @@ import souther.compiler.source.SourceId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
- * One diagnostic as it reads from one of the sources it is said at: the place in that source it is
- * anchored to, every other place it points at, and what it has to say about code it cannot point at
- * at all.
+ * One diagnostic as it reads from one of the sources it is said at: what its primary came to, the
+ * place in that source it is anchored to, every other place it points at, and what it has to say
+ * about code it cannot point at at all.
  *
- * <p>A problem written in two files is one diagnostic and is said in both. Which of its regions is
- * the anchor therefore depends on which file is being read: on the row's file the anchor is the
- * primary region and the stand-in is elsewhere, and on the stand-in's file the two change places.
+ * <p>A problem written in two files is one diagnostic and is said in both. Which of its places is
+ * the anchor therefore depends on which file is being read: on the row's file the anchor is what the
+ * message is about and the stand-in is elsewhere, and on the stand-in's file the two change places.
  * The caret, the editor's squiggle and the linked locations all follow from that, so it is worked
  * out once here rather than in each reader.
  *
  * <p>{@code unquotable} is the third thing, and it is the same on every source: a clause written in
  * a module this compile has no file for is not in one file rather than another, so which file is
- * being read decides nothing about it. It used to be dropped — by the clause reader, by the adequacy
- * warning, by moving a caret — each of which turned "the code is over there" into silence.
+ * being read decides nothing about it.
  *
  * <p>A reader that quotes only one file — the command line and the annotation processor — asks for
- * the view on the diagnostic's own source, where the anchor is always the primary region and
- * nothing changes places.
+ * the view on the source the report is listed under, where the anchor is what the message is about
+ * and nothing changes places.
+ *
+ * @param primary what the report's own place came to, whether or not it is the anchor here. Carried
+ *        so that a surface with no anchor is told which of the reasons it is: a report about no
+ *        stretch of text, one whose code is out of sight, or one the caller did not say which text
+ *        it was reading
+ * @param anchor the place this file's marker goes on, and none where the report is listed on this
+ *        file without pointing into it
  */
-public record DiagnosticView(Spot anchor, List<Spot> others, List<Unquotable> unquotable) {
+public record DiagnosticView(SpotResolution primary, Optional<Shown> anchor,
+                             List<Shown> others, List<Unquotable> unquotable) {
+
+    public DiagnosticView {
+        Objects.requireNonNull(primary, "a view says what the report's own place came to");
+        Objects.requireNonNull(anchor, "a view says whether this file has an anchor");
+    }
 
     /**
      * Something a report has to say about code it cannot point at: where that code came from, and
@@ -47,53 +60,82 @@ public record DiagnosticView(Spot anchor, List<Spot> others, List<Unquotable> un
     }
 
     /**
-     * How {@code d} reads from {@code publishedSourceId}, given that its primary region is in
-     * {@code primarySourceId}.
+     * How {@code d} reads from {@code published}, given what {@code context} says the surface is
+     * listing it under and reading.
      *
-     * <p>The anchor is the first place in the published source, taking the primary region before the
-     * secondaries and the secondaries in the order they were added. Declaration order settles it
+     * <p>The anchor is the first place in the published source, taking what the message is about
+     * before the labels and the labels in the order they were added. Declaration order settles it
      * because it is what the site that found the problem chose; the alternative, the earliest line,
      * would let the line numbers a file happens to have decide which of two notes is the one the
      * editor puts its marker on.
      *
-     * <p>A source none of the regions is in is refused. There is nothing to anchor there, and the
-     * nearest thing to an answer — the primary region — is a line and a column from another file,
-     * which in that one points at whatever happens to sit at those numbers. Where a diagnostic is
-     * said is worked out from where it points, so a source that has nothing here is a caller asking
-     * about a file this was never going to be said in.
+     * <p>A source none of the places is in is refused, unless it is the source the report is listed
+     * under. There is nothing to anchor there and no reason for a caller to be asking — where the
+     * report is said is worked out from where it points. Being listed on a file is the one way a
+     * report reaches a file it points into no part of, and that is a report about the file rather
+     * than about a line of it.
      *
-     * @throws IllegalArgumentException when no region of {@code d} is in {@code publishedSourceId}
+     * @throws IllegalArgumentException when no place of {@code d} is in {@code published} and the
+     *         report is not listed under it either
      */
-    public static DiagnosticView of(Diagnostic d, SourceId primarySourceId, SourceId publishedSourceId) {
-        List<Spot> spots = new ArrayList<>();
+    public static DiagnosticView of(Diagnostic d, ReportContext context) {
+        // Which file this view is for is the text the surface says it is reading, and is not a third
+        // thing to be told. Handed over separately it was a source identity beside a diagnostic —
+        // one more pair a caller could get out of step, and one nothing kept in step.
+        SourceId published = context.textBeingRead()
+                .flatMap(TextBeingRead::identity).orElse(null);
+        SpotResolution primary = SpotResolution.of(d.primary(), context);
+        List<Shown> shown = new ArrayList<>();
+        if (primary instanceof SpotResolution.Found(Spot spot)) {
+            shown.add(new Shown.ItsSubject(spot));
+        }
         List<Unquotable> unquotable = new ArrayList<>();
-        spots.add(Spot.primary(d, primarySourceId));
         for (LabeledRegion label : d.secondary()) {
             switch (label.place()) {
                 case DiagnosticPlace.InSource in ->
-                        spots.add(Spot.secondary(in, label.said()));
+                        shown.add(new Shown.ALabel(new Spot.InSource(in), label.said()));
                 case DiagnosticPlace.Unavailable out ->
                         unquotable.add(new Unquotable(out, label.said()));
             }
         }
-        int at = -1;
-        for (int i = 0; i < spots.size(); i++) {
-            if (Objects.equals(spots.get(i).sourceId(), publishedSourceId)) {
-                at = i;
-                break;
-            }
-        }
-        if (at < 0) {
+        int at = anchorAmong(shown, published);
+        if (at < 0 && !Objects.equals(context.filedUnder().orElse(null), published)) {
             throw new IllegalArgumentException(
-                    "no region of this diagnostic is in " + publishedSourceId
-                            + "; it points into " + spots.stream().map(Spot::sourceId).toList());
+                    "no place of this diagnostic is in " + published
+                            + " and it is not listed under it either; it points into "
+                            + shown.stream().map(Shown::spot).toList());
         }
-        List<Spot> others = new ArrayList<>(spots.size() - 1);
-        for (int i = 0; i < spots.size(); i++) {
+        List<Shown> others = new ArrayList<>(shown.size());
+        for (int i = 0; i < shown.size(); i++) {
             if (i != at) {
-                others.add(spots.get(i));
+                others.add(shown.get(i));
             }
         }
-        return new DiagnosticView(spots.get(at), List.copyOf(others), List.copyOf(unquotable));
+        return new DiagnosticView(primary,
+                at < 0 ? Optional.empty() : Optional.of(shown.get(at)),
+                List.copyOf(others), List.copyOf(unquotable));
+    }
+
+    /**
+     * Which of {@code shown} is in {@code published}, or -1.
+     *
+     * <p>Compared through {@link Spot#knownToBeOneText}, so a place is the anchor when it can be
+     * shown to be in that file and not when nothing rules it out. A place in a text the surface
+     * named answers here as readily as one in a source, which is what lets an editor anchor a report
+     * parsed out of the very document it is publishing.
+     */
+    private static int anchorAmong(List<Shown> shown, SourceId published) {
+        // A caller naming no file is not asking which of several it is reading: it has one text and
+        // everything is quoted from it, so the first place is the one the marker goes on. Read as
+        // "no place is in this file", it would leave a caller that holds the text with no caret.
+        if (published == null) {
+            return shown.isEmpty() ? -1 : 0;
+        }
+        for (int i = 0; i < shown.size(); i++) {
+            if (Spot.knownToBeIn(shown.get(i).spot(), published)) {
+                return i;
+            }
+        }
+        return -1;
     }
 }

--- a/souther-syntax/src/main/java/souther/compiler/diag/HumanRenderer.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/HumanRenderer.java
@@ -37,25 +37,31 @@ public final class HumanRenderer implements DiagnosticRenderer {
     @Override
     public String render(Located located, SourceContextResolver sources, Locale locale) {
         Diagnostic d = located.diagnostic();
-        SourceId own = located.primarySourceId();
-        DiagnosticView view = DiagnosticView.of(d, own, own);
-        SourceContext anchorSource = sources.sourceOf(view.anchor().sourceId());
+        SourceId own = located.context().filedUnder().orElse(null);
+        DiagnosticView view = DiagnosticView.of(d, located.context());
+        // The file the header names: the one the anchor is quoted from, or — where nothing is
+        // anchored here — the one this report is listed under, which is the whole of what a reader
+        // is told about where to look for it.
+        SourceContext anchorSource = view.anchor()
+                .map(shown -> sources.quotedFrom(shown.spot()))
+                .orElseGet(() -> sources.sourceOf(own));
         StringBuilder out = new StringBuilder();
-        header(out, d, anchorSource, locale);
+        header(out, d, anchorSource, view.anchor().map(Shown::spot).orElse(null), locale);
         out.append('\n');
-        snippet(out, view.anchor().region(), anchorSource,
-                d.severity() == Severity.WARNING ? YELLOW : RED);
-        for (Spot other : view.others()) {
+        view.anchor().ifPresent(shown -> snippet(out, shown.spot().region(), anchorSource,
+                d.severity() == Severity.WARNING ? YELLOW : RED));
+        for (Shown other : view.others()) {
             out.append('\n');
-            SourceContext src = sources.sourceOf(other.sourceId());
-            if (!Objects.equals(other.sourceId(), view.anchor().sourceId())) {
-                out.append(color(DIM, location(startOf(other.region()), src))).append('\n');
+            SourceContext src = sources.quotedFrom(other.spot());
+            if (view.anchor().isEmpty()
+                    || !Spot.knownToBeOneText(other.spot(), view.anchor().get().spot())) {
+                out.append(color(DIM, location(startOf(other.spot().region()), src))).append('\n');
             }
-            snippet(out, other.region(), src, CYAN);
-            if (other.labelled()) {
+            snippet(out, other.spot().region(), src, CYAN);
+            if (other instanceof Shown.ALabel(Spot _, souther.compiler.diag.msg.Message said)) {
                 out.append(color(DIM, DiagnosticRenderer.qualified(
-                        Messages.render(other.said(), locale),
-                        startOf(other.region()), locale))).append('\n');
+                        Messages.render(said, locale),
+                        startOf(other.spot().region()), locale))).append('\n');
             }
         }
         // A label with nothing to quote, said after the places there are and before the message.
@@ -84,11 +90,20 @@ public final class HumanRenderer implements DiagnosticRenderer {
         return out.toString();
     }
 
-    private void header(StringBuilder out, Diagnostic d, SourceContext src, Locale locale) {
+    /**
+     * The bar over a report: what it is, and where to look.
+     *
+     * <p>Where to look is the anchor's, not the diagnostic's own place. A report anchored nowhere
+     * has a file to be listed under and no line of it to quote, and one whose numbers are of a text
+     * the caller did not name has neither — writing its line and column would put them against
+     * whichever file the reader had in mind, which is the reading this whole change removes.
+     */
+    private void header(StringBuilder out, Diagnostic d, SourceContext src, Spot anchor,
+                        Locale locale) {
         String title = title(d, locale);
         String code = d.code() == null ? "" : "  " + d.code();
         String left = "-- " + title + code + " ";
-        String loc = location(d.pos(), src);
+        String loc = location(anchor == null ? null : anchor.region().start(), src);
         int dashes = WIDTH - DisplayColumns.width(left) - DisplayColumns.width(loc);
         StringBuilder bar = new StringBuilder(left);
         for (int i = 0; i < dashes; i++) {

--- a/souther-syntax/src/main/java/souther/compiler/diag/JsonRenderer.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/JsonRenderer.java
@@ -31,9 +31,11 @@ public final class JsonRenderer implements DiagnosticRenderer {
     @Override
     public String render(Located located, SourceContextResolver sources, Locale locale) {
         Diagnostic d = located.diagnostic();
-        SourceId own = located.primarySourceId();
-        DiagnosticView view = DiagnosticView.of(d, own, own);
-        SourceContext anchorSource = sources.sourceOf(view.anchor().sourceId());
+        SourceId own = located.context().filedUnder().orElse(null);
+        DiagnosticView view = DiagnosticView.of(d, located.context());
+        SourceContext anchorSource = view.anchor()
+                .map(shown -> sources.quotedFrom(shown.spot()))
+                .orElseGet(() -> sources.sourceOf(own));
         Map<String, Object> obj = new LinkedHashMap<>();
         obj.put("severity", d.severity().name().toLowerCase(Locale.ROOT));
         if (d.code() != null) {
@@ -42,8 +44,10 @@ public final class JsonRenderer implements DiagnosticRenderer {
         if (anchorSource != null && anchorSource.fileName() != null) {
             obj.put("file", anchorSource.fileName());
         }
-        if (view.anchor().region() != null) {
-            obj.put("region", region(view.anchor().region()));
+        // Numbers only where there is a place, which is not the same as only where there is a
+        // region: a report in a text the caller did not name has a region and nowhere to read it.
+        if (view.anchor().isPresent()) {
+            obj.put("region", region(view.anchor().get().spot().region()));
         }
         // A report with nowhere to point says where the code is written, in the words a document
         // already uses for it. Beside the diagnostic rather than inside a region, there being no
@@ -55,29 +59,33 @@ public final class JsonRenderer implements DiagnosticRenderer {
         }
         if (!view.others().isEmpty() || !view.unquotable().isEmpty()) {
             List<Object> secs = new ArrayList<>();
-            for (Spot other : view.others()) {
+            for (Shown other : view.others()) {
                 Map<String, Object> s = new LinkedHashMap<>();
                 // Which of the two kinds of place this is, written on both so that a consumer reads
                 // a value rather than the absence of `region`. An absent field is what a document
                 // written before this existed carries, and reading it as "nowhere to point" would
                 // put those under the same answer as a clause nobody holds a file for.
                 s.put("place", "inSource");
-                if (!Objects.equals(other.sourceId(), view.anchor().sourceId())) {
-                    SourceContext src = sources.sourceOf(other.sourceId());
+                if (view.anchor().isEmpty()
+                        || !Spot.knownToBeOneText(other.spot(), view.anchor().get().spot())) {
+                    SourceContext src = sources.quotedFrom(other.spot());
                     if (src != null && src.fileName() != null) {
                         s.put("file", src.fileName());
                     }
                 }
-                s.put("region", region(other.region()));
+                s.put("region", region(other.spot().region()));
+                souther.compiler.diag.msg.Message note =
+                        other instanceof Shown.ALabel(Spot _, souther.compiler.diag.msg.Message said)
+                                ? said : d.said();
                 s.put("label", DiagnosticRenderer.qualified(
-                        Messages.render(other.said(), locale),
-                        other.region().start(), locale));
+                        Messages.render(note, locale),
+                        other.spot().region().start(), locale));
                 // A label is a message like the line above it and carries values of its own — the
                 // type an operand has, the clause a construction reaches — so a tool reads them by
                 // name here too. Written for one of the three and not the others is how a reader of
                 // this interface comes to parse a sentence for the one that was left out.
                 Map<String, Object> labelled = new LinkedHashMap<>();
-                MessageValues.of(other.said()).forEach((name, value) ->
+                MessageValues.of(note).forEach((name, value) ->
                         labelled.put(name, Messages.text(value, locale)));
                 s.put("values", labelled);
                 secs.add(s);

--- a/souther-syntax/src/main/java/souther/compiler/diag/Located.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Located.java
@@ -5,26 +5,32 @@ import souther.compiler.source.SourceId;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
- * A diagnostic and which of the sources a compile was handed its primary region is in. A
- * {@link Diagnostic} says where in a file it is; which file that is belongs to the compile, not to
- * the diagnostic, so it is carried alongside.
+ * A diagnostic and what the caller holding the files answers for it.
  *
- * <p>Only the primary region. A secondary says which source it is in itself
+ * <p>{@link ReportContext} is that answer, and it is two questions rather than one. This used to
+ * carry a single source called "the source the primary region is in", which the region already said
+ * wherever it said anything — and which was the only answer there was for a report that pointed at
+ * nothing. Both readings lived in one field, so the field was empty for half the reports that had a
+ * file and set for every report that had none.
+ *
+ * <p>Not "the file this diagnostic is in". A label says which source it is in itself
  * ({@link DiagnosticPlace}), and a diagnostic said at more than one source is read from each of them
- * in turn ({@link DiagnosticView}) — so this is not "the file this diagnostic is in", and a caller
- * holding one for a file other than this is not holding a mistake.
+ * in turn ({@link DiagnosticView}) — so a caller holding one of these for a file other than the one
+ * the report points at is not holding a mistake.
  *
  * @param diagnostic what was found
- * @param primarySourceId the source the primary region is in, or null when nothing says: a
- *        position the compiler synthesized, and a report a compile could pin on no source of its
- *        own. A compile of one source is not one of those — it names that source like any other
+ * @param context what the caller says: which file it is listing this under, and which text it is
+ *        reading
  */
-public record Located(Diagnostic diagnostic, SourceId primarySourceId) {
+public record Located(Diagnostic diagnostic, ReportContext context) {
 
-    /** The id a diagnostic that names no source carries. */
-    public static final SourceId NO_SOURCE = null;
+    public Located {
+        Objects.requireNonNull(diagnostic, "something was found");
+        Objects.requireNonNull(context, "a caller showing a report answers for it");
+    }
 
     /** What was found, without where — for a caller reading what a compile says rather than
      * deciding which file to put a marker in. */

--- a/souther-syntax/src/main/java/souther/compiler/diag/OnePlace.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/OnePlace.java
@@ -1,0 +1,42 @@
+package souther.compiler.diag;
+
+/**
+ * Refuses a region that is not one place before anything is asked of it.
+ *
+ * <p>The whole of where a position is, and not just the file. A region whose ends are in two places
+ * is a place that is two places, and a placement is what says which place one end is in — so this is
+ * one comparison rather than a file test and a provenance test that could be kept in step by hand.
+ * Read off the start alone, the second end's answer would go unrecorded: a region running from a
+ * copy of {@code A} to a copy of {@code B} would come back as a report about {@code A}, and nothing
+ * anywhere would say otherwise.
+ *
+ * <p>Here rather than on {@link Region}, which is a pair of positions and is built by every pass;
+ * this is where a pair is asked to be a place. Measured before it was written: no region in the
+ * compiler's own corpus has ends that disagree about provenance.
+ *
+ * <p>Its own class because more than one type asks it. {@link DiagnosticPlace} asks it of a region a
+ * reader may be sent to and {@link UnnamedRegion} of one nobody can be sent to, and those are the
+ * same question about the pair — a region that is two places is two places whichever of them it is
+ * in. Written twice they would be one question with two answers, which is the shape this package
+ * exists to close.
+ */
+final class OnePlace {
+
+    private OnePlace() {
+    }
+
+    static void heldTo(Region region) {
+        if (region == null) {
+            throw new DiagnosticPlace.NotAPlace("a label is about a region and was given none");
+        }
+        SourcePos start = region.start();
+        SourcePos end = region.end();
+        if (start == null || end == null) {
+            throw new DiagnosticPlace.NotAPlace("a region a label is about has two ends: " + region);
+        }
+        if (!start.placement().equals(end.placement())) {
+            throw new DiagnosticPlace.NotOnePlace("a region runs from " + start.placement() + " to "
+                    + end.placement() + ", which is not one place");
+        }
+    }
+}

--- a/souther-syntax/src/main/java/souther/compiler/diag/Primary.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Primary.java
@@ -3,41 +3,63 @@ package souther.compiler.diag;
 import java.util.Objects;
 
 /**
- * What a diagnostic points at: a stretch of text, or nothing to point at and where the code is
- * instead.
+ * What a diagnostic points at, as a finished answer.
  *
- * <p>A {@link Citation} tells five states apart, and this is the boundary it was being flattened at.
- * A finding about code inside a module's published text is a citation that has no place and does know
- * which module the code is in; handed to a diagnostic as a region it did not have, that became a
- * region of {@code null} — which says neither, and left the anchoring to work the provenance out
- * again from whichever module the report was filed under. That is the inference this change removes,
- * arriving one boundary later.
+ * <p>Four arms because a {@link Citation} tells apart four things a report can be in, and this is
+ * the boundary they were being flattened at. A region arrived here unclassified and a report with
+ * nothing to point at arrived as {@code null}, so downstream had to work out which of them it was
+ * holding — from the module the report was filed under, from whether a resolver answered, from
+ * whether a caller had thought to pass a source. Those are three different guesses at one question
+ * this now answers.
  *
- * <p>So the value that could not be carried is carried. {@link Unavailable} is not the absence of a
- * primary: it is a report that knows what to tell a reader and has nowhere to send them, which is
- * exactly what {@link DiagnosticPlace.Unavailable} is for a label.
+ * <p>Which arm a region is in is settled once, in {@link #at}, off the citation its start projects.
+ * A site with nothing to point at says so outright, having nothing to classify.
  *
- * <p>Not {@link DiagnosticPlace} itself, and not yet. That type holds a region to being a place a
- * reader can be sent to, and a primary region is not held to anything — over one compile of this
- * suite 53 of 3545 name no source while saying the code is written there. Classifying them is the
- * open question about whether such a region is a place at all, and this leaves it open: what a pass
- * built arrives here as {@link AtARegion} and is passed on unread.
+ * <h2>What each arm asks of whoever shows the report</h2>
  *
- * <p>A diagnostic may still have none of either, which is a third thing and is null for now — the
- * same open question, at its other end.
+ * <p>Nothing, except one. {@link InSource} carries the source it is in, so a surface reads it and
+ * asks the caller for nothing. {@link Unavailable} carries where the code came from, which is what
+ * a reader is told instead of being sent anywhere. {@link Nowhere} points at nothing and says
+ * nothing about code: the report is about a file or about the compile, and which file it is listed
+ * under is the caller's answer and not a place ({@code ReportContext}).
+ *
+ * <p>{@link InAnUnnamedText} is the one that asks. Its line and column are real and which text they
+ * are of was never given, so a surface can send a reader there only if it says which text it is
+ * showing. That is the whole of what a told source was ever for, and it is now asked for by exactly
+ * the arm that needs it rather than handed to every report and read by whichever reader felt like
+ * it.
  */
 public sealed interface Primary {
 
     /**
-     * A stretch of text a pass built the report at, as it built it.
+     * A stretch of a source this compilation holds, which a reader can be sent to.
      *
-     * <p>Unclassified on purpose. Whether a reader can be sent there is a question this does not
-     * ask, because the answer for some of them is no and nothing has decided what to do about that.
+     * <p>The place answers for its own source ({@link DiagnosticPlace.InSource#source()}), so
+     * nothing beside it does. Both a position read from one of this compile's files and a body
+     * spliced into one of them are here: they differ in where the code is written, which
+     * {@link Diagnostic#whereItsCodeIsWritten()} answers, and not in whether there is somewhere to
+     * send a reader.
      */
-    record AtARegion(Region region) implements Primary {
+    record InSource(DiagnosticPlace.InSource place) implements Primary {
 
-        public AtARegion {
-            Objects.requireNonNull(region, "a report about a region has one");
+        public InSource {
+            Objects.requireNonNull(place, "a report pointing into a source names it");
+        }
+    }
+
+    /**
+     * A stretch of a text this compilation cannot name — an editor's unsaved buffer, a snippet a
+     * caller parsed.
+     *
+     * <p>The numbers are real and the file is not this value's to say. A surface showing one of
+     * these says which text it is reading, and a surface that does not may not guess: quoting
+     * whatever sits at those numbers in whichever file was to hand is the defect this whole family
+     * of types exists to stop.
+     */
+    record InAnUnnamedText(UnnamedRegion where) implements Primary {
+
+        public InAnUnnamedText {
+            Objects.requireNonNull(where, "a report about a stretch of a text has one");
         }
     }
 
@@ -55,10 +77,44 @@ public sealed interface Primary {
         }
     }
 
-    /** The region this points at, or null where there is nothing to point at. What every surface
-     *  reading a primary region already asked for, answered the same way — a report with nowhere to
-     *  point has no region, and now it also has what to say. */
-    static Region regionOf(Primary primary) {
-        return primary instanceof AtARegion(Region region) ? region : null;
+    /**
+     * Nothing to point at, and nothing to say about where code is either.
+     *
+     * <p>Not a report that lost its place: one that never was about a stretch of text. A module
+     * declared here and also on the path is wrong about neither line; the compiler running out of
+     * room is not a fact about the source at all. Which file such a report is listed under is a real
+     * question and is not this one — it is answered where the report is shown, because only a caller
+     * holding the files can answer it.
+     */
+    record Nowhere() implements Primary {
+
+        /** The one of these there is. It carries nothing, so two of them are the same one. */
+        public static final Nowhere IT = new Nowhere();
+    }
+
+    /**
+     * Where {@code region} is, classified once.
+     *
+     * <p>Off the citation the region's start projects, which is where the two questions a placement
+     * is the product of are already answered together. The same reading {@link DiagnosticPlace#of}
+     * makes of a label's region, with one difference: a label that cannot be placed is refused,
+     * because a label is offered to a reader or is not written, and a primary that cannot be placed
+     * is the report itself and has to be carried.
+     *
+     * @throws DiagnosticPlace.NotAPlace where there is no region or it has no ends
+     * @throws DiagnosticPlace.NotOnePlace where the ends are in two places
+     */
+    static Primary at(Region region) {
+        OnePlace.heldTo(region);
+        return switch (Citation.of(region.start())) {
+            case Citation.Written _, Citation.Reached _ ->
+                    new InSource(new DiagnosticPlace.InSource(region));
+            case Citation.Unplaced _, Citation.UnplacedElsewhere _ ->
+                    new InAnUnnamedText(new UnnamedRegion(region));
+            // A position inside a module's published text is a line of a text nobody holds. There is
+            // nothing to point at, and what is known is which module wrote the code — so the region
+            // is not carried on to be read as a place by whoever forgets to ask.
+            case Citation.OutOfSight out -> new Unavailable(out.provenance());
+        };
     }
 }

--- a/souther-syntax/src/main/java/souther/compiler/diag/ReportContext.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/ReportContext.java
@@ -1,0 +1,65 @@
+package souther.compiler.diag;
+
+import souther.compiler.source.SourceId;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * What the surface showing a report answers for it: which file it is listing the report under, and
+ * which text it is reading.
+ *
+ * <p>Two questions, and they were one field. {@code Located} carried a source that meant "the source
+ * the primary region is in" where the region already said so, and meant "the file to list this under"
+ * where the report pointed at nothing — so a report whose region named its file arrived with the
+ * field empty and nothing was lost, while a report that pointed nowhere arrived with it set and it
+ * was the only answer there was. Measured over this suite, the first was 117 of 266 primaries
+ * reaching a renderer and the second was all 10 reports that pointed at nothing.
+ *
+ * <p>Neither is read off the other. A file a report is listed under is a decision about where an
+ * author will look for it, and the text a surface is reading is a fact about what that surface
+ * holds; an editor publishing one document's markers is reading that document while listing a report
+ * whose code is in another file.
+ *
+ * <p>Both optional, and their absence means different things. Nothing to list it under is a caller
+ * that has no files — a renderer handed one diagnostic and asked what it says. Nothing being read is
+ * a caller that did not say, and a report in a text nobody named then has no place to offer
+ * ({@link SpotResolution.TextWasNotProvided}) rather than a place shown against a text somebody
+ * guessed at.
+ */
+public record ReportContext(Optional<SourceId> filedUnder, Optional<TextBeingRead> textBeingRead) {
+
+    public ReportContext {
+        Objects.requireNonNull(filedUnder, "say which file this is listed under, or say none");
+        Objects.requireNonNull(textBeingRead, "say which text is being read, or say none");
+    }
+
+    /** A caller with no files: nothing to list a report under and no text to quote. */
+    public static final ReportContext NONE =
+            new ReportContext(Optional.empty(), Optional.empty());
+
+    /** A compile showing a report on one of its own sources, which is both where the report is
+     *  listed and the text being read. */
+    public static ReportContext inFile(SourceId source) {
+        return source == null ? NONE
+                : new ReportContext(Optional.of(source),
+                        Optional.of(new TextBeingRead.UnderAnId(source)));
+    }
+
+    /**
+     * A surface listing a report under one file while reading another — an editor putting a marker
+     * on the document it is publishing for a report whose primary is in a different source.
+     */
+    public static ReportContext of(SourceId filedUnder, SourceId textBeingRead) {
+        return new ReportContext(Optional.ofNullable(filedUnder),
+                Optional.ofNullable(textBeingRead).map(TextBeingRead.UnderAnId::new));
+    }
+
+    /** A caller holding a text it has no identity for, and quoting the report from it — or holding
+     *  none, which is {@link #NONE} and not a text that happens to be empty. */
+    public static ReportContext ofTheTextItself(SourceContext text) {
+        return text == null ? NONE
+                : new ReportContext(Optional.empty(),
+                        Optional.of(new TextBeingRead.AsHandedOver(text)));
+    }
+}

--- a/souther-syntax/src/main/java/souther/compiler/diag/Shown.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Shown.java
@@ -1,0 +1,47 @@
+package souther.compiler.diag;
+
+import souther.compiler.diag.msg.Message;
+
+import java.util.Objects;
+
+/**
+ * One place a report puts in front of a reader, and what it is doing there.
+ *
+ * <p>The role and not the place. Whether a stretch of text is what the message is about or is a
+ * second place shown to explain it is a fact about the report, and it used to be a note held on the
+ * place itself with null meaning "this is the one the message is about". Every reader of a place had
+ * to know that, and a place with a note and a place without were the same type.
+ *
+ * <p>Which of these is the anchor depends on which file is being read, so both arms reach both
+ * positions: a problem written in two files has the label as the anchor on the file the label is in
+ * ({@link DiagnosticView}).
+ */
+public sealed interface Shown {
+
+    /** Where this is. */
+    Spot spot();
+
+    /**
+     * The place the message is about.
+     *
+     * <p>At most one of these in a view, and exactly one wherever the report's primary resolved to a
+     * place. Where it did not — a report about a module rather than a stretch of text, one whose
+     * code is out of sight, one in a text the surface did not name — there is none, and the reason
+     * is {@link DiagnosticView#primary()}.
+     */
+    record ItsSubject(Spot spot) implements Shown {
+
+        public ItsSubject {
+            Objects.requireNonNull(spot, "the place a message is about is a place");
+        }
+    }
+
+    /** A second place, with what it says about being pointed at. */
+    record ALabel(Spot spot, Message said) implements Shown {
+
+        public ALabel {
+            Objects.requireNonNull(spot, "a second place a reader is sent to is somewhere");
+            Objects.requireNonNull(said, "a second place says why it is pointed at");
+        }
+    }
+}

--- a/souther-syntax/src/main/java/souther/compiler/diag/SourceContextResolver.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/SourceContextResolver.java
@@ -15,9 +15,9 @@ import java.util.function.Function;
  *
  * <p>A secondary is asked about under the source it names, which every one of them does
  * ({@link DiagnosticPlace.InSource}); one with nothing to quote is not asked about at all, because
- * it points at nothing and is said in words instead. A whole diagnostic that names none is asked
- * about as {@link Located#NO_SOURCE}, and what that means is the caller's to say — a report a
- * compile could pin on no source still has to be shown somewhere.
+ * it points at nothing and is said in words instead. A report that points at nothing is asked about
+ * under the file it is listed on ({@link ReportContext#filedUnder()}), and one in a text the caller
+ * handed over is not asked about here at all — {@link #quotedFrom} has the text.
  *
  * <p>Answering twice for one id must give the same text, since a caret is drawn under a line quoted
  * from it. {@link #memoized} is how a caller reading files off disk keeps that true, and it also
@@ -29,6 +29,24 @@ public interface SourceContextResolver {
 
     /** The text and display name for {@code sourceId}, or null when there is none to quote. */
     SourceContext sourceOf(SourceId sourceId);
+
+    /**
+     * The text to quote a spot from, or null when there is none.
+     *
+     * <p>A switch over where the spot is rather than a lookup, because one of the two arms is not a
+     * lookup: a caller reading a text it has no identity for handed the text over, and asking this
+     * for an identity nobody gave is what used to come back as "no file" for a place the caller was
+     * holding the file of.
+     */
+    default SourceContext quotedFrom(Spot spot) {
+        return switch (spot) {
+            case Spot.InSource in -> sourceOf(in.place().source());
+            case Spot.InTextBeingRead(TextBeingRead text, UnnamedRegion _) -> switch (text) {
+                case TextBeingRead.UnderAnId(SourceId source) -> sourceOf(source);
+                case TextBeingRead.AsHandedOver(SourceContext held) -> held;
+            };
+        };
+    }
 
     /** Nothing to quote for anything — a caller that has no sources to hand. */
     static SourceContextResolver none() {

--- a/souther-syntax/src/main/java/souther/compiler/diag/Spot.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Spot.java
@@ -2,102 +2,97 @@ package souther.compiler.diag;
 
 import souther.compiler.source.SourceId;
 
-import souther.compiler.diag.msg.Message;
-
 import java.util.Objects;
+import java.util.Optional;
 
 /**
- * One place a diagnostic points at, in the source it is in. A {@link Diagnostic} says where its
- * primary region is and what its secondaries say, and a reader has to be handed both the region and
- * its file to know what text to quote. A spot is that pairing, made once.
+ * One place a reader can be sent to, with the text to quote it from settled.
  *
- * <p>Made two ways, and there is no constructor that takes a source and a region separately.
+ * <p>Two arms, and the difference is which value answers for the text. {@link InSource} reads it off
+ * the place, which carries it ({@link DiagnosticPlace.InSource#source()}). {@link InTextBeingRead}
+ * is handed it, because its region is in a text this compilation cannot name and the surface showing
+ * the report is the only thing that knows which text that is.
  *
- * <p>A secondary reads its source off its place ({@link DiagnosticPlace.InSource}), which is where
- * that answer already is. What a renderer does with a spot is take the two apart again — the file to
- * quote from, the numbers to quote at — so a pair that could disagree is a marker put in one file
- * with its line read from another. That is the defect this whole change is about, and it does not
- * stop being it one layer downstream of where it was closed.
+ * <p>So a source identity is never held beside something that already answers for one. That pairing
+ * is what this class used to be — a told source and a region, taken apart again by every renderer,
+ * so a pair that disagreed was a marker put in one file with its line quoted from another. It is
+ * gone rather than checked: the arm whose region answers does not carry a second answer, and the arm
+ * that carries one has a region that answers nothing ({@link UnnamedRegion}).
  *
- * <p>A primary is told, and a secondary is not. Which is not because the two are different kinds of
- * place: it is because a primary region is not held to being one. A secondary goes through
- * {@link DiagnosticPlace}, so it names a source by construction; a primary does not, and over one
- * compile of this suite 53 of 3545 diagnostics carried a primary region that names no source while
- * saying the code is written at it, with another 22 carrying no region at all. For those, what this
- * is told is the only answer there is, and it comes from where the report was filed rather than from
- * the place — so a reader is sent to a file the numbers may not be of.
- *
- * <p>So this pairing is not the defect the rest of this package closed, and it is not settled
- * either. The rule those values keep is that a place answering for a source is not asked twice; here
- * the place does not always answer. What the field means where it does — the source the region is
- * in, or the file this report is being read from — is what has to be decided before it can be given
- * a type, and deciding it means reading what those diagnostics are about.
- *
- * <p>Every spot is somewhere. A label with nothing to quote is not one — it is
- * {@link DiagnosticPlace.Unavailable}, and a reader is told where the code came from rather than
- * sent anywhere ({@link DiagnosticView#unquotable()}).
- *
- * <p>{@link #said()} is null for the primary region, which has no note of its own: what it points at
- * is what the message is about.
+ * <p>What a spot says it is about is not here. A place is a place whether the report is about it or
+ * points at it to explain something, and which of those it is belongs to the report
+ * ({@link Shown}). Held here, every reader of a place had to know that a null note meant "this is
+ * the primary".
  */
-public final class Spot {
+public sealed interface Spot {
 
-    private final SourceId sourceId;
-    private final Region region;
-    private final Message said;
+    /** The stretch this points at. Both arms have exactly one, so asking for it skips no case. */
+    Region region();
 
-    private Spot(SourceId sourceId, Region region, Message said) {
-        this.sourceId = sourceId;
-        this.region = region;
-        this.said = said;
+    /** A place in a source this compilation holds. */
+    record InSource(DiagnosticPlace.InSource place) implements Spot {
+
+        public InSource {
+            Objects.requireNonNull(place, "a place in a source names the source");
+        }
+
+        @Override
+        public Region region() {
+            return place.region();
+        }
     }
 
-    /** The primary region of {@code d}, in {@code sourceId} — which the caller says, holding the
-     *  files, and which is none for a compile that names none. */
-    public static Spot primary(Diagnostic d, SourceId sourceId) {
-        return new Spot(sourceId, d.region(), null);
+    /** A place in the text the surface says it is reading. */
+    record InTextBeingRead(TextBeingRead text, UnnamedRegion where) implements Spot {
+
+        public InTextBeingRead {
+            Objects.requireNonNull(text, "a place in a text the caller is reading names that text");
+            Objects.requireNonNull(where, "a place is a stretch of it");
+        }
+
+        @Override
+        public Region region() {
+            return where.region();
+        }
     }
 
-    /** A second place, in the source its own place names. */
-    public static Spot secondary(DiagnosticPlace.InSource place, Message said) {
-        Objects.requireNonNull(place, "a second place a reader is sent to is somewhere");
-        return new Spot(place.source(), place.region(),
-                Objects.requireNonNull(said, "a second place says why it is pointed at"));
+    /**
+     * Whether two spots are known to be in one text.
+     *
+     * <p>Answered from identities, and only where both have one. A surface asks this to decide
+     * whether to write a file name over a place it is about to quote, and "cannot tell" has to come
+     * back as "not known to be one": naming the file of a place that turns out to be the same one
+     * costs a reader a line they did not need, and leaving it off a place in another file leaves
+     * them a line and column with no file to read them in.
+     *
+     * <p>Across the arms as readily as within them. A document an editor publishes by name and a
+     * report parsed out of that same document's unsaved text are one text, and the day
+     * {@link TextBeingRead} carries an identity for a text handed over, more pairs answer yes here
+     * and nowhere else.
+     */
+    static boolean knownToBeOneText(Spot one, Spot other) {
+        Optional<SourceId> here = identityOf(one);
+        Optional<SourceId> there = identityOf(other);
+        return here.isPresent() && here.equals(there);
     }
 
-    /** The source this is in, or none where a compile of one file named none. */
-    public SourceId sourceId() {
-        return sourceId;
+    /** Whether this spot is known to be in the text {@code source} names — the same question,
+     *  asked of a text a caller has an identity for and no spot in. */
+    static boolean knownToBeIn(Spot spot, SourceId source) {
+        return source != null && identityOf(spot).filter(source::equals).isPresent();
     }
 
-    /** The stretch this points at. */
-    public Region region() {
-        return region;
-    }
-
-    /** What this says, or null for the primary region. */
-    public Message said() {
-        return said;
-    }
-
-    /** Whether this spot carries a note — false for the primary region. */
-    public boolean labelled() {
-        return said != null;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        return other instanceof Spot that && Objects.equals(sourceId, that.sourceId)
-                && Objects.equals(region, that.region) && Objects.equals(said, that.said);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(sourceId, region, said);
-    }
-
-    @Override
-    public String toString() {
-        return "Spot[" + sourceId + " " + region + (said == null ? "" : " " + said) + "]";
+    /**
+     * The identity of the text a spot is in, where there is one to compare.
+     *
+     * <p>Private, and the only reader is the comparison above. Published, it would be the accessor
+     * spanning the arms that this package refuses everywhere else: a caller would read it, find an
+     * empty answer for a text handed over, and put the report wherever it was being shown.
+     */
+    private static Optional<SourceId> identityOf(Spot spot) {
+        return switch (spot) {
+            case InSource in -> Optional.of(in.place().source());
+            case InTextBeingRead(TextBeingRead text, UnnamedRegion _) -> text.identity();
+        };
     }
 }

--- a/souther-syntax/src/main/java/souther/compiler/diag/SpotResolution.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/SpotResolution.java
@@ -1,0 +1,84 @@
+package souther.compiler.diag;
+
+import java.util.Objects;
+
+/**
+ * What came of asking a report's primary for a place a reader can be sent to.
+ *
+ * <p>Four answers, because there are three ways the answer can be no and they are not the same
+ * thing. A report about a module rather than a stretch of text has no place to offer and nothing to
+ * say instead; one about code out of sight has nowhere to point and does have something to say; and
+ * one in a text nobody named is a place the surface could have shown had it said which text it is
+ * reading. The first two are the report's state. The third is the surface's, and it is the one that
+ * is somebody's mistake rather than a fact about the code.
+ *
+ * <p>Which is why it is a value rather than an empty {@link java.util.Optional}. A missing display
+ * context that came back as absence would read as "this report points nowhere", so a surface would
+ * show the sentence and nobody would learn that a caller had not said which text it was showing.
+ * Nothing is thrown for it: an editor holding an unsaved buffer is the ordinary reason a report is
+ * in a text with no name, and taking a session down over a caller that did not pass one is worse
+ * than showing the sentence with no caret.
+ */
+public sealed interface SpotResolution {
+
+    /** There is a place, and here it is. */
+    record Found(Spot spot) implements SpotResolution {
+
+        public Found {
+            Objects.requireNonNull(spot, "a resolution that found a place has one");
+        }
+    }
+
+    /** The report is not about a stretch of text. Which file it is listed under is a separate
+     *  question, answered by {@link ReportContext#filedUnder()}. */
+    record NoPrimary() implements SpotResolution {
+
+        /** The one of these there is. */
+        public static final NoPrimary IT = new NoPrimary();
+    }
+
+    /** There is nowhere to point, and this is where the code is written — what a reader is told
+     *  instead of being sent anywhere. */
+    record CodeUnavailable(SourceProvenance from) implements SpotResolution {
+
+        public CodeUnavailable {
+            Objects.requireNonNull(from, "code out of sight came from somewhere");
+        }
+    }
+
+    /**
+     * There is a stretch of text and the surface did not say which text it is reading.
+     *
+     * <p>The line and the column are real and are carried, so what happened is legible: this is a
+     * caller that had a place to show and did not name the text it was showing it from. Nothing
+     * downstream may put those numbers against a text it guessed at, which is the whole of what
+     * telling this apart is for.
+     */
+    record TextWasNotProvided(UnnamedRegion where) implements SpotResolution {
+
+        public TextWasNotProvided {
+            Objects.requireNonNull(where, "a place nobody named is still a place");
+        }
+    }
+
+    /**
+     * What {@code primary} comes to, given what the surface says it is reading.
+     *
+     * <p>The one place the two are put together. Every surface asked its own version of this
+     * question before — of a told source, of whether a resolver answered, of whether a region was
+     * null — and each answered a different one of the four with the same silence.
+     */
+    static SpotResolution of(Primary primary, ReportContext context) {
+        return switch (primary) {
+            case Primary.InSource(DiagnosticPlace.InSource place) ->
+                    new Found(new Spot.InSource(place));
+            case Primary.InAnUnnamedText(UnnamedRegion where) ->
+                    context.textBeingRead()
+                            .<SpotResolution>map(text ->
+                                    new Found(new Spot.InTextBeingRead(text, where)))
+                            .orElseGet(() -> new TextWasNotProvided(where));
+            case Primary.Unavailable(SourceProvenance from) -> new CodeUnavailable(from);
+            case Primary.Nowhere _ -> NoPrimary.IT;
+        };
+    }
+}

--- a/souther-syntax/src/main/java/souther/compiler/diag/TextBeingRead.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/TextBeingRead.java
@@ -1,0 +1,58 @@
+package souther.compiler.diag;
+
+import souther.compiler.source.SourceId;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * The text a surface is showing a report from, as that surface names it.
+ *
+ * <p>A report found in a text this compilation cannot name has a real line and a real column and no
+ * file ({@link Citation.Unplaced}). Which text those numbers are of is not the report's to say and
+ * is not lost either: an editor holding an unsaved buffer knows which document it is looking at, and
+ * a caller that parsed a snippet is holding the snippet. This is that answer, given where the report
+ * is shown rather than where it was found.
+ *
+ * <p>Two arms because there are two ways a surface has a text. A compile, a build and an editor
+ * identify their sources, and hand over the identity; a caller with a text and no identity for it
+ * hands over the text. Neither is the other's default: a resolver asked for an identity nobody gave
+ * answers nothing, and that is what put a report's numbers in front of whichever file was to hand.
+ *
+ * <p>An identity where there is one, so that a place in a named text and a place in the same text
+ * shown by name can be seen to be one place ({@link Spot#knownToBeOneText}). Where there is none,
+ * two places cannot be shown to be one and are not treated as one — which is the honest answer and
+ * not a claim that they differ.
+ */
+public sealed interface TextBeingRead {
+
+    /** The identity this text is under, where the surface has one to compare. */
+    Optional<SourceId> identity();
+
+    /** A text the surface names — a source of a compile, a document in an editor. */
+    record UnderAnId(SourceId source) implements TextBeingRead {
+
+        public UnderAnId {
+            Objects.requireNonNull(source, "a text named by an identity has one");
+        }
+
+        @Override
+        public Optional<SourceId> identity() {
+            return Optional.of(source);
+        }
+    }
+
+    /** A text the surface is holding and has no identity for — a snippet somebody parsed. What is
+     *  handed over is what to quote from and what to call it. */
+    record AsHandedOver(SourceContext text) implements TextBeingRead {
+
+        public AsHandedOver {
+            Objects.requireNonNull(text, "a text handed over is a text");
+        }
+
+        @Override
+        public Optional<SourceId> identity() {
+            return Optional.empty();
+        }
+    }
+}

--- a/souther-syntax/src/main/java/souther/compiler/diag/UnnamedRegion.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/UnnamedRegion.java
@@ -1,0 +1,54 @@
+package souther.compiler.diag;
+
+/**
+ * A stretch of a text this compilation cannot name: a real line and a real column, of a text whose
+ * identity was never given.
+ *
+ * <p>The counterpart of {@link DiagnosticPlace.InSource}, and the reason both exist as types rather
+ * than as regions somebody checked. That one refuses a region that does not name a source; this one
+ * refuses a region that does. So a value holding a source identity beside one of these is not
+ * holding two answers to one question — this says, in the type, that it has no answer of its own —
+ * and a value holding one beside the other would be, which is what the check written for #760 is
+ * about.
+ *
+ * <p>Which text it is remains somebody's to say, and it is said where the report is shown rather
+ * than where it was found: an editor holding an unsaved buffer knows which document it is looking
+ * at, and the parse that read that buffer did not ({@link Citation.Unplaced}). That is a state a
+ * compile has and not one left over from a compile, so what a report built over such a text carries
+ * is this, and the identity arrives beside it at the surface ({@link Spot.InTextBeingRead}).
+ *
+ * <p>Code copied in from elsewhere is admitted too ({@link Citation.UnplacedElsewhere}): a body
+ * spliced into a buffer is still a stretch of that buffer, and where the code came from is a
+ * separate question that {@link Diagnostic#whereItsCodeIsWritten()} answers. Refusing it here would
+ * put a splice into a buffer somewhere neither type covers.
+ */
+public record UnnamedRegion(Region region) {
+
+    public UnnamedRegion {
+        OnePlace.heldTo(region);
+        switch (Citation.of(region.start())) {
+            case Citation.Unplaced _, Citation.UnplacedElsewhere _ -> { }
+            case Citation.Written _, Citation.Reached _, Citation.OutOfSight _ ->
+                    throw new NotInAnUnnamedText(
+                            "this region is in a text something can name, so a source identity"
+                                    + " beside it would be a second answer: " + region);
+        }
+    }
+
+    /**
+     * A region that is in a text something already names, handed over as one that is not.
+     *
+     * <p>Marked for the reason {@link DiagnosticPlace.NotAPlace} is: what raises one of these runs
+     * inside an analysis that falls open, and an unmarked refusal would be swallowed there — turning
+     * a report the compiler built wrongly into a subject with nothing wrong with it.
+     */
+    public static final class NotInAnUnnamedText extends IllegalArgumentException
+            implements TheCompilerDisagreesWithItself {
+
+        private static final long serialVersionUID = 1L;
+
+        NotInAnUnnamedText(String message) {
+            super(message);
+        }
+    }
+}

--- a/souther-syntax/src/test/java/souther/compiler/diag/AnErrorKeepsTheMessageItWasRaisedWithTest.java
+++ b/souther-syntax/src/test/java/souther/compiler/diag/AnErrorKeepsTheMessageItWasRaisedWithTest.java
@@ -8,8 +8,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * An error that takes on the other errors a compilation found still says what it was raised with.
@@ -30,8 +28,8 @@ class AnErrorKeepsTheMessageItWasRaisedWithTest {
                 "2 example rows did not hold");
         String said = raised.getMessage();
 
-        CompileException joined = raised.alsoReporting(List.of(at(9, "elsewhere")),
-                java.util.Arrays.asList(Located.NO_SOURCE));
+        CompileException joined = raised.alsoReporting(
+                List.of(new Located(at(9, "elsewhere"), ReportContext.NONE)));
 
         assertEquals(said, joined.getMessage());
         assertEquals(3, joined.diagnostics().size());
@@ -43,19 +41,20 @@ class AnErrorKeepsTheMessageItWasRaisedWithTest {
     void whatItTakesOnComesAfterWhatItHad() {
         CompileException raised = CompileException.of(at(3, "first"));
 
-        CompileException joined = raised.alsoReporting(List.of(at(5, "second"), at(7, "third")),
-                java.util.Arrays.asList(new SourceId("b.sou"), Located.NO_SOURCE));
+        CompileException joined = raised.alsoReporting(List.of(
+                new Located(at(5, "second"), ReportContext.inFile(new SourceId("b.sou"))),
+                new Located(at(7, "third"), ReportContext.NONE)));
 
         assertEquals(List.of("first", "second", "third"),
                 joined.diagnostics().stream().map(DiagnosticRenderer::legacyBody).toList());
         assertEquals(new SourceId("b.sou"), joined.sourceIdOf(1));
-        assertEquals(Located.NO_SOURCE, joined.sourceIdOf(2));
+        assertEquals(null, joined.sourceIdOf(2), "the third named none");
     }
 
     @Test
     void anUnnamedSourceIsStillTaggedAfterwards() {
         CompileException joined = CompileException.of(at(3, "first"))
-                .alsoReporting(List.of(at(5, "second")), java.util.Arrays.asList(Located.NO_SOURCE))
+                .alsoReporting(List.of(new Located(at(5, "second"), ReportContext.NONE)))
                 .inSource(new SourceId("a.sou"));
 
         assertEquals(new SourceId("a.sou"), joined.sourceIdOf(0));
@@ -66,16 +65,7 @@ class AnErrorKeepsTheMessageItWasRaisedWithTest {
     void takingOnNothingIsTheSameError() {
         CompileException raised = CompileException.of(at(3, "first"));
 
-        assertSame(raised, raised.alsoReporting(List.of(), List.of()));
+        assertSame(raised, raised.alsoReporting(List.of()));
     }
 
-    @Test
-    void everyDiagnosticTakenOnNamesASource() {
-        CompileException raised = CompileException.of(at(3, "first"));
-
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-                () -> raised.alsoReporting(List.of(at(5, "second"), at(7, "third")),
-                        List.of(new SourceId("b.sou"))));
-        assertTrue(e.getMessage().contains("one source per diagnostic"), e.getMessage());
-    }
 }


### PR DESCRIPTION
Closes #769.

## What it was

A diagnostic's primary arrived downstream as a region and a null, and the source
it was in was told to it from wherever the report had been filed
(`Spot.primary(d, sourceId)`). Neither value said which of four things it was, so
each reader read the null as whichever it had in mind and read the told source as
whichever question it was answering.

## What the measurement said

Instrumented at construction and at both delivery points, over the whole suite:

| where | |
|---|---|
| primaries reaching a renderer | 266 |
| — told source agrees with the region's own | 119 |
| — **told nothing while the region named the file** | **117** |
| — region names no file, told a source anyway | 11 |
| — region names no file, told nothing | 17 |
| — **told source contradicts the region** | **0** |
| reports the compiler anchored | 5346 |
| — region names the file, told agrees | 5334 |
| — no region at all (E1503) | 10 |
| — contradicts (its own fallback's test) | 2 |

So the pair carried no information where the region answered, was the only answer
where it did not, and was never a second, contradicting answer. The issue's 53
turned out to be one state rather than fourteen codes' worth of separate
problems: a parse of a text nobody named (`Citation.Unplaced`), plus test
fixtures building positions by hand.

## What it is now

The region is classified where the report is built, through the citation its
start projects; what a surface knows is a value it hands over.

```java
sealed interface Primary { InSource | InAnUnnamedText | Unavailable | Nowhere }
sealed interface Spot    { InSource | InTextBeingRead }
sealed interface Shown   { ItsSubject | ALabel }
record ReportContext(Optional<SourceId> filedUnder, Optional<TextBeingRead> textBeingRead)
sealed interface SpotResolution { Found | NoPrimary | CodeUnavailable | TextWasNotProvided }
```

A place a reader is sent to carries its own source. A place in a text this
compilation cannot name carries the text the surface says it is reading, which is
not a second answer because `UnnamedRegion` refuses a region that answers for
one. Which file a report is listed under is neither of those, and is on the
context.

Gone rather than renamed:

- `Diagnostic.region()` and `Diagnostic.pos()` — four questions under one
  nullable, and every reader picked one.
- `Compilation.sourceIdOf(Db.Found)` — half of it is answered by the place now,
  and the half that is left is `filedUnderOf`, which the report cannot answer.
- `Spot`'s told source, `Located.primarySourceId`, `Located.inFile`,
  `CompileException`'s parallel `List<Diagnostic>`/`List<SourceId>`, and
  `Main.indexOf`'s "one file handed over answers for any id".

## Two defects this turned up

**A report about a path module could be moved as another module's.**
`Front.needs` and `cannotBeReadBack` said nothing about where their code was, and
`Diagnostic.reachedFrom` takes the caller's word in exactly that state. Saying it
at the producer puts the two under one check. Nothing a reader sees changes.

**The command line quoted the only file it had for a report about another.**
`indexOf` answered index 0 for whatever id it was asked, including for none.

## What is checked

- `AReportAboutAPathModuleSaysWhichModuleItIsAboutTest` — both producers name
  their provenance; a move that agrees goes through; a move to another module's
  code is refused. Negative control: with the old `.nowhere()`, nothing is
  thrown.
- `HowManyFilesWereHandedOverDoesNotDecideWhatIsQuotedTest` — one file and two
  render the same string; a report the command cannot place is not quoted from
  the only file to hand. Negative control: with the shortcut, the header names
  that file.
- `ASecondaryRegionNamesItsFileTest` — a report in a text the caller names is
  quoted from it; one in a text nobody named is not quoted from whatever a
  resolver answers with.
- `AnalyzerTest#aSemanticErrorIsMarkedWhereItIsWritten` — the single-document
  route marks the reported line. This caught a regression made while writing
  this: the marker had fallen to the head of the document.
- `AReportAboutAModuleOffThePathIsSaidWhereItWasReachedTest` — the old
  `twoFindingsInOnePublishedModuleAreSaidOnce` bundled two claims, one of which
  its own denominator carried. Split into an identity test and a walk-completeness
  test with a fixture whose two findings differ in what they say.
- `NoValueHoldsASourceBesideOneThatAnswersForItTest` — `OPEN` is empty, and
  `Diagnostic` joins the types that answer for a source.

## Verification

Full suite green on the tip (4975 tests, from a clean build). Each of the four
commits was checked out and `test-compile`d on its own; only the tip has had the
whole suite run against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)