### PR TITLE
Answer what a report found about a position in one place

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/inputs/BlockReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/BlockReason.java
@@ -22,6 +22,24 @@ package souther.compiler.inputs;
 public sealed interface BlockReason {
 
     /**
+     * What a value reading's account of what it left unread comes to here.
+     *
+     * <p>The one place the two vocabularies meet, so a reader holding a reading's completeness and
+     * one holding a block reason cannot come to different words for one stop. A relation between
+     * two positions is what {@link ComparisonBetweenPositions} already says, whichever rule wrote
+     * it: a {@code guard} comparing two inputs and an {@code invariant} relating two fields leave a
+     * reader the same thing to know. The other two are their own, because what would lift each is
+     * different work — one wants a reader for a form, and one wants the gathering to reach further.
+     */
+    static BlockReason of(souther.compiler.values.UnreadReason why) {
+        return switch (why) {
+            case RELATES_TWO_POSITIONS -> new ComparisonBetweenPositions();
+            case FORM_NOT_READ, ALTERNATIVE_NOT_READ -> new UnreadValueRule();
+            case NOT_REACHED -> new ValueRulesNotReached();
+        };
+    }
+
+    /**
      * The type at the position could not be interpreted: a name denoting no declaration, or a
      * declaration reachable from itself. Such a model compiles, so this is a position a report is
      * asked about and cannot be answered for.

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Crossing.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Crossing.java
@@ -67,11 +67,7 @@ final class Crossing {
      * and one wants the gathering to reach further.
      */
     static BlockReason stopped(souther.compiler.values.UnreadReason why) {
-        return switch (why) {
-            case RELATES_TWO_POSITIONS -> new BlockReason.ComparisonBetweenPositions();
-            case FORM_NOT_READ, ALTERNATIVE_NOT_READ -> new BlockReason.UnreadValueRule();
-            case NOT_REACHED -> new BlockReason.ValueRulesNotReached();
-        };
+        return BlockReason.of(why);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReportedReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReportedReason.java
@@ -34,11 +34,14 @@ public final class ReportedReason {
                     UndividedPosition.Reason.UNSUPPORTED_TRAVERSAL;
             case BlockReason.UnreadComparisonForm _ ->
                     UndividedPosition.Reason.UNSUPPORTED_SYNTAX;
-            // Both of these are a rule this could not read, which is the one thing a reader of a
-            // document is being told. Which reader of the clause gave up, and whether it gave up on
-            // the form or never arrived at the clause, are this compiler's own business.
-            case BlockReason.UnreadValueRule _, BlockReason.ValueRulesNotReached _ ->
-                    UndividedPosition.Reason.UNSUPPORTED_SYNTAX;
+            case BlockReason.UnreadValueRule _ -> UndividedPosition.Reason.UNSUPPORTED_SYNTAX;
+            // Its own word, and not the one above. Both are rules this reading did not turn into a
+            // line, and a reader acting on them is doing different work: one wants a reader for a
+            // form that was seen, and one wants the gathering to reach the rules at all. Collapsed
+            // together, a position whose rules nothing had looked at was reported as an expression
+            // the terms do not name, which is a cause it was never observed to have.
+            case BlockReason.ValueRulesNotReached _ ->
+                    UndividedPosition.Reason.RULES_NOT_READ_AT_ALL;
             case BlockReason.UnreadComparisonDomain _ ->
                     UndividedPosition.Reason.UNSUPPORTED_DOMAIN;
             case BlockReason.ComparisonBetweenPositions _ ->

--- a/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
@@ -77,16 +77,29 @@ public record UndividedPosition(TermPath at, Why why) {
      */
     public enum Reason {
         /**
-         * A rule about this position is one this compiler did not read.
+         * A rule about this position was read and could not be used.
          *
-         * <p>Said of the rule and not of one way of failing to read it. A comparison inside a
+         * <p>Said of the rule and not of one way of failing to use it. A comparison inside a
          * condition this does not take apart is one; a rule naming which values may stand here,
-         * written as something other than a value written out, is another; a rule this never
-         * reached at all is a third. The word is the whole of what a reader is promised — that the
-         * model states something here and this compiler did not read it — and which reader of the
+         * written as something other than a value written out, is another. Which reader of the
          * clause gave up is not part of the promise.
+         *
+         * <p>A rule this never arrived at is {@link #RULES_NOT_READ_AT_ALL} and not this. The two
+         * were one word, and the sentence this one prints — an expression the terms do not name —
+         * was said of positions whose rules nothing had looked at, which is a different thing and
+         * is lifted by different work.
          */
         UNSUPPORTED_SYNTAX,
+        /**
+         * The reading did not reach the rules written about this position.
+         *
+         * <p>Nothing here was read and found wanting: the rules are behind something this walk did
+         * not enter, and what is written under it is whatever it is. Which limit stopped the walk
+         * is not recorded and is not promised — a depth, a type it had been through, a shape it
+         * does not descend into, and a clause that could not be typed all leave the same hole, and
+         * a reader is told the hole and not this compiler's route to it.
+         */
+        RULES_NOT_READ_AT_ALL,
         /** The values the comparison is against are not ones a line can be drawn on here. */
         UNSUPPORTED_DOMAIN,
         /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1868,6 +1868,8 @@ public final class Adequacy {
         private static String said(souther.compiler.partition.UndividedPosition.Reason reason) {
             return switch (reason) {
                 case UNSUPPORTED_SYNTAX -> "a rule about it is one this compiler did not read";
+                case RULES_NOT_READ_AT_ALL ->
+                        "the rules written about it were not reached at all";
                 case UNSUPPORTED_DOMAIN ->
                         "it is compared against values no line can be drawn on here";
                 case UNSUPPORTED_PARTITION_SHAPE ->

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1341,7 +1341,7 @@ public final class Adequacy {
                     // that the switch stays exhaustive over the kinds rather than over the ones
                     // thought of here.
                     case OUTPUT_CASE_UNVERIFIED, AXIS_CLASS_UNCOVERED, PARTITION_NOT_DERIVABLE,
-                            PARTITION_NOT_READ, PARTITION_OMITTED ->
+                            PARTITION_NOT_READ, PARTITION_READ_IN_PART, PARTITION_OMITTED ->
                             throw new IllegalStateException("not a gap a build refuses: " + gap);
                 }));
             }
@@ -1603,6 +1603,16 @@ public final class Adequacy {
         PARTITION_NOT_DERIVABLE(null, false),
         /** A position something is written about that this did not read, with what stopped it. */
         PARTITION_NOT_READ(null, false),
+        /**
+         * A position the axes measure whose rules this reading is short of, with what stopped it.
+         *
+         * <p>Told apart from {@link #PARTITION_NOT_READ} because they are different things to act
+         * on. Nothing was established about a position this could not read; here the classes are
+         * what the model was read to say, and what went unread may yet refuse one of them — so a
+         * reader is told that the numbers beside it rest on a reading that did not run to the end,
+         * rather than that there are none.
+         */
+        PARTITION_READ_IN_PART(null, false),
         /** A position left out because the axis limit was reached. */
         PARTITION_OMITTED(null, false);
 
@@ -1826,28 +1836,26 @@ public final class Adequacy {
                             List.of(position.at().toString())));
                 }
             }
-            // And what this could not read, which is asked of the comparisons. A position with
-            // classes can still carry a statement nothing read, so this is not filtered by the list
-            // above — and the walk stopping short is the one reason that comes from neither.
-            List<List<Object>> unread = new ArrayList<>();
-            for (souther.compiler.inputs.UnreadRule each : partition.unread()) {
-                unread.add(List.<Object>of(each.at().toString(),
-                        said(souther.compiler.partition.ReportedReason.of(each.why()))));
-            }
-            for (souther.compiler.partition.UndividedPosition position : partition.notDerivable()) {
-                if (position.why() instanceof souther.compiler.partition.UndividedPosition.Why
-                        .CannotDerive stopped) {
-                    List<Object> said =
-                            List.<Object>of(position.at().toString(), said(stopped.reason()));
-                    if (!unread.contains(said)) {
-                        unread.add(said);
-                    }
-                }
-            }
-            for (List<Object> each : unread) {
+            // And what this could not read, asked of the one reading that answers it. A position
+            // with classes can still carry a statement nothing read, so this is not filtered by the
+            // list above.
+            for (PartitionEvidence.UnreadPosition each : partition.notRead()) {
                 // Not measured, because nothing here established anything either way about it.
                 out.add(new Finding(Kind.PARTITION_NOT_READ, behavior.name(),
-                        MeasurementStatus.NOT_MEASURED, Citation.of(behavior.pos()), each));
+                        MeasurementStatus.NOT_MEASURED, Citation.of(behavior.pos()),
+                        List.of(each.at(), said(each.reason()))));
+            }
+            // A position the axes did measure, whose rules this reading is short of. A different
+            // thing to act on from one nothing divided: the classes beside it are what the model
+            // was read to say, and what was left unread may yet refuse one of them. What says how
+            // much was read is what the axis carries — asked here rather than worked out a second
+            // time from the lists above, which answer about rules and not about positions.
+            for (PartitionEvidence.AxisCoverage axis : partition.axes()) {
+                if (axis.read() instanceof PartitionEvidence.AxisCoverage.Reading.InPart short_) {
+                    out.add(new Finding(Kind.PARTITION_READ_IN_PART, behavior.name(),
+                            MeasurementStatus.NOT_MEASURED, Citation.of(behavior.pos()),
+                            List.of(axis.path(), said(short_.why()))));
+                }
             }
             for (souther.compiler.partition.Partitions.OmittedAxis dropped : partition.omitted()) {
                 out.add(new Finding(Kind.PARTITION_OMITTED, behavior.name(),

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -251,6 +251,16 @@ final class Coverages {
 
     private static PartitionEvidence.AxisCoverage coverageOf(Axis axis, Readings readings) {
         List<String> classes = axis.classes().stream().map(PartitionClass::id).toList();
+        // What the axis already says about how far the rules were read, in the word a document
+        // promises. Read off the axis rather than worked out here: the reading that made the
+        // classes is the one that knows what it was short of.
+        PartitionEvidence.AxisCoverage.Reading read =
+                axis.read() instanceof souther.compiler.values.AdmissibleSet.Completeness.Partial
+                        partial
+                        ? new PartitionEvidence.AxisCoverage.Reading.InPart(
+                                souther.compiler.partition.ReportedReason.of(
+                                        souther.compiler.inputs.BlockReason.of(partial.why())))
+                        : PartitionEvidence.AxisCoverage.READ_IN_FULL;
         // Nothing a body claims is in scope here. What a row is owed at is counted first and on its
         // own, and what was declared about those positions is put beside it afterwards
         // ({@link ClaimReport}) — which is what keeps a claim from narrowing a denominator by being
@@ -258,7 +268,7 @@ final class Coverages {
         if (readings.noRows() && !readings.someRowsUnseen()) {
             return PartitionEvidence.AxisCoverage.unavailable(axis.id().toString(),
                     axis.term().toString(), classes,
-                    PartitionEvidence.AxisCoverage.Reason.NO_ROWS);
+                    PartitionEvidence.AxisCoverage.Reason.NO_ROWS, read);
         }
         Set<String> covered = new LinkedHashSet<>();
         for (Map<AxisId, Classification> where : readings.byRow()) {
@@ -268,7 +278,8 @@ final class Coverages {
             }
         }
         return new PartitionEvidence.AxisCoverage(axis.id().toString(), axis.term().toString(),
-                classes, covered, readings.couldNotSay(axis), readings.status(List.of(axis)), null);
+                classes, covered, readings.couldNotSay(axis), readings.status(List.of(axis)), null,
+                read);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -68,7 +68,15 @@ public record PartitionEvidence(Partitioned partitioned, Bounded bounded,
                                  souther.compiler.partition.UndividedPosition.Reason reason) {}
 
     /**
-     * Every position this reading could not finish reading the rules about.
+     * Every position this reading carries an unread finding about: a rule it did not turn into a
+     * line, and a position it divided no way and said why.
+     *
+     * <p>Not every position whose rules this reading is short of. How far the reading of a position
+     * ran is what its axis carries ({@link AxisCoverage#read()}), and a position measured on a
+     * reading that did not run to the end need have no entry here — these are findings about rules
+     * and that is an account of a position. Read as the whole of what was left unread, this would
+     * be the very thing it was written to stop: one question answered by a list that answers
+     * another.
      *
      * <p>One reading, and the two surfaces write from it. It used to be assembled twice — a person
      * was shown the rules no line came from together with the positions divided no way, and the

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -56,6 +56,51 @@ public record PartitionEvidence(Partitioned partitioned, Bounded bounded,
         whyUnclassified = List.copyOf(whyUnclassified);
     }
 
+    /**
+     * A position something is written about that this reading did not turn into a line, and what
+     * stopped it.
+     *
+     * <p>The reason in the vocabulary a document promises its reader, not the one this compiler
+     * records for itself: which capability was missing is this compiler's own business, and which
+     * kind of thing stopped the derivation is what a reader can act on.
+     */
+    public record UnreadPosition(String at,
+                                 souther.compiler.partition.UndividedPosition.Reason reason) {}
+
+    /**
+     * Every position this reading could not finish reading the rules about.
+     *
+     * <p>One reading, and the two surfaces write from it. It used to be assembled twice — a person
+     * was shown the rules no line came from together with the positions divided no way, and the
+     * document was written from the second alone — so a rule left unread at a position the axes
+     * went on to measure reached one reader and stopped there. Nothing was wrong with either list;
+     * what was wrong is that one question was answered by reading two of them in one place and one
+     * of them in the other.
+     *
+     * <p>The rules come first and the undivided positions after, deduplicated: a position can be
+     * in both, and it is one thing that was found about it either way.
+     */
+    public List<UnreadPosition> notRead() {
+        List<UnreadPosition> out = new java.util.ArrayList<>();
+        for (souther.compiler.inputs.UnreadRule each : unread) {
+            add(out, new UnreadPosition(each.at().toString(),
+                    souther.compiler.partition.ReportedReason.of(each.why())));
+        }
+        for (souther.compiler.partition.UndividedPosition position : notDerivable) {
+            if (position.why() instanceof souther.compiler.partition.UndividedPosition.Why
+                    .CannotDerive stopped) {
+                add(out, new UnreadPosition(position.at().toString(), stopped.reason()));
+            }
+        }
+        return List.copyOf(out);
+    }
+
+    private static void add(List<UnreadPosition> out, UnreadPosition said) {
+        if (!out.contains(said)) {
+            out.add(said);
+        }
+    }
+
     /** The positions, for a reader that wants them and not what the measure made of itself. */
     public List<AxisCoverage> axes() {
         return partitioned.at();
@@ -231,7 +276,40 @@ public record PartitionEvidence(Partitioned partitioned, Bounded bounded,
      *                         unreached class is undecided rather than unreached.
      */
     public record AxisCoverage(String axis, String path, List<String> classes, Set<String> covered,
-                               int unclassifiedRows, MeasurementStatus status, Reason reason) {
+                               int unclassifiedRows, MeasurementStatus status, Reason reason,
+                               Reading read) {
+
+        /**
+         * How much of what this position's rules say was read.
+         *
+         * <p>It qualifies the classes and nothing else says it. A class arrived at from part of the
+         * rules is a value the model singled out, and a rule that went unread may yet refuse it —
+         * so the classes are the denominator the model states and not one every class of which is
+         * known to be inhabited.
+         *
+         * <p>Said in the vocabulary the document promises, and taken from what the axis already
+         * carries rather than worked out a second time from the lists beside it. Those answer about
+         * rules; this answers about a position.
+         */
+        public sealed interface Reading {
+
+            /** Every rule about the position was read. */
+            record InFull() implements Reading {}
+
+            /** Something about the position was left unread, and what stopped it. */
+            record InPart(souther.compiler.partition.UndividedPosition.Reason why) implements Reading {
+
+                public InPart {
+                    if (why == null) {
+                        throw new IllegalArgumentException(
+                                "a reading short of the rules says what stopped it");
+                    }
+                }
+            }
+        }
+
+        /** Every rule read, which is what a caller holding no account of its own says. */
+        public static final Reading READ_IN_FULL = new Reading.InFull();
 
         /** Why a position has no coverage numbers. */
         public enum Reason implements souther.compiler.observe.MeasureReason {
@@ -254,13 +332,17 @@ public record PartitionEvidence(Partitioned partitioned, Bounded bounded,
         /** Which classes there are is a fact about the model, and no row has to exist for it to be
          *  so — which is why a position nothing was measured at still names them. */
         public static AxisCoverage unavailable(String axis, String path, List<String> classes,
-                                               Reason reason) {
-            return new AxisCoverage(axis, path, classes, Set.of(), 0, reason.status(), reason);
+                                               Reason reason, Reading read) {
+            return new AxisCoverage(axis, path, classes, Set.of(), 0, reason.status(), reason, read);
         }
 
         public AxisCoverage {
             classes = List.copyOf(classes);
             covered = Set.copyOf(covered);
+            if (read == null) {
+                throw new IllegalArgumentException(
+                        "a position with no account of what was read about its values: " + path);
+            }
             Unavailable.check(status, reason);
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -735,6 +735,14 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             out.append(String.format("      %s not read: %s (%s)%n",
                     mark(f), f.args().get(0), f.args().get(1)));
         }
+        // And a third thing, said apart from both: a position the axes did measure, on a reading
+        // that did not run to the end. The classes beside it are what the model was read to say,
+        // and a rule that went unread may yet refuse one of them — which is a different thing to
+        // act on from a position nothing established anything about.
+        for (Adequacy.Finding f : behavior.of(Adequacy.Kind.PARTITION_READ_IN_PART)) {
+            out.append(String.format("      %s read in part: %s (%s)%n",
+                    mark(f), f.args().get(0), f.args().get(1)));
+        }
         for (Adequacy.Finding f : behavior.of(Adequacy.Kind.PARTITION_OMITTED)) {
             out.append(String.format("      %s omitted: %s (axis limit)%n",
                     mark(f), f.args().get(0)));
@@ -917,6 +925,20 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     }
 
     /**
+     * The word a document writes for how far a position's rules were read.
+     *
+     * <p>Here rather than at the one place it is written, so a reader holding the arms can be held
+     * to the words without reading the writer. No {@code default}: an arm added and not given a
+     * word stops the compile rather than arriving in a document as one that already existed.
+     */
+    public static String readingWord(PartitionEvidence.AxisCoverage.Reading read) {
+        return switch (read) {
+            case PartitionEvidence.AxisCoverage.Reading.InFull _ -> "complete";
+            case PartitionEvidence.AxisCoverage.Reading.InPart _ -> "partial";
+        };
+    }
+
+    /**
      * The report as a build reads it, explaining the source identities it carries.
      *
      * <p>The names are asked for here for the reason {@link #human} asks for them, and are put to a
@@ -1087,6 +1109,19 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             ObjectNode a = axes.addObject();
             a.put("axis", axis.axis());
             a.put("path", axis.path());
+            // How far the rules about this position were read, beside the classes it came to. A
+            // class arrived at from part of the rules is a value the model singled out, and a rule
+            // that went unread may yet refuse it — so a consumer holding these classes is told what
+            // they rest on rather than left to take them for a set every member of which stands.
+            // Its own words, not the ones a measure uses. `status` and `reason` say elsewhere in
+            // this document whether a number was arrived at and why there is none; this says how
+            // far a reading got, which is a different question about a position that has numbers.
+            // Under one pair of keys a consumer would read one as the other.
+            ObjectNode read = a.putObject("read");
+            read.put("extent", readingWord(axis.read()));
+            if (axis.read() instanceof PartitionEvidence.AxisCoverage.Reading.InPart short_) {
+                read.put("stoppedBy", word(short_.why()));
+            }
             axis.classes().forEach(a.putArray("classes")::add);
             axis.covered().stream().sorted().forEach(a.putArray("covered")::add);
             ArrayNode excluded = a.putArray("excluded");
@@ -1156,15 +1191,20 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         partition.notDerivable().forEach(each -> {
             if (each.isAbsent()) {
                 undivided.add(each.at().toString());
-                return;
             }
-            // The position and what stopped it, kept as the product they are. Which limit a position
-            // is waiting on is the thing this list was added to say, and a document that named only
-            // the position would leave a consumer to guess it back.
+        });
+        // The position and what stopped it, kept as the product they are. Which limit a position is
+        // waiting on is the thing this list was added to say, and a document that named only the
+        // position would leave a consumer to guess it back.
+        //
+        // Asked of the one reading both surfaces write from. Written from the undivided positions
+        // alone, this list was short of every rule left unread at a position the axes went on to
+        // measure — which a person reading the report was shown and a consumer keyed on this
+        // document was not.
+        partition.notRead().forEach(each -> {
             ObjectNode said = unread.addObject();
-            said.put("position", each.at().toString());
-            said.put("reason", word(((souther.compiler.partition.UndividedPosition.Why.CannotDerive)
-                    each.why()).reason()));
+            said.put("position", each.at());
+            said.put("reason", word(each.reason()));
         });
         ArrayNode omitted = out.putArray("omitted");
         partition.omitted().forEach(o -> omitted.add(o.axis().toString()));
@@ -1254,7 +1294,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             case ARM_UNREACHED -> finding.at();
             case OUTPUT_CASE_UNSPECIFIED, OUTPUT_CASE_UNVERIFIED, INPUT_CASE_UNSPECIFIED,
                     AXIS_CLASS_UNCOVERED, BOUNDARY_UNMET, PARTITION_NOT_DERIVABLE,
-                    PARTITION_NOT_READ, PARTITION_OMITTED -> null;
+                    PARTITION_NOT_READ, PARTITION_READ_IN_PART, PARTITION_OMITTED -> null;
         };
     }
 
@@ -1275,7 +1315,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         List<Object> args = finding.args();
         return switch (finding.kind()) {
             case OUTPUT_CASE_UNSPECIFIED, OUTPUT_CASE_UNVERIFIED, AXIS_CLASS_UNCOVERED,
-                    ARM_UNREACHED, PARTITION_NOT_DERIVABLE, PARTITION_NOT_READ, PARTITION_OMITTED ->
+                    ARM_UNREACHED, PARTITION_NOT_DERIVABLE, PARTITION_NOT_READ,
+                    PARTITION_READ_IN_PART, PARTITION_OMITTED ->
                     String.valueOf(args.get(0));
             case INPUT_CASE_UNSPECIFIED ->
                     String.valueOf(args.get(0)) + " (in #" + args.get(1) + ")";

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -357,7 +357,7 @@ public final class GeneratedRows {
             // Not gaps a build refuses, and a disposition is not held for one. Listed rather than
             // defaulted so that a kind added later has to be given words here.
             case OUTPUT_CASE_UNVERIFIED, AXIS_CLASS_UNCOVERED, PARTITION_NOT_DERIVABLE,
-                    PARTITION_NOT_READ, PARTITION_OMITTED ->
+                    PARTITION_NOT_READ, PARTITION_READ_IN_PART, PARTITION_OMITTED ->
                     throw new IllegalStateException("not a gap a build refuses: " + gap);
         };
     }

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-1.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-1.json
@@ -4,13 +4,7 @@
   "title": "Souther adequacy report",
   "description": "How well a model's `example`s cover it. Emitted by `souther examples --format json`. A reader keys on `schemaVersion`: a change that removes or renames anything here raises it, and something added since does not — a key added since is optional, and a word added to an enumerated field is one no earlier document carried, so a document written before either existed is still a document of this version. That is one direction: every object here is closed, so an older copy of this schema refuses a document carrying a key added since. A reader that has to accept newer documents wants the newer schema, not a higher number.",
   "type": "object",
-  "required": [
-    "schemaVersion",
-    "compilerVersion",
-    "status",
-    "adequacy",
-    "modules"
-  ],
+  "required": ["schemaVersion", "compilerVersion", "status", "adequacy", "modules"],
   "additionalProperties": false,
   "properties": {
     "schemaVersion": {
@@ -26,85 +20,53 @@
       "description": "The weakest status among the modules. `partial` means something could not be read, so an absent number is not evidence of a gap."
     },
     "adequacy": {
-      "enum": [
-        "satisfied",
-        "not_satisfied",
-        "undetermined"
-      ],
+      "enum": ["satisfied", "not_satisfied", "undetermined"],
       "description": "Whether the rows meet what the asked measures require, which is not what `status` says. `undetermined` is a measure that was not asked for or could not be made; a build that gates on this refuses `not_satisfied` and nothing else."
     },
     "modules": {
       "type": "array",
-      "items": {
-        "$ref": "#/$defs/module"
-      }
+      "items": { "$ref": "#/$defs/module" }
     },
     "sources": {
       "type": "object",
       "description": "What each source identity written elsewhere in this document is called, keyed on the identity. Every identity the document carries has an entry — a `source` subject, and the `sourceId` of every `at`. Not a list of what the compile was handed: a source this report says nothing about has no entry, so this says which files the report is about rather than which files were read. The names are the ones the same run's diagnostics use, which are chosen from the set of files in front of a reader and are neither stable across runs nor a key — which is why they are here and not in place of the identities. Not in `required`: a document written before this field existed is still a document of this version.",
-      "additionalProperties": {
-        "type": "string"
-      }
+      "additionalProperties": { "type": "string" }
     }
   },
   "$defs": {
+    "notReadReason": {
+      "description": "Why a reading is short of the rules. `unsupported_syntax` is a rule that was read and could not be used — an expression the terms do not name; `rules_not_read_at_all` is a rule the reading never arrived at, with which limit stopped the walk neither recorded nor promised; `unsupported_domain` is a comparison against values no line can be drawn on; `unsupported_partition_shape` is a comparison relating two positions rather than dividing one; `depth_limit` is the walk stopping before it reached the position; `type_unresolved` is a type at the position that could not be worked out; `unsupported_traversal` is values held inside something the walk does not reach into. Every one of them is a fact about the compiler and none is a fact about the model.",
+      "enum": ["unsupported_syntax", "rules_not_read_at_all", "unsupported_domain", "unsupported_partition_shape", "depth_limit", "type_unresolved", "unsupported_traversal"]
+    },
     "status": {
       "description": "Whether a measure has a number. `unavailable` says only that it has none; the `reason` beside it says why, and the two are not read off one another.",
-      "enum": [
-        "complete",
-        "partial",
-        "unavailable"
-      ]
+      "enum": ["complete", "partial", "unavailable"]
     },
     "module": {
       "type": "object",
-      "required": [
-        "module",
-        "status",
-        "incompleteness",
-        "behaviors"
-      ],
+      "required": ["module", "status", "incompleteness", "behaviors"],
       "additionalProperties": false,
       "properties": {
-        "module": {
-          "type": "string"
-        },
-        "status": {
-          "$ref": "#/$defs/status"
-        },
+        "module": { "type": "string" },
+        "status": { "$ref": "#/$defs/status" },
         "incompleteness": {
           "type": "array",
-          "items": {
-            "$ref": "#/$defs/incompleteness"
-          }
+          "items": { "$ref": "#/$defs/incompleteness" }
         },
         "behaviors": {
           "type": "array",
-          "items": {
-            "$ref": "#/$defs/behavior"
-          }
+          "items": { "$ref": "#/$defs/behavior" }
         }
       }
     },
     "behavior": {
       "type": "object",
-      "required": [
-        "name",
-        "implementation",
-        "rows",
-        "pending",
-        "status"
-      ],
+      "required": ["name", "implementation", "rows", "pending", "status"],
       "additionalProperties": false,
       "properties": {
-        "name": {
-          "type": "string"
-        },
+        "name": { "type": "string" },
         "implementation": {
-          "enum": [
-            "implemented",
-            "injected"
-          ],
+          "enum": ["implemented", "injected"],
           "description": "`injected` is a behavior with no `let` yet; its rows are recorded rather than evaluated."
         },
         "rows": {
@@ -117,21 +79,11 @@
           "minimum": 0,
           "description": "How many of those rows are recorded rather than evaluated."
         },
-        "status": {
-          "$ref": "#/$defs/status"
-        },
-        "signature": {
-          "$ref": "#/$defs/signature"
-        },
-        "partition": {
-          "$ref": "#/$defs/partition"
-        },
-        "branch": {
-          "$ref": "#/$defs/branch"
-        },
-        "findings": {
-          "$ref": "#/$defs/findings"
-        }
+        "status": { "$ref": "#/$defs/status" },
+        "signature": { "$ref": "#/$defs/signature" },
+        "partition": { "$ref": "#/$defs/partition" },
+        "branch": { "$ref": "#/$defs/branch" },
+        "findings": { "$ref": "#/$defs/findings" }
       }
     },
     "findings": {
@@ -139,35 +91,16 @@
       "description": "Everything the measures found about this behavior and nothing filled, and what a build does about each. The measures above each say what they measured; this says which findings came out of them and which of those a build refuses over, which no measure's own object can say. Not in `required`: a document written before this array existed is still a document of this version.",
       "items": {
         "type": "object",
-        "required": [
-          "kind",
-          "disposition",
-          "subject"
-        ],
+        "required": ["kind", "disposition", "subject"],
         "additionalProperties": false,
         "properties": {
           "kind": {
-            "description": "What the measure established. `output_case_unspecified` is a case of the output no row expects and `output_case_unverified` is one some row expects and nothing was seen to produce; `input_case_unspecified` is a case of an input no row applies the behavior to and `axis_class_uncovered` is a class of a derived position no row is in — the two read alike about one class and only one of them is refused over. `boundary_unmet` is a line some rule draws that no row sits on, `arm_unreached` an arm of the body no row goes through. `partition_not_derivable`, `partition_not_read`, `partition_read_in_part` and `partition_omitted` are positions the model divides no way, positions this could not read, positions the axes did measure on a reading short of their rules, and positions past the axis limit.",
-            "enum": [
-              "output_case_unspecified",
-              "input_case_unspecified",
-              "boundary_unmet",
-              "arm_unreached",
-              "output_case_unverified",
-              "axis_class_uncovered",
-              "partition_not_derivable",
-              "partition_not_read",
-              "partition_read_in_part",
-              "partition_omitted"
-            ]
+            "description": "What the measure established. `output_case_unspecified` is a case of the output no row expects and `output_case_unverified` is one some row expects and nothing was seen to produce; `input_case_unspecified` is a case of an input no row applies the behavior to and `axis_class_uncovered` is a class of a derived position no row is in — the two read alike about one class and only one of them is refused over. `boundary_unmet` is a line some rule draws that no row sits on, `arm_unreached` an arm of the body no row goes through. `partition_not_derivable`, `partition_not_read`, `partition_read_in_part` and `partition_omitted` are positions the model divides no way, positions some rule about which was not read, positions the axes did measure on a reading short of their rules, and positions past the axis limit.",
+            "enum": ["output_case_unspecified", "input_case_unspecified", "boundary_unmet", "arm_unreached", "output_case_unverified", "axis_class_uncovered", "partition_not_derivable", "partition_not_read", "partition_read_in_part", "partition_omitted"]
           },
           "disposition": {
             "description": "What a build does about this one. `refused` is a gap `--strict` and a warned build refuse over; `reported` is a kind neither refuses over, whatever its measurement managed; `undecided` is a kind they would refuse over, from a measurement that came to no answer — telling an author to write a row they may already have written is worse than saying nothing, so it is named and not refused.",
-            "enum": [
-              "refused",
-              "undecided",
-              "reported"
-            ]
+            "enum": ["refused", "undecided", "reported"]
           },
           "subject": {
             "type": "string",
@@ -188,61 +121,27 @@
     "branch": {
       "type": "object",
       "description": "Which arms of the behavior's body the rows go through. Branch-arm coverage, not path coverage: going through both arms of two nested conditions says nothing about their combinations.",
-      "required": [
-        "status",
-        "arms",
-        "covered",
-        "unreached"
-      ],
+      "required": ["status", "arms", "covered", "unreached"],
       "additionalProperties": false,
       "properties": {
-        "status": {
-          "$ref": "#/$defs/status"
-        },
+        "status": { "$ref": "#/$defs/status" },
         "reason": {
           "description": "Why there is no number, present exactly where `status` is `unavailable`. `no_body` is a behavior that has no arms to measure at all — a `>->` composition or one with no `let` — rather than arms nothing measured; `not_asked` is a build that did not ask for them; `unreadable` is a run whose instrumentation could not be tied back to the body; `no_rows` is a behavior no row names.",
-          "enum": [
-            "no_body",
-            "not_asked",
-            "unreadable",
-            "no_rows"
-          ]
+          "enum": ["no_body", "not_asked", "unreadable", "no_rows"]
         },
-        "arms": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "covered": {
-          "type": "integer",
-          "minimum": 0
-        },
+        "arms": { "type": "integer", "minimum": 0 },
+        "covered": { "type": "integer", "minimum": 0 },
         "unreached": {
           "type": "array",
           "description": "Arms no row goes through.",
           "items": {
             "type": "object",
-            "required": [
-              "label",
-              "kind",
-              "at"
-            ],
+            "required": ["label", "kind", "at"],
             "additionalProperties": false,
             "properties": {
-              "label": {
-                "type": "string"
-              },
-              "kind": {
-                "enum": [
-                  "then",
-                  "else",
-                  "case",
-                  "constructed",
-                  "departure"
-                ]
-              },
-              "at": {
-                "$ref": "#/$defs/at"
-              }
+              "label": { "type": "string" },
+              "kind": { "enum": ["then", "else", "case", "constructed", "departure"] },
+              "at": { "$ref": "#/$defs/at" }
             }
           }
         }
@@ -251,52 +150,32 @@
     "partition": {
       "type": "object",
       "description": "How much of what the model distinguishes about this behavior's inputs the rows reach.",
-      "required": [
-        "axes",
-        "boundaries",
-        "pairs",
-        "notDerivable",
-        "omitted"
-      ],
+      "required": ["axes", "boundaries", "pairs", "notDerivable", "omitted"],
       "additionalProperties": false,
       "properties": {
         "axesMeasure": {
           "type": "object",
           "description": "Whether the positions were measured at all, which the `axes` array cannot say: an empty one is what a behavior with no position to divide has and what a behavior whose positions could not be read has. Not in `required`: a document written before this field existed is still a document of this version.",
-          "required": [
-            "status"
-          ],
+          "required": ["status"],
           "additionalProperties": false,
           "properties": {
-            "status": {
-              "$ref": "#/$defs/status"
-            },
+            "status": { "$ref": "#/$defs/status" },
             "reason": {
               "description": "Why there is no measure, present exactly where `status` is `unavailable`. `no_axis_derived` is a reading that produced no position — which is not itself evidence that the model divides none; `no_subject` is a behavior with no positions of its own, a `>->` composition, which is measured at its stages.",
-              "enum": [
-                "no_axis_derived",
-                "no_subject"
-              ]
+              "enum": ["no_axis_derived", "no_subject"]
             }
           }
         },
         "boundariesMeasure": {
           "type": "object",
           "description": "The same for the lines. An empty `boundaries` array is what a model with no bound has and what a model whose bounds the reading could not reach has.",
-          "required": [
-            "status"
-          ],
+          "required": ["status"],
           "additionalProperties": false,
           "properties": {
-            "status": {
-              "$ref": "#/$defs/status"
-            },
+            "status": { "$ref": "#/$defs/status" },
             "reason": {
               "description": "Why there is no measure, present exactly where `status` is `unavailable`. `no_lines_derived` is a reading that produced no obligation — which is not itself evidence that the model draws no line; `no_subject` is a behavior with no positions of its own.",
-              "enum": [
-                "no_lines_derived",
-                "no_subject"
-              ]
+              "enum": ["no_lines_derived", "no_subject"]
             }
           }
         },
@@ -304,76 +183,35 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": [
-              "axis",
-              "path",
-              "classes",
-              "covered",
-              "unclassifiedRows",
-              "status"
-            ],
+            "required": ["axis", "path", "classes", "covered", "unclassifiedRows", "status"],
             "additionalProperties": false,
             "properties": {
-              "axis": {
-                "type": "string"
-              },
-              "path": {
-                "type": "string",
-                "description": "The input position, as a parameter and the fields read off it. A newtype's `value` is never a step."
-              },
+              "axis": { "type": "string" },
+              "path": { "type": "string", "description": "The input position, as a parameter and the fields read off it. A newtype's `value` is never a step." },
               "read": {
                 "type": "object",
-                "description": "How much of what this position's rules say was read. It qualifies `classes` and nothing else says it: a class arrived at from part of the rules is a value the model singled out, and a rule that went unread may yet refuse it — so `classes` is the denominator the model states and not one every member of which is known to stand. Not in `required`: a document written before this field existed is still a document of this version.",
-                "required": [
-                  "extent"
-                ],
+                "description": "How much of what this position's rules say was read. It qualifies `classes` and nothing else says it: a class arrived at from part of the rules is a value the model singled out, and a rule that went unread may yet refuse it — so `classes` is the denominator the model states and not one every member of which is known to stand. Its own words rather than the `status` and `reason` a measure carries: those say whether a number was arrived at and why there is none, and this says how far a reading got at a position that has numbers. Not in `required`: a document written before this field existed is still a document of this version.",
+                "required": ["extent"],
                 "additionalProperties": false,
                 "properties": {
-                  "extent": {
-                    "enum": [
-                      "complete",
-                      "partial"
-                    ],
-                    "description": "Whether every rule about this position was read. Its own word rather than the `status` a measure carries: that one says whether a number was arrived at, and this says how far a reading got at a position that has numbers."
-                  },
-                  "stoppedBy": {
-                    "description": "What stopped the reading, present exactly where `extent` is `partial`. The same vocabulary `notRead` writes, because it is the same question asked of a position rather than of a rule.",
-                    "$ref": "#/$defs/notReadReason"
-                  }
+                  "extent": { "enum": ["complete", "partial"], "description": "Whether every rule about this position was read." },
+                  "stoppedBy": { "description": "What stopped the reading, present exactly where `extent` is `partial`. The same words `notRead` writes, because it is the same question asked of a position rather than of a rule.", "$ref": "#/$defs/notReadReason" }
                 }
               },
-              "classes": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "description": "The classes a row can be written at: what the model divides this position into, less what its own rules refuse."
-              },
-              "covered": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
+              "classes": { "type": "array", "items": { "type": "string" }, "description": "The classes a row can be written at: what the model divides this position into, less what its own rules refuse." },
+              "covered": { "type": "array", "items": { "type": "string" } },
               "excluded": {
                 "type": "array",
                 "description": "Classes the position's own rules refuse, that the body also answers `unreachable` for. Out of `classes` because no value of one can be constructed, and named here because the type still has them.",
                 "items": {
                   "type": "object",
-                  "required": [
-                    "class",
-                    "reasons"
-                  ],
+                  "required": ["class", "reasons"],
                   "additionalProperties": false,
                   "properties": {
-                    "class": {
-                      "type": "string"
-                    },
+                    "class": { "type": "string" },
                     "reasons": {
                       "type": "array",
-                      "items": {
-                        "type": "string"
-                      },
+                      "items": { "type": "string" },
                       "description": "The reasons written at the `unreachable`s this class leads to — one, unless several paths abort for different reasons."
                     }
                   }
@@ -384,47 +222,27 @@
                 "description": "Classes the body answers `unreachable` for that nothing settled. Still in `classes` and still owed a row: what removes an obligation is a proof, and a row written at one may reach the `unreachable` and be refused.",
                 "items": {
                   "type": "object",
-                  "required": [
-                    "class",
-                    "reasons",
-                    "why"
-                  ],
+                  "required": ["class", "reasons", "why"],
                   "additionalProperties": false,
                   "properties": {
-                    "class": {
-                      "type": "string"
-                    },
+                    "class": { "type": "string" },
                     "reasons": {
                       "type": "array",
-                      "items": {
-                        "type": "string"
-                      },
+                      "items": { "type": "string" },
                       "description": "The reasons written at the `unreachable`s this class leads to."
                     },
                     "why": {
                       "description": "What stopped the answer.",
-                      "enum": [
-                        "a_rule_went_unread",
-                        "the_rules_leave_the_position_nothing",
-                        "nothing_was_read_about_the_case",
-                        "the_fork_is_not_known_to_be_reached"
-                      ]
+                      "enum": ["a_rule_went_unread", "the_rules_leave_the_position_nothing", "nothing_was_read_about_the_case", "the_fork_is_not_known_to_be_reached"]
                     }
                   }
                 }
               },
-              "unclassifiedRows": {
-                "type": "integer",
-                "minimum": 0
-              },
-              "status": {
-                "$ref": "#/$defs/status"
-              },
+              "unclassifiedRows": { "type": "integer", "minimum": 0 },
+              "status": { "$ref": "#/$defs/status" },
               "reason": {
                 "description": "Why there is no number, present exactly where `status` is `unavailable`. A behavior no row names was not measured here, so the classes nothing sits in are not classes nothing reaches.",
-                "enum": [
-                  "no_rows"
-                ]
+                "enum": ["no_rows"]
               }
             }
           }
@@ -433,60 +251,26 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": [
-              "axis",
-              "origin",
-              "side",
-              "value",
-              "hit",
-              "knownWritable",
-              "status"
-            ],
+            "required": ["axis", "origin", "side", "value", "hit", "knownWritable", "status"],
             "additionalProperties": false,
             "properties": {
-              "axis": {
-                "type": "string"
-              },
-              "origin": {
-                "type": "string",
-                "description": "The rule that drew this line — a type's invariant, or a guard."
-              },
-              "side": {
-                "enum": [
-                  "below",
-                  "at",
-                  "above"
-                ]
-              },
+              "axis": { "type": "string" },
+              "origin": { "type": "string", "description": "The rule that drew this line — a type's invariant, or a guard." },
+              "side": { "enum": ["below", "at", "above"] },
               "kind": {
-                "enum": [
-                  "at_value",
-                  "between_positions"
-                ],
+                "enum": ["at_value", "between_positions"],
                 "description": "What this line is a line at. `at_value` is a place of the position `axis` names, which is what an invariant's bound and a guard against a constant draw. `between_positions` is a guard comparing one position against another: the line is where the two hold the same place, `axis` names the left of it and `value` the other position rather than a value. Reading `value` without reading this reads a position's name as a value. Absent in a document written before this key existed, where every line was at a value."
               },
-              "value": {
-                "type": "string",
-                "description": "The other side of the line, as an author would write it: a value where `kind` is `at_value` or absent, and the other position where it is `between_positions`. The place a row happens to satisfy such a line with belongs to that row and not to the line, so it is not written here."
-              },
-              "hit": {
-                "type": "boolean"
-              },
+              "value": { "type": "string", "description": "The other side of the line, as an author would write it: a value where `kind` is `at_value` or absent, and the other position where it is `between_positions`. The place a row happens to satisfy such a line with belongs to that row and not to the line, so it is not written here." },
+              "hit": { "type": "boolean" },
               "knownWritable": {
                 "type": "boolean",
                 "description": "Whether some row could carry this value. False where a rule reaching the value this position sits in was not read in full — a pattern, a disequality, a strict bound on a decimal — so the edge is where the reading stopped rather than where the model does. Such a line is reported and not counted, and no build is refused over it."
               },
-              "status": {
-                "$ref": "#/$defs/status"
-              },
+              "status": { "$ref": "#/$defs/status" },
               "reason": {
                 "description": "Why there is no answer, present exactly where `status` is `unavailable`. `arms_not_asked` and `arms_unreadable` belong to a guard's line only, which is met by getting the comparison to produce a value rather than by writing the value; an invariant's line is met by writing it and is never waiting on the instrumentation. `no_arm_witnesses_it` was a guard's line whose comparison sat inside a condition whose arms did not separate the rows that reached it from the rows that did not — the second operand of an `&&` on the side where it is false. No compiler writes it any more: the comparison carries a site of its own and is observed where it runs. It is here because reports of this version were written carrying it, and a version says what its documents may carry rather than what is emitted today.",
-                "enum": [
-                  "arms_not_asked",
-                  "arms_unreadable",
-                  "no_rows",
-                  "no_arm_witnesses_it"
-                ]
+                "enum": ["arms_not_asked", "arms_unreadable", "no_rows", "no_arm_witnesses_it"]
               }
             }
           }
@@ -494,25 +278,11 @@
         "pairs": {
           "type": "object",
           "description": "Two-class combinations across two positions. Counts rather than a ratio: a combination no row reaches has not been shown unreachable, only untried, so the denominator is not known.",
-          "required": [
-            "total",
-            "covered",
-            "witnessedFeasible",
-            "provenInfeasible",
-            "unknown",
-            "truncated",
-            "status"
-          ],
+          "required": ["total", "covered", "witnessedFeasible", "provenInfeasible", "unknown", "truncated", "status"],
           "additionalProperties": false,
           "properties": {
-            "total": {
-              "type": "integer",
-              "minimum": 0
-            },
-            "covered": {
-              "type": "integer",
-              "minimum": 0
-            },
+            "total": { "type": "integer", "minimum": 0 },
+            "covered": { "type": "integer", "minimum": 0 },
             "witnessedFeasible": {
               "type": "integer",
               "minimum": 0,
@@ -523,23 +293,16 @@
               "minimum": 0,
               "description": "Combinations shown impossible. A candidate that failed to build is not one of these — another value of the same two classes may build."
             },
-            "unknown": {
-              "type": "integer",
-              "minimum": 0
-            },
+            "unknown": { "type": "integer", "minimum": 0 },
             "status": {
-              "$ref": "#/$defs/status",
-              "description": "`partial` where some rows were not read at all: a combination none of the rows seen reaches has not been left untried by anybody."
-            },
-            "reason": {
-              "description": "Why there are no numbers, present exactly where `status` is `unavailable`. How large the space is says nothing about a behavior no row names.",
-              "enum": [
-                "no_rows"
-              ]
-            },
-            "truncated": {
-              "type": "boolean"
-            }
+            "$ref": "#/$defs/status",
+            "description": "`partial` where some rows were not read at all: a combination none of the rows seen reaches has not been left untried by anybody."
+          },
+          "reason": {
+            "description": "Why there are no numbers, present exactly where `status` is `unavailable`. How large the space is says nothing about a behavior no row names.",
+            "enum": ["no_rows"]
+          },
+          "truncated": { "type": "boolean" }
           }
         },
         "claimsOffAxis": {
@@ -547,33 +310,15 @@
           "description": "Claims about positions this report has no axis for — past the axis limit, or deeper than the walk goes. Named by position, and carrying `why` exactly where nothing settled the claim.",
           "items": {
             "type": "object",
-            "required": [
-              "at",
-              "class",
-              "reasons"
-            ],
+            "required": ["at", "class", "reasons"],
             "additionalProperties": false,
             "properties": {
-              "at": {
-                "type": "string"
-              },
-              "class": {
-                "type": "string"
-              },
-              "reasons": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
+              "at": { "type": "string" },
+              "class": { "type": "string" },
+              "reasons": { "type": "array", "items": { "type": "string" } },
               "why": {
                 "description": "What stopped the answer, present exactly where nothing settled the claim.",
-                "enum": [
-                  "a_rule_went_unread",
-                  "the_rules_leave_the_position_nothing",
-                  "nothing_was_read_about_the_case",
-                  "the_fork_is_not_known_to_be_reached"
-                ]
+                "enum": ["a_rule_went_unread", "the_rules_leave_the_position_nothing", "nothing_was_read_about_the_case", "the_fork_is_not_known_to_be_reached"]
               }
             }
           }
@@ -581,73 +326,45 @@
         "notDerivable": {
           "type": "array",
           "description": "Positions the reading ran to the end at and divided no way. Not a finding: no boundary obligation was established here, so nothing is reported against the rows. Not a statement that nothing is owed either — a bound one type away from the position a behavior takes lands in this list, and the reading cannot tell that from a position nothing bounds. A position something is written about that the reading could not take apart is in `notRead` instead, and used to be in this one. Read `boundariesMeasure` for whether the measure was made.",
-          "items": {
-            "type": "string"
-          }
+          "items": { "type": "string" }
         },
         "notRead": {
           "type": "array",
-          "description": "Positions something in the body names that this reading did not turn into a line, each with what stopped it. Nothing is established about these either way, which is what separates them from `notDerivable` — and which limit stopped each one is what says whose work it is to lift. Not in `required`: a document written before this field existed is still a document of this version.",
+          "description": "Positions some rule about which this reading did not turn into a line, each with what stopped it. What separates them from `notDerivable` is that the model does state something here — which limit stopped each one is what says whose work it is to lift. Not a statement that the position was not measured: a position with an axis and classes can carry a rule nothing read, and whether the reading of a position ran to the end is what that axis's `read` says. Not in `required`: a document written before this field existed is still a document of this version.",
           "items": {
             "type": "object",
-            "required": [
-              "position",
-              "reason"
-            ],
+            "required": ["position", "reason"],
             "additionalProperties": false,
             "properties": {
-              "position": {
-                "type": "string"
-              },
-              "reason": {
-                "$ref": "#/$defs/notReadReason"
-              }
+              "position": { "type": "string" },
+              "reason": { "$ref": "#/$defs/notReadReason" }
             }
           }
         },
         "omitted": {
           "type": "array",
           "description": "Positions dropped for being past the axis limit.",
-          "items": {
-            "type": "string"
-          }
+          "items": { "type": "string" }
         }
       }
     },
     "signature": {
       "type": "object",
       "description": "What the rows establish about the cases of the behavior's inputs and its output. Absent where the behavior has no signature to read.",
-      "required": [
-        "status",
-        "output",
-        "inputs"
-      ],
+      "required": ["status", "output", "inputs"],
       "additionalProperties": false,
       "properties": {
-        "status": {
-          "$ref": "#/$defs/status"
-        },
+        "status": { "$ref": "#/$defs/status" },
         "reason": {
           "description": "Why there is no number, present exactly where `status` is `unavailable`. `no_rows` is a behavior no row names; `not_a_sum` is a signature with no sum anywhere in it, which no row could give a case to cover.",
-          "enum": [
-            "no_rows",
-            "not_a_sum"
-          ]
+          "enum": ["no_rows", "not_a_sum"]
         },
         "output": {
           "type": "object",
-          "required": [
-            "declared",
-            "specified",
-            "observed",
-            "verified",
-            "unclassifiedRows"
-          ],
+          "required": ["declared", "specified", "observed", "verified", "unclassifiedRows"],
           "additionalProperties": false,
           "properties": {
-            "declared": {
-              "$ref": "#/$defs/caseNames"
-            },
+            "declared": { "$ref": "#/$defs/caseNames" },
             "specified": {
               "$ref": "#/$defs/caseNames",
               "description": "Cases a row expects. Somebody wrote down that the model owes this answer."
@@ -672,36 +389,21 @@
           "description": "One entry per parameter, in order. A parameter that is not a sum has nothing to cover and reports empty sets.",
           "items": {
             "type": "object",
-            "required": [
-              "declared",
-              "specified",
-              "executed",
-              "verified",
-              "unclassifiedRows"
-            ],
+            "required": ["declared", "specified", "executed", "verified", "unclassifiedRows"],
             "additionalProperties": false,
             "properties": {
-              "declared": {
-                "$ref": "#/$defs/caseNames"
-              },
-              "specified": {
-                "$ref": "#/$defs/caseNames"
-              },
+              "declared": { "$ref": "#/$defs/caseNames" },
+              "specified": { "$ref": "#/$defs/caseNames" },
               "executed": {
                 "$ref": "#/$defs/caseNames",
                 "description": "Cases the behavior was applied to. Not `observed`: nothing is claimed about what came back."
               },
-              "verified": {
-                "$ref": "#/$defs/caseNames"
-              },
+              "verified": { "$ref": "#/$defs/caseNames" },
               "excluded": {
                 "$ref": "#/$defs/caseNames",
                 "description": "Cases the position's own rules refuse. Declared and not coverable: no value of one can be constructed, so they are counted out of what the rows are held to."
               },
-              "unclassifiedRows": {
-                "type": "integer",
-                "minimum": 0
-              }
+              "unclassifiedRows": { "type": "integer", "minimum": 0 }
             }
           }
         }
@@ -710,124 +412,60 @@
     "caseNames": {
       "type": "array",
       "description": "Case names, sorted, so that two runs of the same model compare.",
-      "items": {
-        "type": "string"
-      }
+      "items": { "type": "string" }
     },
     "incompleteness": {
       "type": "object",
-      "required": [
-        "code",
-        "scope",
-        "subject"
-      ],
+      "required": ["code", "scope", "subject"],
       "additionalProperties": false,
       "properties": {
         "scope": {
-          "enum": [
-            "behavior",
-            "source",
-            "module",
-            "position"
-          ],
+          "enum": ["behavior", "source", "module", "position"],
           "description": "What `subject` names, and so what the reason counts against. A `behavior` and a `position` count against the behavior they are in, and a position is in one. A `module` counts against every behavior in it, because that is what a module holds. A `source` counts against every behavior too, and not for that reason: one is written only where the source was not evaluated, so which behaviors had rows in it is exactly what could not be read."
         },
         "code": {
           "description": "`observation_absent` is a source none of whose rows were observed, whatever stopped them — the diagnostics say what. `linkage_failed` is the generated classes not linking: the case it exists for is the runtime being off the host's classpath, and the JVM raises the same error for a class it will not verify or accept the format of, which is why the word is the error and not one of its causes. One place writes it, an example whose evaluation raised one and observed nothing, so the rows behind it did not run and that is part of what it says. It had three, and the other two were a value being built after the rows had been read — those are the generator's to report and are not written here. `instrumentation_absent` is the classes an arm-measuring evaluation needs not having been made, named for the absence rather than for a backend that failed or inputs that were not there, which nothing here can tell apart. `answerer_not_established` is a row that was not handed to what answers its behavior, because nothing could establish that what answers it was built against this model — either the two builds say different things about something a value crossing between them depends on, or what the answer carries could not be read at all. The rows behind it were read: they were built and held to their invariants, and what is missing is only what the running would have decided. `probe_mapping_lost` is what it was called, and no compiler writes it any more: it is here because reports of this version were written carrying it, and a version says what its documents may carry rather than what is emitted today.",
-          "enum": [
-            "value_unreadable",
-            "value_truncated",
-            "row_undecided",
-            "answerer_not_established",
-            "observation_absent",
-            "linkage_failed",
-            "instrumentation_absent",
-            "probe_mapping_lost"
-          ]
+          "enum": ["value_unreadable", "value_truncated", "row_undecided",
+                   "answerer_not_established", "observation_absent",
+                   "linkage_failed", "instrumentation_absent", "probe_mapping_lost"]
         },
         "subject": {
           "type": "string",
           "description": "What the reason is about, as an identity. A `behavior`, a `module` and a `position` are named as the author wrote them. A `source` is named as the compile was handed it, which is the caller's own identity for the file and not a name to show a reader: a build passing a list of files gets that file's position in the list, and an editor keyed on document URIs gets the URI. What to call a source in front of a person is decided where a report is rendered, since it depends on which other files are being read beside it — and `sources` says what this run decided, so the identity can be looked up without holding what was handed over."
         },
-        "at": {
-          "$ref": "#/$defs/at"
-        }
+        "at": { "$ref": "#/$defs/at" }
       }
     },
     "at": {
       "type": "object",
       "description": "Where in which source. A position alone cannot say which file, since a module's rows are written across its own source and any attached ones. It says where this compile met the code, which `writtenAt` says whether to read as where the code is written.",
-      "required": [
-        "sourceId",
-        "line",
-        "column"
-      ],
+      "required": ["sourceId", "line", "column"],
       "additionalProperties": false,
       "properties": {
         "sourceId": {
           "type": "string",
           "description": "The source, as an identity, read the way a `source` subject is. `sources` says what it is called."
         },
-        "line": {
-          "type": "integer"
-        },
-        "column": {
-          "type": "integer"
-        },
-        "writtenAt": {
-          "$ref": "#/$defs/writtenAt"
-        }
+        "line": { "type": "integer" },
+        "column": { "type": "integer" },
+        "writtenAt": { "$ref": "#/$defs/writtenAt" }
       }
     },
     "writtenAt": {
       "type": "object",
       "description": "Whether the position beside this is where the code it names is written. A body is copied into everything that calls it, and a copy from a module this compile has no source for is given the call site, since the positions it was written at name a file nobody holds. Absent in a document written before this key existed, which is not the same as `here`: such a document does not answer the question.",
-      "required": [
-        "kind"
-      ],
+      "required": ["kind"],
       "additionalProperties": false,
       "properties": {
-        "kind": {
-          "enum": [
-            "here",
-            "outOfSight"
-          ]
-        },
+        "kind": { "enum": ["here", "outOfSight"] },
         "declaration": {
           "type": "string",
           "description": "The name a reader of the file the position is in reaches that code by — `List.filter`. Written where `kind` is `outOfSight` and never otherwise. How it is reached and not which module declares it: a name reached from out of sight is qualified, so it is already enough to look the code up by."
         }
       },
-      "if": {
-        "properties": {
-          "kind": {
-            "const": "outOfSight"
-          }
-        }
-      },
-      "then": {
-        "required": [
-          "declaration"
-        ]
-      },
-      "else": {
-        "not": {
-          "required": [
-            "declaration"
-          ]
-        }
-      }
-    },
-    "notReadReason": {
-      "description": "Why a reading is short of the rules. `unsupported_syntax` is an expression the terms do not name; `unsupported_domain` is a comparison against values no line can be drawn on; `unsupported_partition_shape` is a comparison relating two positions rather than dividing one; `depth_limit` is the walk stopping before it reached the position; `type_unresolved` is a type at the position that could not be worked out; `unsupported_traversal` is values held inside something the walk does not reach into. Every one of them is a fact about the compiler and none is a fact about the model.",
-      "enum": [
-        "unsupported_syntax",
-        "unsupported_domain",
-        "unsupported_partition_shape",
-        "depth_limit",
-        "type_unresolved",
-        "unsupported_traversal"
-      ]
+      "if": { "properties": { "kind": { "const": "outOfSight" } } },
+      "then": { "required": ["declaration"] },
+      "else": { "not": { "required": ["declaration"] } }
     }
   }
 }

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-1.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-1.json
@@ -4,7 +4,13 @@
   "title": "Souther adequacy report",
   "description": "How well a model's `example`s cover it. Emitted by `souther examples --format json`. A reader keys on `schemaVersion`: a change that removes or renames anything here raises it, and something added since does not — a key added since is optional, and a word added to an enumerated field is one no earlier document carried, so a document written before either existed is still a document of this version. That is one direction: every object here is closed, so an older copy of this schema refuses a document carrying a key added since. A reader that has to accept newer documents wants the newer schema, not a higher number.",
   "type": "object",
-  "required": ["schemaVersion", "compilerVersion", "status", "adequacy", "modules"],
+  "required": [
+    "schemaVersion",
+    "compilerVersion",
+    "status",
+    "adequacy",
+    "modules"
+  ],
   "additionalProperties": false,
   "properties": {
     "schemaVersion": {
@@ -20,49 +26,85 @@
       "description": "The weakest status among the modules. `partial` means something could not be read, so an absent number is not evidence of a gap."
     },
     "adequacy": {
-      "enum": ["satisfied", "not_satisfied", "undetermined"],
+      "enum": [
+        "satisfied",
+        "not_satisfied",
+        "undetermined"
+      ],
       "description": "Whether the rows meet what the asked measures require, which is not what `status` says. `undetermined` is a measure that was not asked for or could not be made; a build that gates on this refuses `not_satisfied` and nothing else."
     },
     "modules": {
       "type": "array",
-      "items": { "$ref": "#/$defs/module" }
+      "items": {
+        "$ref": "#/$defs/module"
+      }
     },
     "sources": {
       "type": "object",
       "description": "What each source identity written elsewhere in this document is called, keyed on the identity. Every identity the document carries has an entry — a `source` subject, and the `sourceId` of every `at`. Not a list of what the compile was handed: a source this report says nothing about has no entry, so this says which files the report is about rather than which files were read. The names are the ones the same run's diagnostics use, which are chosen from the set of files in front of a reader and are neither stable across runs nor a key — which is why they are here and not in place of the identities. Not in `required`: a document written before this field existed is still a document of this version.",
-      "additionalProperties": { "type": "string" }
+      "additionalProperties": {
+        "type": "string"
+      }
     }
   },
   "$defs": {
     "status": {
       "description": "Whether a measure has a number. `unavailable` says only that it has none; the `reason` beside it says why, and the two are not read off one another.",
-      "enum": ["complete", "partial", "unavailable"]
+      "enum": [
+        "complete",
+        "partial",
+        "unavailable"
+      ]
     },
     "module": {
       "type": "object",
-      "required": ["module", "status", "incompleteness", "behaviors"],
+      "required": [
+        "module",
+        "status",
+        "incompleteness",
+        "behaviors"
+      ],
       "additionalProperties": false,
       "properties": {
-        "module": { "type": "string" },
-        "status": { "$ref": "#/$defs/status" },
+        "module": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/status"
+        },
         "incompleteness": {
           "type": "array",
-          "items": { "$ref": "#/$defs/incompleteness" }
+          "items": {
+            "$ref": "#/$defs/incompleteness"
+          }
         },
         "behaviors": {
           "type": "array",
-          "items": { "$ref": "#/$defs/behavior" }
+          "items": {
+            "$ref": "#/$defs/behavior"
+          }
         }
       }
     },
     "behavior": {
       "type": "object",
-      "required": ["name", "implementation", "rows", "pending", "status"],
+      "required": [
+        "name",
+        "implementation",
+        "rows",
+        "pending",
+        "status"
+      ],
       "additionalProperties": false,
       "properties": {
-        "name": { "type": "string" },
+        "name": {
+          "type": "string"
+        },
         "implementation": {
-          "enum": ["implemented", "injected"],
+          "enum": [
+            "implemented",
+            "injected"
+          ],
           "description": "`injected` is a behavior with no `let` yet; its rows are recorded rather than evaluated."
         },
         "rows": {
@@ -75,11 +117,21 @@
           "minimum": 0,
           "description": "How many of those rows are recorded rather than evaluated."
         },
-        "status": { "$ref": "#/$defs/status" },
-        "signature": { "$ref": "#/$defs/signature" },
-        "partition": { "$ref": "#/$defs/partition" },
-        "branch": { "$ref": "#/$defs/branch" },
-        "findings": { "$ref": "#/$defs/findings" }
+        "status": {
+          "$ref": "#/$defs/status"
+        },
+        "signature": {
+          "$ref": "#/$defs/signature"
+        },
+        "partition": {
+          "$ref": "#/$defs/partition"
+        },
+        "branch": {
+          "$ref": "#/$defs/branch"
+        },
+        "findings": {
+          "$ref": "#/$defs/findings"
+        }
       }
     },
     "findings": {
@@ -87,16 +139,35 @@
       "description": "Everything the measures found about this behavior and nothing filled, and what a build does about each. The measures above each say what they measured; this says which findings came out of them and which of those a build refuses over, which no measure's own object can say. Not in `required`: a document written before this array existed is still a document of this version.",
       "items": {
         "type": "object",
-        "required": ["kind", "disposition", "subject"],
+        "required": [
+          "kind",
+          "disposition",
+          "subject"
+        ],
         "additionalProperties": false,
         "properties": {
           "kind": {
-            "description": "What the measure established. `output_case_unspecified` is a case of the output no row expects and `output_case_unverified` is one some row expects and nothing was seen to produce; `input_case_unspecified` is a case of an input no row applies the behavior to and `axis_class_uncovered` is a class of a derived position no row is in — the two read alike about one class and only one of them is refused over. `boundary_unmet` is a line some rule draws that no row sits on, `arm_unreached` an arm of the body no row goes through. `partition_not_derivable`, `partition_not_read` and `partition_omitted` are positions the model divides no way, positions this could not read, and positions past the axis limit.",
-            "enum": ["output_case_unspecified", "input_case_unspecified", "boundary_unmet", "arm_unreached", "output_case_unverified", "axis_class_uncovered", "partition_not_derivable", "partition_not_read", "partition_omitted"]
+            "description": "What the measure established. `output_case_unspecified` is a case of the output no row expects and `output_case_unverified` is one some row expects and nothing was seen to produce; `input_case_unspecified` is a case of an input no row applies the behavior to and `axis_class_uncovered` is a class of a derived position no row is in — the two read alike about one class and only one of them is refused over. `boundary_unmet` is a line some rule draws that no row sits on, `arm_unreached` an arm of the body no row goes through. `partition_not_derivable`, `partition_not_read`, `partition_read_in_part` and `partition_omitted` are positions the model divides no way, positions this could not read, positions the axes did measure on a reading short of their rules, and positions past the axis limit.",
+            "enum": [
+              "output_case_unspecified",
+              "input_case_unspecified",
+              "boundary_unmet",
+              "arm_unreached",
+              "output_case_unverified",
+              "axis_class_uncovered",
+              "partition_not_derivable",
+              "partition_not_read",
+              "partition_read_in_part",
+              "partition_omitted"
+            ]
           },
           "disposition": {
             "description": "What a build does about this one. `refused` is a gap `--strict` and a warned build refuse over; `reported` is a kind neither refuses over, whatever its measurement managed; `undecided` is a kind they would refuse over, from a measurement that came to no answer — telling an author to write a row they may already have written is worse than saying nothing, so it is named and not refused.",
-            "enum": ["refused", "undecided", "reported"]
+            "enum": [
+              "refused",
+              "undecided",
+              "reported"
+            ]
           },
           "subject": {
             "type": "string",
@@ -117,27 +188,61 @@
     "branch": {
       "type": "object",
       "description": "Which arms of the behavior's body the rows go through. Branch-arm coverage, not path coverage: going through both arms of two nested conditions says nothing about their combinations.",
-      "required": ["status", "arms", "covered", "unreached"],
+      "required": [
+        "status",
+        "arms",
+        "covered",
+        "unreached"
+      ],
       "additionalProperties": false,
       "properties": {
-        "status": { "$ref": "#/$defs/status" },
+        "status": {
+          "$ref": "#/$defs/status"
+        },
         "reason": {
           "description": "Why there is no number, present exactly where `status` is `unavailable`. `no_body` is a behavior that has no arms to measure at all — a `>->` composition or one with no `let` — rather than arms nothing measured; `not_asked` is a build that did not ask for them; `unreadable` is a run whose instrumentation could not be tied back to the body; `no_rows` is a behavior no row names.",
-          "enum": ["no_body", "not_asked", "unreadable", "no_rows"]
+          "enum": [
+            "no_body",
+            "not_asked",
+            "unreadable",
+            "no_rows"
+          ]
         },
-        "arms": { "type": "integer", "minimum": 0 },
-        "covered": { "type": "integer", "minimum": 0 },
+        "arms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "covered": {
+          "type": "integer",
+          "minimum": 0
+        },
         "unreached": {
           "type": "array",
           "description": "Arms no row goes through.",
           "items": {
             "type": "object",
-            "required": ["label", "kind", "at"],
+            "required": [
+              "label",
+              "kind",
+              "at"
+            ],
             "additionalProperties": false,
             "properties": {
-              "label": { "type": "string" },
-              "kind": { "enum": ["then", "else", "case", "constructed", "departure"] },
-              "at": { "$ref": "#/$defs/at" }
+              "label": {
+                "type": "string"
+              },
+              "kind": {
+                "enum": [
+                  "then",
+                  "else",
+                  "case",
+                  "constructed",
+                  "departure"
+                ]
+              },
+              "at": {
+                "$ref": "#/$defs/at"
+              }
             }
           }
         }
@@ -146,32 +251,52 @@
     "partition": {
       "type": "object",
       "description": "How much of what the model distinguishes about this behavior's inputs the rows reach.",
-      "required": ["axes", "boundaries", "pairs", "notDerivable", "omitted"],
+      "required": [
+        "axes",
+        "boundaries",
+        "pairs",
+        "notDerivable",
+        "omitted"
+      ],
       "additionalProperties": false,
       "properties": {
         "axesMeasure": {
           "type": "object",
           "description": "Whether the positions were measured at all, which the `axes` array cannot say: an empty one is what a behavior with no position to divide has and what a behavior whose positions could not be read has. Not in `required`: a document written before this field existed is still a document of this version.",
-          "required": ["status"],
+          "required": [
+            "status"
+          ],
           "additionalProperties": false,
           "properties": {
-            "status": { "$ref": "#/$defs/status" },
+            "status": {
+              "$ref": "#/$defs/status"
+            },
             "reason": {
               "description": "Why there is no measure, present exactly where `status` is `unavailable`. `no_axis_derived` is a reading that produced no position — which is not itself evidence that the model divides none; `no_subject` is a behavior with no positions of its own, a `>->` composition, which is measured at its stages.",
-              "enum": ["no_axis_derived", "no_subject"]
+              "enum": [
+                "no_axis_derived",
+                "no_subject"
+              ]
             }
           }
         },
         "boundariesMeasure": {
           "type": "object",
           "description": "The same for the lines. An empty `boundaries` array is what a model with no bound has and what a model whose bounds the reading could not reach has.",
-          "required": ["status"],
+          "required": [
+            "status"
+          ],
           "additionalProperties": false,
           "properties": {
-            "status": { "$ref": "#/$defs/status" },
+            "status": {
+              "$ref": "#/$defs/status"
+            },
             "reason": {
               "description": "Why there is no measure, present exactly where `status` is `unavailable`. `no_lines_derived` is a reading that produced no obligation — which is not itself evidence that the model draws no line; `no_subject` is a behavior with no positions of its own.",
-              "enum": ["no_lines_derived", "no_subject"]
+              "enum": [
+                "no_lines_derived",
+                "no_subject"
+              ]
             }
           }
         },
@@ -179,25 +304,76 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["axis", "path", "classes", "covered", "unclassifiedRows", "status"],
+            "required": [
+              "axis",
+              "path",
+              "classes",
+              "covered",
+              "unclassifiedRows",
+              "status"
+            ],
             "additionalProperties": false,
             "properties": {
-              "axis": { "type": "string" },
-              "path": { "type": "string", "description": "The input position, as a parameter and the fields read off it. A newtype's `value` is never a step." },
-              "classes": { "type": "array", "items": { "type": "string" }, "description": "The classes a row can be written at: what the model divides this position into, less what its own rules refuse." },
-              "covered": { "type": "array", "items": { "type": "string" } },
+              "axis": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string",
+                "description": "The input position, as a parameter and the fields read off it. A newtype's `value` is never a step."
+              },
+              "read": {
+                "type": "object",
+                "description": "How much of what this position's rules say was read. It qualifies `classes` and nothing else says it: a class arrived at from part of the rules is a value the model singled out, and a rule that went unread may yet refuse it — so `classes` is the denominator the model states and not one every member of which is known to stand. Not in `required`: a document written before this field existed is still a document of this version.",
+                "required": [
+                  "extent"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "extent": {
+                    "enum": [
+                      "complete",
+                      "partial"
+                    ],
+                    "description": "Whether every rule about this position was read. Its own word rather than the `status` a measure carries: that one says whether a number was arrived at, and this says how far a reading got at a position that has numbers."
+                  },
+                  "stoppedBy": {
+                    "description": "What stopped the reading, present exactly where `extent` is `partial`. The same vocabulary `notRead` writes, because it is the same question asked of a position rather than of a rule.",
+                    "$ref": "#/$defs/notReadReason"
+                  }
+                }
+              },
+              "classes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "The classes a row can be written at: what the model divides this position into, less what its own rules refuse."
+              },
+              "covered": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
               "excluded": {
                 "type": "array",
                 "description": "Classes the position's own rules refuse, that the body also answers `unreachable` for. Out of `classes` because no value of one can be constructed, and named here because the type still has them.",
                 "items": {
                   "type": "object",
-                  "required": ["class", "reasons"],
+                  "required": [
+                    "class",
+                    "reasons"
+                  ],
                   "additionalProperties": false,
                   "properties": {
-                    "class": { "type": "string" },
+                    "class": {
+                      "type": "string"
+                    },
                     "reasons": {
                       "type": "array",
-                      "items": { "type": "string" },
+                      "items": {
+                        "type": "string"
+                      },
                       "description": "The reasons written at the `unreachable`s this class leads to — one, unless several paths abort for different reasons."
                     }
                   }
@@ -208,27 +384,47 @@
                 "description": "Classes the body answers `unreachable` for that nothing settled. Still in `classes` and still owed a row: what removes an obligation is a proof, and a row written at one may reach the `unreachable` and be refused.",
                 "items": {
                   "type": "object",
-                  "required": ["class", "reasons", "why"],
+                  "required": [
+                    "class",
+                    "reasons",
+                    "why"
+                  ],
                   "additionalProperties": false,
                   "properties": {
-                    "class": { "type": "string" },
+                    "class": {
+                      "type": "string"
+                    },
                     "reasons": {
                       "type": "array",
-                      "items": { "type": "string" },
+                      "items": {
+                        "type": "string"
+                      },
                       "description": "The reasons written at the `unreachable`s this class leads to."
                     },
                     "why": {
                       "description": "What stopped the answer.",
-                      "enum": ["a_rule_went_unread", "the_rules_leave_the_position_nothing", "nothing_was_read_about_the_case", "the_fork_is_not_known_to_be_reached"]
+                      "enum": [
+                        "a_rule_went_unread",
+                        "the_rules_leave_the_position_nothing",
+                        "nothing_was_read_about_the_case",
+                        "the_fork_is_not_known_to_be_reached"
+                      ]
                     }
                   }
                 }
               },
-              "unclassifiedRows": { "type": "integer", "minimum": 0 },
-              "status": { "$ref": "#/$defs/status" },
+              "unclassifiedRows": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "status": {
+                "$ref": "#/$defs/status"
+              },
               "reason": {
                 "description": "Why there is no number, present exactly where `status` is `unavailable`. A behavior no row names was not measured here, so the classes nothing sits in are not classes nothing reaches.",
-                "enum": ["no_rows"]
+                "enum": [
+                  "no_rows"
+                ]
               }
             }
           }
@@ -237,26 +433,60 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["axis", "origin", "side", "value", "hit", "knownWritable", "status"],
+            "required": [
+              "axis",
+              "origin",
+              "side",
+              "value",
+              "hit",
+              "knownWritable",
+              "status"
+            ],
             "additionalProperties": false,
             "properties": {
-              "axis": { "type": "string" },
-              "origin": { "type": "string", "description": "The rule that drew this line — a type's invariant, or a guard." },
-              "side": { "enum": ["below", "at", "above"] },
+              "axis": {
+                "type": "string"
+              },
+              "origin": {
+                "type": "string",
+                "description": "The rule that drew this line — a type's invariant, or a guard."
+              },
+              "side": {
+                "enum": [
+                  "below",
+                  "at",
+                  "above"
+                ]
+              },
               "kind": {
-                "enum": ["at_value", "between_positions"],
+                "enum": [
+                  "at_value",
+                  "between_positions"
+                ],
                 "description": "What this line is a line at. `at_value` is a place of the position `axis` names, which is what an invariant's bound and a guard against a constant draw. `between_positions` is a guard comparing one position against another: the line is where the two hold the same place, `axis` names the left of it and `value` the other position rather than a value. Reading `value` without reading this reads a position's name as a value. Absent in a document written before this key existed, where every line was at a value."
               },
-              "value": { "type": "string", "description": "The other side of the line, as an author would write it: a value where `kind` is `at_value` or absent, and the other position where it is `between_positions`. The place a row happens to satisfy such a line with belongs to that row and not to the line, so it is not written here." },
-              "hit": { "type": "boolean" },
+              "value": {
+                "type": "string",
+                "description": "The other side of the line, as an author would write it: a value where `kind` is `at_value` or absent, and the other position where it is `between_positions`. The place a row happens to satisfy such a line with belongs to that row and not to the line, so it is not written here."
+              },
+              "hit": {
+                "type": "boolean"
+              },
               "knownWritable": {
                 "type": "boolean",
                 "description": "Whether some row could carry this value. False where a rule reaching the value this position sits in was not read in full — a pattern, a disequality, a strict bound on a decimal — so the edge is where the reading stopped rather than where the model does. Such a line is reported and not counted, and no build is refused over it."
               },
-              "status": { "$ref": "#/$defs/status" },
+              "status": {
+                "$ref": "#/$defs/status"
+              },
               "reason": {
                 "description": "Why there is no answer, present exactly where `status` is `unavailable`. `arms_not_asked` and `arms_unreadable` belong to a guard's line only, which is met by getting the comparison to produce a value rather than by writing the value; an invariant's line is met by writing it and is never waiting on the instrumentation. `no_arm_witnesses_it` was a guard's line whose comparison sat inside a condition whose arms did not separate the rows that reached it from the rows that did not — the second operand of an `&&` on the side where it is false. No compiler writes it any more: the comparison carries a site of its own and is observed where it runs. It is here because reports of this version were written carrying it, and a version says what its documents may carry rather than what is emitted today.",
-                "enum": ["arms_not_asked", "arms_unreadable", "no_rows", "no_arm_witnesses_it"]
+                "enum": [
+                  "arms_not_asked",
+                  "arms_unreadable",
+                  "no_rows",
+                  "no_arm_witnesses_it"
+                ]
               }
             }
           }
@@ -264,11 +494,25 @@
         "pairs": {
           "type": "object",
           "description": "Two-class combinations across two positions. Counts rather than a ratio: a combination no row reaches has not been shown unreachable, only untried, so the denominator is not known.",
-          "required": ["total", "covered", "witnessedFeasible", "provenInfeasible", "unknown", "truncated", "status"],
+          "required": [
+            "total",
+            "covered",
+            "witnessedFeasible",
+            "provenInfeasible",
+            "unknown",
+            "truncated",
+            "status"
+          ],
           "additionalProperties": false,
           "properties": {
-            "total": { "type": "integer", "minimum": 0 },
-            "covered": { "type": "integer", "minimum": 0 },
+            "total": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "covered": {
+              "type": "integer",
+              "minimum": 0
+            },
             "witnessedFeasible": {
               "type": "integer",
               "minimum": 0,
@@ -279,16 +523,23 @@
               "minimum": 0,
               "description": "Combinations shown impossible. A candidate that failed to build is not one of these — another value of the same two classes may build."
             },
-            "unknown": { "type": "integer", "minimum": 0 },
+            "unknown": {
+              "type": "integer",
+              "minimum": 0
+            },
             "status": {
-            "$ref": "#/$defs/status",
-            "description": "`partial` where some rows were not read at all: a combination none of the rows seen reaches has not been left untried by anybody."
-          },
-          "reason": {
-            "description": "Why there are no numbers, present exactly where `status` is `unavailable`. How large the space is says nothing about a behavior no row names.",
-            "enum": ["no_rows"]
-          },
-          "truncated": { "type": "boolean" }
+              "$ref": "#/$defs/status",
+              "description": "`partial` where some rows were not read at all: a combination none of the rows seen reaches has not been left untried by anybody."
+            },
+            "reason": {
+              "description": "Why there are no numbers, present exactly where `status` is `unavailable`. How large the space is says nothing about a behavior no row names.",
+              "enum": [
+                "no_rows"
+              ]
+            },
+            "truncated": {
+              "type": "boolean"
+            }
           }
         },
         "claimsOffAxis": {
@@ -296,15 +547,33 @@
           "description": "Claims about positions this report has no axis for — past the axis limit, or deeper than the walk goes. Named by position, and carrying `why` exactly where nothing settled the claim.",
           "items": {
             "type": "object",
-            "required": ["at", "class", "reasons"],
+            "required": [
+              "at",
+              "class",
+              "reasons"
+            ],
             "additionalProperties": false,
             "properties": {
-              "at": { "type": "string" },
-              "class": { "type": "string" },
-              "reasons": { "type": "array", "items": { "type": "string" } },
+              "at": {
+                "type": "string"
+              },
+              "class": {
+                "type": "string"
+              },
+              "reasons": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
               "why": {
                 "description": "What stopped the answer, present exactly where nothing settled the claim.",
-                "enum": ["a_rule_went_unread", "the_rules_leave_the_position_nothing", "nothing_was_read_about_the_case", "the_fork_is_not_known_to_be_reached"]
+                "enum": [
+                  "a_rule_went_unread",
+                  "the_rules_leave_the_position_nothing",
+                  "nothing_was_read_about_the_case",
+                  "the_fork_is_not_known_to_be_reached"
+                ]
               }
             }
           }
@@ -312,20 +581,26 @@
         "notDerivable": {
           "type": "array",
           "description": "Positions the reading ran to the end at and divided no way. Not a finding: no boundary obligation was established here, so nothing is reported against the rows. Not a statement that nothing is owed either — a bound one type away from the position a behavior takes lands in this list, and the reading cannot tell that from a position nothing bounds. A position something is written about that the reading could not take apart is in `notRead` instead, and used to be in this one. Read `boundariesMeasure` for whether the measure was made.",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "notRead": {
           "type": "array",
           "description": "Positions something in the body names that this reading did not turn into a line, each with what stopped it. Nothing is established about these either way, which is what separates them from `notDerivable` — and which limit stopped each one is what says whose work it is to lift. Not in `required`: a document written before this field existed is still a document of this version.",
           "items": {
             "type": "object",
-            "required": ["position", "reason"],
+            "required": [
+              "position",
+              "reason"
+            ],
             "additionalProperties": false,
             "properties": {
-              "position": { "type": "string" },
+              "position": {
+                "type": "string"
+              },
               "reason": {
-                "description": "`unsupported_syntax` is an expression the terms do not name; `unsupported_domain` is a comparison against values no line can be drawn on; `unsupported_partition_shape` is a comparison relating two positions rather than dividing one; `depth_limit` is the walk stopping before it reached the position; `type_unresolved` is a type at the position that could not be worked out; `unsupported_traversal` is values held inside something the walk does not reach into. Every one of them is a fact about the compiler and none is a fact about the model.",
-                "enum": ["unsupported_syntax", "unsupported_domain", "unsupported_partition_shape", "depth_limit", "type_unresolved", "unsupported_traversal"]
+                "$ref": "#/$defs/notReadReason"
               }
             }
           }
@@ -333,27 +608,46 @@
         "omitted": {
           "type": "array",
           "description": "Positions dropped for being past the axis limit.",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
     "signature": {
       "type": "object",
       "description": "What the rows establish about the cases of the behavior's inputs and its output. Absent where the behavior has no signature to read.",
-      "required": ["status", "output", "inputs"],
+      "required": [
+        "status",
+        "output",
+        "inputs"
+      ],
       "additionalProperties": false,
       "properties": {
-        "status": { "$ref": "#/$defs/status" },
+        "status": {
+          "$ref": "#/$defs/status"
+        },
         "reason": {
           "description": "Why there is no number, present exactly where `status` is `unavailable`. `no_rows` is a behavior no row names; `not_a_sum` is a signature with no sum anywhere in it, which no row could give a case to cover.",
-          "enum": ["no_rows", "not_a_sum"]
+          "enum": [
+            "no_rows",
+            "not_a_sum"
+          ]
         },
         "output": {
           "type": "object",
-          "required": ["declared", "specified", "observed", "verified", "unclassifiedRows"],
+          "required": [
+            "declared",
+            "specified",
+            "observed",
+            "verified",
+            "unclassifiedRows"
+          ],
           "additionalProperties": false,
           "properties": {
-            "declared": { "$ref": "#/$defs/caseNames" },
+            "declared": {
+              "$ref": "#/$defs/caseNames"
+            },
             "specified": {
               "$ref": "#/$defs/caseNames",
               "description": "Cases a row expects. Somebody wrote down that the model owes this answer."
@@ -378,21 +672,36 @@
           "description": "One entry per parameter, in order. A parameter that is not a sum has nothing to cover and reports empty sets.",
           "items": {
             "type": "object",
-            "required": ["declared", "specified", "executed", "verified", "unclassifiedRows"],
+            "required": [
+              "declared",
+              "specified",
+              "executed",
+              "verified",
+              "unclassifiedRows"
+            ],
             "additionalProperties": false,
             "properties": {
-              "declared": { "$ref": "#/$defs/caseNames" },
-              "specified": { "$ref": "#/$defs/caseNames" },
+              "declared": {
+                "$ref": "#/$defs/caseNames"
+              },
+              "specified": {
+                "$ref": "#/$defs/caseNames"
+              },
               "executed": {
                 "$ref": "#/$defs/caseNames",
                 "description": "Cases the behavior was applied to. Not `observed`: nothing is claimed about what came back."
               },
-              "verified": { "$ref": "#/$defs/caseNames" },
+              "verified": {
+                "$ref": "#/$defs/caseNames"
+              },
               "excluded": {
                 "$ref": "#/$defs/caseNames",
                 "description": "Cases the position's own rules refuse. Declared and not coverable: no value of one can be constructed, so they are counted out of what the rows are held to."
               },
-              "unclassifiedRows": { "type": "integer", "minimum": 0 }
+              "unclassifiedRows": {
+                "type": "integer",
+                "minimum": 0
+              }
             }
           }
         }
@@ -401,60 +710,124 @@
     "caseNames": {
       "type": "array",
       "description": "Case names, sorted, so that two runs of the same model compare.",
-      "items": { "type": "string" }
+      "items": {
+        "type": "string"
+      }
     },
     "incompleteness": {
       "type": "object",
-      "required": ["code", "scope", "subject"],
+      "required": [
+        "code",
+        "scope",
+        "subject"
+      ],
       "additionalProperties": false,
       "properties": {
         "scope": {
-          "enum": ["behavior", "source", "module", "position"],
+          "enum": [
+            "behavior",
+            "source",
+            "module",
+            "position"
+          ],
           "description": "What `subject` names, and so what the reason counts against. A `behavior` and a `position` count against the behavior they are in, and a position is in one. A `module` counts against every behavior in it, because that is what a module holds. A `source` counts against every behavior too, and not for that reason: one is written only where the source was not evaluated, so which behaviors had rows in it is exactly what could not be read."
         },
         "code": {
           "description": "`observation_absent` is a source none of whose rows were observed, whatever stopped them — the diagnostics say what. `linkage_failed` is the generated classes not linking: the case it exists for is the runtime being off the host's classpath, and the JVM raises the same error for a class it will not verify or accept the format of, which is why the word is the error and not one of its causes. One place writes it, an example whose evaluation raised one and observed nothing, so the rows behind it did not run and that is part of what it says. It had three, and the other two were a value being built after the rows had been read — those are the generator's to report and are not written here. `instrumentation_absent` is the classes an arm-measuring evaluation needs not having been made, named for the absence rather than for a backend that failed or inputs that were not there, which nothing here can tell apart. `answerer_not_established` is a row that was not handed to what answers its behavior, because nothing could establish that what answers it was built against this model — either the two builds say different things about something a value crossing between them depends on, or what the answer carries could not be read at all. The rows behind it were read: they were built and held to their invariants, and what is missing is only what the running would have decided. `probe_mapping_lost` is what it was called, and no compiler writes it any more: it is here because reports of this version were written carrying it, and a version says what its documents may carry rather than what is emitted today.",
-          "enum": ["value_unreadable", "value_truncated", "row_undecided",
-                   "answerer_not_established", "observation_absent",
-                   "linkage_failed", "instrumentation_absent", "probe_mapping_lost"]
+          "enum": [
+            "value_unreadable",
+            "value_truncated",
+            "row_undecided",
+            "answerer_not_established",
+            "observation_absent",
+            "linkage_failed",
+            "instrumentation_absent",
+            "probe_mapping_lost"
+          ]
         },
         "subject": {
           "type": "string",
           "description": "What the reason is about, as an identity. A `behavior`, a `module` and a `position` are named as the author wrote them. A `source` is named as the compile was handed it, which is the caller's own identity for the file and not a name to show a reader: a build passing a list of files gets that file's position in the list, and an editor keyed on document URIs gets the URI. What to call a source in front of a person is decided where a report is rendered, since it depends on which other files are being read beside it — and `sources` says what this run decided, so the identity can be looked up without holding what was handed over."
         },
-        "at": { "$ref": "#/$defs/at" }
+        "at": {
+          "$ref": "#/$defs/at"
+        }
       }
     },
     "at": {
       "type": "object",
       "description": "Where in which source. A position alone cannot say which file, since a module's rows are written across its own source and any attached ones. It says where this compile met the code, which `writtenAt` says whether to read as where the code is written.",
-      "required": ["sourceId", "line", "column"],
+      "required": [
+        "sourceId",
+        "line",
+        "column"
+      ],
       "additionalProperties": false,
       "properties": {
         "sourceId": {
           "type": "string",
           "description": "The source, as an identity, read the way a `source` subject is. `sources` says what it is called."
         },
-        "line": { "type": "integer" },
-        "column": { "type": "integer" },
-        "writtenAt": { "$ref": "#/$defs/writtenAt" }
+        "line": {
+          "type": "integer"
+        },
+        "column": {
+          "type": "integer"
+        },
+        "writtenAt": {
+          "$ref": "#/$defs/writtenAt"
+        }
       }
     },
     "writtenAt": {
       "type": "object",
       "description": "Whether the position beside this is where the code it names is written. A body is copied into everything that calls it, and a copy from a module this compile has no source for is given the call site, since the positions it was written at name a file nobody holds. Absent in a document written before this key existed, which is not the same as `here`: such a document does not answer the question.",
-      "required": ["kind"],
+      "required": [
+        "kind"
+      ],
       "additionalProperties": false,
       "properties": {
-        "kind": { "enum": ["here", "outOfSight"] },
+        "kind": {
+          "enum": [
+            "here",
+            "outOfSight"
+          ]
+        },
         "declaration": {
           "type": "string",
           "description": "The name a reader of the file the position is in reaches that code by — `List.filter`. Written where `kind` is `outOfSight` and never otherwise. How it is reached and not which module declares it: a name reached from out of sight is qualified, so it is already enough to look the code up by."
         }
       },
-      "if": { "properties": { "kind": { "const": "outOfSight" } } },
-      "then": { "required": ["declaration"] },
-      "else": { "not": { "required": ["declaration"] } }
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "outOfSight"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "declaration"
+        ]
+      },
+      "else": {
+        "not": {
+          "required": [
+            "declaration"
+          ]
+        }
+      }
+    },
+    "notReadReason": {
+      "description": "Why a reading is short of the rules. `unsupported_syntax` is an expression the terms do not name; `unsupported_domain` is a comparison against values no line can be drawn on; `unsupported_partition_shape` is a comparison relating two positions rather than dividing one; `depth_limit` is the walk stopping before it reached the position; `type_unresolved` is a type at the position that could not be worked out; `unsupported_traversal` is values held inside something the walk does not reach into. Every one of them is a fact about the compiler and none is a fact about the model.",
+      "enum": [
+        "unsupported_syntax",
+        "unsupported_domain",
+        "unsupported_partition_shape",
+        "depth_limit",
+        "type_unresolved",
+        "unsupported_traversal"
+      ]
     }
   }
 }

--- a/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
@@ -493,7 +493,14 @@ class AMeasureWithNoNumberSaysWhyTest {
                 List.of(), java.util.Set.of(), java.util.Set.of(),
                 MeasurementStatus.COMPLETE, Adequacy.BranchEvidence.Reason.NO_BODY));
         assertThrows(IllegalArgumentException.class, () -> new PartitionEvidence.AxisCoverage(
-                "a", "a", List.of(), java.util.Set.of(), 0, MeasurementStatus.NOT_MEASURED, null));
+                "a", "a", List.of(), java.util.Set.of(), 0, MeasurementStatus.NOT_MEASURED, null,
+                PartitionEvidence.AxisCoverage.READ_IN_FULL));
+        // And a position handed over with no account of what was read about its values. The classes
+        // beside it mean one thing on a reading that ran to the end and another on one that did
+        // not, so a coverage that does not say which is a set of classes nobody can read.
+        assertThrows(IllegalArgumentException.class, () -> new PartitionEvidence.AxisCoverage(
+                "a", "a", List.of(), java.util.Set.of(), 0, MeasurementStatus.COMPLETE, null,
+                null));
 
         // The kinds are held against each other and not only for presence. A measure carrying a
         // reason of the other kind is the confusion the two words were split to prevent: it says its

--- a/souther-compiler/src/test/java/souther/compiler/AMeasuredPositionSaysHowFarItsRulesWereReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasuredPositionSaysHowFarItsRulesWereReadTest.java
@@ -87,10 +87,15 @@ class AMeasuredPositionSaysHowFarItsRulesWereReadTest {
         assertEquals(2, axis.get("classes").size(), axis.toString());
         assertEquals("partial", axis.get("read").get("extent").asText(),
                 "the axis says how much of what its position's rules say was read");
-        assertTrue(axis.get("read").has("stoppedBy"), axis.toString());
+        // The word, and not only that there is one. What stopped this reading is that it never
+        // reached the rules behind the option — which is not a rule it read and could not use, and
+        // saying so would publish a cause this was not observed to have.
+        assertEquals("rules_not_read_at_all", axis.get("read").get("stoppedBy").asText(),
+                axis.toString());
 
         String human = humanOf(MEASURED_IN_PART);
-        assertTrue(human.contains("read in part: i.assignee"),
+        assertTrue(human.contains(
+                        "read in part: i.assignee (the rules written about it were not reached"),
                 "a measured position says it is read in part, which a position with no axis"
                         + " does not: " + human);
         assertFalse(human.contains("not read: i.assignee"),

--- a/souther-compiler/src/test/java/souther/compiler/AMeasuredPositionSaysHowFarItsRulesWereReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasuredPositionSaysHowFarItsRulesWereReadTest.java
@@ -1,0 +1,110 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A position the axes measure says how far its rules were read.
+ *
+ * <p>The classes beside a position mean one thing on a reading that ran to the end and another on
+ * one that did not: a class arrived at from part of the rules is a value the model singled out, and
+ * a rule that went unread may yet refuse it. The axis has carried that since it was measured, with
+ * nothing reading it — so two classes were offered and neither surface said what they rested on.
+ *
+ * <p>Said apart from a position with no axis at all. Both are readings that did not finish, and
+ * they are not the same thing to act on: reading the same sentence about a position with three
+ * classes as about one with none says the numbers beside it are not to be believed.
+ */
+class AMeasuredPositionSaysHowFarItsRulesWereReadTest {
+
+    /**
+     * A position the axes measure whose rules were not read in full.
+     *
+     * <p>The option divides `i.assignee` into `None` and `Some`, so the position is measured. What
+     * `Assignee` says about the value inside is behind the option, and this reading does not go
+     * there.
+     */
+    private static final String MEASURED_IN_PART = """
+            module o
+
+            data Assignee = String
+                invariant String.length(value) >= 1
+
+            data Issue = { assignee: Assignee? }
+            data Accepted = { at: Int }
+
+            behavior classify : (i: Issue) -> Accepted
+            """;
+
+    /** The control: the same shape with nothing left unread. */
+    private static final String READ_IN_FULL = """
+            module u
+
+            data Low
+            data Accepted = { at: Int }
+
+            behavior classify : (n: Int) -> Accepted | Low
+                constructs Accepted, Low
+
+            let classify (n) = {
+                guard n >= 60 else Low
+                Accepted { at = n }
+            }
+            """;
+
+    private static AdequacyReport reportOf(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation);
+    }
+
+    private static String humanOf(String source) {
+        return reportOf(source).human(SourceNameResolver.identity());
+    }
+
+    private static JsonNode partitionOf(String source) {
+        JsonNode document = JsonMapper.builder().build()
+                .readTree(reportOf(source).json(SourceNameResolver.identity()));
+        return document.get("modules").get(0).get("behaviors").get(0).get("partition");
+    }
+
+    @Test
+    void aMeasuredPositionIsToldApartFromOneWithNoAxis() {
+        JsonNode axis = partitionOf(MEASURED_IN_PART).get("axes").get(0);
+        assertEquals("i.assignee", axis.get("path").asText());
+        assertEquals(2, axis.get("classes").size(), axis.toString());
+        assertEquals("partial", axis.get("read").get("extent").asText(),
+                "the axis says how much of what its position's rules say was read");
+        assertTrue(axis.get("read").has("stoppedBy"), axis.toString());
+
+        String human = humanOf(MEASURED_IN_PART);
+        assertTrue(human.contains("read in part: i.assignee"),
+                "a measured position says it is read in part, which a position with no axis"
+                        + " does not: " + human);
+        assertFalse(human.contains("not read: i.assignee"),
+                "and is not said as one nothing divided: " + human);
+    }
+
+    /** Nothing is invented: a position whose rules were read in full gains no line either way. */
+    @Test
+    void aPositionWhoseRulesWereReadInFullGainsNoLine() {
+        String human = humanOf(READ_IN_FULL);
+        assertFalse(human.contains("read in part"), human);
+
+        JsonNode read = partitionOf(READ_IN_FULL).get("axes").get(0).get("read");
+        assertEquals("complete", read.get("extent").asText());
+        assertFalse(read.has("stoppedBy"), "nothing stopped it, so nothing says what did: " + read);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/BothSurfacesSayWhatWasFoundAboutAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/BothSurfacesSayWhatWasFoundAboutAPositionTest.java
@@ -1,0 +1,87 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a report found it could not read about a position is one reading, and both surfaces write
+ * from it.
+ *
+ * <p>They used to be assembled twice. A person reading the report was shown two lists — every rule
+ * this compiler could not turn into a line, and the positions it divided no way — and the document
+ * was written from the second alone. So a rule left unread at a position the axes went on to
+ * measure reached one reader and stopped there, and `souther examples --strict` and a person
+ * reading the same run were told different things about the same position.
+ */
+class BothSurfacesSayWhatWasFoundAboutAPositionTest {
+
+    /**
+     * A position the axes measure, with a rule about it the reading could not take in.
+     *
+     * <p>The guard divides `n`, so the position has classes. The second guard compares a form the
+     * reading does not take apart, which is a rule about `n` that no line came from — and which no
+     * list of positions divided no way has an entry for, because this one was divided.
+     */
+    private static final String MEASURED_AND_UNREAD = """
+            module t
+
+            data Low
+            data Accepted = { at: Int }
+
+            behavior classify : (n: Int) -> Accepted | Low
+                constructs Accepted, Low
+
+            let classify (n) = {
+                guard n >= 60 else Low
+                guard Int.clamp(0, 100, n) > 70 else Low
+                Accepted { at = n }
+            }
+            """;
+
+    private static AdequacyReport reportOf(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation);
+    }
+
+    private static String humanOf(String source) {
+        return reportOf(source).human(SourceNameResolver.identity());
+    }
+
+    private static JsonNode partitionOf(String source) {
+        JsonNode document = JsonMapper.builder().build()
+                .readTree(reportOf(source).json(SourceNameResolver.identity()));
+        return document.get("modules").get(0).get("behaviors").get(0).get("partition");
+    }
+
+    /** Every position the document says something was not read about, as `position:reason`. */
+    private static List<String> documentSaysNotRead(String source) {
+        List<String> said = new ArrayList<>();
+        partitionOf(source).get("notRead").forEach(each ->
+                said.add(each.get("position").asText() + ":" + each.get("reason").asText()));
+        return said;
+    }
+
+    @Test
+    void aPositionOnlyTheHumanLineNamedIsInTheDocumentToo() {
+        assertTrue(humanOf(MEASURED_AND_UNREAD).contains("not read: n"),
+                humanOf(MEASURED_AND_UNREAD));
+
+        assertEquals(List.of("n:unsupported_syntax"), documentSaysNotRead(MEASURED_AND_UNREAD),
+                "the document says what the report said");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
@@ -159,9 +159,11 @@ class EverySchemaWordIsAccountedForTest {
                     List.of("$defs", "partition", "properties", "axesMeasure", "properties",
                             "reason"),
                     PartitionEvidence.Partitioned.Reason.class),
-            new Vocabulary("partition.notRead[].reason",
-                    List.of("$defs", "partition", "properties", "notRead", "items", "properties",
-                            "reason"),
+            // Written once and referred to twice: a position's reading and a rule left unread are
+            // the same question asked of two things, and two copies of the words would be two
+            // places for one of them to gain a word the other does not have.
+            new Vocabulary("notReadReason",
+                    List.of("$defs", "notReadReason"),
                     souther.compiler.partition.UndividedPosition.Reason.class),
             new Vocabulary("partition.boundariesMeasure.reason",
                     List.of("$defs", "partition", "properties", "boundariesMeasure", "properties",
@@ -258,6 +260,22 @@ class EverySchemaWordIsAccountedForTest {
                 allowedAt(schema(), List.of("$defs", "behavior", "properties", "implementation")));
     }
 
+    /**
+     * And the other field with no enum behind it: how far a position's rules were read, which is
+     * two arms of a sealed type rather than an enumeration.
+     */
+    @Test
+    void theOtherFieldWithNoEnumBehindItIsWrittenFromTheArmsOfAReading() {
+        assertEquals(Set.of(AdequacyReport.readingWord(
+                        new PartitionEvidence.AxisCoverage.Reading.InFull()),
+                        AdequacyReport.readingWord(
+                                new PartitionEvidence.AxisCoverage.Reading.InPart(
+                                        souther.compiler.partition.UndividedPosition.Reason
+                                                .DEPTH_LIMIT))),
+                allowedAt(schema(), List.of("$defs", "partition", "properties", "axes", "items",
+                        "properties", "read", "properties", "extent")));
+    }
+
     /** Every enumerated field of the schema is either held above or named as the exception. */
     @Test
     void noEnumeratedFieldIsUnaccountedFor() {
@@ -268,6 +286,7 @@ class EverySchemaWordIsAccountedForTest {
             held.add("/" + String.join("/", each.at()));
         }
         held.add("/$defs/behavior/properties/implementation");
+        held.add("/$defs/partition/properties/axes/items/properties/read/properties/extent");
 
         List<String> unaccounted = paths.stream().filter(p -> !held.contains(p)).toList();
         assertEquals(List.of(), unaccounted,

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
@@ -48,6 +48,9 @@
         "axes" : [ {
           "axis" : "discount/item.note",
           "path" : "item.note",
+          "read" : {
+            "extent" : "complete"
+          },
           "classes" : [ "None", "Some" ],
           "covered" : [ "None", "Some" ],
           "excluded" : [ ],
@@ -143,6 +146,9 @@
         "axes" : [ {
           "axis" : "台帳へ書く/指示.区分",
           "path" : "指示.区分",
+          "read" : {
+            "extent" : "complete"
+          },
           "classes" : [ "通常", "速達", "冷蔵" ],
           "covered" : [ "冷蔵", "通常", "速達" ],
           "excluded" : [ ],
@@ -248,6 +254,10 @@
         "axes" : [ {
           "axis" : "出荷する/指示.重量",
           "path" : "指示.重量",
+          "read" : {
+            "extent" : "partial",
+            "stoppedBy" : "unsupported_syntax"
+          },
           "classes" : [ "指示.重量/1 <= x <= 30000", "指示.重量/30000 < x" ],
           "covered" : [ "指示.重量/1 <= x <= 30000", "指示.重量/30000 < x" ],
           "excluded" : [ ],
@@ -257,6 +267,9 @@
         }, {
           "axis" : "出荷する/指示.区分",
           "path" : "指示.区分",
+          "read" : {
+            "extent" : "complete"
+          },
           "classes" : [ "通常", "速達", "冷蔵" ],
           "covered" : [ "冷蔵", "通常", "速達" ],
           "excluded" : [ ],
@@ -313,9 +326,6 @@
         },
         "notDerivable" : [ "指示.記録時刻" ],
         "notRead" : [ {
-          "position" : "指示.品目",
-          "reason" : "unsupported_traversal"
-        }, {
           "position" : "指示.受付日",
           "reason" : "unsupported_syntax"
         }, {
@@ -324,6 +334,9 @@
         }, {
           "position" : "指示.集荷時刻",
           "reason" : "unsupported_syntax"
+        }, {
+          "position" : "指示.品目",
+          "reason" : "unsupported_traversal"
         } ],
         "omitted" : [ ]
       },
@@ -353,6 +366,10 @@
         "kind" : "partition_not_read",
         "disposition" : "reported",
         "subject" : "指示.品目"
+      }, {
+        "kind" : "partition_read_in_part",
+        "disposition" : "reported",
+        "subject" : "指示.重量"
       } ]
     } ]
   } ],


### PR DESCRIPTION
Closes #791.

## What it measures

A report can measure a position and, in the same breath, say that a rule about
it went unread — and only the human surface says the second part. Over the
example corpus, of the positions a rule was left unread at:

| | |
| --- | --- |
| named by both surfaces | 55 |
| **named by the human line and absent from the document** | **64** |

The other half nothing wrote at all. Of the 244 axes a report shows, **85 rest
on a reading that did not run to the end** — 62 stopped where the walk does not
enter what the position holds, 19 at a rule form nothing read, 4 at a rule
relating two positions — and neither surface said so.

```souther
data Assignee = String
    invariant String.length(value) >= 1

data Issue = { assignee: Assignee? }
behavior classify : (i: Issue) -> Accepted
```

`i.assignee` is offered as `None` and `Some`. What `Assignee` says about the
value inside is behind the option and was not read. Nothing said that.

## Why

`Adequacy` built the human line out of two lists — every rule this compiler
could not turn into a line, and the `CannotDerive` arm of the positions it
divided no way — and `AdequacyReport` wrote only the second. One question,
answered by reading two of them in one place and one of them in the other.

And what an axis carries about how far its rules were read has had no consumer
since it was measured. That is the half nothing wrote.

## The shape

- `PartitionEvidence.notRead()` is the one reading, and both surfaces write from
  it. The merge and its deduplication live there rather than in each surface.
- `AxisCoverage.Reading` is `InFull | InPart(reason)`, taken from what the axis
  already carries. Not a second account worked out beside the lists: those
  answer about rules, and this answers about a position.
- `PARTITION_READ_IN_PART` is its own finding kind, so a measured position is
  said apart from one with no axis. The sealed switches over the kinds made
  every reader say what it does with it.
- `BlockReason.of(UnreadReason)` is the one projection between the two
  vocabularies, so a reader holding a reading's completeness and one holding a
  block reason cannot come to different words for one stop.

In the document, `status` and `reason` say whether a number was arrived at and
why there is none. How far a reading got is a different question about a
position that *has* numbers, so it is `extent` and `stoppedBy` — a test that
holds every `status` node to the measure vocabulary is what caught the overload.
The words for what stopped a reading are written once (`$defs/notReadReason`)
and referred to twice.

## What was left alone

Whether the unread remainder could refuse one of the classes offered is not
judged. `Completeness` says how far a reading got; whether what it missed bears
on the answer is a different question at a different altitude, and folding it in
would turn a `complete | partial` observation into a semantic verdict. If it is
ever wanted it is an orthogonal axis, not a wider enum.

The reasons are published as they are. `NOT_REACHED` was measured before this
was written, to check it is not a reader's control flow reported as a fact about
the model: of the stops that fire in the corpus, all are positions whose
contents sit behind a shape the walk does not enter, and every one is guarded by
"is there any rule under what is being left". No depth limit and no recursion
guard fires. It is an honest reading.

## Measured

- `CI=1 mvn -Plint verify` green: syntax 114, formatter 2233, compiler 5115,
  build driver 10, LSP 255, CLI 340, benchmarks 7 and 13.
- The conformance snapshot moved by the `read` field alone (+20/−3 in one
  document).
- `crm` gains 40 `read in part` lines beside its 232 existing `not read` lines;
  the corpus total is the 85 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
