### PR TITLE
Write down how the conformance corpus is run

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,23 @@ java -jar souther-bench/target/souther-bench.jar
 java -jar souther-bench/target/souther-bench.jar phase edit
 ```
 
+`souther-compiler` carries a conformance corpus: a model written for this compiler, held to reaching every top-level form, every reserved word and every standard library module the language declares, and checked against what the compiler answered about it last — the whole adequacy report and every diagnostic, written down beside the sources. A change that moves an answer is a change to those documents, made in the commit that moved it. This is what answers "did this break a model of the size someone writes"; running the examples repository is not part of it.
+
+```sh
+# Everything the corpus is held to. Ten seconds after an edited compiler source.
+mvn -pl souther-compiler test -Dtest='souther.compiler.conformance.*Test'
+
+# One corpus while iterating.
+mvn -pl souther-compiler test -Dtest='souther.compiler.conformance.*Test' \
+  -Dsouther.conformance.corpus=catalog
+
+# Take up what a deliberate change did to the answers, then read the diff and commit it.
+mvn -pl souther-compiler test -Dtest='souther.compiler.conformance.*Test' \
+  -Dsouther.conformance.update=true
+```
+
+The last one rewrites the expected documents and then fails: a run that rewrote what it was going to be measured against has not measured anything.
+
 To integrate Souther into an application's Maven build, configure `SoutherProcessor` as an annotation processor. The [examples repository](https://github.com/souther-lang/examples) contains that configuration and examples using the generated types from Java, Kotlin, and Clojure boundaries (Spring Boot, jOOQ, Pedestal).
 
 Embedding the compiler goes through `souther.compiler.Compiler`, the one class name a caller outside this repository is meant to write down. It compiles a source string containing either one module or several linked modules:

--- a/souther-bench/src/main/java/souther/bench/Corpus.java
+++ b/souther-bench/src/main/java/souther/bench/Corpus.java
@@ -28,6 +28,13 @@ import java.util.Map;
  * <p>Every corpus must compile without an error. A language change that leaves one behind is caught
  * by {@link #check()} before any timing is reported — a compile that stops early is faster and would
  * read as an improvement.
+ *
+ * <p>Compiling is all that is asked of these. What the compiler <em>answers</em> about a model of
+ * this size is held by the conformance corpus in {@code souther-compiler}, against documents written
+ * down beside it. These two were one thing once, and asking both of one corpus pulls it two ways: a
+ * corpus a number is compared against must not move, and a corpus an answer is checked against grows
+ * whenever a rule is tightened. So what is here is chosen for its size and shape, and it is not
+ * where a change of answer is found.
  */
 public record Corpus(String name, List<String> sources, int lines) {
 

--- a/souther-bench/src/main/java/souther/bench/Scale.java
+++ b/souther-bench/src/main/java/souther/bench/Scale.java
@@ -21,15 +21,23 @@ import java.util.List;
  *
  * <p>Neither says anything about how much a module imports, because a module in either imports one
  * thing or none. A walk that re-reads a module's imports once per import is quadratic in that number
- * and flat at one, so {@link #narrow} and {@link #wide} vary it and nothing else: same modules, same
- * declarations, a type that holds nothing across a boundary, and one import against {@link #LINKS}.
- * {@link Values} asks this of a module's values and has had the fan-out shape from the start.
+ * and flat at one, so {@link #imports} varies that number itself — {@link #WIDTHS}, at one size — and
+ * holds everything else still. {@link Values} asks this of a module's values and has had the fan-out
+ * shape from the start.
  *
- * <p>Widening the chain instead does not answer it. Each of its types contains the one before it, so
- * a module importing four would contain four, and each of those four — the type grows as a tree
- * rather than the imports as a list. Measured at fourteen modules that shape already cost four times
- * a chain of the same length and was doubling every two, which is a number about the type and not
- * about the imports.
+ * <p>Held still means every module of every width declaring the same data, the same behavior and the
+ * same body, down to the text. An import with no name list is what makes that possible: the module is
+ * resolved and read, and nothing in the body has to mention it, so what separates two widths is the
+ * imports and not the expressions written to justify them. The figure to read is the cost per import
+ * — per module, a wider module doing more is what widening means, and the question is whether each
+ * import costs the same as the last.
+ *
+ * <p>Two shapes this is not. Widening the chain does not answer it: each of its types contains the
+ * one before it, so a module importing four contains four and each of those four, and what grows is
+ * the type as a tree — measured, that cost four times a chain of the same length at fourteen modules
+ * and was doubling every two. Nor does importing a name and using it: the use is a construction, a
+ * call, a field read and an addition, so four imports carry four of each and the difference between
+ * two widths is mostly the bodies.
  */
 final class Scale {
 
@@ -37,16 +45,26 @@ final class Scale {
 
     private static final int[] SIZES = {10, 25, 50, 100, 200};
 
-    /** How many modules a wide link imports. Enough that a term in the square of it is visible
-     *  against the linear one, and small enough to be an arrangement someone writes. */
-    static final int LINKS = 4;
+    /** Imports per module, doubling, so the ratio between two lines names the exponent the way the
+     *  doubling sizes do. */
+    static final int[] WIDTHS = {1, 2, 4, 8};
+
+    /** The size the widths are measured at: the largest, where the fixed cost of a compile is
+     *  smallest against the rest and a difference between widths is least buried in it. */
+    private static final int WIDTH_MODULES = 200;
 
     static void measure(Report report) {
         for (int modules : SIZES) {
             line(report, modules, "independent", independent(modules));
             line(report, modules, "chain", chain(modules));
-            line(report, modules, "narrow (1 import)", narrow(modules));
-            line(report, modules, "wide (%d imports)".formatted(LINKS), wide(modules));
+        }
+        for (int width : WIDTHS) {
+            Timing timing = timeOf(imports(WIDTH_MODULES, width));
+            report.line("SCALE n=%-4d imports=%-2d      %7.1f ms (%5.3f ms/module, "
+                            + "%6.4f ms/import)",
+                    WIDTH_MODULES, width, timing.medianMillis(),
+                    timing.medianMillis() / WIDTH_MODULES,
+                    timing.medianMillis() / ((double) WIDTH_MODULES * width));
         }
     }
 
@@ -67,59 +85,30 @@ final class Scale {
     }
 
     /**
-     * A chain whose modules import one another and hold nothing of one another.
+     * {@code modules} modules, each importing the {@code width} written just before it.
      *
-     * <p>This exists to be read against {@link #wide}, and the two differ in one thing. It cannot be
-     * read against {@link #chain}, whose data nests: there each module's type contains the one
-     * before it, so widening those links would multiply the type as well as the imports and the
-     * difference between the two lines would be neither.
-     */
-    static List<String> narrow(int modules) {
-        return flat("p", modules, 1);
-    }
-
-    /**
-     * The same, with each module importing the {@link #LINKS} before it.
+     * <p>Every module is the same module. It declares the same data under a different number, the
+     * same behavior over it and the same body, and the import lines are the only text that differs
+     * between one width and another — so are the only thing a difference between two of these can be
+     * about.
      *
-     * <p>Read against {@link #narrow} at the same size, what is between the two lines is what the
-     * imports cost, because that is all there is between the two workspaces: the same modules, the
-     * same declarations, the same flat type, and every body doing the same thing to each module it
-     * names.
+     * <p>The first {@code width} modules import fewer, there being fewer written before them. At the
+     * sizes this is measured at that is a fixed handful against the rest and it is the same handful
+     * at every width.
      */
-    static List<String> wide(int modules) {
-        return flat("q", modules, LINKS);
-    }
-
-    /**
-     * {@code modules} modules, each importing up to {@code links} of those before it and calling
-     * every one of them.
-     *
-     * <p>Nothing is held across a module boundary. A module's data is one {@code Int} whatever it
-     * imports, so what a compile walks grows with the number of modules and not with what they name
-     * — which is what lets the number of imports be varied on its own.
-     */
-    private static List<String> flat(String prefix, int modules, int links) {
+    static List<String> imports(int modules, int width) {
         List<String> sources = new ArrayList<>();
-        sources.add("""
-                module %s0 exposing ( D0, f0 )
-                data D0 = { v: Int }
-                behavior f0 : (d: D0) -> D0
-                let f0 (d) = D0 { v = d.v + 1 }
-                """.formatted(prefix));
-        for (int i = 1; i < modules; i++) {
-            StringBuilder imports = new StringBuilder();
-            StringBuilder sum = new StringBuilder();
-            for (int j = Math.max(0, i - links); j < i; j++) {
-                imports.append("import %s%d ( D%d, f%d )%n".formatted(prefix, j, j, j));
-                sum.append(sum.isEmpty() ? "" : " + ")
-                        .append("f%d(D%d { v = d.v }).v".formatted(j, j));
+        for (int i = 0; i < modules; i++) {
+            StringBuilder imported = new StringBuilder();
+            for (int j = Math.max(0, i - width); j < i; j++) {
+                imported.append("import i%d%n".formatted(j));
             }
             sources.add("""
-                    module %s%d exposing ( D%d, f%d )
+                    module i%d exposing ( D%d, f%d )
                     %sdata D%d = { v: Int }
                     behavior f%d : (d: D%d) -> D%d
-                    let f%d (d) = D%d { v = %s }
-                    """.formatted(prefix, i, i, i, imports, i, i, i, i, i, i, sum));
+                    let f%d (d) = D%d { v = d.v + 1 }
+                    """.formatted(i, i, i, imported, i, i, i, i, i, i));
         }
         return sources;
     }

--- a/souther-bench/src/main/java/souther/bench/Scale.java
+++ b/souther-bench/src/main/java/souther/bench/Scale.java
@@ -46,8 +46,9 @@ final class Scale {
     private static final int[] SIZES = {10, 25, 50, 100, 200};
 
     /** Imports per module, doubling, so the ratio between two lines names the exponent the way the
-     *  doubling sizes do. */
-    static final int[] WIDTHS = {1, 2, 4, 8};
+     *  doubling sizes do. Zero is among them and is the floor the rest are read against: what an
+     *  import costs is what a line has above that one. */
+    static final int[] WIDTHS = {0, 1, 2, 4, 8};
 
     /** The size the widths are measured at: the largest, where the fixed cost of a compile is
      *  smallest against the rest and a difference between widths is least buried in it. */
@@ -60,11 +61,8 @@ final class Scale {
         }
         for (int width : WIDTHS) {
             Timing timing = timeOf(imports(WIDTH_MODULES, width));
-            report.line("SCALE n=%-4d imports=%-2d      %7.1f ms (%5.3f ms/module, "
-                            + "%6.4f ms/import)",
-                    WIDTH_MODULES, width, timing.medianMillis(),
-                    timing.medianMillis() / WIDTH_MODULES,
-                    timing.medianMillis() / ((double) WIDTH_MODULES * width));
+            report.line("SCALE n=%-4d imports=%-2d  %5d links  %7.1f ms",
+                    WIDTH_MODULES, width, links(WIDTH_MODULES, width), timing.medianMillis());
         }
     }
 
@@ -96,6 +94,18 @@ final class Scale {
      * sizes this is measured at that is a fixed handful against the rest and it is the same handful
      * at every width.
      */
+    /**
+     * How many imports {@link #imports} writes, which is not {@code modules * width}: the first
+     * {@code width} modules import what is written before them and there is less of it.
+     */
+    static int links(int modules, int width) {
+        int total = 0;
+        for (int i = 0; i < modules; i++) {
+            total += Math.min(i, width);
+        }
+        return total;
+    }
+
     static List<String> imports(int modules, int width) {
         List<String> sources = new ArrayList<>();
         for (int i = 0; i < modules; i++) {

--- a/souther-bench/src/main/java/souther/bench/Scale.java
+++ b/souther-bench/src/main/java/souther/bench/Scale.java
@@ -15,10 +15,21 @@ import java.util.List;
  * are. Each is the smallest thing that still goes all the way through: a data type, a behavior over
  * it, and a body that constructs one.
  *
- * <p>Two shapes, because they stress different things. Independent modules share nothing, so the
- * cost should be the sum of theirs. A chain has each module importing the one before it, so a name
- * resolved at the end is resolved through every link — the arrangement where a per-module
- * re-derivation shows up as a curve.
+ * <p>Independent modules share nothing, so the cost should be the sum of theirs. A chain has each
+ * module importing the one before it and holding its type, so a name resolved at the end is resolved
+ * through every link — the arrangement where a per-module re-derivation shows up as a curve.
+ *
+ * <p>Neither says anything about how much a module imports, because a module in either imports one
+ * thing or none. A walk that re-reads a module's imports once per import is quadratic in that number
+ * and flat at one, so {@link #narrow} and {@link #wide} vary it and nothing else: same modules, same
+ * declarations, a type that holds nothing across a boundary, and one import against {@link #LINKS}.
+ * {@link Values} asks this of a module's values and has had the fan-out shape from the start.
+ *
+ * <p>Widening the chain instead does not answer it. Each of its types contains the one before it, so
+ * a module importing four would contain four, and each of those four — the type grows as a tree
+ * rather than the imports as a list. Measured at fourteen modules that shape already cost four times
+ * a chain of the same length and was doubling every two, which is a number about the type and not
+ * about the imports.
  */
 final class Scale {
 
@@ -26,15 +37,25 @@ final class Scale {
 
     private static final int[] SIZES = {10, 25, 50, 100, 200};
 
+    /** How many modules a wide link imports. Enough that a term in the square of it is visible
+     *  against the linear one, and small enough to be an arrangement someone writes. */
+    static final int LINKS = 4;
+
     static void measure(Report report) {
         for (int modules : SIZES) {
-            Timing independent = timeOf(independent(modules));
-            Timing chain = timeOf(chain(modules));
-            report.line("SCALE n=%-4d  independent %7.1f ms (%5.3f ms/module)   "
-                            + "chain %7.1f ms (%5.3f ms/module)",
-                    modules, independent.medianMillis(), independent.medianMillis() / modules,
-                    chain.medianMillis(), chain.medianMillis() / modules);
+            line(report, modules, "independent", independent(modules));
+            line(report, modules, "chain", chain(modules));
+            line(report, modules, "narrow (1 import)", narrow(modules));
+            line(report, modules, "wide (%d imports)".formatted(LINKS), wide(modules));
         }
+    }
+
+    /** One line per shape, as {@link Values} reports: the per-module figure is the one to read, and
+     *  four numbers of two shapes on one line left no room for a third. */
+    private static void line(Report report, int modules, String shape, List<String> sources) {
+        Timing timing = timeOf(sources);
+        report.line("SCALE n=%-4d %-18s %7.1f ms (%5.3f ms/module)",
+                modules, shape, timing.medianMillis(), timing.medianMillis() / modules);
     }
 
     private static Timing timeOf(List<String> sources) {
@@ -45,7 +66,65 @@ final class Scale {
         });
     }
 
-    private static List<String> independent(int modules) {
+    /**
+     * A chain whose modules import one another and hold nothing of one another.
+     *
+     * <p>This exists to be read against {@link #wide}, and the two differ in one thing. It cannot be
+     * read against {@link #chain}, whose data nests: there each module's type contains the one
+     * before it, so widening those links would multiply the type as well as the imports and the
+     * difference between the two lines would be neither.
+     */
+    static List<String> narrow(int modules) {
+        return flat("p", modules, 1);
+    }
+
+    /**
+     * The same, with each module importing the {@link #LINKS} before it.
+     *
+     * <p>Read against {@link #narrow} at the same size, what is between the two lines is what the
+     * imports cost, because that is all there is between the two workspaces: the same modules, the
+     * same declarations, the same flat type, and every body doing the same thing to each module it
+     * names.
+     */
+    static List<String> wide(int modules) {
+        return flat("q", modules, LINKS);
+    }
+
+    /**
+     * {@code modules} modules, each importing up to {@code links} of those before it and calling
+     * every one of them.
+     *
+     * <p>Nothing is held across a module boundary. A module's data is one {@code Int} whatever it
+     * imports, so what a compile walks grows with the number of modules and not with what they name
+     * — which is what lets the number of imports be varied on its own.
+     */
+    private static List<String> flat(String prefix, int modules, int links) {
+        List<String> sources = new ArrayList<>();
+        sources.add("""
+                module %s0 exposing ( D0, f0 )
+                data D0 = { v: Int }
+                behavior f0 : (d: D0) -> D0
+                let f0 (d) = D0 { v = d.v + 1 }
+                """.formatted(prefix));
+        for (int i = 1; i < modules; i++) {
+            StringBuilder imports = new StringBuilder();
+            StringBuilder sum = new StringBuilder();
+            for (int j = Math.max(0, i - links); j < i; j++) {
+                imports.append("import %s%d ( D%d, f%d )%n".formatted(prefix, j, j, j));
+                sum.append(sum.isEmpty() ? "" : " + ")
+                        .append("f%d(D%d { v = d.v }).v".formatted(j, j));
+            }
+            sources.add("""
+                    module %s%d exposing ( D%d, f%d )
+                    %sdata D%d = { v: Int }
+                    behavior f%d : (d: D%d) -> D%d
+                    let f%d (d) = D%d { v = %s }
+                    """.formatted(prefix, i, i, i, imports, i, i, i, i, i, i, sum));
+        }
+        return sources;
+    }
+
+    static List<String> independent(int modules) {
         List<String> sources = new ArrayList<>();
         for (int i = 0; i < modules; i++) {
             sources.add("""
@@ -58,7 +137,7 @@ final class Scale {
         return sources;
     }
 
-    private static List<String> chain(int modules) {
+    static List<String> chain(int modules) {
         List<String> sources = new ArrayList<>();
         sources.add("""
                 module c0 exposing ( D0, f0 )

--- a/souther-bench/src/main/java/souther/bench/Scale.java
+++ b/souther-bench/src/main/java/souther/bench/Scale.java
@@ -83,20 +83,13 @@ final class Scale {
     }
 
     /**
-     * {@code modules} modules, each importing the {@code width} written just before it.
-     *
-     * <p>Every module is the same module. It declares the same data under a different number, the
-     * same behavior over it and the same body, and the import lines are the only text that differs
-     * between one width and another — so are the only thing a difference between two of these can be
-     * about.
-     *
-     * <p>The first {@code width} modules import fewer, there being fewer written before them. At the
-     * sizes this is measured at that is a fixed handful against the rest and it is the same handful
-     * at every width.
-     */
-    /**
      * How many imports {@link #imports} writes, which is not {@code modules * width}: the first
      * {@code width} modules import what is written before them and there is less of it.
+     *
+     * <p>What is short of the product is {@code width * (width + 1) / 2} — 1, 3, 10 and 36 at the
+     * widths measured — so it grows with the width rather than being the same allowance at each,
+     * and a run that reported the product would overstate the wide lines by more than the narrow
+     * ones. Counted here, and held against the imports the shape writes by a test.
      */
     static int links(int modules, int width) {
         int total = 0;
@@ -106,6 +99,17 @@ final class Scale {
         return total;
     }
 
+    /**
+     * {@code modules} modules, each importing the {@code width} written just before it.
+     *
+     * <p>Every module is the same module. It declares the same data under a different number, the
+     * same behavior over it and the same body, and the import lines are the only text that differs
+     * between one width and another — so are the only thing a difference between two of these can be
+     * about.
+     *
+     * <p>The first {@code width} modules import fewer, there being fewer written before them. How
+     * many fewer is {@link #links}'s to say, and what a run reports is that count.
+     */
     static List<String> imports(int modules, int width) {
         List<String> sources = new ArrayList<>();
         for (int i = 0; i < modules; i++) {

--- a/souther-bench/src/main/java/souther/bench/Values.java
+++ b/souther-bench/src/main/java/souther/bench/Values.java
@@ -63,7 +63,7 @@ final class Values {
 
     /** {@code n} values, each naming the one before it — {@code bottomUp} writing the one that
      * names before the one it names. */
-    private static String chain(int n, boolean bottomUp) {
+    static String chain(int n, boolean bottomUp) {
         List<String> declarations = new ArrayList<>();
         declarations.add("let v0 = 1");
         for (int i = 1; i < n; i++) {
@@ -74,7 +74,7 @@ final class Values {
 
     /** The same reaching with none of the names: each value calls a helper, and the helper is what
      * names the value before it. */
-    private static String throughHelpers(int n, boolean bottomUp) {
+    static String throughHelpers(int n, boolean bottomUp) {
         List<String> declarations = new ArrayList<>();
         declarations.add("let v0 = 1");
         for (int i = 1; i < n; i++) {
@@ -86,7 +86,7 @@ final class Values {
 
     /** One value reaching every other, written as a list so that reaching many is not also nesting
      * deeply. */
-    private static String fanOut(int n) {
+    static String fanOut(int n) {
         List<String> declarations = new ArrayList<>();
         StringBuilder hub = new StringBuilder("let hub = [ ");
         for (int i = 0; i < n; i++) {
@@ -98,7 +98,7 @@ final class Values {
     }
 
     /** {@code n} values reaching none of them. */
-    private static String flat(int n) {
+    static String flat(int n) {
         List<String> declarations = new ArrayList<>();
         for (int i = 0; i < n; i++) {
             declarations.add("let v" + i + " = " + i + " + 1");

--- a/souther-bench/src/test/java/souther/bench/CorpusTest.java
+++ b/souther-bench/src/test/java/souther/bench/CorpusTest.java
@@ -11,6 +11,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * says nothing reliable about how long anything takes — but what they are measured against has to
  * keep working, and a language change that leaves a corpus behind would otherwise be found the next
  * time someone took a measurement and read a faster number as an improvement.
+ *
+ * <p>Compiling is the whole claim. Whether the compiler still answers what it did about a model this
+ * size is the conformance corpus's, in {@code souther-compiler}, and looking for it here would find
+ * nothing: these sources are timed, not read back, and every measure a report carries could move
+ * without one of them failing to compile.
  */
 class CorpusTest {
 

--- a/souther-bench/src/test/java/souther/bench/EveryShapeThatIsTimedStillCompilesTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryShapeThatIsTimedStillCompilesTest.java
@@ -68,6 +68,9 @@ class EveryShapeThatIsTimedStillCompilesTest {
     void aWidthIsItsImportsAndNothingElse() {
         String previous = null;
         for (int width : Scale.WIDTHS) {
+            if (width == 0) {
+                continue;
+            }
             String last = Scale.imports(MODULES, width).getLast();
             long imports = last.lines().filter(line -> line.startsWith("import ")).count();
             if (imports != width) {
@@ -82,6 +85,29 @@ class EveryShapeThatIsTimedStillCompilesTest {
                         + "\n--- against ---\n" + body);
             }
             previous = body;
+        }
+    }
+
+    /**
+     * That the number of imports reported beside a time is the number there are.
+     *
+     * <p>Counted rather than multiplied out, and this says why it has to be: the first modules
+     * import what is written before them and there is less of it, so {@code modules * width} is over
+     * by a widening amount. A run reporting that number would say a workspace held more links than
+     * it does, and anyone reading a cost out of a time and a count would read it against the wrong
+     * one.
+     */
+    @Test
+    void theLinksReportedAreTheLinksThereAre() {
+        for (int width : Scale.WIDTHS) {
+            long written = Scale.imports(MODULES, width).stream()
+                    .flatMap(String::lines)
+                    .filter(line -> line.startsWith("import "))
+                    .count();
+            if (written != Scale.links(MODULES, width)) {
+                throw new AssertionError("at width " + width + " the shape writes " + written
+                        + " import(s) and reports " + Scale.links(MODULES, width));
+            }
         }
     }
 

--- a/souther-bench/src/test/java/souther/bench/EveryShapeThatIsTimedStillCompilesTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryShapeThatIsTimedStillCompilesTest.java
@@ -63,14 +63,15 @@ class EveryShapeThatIsTimedStillCompilesTest {
      * lines would be about both and attributable to neither — which is what the first attempt at
      * this did, importing a name and using it in a construction, a call, a field read and an
      * addition.
+     *
+     * <p>The floor is among the widths asked, and is the one it matters most to ask of: every other
+     * line is read as what it has above that one, so a body that differed only there would move
+     * every reading and nothing would say it had.
      */
     @Test
     void aWidthIsItsImportsAndNothingElse() {
         String previous = null;
         for (int width : Scale.WIDTHS) {
-            if (width == 0) {
-                continue;
-            }
             String last = Scale.imports(MODULES, width).getLast();
             long imports = last.lines().filter(line -> line.startsWith("import ")).count();
             if (imports != width) {

--- a/souther-bench/src/test/java/souther/bench/EveryShapeThatIsTimedStillCompilesTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryShapeThatIsTimedStillCompilesTest.java
@@ -27,9 +27,9 @@ import java.util.List;
  */
 class EveryShapeThatIsTimedStillCompilesTest {
 
-    /** Enough of each shape to be that shape: a chain of four has a middle, and a wide link at four
-     *  imports {@link Scale#LINKS} modules rather than however many there are. */
-    private static final int MODULES = Scale.LINKS + 2;
+    /** Enough of each shape to be that shape: a chain has a middle, and the widest module imports
+     *  its full width rather than however many happen to be written before it. */
+    private static final int MODULES = 2 * Scale.WIDTHS[Scale.WIDTHS.length - 1];
 
     /** Enough values that a fan-out fans and a chain has links that are not its ends. */
     private static final int VALUES = 8;
@@ -38,8 +38,9 @@ class EveryShapeThatIsTimedStillCompilesTest {
     void everyWorkspaceShapeCompiles() {
         compiles("independent", Scale.independent(MODULES));
         compiles("chain", Scale.chain(MODULES));
-        compiles("narrow", Scale.narrow(MODULES));
-        compiles("wide", Scale.wide(MODULES));
+        for (int width : Scale.WIDTHS) {
+            compiles("imports=" + width, Scale.imports(MODULES, width));
+        }
     }
 
     @Test
@@ -53,20 +54,34 @@ class EveryShapeThatIsTimedStillCompilesTest {
     }
 
     /**
-     * That the wide link is wide.
+     * That each width is that width, and that widths are all that separate them.
      *
-     * <p>The shape is written by a loop over what a module imports, and a loop that produced one
-     * import would still compile, still be timed, and still be reported under a name saying it was
-     * several. What the measurement is for is the difference between this and {@code narrow}, and
-     * there is no difference to measure if the two are the same arrangement.
+     * <p>Both halves, because either alone passes on a shape that measures nothing. A loop that
+     * produced one import at every width would still compile, still be timed, and still be reported
+     * under a number saying it was eight. And a shape whose bodies grew with its imports would
+     * differ by width in what it declares as well as in what it imports, so a difference between two
+     * lines would be about both and attributable to neither — which is what the first attempt at
+     * this did, importing a name and using it in a construction, a call, a field read and an
+     * addition.
      */
     @Test
-    void aWideLinkImportsSeveralModules() {
-        String last = Scale.wide(MODULES).getLast();
-        long imports = last.lines().filter(line -> line.startsWith("import ")).count();
-        if (imports != Scale.LINKS) {
-            throw new AssertionError("a wide link imports " + imports + " module(s), not "
-                    + Scale.LINKS + ":\n" + last);
+    void aWidthIsItsImportsAndNothingElse() {
+        String previous = null;
+        for (int width : Scale.WIDTHS) {
+            String last = Scale.imports(MODULES, width).getLast();
+            long imports = last.lines().filter(line -> line.startsWith("import ")).count();
+            if (imports != width) {
+                throw new AssertionError("a module at width " + width + " imports " + imports
+                        + " module(s):\n" + last);
+            }
+            String body = last.lines().filter(line -> !line.startsWith("import "))
+                    .collect(java.util.stream.Collectors.joining("\n"));
+            if (previous != null && !previous.equals(body)) {
+                throw new AssertionError("what a module declares changes with its width, so a"
+                        + " difference between two widths is not about the imports:\n" + previous
+                        + "\n--- against ---\n" + body);
+            }
+            previous = body;
         }
     }
 

--- a/souther-bench/src/test/java/souther/bench/EveryShapeThatIsTimedStillCompilesTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryShapeThatIsTimedStillCompilesTest.java
@@ -1,0 +1,93 @@
+package souther.bench;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Located;
+import souther.compiler.diag.Severity;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Compilation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * That the shapes these measurements are taken against still compile.
+ *
+ * <p>{@link CorpusTest} makes this claim about the sources carried in this module. The generated
+ * ones had nobody making it, and they are the arrangement most of the reasoning here rests on: a
+ * language change that leaves one of them behind leaves a measurement being taken of a compile that
+ * stops early, which is faster than one that finishes and reads as an improvement. Nothing about a
+ * timing says which of the two it timed.
+ *
+ * <p>At small sizes. What is asked here is whether the shape is admissible, and a shape that is
+ * admissible at ten modules is admissible at two hundred — the sizes are what the measurement varies
+ * and are no part of this. Held small on purpose: a test that took as long as the benchmark would be
+ * a benchmark, and would stop being run.
+ */
+class EveryShapeThatIsTimedStillCompilesTest {
+
+    /** Enough of each shape to be that shape: a chain of four has a middle, and a wide link at four
+     *  imports {@link Scale#LINKS} modules rather than however many there are. */
+    private static final int MODULES = Scale.LINKS + 2;
+
+    /** Enough values that a fan-out fans and a chain has links that are not its ends. */
+    private static final int VALUES = 8;
+
+    @Test
+    void everyWorkspaceShapeCompiles() {
+        compiles("independent", Scale.independent(MODULES));
+        compiles("chain", Scale.chain(MODULES));
+        compiles("narrow", Scale.narrow(MODULES));
+        compiles("wide", Scale.wide(MODULES));
+    }
+
+    @Test
+    void everyModuleShapeCompiles() {
+        compiles("chain", List.of(Values.chain(VALUES, false)));
+        compiles("chain bottom-up", List.of(Values.chain(VALUES, true)));
+        compiles("chain via helpers", List.of(Values.throughHelpers(VALUES, false)));
+        compiles("same, bottom-up", List.of(Values.throughHelpers(VALUES, true)));
+        compiles("fan-out", List.of(Values.fanOut(VALUES)));
+        compiles("flat", List.of(Values.flat(VALUES)));
+    }
+
+    /**
+     * That the wide link is wide.
+     *
+     * <p>The shape is written by a loop over what a module imports, and a loop that produced one
+     * import would still compile, still be timed, and still be reported under a name saying it was
+     * several. What the measurement is for is the difference between this and {@code narrow}, and
+     * there is no difference to measure if the two are the same arrangement.
+     */
+    @Test
+    void aWideLinkImportsSeveralModules() {
+        String last = Scale.wide(MODULES).getLast();
+        long imports = last.lines().filter(line -> line.startsWith("import ")).count();
+        if (imports != Scale.LINKS) {
+            throw new AssertionError("a wide link imports " + imports + " module(s), not "
+                    + Scale.LINKS + ":\n" + last);
+        }
+    }
+
+    private static void compiles(String shape, List<String> sources) {
+        Compilation compilation = Compilation.ofSources(sources, ModulePath.EMPTY);
+        List<String> errors = new ArrayList<>();
+        for (List<Diagnostic> found : Located.diagnosticsOf(compilation.diagnostics()).values()) {
+            for (Diagnostic diagnostic : found) {
+                if (diagnostic.severity() == Severity.ERROR) {
+                    errors.add(diagnostic.code() + " at " + diagnostic.primary());
+                }
+            }
+        }
+        if (!errors.isEmpty()) {
+            throw new AssertionError("the `" + shape + "` shape no longer compiles:\n  "
+                    + String.join("\n  ", errors));
+        }
+        // Asked after the errors, and asked at all: a shape that compiles to nothing is one the
+        // measurement walks past, and the timing would be of a compile that reached no back end.
+        if (compilation.classes().isEmpty()) {
+            throw new AssertionError("the `" + shape + "` shape generated no classes");
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/conformance/TheAnswersAboutEachConformanceCorpusAreTheOnesCheckedInTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/conformance/TheAnswersAboutEachConformanceCorpusAreTheOnesCheckedInTest.java
@@ -35,11 +35,35 @@ class TheAnswersAboutEachConformanceCorpusAreTheOnesCheckedInTest {
      */
     private static final String UPDATE = "souther.conformance.update";
 
+    /**
+     * One corpus instead of all of them, for someone going round this loop.
+     *
+     * <p>Only here. What the corpus reaches of the language is a claim about the corpus as a whole —
+     * a form written in one of them is written, whichever it is in — and narrowing that claim to a
+     * part would report the rest of the language as unreached. So the sibling test does not read
+     * this, and a narrowed run is still held to everything that test holds.
+     *
+     * <p>A name matching no corpus raises rather than narrowing to nothing. Every document passing
+     * is what this answers with, and a run that checked none of them would answer the same way.
+     */
+    private static final String ONLY = "souther.conformance.corpus";
+
     private record Document(String name, String file, String actual) {}
 
     private static List<Document> documents() {
+        String only = System.getProperty(ONLY);
+        List<ConformanceCorpus> corpora = ConformanceCorpus.all();
+        if (only != null && !only.isBlank()) {
+            List<ConformanceCorpus> named = corpora.stream()
+                    .filter(c -> c.name().equals(only.strip())).toList();
+            if (named.isEmpty()) {
+                throw new AssertionError("-D" + ONLY + "=" + only + " names no corpus. There is "
+                        + corpora.stream().map(ConformanceCorpus::name).toList());
+            }
+            corpora = named;
+        }
         List<Document> out = new ArrayList<>();
-        for (ConformanceCorpus corpus : ConformanceCorpus.all()) {
+        for (ConformanceCorpus corpus : corpora) {
             ConformanceCorpus.Analysed analysed = corpus.analyse();
             out.add(new Document(corpus.name(), corpus.name() + "/expected.report.json",
                     ConformanceSnapshot.report(analysed)));
@@ -57,7 +81,8 @@ class TheAnswersAboutEachConformanceCorpusAreTheOnesCheckedInTest {
                 write(ConformanceCorpus.SOURCE_DIR.resolve(document.file()), document.actual());
             }
             throw new AssertionError("rewrote " + documents.size() + " expected document(s) under "
-                    + ConformanceCorpus.SOURCE_DIR + ". Read the diff: it is what this change did to"
+                    + ConformanceCorpus.SOURCE_DIR + " (" + documents.stream().map(Document::name)
+                            .distinct().toList() + "). Read the diff: it is what this change did to"
                     + " the compiler's answers. Then run again without -D" + UPDATE + ".");
         }
         List<String> differences = new ArrayList<>();


### PR DESCRIPTION
The rest of #799: the three things the corpus landed without. After this, what remains under that
issue is the two follow-ups it names as follow-ups — the benchmark corpus written to shapes, and
`souther-examples` moving from a merge gate to a release one.

## The command is written down

In the README, beside the one for `souther-bench`, which is where every other command in this
repository lives.

    mvn -pl souther-compiler test -Dtest='souther.compiler.conformance.*Test'

The issue said `CLAUDE.md`. There is none in this repository, and adding one to hold a second copy
of a command would be the opposite of what that line was for.

The selector is the package rather than `*Conformance*`: the latter misses
`ADifferenceIsAboutThePartThatMovedTest`, which is in the conformance package and has no
"Conformance" in its name, and picks up `StructuralCostConformanceTest`, which is not. Measured: the
package selector runs 14 and nothing else.

## One corpus while iterating

    -Dsouther.conformance.corpus=catalog

Read only by the comparison. What the corpus reaches of the language is a claim about the corpus as
a whole — a form written in one of them is written, whichever it is in — so narrowing it to a part
would report the rest of the language as unreached. The sibling test goes on holding everything,
narrowed or not. A name matching no corpus raises rather than narrowing to nothing.

## `souther-bench`'s corpus says what it is not

Its comments read as though compiling there were the check on what the compiler answers. It never
was, and the conformance corpus makes that worse to leave standing. Both now say which question they
answer, and why they are not one corpus: a corpus a number is compared against must not move, and a
corpus an answer is checked against grows whenever a rule is tightened.

## Checked

    mvn verify                                                          71s, green
    mvn -pl souther-compiler test -Dtest='souther.compiler.conformance.*Test'   14 tests
    ... the same, 10s after touching one compiler source
    -Dsouther.conformance.corpus=catalog                                green
    -Dsouther.conformance.corpus=nope   -> "names no corpus. There is [catalog]"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## The benchmark shapes

The rest of what #799 called the benchmark corpus. What that issue asked for — the bench corpus
written to shapes rather than domains — is mostly there already and was before this: `Values`
generates chain, chain-through-helpers, either written bottom-up, fan-out and flat, per value at
doubling sizes, which is the whole of what souther#523's lesson asked for. `Scale` generates
independent and chain workspaces. Neither reads the carried sources.

Two gaps, and one non-change.

`Scale`'s two arrangements both hold the number of imports at one — independent modules import
nothing, a chain imports one. A walk that re-reads a module's imports once per import is quadratic in
that number and flat at one, so neither could bend. `imports(modules, width)` varies that number on
its own: widths 1, 2, 4, 8 at 200 modules, every module of every width declaring the same data, the
same behavior and the same body down to the text, with the import lines the only thing that differs.
An import with no name list is what allows that — the module is resolved and read, and nothing in the
body has to mention it.

What is reported is the time and the number of links there are, and no figure derived from the two.
A cost per import taken as the whole time over the imports divides the floor across them too, and
falls as the width rises however much an import costs — a shape that grew quadratically would go on
reporting a falling number and read as an improvement. So the widths start at zero and that line is
the floor. The count is counted rather than multiplied out: the first modules import what is written
before them, so eight imports over two hundred modules is 1564 links and not 1600, and a test holds
the reported number against the imports the shape writes.

Measured at two hundred modules: the floor is 104 ms, and widths 1, 2, 4, 8 come to 113, 108, 116 and
114. Links go 199 → 1564 while what stands above the floor stays between 4 and 11 ms without becoming
monotone — noise, on a compile of that length. An import is not measurably costed at these widths.

Two shapes this is not, both tried first. Widening the existing chain does not ask it: each of its
types contains the one before it, so a module importing four contains four and each of those four —
at fourteen modules that cost four times the chain and was doubling every two, and a run at two
hundred did not finish. Nor does importing a name and using it, which is what the first version of
this commit did: the use is a construction, a call, a field read and an addition, so four imports
carry four of each and the difference between two widths is mostly the bodies. The test now holds
both halves — that each width is its width, and that what a module declares does not change with
it.

Nothing checked that any generated shape still compiles. `CorpusTest` makes that claim about the
carried sources; a shape a language change leaves behind is a compile that stops early, which is
faster than one that finishes and reads as an improvement.

The carried `crm` and `issuetracker` sources are **not** rewritten. They answer what a model someone
writes costs, which a generated shape cannot, and a corpus a number is compared against must not
move — rewriting them would invalidate every number ever taken against them for no measured gain.
What changed about them is what the previous commit changed: their comments, which read as though
compiling there were the check on what the compiler answers.


