### PR TITLE
Ask whether a path is reached of the state, not of one domain of it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
@@ -47,12 +47,12 @@ import java.util.Set;
  * later is a component of this and an arm of {@link #isBottom}, and every such reader has it without
  * being touched.
  *
- * <p>One reader still asks the numbers alone, and it is the other question. Whether a path is
- * reached — whether the conditions guarding a construction can all hold — is asked of
- * {@code numbers} where the walk reads a branch, so a path made impossible by predicates alone is
- * walked and what stands on it is reported. That is a mistake of the same shape as the one above,
- * and it is not this one: what it moves is which constructions are reported at, and a change to
- * that is its own change with its own reason to make.
+ * <p>Two questions are asked here and they are one answer. Whether any value of a declaration
+ * exists, and whether a path a construction stands on is reached, are both whether anything at all
+ * satisfies what has been taken in — so both are {@link #isBottom}, under the name each context
+ * reads it by ({@link FieldDomains#infeasible}, {@link Known#reachesNothing}). They were once two
+ * readers of two domains, and each of them answered that there was something wherever the domain it
+ * happened to ask had nothing to say.
  */
 record ConstraintState(NumericDomain<Term> numbers, PredicateFacts facts,
                        AdmissibleValues<Term> values, OrderedIntervals<Term> ordered) {

--- a/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
@@ -55,12 +55,13 @@ import java.util.Set;
  * happened to ask had nothing to say.
  */
 record ConstraintState(NumericDomain<Term> numbers, PredicateFacts facts,
-                       AdmissibleValues<Term> values, OrderedIntervals<Term> ordered) {
+                       AdmissibleValues<Term> values, OrderedIntervals<Term> ordered,
+                       boolean shown) {
 
     /** Nothing taken in, so nothing ruled out. */
     static ConstraintState top() {
         return new ConstraintState(NumericDomain.top(), PredicateFacts.none(),
-                AdmissibleValues.top(), OrderedIntervals.top());
+                AdmissibleValues.top(), OrderedIntervals.top(), false);
     }
 
     /**
@@ -69,9 +70,30 @@ record ConstraintState(NumericDomain<Term> numbers, PredicateFacts facts,
      * <p>Every domain, because each of them can hold the whole state's contradiction on its own: what
      * one of them cannot express it leaves alone, so a contradiction found anywhere is a
      * contradiction, and one found nowhere is only what these readings were able to show.
+     *
+     * <p>And {@code shown}, which is a caller having shown it by an argument none of the domains
+     * makes: a condition no case of what it is written over satisfies is one nothing enters, and
+     * what says so is a reading of the cases rather than anything an interval or a predicate holds.
+     * It is another piece of evidence for the one answer and not a second answer — a state that
+     * carried its own reachability beside the domains would be two records to keep in step, and the
+     * first domain added without touching the second would put them out of agreement.
      */
     boolean isBottom() {
-        return numbers.isBottom() || facts.isBottom() || values.isBottom() || ordered.isBottom();
+        return shown || numbers.isBottom() || facts.isBottom() || values.isBottom()
+                || ordered.isBottom();
+    }
+
+    /**
+     * This, with nothing satisfying it, shown by an argument outside the domains.
+     *
+     * <p>Written here rather than as a contradiction lodged in one of them. Said as {@code 1 <= 0}
+     * in the numbers, which is how it read before, the claim came out as an arithmetic one: a reader
+     * asking why a state holds nothing was told the rules about numbers conflict, and a reader
+     * asking whether a path is reached was pulled back to {@code numbers.isBottom()} — which is the
+     * reading this question came apart along.
+     */
+    ConstraintState shownToHoldNothing() {
+        return shown ? this : new ConstraintState(numbers, facts, values, ordered, true);
     }
 
     /**
@@ -112,21 +134,21 @@ record ConstraintState(NumericDomain<Term> numbers, PredicateFacts facts,
 
     /** This, with {@code f rel 0} taken as holding. */
     ConstraintState taking(LinearForm<Term> f, Rel rel, Map<Term, Granularity> kinds) {
-        return new ConstraintState(numbers.assume(f, rel, kinds), facts, values, ordered);
+        return new ConstraintState(numbers.assume(f, rel, kinds), facts, values, ordered, shown);
     }
 
     /** This, with the predicate {@code key} taken as holding, or as failing. */
     ConstraintState taking(Term key, boolean positive) {
-        return new ConstraintState(numbers, facts.assume(key, positive), values, ordered);
+        return new ConstraintState(numbers, facts.assume(key, positive), values, ordered, shown);
     }
 
     /** This, with {@code admitted} taken as holding of the positions it speaks about. */
     ConstraintState taking(AdmissibleValues<Term> admitted) {
-        return new ConstraintState(numbers, facts, values.meet(admitted), ordered);
+        return new ConstraintState(numbers, facts, values.meet(admitted), ordered, shown);
     }
 
     /** This, with {@code bounded} taken as holding of the positions it bounds. */
     ConstraintState taking(OrderedIntervals<Term> bounded) {
-        return new ConstraintState(numbers, facts, values, ordered.meet(bounded));
+        return new ConstraintState(numbers, facts, values, ordered.meet(bounded), shown);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -935,6 +935,14 @@ public final class InvariantChecker {
     // --- the walk ------------------------------------------------------------------------------
 
     private void walk(Core e, Known k, Denotations at, int depth) {
+        // Nothing reaches here, so there is nothing here to be about. Asked once, at the one door
+        // every reading goes through: a branch, an arm, a departure, an attempt's success and a
+        // closure's body are each walked with something further settled, and each of them is a place
+        // the conditions can come to contradict. Asked at the reports instead, a reading added to
+        // this walk would be one more that has to remember.
+        if (k.reachesNothing()) {
+            return;
+        }
         Core.LetIn standing = bindingInValueIn(e);
         if (standing != null) {
             // A call this analysis expanded is a binding holding what it was given, and where that
@@ -1641,12 +1649,10 @@ public final class InvariantChecker {
         }
     }
 
-    /** What reading {@code e} finds, or nothing where the conditions along the way contradict — a
-     * branch nothing reaches finds nothing, and what is not there violates nothing. */
+    /** What reading {@code e} finds. A branch nothing reaches finds nothing, which is the walk's
+     * answer ({@link Known#reachesNothing}) and not a second one taken here: this collects what the
+     * reading found and decides nothing about whether there was anything to find. */
     private Map<Occurrence, Reported> reading(Core e, Known k, Denotations at, int depth) {
-        if (k.numbers().isBottom()) {
-            return Map.of();
-        }
         Capture outer = capturing;
         Capture mine = Capture.empty();
         capturing = mine;

--- a/souther-compiler/src/main/java/souther/compiler/check/Known.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Known.java
@@ -105,14 +105,14 @@ record Known(ConstraintState constraints, List<Quantified> quantified,
     /**
      * This, where the conditions on the path cannot all hold, so nothing here is reached.
      *
-     * <p>Said as a contradiction in the numbers, which is how the domain already records that it
-     * holds nothing. The reading that ignores the path is left as it was: it is the guards that
-     * cannot all hold, not the values that fail, and a construction under them is one the program
-     * never builds rather than one it builds wrongly.
+     * <p>Said of the state and not lodged in a domain ({@link ConstraintState#shownToHoldNothing}):
+     * what shows it is a reading of the cases an operation is defined in, and no interval and no
+     * predicate holds that argument. The reading that ignores the path is left as it was — it is the
+     * guards that cannot all hold, not the values that fail, and a construction under them is one
+     * the program never builds rather than one it builds wrongly.
      */
     Known reachingNothing() {
-        return taking(LinearForm.constant(java.math.BigDecimal.ONE), Rel.LE, Held.ON_THE_PATH,
-                Map.of());
+        return new Known(constraints.shownToHoldNothing(), quantified, spoken, unguarded);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Known.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Known.java
@@ -50,9 +50,10 @@ record Known(ConstraintState constraints, List<Quantified> quantified,
         }
     }
 
-    /** The relations between numbers this state holds. Handed out because a bound is read off an
-     * interval and off nothing else; whether anything satisfies the state at all is
-     * {@link ConstraintState#isBottom} and is not assembled from this. */
+    /** The relations between numbers this state holds. Handed out for what only an interval can
+     * answer — a bound is read off one and off nothing else — and for nothing about the state as a
+     * whole. Whether a value exists and whether a path is reached are both
+     * {@link ConstraintState#isBottom}, and neither is assembled from this. */
     NumericDomain<Term> numbers() {
         return constraints.numbers();
     }
@@ -60,6 +61,23 @@ record Known(ConstraintState constraints, List<Quantified> quantified,
     /** The predicates this state has settled, read the same way and for the same reason. */
     PredicateFacts facts() {
         return constraints.facts();
+    }
+
+    /**
+     * Whether the conditions that hold here cannot all hold, so nothing stands where this does.
+     *
+     * <p>Asked of the whole state ({@link ConstraintState#isBottom}) and not of a domain, because a
+     * clause reaches whatever domain has a word for it: guards that settle a predicate both ways
+     * leave the predicates contradictory and every number untouched, and a reader that asked the
+     * numbers would walk that path and report the construction standing on it. That is a report
+     * about a value the program never builds.
+     *
+     * <p>No flag of its own, for the same reason. A second record of the answer is a second thing to
+     * keep in step, and the first domain added without touching it would put the two out of
+     * agreement — which is the shape this question already came apart along once.
+     */
+    boolean reachesNothing() {
+        return constraints.isBottom();
     }
 
     /** How far a fact reaches: a value's type and a name's binding say something wherever that value

--- a/souther-compiler/src/test/java/souther/compiler/check/WhetherAPathIsReachedIsAskedOfEveryDomainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhetherAPathIsReachedIsAskedOfEveryDomainTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.Compiler;
+import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.Severity;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Endpoint;
@@ -28,10 +29,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * contradiction.
  *
  * <p>A guard reaches whatever domain has a word for what it says. A comparison reaches the numbers;
- * a predicate about a list reaches the facts and says nothing to them. So the conditions on a path
- * can come to contradict in one domain while every other is untouched, and a reader asking a single
- * domain whether the path is reached walks it whenever it asked the domain that had never heard of
- * the guards. What it then reports is a violation on a path the program never takes.
+ * a predicate about a list reaches the facts and says nothing to the numbers. So the conditions on
+ * a path can come to contradict in one domain while every other is untouched, and a reader asking
+ * a single domain whether the path is reached walks it whenever it asked the domain that had never
+ * heard of the guards. What it then reports is a violation on a path the program never takes.
  *
  * <p>Which domain is not something the author chose, so the programs below are the same program
  * twice with the contradiction moved. What made the difference visible is a clause that only the
@@ -51,9 +52,15 @@ class WhetherAPathIsReachedIsAskedOfEveryDomainTest {
             behavior f : (a: List<Int>, b: List<Int>) -> NEL | Bad constructs NEL, Bad
             """;
 
-    private static long warnings(String source) {
+    /** What this compile warns about, as the codes it says it under. The codes and not how many
+     * there are: a path that is walked and a path that is not differ by one warning either way, and
+     * a count would be answered the same by a compile that lost the report and by one that swapped
+     * it for another. */
+    private static List<String> warnedAbout(String source) {
         return Compiler.compileWithWarnings(source).warnings().stream()
-                .filter(d -> d.severity() == Severity.WARNING).count();
+                .filter(d -> d.severity() == Severity.WARNING)
+                .map(Diagnostic::code)
+                .toList();
     }
 
     /**
@@ -65,7 +72,7 @@ class WhetherAPathIsReachedIsAskedOfEveryDomainTest {
      */
     @Test
     void aPathTheNumbersRuleOutIsNotWalked() {
-        assertEquals(0, warnings(NEL + """
+        assertEquals(List.of(), warnedAbout(NEL + """
                 let f (a, b) =
                     if List.length(a) >= 5 then
                         Bad
@@ -78,7 +85,7 @@ class WhetherAPathIsReachedIsAskedOfEveryDomainTest {
     /** The same guards as a predicate, which reaches no number at all. */
     @Test
     void aPathThePredicatesRuleOutIsNotWalked() {
-        assertEquals(0, warnings(NEL + """
+        assertEquals(List.of(), warnedAbout(NEL + """
                 let f (a, b) =
                     if List.contains(1, a) then
                         Bad
@@ -97,7 +104,7 @@ class WhetherAPathIsReachedIsAskedOfEveryDomainTest {
      */
     @Test
     void aPathThatIsReachedIsWalkedAndWhatStandsOnItIsReported() {
-        assertEquals(1, warnings(NEL + """
+        assertEquals(List.of("E2011"), warnedAbout(NEL + """
                 let f (a, b) =
                     if List.contains(1, a) then
                         Bad

--- a/souther-compiler/src/test/java/souther/compiler/check/WhetherAPathIsReachedIsAskedOfEveryDomainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhetherAPathIsReachedIsAskedOfEveryDomainTest.java
@@ -1,0 +1,169 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.Severity;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.NumericDomain.LinearForm;
+import souther.compiler.numeric.NumericDomain.Rel;
+import souther.compiler.numeric.OrderedInterval;
+import souther.compiler.numeric.OrderedIntervals;
+import souther.compiler.values.AdmissibleValues;
+import souther.compiler.values.Value;
+import souther.compiler.values.ValueSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A construction under guards that cannot all hold is not reported, whichever domain holds the
+ * contradiction.
+ *
+ * <p>A guard reaches whatever domain has a word for what it says. A comparison reaches the numbers;
+ * a predicate about a list reaches the facts and says nothing to them. So the conditions on a path
+ * can come to contradict in one domain while every other is untouched, and a reader asking a single
+ * domain whether the path is reached walks it whenever it asked the domain that had never heard of
+ * the guards. What it then reports is a violation on a path the program never takes.
+ *
+ * <p>Which domain is not something the author chose, so the programs below are the same program
+ * twice with the contradiction moved. What made the difference visible is a clause that only the
+ * numbers have a word for: a state at bottom proves everything, so a clause the contradicted domain
+ * can read comes out discharged by that alone, and the two readings agree for a reason that has
+ * nothing to do with the path. {@code List.length(value) >= 1} over a container built by
+ * {@code List.append} is such a clause — no guard could be written about the built container, so it
+ * is owed as a number and as nothing else.
+ */
+class WhetherAPathIsReachedIsAskedOfEveryDomainTest {
+
+    private static final String NEL = """
+            module demo
+            data Bad
+            data NEL = List<Int>
+                invariant nonEmpty = List.length(value) >= 1
+            behavior f : (a: List<Int>, b: List<Int>) -> NEL | Bad constructs NEL, Bad
+            """;
+
+    private static long warnings(String source) {
+        return Compiler.compileWithWarnings(source).warnings().stream()
+                .filter(d -> d.severity() == Severity.WARNING).count();
+    }
+
+    /**
+     * Guards that cannot both hold as a comparison, which is the domain the reading always asked.
+     *
+     * <p>This one holds whether or not the walk asks anything: a numeric clause under numbers that
+     * contradict is proved by the contradiction itself. So it is here to say what the answer is and
+     * not to catch a walk that stopped asking — the case below is the one that does that.
+     */
+    @Test
+    void aPathTheNumbersRuleOutIsNotWalked() {
+        assertEquals(0, warnings(NEL + """
+                let f (a, b) =
+                    if List.length(a) >= 5 then
+                        Bad
+                    else
+                        (if List.length(a) >= 10 then NEL(List.append(a, b)) else Bad)
+                """),
+                "nothing of length under five is of length ten, so nothing builds this");
+    }
+
+    /** The same guards as a predicate, which reaches no number at all. */
+    @Test
+    void aPathThePredicatesRuleOutIsNotWalked() {
+        assertEquals(0, warnings(NEL + """
+                let f (a, b) =
+                    if List.contains(1, a) then
+                        Bad
+                    else
+                        (if List.contains(1, a) then NEL(List.append(a, b)) else Bad)
+                """),
+                "a list both holding and not holding one is no list, so nothing builds this");
+    }
+
+    /**
+     * And the construction is still reported where the guards can hold.
+     *
+     * <p>Without this the two above are passed by a check that stopped reading conditionals
+     * altogether: what they say is that these constructions go unreported, and going unreported is
+     * what a walk that reads nothing does everywhere.
+     */
+    @Test
+    void aPathThatIsReachedIsWalkedAndWhatStandsOnItIsReported() {
+        assertEquals(1, warnings(NEL + """
+                let f (a, b) =
+                    if List.contains(1, a) then
+                        Bad
+                    else
+                        (if List.contains(2, a) then NEL(List.append(a, b)) else Bad)
+                """),
+                "a list may hold two and not one, and nothing there says the built list is not empty");
+    }
+
+    // --- the question itself -------------------------------------------------------------------
+
+    private static final Term.Interner NAMES = new Term.Interner();
+    private static final Term A_PREDICATE = NAMES.written("some predicate");
+    private static final Term A_POSITION = NAMES.written("some position");
+
+    /**
+     * Each domain at its own bottom, asked of the walk's own question.
+     *
+     * <p>Written here as well as over the programs above because a program can only reach the
+     * domains the walk refines today — the guards settle numbers and predicates, and nothing on a
+     * path names a value or moves an end. A domain that cannot hold a path's contradiction this year
+     * can hold one the year a guard learns to speak to it, and the question has to be right before
+     * then rather than after.
+     */
+    @Test
+    void aPathIsReachedOnlyWhereEveryDomainLeavesSomething() {
+        assertFalse(Known.top().reachesNothing(), "nothing taken in leaves the path as it was");
+        assertTrue(reaching(numbersAtBottom()).reachesNothing());
+        assertTrue(reaching(factsAtBottom()).reachesNothing());
+        assertTrue(reaching(valuesAtBottom()).reachesNothing());
+        assertTrue(reaching(orderedAtBottom()).reachesNothing());
+    }
+
+    /** What the walk says of a path it has been told is not taken, and of the values there. */
+    @Test
+    void aPathSaidNotToBeTakenIsNotTakenAndTheValuesAreLeftAsTheyWere() {
+        Known nothing = Known.top().reachingNothing();
+        assertTrue(nothing.reachesNothing());
+        assertFalse(nothing.unguarded().constraints().isBottom(),
+                "it is the guards that cannot all hold, not the values that fail");
+    }
+
+    private static Known reaching(ConstraintState constraints) {
+        return new Known(constraints, List.of(), Set.of(), new Known.Unguarded(ConstraintState.top()));
+    }
+
+    private static ConstraintState numbersAtBottom() {
+        return ConstraintState.top()
+                .taking(LinearForm.constant(BigDecimal.ONE), Rel.LE, Map.of());
+    }
+
+    private static ConstraintState factsAtBottom() {
+        return ConstraintState.top().taking(A_PREDICATE, true).taking(A_PREDICATE, false);
+    }
+
+    private static ConstraintState valuesAtBottom() {
+        return ConstraintState.top()
+                .taking(AdmissibleValues.at(A_POSITION, ValueSet.just(Value.text("A"))))
+                .taking(AdmissibleValues.at(A_POSITION, ValueSet.just(Value.text("B"))));
+    }
+
+    private static ConstraintState orderedAtBottom() {
+        return ConstraintState.top()
+                .taking(OrderedIntervals.at(A_POSITION,
+                        new OrderedInterval(Endpoint.inclusive(Count.of(6)), null)))
+                .taking(OrderedIntervals.at(A_POSITION,
+                        new OrderedInterval(null, Endpoint.inclusive(Count.of(2)))));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhetherAPathIsReachedIsAskedOfEveryDomainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhetherAPathIsReachedIsAskedOfEveryDomainTest.java
@@ -131,11 +131,23 @@ class WhetherAPathIsReachedIsAskedOfEveryDomainTest {
         assertTrue(reaching(orderedAtBottom()).reachesNothing());
     }
 
-    /** What the walk says of a path it has been told is not taken, and of the values there. */
+    /**
+     * What the walk says of a path it has been told is not taken, and of the values there.
+     *
+     * <p>The saying reaches the state and no domain of it. Written into the numbers, as
+     * {@code 1 <= 0}, it read as an arithmetic claim the model never made — so a reader asking why
+     * nothing satisfies the state was told the rules about numbers conflict, and a reader asking
+     * whether the path is reached was answered by {@code numbers.isBottom()}, which is the reading
+     * that walked a path the predicates alone ruled out.
+     */
     @Test
-    void aPathSaidNotToBeTakenIsNotTakenAndTheValuesAreLeftAsTheyWere() {
+    void aPathSaidNotToBeTakenIsNotTakenAndNoDomainIsMadeToSaySo() {
         Known nothing = Known.top().reachingNothing();
         assertTrue(nothing.reachesNothing());
+        assertFalse(nothing.numbers().isBottom(), "no domain was made to carry the argument");
+        assertFalse(nothing.facts().isBottom());
+        assertFalse(nothing.constraints().values().isBottom());
+        assertFalse(nothing.constraints().ordered().isBottom());
         assertFalse(nothing.unguarded().constraints().isBottom(),
                 "it is the guards that cannot all hold, not the values that fail");
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhetherAValueExistsIsAskedOfEveryDomainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhetherAValueExistsIsAskedOfEveryDomainTest.java
@@ -35,6 +35,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>Each domain is put at its own bottom on its own here, because that is the shape of the mistake:
  * not that the answer was wrong about a state where everything contradicts, but that it was wrong
  * about a state where one thing does.
+ *
+ * <p>And a state holds nothing for one reason more than a domain finding a contradiction: a caller
+ * may have shown it by an argument none of the domains makes
+ * ({@link ConstraintState#shownToHoldNothing}). That is put at its own bottom on its own here too,
+ * for the same reason as the rest.
  */
 class WhetherAValueExistsIsAskedOfEveryDomainTest {
 
@@ -86,6 +91,17 @@ class WhetherAValueExistsIsAskedOfEveryDomainTest {
         assertFalse(orderedAtBottom().values().isBottom());
     }
 
+    /** A caller having shown it, by an argument no domain holds: the cases an operation is defined
+     * in leave the condition unsatisfiable, and nothing an interval or a predicate carries says so. */
+    @Test
+    void aStateShownToHoldNothingHoldsNothing() {
+        assertTrue(shownAtBottom().isBottom());
+        assertFalse(shownAtBottom().numbers().isBottom(), "and every domain is untouched");
+        assertFalse(shownAtBottom().facts().isBottom());
+        assertFalse(shownAtBottom().values().isBottom());
+        assertFalse(shownAtBottom().ordered().isBottom());
+    }
+
     private static ConstraintState numbersAtBottom() {
         // `1 <= 0`, which is how a reading already says that what it stands in is never reached.
         return ConstraintState.top()
@@ -110,21 +126,31 @@ class WhetherAValueExistsIsAskedOfEveryDomainTest {
                         new OrderedInterval(null, Endpoint.inclusive(Count.of(2)))));
     }
 
+    private static ConstraintState shownAtBottom() {
+        return ConstraintState.top().shownToHoldNothing();
+    }
+
     /**
      * A tripwire and not the proof above it.
      *
-     * <p>What the tests above establish is that {@link ConstraintState#isBottom} reads each domain
-     * this state has today. They cannot establish it of a domain added tomorrow, and the failure
-     * they would leave is the silent one: the new domain reaches its own bottom, nothing asks it,
-     * and every type whose rules only that domain can read is built. So the count is pinned here.
-     * A domain added to the state fails this until it is added to the table above as well.
+     * <p>What the tests above establish is that {@link ConstraintState#isBottom} reads each part of
+     * this state that can make it hold today. They cannot establish it of a part added tomorrow, and
+     * the failure they would leave is the silent one: the new part reaches its own bottom, nothing
+     * asks it, and every type whose rules only that part can read is built — and every path only it
+     * rules out is walked. So the count is pinned here. A component added to the state fails this
+     * until it is added to the table above as well.
+     *
+     * <p>Every component and not every domain. What makes the state hold nothing is not only a
+     * domain finding a contradiction in what it was given: a caller may have shown it by an argument
+     * none of them holds ({@link ConstraintState#shownToHoldNothing}), and that is a component here
+     * on the same footing. Counting domains would have let it in unread.
      */
     @Test
-    void everyDomainOfTheStateIsOneThisTestPutAtItsOwnBottom() {
-        RecordComponent[] domains = ConstraintState.class.getRecordComponents();
-        assertEquals(4, domains.length,
-                "each domain of the state needs a case above putting that one, and only that one, "
-                        + "at its bottom");
+    void everyComponentThatCanMakeTheStateHoldNothingIsOneThisTestPutAtItsOwnBottom() {
+        RecordComponent[] components = ConstraintState.class.getRecordComponents();
+        assertEquals(5, components.length,
+                "each component of the state needs a case above putting that one, and only that "
+                        + "one, at its bottom");
     }
 
     /** And the interval algebra's own answer is left as it was: a state is not bottom because some


### PR DESCRIPTION
Closes #782.

A guard reaches whatever domain has a word for what it says. A comparison reaches the
numbers; `List.contains` reaches the facts and says nothing to the numbers. So the conditions on a
path can come to contradict in one domain while every other is untouched, and a reader
asking a single domain whether the path is reached walks it whenever it asked the domain
that had never heard of the guards.

```
data NEL = List<Int>
    invariant nonEmpty = List.length(value) >= 1

let f (a, b) =
    if List.contains(1, a) then
        Bad
    else
        (if List.contains(1, a) then NEL(List.append(a, b)) else Bad)
```

Nothing both holds and does not hold one, so nothing builds that value. It was reported all
the same. The same program with the guards written as `List.length(a) >= 5` and
`>= 10` — the same contradiction, moved to the numbers — is silent.

## What the issue asked to establish first

Whether any model reaches it. One does, and finding it took two conditions the issue does
not name.

The reading in `reading` asked the numbers, which is the shape #771 fixed for the other
question. But that gate is not what was suppressing anything. Disabled outright, the whole
compiler suite stays green — no test observes it. What actually silences a construction
under contradictory guards is each domain proving everything once it is at bottom, which
works exactly when the contradicted domain is one the clause has a word in. Where they do
not line up, the report comes out.

So the second condition is a clause owed as a number and as nothing else. Every clause the
check can name gets a fact key too, and on a facts-bottom path that key discharges it by
ex falso. `List.length` of a container built by `List.append` does not get one — no guard
could be written about the built container — and that is where the two come apart.

Across the whole suite the walk enters a bottom state 34 times, 6 of them with the facts
contradicted and the numbers untouched. All 6 came out proved, each because the clause
happened to have a fact route.

## The change

**Ask the question once, of the state, at the one door every reading goes through.**
`Known.reachesNothing` is `ConstraintState.isBottom` under the name the walk reads it by,
beside `FieldDomains.infeasible` for whether a value exists — both are whether anything at
all satisfies what has been taken in. The gate is at `walk`'s entry, so a branch, an arm, a
departure, an attempt's success and a closure's body are covered without any of them
remembering to ask, and so is the next kind of branch. The gate in `reading` is deleted
rather than corrected: a second reader of one question is what this came apart along.

Being at bottom still proves everything, which is sound. Nothing depends on it for this any
more.

**Stop lodging "nothing satisfies this" in a domain.** `reachingNothing` took `1 <= 0` into
the numbers, which made an arithmetic claim the model never made and put the answer exactly
where the last reader went looking for it. The state carries the evidence itself now
(`shownToHoldNothing`), read by `isBottom` beside the domains — another arm of the one
answer, not a reachability flag kept alongside it.

`holdsNothing` answers as before, and `reachingNothing` is reached only from the path side,
so no declaration's refusal reads differently.

## Tests

The probe writes the numeric shape and the predicate shape beside each other, with a third
program whose guards can hold so that "not reported" cannot be passed by a walk that stopped
reading conditionals. Removing the gate fails the predicate case and only that one — the
numeric case holds either way, and the test says so rather than looking like a control.

Over `Known` itself, each domain is put at its own bottom on its own, including the two no
guard can reach today: nothing on a path names a value or moves an end, so those are there
for the year a guard learns to speak to them.

The component tripwire on `ConstraintState` caught the second commit and was widened for it.
It counted domains; what makes a state hold nothing is not only a domain finding a
contradiction in what it was given, so it counts components now.

## Verified

- Full reactor green, 5032 tests in souther-compiler.
- souther-examples: 12 modules SUCCESS, no souther diagnostics anywhere. `todomvc` fails at
  the pre-existing spot (`TodomvcTest.java` cannot see the generated types), unchanged by
  this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
