### PR TITLE
Answer what a case means where a subject's cases are

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/CaseSpace.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CaseSpace.java
@@ -26,9 +26,6 @@ import java.util.Set;
  * arity and or-pattern-ness while emitting, which is what {@code Core}'s own contract says it must
  * not do.
  *
- * <p>The selectors are ordered, in the order the subject states them. A {@code match} reads that
- * order as the order its arms are tried against, and a report reads it to list what is missing, so
- * the sequence is part of the answer and not an artefact of how it was collected.
  */
 sealed interface CaseSpace {
 
@@ -40,13 +37,16 @@ sealed interface CaseSpace {
     String described();
 
     /**
-     * The cases, in the order the subject states them; empty for a subject that has none.
+     * The cases; empty for a subject that has none.
      *
-     * <p>The order is the subject's own — a union's members as written, a sum's cases as declared,
-     * an optional's present carrier before its absent one. It is what a report listing what a match
-     * left out is stable against, and what a reader walking the cases gets. It is not the order arms
-     * are tried in: which arm of a {@code match} takes a value is decided by the order the arms are
-     * written, which is the match's and not the subject's.
+     * <p>Ordered so that two readings of one subject list them alike — a report saying what a match
+     * left out reads this, and an order that came out differently each time would move a message
+     * nothing about the program had changed. A sum's cases come as declared and an optional's
+     * present carrier before its absent one; a union's members are a set, so what comes out is that
+     * set's iteration order and no claim is made about which member was written first.
+     *
+     * <p>It is not the order arms are tried in. Which arm of a {@code match} takes a value is
+     * decided by the order the arms are written, which is the match's and not the subject's.
      */
     List<CaseSelector> selectors();
 
@@ -147,7 +147,7 @@ sealed interface CaseSpace {
         }
         List<CaseSelector> out = new ArrayList<>();
         for (TypeSymbol member : seen) {
-            out.add(CaseSelector.direct(member, TypeOps.caseBindType(member)));
+            out.add(CaseSelector.direct(member));
         }
         return out;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/CaseSpace.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CaseSpace.java
@@ -39,7 +39,15 @@ sealed interface CaseSpace {
      *  {@code Option}. Written here beside the cases so a diagnostic never spells it a second way. */
     String described();
 
-    /** The cases, in the order the subject states them; empty for a subject that has none. */
+    /**
+     * The cases, in the order the subject states them; empty for a subject that has none.
+     *
+     * <p>The order is the subject's own — a union's members as written, a sum's cases as declared,
+     * an optional's present carrier before its absent one. It is what a report listing what a match
+     * left out is stable against, and what a reader walking the cases gets. It is not the order arms
+     * are tried in: which arm of a {@code match} takes a value is decided by the order the arms are
+     * written, which is the match's and not the subject's.
+     */
     List<CaseSelector> selectors();
 
     /** A subject with no cases: nothing selects from it and nothing opens it. */
@@ -56,7 +64,27 @@ sealed interface CaseSpace {
         }
     }
 
-    /** A subject something can be selected from. */
+    /**
+     * An optional, whose two carriers are the present one and the absent one.
+     *
+     * <p>Its own arm because what may be <em>written</em> over one differs, and a reader choosing
+     * those rules reads this rather than asking the subject's type a second time. Every form that
+     * admits a different surface is an arm here, so gaining one is a compile error at each reader
+     * that decides by form rather than a silent fall into the general reading.
+     */
+    record Optional(Type subject, List<CaseSelector> selectors) implements CaseSpace {
+
+        public Optional {
+            selectors = List.copyOf(selectors);
+        }
+
+        @Override
+        public String described() {
+            return "Option";
+        }
+    }
+
+    /** A subject whose cases are named data: a union's members, or a sum's declared cases. */
     record Cases(Type subject, String described, List<CaseSelector> selectors) implements CaseSpace {
 
         public Cases {
@@ -67,22 +95,21 @@ sealed interface CaseSpace {
     /**
      * What {@code subject} can be selected as.
      *
-     * <p>The one place the three forms are told apart. An optional is read before a name is, because
+     * <p>The one place the forms are told apart. An optional is read before a name is, because
      * {@code Option} is not a declaration a module holds; a union is read before a name because it
      * has no name to look up.
      */
     static CaseSpace of(Type subject, Symbols symbols) {
         if (subject instanceof Type.OptionOf option) {
-            return new Cases(subject, "Option", List.of(
-                    new CaseSelector(TypeSymbol.SOME, new Refinement.Wrapped(option.element())),
-                    new CaseSelector(TypeSymbol.NONE, new Refinement.Absent())));
+            return new Optional(subject, List.of(
+                    CaseSelector.optionPresent(option.element()), CaseSelector.optionAbsent()));
         }
         if (subject instanceof Type.Union union) {
-            return new Cases(subject, "union `" + Type.show(union) + "`", itself(union.members()));
+            return new Cases(subject, "union `" + Type.show(union) + "`", direct(union.members()));
         }
         if (subject instanceof Type.Ref ref
                 && symbols.declarations().declaration(ref.name().key()) instanceof Hir.SumData sum) {
-            return new Cases(subject, "data `" + sum.name() + "`", itself(TypeOps.caseNames(sum)));
+            return new Cases(subject, "data `" + sum.name() + "`", direct(TypeOps.caseNames(sum)));
         }
         return new Plain(subject);
     }
@@ -113,14 +140,14 @@ sealed interface CaseSpace {
 
     /** Cases whose carrier is the value itself, de-duplicated the way the subject states them: a
      *  member written twice is one case, and the first spelling is the one the order keeps. */
-    private static List<CaseSelector> itself(Iterable<TypeSymbol> members) {
+    private static List<CaseSelector> direct(Iterable<TypeSymbol> members) {
         Set<TypeSymbol> seen = new LinkedHashSet<>();
         for (TypeSymbol member : members) {
             seen.add(member);
         }
         List<CaseSelector> out = new ArrayList<>();
         for (TypeSymbol member : seen) {
-            out.add(new CaseSelector(member, new Refinement.Itself(TypeOps.caseBindType(member))));
+            out.add(CaseSelector.direct(member, TypeOps.caseBindType(member)));
         }
         return out;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/CaseSpace.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CaseSpace.java
@@ -1,0 +1,127 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.types.CaseSelector;
+import souther.compiler.types.Refinement;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The cases a subject can be selected as, worked out once from the subject's type.
+ *
+ * <p>A subject is one of three things and they are told apart here and nowhere else: an optional,
+ * whose two carriers are the present one and the absent one; an anonymous union, whose cases are its
+ * members; a named sum, whose cases are the ones declared with it. Anything else has no cases, and
+ * that is an answer rather than a failure — what a reader does about a subject it cannot open is the
+ * reader's ({@code E1202} for a {@code match}).
+ *
+ * <p>Everything a later stage needs to know about a case is on the {@link CaseSelector}: what to
+ * test, and what the value is once the test answers. So a reader never asks the subject a second
+ * time. That is the rule this type exists to keep — the backend used to re-derive optional-ness,
+ * arity and or-pattern-ness while emitting, which is what {@code Core}'s own contract says it must
+ * not do.
+ *
+ * <p>The selectors are ordered, in the order the subject states them. A {@code match} reads that
+ * order as the order its arms are tried against, and a report reads it to list what is missing, so
+ * the sequence is part of the answer and not an artefact of how it was collected.
+ */
+sealed interface CaseSpace {
+
+    /** The type the cases are of. */
+    Type subject();
+
+    /** How a report names what is being selected from: {@code union `A | B`}, {@code data `X`},
+     *  {@code Option}. Written here beside the cases so a diagnostic never spells it a second way. */
+    String described();
+
+    /** The cases, in the order the subject states them; empty for a subject that has none. */
+    List<CaseSelector> selectors();
+
+    /** A subject with no cases: nothing selects from it and nothing opens it. */
+    record Plain(Type subject) implements CaseSpace {
+
+        @Override
+        public String described() {
+            return Type.show(subject);
+        }
+
+        @Override
+        public List<CaseSelector> selectors() {
+            return List.of();
+        }
+    }
+
+    /** A subject something can be selected from. */
+    record Cases(Type subject, String described, List<CaseSelector> selectors) implements CaseSpace {
+
+        public Cases {
+            selectors = List.copyOf(selectors);
+        }
+    }
+
+    /**
+     * What {@code subject} can be selected as.
+     *
+     * <p>The one place the three forms are told apart. An optional is read before a name is, because
+     * {@code Option} is not a declaration a module holds; a union is read before a name because it
+     * has no name to look up.
+     */
+    static CaseSpace of(Type subject, Symbols symbols) {
+        if (subject instanceof Type.OptionOf option) {
+            return new Cases(subject, "Option", List.of(
+                    new CaseSelector(TypeSymbol.SOME, new Refinement.Wrapped(option.element())),
+                    new CaseSelector(TypeSymbol.NONE, new Refinement.Absent())));
+        }
+        if (subject instanceof Type.Union union) {
+            return new Cases(subject, "union `" + Type.show(union) + "`", itself(union.members()));
+        }
+        if (subject instanceof Type.Ref ref
+                && symbols.declarations().declaration(ref.name().key()) instanceof Hir.SumData sum) {
+            return new Cases(subject, "data `" + sum.name() + "`", itself(TypeOps.caseNames(sum)));
+        }
+        return new Plain(subject);
+    }
+
+    /** Whether {@code name} is one of these cases. */
+    default boolean holds(TypeSymbol name) {
+        return selector(name) != null;
+    }
+
+    /** The case {@code name} selects, or null where it selects none of these. */
+    default CaseSelector selector(TypeSymbol name) {
+        for (CaseSelector selector : selectors()) {
+            if (selector.name().equals(name)) {
+                return selector;
+            }
+        }
+        return null;
+    }
+
+    /** The names of these cases, in the order the subject states them. */
+    default List<TypeSymbol> names() {
+        List<TypeSymbol> out = new ArrayList<>();
+        for (CaseSelector selector : selectors()) {
+            out.add(selector.name());
+        }
+        return out;
+    }
+
+    /** Cases whose carrier is the value itself, de-duplicated the way the subject states them: a
+     *  member written twice is one case, and the first spelling is the one the order keeps. */
+    private static List<CaseSelector> itself(Iterable<TypeSymbol> members) {
+        Set<TypeSymbol> seen = new LinkedHashSet<>();
+        for (TypeSymbol member : members) {
+            seen.add(member);
+        }
+        List<CaseSelector> out = new ArrayList<>();
+        for (TypeSymbol member : seen) {
+            out.add(new CaseSelector(member, new Refinement.Itself(TypeOps.caseBindType(member))));
+        }
+        return out;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -3,6 +3,7 @@ package souther.compiler.check;
 import souther.compiler.ast.Hir;
 import souther.compiler.diag.CompileException;
 import souther.compiler.types.BindingId;
+import souther.compiler.types.CaseSelector;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
@@ -875,8 +876,10 @@ final class HelperParams {
                 return env;   // it names no case, so it binds nothing this can say the type of
             }
             TypeSymbol arm = c.caseTypes().get(0).answered().type();
-            Type bound = scrutinee instanceof Type.OptionOf opt && TypeSymbol.SOME.equals(arm)
-                    ? opt.element() : MatchElaborator.caseBindType(arm);
+            // What the case refines the value to, asked of the subject's cases rather than worked
+            // out from the subject's shape a second time.
+            CaseSelector selector = CaseSpace.of(scrutinee, symbols).selector(arm);
+            Type bound = selector == null ? null : selector.bound();
             return bound == null ? env : MatchElaborator.bound(env, c.binding(), bound);
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
@@ -40,13 +40,17 @@ public final class MatchElaborator {
                                        Type expected) {
         Core scrutinee = Elaborator.elaborate(m.scrutinee(), env, ctx);
         Type st = scrutinee.type();
-        CaseSpace space = CaseSpace.of(st, ctx.symbols());
-        if (space instanceof CaseSpace.Plain) {
-            throw CompileException.of(Diagnostic.at(m.pos(), 5).say(new MatchMessage.TheSubjectIsNotASum(Type.show(st))).build());
-        }
-        return st instanceof Type.OptionOf
-                ? elaborateOptionMatch(m, scrutinee, space, env, ctx, expected)
-                : elaborateCasesMatch(m, scrutinee, space, st, env, ctx, expected);
+        // Which form the subject is was answered where its cases were worked out. Read as a form
+        // rather than by asking the type again, so a form the space gains has to be answered here
+        // too rather than falling into the general reading with nobody the wiser.
+        return switch (CaseSpace.of(st, ctx.symbols())) {
+            case CaseSpace.Plain ignored -> throw CompileException.of(Diagnostic.at(m.pos(), 5)
+                    .say(new MatchMessage.TheSubjectIsNotASum(Type.show(st))).build());
+            case CaseSpace.Optional option ->
+                    elaborateOptionMatch(m, scrutinee, option, env, ctx, expected);
+            case CaseSpace.Cases cases ->
+                    elaborateCasesMatch(m, scrutinee, cases, st, env, ctx, expected);
+        };
     }
 
     /**
@@ -86,7 +90,7 @@ public final class MatchElaborator {
      * A single-case case binds that case's type; an or-pattern ({@code A | B}) binds {@code scrutinee}
      * (the sum type), since no one case type fits all its alternatives. Every case must be covered
      * exactly once (E1201; a second cover is an overlap error). */
-    static Core elaborateCasesMatch(Hir.Match m, Core scrutineeCore, CaseSpace space,
+    static Core elaborateCasesMatch(Hir.Match m, Core scrutineeCore, CaseSpace.Cases space,
                                         Type scrutinee,
                                         Scope env, CheckContext ctx, Type expected) {
         Set<TypeSymbol> cases = new HashSet<>(space.names());
@@ -112,7 +116,7 @@ public final class MatchElaborator {
             // One case binds what that case refines the value to; an or-pattern binds the subject,
             // no single case type fitting all of its alternatives.
             Refinement binding = selected.size() == 1
-                    ? selected.get(0).refinement() : new Refinement.Itself(scrutinee);
+                    ? selected.get(0).refinement() : new Refinement.Direct(scrutinee);
             Type bindType = binding.bound();
             if (c.unwrapAsserts() != null) {
                 if (selected.size() != 1) {
@@ -145,7 +149,7 @@ public final class MatchElaborator {
 
     /** Match over {@code Option<element>}: cases are {@code Some} (binds the element) and
      * {@code None}; both must be present (spec §match). */
-    static Core elaborateOptionMatch(Hir.Match m, Core scrutineeCore, CaseSpace space,
+    static Core elaborateOptionMatch(Hir.Match m, Core scrutineeCore, CaseSpace.Optional space,
                                           Scope env, CheckContext ctx, Type expected) {
         Set<TypeSymbol> covered = new HashSet<>();
         List<Core.Case> arms = new ArrayList<>();
@@ -164,7 +168,7 @@ public final class MatchElaborator {
             Type bind = selector.bound();
             if (c.unwrapAsserts() != null) {
                 // Only the carrier that holds something has something to open.
-                if (!(selector.refinement() instanceof Refinement.Wrapped wrapped)) {
+                if (!(selector.refinement() instanceof Refinement.OptionPresent wrapped)) {
                     throw CompileException.of(Diagnostic.at(c.pos()).say(new MatchMessage.TheCaseHasNoValueToOpen(caseType)).build());
                 }
                 checkOptionUnwrapAsserts(c, wrapped.bound(), ctx.symbols());

--- a/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
@@ -7,6 +7,8 @@ import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.msg.DeclarationMessage;
 import souther.compiler.diag.msg.MatchMessage;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.CaseSelector;
+import souther.compiler.types.Refinement;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 
@@ -23,22 +25,28 @@ public final class MatchElaborator {
 
     private MatchElaborator() {}
 
+    /**
+     * Types a {@code match}. What the subject can be selected as is asked once, of {@link CaseSpace};
+     * what the surface admits is asked here, and the two forms differ in what they admit rather than
+     * in what a case means.
+     *
+     * <p>An optional keeps its own reading. An or-pattern is refused over one, {@code Some(x)} opens
+     * the element rather than a newtype layer of its own, and an arm naming neither carrier is
+     * reported as not a case of an optional rather than as a case of some other sum. Those are rules
+     * about what may be written, so they stay where the text is read; which cases exist and what each
+     * one binds comes from the space either way.
+     */
     static Core elaborateMatch(Hir.Match m, Scope env, CheckContext ctx,
                                        Type expected) {
         Core scrutinee = Elaborator.elaborate(m.scrutinee(), env, ctx);
         Type st = scrutinee.type();
-        if (st instanceof Type.OptionOf oo) {
-            return elaborateOptionMatch(m, scrutinee, oo.element(), env, ctx, expected);
-        }
-        if (st instanceof Type.Union union) {
-            return elaborateCasesMatch(m, scrutinee, union.members(), "union `" + Type.show(union) + "`",
-                    st, env, ctx, expected);
-        }
-        if (!(st instanceof Type.Ref ref) || !(ctx.symbols().declarations().declaration(ref.name().key()) instanceof Hir.SumData sum)) {
+        CaseSpace space = CaseSpace.of(st, ctx.symbols());
+        if (space instanceof CaseSpace.Plain) {
             throw CompileException.of(Diagnostic.at(m.pos(), 5).say(new MatchMessage.TheSubjectIsNotASum(Type.show(st))).build());
         }
-        return elaborateCasesMatch(m, scrutinee, new HashSet<>(TypeOps.caseNames(sum)),
-                "data `" + sum.name() + "`", st, env, ctx, expected);
+        return st instanceof Type.OptionOf
+                ? elaborateOptionMatch(m, scrutinee, space, env, ctx, expected)
+                : elaborateCasesMatch(m, scrutinee, space, st, env, ctx, expected);
     }
 
     /**
@@ -78,16 +86,20 @@ public final class MatchElaborator {
      * A single-case case binds that case's type; an or-pattern ({@code A | B}) binds {@code scrutinee}
      * (the sum type), since no one case type fits all its alternatives. Every case must be covered
      * exactly once (E1201; a second cover is an overlap error). */
-    static Core elaborateCasesMatch(Hir.Match m, Core scrutineeCore, Set<TypeSymbol> cases,
-                                        String what, Type scrutinee,
+    static Core elaborateCasesMatch(Hir.Match m, Core scrutineeCore, CaseSpace space,
+                                        Type scrutinee,
                                         Scope env, CheckContext ctx, Type expected) {
+        Set<TypeSymbol> cases = new HashSet<>(space.names());
+        String what = space.described();
         Set<TypeSymbol> covered = new HashSet<>();
         List<Core.Case> arms = new ArrayList<>();
         Type branchType = null;
         for (Hir.Case c : m.cases()) {
+            List<CaseSelector> selected = new ArrayList<>();
             for (Hir.Name written : c.caseTypes()) {
                 TypeSymbol caseName = names(written);
-                if (!cases.contains(caseName)) {
+                CaseSelector selector = space.selector(caseName);
+                if (selector == null) {
                     throw notCase(written, what, c, m, cases, ctx.symbols());
                 }
                 if (!covered.add(caseName)) {
@@ -95,11 +107,15 @@ public final class MatchElaborator {
                             .say(new MatchMessage.MatchedByMoreThanOneCase(written.written()))
                             .build());
                 }
+                selected.add(selector);
             }
-            Type bindType = c.caseTypes().size() == 1
-                    ? caseBindType(names(c.caseTypes().get(0))) : scrutinee;
+            // One case binds what that case refines the value to; an or-pattern binds the subject,
+            // no single case type fitting all of its alternatives.
+            Refinement binding = selected.size() == 1
+                    ? selected.get(0).refinement() : new Refinement.Itself(scrutinee);
+            Type bindType = binding.bound();
             if (c.unwrapAsserts() != null) {
-                if (c.caseTypes().size() != 1) {
+                if (selected.size() != 1) {
                     throw CompileException.of(Diagnostic.at(c.pos()).say(new MatchMessage.AnOrPatternOpensNothing()).build());
                 }
                 checkUnwrapAsserts(c, ctx.symbols());
@@ -107,11 +123,12 @@ public final class MatchElaborator {
             Core body = Elaborator.liftIntoOption(
                     Elaborator.elaborate(c.body(), bound(env, c.binding(), bindType), ctx, expected),
                     expected, ctx.symbols());
-            arms.add(new Core.Case(denoted(c.caseTypes()), c.binding(), body, bindType, c.pos()));
+            arms.add(new Core.Case(new Core.ResolvedPattern(selected, binding), c.binding(), body,
+                    c.pos()));
             branchType = mergeBranch(m, branchType, body.type(), c, expected);
         }
         List<String> missing = new ArrayList<>();
-        for (TypeSymbol caseName : cases) {
+        for (TypeSymbol caseName : space.names()) {
             if (!covered.contains(caseName)) {
                 missing.add(caseName.name());
             }
@@ -128,7 +145,7 @@ public final class MatchElaborator {
 
     /** Match over {@code Option<element>}: cases are {@code Some} (binds the element) and
      * {@code None}; both must be present (spec §match). */
-    static Core elaborateOptionMatch(Hir.Match m, Core scrutineeCore, Type element,
+    static Core elaborateOptionMatch(Hir.Match m, Core scrutineeCore, CaseSpace space,
                                           Scope env, CheckContext ctx, Type expected) {
         Set<TypeSymbol> covered = new HashSet<>();
         List<Core.Case> arms = new ArrayList<>();
@@ -140,19 +157,17 @@ public final class MatchElaborator {
             Hir.Name arm = c.caseTypes().get(0);
             String caseType = arm.written();
             TypeSymbol armName = names(arm);
-            Type bind;
-            if (TypeSymbol.SOME.equals(armName)) {
-                bind = element;
-            } else if (TypeSymbol.NONE.equals(armName)) {
-                bind = null;
-            } else {
+            CaseSelector selector = space.selector(armName);
+            if (selector == null) {
                 throw CompileException.of(Diagnostic.at(c.pos()).say(new MatchMessage.NotACaseOfAnOptional(caseType)).build());
             }
+            Type bind = selector.bound();
             if (c.unwrapAsserts() != null) {
-                if (!TypeSymbol.SOME.equals(armName)) {
+                // Only the carrier that holds something has something to open.
+                if (!(selector.refinement() instanceof Refinement.Wrapped wrapped)) {
                     throw CompileException.of(Diagnostic.at(c.pos()).say(new MatchMessage.TheCaseHasNoValueToOpen(caseType)).build());
                 }
-                checkOptionUnwrapAsserts(c, element, ctx.symbols());
+                checkOptionUnwrapAsserts(c, wrapped.bound(), ctx.symbols());
             }
             if (!covered.add(armName)) {
                 throw CompileException.of(Diagnostic.at(c.pos()).say(new MatchMessage.MatchedByMoreThanOneCase(caseType)).build());
@@ -160,11 +175,12 @@ public final class MatchElaborator {
             Core body = Elaborator.liftIntoOption(
                     Elaborator.elaborate(c.body(), bound(env, c.binding(), bind), ctx, expected),
                     expected, ctx.symbols());
-            arms.add(new Core.Case(denoted(c.caseTypes()), c.binding(), body, bind, c.pos()));
+            arms.add(new Core.Case(new Core.ResolvedPattern(List.of(selector), selector.refinement()),
+                    c.binding(), body, c.pos()));
             branchType = mergeBranch(m, branchType, body.type(), c, expected);
         }
         List<String> missing = new ArrayList<>();
-        for (TypeSymbol caseName : List.of(TypeSymbol.SOME, TypeSymbol.NONE)) {
+        for (TypeSymbol caseName : space.names()) {
             if (!covered.contains(caseName)) {
                 missing.add(caseName.name());
             }
@@ -198,21 +214,6 @@ public final class MatchElaborator {
             throw new Unanswerable(arm.pos());
         }
         return named.type();
-    }
-
-    /** The type a match case binds. A primitive-named case (e.g. {@code Int} in {@code Int |
-     * DivisionByZero}) binds that primitive; a data-named case binds its data type. Option's own
-     * cases bind nothing readable here — an Option match binds the element, which
-     * {@link #elaborateOptionMatch} knows and this does not. */
-    public static Type caseBindType(TypeSymbol caseName) {
-        if (!caseName.isPrimitive()) {
-            return Type.ref(caseName);
-        }
-        // Read back through the one spelling table rather than repeating it here. `Some`/`None` are
-        // primitive-module names too and denote no type, and neither does `Raw`, which no stage
-        // produces — those are the null this answers, as before.
-        Type.Prim prim = caseName.primitiveKind();
-        return prim == null || prim == Type.Prim.RAW ? null : prim;
     }
 
     /** A constructor-destructuring pattern {@code X(Y(s))} opens one newtype per layer: {@code X}

--- a/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
@@ -113,13 +113,12 @@ public final class MatchElaborator {
                 }
                 selected.add(selector);
             }
-            // One case binds what that case refines the value to; an or-pattern binds the subject,
-            // no single case type fitting all of its alternatives.
-            Refinement binding = selected.size() == 1
-                    ? selected.get(0).refinement() : new Refinement.Direct(scrutinee);
-            Type bindType = binding.bound();
+            Core.ResolvedPattern pattern = selected.size() == 1
+                    ? new Core.ResolvedPattern.Single(selected.get(0))
+                    : new Core.ResolvedPattern.AnyOf(selected, scrutinee);
+            Type bindType = pattern.bindType();
             if (c.unwrapAsserts() != null) {
-                if (selected.size() != 1) {
+                if (!(pattern instanceof Core.ResolvedPattern.Single)) {
                     throw CompileException.of(Diagnostic.at(c.pos()).say(new MatchMessage.AnOrPatternOpensNothing()).build());
                 }
                 checkUnwrapAsserts(c, ctx.symbols());
@@ -127,8 +126,7 @@ public final class MatchElaborator {
             Core body = Elaborator.liftIntoOption(
                     Elaborator.elaborate(c.body(), bound(env, c.binding(), bindType), ctx, expected),
                     expected, ctx.symbols());
-            arms.add(new Core.Case(new Core.ResolvedPattern(selected, binding), c.binding(), body,
-                    c.pos()));
+            arms.add(new Core.Case(pattern, c.binding(), body, c.pos()));
             branchType = mergeBranch(m, branchType, body.type(), c, expected);
         }
         List<String> missing = new ArrayList<>();
@@ -179,8 +177,7 @@ public final class MatchElaborator {
             Core body = Elaborator.liftIntoOption(
                     Elaborator.elaborate(c.body(), bound(env, c.binding(), bind), ctx, expected),
                     expected, ctx.symbols());
-            arms.add(new Core.Case(new Core.ResolvedPattern(List.of(selector), selector.refinement()),
-                    c.binding(), body, c.pos()));
+            arms.add(new Core.Case(new Core.ResolvedPattern.Single(selector), c.binding(), body, c.pos()));
             branchType = mergeBranch(m, branchType, body.type(), c, expected);
         }
         List<String> missing = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -419,6 +419,21 @@ public final class TypeOps {
         return names;
     }
 
+    /** The type a case holds when a value turns out to be it. A primitive-named case (the
+     * {@code Int} of {@code Int | DivisionByZero}) holds that primitive; a data-named case holds its
+     * data type. Null where the name denotes no type — {@code Some} and {@code None} are
+     * primitive-module names that denote none, and neither does {@code Raw}, which no stage
+     * produces. An optional's carriers are read through {@link CaseSpace} instead, which knows the
+     * element this cannot. */
+    public static Type caseBindType(TypeSymbol caseName) {
+        if (!caseName.isPrimitive()) {
+            return Type.ref(caseName);
+        }
+        // Read back through the one spelling table rather than repeating it here.
+        Type.Prim prim = caseName.primitiveKind();
+        return prim == null || prim == Type.Prim.RAW ? null : prim;
+    }
+
     /**
      * What a sum's encoding adds to this case, or a behavior's answer to this member — read from the
      * declaration the name denotes (spec §encoder-derivation). A braced data lays its fields beside the

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -11,6 +11,7 @@ import souther.compiler.diag.msg.TypeMessage;
 import souther.compiler.diag.msg.ModuleMessage;
 import souther.compiler.diag.msg.DataMessage;
 import souther.compiler.types.BindingId;
+import souther.compiler.types.CaseSelector;
 import souther.compiler.types.LeafScalar;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.CaseShape;
@@ -419,19 +420,10 @@ public final class TypeOps {
         return names;
     }
 
-    /** The type a case holds when a value turns out to be it. A primitive-named case (the
-     * {@code Int} of {@code Int | DivisionByZero}) holds that primitive; a data-named case holds its
-     * data type. Null where the name denotes no type — {@code Some} and {@code None} are
-     * primitive-module names that denote none, and neither does {@code Raw}, which no stage
-     * produces. An optional's carriers are read through {@link CaseSpace} instead, which knows the
-     * element this cannot. */
+    /** The type a case holds when a value turns out to be it — {@link CaseSelector#heldBy}, which is
+     * where a selector reads it, under the name the callers outside a match know it by. */
     public static Type caseBindType(TypeSymbol caseName) {
-        if (!caseName.isPrimitive()) {
-            return Type.ref(caseName);
-        }
-        // Read back through the one spelling table rather than repeating it here.
-        Type.Prim prim = caseName.primitiveKind();
-        return prim == null || prim == Type.Prim.RAW ? null : prim;
+        return CaseSelector.heldBy(caseName);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -901,7 +901,7 @@ final class BodyGen {
          *  under it is reached at all. */
         private void bindArm(Core.Case c, int sSlot, Type st) {
             switch (c.pattern().binding()) {
-                case Refinement.Wrapped wrapped -> {
+                case Refinement.OptionPresent wrapped -> {
                     Type element = wrapped.bound();
                     CaseGen.pushBound(code, wrapped, sSlot);
                     int bslot = slot(element);
@@ -910,7 +910,7 @@ final class BodyGen {
                         bind(c.binding(), bslot, element);
                     }
                 }
-                case Refinement.Itself itself -> {
+                case Refinement.Direct itself -> {
                     Type bound = itself.bound();
                     if (c.binding() == null || bound == null) {
                         return;
@@ -926,7 +926,7 @@ final class BodyGen {
                     unbox(code, bound, bslot);
                     bind(c.binding(), bslot, bound);
                 }
-                case Refinement.Absent ignored -> { }
+                case Refinement.OptionAbsent ignored -> { }
             }
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -21,6 +21,8 @@ import souther.compiler.core.Core;
 import souther.compiler.core.GrowingFold;
 
 import souther.compiler.jvm.GeneratedClass;
+import souther.compiler.types.CaseSelector;
+import souther.compiler.types.Refinement;
 import souther.compiler.types.ValueName;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.CodeBuilder;
@@ -832,7 +834,6 @@ final class BodyGen {
             Type st = genExpr(m.scrutinee());
             int sSlot = slot(st);
             store(code, sSlot, st);
-            Type element = st instanceof Type.OptionOf oo ? oo.element() : null;
             Label end = code.newLabel();
             Type want = shapeOf(m, expected);
             for (int i = 0; i < m.cases().size(); i++) {
@@ -841,7 +842,7 @@ final class BodyGen {
                 // A case binding is scoped to its arm: save any outer binding it shadows and restore it
                 // after the arm, or a later arm reusing the name would resolve to this arm's slot.
 
-                emitCaseGuard(c, sSlot, st, element, nextCase);
+                emitCaseGuard(c, sSlot, st, nextCase);
                 probe(m, i);
                 genExpr(c.body(), want);
                 if (c.binding() != null) {
@@ -863,14 +864,13 @@ final class BodyGen {
             Type st = genExpr(m.scrutinee());
             int sSlot = slot(st);
             store(code, sSlot, st);
-            Type element = st instanceof Type.OptionOf oo ? oo.element() : null;
             for (int i = 0; i < m.cases().size(); i++) {
                 Core.Case c = m.cases().get(i);
                 Label nextCase = code.newLabel();
                 // A case binding is scoped to its arm (see {@link #match}): restore any outer binding it
                 // shadows before the next arm's dispatch.
 
-                emitCaseGuard(c, sSlot, st, element, nextCase);
+                emitCaseGuard(c, sSlot, st, nextCase);
                 probe(m, i);
                 emitTail(c.body(), cdB, requiredNames, requiredSuccess, expected);
                 if (c.binding() != null) {
@@ -880,54 +880,53 @@ final class BodyGen {
             emitMatchFallthrough();
         }
 
-        /** The {@code instanceof} dispatch and case binding for one {@code match} arm; on no match,
-         * jumps to {@code nextCase}. Shared by value-position {@link #match} and tail-position
-         * {@link #emitTailMatch} so the two stay in step. */
-        private void emitCaseGuard(Core.Case c, int sSlot, Type st, Type element, Label nextCase) {
-            List<TypeSymbol> cases = c.caseTypes();
-            if (element != null) {
-                // Option match: a single Some/None case (or-patterns are rejected by the checker)
-                boolean isSome = cases.get(0).name().equals("Some");
-                code.aload(sSlot);
-                code.instanceOf(isSome ? CD_OptionSome : CD_OptionNone);
-                code.ifeq(nextCase);
-                if (isSome) {
-                    // unwrap Some(v) -> v, bound to the element type
-                    code.aload(sSlot);
-                    code.checkcast(CD_OptionSome);
-                    code.invokevirtual(CD_OptionSome, "value", MTD_Object);
+        /**
+         * The dispatch and case binding for one {@code match} arm; on no match, jumps to
+         * {@code nextCase}. Shared by value-position {@link #match} and tail-position
+         * {@link #emitTailMatch} so the two stay in step.
+         *
+         * <p>What each selector tests and what the arm binds are read off the pattern the checker
+         * resolved. Nothing here asks whether the subject was an optional or what a case name means:
+         * a carrier that is the value, one that wraps it, and one that holds nothing are three arms
+         * of {@link Refinement}, and the emission follows the arm rather than working out which it
+         * would have been.
+         */
+        private void emitCaseGuard(Core.Case c, int sSlot, Type st, Label nextCase) {
+            CaseGen.jumpUnlessAny(code, ctx, c.pattern().selectors(), sSlot, nextCase);
+            bindArm(c, sSlot, st);
+        }
+
+        /** Reads the arm's value out of the carrier and binds it. A wrapping carrier is opened
+         *  whether or not the arm names what it holds, as it always was: opening it is how the value
+         *  under it is reached at all. */
+        private void bindArm(Core.Case c, int sSlot, Type st) {
+            switch (c.pattern().binding()) {
+                case Refinement.Wrapped wrapped -> {
+                    Type element = wrapped.bound();
+                    CaseGen.pushBound(code, wrapped, sSlot);
                     int bslot = slot(element);
                     unbox(code, element, bslot);
                     if (c.binding() != null) {
                         bind(c.binding(), bslot, element);
                     }
                 }
-            } else if (cases.size() == 1) {
-                code.aload(sSlot);
-                code.instanceOf(matchCaseClass(cases.get(0)));
-                code.ifeq(nextCase);
-                if (c.binding() != null) {
+                case Refinement.Itself itself -> {
+                    Type bound = itself.bound();
+                    if (c.binding() == null || bound == null) {
+                        return;
+                    }
+                    if (bound.equals(st)) {
+                        // nothing narrowed it: the value is the subject, where it already is
+                        bind(c.binding(), sSlot, st);
+                        return;
+                    }
                     // a data case binds the instance; a primitive case (e.g. Int) unboxes the value
-                    Type bt = c.bindType();   // what the checker narrowed the scrutinee to here
-                    code.aload(sSlot);
-                    int bslot = slot(bt);
-                    unbox(code, bt, bslot);
-                    bind(c.binding(), bslot, bt);
+                    CaseGen.pushBound(code, itself, sSlot);
+                    int bslot = slot(bound);
+                    unbox(code, bound, bslot);
+                    bind(c.binding(), bslot, bound);
                 }
-            } else {
-                // or-pattern: run the body if the value is any of the cases; the binding (if any)
-                // is the scrutinee's sum type, which every alternative already is
-                Label body = code.newLabel();
-                for (TypeSymbol caseName : cases) {
-                    code.aload(sSlot);
-                    code.instanceOf(matchCaseClass(caseName));
-                    code.ifne(body);
-                }
-                code.goto_(nextCase);
-                code.labelBinding(body);
-                if (c.binding() != null) {
-                    bind(c.binding(), sSlot, st);
-                }
+                case Refinement.Absent ignored -> { }
             }
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CaseGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CaseGen.java
@@ -32,9 +32,9 @@ final class CaseGen {
      *  represented by. */
     static ClassDesc carrierOf(CodegenContext ctx, CaseSelector selector) {
         return switch (selector.refinement()) {
-            case Refinement.Itself ignored -> ctx.matchCaseClass(selector.name());
-            case Refinement.Wrapped ignored -> CD_OptionSome;
-            case Refinement.Absent ignored -> CD_OptionNone;
+            case Refinement.Direct ignored -> ctx.matchCaseClass(selector.name());
+            case Refinement.OptionPresent ignored -> CD_OptionSome;
+            case Refinement.OptionAbsent ignored -> CD_OptionNone;
         };
     }
 
@@ -79,13 +79,13 @@ final class CaseGen {
      */
     static void pushBound(CodeBuilder code, Refinement refinement, int subjectSlot) {
         switch (refinement) {
-            case Refinement.Wrapped ignored -> {
+            case Refinement.OptionPresent ignored -> {
                 code.aload(subjectSlot);
                 code.checkcast(CD_OptionSome);
                 code.invokevirtual(CD_OptionSome, "value", MTD_Object);
             }
-            case Refinement.Itself ignored -> code.aload(subjectSlot);
-            case Refinement.Absent ignored -> { }
+            case Refinement.Direct ignored -> code.aload(subjectSlot);
+            case Refinement.OptionAbsent ignored -> { }
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CaseGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CaseGen.java
@@ -1,0 +1,91 @@
+package souther.compiler.codegen;
+
+import souther.compiler.types.CaseSelector;
+import souther.compiler.types.Refinement;
+
+import java.lang.classfile.CodeBuilder;
+import java.lang.classfile.Label;
+import java.lang.constant.ClassDesc;
+import java.util.List;
+
+import static souther.compiler.codegen.Descriptors.CD_OptionNone;
+import static souther.compiler.codegen.Descriptors.CD_OptionSome;
+import static souther.compiler.codegen.Descriptors.MTD_Object;
+
+/**
+ * Testing whether a value is a case, and reading the value out of the carrier once it is.
+ *
+ * <p>These two are what every reader of a {@link CaseSelector} needs and all that they share. How
+ * several of them are put together is not here and is not the same question: a {@code match} takes
+ * the first arm whose selector answers, and a behavior's declared relation holds every rule whose
+ * selector answers. Sharing the composition as well is what made one emitter's rule the other's, so
+ * only the test and the projection are shared and each caller writes its own control flow.
+ *
+ * <p>Nothing here decides what a case means. Which carrier a selector has was settled where the
+ * subject's cases were worked out, and this reads the answer.
+ */
+final class CaseGen {
+
+    private CaseGen() {}
+
+    /** The class a selector's carrier is: the case's own class, or one of the two an optional is
+     *  represented by. */
+    static ClassDesc carrierOf(CodegenContext ctx, CaseSelector selector) {
+        return switch (selector.refinement()) {
+            case Refinement.Itself ignored -> ctx.matchCaseClass(selector.name());
+            case Refinement.Wrapped ignored -> CD_OptionSome;
+            case Refinement.Absent ignored -> CD_OptionNone;
+        };
+    }
+
+    /** Tests the value in {@code subjectSlot} and jumps to {@code noMatch} when it is not this case. */
+    static void jumpUnlessMatches(CodeBuilder code, CodegenContext ctx, CaseSelector selector,
+                                  int subjectSlot, Label noMatch) {
+        code.aload(subjectSlot);
+        code.instanceOf(carrierOf(ctx, selector));
+        code.ifeq(noMatch);
+    }
+
+    /**
+     * The same for several selectors at once: falls through when the value is any of them and jumps
+     * to {@code noMatch} when it is none.
+     *
+     * <p>Written as its own emission rather than as a loop over the single-selector one, because the
+     * jumps run the other way — each test that answers goes to the code below, and only running out
+     * of them is the miss.
+     */
+    static void jumpUnlessAny(CodeBuilder code, CodegenContext ctx, List<CaseSelector> selectors,
+                              int subjectSlot, Label noMatch) {
+        if (selectors.size() == 1) {
+            jumpUnlessMatches(code, ctx, selectors.get(0), subjectSlot, noMatch);
+            return;
+        }
+        Label matched = code.newLabel();
+        for (CaseSelector selector : selectors) {
+            code.aload(subjectSlot);
+            code.instanceOf(carrierOf(ctx, selector));
+            code.ifne(matched);
+        }
+        code.goto_(noMatch);
+        code.labelBinding(matched);
+    }
+
+    /**
+     * Pushes what {@code refinement} refines the value in {@code subjectSlot} to, boxed as the
+     * carrier holds it. The caller converts and stores it — where a bound value lives is the
+     * caller's, and only how it is reached is here.
+     *
+     * <p>Nothing is pushed for a carrier with nothing under it.
+     */
+    static void pushBound(CodeBuilder code, Refinement refinement, int subjectSlot) {
+        switch (refinement) {
+            case Refinement.Wrapped ignored -> {
+                code.aload(subjectSlot);
+                code.checkcast(CD_OptionSome);
+                code.invokevirtual(CD_OptionSome, "value", MTD_Object);
+            }
+            case Refinement.Itself ignored -> code.aload(subjectSlot);
+            case Refinement.Absent ignored -> { }
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
@@ -1993,7 +1993,7 @@ final class CodecGen {
             return;
         }
         ClassDesc bridge = ctx.bridgeCaseClass(member);
-        Type held = MatchElaborator.caseBindType(member);
+        Type held = TypeOps.caseBindType(member);
         code.checkcast(bridge);
         code.invokevirtual(bridge, "value", MethodTypeDesc.of(JvmTypes.jvmType(held, ctx)));
         JvmTypes.box(code, held);

--- a/souther-compiler/src/main/java/souther/compiler/codegen/ResultBoundary.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/ResultBoundary.java
@@ -1,6 +1,6 @@
 package souther.compiler.codegen;
 
-import souther.compiler.check.MatchElaborator;
+import souther.compiler.check.TypeOps;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
@@ -50,7 +50,7 @@ final class ResultBoundary {
             code.instanceOf(ctx.matchCaseClass(member));
             code.ifeq(next);
             ClassDesc bridge = ctx.bridgeCaseClass(member);
-            Type held = MatchElaborator.caseBindType(member);
+            Type held = TypeOps.caseBindType(member);
             code.new_(bridge);
             code.dup();
             code.aload(slot);
@@ -81,7 +81,7 @@ final class ResultBoundary {
             code.ifeq(next);
             code.aload(slot);
             code.checkcast(bridge);
-            Type held = MatchElaborator.caseBindType(member);
+            Type held = TypeOps.caseBindType(member);
             code.invokevirtual(bridge, "value", MethodTypeDesc.of(JvmTypes.jvmType(held, ctx)));
             JvmTypes.box(code, held);
             code.goto_(done);

--- a/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
@@ -315,7 +315,7 @@ final class ValueClassGen {
      */
     byte[] generateBridgeCase(TypeSymbol member, List<GeneratedClass.BehaviorResult> unions) {
         ClassDesc cdB = ctx.bridgeCaseClass(member);
-        Map<String, Type> held = Map.of("value", MatchElaborator.caseBindType(member));
+        Map<String, Type> held = Map.of("value", TypeOps.caseBindType(member));
         List<ClassDesc> ifaces = new ArrayList<>();
         for (GeneratedClass.BehaviorResult union : unions) {
             ifaces.add(cd(union));

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -1,7 +1,9 @@
 package souther.compiler.core;
 
 import souther.compiler.types.BindingId;
+import souther.compiler.types.CaseSelector;
 import souther.compiler.types.CoverageOrigin;
+import souther.compiler.types.Refinement;
 import souther.compiler.types.ReachName;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
@@ -297,14 +299,65 @@ public sealed interface Core {
     record Construct(TypeSymbol typeName, List<FieldValue> values, Type type,
                      SourcePos pos) implements Core {}
 
-    /** {@code bindType} is the type the case binding takes inside the arm — the case type a union
-     * narrows to, or the element a {@code Some x} opens. */
-    record Case(List<TypeSymbol> caseTypes, Hir.Binder binding, Core body, Type bindType,
-                SourcePos pos) {
+    /**
+     * What an arm selects and what it binds, both decided by the checker.
+     *
+     * <p>{@code selectors} are the cases the arm answers for, in the order they are written; more
+     * than one is an or-pattern. {@code binding} is what the value is read as once the arm is taken,
+     * and it is the arm's own rather than any one selector's: an or-pattern binds the subject,
+     * because no single case type fits all of its alternatives.
+     *
+     * <p>Nothing here is worked out again downstream. A reader emitting this tests each selector's
+     * {@link Refinement} and reads the binding through {@code binding}, and never asks whether the
+     * subject was an optional, whether the arm named one case or several, or whether a case is a
+     * primitive. Those are the questions {@code Core} exists to have answered already.
+     */
+    record ResolvedPattern(List<CaseSelector> selectors, Refinement binding) {
+
+        public ResolvedPattern {
+            if (selectors == null || selectors.isEmpty()) {
+                throw new IllegalArgumentException("an arm selects at least one case");
+            }
+            selectors = List.copyOf(selectors);
+        }
+
+        /** The cases this answers for. */
+        public List<TypeSymbol> caseTypes() {
+            List<TypeSymbol> out = new java.util.ArrayList<>();
+            for (CaseSelector selector : selectors) {
+                out.add(selector.name());
+            }
+            return out;
+        }
+
+        /** The type the binding takes inside the arm, or null where the arm binds nothing readable. */
+        public Type bindType() {
+            return binding == null ? null : binding.bound();
+        }
+    }
+
+    /** One arm of a {@code match}: what it selects, what it calls the value, and what it answers. */
+    record Case(ResolvedPattern pattern, Hir.Binder binding, Core body, SourcePos pos) {
 
         /** How the binding was written, or null where the arm binds nothing. */
         public String bindingName() {
             return binding == null ? null : binding.name();
+        }
+
+        /** The cases this arm answers for. */
+        public List<TypeSymbol> caseTypes() {
+            return pattern.caseTypes();
+        }
+
+        /** The type the binding takes inside this arm. */
+        public Type bindType() {
+            return pattern.bindType();
+        }
+
+        /** The same arm answering a rewritten body — what a pass rewriting expressions produces, so
+         * a rewrite carries what the arm selects and binds rather than restating it. */
+        public Case answering(Core rewritten) {
+            return rewritten == body ? this : new Case(pattern, binding, rewritten, pos);
         }
     }
 
@@ -430,11 +483,7 @@ public sealed interface Core {
             case Construct nd -> atSlots(nd, atExpr);
             case Match m -> {
                 Core scrutinee = atExpr.apply(m.scrutinee());
-                List<Case> cases = each(m.cases(), c -> {
-                    Core body = atExpr.apply(c.body());
-                    return body == c.body() ? c
-                            : new Case(c.caseTypes(), c.binding(), body, c.bindType(), c.pos());
-                });
+                List<Case> cases = each(m.cases(), c -> c.answering(atExpr.apply(c.body())));
                 yield scrutinee == m.scrutinee() && cases == m.cases() ? m
                         : new Match(scrutinee, cases, m.origin(), m.type(), m.pos());
             }

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -312,33 +312,76 @@ public sealed interface Core {
      * subject was an optional, whether the arm named one case or several, or whether a case is a
      * primitive. Those are the questions {@code Core} exists to have answered already.
      */
-    record ResolvedPattern(List<CaseSelector> selectors, Refinement binding) {
+    sealed interface ResolvedPattern {
 
-        public ResolvedPattern {
-            if (selectors == null || selectors.isEmpty()) {
-                throw new IllegalArgumentException("an arm selects at least one case");
-            }
-            if (binding == null) {
-                // A carrier with nothing under it is a refinement of its own, so there is no arm
-                // that binds nothing and no null to stand for one. Resolved means resolved.
-                throw new IllegalArgumentException("an arm binds what its carrier holds, which a"
-                        + " carrier holding nothing says as much as any other");
-            }
-            selectors = List.copyOf(selectors);
-        }
+        /** The cases the arm answers for, in the order they are written. */
+        List<CaseSelector> selectors();
+
+        /**
+         * What the value is read as once the arm is taken.
+         *
+         * <p>Derived rather than carried. What an arm binds follows from what it selects — one case
+         * binds what that case's carrier holds, several bind the subject — so holding the two apart
+         * would be holding one fact in two places, and a pattern selecting an optional's absent
+         * carrier while binding its present one would be a Core the emitter has no meaning for: it
+         * would test one carrier and read the value out of the other.
+         */
+        Refinement binding();
 
         /** The cases this answers for. */
-        public List<TypeSymbol> caseTypes() {
+        default List<TypeSymbol> caseTypes() {
             List<TypeSymbol> out = new java.util.ArrayList<>();
-            for (CaseSelector selector : selectors) {
+            for (CaseSelector selector : selectors()) {
                 out.add(selector.name());
             }
             return out;
         }
 
         /** The type the binding takes inside the arm, or null where the arm binds nothing readable. */
-        public Type bindType() {
-            return binding.bound();
+        default Type bindType() {
+            return binding().bound();
+        }
+
+        /** An arm answering for one case, which binds what that case's carrier holds. */
+        record Single(CaseSelector selector) implements ResolvedPattern {
+
+            public Single {
+                if (selector == null) {
+                    throw new IllegalArgumentException("an arm selects a case");
+                }
+            }
+
+            @Override
+            public List<CaseSelector> selectors() {
+                return List.of(selector);
+            }
+
+            @Override
+            public Refinement binding() {
+                return selector.refinement();
+            }
+        }
+
+        /**
+         * An arm answering for several, which binds the subject: no one case type fits all of its
+         * alternatives, and every alternative is already the subject.
+         */
+        record AnyOf(List<CaseSelector> selectors, Type subject) implements ResolvedPattern {
+
+            public AnyOf {
+                if (selectors == null || selectors.size() < 2) {
+                    throw new IllegalArgumentException("an arm answering for several names several");
+                }
+                if (subject == null) {
+                    throw new IllegalArgumentException("what such an arm binds is the subject");
+                }
+                selectors = List.copyOf(selectors);
+            }
+
+            @Override
+            public Refinement binding() {
+                return new Refinement.Direct(subject);
+            }
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -318,6 +318,12 @@ public sealed interface Core {
             if (selectors == null || selectors.isEmpty()) {
                 throw new IllegalArgumentException("an arm selects at least one case");
             }
+            if (binding == null) {
+                // A carrier with nothing under it is a refinement of its own, so there is no arm
+                // that binds nothing and no null to stand for one. Resolved means resolved.
+                throw new IllegalArgumentException("an arm binds what its carrier holds, which a"
+                        + " carrier holding nothing says as much as any other");
+            }
             selectors = List.copyOf(selectors);
         }
 
@@ -332,7 +338,7 @@ public sealed interface Core {
 
         /** The type the binding takes inside the arm, or null where the arm binds nothing readable. */
         public Type bindType() {
-            return binding == null ? null : binding.bound();
+            return binding.bound();
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/core/GrowingFold.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/GrowingFold.java
@@ -427,7 +427,7 @@ public final class GrowingFold {
                     if (body == null) {
                         return null;
                     }
-                    cases.add(new Core.Case(c.caseTypes(), c.binding(), body, c.bindType(), c.pos()));
+                    cases.add(c.answering(body));
                 }
                 return new Core.Match(m.scrutinee(), cases, m.origin(), m.type(), m.pos());
             }

--- a/souther-compiler/src/main/java/souther/compiler/types/CaseSelector.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/CaseSelector.java
@@ -32,9 +32,34 @@ public record CaseSelector(TypeSymbol name, Refinement refinement) {
         }
     }
 
-    /** A case whose carrier is the value: a union member, or a case of a named sum. */
-    public static CaseSelector direct(TypeSymbol name, Type bound) {
-        return new CaseSelector(name, new Refinement.Direct(bound));
+    /**
+     * A case whose carrier is the value: a union member, or a case of a named sum.
+     *
+     * <p>What it holds is not taken from the caller. A name and the type it holds are one fact
+     * written twice, and the emitter reads them apart — the name says which class is tested, the
+     * bound type says what the value is read as — so a pair that disagreed would test one class and
+     * read the value as something else.
+     */
+    public static CaseSelector direct(TypeSymbol name) {
+        return new CaseSelector(name, new Refinement.Direct(heldBy(name)));
+    }
+
+    /**
+     * The type a case holds when a value turns out to be it. A primitive-named case (the
+     * {@code Int} of {@code Int | DivisionByZero}) holds that primitive; a data-named case holds its
+     * data type.
+     *
+     * <p>Null where the name denotes no type. {@code Some} and {@code None} are primitive-module
+     * names that denote none — an optional's carriers are made by their own factories, which know
+     * the element this cannot — and neither does {@code Raw}, which no stage produces.
+     */
+    public static Type heldBy(TypeSymbol caseName) {
+        if (!caseName.isPrimitive()) {
+            return Type.ref(caseName);
+        }
+        // Read back through the one spelling table rather than repeating it here.
+        Type.Prim prim = caseName.primitiveKind();
+        return prim == null || prim == Type.Prim.RAW ? null : prim;
     }
 
     /** The carrier an optional holding {@code element} is. */

--- a/souther-compiler/src/main/java/souther/compiler/types/CaseSelector.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/CaseSelector.java
@@ -30,6 +30,14 @@ public record CaseSelector(TypeSymbol name, Refinement refinement) {
         if (named(refinement) == null && (TypeSymbol.SOME.equals(name) || TypeSymbol.NONE.equals(name))) {
             throw new IllegalArgumentException("an optional's case is one of its own carriers: " + name);
         }
+        // A case whose carrier is the value holds what its name says it holds. The emitter reads the
+        // two apart — the name picks the class it tests, the held type says what the value is read
+        // as — so a pair that disagreed would test one class and read the value as something else.
+        if (refinement instanceof Refinement.Direct direct
+                && !java.util.Objects.equals(direct.bound(), heldBy(name))) {
+            throw new IllegalArgumentException("`" + name + "` holds " + heldBy(name)
+                    + ", which is not " + direct.bound());
+        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/types/CaseSelector.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/CaseSelector.java
@@ -10,6 +10,11 @@ package souther.compiler.types;
  * answer yes. What that means is the reader's to decide — a {@code match} takes the first arm whose
  * selector answers, a behavior's declared relation holds every rule whose selector answers — and
  * nothing here decides it for them.
+ *
+ * <p>The name and the carrier agree, and are made together so that they cannot disagree. An
+ * optional's carriers are named by the optional's own cases and nothing else may be: a selector
+ * spelled {@code Some} whose carrier were the absent one would be tested as absent and reported as
+ * present, and a reader would have no way to tell which half was the mistake.
  */
 public record CaseSelector(TypeSymbol name, Refinement refinement) {
 
@@ -17,10 +22,43 @@ public record CaseSelector(TypeSymbol name, Refinement refinement) {
         if (name == null || refinement == null) {
             throw new IllegalArgumentException("a selector is a name and what it refines the value to");
         }
+        if (named(refinement) != null && !named(refinement).equals(name)) {
+            throw new IllegalArgumentException(
+                    "an optional's carrier is named by the case it is: " + name + " is not "
+                            + named(refinement));
+        }
+        if (named(refinement) == null && (TypeSymbol.SOME.equals(name) || TypeSymbol.NONE.equals(name))) {
+            throw new IllegalArgumentException("an optional's case is one of its own carriers: " + name);
+        }
+    }
+
+    /** A case whose carrier is the value: a union member, or a case of a named sum. */
+    public static CaseSelector direct(TypeSymbol name, Type bound) {
+        return new CaseSelector(name, new Refinement.Direct(bound));
+    }
+
+    /** The carrier an optional holding {@code element} is. */
+    public static CaseSelector optionPresent(Type element) {
+        return new CaseSelector(TypeSymbol.SOME, new Refinement.OptionPresent(element));
+    }
+
+    /** The carrier an optional holding nothing is. */
+    public static CaseSelector optionAbsent() {
+        return new CaseSelector(TypeSymbol.NONE, new Refinement.OptionAbsent());
     }
 
     /** What a value selected by this is read as, or null where nothing readable stands under it. */
     public Type bound() {
         return refinement.bound();
+    }
+
+    /** The case a carrier is the one of, for the carriers that are a particular case; null for one
+     *  that stands for whatever case names it. */
+    private static TypeSymbol named(Refinement refinement) {
+        return switch (refinement) {
+            case Refinement.Direct ignored -> null;
+            case Refinement.OptionPresent ignored -> TypeSymbol.SOME;
+            case Refinement.OptionAbsent ignored -> TypeSymbol.NONE;
+        };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/types/CaseSelector.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/CaseSelector.java
@@ -1,0 +1,26 @@
+package souther.compiler.types;
+
+/**
+ * One case a subject can be selected as: the name it is written by, and what the value turns out to
+ * be once it has been ({@link Refinement}).
+ *
+ * <p>A <em>selector</em> rather than a variant or a partition, because one value can satisfy more
+ * than one of them. A data may be a case of two named sums declared in its module, and the classes
+ * generated for it implement the interface of each, so testing two selectors of one subject can both
+ * answer yes. What that means is the reader's to decide — a {@code match} takes the first arm whose
+ * selector answers, a behavior's declared relation holds every rule whose selector answers — and
+ * nothing here decides it for them.
+ */
+public record CaseSelector(TypeSymbol name, Refinement refinement) {
+
+    public CaseSelector {
+        if (name == null || refinement == null) {
+            throw new IllegalArgumentException("a selector is a name and what it refines the value to");
+        }
+    }
+
+    /** What a value selected by this is read as, or null where nothing readable stands under it. */
+    public Type bound() {
+        return refinement.bound();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/types/Refinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/Refinement.java
@@ -1,17 +1,20 @@
 package souther.compiler.types;
 
 /**
- * What a value turns out to be once a case has been selected, and where the selected value is read
- * from — the carrier is tested, and this says what stands under it.
+ * What a value turns out to be once a case has been selected: which carrier is tested for, and what
+ * stands under it.
  *
  * <p>Written by whoever builds a {@link CaseSelector} and read by everything downstream. Which of
  * these a case takes is decided once, where the cases of a subject are worked out, so no later stage
- * asks whether a subject is an {@code Option}, whether an arm named one case or several, or whether a
- * case is a primitive. Those questions have one answer each and it is recorded here.
+ * asks whether a subject is an optional, whether an arm named one case or several, or whether a case
+ * is a primitive. Those questions have one answer each and it is recorded here.
  *
- * <p>The arms are named for what the carrier holds rather than for the case that happens to take
- * them today. {@code Some} and {@code None} are the two carriers an optional is represented by, and
- * naming the arms after them would make a reader look up an {@code Option} to know what to emit.
+ * <p>The arms are the carriers the language has, named as the carriers they are. An earlier reading
+ * of this called them for what they hold — one that is the value, one that wraps it, one that holds
+ * nothing — which reads as a general account of carriers and is not one: the wrapping arm is an
+ * optional's present carrier and the empty arm is its absent one, and a reader emitting either
+ * writes {@code Option}'s classes. Saying so is what keeps a second carrier, when the language gains
+ * one, from arriving as a case of a word that already means something narrower.
  */
 public sealed interface Refinement {
 
@@ -19,26 +22,26 @@ public sealed interface Refinement {
     Type bound();
 
     /**
-     * The carrier is the value. Testing it is testing the case's own class, and the value read is
-     * that class's instance — a declared data as its own type, a primitive-named case (the
-     * {@code Int} of {@code Int | DivisionByZero}) as that primitive.
+     * The carrier is the value: the case's own class is what is tested, and the value read is that
+     * class's instance — a declared data as its own type, a primitive-named case (the {@code Int} of
+     * {@code Int | DivisionByZero}) as that primitive.
      *
      * <p>{@code bound} is null for a case that denotes no type at all, which is what a name outside
      * the spelling table answers; nothing readable stands under such a carrier either.
      */
-    record Itself(Type bound) implements Refinement {}
+    record Direct(Type bound) implements Refinement {}
 
-    /** The carrier wraps the value: an optional's present carrier, under which its element stands. */
-    record Wrapped(Type bound) implements Refinement {
-        public Wrapped {
+    /** An optional's present carrier, under which its element stands. */
+    record OptionPresent(Type bound) implements Refinement {
+        public OptionPresent {
             if (bound == null) {
-                throw new IllegalArgumentException("a wrapping carrier holds something");
+                throw new IllegalArgumentException("a present optional holds its element");
             }
         }
     }
 
-    /** The carrier has nothing under it: an optional's absent carrier. */
-    record Absent() implements Refinement {
+    /** An optional's absent carrier, which has nothing under it. */
+    record OptionAbsent() implements Refinement {
 
         @Override
         public Type bound() {

--- a/souther-compiler/src/main/java/souther/compiler/types/Refinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/Refinement.java
@@ -1,0 +1,48 @@
+package souther.compiler.types;
+
+/**
+ * What a value turns out to be once a case has been selected, and where the selected value is read
+ * from — the carrier is tested, and this says what stands under it.
+ *
+ * <p>Written by whoever builds a {@link CaseSelector} and read by everything downstream. Which of
+ * these a case takes is decided once, where the cases of a subject are worked out, so no later stage
+ * asks whether a subject is an {@code Option}, whether an arm named one case or several, or whether a
+ * case is a primitive. Those questions have one answer each and it is recorded here.
+ *
+ * <p>The arms are named for what the carrier holds rather than for the case that happens to take
+ * them today. {@code Some} and {@code None} are the two carriers an optional is represented by, and
+ * naming the arms after them would make a reader look up an {@code Option} to know what to emit.
+ */
+public sealed interface Refinement {
+
+    /** What the case binds, or null where nothing readable stands under the carrier. */
+    Type bound();
+
+    /**
+     * The carrier is the value. Testing it is testing the case's own class, and the value read is
+     * that class's instance — a declared data as its own type, a primitive-named case (the
+     * {@code Int} of {@code Int | DivisionByZero}) as that primitive.
+     *
+     * <p>{@code bound} is null for a case that denotes no type at all, which is what a name outside
+     * the spelling table answers; nothing readable stands under such a carrier either.
+     */
+    record Itself(Type bound) implements Refinement {}
+
+    /** The carrier wraps the value: an optional's present carrier, under which its element stands. */
+    record Wrapped(Type bound) implements Refinement {
+        public Wrapped {
+            if (bound == null) {
+                throw new IllegalArgumentException("a wrapping carrier holds something");
+            }
+        }
+    }
+
+    /** The carrier has nothing under it: an optional's absent carrier. */
+    record Absent() implements Refinement {
+
+        @Override
+        public Type bound() {
+            return null;
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatACaseMeansIsDecidedInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatACaseMeansIsDecidedInOnePlaceTest.java
@@ -31,16 +31,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class WhatACaseMeansIsDecidedInOnePlaceTest {
 
     /**
-     * Where reading a subject as an optional is still part of the answer.
+     * Where reading a subject as an optional is part of the answer: where the forms are told apart,
+     * which is the point of it, and nowhere else.
      *
-     * <p>{@code CaseSpace} is where the three forms are told apart, which is the point of it. The
-     * elaborator reads it once more, and that one is not the same question: an optional's
-     * <em>surface</em> rules differ — an or-pattern is refused over one, {@code Some(x)} opens the
-     * element rather than a newtype layer, and an arm naming neither carrier is reported as not a
-     * case of an optional. Which rules the text is held to is decided there; what a case means is not.
+     * <p>A reader that needs the form reads the form. An optional's <em>surface</em> rules do differ
+     * — an or-pattern is refused over one, {@code Some(x)} opens the element rather than a newtype
+     * layer, an arm naming neither carrier is reported as not a case of an optional — and choosing
+     * those rules is a second question, not a second answer to this one. It is asked of the space's
+     * own arms, so a form the space gains has to be answered by every reader that decides by form
+     * rather than falling into whichever reading is written last.
      */
     private static final List<String> MAY_READ_AN_OPTIONAL_SUBJECT =
-            List.of("check/CaseSpace.java", "check/MatchElaborator.java");
+            List.of("check/CaseSpace.java");
 
     /**
      * Files that take a {@code match} apart. Anything reading a subject's shape here would be

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatACaseMeansIsDecidedInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatACaseMeansIsDecidedInOnePlaceTest.java
@@ -1,0 +1,121 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Which cases a subject has, and what a value turns out to be once it is one of them, is worked out
+ * where the subject's cases are and nowhere else.
+ *
+ * <p>{@code Core}'s own contract says a construct the backend used to re-detect becomes a node
+ * rather than a shape read a second time. Case dispatch had not caught up: the emitter asked whether
+ * a subject was an optional, whether an arm named one case or several, and whether a case was a
+ * primitive, each time it wrote an arm, and a third reader in the checker asked the same questions
+ * its own way. Three readings of one thing agree until the day one of them is extended.
+ *
+ * <p>So {@code CaseSpace} answers it once, a {@code CaseSelector} carries the answer, and everything
+ * downstream reads the selector. This is asked of the sources: a tripwire and not a proof — a helper
+ * in between defeats it — but the line that would have to be added first is the one it fails on.
+ */
+class WhatACaseMeansIsDecidedInOnePlaceTest {
+
+    /**
+     * Where reading a subject as an optional is still part of the answer.
+     *
+     * <p>{@code CaseSpace} is where the three forms are told apart, which is the point of it. The
+     * elaborator reads it once more, and that one is not the same question: an optional's
+     * <em>surface</em> rules differ — an or-pattern is refused over one, {@code Some(x)} opens the
+     * element rather than a newtype layer, and an arm naming neither carrier is reported as not a
+     * case of an optional. Which rules the text is held to is decided there; what a case means is not.
+     */
+    private static final List<String> MAY_READ_AN_OPTIONAL_SUBJECT =
+            List.of("check/CaseSpace.java", "check/MatchElaborator.java");
+
+    /**
+     * Files that take a {@code match} apart. Anything reading a subject's shape here would be
+     * deciding what an arm selects or binds, which is what this test exists to stop.
+     */
+    private static final List<String> WHERE_A_MATCH_IS_TAKEN_APART =
+            List.of("check/CaseSpace.java", "check/MatchElaborator.java", "check/HelperParams.java",
+                    "codegen/BodyGen.java", "codegen/CaseGen.java");
+
+    @Test
+    void onlyTheCasesOfASubjectDecideWhetherItIsAnOptional() throws IOException {
+        List<String> seen = new ArrayList<>();
+        List<String> readers = new ArrayList<>();
+        for (Path source : mainSources()) {
+            String where = where(source);
+            if (!WHERE_A_MATCH_IS_TAKEN_APART.contains(where)) {
+                continue;
+            }
+            seen.add(where);
+            if (Files.readString(source, StandardCharsets.UTF_8).contains("instanceof Type.OptionOf")) {
+                readers.add(where);
+            }
+        }
+        assertEquals(WHERE_A_MATCH_IS_TAKEN_APART.stream().sorted().toList(),
+                seen.stream().sorted().toList(),
+                "the files this rule is about moved or were renamed, so it was asked of nothing");
+        assertEquals(MAY_READ_AN_OPTIONAL_SUBJECT.stream().sorted().toList(),
+                readers.stream().sorted().toList(),
+                "what a case means comes from CaseSpace; a match reader asking the subject's shape"
+                        + " again is deciding it a second time");
+    }
+
+    @Test
+    void theEmitterNeverAsksHowManyCasesAnArmNames() throws IOException {
+        int emitters = 0;
+        List<String> askers = new ArrayList<>();
+        for (Path source : mainSources()) {
+            String where = where(source);
+            if (!where.startsWith("codegen/")) {
+                continue;
+            }
+            emitters++;
+            String text = Files.readString(source, StandardCharsets.UTF_8);
+            if (text.contains("caseTypes().size()") || text.contains("caseTypes().get(0)")) {
+                askers.add(where);
+            }
+        }
+        assertTrue(emitters > 5, "the emitters moved out of codegen, so this was asked of nothing");
+        assertEquals(List.of(), askers,
+                "an arm's selectors and what it binds are on its resolved pattern; counting the"
+                        + " names it wrote is working out what the checker already answered");
+    }
+
+    /** The module-relative name a rule is written against: {@code check/CaseSpace.java}. */
+    private static String where(Path source) {
+        return source.getParent().getFileName() + "/" + source.getFileName();
+    }
+
+    private static List<Path> mainSources() throws IOException {
+        Path module = Path.of("").toAbsolutePath();
+        Path repo = Files.isDirectory(module.resolve(Path.of("src", "main", "java")))
+                ? module.getParent() : module;
+        List<Path> sources = new ArrayList<>();
+        try (Stream<Path> modules = Files.list(repo)) {
+            for (Path candidate : modules.toList()) {
+                Path root = candidate.resolve(Path.of("src", "main", "java"));
+                if (!Files.isDirectory(root)) {
+                    continue;
+                }
+                try (Stream<Path> walk = Files.walk(root)) {
+                    walk.filter(p -> p.toString().endsWith(".java")).forEach(sources::add);
+                }
+            }
+        }
+        assertFalse(sources.isEmpty(), "found no sources at all — the scan missed the tree");
+        return sources;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/types/ACaseIsNotHalfDecidedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/types/ACaseIsNotHalfDecidedTest.java
@@ -59,6 +59,16 @@ class ACaseIsNotHalfDecidedTest {
     }
 
     @Test
+    void aCaseHoldsWhatItsNameHoldsHoweverItIsMade() {
+        // The factory derives it; the constructor is a second way in and is held to the same thing,
+        // or the rule would be one a caller can walk around by not using the factory.
+        assertThrows(IllegalArgumentException.class,
+                () -> new CaseSelector(TypeSymbol.primitive(Type.Prim.INT),
+                        new Refinement.Direct(Type.BOOL)),
+                "testing `Int`'s class and reading the value as `Bool` is not a case of anything");
+    }
+
+    @Test
     void anArmsBindingIsReadOffWhatItSelects() {
         CaseSelector present = CaseSelector.optionPresent(ELEMENT);
         assertEquals(present.refinement(), new Core.ResolvedPattern.Single(present).binding(),

--- a/souther-compiler/src/test/java/souther/compiler/types/ACaseIsNotHalfDecidedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/types/ACaseIsNotHalfDecidedTest.java
@@ -1,0 +1,70 @@
+package souther.compiler.types;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.core.Core;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A resolved case says everything about itself, and the states that would say half of it are not
+ * representable.
+ *
+ * <p>Two of them. A selector's name and its carrier are one decision written twice, and a selector
+ * spelled {@code Some} whose carrier were the absent one would be tested as absent and reported as
+ * present, with nothing to say which half was the mistake. And an arm binds what its carrier holds,
+ * which a carrier holding nothing says as fully as any other — so there is no arm that binds
+ * nothing, and no null standing for one.
+ *
+ * <p>Both are refused where the value is made rather than checked by whoever reads it. What a
+ * checker could produce is what a backend has to handle, so a state the backend has no meaning for
+ * is one the checker must not be able to write.
+ */
+class ACaseIsNotHalfDecidedTest {
+
+    private static final Type ELEMENT = Type.STRING;
+
+    @Test
+    void anOptionalsCarrierIsNamedByTheCaseItIs() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new CaseSelector(TypeSymbol.SOME, new Refinement.OptionAbsent()),
+                "`Some` carrying the absent carrier would be tested as absent and read as present");
+        assertThrows(IllegalArgumentException.class,
+                () -> new CaseSelector(TypeSymbol.NONE, new Refinement.OptionPresent(ELEMENT)),
+                "`None` carrying the present one is the same mistake the other way round");
+    }
+
+    @Test
+    void anOptionalsCaseIsOneOfItsOwnCarriers() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CaseSelector.direct(TypeSymbol.SOME, ELEMENT),
+                "`Some` is a carrier of an optional, not a case whose class is the value");
+    }
+
+    @Test
+    void theCarriersAnOptionalHasAreMadeWithTheirNames() {
+        assertEquals(TypeSymbol.SOME, CaseSelector.optionPresent(ELEMENT).name());
+        assertEquals(TypeSymbol.NONE, CaseSelector.optionAbsent().name());
+        assertEquals(ELEMENT, CaseSelector.optionPresent(ELEMENT).bound());
+        assertEquals(null, CaseSelector.optionAbsent().bound(),
+                "nothing readable stands under the absent carrier");
+    }
+
+    @Test
+    void anArmBindsWhatItsCarrierHolds() {
+        List<CaseSelector> one = List.of(CaseSelector.optionAbsent());
+        assertThrows(IllegalArgumentException.class,
+                () -> new Core.ResolvedPattern(one, null),
+                "a carrier holding nothing is a refinement of its own, so no null stands for one");
+        assertEquals(null, new Core.ResolvedPattern(one, new Refinement.OptionAbsent()).bindType(),
+                "and the arm that selects it binds nothing readable, said by the refinement");
+    }
+
+    @Test
+    void anArmSelectsSomething() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Core.ResolvedPattern(List.of(), new Refinement.OptionAbsent()));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/types/ACaseIsNotHalfDecidedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/types/ACaseIsNotHalfDecidedTest.java
@@ -6,21 +6,19 @@ import souther.compiler.core.Core;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * A resolved case says everything about itself, and the states that would say half of it are not
  * representable.
  *
- * <p>Two of them. A selector's name and its carrier are one decision written twice, and a selector
- * spelled {@code Some} whose carrier were the absent one would be tested as absent and reported as
- * present, with nothing to say which half was the mistake. And an arm binds what its carrier holds,
- * which a carrier holding nothing says as fully as any other — so there is no arm that binds
- * nothing, and no null standing for one.
- *
- * <p>Both are refused where the value is made rather than checked by whoever reads it. What a
- * checker could produce is what a backend has to handle, so a state the backend has no meaning for
- * is one the checker must not be able to write.
+ * <p>What a checker can produce is what a backend has to handle, so a state the backend has no
+ * meaning for is one the checker must not be able to write. Three of them were reachable and are
+ * not: a selector whose name and carrier disagree, a case whose held type disagrees with its name,
+ * and an arm whose binding disagrees with what it selects. The first two are refused where the value
+ * is made; the third is not refused but absent, the binding being read off the selection rather than
+ * stored beside it.
  */
 class ACaseIsNotHalfDecidedTest {
 
@@ -39,7 +37,7 @@ class ACaseIsNotHalfDecidedTest {
     @Test
     void anOptionalsCaseIsOneOfItsOwnCarriers() {
         assertThrows(IllegalArgumentException.class,
-                () -> CaseSelector.direct(TypeSymbol.SOME, ELEMENT),
+                () -> CaseSelector.direct(TypeSymbol.SOME),
                 "`Some` is a carrier of an optional, not a case whose class is the value");
     }
 
@@ -48,23 +46,53 @@ class ACaseIsNotHalfDecidedTest {
         assertEquals(TypeSymbol.SOME, CaseSelector.optionPresent(ELEMENT).name());
         assertEquals(TypeSymbol.NONE, CaseSelector.optionAbsent().name());
         assertEquals(ELEMENT, CaseSelector.optionPresent(ELEMENT).bound());
-        assertEquals(null, CaseSelector.optionAbsent().bound(),
+        assertNull(CaseSelector.optionAbsent().bound(),
                 "nothing readable stands under the absent carrier");
     }
 
     @Test
-    void anArmBindsWhatItsCarrierHolds() {
-        List<CaseSelector> one = List.of(CaseSelector.optionAbsent());
+    void whatACaseHoldsComesFromItsName() {
+        TypeSymbol anInt = TypeSymbol.primitive(Type.Prim.INT);
+        assertEquals(Type.Prim.INT, CaseSelector.direct(anInt).bound(),
+                "a case's name and what it holds are one fact, so a caller does not supply both");
+        assertEquals(CaseSelector.heldBy(anInt), CaseSelector.direct(anInt).bound());
+    }
+
+    @Test
+    void anArmsBindingIsReadOffWhatItSelects() {
+        CaseSelector present = CaseSelector.optionPresent(ELEMENT);
+        assertEquals(present.refinement(), new Core.ResolvedPattern.Single(present).binding(),
+                "one case binds what that case's carrier holds, and there is nowhere to say"
+                        + " otherwise");
+        assertNull(new Core.ResolvedPattern.Single(CaseSelector.optionAbsent()).bindType(),
+                "a carrier holding nothing says so as fully as any other");
+    }
+
+    @Test
+    void anArmAnsweringForSeveralBindsTheSubject() {
+        TypeSymbol anInt = TypeSymbol.primitive(Type.Prim.INT);
+        TypeSymbol aBool = TypeSymbol.primitive(Type.Prim.BOOL);
+        Type subject = Type.union(java.util.Set.of(anInt, aBool));
+        Core.ResolvedPattern.AnyOf several = new Core.ResolvedPattern.AnyOf(
+                List.of(CaseSelector.direct(anInt), CaseSelector.direct(aBool)), subject);
+        assertEquals(new Refinement.Direct(subject), several.binding(),
+                "no one case type fits all of the alternatives, and each is already the subject");
+    }
+
+    @Test
+    void anArmAnsweringForSeveralNamesSeveral() {
+        TypeSymbol anInt = TypeSymbol.primitive(Type.Prim.INT);
+        Type subject = Type.union(java.util.Set.of(anInt));
         assertThrows(IllegalArgumentException.class,
-                () -> new Core.ResolvedPattern(one, null),
-                "a carrier holding nothing is a refinement of its own, so no null stands for one");
-        assertEquals(null, new Core.ResolvedPattern(one, new Refinement.OptionAbsent()).bindType(),
-                "and the arm that selects it binds nothing readable, said by the refinement");
+                () -> new Core.ResolvedPattern.AnyOf(List.of(CaseSelector.direct(anInt)), subject),
+                "one case is a Single, which reads its binding off the case");
+        assertThrows(IllegalArgumentException.class,
+                () -> new Core.ResolvedPattern.AnyOf(List.of(), subject));
     }
 
     @Test
     void anArmSelectsSomething() {
         assertThrows(IllegalArgumentException.class,
-                () -> new Core.ResolvedPattern(List.of(), new Refinement.OptionAbsent()));
+                () -> new Core.ResolvedPattern.Single(null));
     }
 }


### PR DESCRIPTION
`Core` states that a construct the backend used to re-detect during emission becomes a node here, so the backend only emits. Case dispatch had not caught up: `BodyGen.emitCaseGuard` asked whether the subject was an optional, whether the arm named one case or several, and whether the case was a primitive, each time it wrote an arm — the first from the subject's shape, the second from the arm's arity, the third from the spelling `Some`. `HelperParams.armScope` asked the same thing its own way.

Found while designing #803. A behavior's `ensures` needs the same test and the same projection, and adding it would have written a third re-derivation. This is that groundwork, and it stands on its own: no `ensures` behaviour is in it.

## What changed

- `types/Refinement` — `Direct` / `OptionPresent` / `OptionAbsent`, the carriers the language has, named as the carriers they are. A reader emitting one does not look up an optional to know what to write, and a second wrapping carrier would arrive as its own arm rather than as a second meaning for a word already narrower than it looked.
- `types/CaseSelector` — a name and its carrier. `heldBy` is the one mapping from a case's name to what it holds; the factory derives it and the constructor is held to the same answer.
- `check/CaseSpace` — the one place the forms are told apart, with an arm per form. A reader that needs the form reads the form, so one the space gains is a compile error at every reader that decides by form rather than a silent fall into the general reading.
- `Core.ResolvedPattern` — `Single(selector)` and `AnyOf(selectors, subject)`, each answering what it binds rather than carrying it. One case binds what that case's carrier holds; several bind the subject.
- `codegen/CaseGen` — the test and the projection, and nothing about how several go together. That is not shared: a `match` is ordered choice, and sharing the composition too is what made one emitter's rule the other's.

`Core.Case.caseTypes()` and `bindType()` stay as readings of the pattern, which is why 13 of the 16 files that read an arm are untouched. `answering(rewritten)` carries the pattern across a body rewrite, so a pass cannot drop it.

## What the backend can now trust

A backend reads a selector's name and its held type apart, and reads an arm's selection and its binding apart. Each pair that could disagree is closed, and where the answer was derivable it is derived rather than checked:

- an arm whose binding disagrees with what it selects is **absent** — the binding is read off the selection, so there is nowhere to write one;
- a selector whose name and carrier disagree is refused, at the factory and at the constructor;
- a case whose held type disagrees with its name is refused, at both entrances;
- an arm that selects nothing, or an `AnyOf` naming fewer than two, is refused.

`ACaseIsNotHalfDecidedTest` holds them, entering through the constructor as well as the factories.

## Verification

Full reactor green — syntax 114, compiler 5126, fmt 2233, cli 340, lsp 255, runtime 113, 0 failures. The compiler count is 5115 before this change plus the eleven assertions added here; nothing else moved, which is what a refactor that only relocates a decision should look like.

`WhatACaseMeansIsDecidedInOnePlaceTest` was checked against a broken expectation: both of its assertions fail when the allowlist is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)