### PR TITLE
Read where an offset stands off a table, not off a walk of the tokens

### DIFF
--- a/souther-fmt/src/main/java/souther/compiler/fmt/Repair.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Repair.java
@@ -256,19 +256,15 @@ final class Repair {
      */
     private static List<Integer> opportunitiesOf(String source, Formatter.CanonicalForm canonical,
             Witnesses.Pairing pairing, Doc.GroupRef group) {
-        List<SyntaxToken> had = pairing.hadCode();
-        List<SyntaxToken> writes = pairing.writesCode();
         List<Integer> out = new ArrayList<>();
         for (Opportunity o : canonical.layout().opportunities()) {
             if (o.settledBy() != group
-                    || Witnesses.brokeInSource(source, had, writes, o.at()) == o.broke()) {
+                    || Witnesses.brokeInSource(source, pairing, o.at()) == o.broke()) {
                 continue;
             }
-            for (int i = 0; i + 1 < writes.size(); i++) {
-                if (writes.get(i).end() <= o.at() && o.at() <= writes.get(i + 1).start()) {
-                    out.add(i);
-                    break;
-                }
+            int i = pairing.adjacencyAt(o.at());
+            if (i >= 0) {
+                out.add(i);
             }
         }
         out.sort(null);
@@ -316,8 +312,10 @@ final class Repair {
     private static Edit aboveTheLastComment(String source, Formatter.CanonicalForm canonical,
             Witnesses.Pairing pairing) {
         String text = canonical.layout().text();
-        String has = Witnesses.aboveTheLastComment(source);
-        String wrote = Witnesses.aboveTheLastComment(text);
+        String has = Witnesses.aboveTheLastComment(source, pairing.hadCode(),
+                pairing.hadComments());
+        String wrote = Witnesses.aboveTheLastComment(text, pairing.writesCode(),
+                pairing.writesComments());
         List<SyntaxToken> code = pairing.hadCode();
         int from = code.isEmpty() ? 0 : code.get(code.size() - 1).end();
         return new Edit(from, from + has.length(), wrote);

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Witnesses.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Witnesses.java
@@ -7,6 +7,7 @@ import souther.compiler.cst.SyntaxNode;
 import souther.compiler.cst.SyntaxToken;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
@@ -192,8 +193,13 @@ final class Witnesses {
      * next token — a line the comment is not on. That is what left a comment written anywhere at all
      * with no rule to answer for its column.
      */
-    record Pairing(List<SyntaxToken> hadCode, List<SyntaxToken> writesCode,
-            List<SyntaxToken> hadComments, List<SyntaxToken> writesComments) {
+    static final class Pairing {
+
+        private final Run hadCode;
+        private final Run writesCode;
+        private final List<SyntaxToken> hadComments;
+        private final List<SyntaxToken> writesComments;
+        private final Map<Integer, Integer> writesCommentAt;
 
         Pairing(String source, Formatter.CanonicalForm canonical) {
             this(source, canonical.layout().text());
@@ -205,6 +211,146 @@ final class Witnesses {
 
         private Pairing(SyntaxNode source, SyntaxNode text) {
             this(code(source), code(text), comments(source), comments(text));
+        }
+
+        Pairing(List<SyntaxToken> hadCode, List<SyntaxToken> writesCode,
+                List<SyntaxToken> hadComments, List<SyntaxToken> writesComments) {
+            this.hadCode = new Run(hadCode);
+            this.writesCode = new Run(writesCode);
+            this.hadComments = List.copyOf(hadComments);
+            this.writesComments = List.copyOf(writesComments);
+            Map<Integer, Integer> at = new LinkedHashMap<>();
+            for (int i = 0; i < this.writesComments.size(); i++) {
+                at.putIfAbsent(this.writesComments.get(i).start(), i);
+            }
+            this.writesCommentAt = at;
+        }
+
+        List<SyntaxToken> hadCode() {
+            return hadCode.tokens();
+        }
+
+        List<SyntaxToken> writesCode() {
+            return writesCode.tokens();
+        }
+
+        List<SyntaxToken> hadComments() {
+            return hadComments;
+        }
+
+        List<SyntaxToken> writesComments() {
+            return writesComments;
+        }
+
+        /**
+         * Which adjacency of the canonical form's tokens {@code at} stands in, or -1 where it
+         * stands in none of them.
+         *
+         * <p>Every question about a place of the canonical form is asked at an offset of it — a
+         * break's, an opportunity's — and answered at the adjacency the offset stands in. The
+         * canonical form's run is the one they are asked of, because it is the one that has the
+         * places; what the source has at the same adjacency is then read from its own tokens.
+         */
+        int adjacencyAt(int at) {
+            return writesCode.adjacencyAt(at);
+        }
+
+        /** Which of the canonical form's code tokens stands in front of {@code at}, or -1 where
+         *  none does. */
+        int writesInFrontOf(int at) {
+            return writesCode.inFrontOf(at);
+        }
+
+        /** Which of the source's code tokens stands in front of {@code at}, or -1 where none
+         *  does. */
+        int hadInFrontOf(int at) {
+            return hadCode.inFrontOf(at);
+        }
+
+        /** Which comment the canonical form writes at {@code start}, or null where it writes none
+         *  there. */
+        Integer commentWrittenAt(int start) {
+            return writesCommentAt.get(start);
+        }
+    }
+
+    /**
+     * A run of code tokens, with where an offset stands among them answered in one step.
+     *
+     * <p>The families ask the same two questions of the same two runs, once for every place they
+     * answer about: which adjacency an offset stands in, and which token stands in front of it.
+     * Asked by walking the run, each answer costs its length, and the places are as many as the
+     * tokens — so a report over a file cost the square of it.
+     *
+     * <p>What is held here is what those walks said, written down instead of restated. Both tables
+     * are indexed by offset and built in one pass over the run, so an answer is a read.
+     *
+     * <p>Two tables and not one, because the two questions are not the same question. An offset
+     * inside a token stands in no adjacency and still has a token in front of it, and an offset
+     * past the last token has a token in front of it and no adjacency after it. Each table holds
+     * what its own walk answered.
+     */
+    static final class Run {
+
+        private final List<SyntaxToken> tokens;
+
+        /** For each offset, the first {@code i} with {@code end(i) <= at <= start(i + 1)}, or -1. */
+        private final int[] adjacency;
+
+        /** For each offset, the last {@code i} with {@code end(i) <= at}, or -1. */
+        private final int[] inFrontOf;
+
+        Run(List<SyntaxToken> tokens) {
+            this.tokens = List.copyOf(tokens);
+            int width = this.tokens.isEmpty()
+                    ? 0 : this.tokens.get(this.tokens.size() - 1).end() + 1;
+            this.adjacency = new int[width];
+            Arrays.fill(this.adjacency, -1);
+            for (int i = 0; i + 1 < this.tokens.size(); i++) {
+                int from = Math.max(0, this.tokens.get(i).end());
+                int to = Math.min(width - 1, this.tokens.get(i + 1).start());
+                for (int at = from; at <= to; at++) {
+                    if (this.adjacency[at] < 0) {
+                        this.adjacency[at] = i;   // the first one the walk would have stopped at
+                    }
+                }
+            }
+            this.inFrontOf = new int[width];
+            int ended = -1;
+            for (int at = 0; at < width; at++) {
+                while (ended + 1 < this.tokens.size()
+                        && this.tokens.get(ended + 1).end() <= at) {
+                    ended++;
+                }
+                this.inFrontOf[at] = ended;
+            }
+        }
+
+        List<SyntaxToken> tokens() {
+            return tokens;
+        }
+
+        /**
+         * Which adjacency {@code at} stands in, or -1 where it stands in none.
+         *
+         * <p>Past the last token there is no adjacency: the run has one fewer than it has tokens,
+         * and an offset after the last of them is inside none of them.
+         */
+        int adjacencyAt(int at) {
+            return at < 0 || at >= adjacency.length ? -1 : adjacency[at];
+        }
+
+        /**
+         * Which token stands in front of {@code at}, or -1 where none does.
+         *
+         * <p>Past the last token that is the last of them, which is why this is not answered from
+         * the table alone.
+         */
+        int inFrontOf(int at) {
+            if (at < 0) {
+                return -1;
+            }
+            return at >= inFrontOf.length ? tokens.size() - 1 : inFrontOf[at];
         }
     }
 
@@ -262,15 +408,13 @@ final class Witnesses {
         if (had.size() != writes.size()) {
             return null;
         }
-        for (int i = 0; i + 1 < writes.size(); i++) {
-            if (writes.get(i).end() > n.offset() || n.offset() > writes.get(i + 1).start()) {
-                continue;
-            }
-            int at = had.get(i + 1).start();
-            int lineStart = source.lastIndexOf('\n', Math.max(0, at - 1)) + 1;
-            return source.substring(lineStart, at).isBlank() ? lineStart : null;
+        int i = pairing.adjacencyAt(n.offset());
+        if (i < 0) {
+            return null;
         }
-        return null;
+        int at = had.get(i + 1).start();
+        int lineStart = source.lastIndexOf('\n', Math.max(0, at - 1)) + 1;
+        return source.substring(lineStart, at).isBlank() ? lineStart : null;
     }
 
     /**
@@ -296,19 +440,16 @@ final class Witnesses {
                 || pairing.hadCode().size() != pairing.writesCode().size()) {
             return null;
         }
-        for (int i = 0; i < pairing.writesComments().size(); i++) {
-            if (pairing.writesComments().get(i).start() != begins) {
-                continue;
-            }
-            int at = pairing.hadComments().get(i).start();
-            if (follows(pairing.writesCode(), pairing.writesComments().get(i).start())
-                    != follows(pairing.hadCode(), at)) {
-                return null;   // carried somewhere else, so this is not the line it is written on
-            }
-            int lineStart = source.lastIndexOf('\n', Math.max(0, at - 1)) + 1;
-            return source.substring(lineStart, at).isBlank() ? lineStart : null;
+        Integer written = pairing.commentWrittenAt(begins);
+        if (written == null) {
+            return null;
         }
-        return null;
+        int at = pairing.hadComments().get(written).start();
+        if (pairing.writesInFrontOf(begins) != pairing.hadInFrontOf(at)) {
+            return null;   // carried somewhere else, so this is not the line it is written on
+        }
+        int lineStart = source.lastIndexOf('\n', Math.max(0, at - 1)) + 1;
+        return source.substring(lineStart, at).isBlank() ? lineStart : null;
     }
 
     /**
@@ -396,15 +537,14 @@ final class Witnesses {
                     "the source holds " + had.size() + " comments and its canonical form "
                             + writes.size() + "; the two cannot be held side by side");
         }
-        List<SyntaxToken> hadCode = pairing.hadCode();
-        List<SyntaxToken> writesCode = pairing.writesCode();
-        boolean aligned = hadCode.size() == writesCode.size();
+        boolean aligned = pairing.hadCode().size() == pairing.writesCode().size();
+        int lastWritten = lastStandingIn(text);
         List<Witness> out = new ArrayList<>();
         for (int i = 0; i < had.size(); i++) {
             Witness.Comment unit = new Witness.Comment(had.get(i).start());
             if (aligned) {
-                int wroteAt = follows(writesCode, writes.get(i).start());
-                int hasAt = follows(hadCode, had.get(i).start());
+                int wroteAt = pairing.writesInFrontOf(writes.get(i).start());
+                int hasAt = pairing.hadInFrontOf(had.get(i).start());
                 if (wroteAt != hasAt) {
                     out.add(new Witness.CommentCarrier(unit, wroteAt, hasAt));
                     continue;   // what stands beside it is asked where it is written, not where
@@ -417,7 +557,8 @@ final class Witnesses {
                     && !hadBefore.equals(writesBefore)) {
                 out.add(new Witness.TrailingComment(unit, writesBefore, hadBefore));
             }
-            if (opensItsLine(text, writes.get(i)) && !endsTheFile(text, writes.get(i))) {
+            if (opensItsLine(text, writes.get(i))
+                    && writes.get(i).end() <= lastWritten) {
                 int wrote = newlines(after(text, writes.get(i)));
                 int has = newlines(after(source, had.get(i)));
                 if (wrote != has) {
@@ -428,26 +569,25 @@ final class Witnesses {
         return out;
     }
 
-    /** Which code token a comment stands after, as its index, or -1 where none is in front of it. */
-    private static int follows(List<SyntaxToken> tokens, int at) {
-        int found = -1;
-        for (int i = 0; i < tokens.size(); i++) {
-            if (tokens.get(i).end() <= at) {
-                found = i;
+    /**
+     * The last offset of {@code text} something is written at, or -1 where nothing is.
+     *
+     * <p>What it answers is whether anything is written after a comment. Such a comment is written
+     * above nothing, so what stands under it is not the distance the rule about a comment's line
+     * answers about — it is the end of the file, and how a file ends is the file's own rule.
+     * Answered there as well, the two would both write the same newline.
+     *
+     * <p>Read once for a whole run of comments. Asked comment by comment, of the stretch after each
+     * of them, it is the length of that stretch every time and the last comment of a file is as far
+     * from its end as the first.
+     */
+    private static int lastStandingIn(String text) {
+        for (int i = text.length() - 1; i >= 0; i--) {
+            if (!Character.isWhitespace(text.charAt(i))) {
+                return i;
             }
         }
-        return found;
-    }
-
-    /**
-     * Whether nothing is written after a comment.
-     *
-     * <p>Such a comment is written above nothing, so what stands under it is not the distance this
-     * rule answers about — it is the end of the file, and how a file ends is the file's own rule.
-     * Answered here as well, the two would both write the same newline.
-     */
-    private static boolean endsTheFile(String text, SyntaxToken comment) {
-        return text.substring(comment.end()).isBlank();
+        return -1;
     }
 
     /**
@@ -520,11 +660,12 @@ final class Witnesses {
     /** What the separation rule has against {@code source}. */
     static List<Witness> separation(String source, Formatter.CanonicalForm canonical) {
         List<Place> items = topLevel(canonical);
+        int[] separating = separatingBreaks(canonical);
         List<Witness> out = new ArrayList<>();
         for (int i = 0; i + 1 < items.size(); i++) {
             Place previous = items.get(i);
             Place next = items.get(i + 1);
-            int writes = separates(canonical, previous, next) ? 1 : 0;
+            int writes = separates(canonical, separating, previous, next) ? 1 : 0;
             Integer has = blankLines(source, canonical, previous, next);
             if (has != null && has != writes) {
                 out.add(new Witness.Separation(new Witness.Items(previous, next), writes, has));
@@ -588,7 +729,7 @@ final class Witnesses {
         Map<Doc.GroupRef, Opportunity> parted = new IdentityHashMap<>();
         Map<Doc.GroupRef, Boolean> brokeAnywhere = new IdentityHashMap<>();
         for (Opportunity o : layout.opportunities()) {
-            boolean brokeThere = brokeInSource(source, had, writes, o.at());
+            boolean brokeThere = brokeInSource(source, pairing, o.at());
             brokeAnywhere.merge(o.settledBy(), brokeThere, (a, b) -> a || b);
             if (brokeThere == o.broke()) {
                 continue;   // the source settled this place the way the group did
@@ -696,7 +837,7 @@ final class Witnesses {
         Set<Integer> obliged = new LinkedHashSet<>();
         for (Newline n : layout.breaks()) {
             if (n.cause() instanceof Newline.Cause.Forced) {
-                obliged.add(adjacencyAt(writes, n.offset()));
+                obliged.add(pairing.adjacencyAt(n.offset()));
             }
         }
         List<Witness> out = new ArrayList<>();
@@ -705,7 +846,7 @@ final class Witnesses {
             if (!o.broke()) {
                 continue;
             }
-            int i = adjacencyAt(writes, o.at());
+            int i = pairing.adjacencyAt(o.at());
             if (i < 0 || obliged.contains(i) || !seen.add(i)) {
                 continue;
             }
@@ -778,8 +919,10 @@ final class Witnesses {
                                 1, ends));
                     }
                 } else {
-                    int wrote = newlines(aboveTheLastComment(text));
-                    int has = newlines(aboveTheLastComment(source));
+                    int wrote = newlines(aboveTheLastComment(text, pairing.writesCode(),
+                            pairing.writesComments()));
+                    int has = newlines(aboveTheLastComment(source, pairing.hadCode(),
+                            pairing.hadComments()));
                     if (wrote != has) {
                         out.add(new Witness.Forced(new Witness.ForcedBoundary(-2, f.obligation()),
                                 wrote, has));
@@ -787,7 +930,7 @@ final class Witnesses {
                 }
                 continue;
             }
-            int i = adjacencyAt(writes, n.offset());
+            int i = pairing.adjacencyAt(n.offset());
             if (i >= 0) {
                 at.computeIfAbsent(i, _ -> new ArrayList<>()).add(f.obligation());
             }
@@ -810,12 +953,15 @@ final class Witnesses {
         return out;
     }
 
-    /** What stands between a text's last code token and the comment written after it, or nothing
-     *  where no comment is. */
-    static String aboveTheLastComment(String text) {
-        SyntaxNode root = CstParser.parse(text).root();
-        List<SyntaxToken> code = code(root);
-        List<SyntaxToken> comments = comments(root);
+    /**
+     * What stands between a text's last code token and the comment written after it, or nothing
+     * where no comment is.
+     *
+     * <p>Asked with the tokens the caller has already read. Read from the text alone it is another
+     * parse of the whole file, made to answer about its last few characters.
+     */
+    static String aboveTheLastComment(String text, List<SyntaxToken> code,
+            List<SyntaxToken> comments) {
         if (code.isEmpty() || comments.isEmpty()) {
             return "";
         }
@@ -845,29 +991,26 @@ final class Witnesses {
         return n;
     }
 
-    /** Which adjacency of {@code tokens} the offset {@code at} stands in, or -1 where it stands
-     *  before the first of them. */
-    private static int adjacencyAt(List<SyntaxToken> tokens, int at) {
-        for (int i = 0; i + 1 < tokens.size(); i++) {
-            if (tokens.get(i).end() <= at && at <= tokens.get(i + 1).start()) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
     /**
      * Whether the source broke at the adjacency the canonical form has an opportunity at.
      *
      * <p>The opportunity stands between two of the canonical form's tokens, and the source's
      * answer is what it wrote between the same two of its own.
      */
-    static boolean brokeInSource(String source, List<SyntaxToken> had,
-            List<SyntaxToken> writes, int at) {
-        for (int i = 0; i + 1 < writes.size(); i++) {
-            if (writes.get(i).end() <= at && at <= writes.get(i + 1).start()) {
-                return source.substring(had.get(i).end(), had.get(i + 1).start())
-                        .indexOf('\n') >= 0;
+    static boolean brokeInSource(String source, Pairing pairing, int at) {
+        int i = pairing.adjacencyAt(at);
+        if (i < 0) {
+            return false;
+        }
+        List<SyntaxToken> had = pairing.hadCode();
+        return brokeBetween(source, had.get(i).end(), had.get(i + 1).start());
+    }
+
+    /** Whether a line ends somewhere in {@code [from, to)} of {@code text}. */
+    private static boolean brokeBetween(String text, int from, int to) {
+        for (int i = from; i < to; i++) {
+            if (text.charAt(i) == '\n') {
+                return true;
             }
         }
         return false;
@@ -887,18 +1030,36 @@ final class Witnesses {
         return out;
     }
 
-    /** Whether the canonical form wrote the break it writes to separate two items. */
-    private static boolean separates(Formatter.CanonicalForm canonical, Place previous, Place next) {
-        int from = canonical.layout().extents().get(previous).end();
-        int to = canonical.layout().extents().get(next).start();
+    /**
+     * Where the canonical form wrote the break it writes to separate two items, in order.
+     *
+     * <p>Read once for a whole run of pairs. A file's items and its breaks both grow with it, so
+     * asked pair by pair of every break the rule costs the two multiplied together.
+     */
+    private static int[] separatingBreaks(Formatter.CanonicalForm canonical) {
+        List<Integer> out = new ArrayList<>();
         for (Newline n : canonical.layout().breaks()) {
-            if (n.offset() >= from && n.offset() < to
-                    && n.cause() instanceof Newline.Cause.Forced f
+            if (n.cause() instanceof Newline.Cause.Forced f
                     && f.obligation() == Obligation.A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS) {
-                return true;
+                out.add(n.offset());
             }
         }
-        return false;
+        int[] offsets = new int[out.size()];
+        for (int i = 0; i < offsets.length; i++) {
+            offsets[i] = out.get(i);
+        }
+        Arrays.sort(offsets);
+        return offsets;
+    }
+
+    /** Whether the canonical form wrote the break it writes to separate two items. */
+    private static boolean separates(Formatter.CanonicalForm canonical, int[] separating,
+            Place previous, Place next) {
+        int from = canonical.layout().extents().get(previous).end();
+        int to = canonical.layout().extents().get(next).start();
+        int at = Arrays.binarySearch(separating, from);
+        int first = at >= 0 ? at : -(at + 1);   // the first break at or after the first item's end
+        return first < separating.length && separating[first] < to;
     }
 
     /** How many lines the source left blank between two items, or null where it has nothing for

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Witnesses.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Witnesses.java
@@ -275,54 +275,46 @@ final class Witnesses {
     }
 
     /**
-     * A run of code tokens, with where an offset stands among them answered in one step.
+     * A run of code tokens, with where an offset stands among them searched for rather than walked
+     * to.
      *
      * <p>The families ask the same two questions of the same two runs, once for every place they
      * answer about: which adjacency an offset stands in, and which token stands in front of it.
      * Asked by walking the run, each answer costs its length, and the places are as many as the
      * tokens — so a report over a file cost the square of it.
      *
-     * <p>What is held here is what those walks said, written down instead of restated. Both tables
-     * are indexed by offset and built in one pass over the run, so an answer is a read.
+     * <p>A run is written in order and its tokens do not overlap, so both of a token's ends rise
+     * along it and either question is a search on a sorted list. What is held beside the tokens is
+     * two runs of {@code int} the length of the run — where each token starts, and where it ends —
+     * so that a search reads numbers laid out together rather than following a token at every step.
      *
-     * <p>Two tables and not one, because the two questions are not the same question. An offset
+     * <p>Searched and not tabulated by offset. A table indexed by character would answer in one
+     * step, and it would be the length of the text rather than of the run: a source is not made of
+     * tokens at an even rate, and one holding a long literal or a page of comments above its first
+     * declaration would carry a table many times the size of everything else about it — for a
+     * question asked at a few thousand offsets.
+     *
+     * <p>Two searches and not one, because the two questions are not the same question. An offset
      * inside a token stands in no adjacency and still has a token in front of it, and an offset
-     * past the last token has a token in front of it and no adjacency after it. Each table holds
-     * what its own walk answered.
+     * past the last token has a token in front of it and no adjacency after it.
      */
     static final class Run {
 
         private final List<SyntaxToken> tokens;
 
-        /** For each offset, the first {@code i} with {@code end(i) <= at <= start(i + 1)}, or -1. */
-        private final int[] adjacency;
+        /** Where each token starts, rising along the run. */
+        private final int[] starts;
 
-        /** For each offset, the last {@code i} with {@code end(i) <= at}, or -1. */
-        private final int[] inFrontOf;
+        /** Where each token ends, rising along the run. */
+        private final int[] ends;
 
         Run(List<SyntaxToken> tokens) {
             this.tokens = List.copyOf(tokens);
-            int width = this.tokens.isEmpty()
-                    ? 0 : this.tokens.get(this.tokens.size() - 1).end() + 1;
-            this.adjacency = new int[width];
-            Arrays.fill(this.adjacency, -1);
-            for (int i = 0; i + 1 < this.tokens.size(); i++) {
-                int from = Math.max(0, this.tokens.get(i).end());
-                int to = Math.min(width - 1, this.tokens.get(i + 1).start());
-                for (int at = from; at <= to; at++) {
-                    if (this.adjacency[at] < 0) {
-                        this.adjacency[at] = i;   // the first one the walk would have stopped at
-                    }
-                }
-            }
-            this.inFrontOf = new int[width];
-            int ended = -1;
-            for (int at = 0; at < width; at++) {
-                while (ended + 1 < this.tokens.size()
-                        && this.tokens.get(ended + 1).end() <= at) {
-                    ended++;
-                }
-                this.inFrontOf[at] = ended;
+            this.starts = new int[this.tokens.size()];
+            this.ends = new int[this.tokens.size()];
+            for (int i = 0; i < this.tokens.size(); i++) {
+                this.starts[i] = this.tokens.get(i).start();
+                this.ends[i] = this.tokens.get(i).end();
             }
         }
 
@@ -333,24 +325,56 @@ final class Witnesses {
         /**
          * Which adjacency {@code at} stands in, or -1 where it stands in none.
          *
+         * <p>The first of them, which is what the walk this replaced returned. An adjacency holds
+         * {@code at} where the token before it has ended and the token after it has not begun; the
+         * first is a prefix of the run and the second a suffix, so the ones that hold it are a
+         * stretch and the answer is where that stretch begins.
+         *
          * <p>Past the last token there is no adjacency: the run has one fewer than it has tokens,
          * and an offset after the last of them is inside none of them.
          */
         int adjacencyAt(int at) {
-            return at < 0 || at >= adjacency.length ? -1 : adjacency[at];
+            int ended = inFrontOf(at);
+            if (ended < 0) {
+                return -1;
+            }
+            int first = Math.max(firstStartingAt(at) - 1, 0);
+            return first <= Math.min(ended, tokens.size() - 2) ? first : -1;
+        }
+
+        /** The first token that begins at or after {@code at}, or the length of the run. */
+        private int firstStartingAt(int at) {
+            int low = 0;
+            int high = starts.length;
+            while (low < high) {
+                int mid = (low + high) >>> 1;
+                if (starts[mid] < at) {
+                    low = mid + 1;
+                } else {
+                    high = mid;
+                }
+            }
+            return low;
         }
 
         /**
-         * Which token stands in front of {@code at}, or -1 where none does.
-         *
-         * <p>Past the last token that is the last of them, which is why this is not answered from
-         * the table alone.
+         * Which token stands in front of {@code at}, or -1 where none does: the last one to have
+         * ended by it.
          */
         int inFrontOf(int at) {
-            if (at < 0) {
-                return -1;
+            int low = 0;
+            int high = ends.length - 1;
+            int found = -1;
+            while (low <= high) {
+                int mid = (low + high) >>> 1;
+                if (ends[mid] <= at) {
+                    found = mid;
+                    low = mid + 1;
+                } else {
+                    high = mid - 1;
+                }
             }
-            return at >= inFrontOf.length ? tokens.size() - 1 : inFrontOf[at];
+            return found;
         }
     }
 

--- a/souther-fmt/src/test/java/souther/compiler/fmt/WhereAnOffsetStandsAmongTheTokensIsWhatWalkingThemSaysTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/WhereAnOffsetStandsAmongTheTokensIsWhatWalkingThemSaysTest.java
@@ -84,6 +84,32 @@ class WhereAnOffsetStandsAmongTheTokensIsWhatWalkingThemSaysTest {
     }
 
     /**
+     * And a run is written in order, which is what lets either question be searched for.
+     *
+     * <p>The walk this replaced read the run from its first token and needed nothing of the sort. A
+     * search does: it is right because a token that begins later ends later, and a run that broke
+     * that would be answered wrongly at offsets no case above happens to ask about. So it is held
+     * of the runs the corpus makes rather than assumed of the tree that makes them.
+     */
+    @Test
+    void andARunIsWrittenInOrder() {
+        for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
+            String canonical = Formatter.format(CstParser.parse(source).root());
+            for (String text : List.of(source, canonical)) {
+                List<SyntaxToken> tokens = Witnesses.code(CstParser.parse(text).root());
+                for (int i = 0; i + 1 < tokens.size(); i++) {
+                    assertTrue(tokens.get(i).start() <= tokens.get(i + 1).start(),
+                            "a token begins before the one written in front of it, at " + i);
+                    assertTrue(tokens.get(i).end() <= tokens.get(i + 1).end(),
+                            "a token ends before the one written in front of it, at " + i);
+                    assertTrue(tokens.get(i).end() <= tokens.get(i + 1).start(),
+                            "two tokens of a run overlap, at " + i);
+                }
+            }
+        }
+    }
+
+    /**
      * And the sweep reaches the offsets the two questions are told apart by.
      *
      * <p>An offset inside a token stands in no adjacency and still has a token in front of it; one

--- a/souther-fmt/src/test/java/souther/compiler/fmt/WhereAnOffsetStandsAmongTheTokensIsWhatWalkingThemSaysTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/WhereAnOffsetStandsAmongTheTokensIsWhatWalkingThemSaysTest.java
@@ -1,0 +1,128 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.cst.CstParser;
+import souther.compiler.cst.SyntaxToken;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The table an offset is answered from says what walking the tokens said.
+ *
+ * <p>The families ask two questions of a run of code tokens — which adjacency an offset stands in,
+ * and which token stands in front of it — and both used to be answered by walking the run from its
+ * first token. The walk is what the rules were written against, so the table that replaced it is
+ * held against the walk rather than against a second statement of what the answers ought to be.
+ *
+ * <p>Asked at every offset of every source in the corpus, and not at the offsets the families
+ * happen to ask about. Which of them a family asks is that family's to change, and a table that
+ * agreed only where it is asked today would be one the next question can find a hole in.
+ */
+class WhereAnOffsetStandsAmongTheTokensIsWhatWalkingThemSaysTest {
+
+    /** Which adjacency {@code at} stands in, by walking: the first one it is inside. */
+    private static int walkToTheAdjacency(List<SyntaxToken> tokens, int at) {
+        for (int i = 0; i + 1 < tokens.size(); i++) {
+            if (tokens.get(i).end() <= at && at <= tokens.get(i + 1).start()) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /** Which token stands in front of {@code at}, by walking: the last one to have ended. */
+    private static int walkToTheTokenInFront(List<SyntaxToken> tokens, int at) {
+        int found = -1;
+        for (int i = 0; i < tokens.size(); i++) {
+            if (tokens.get(i).end() <= at) {
+                found = i;
+            }
+        }
+        return found;
+    }
+
+    /** Every offset of a text, and a few on either side of it. */
+    private static void heldAtEveryOffset(String text, List<SyntaxToken> tokens, String said) {
+        Witnesses.Run run = new Witnesses.Run(tokens);
+        for (int at = -2; at <= text.length() + 2; at++) {
+            assertEquals(walkToTheAdjacency(tokens, at), run.adjacencyAt(at),
+                    "the adjacency at offset " + at + " of " + said);
+            assertEquals(walkToTheTokenInFront(tokens, at), run.inFrontOf(at),
+                    "the token in front of offset " + at + " of " + said);
+        }
+    }
+
+    @Test
+    void theTableSaysWhatTheWalkSaidOverTheCorpus() {
+        for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
+            String canonical = Formatter.format(CstParser.parse(source).root());
+            heldAtEveryOffset(source, Witnesses.code(CstParser.parse(source).root()),
+                    "a source of the corpus");
+            heldAtEveryOffset(canonical, Witnesses.code(CstParser.parse(canonical).root()),
+                    "the canonical form of a source of the corpus");
+        }
+    }
+
+    /**
+     * And a run with nothing in it, or one token, which the corpus has neither of.
+     *
+     * <p>Both are runs with no adjacency at all, and the second still has a token that can stand in
+     * front of an offset. A table sized from the last token is where those two part company.
+     */
+    @Test
+    void andOverARunTheCorpusDoesNotHave() {
+        heldAtEveryOffset("", List.of(), "an empty run");
+
+        String one = "module m exposing (a)\n";
+        List<SyntaxToken> tokens = Witnesses.code(CstParser.parse(one).root());
+        heldAtEveryOffset(one, tokens.subList(0, 1), "a run of one token");
+        heldAtEveryOffset(one, tokens.subList(0, 2), "a run of two tokens");
+    }
+
+    /**
+     * And the sweep reaches the offsets the two questions are told apart by.
+     *
+     * <p>An offset inside a token stands in no adjacency and still has a token in front of it; one
+     * past the last token has neither an adjacency nor a token after it; and where two tokens touch,
+     * the adjacency between them is a single offset. Held over a corpus that had none of those, the
+     * check above is a check of nothing.
+     */
+    @Test
+    void andTheCorpusHasTheOffsetsThatTellTheTwoApart() {
+        int inside = 0;
+        int past = 0;
+        int touching = 0;
+        int spanning = 0;
+        for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
+            List<SyntaxToken> tokens = Witnesses.code(CstParser.parse(source).root());
+            Witnesses.Run run = new Witnesses.Run(tokens);
+            for (int i = 0; i + 1 < tokens.size(); i++) {
+                if (tokens.get(i).end() == tokens.get(i + 1).start()) {
+                    touching++;
+                } else {
+                    spanning++;
+                }
+            }
+            for (int at = 0; at <= source.length(); at++) {
+                if (run.adjacencyAt(at) < 0 && run.inFrontOf(at) >= 0
+                        && run.inFrontOf(at) + 1 < tokens.size()) {
+                    inside++;
+                }
+            }
+            int last = tokens.isEmpty() ? 0 : tokens.get(tokens.size() - 1).end();
+            for (int at = last; at <= source.length(); at++) {
+                if (run.inFrontOf(at) == tokens.size() - 1) {
+                    past++;
+                }
+            }
+        }
+        assertTrue(inside > 0, "no offset of the corpus stands inside a token");
+        assertTrue(past > 0, "no offset of the corpus stands past the last token");
+        assertTrue(touching > 0, "no two tokens of the corpus touch");
+        assertTrue(spanning > 0, "no two tokens of the corpus have anything between them");
+    }
+}


### PR DESCRIPTION
Closes #809.

Every rule family asks the same two questions of a run of code tokens — which adjacency an offset stands in, and which token stands in front of it — and both were answered by walking the run from its first token. A file's breaks, opportunities and comments all grow with it, so each answer cost the length of the run and there was one per place a rule answers about. A report cost the square of the file.

`souther fmt --check` prints its decisions rather than a diff and reads them from `Deviations.of` (`souther-cli/.../Main.java:544`), so the file this was worst on — a large one nobody has formatted yet — is exactly the one a reader waits for.

## The questions move onto the run, and are searched for

`Run` holds the tokens and, beside them, two runs of `int` its own length: where each token starts, and where each one ends. A run is written in order and its tokens do not overlap, so both rise along it and either question is a search on a sorted list.

- `adjacencyAt(at)` — the first adjacency whose token has ended and whose next token has not begun. The first is a prefix of the run and the second a suffix, so the ones that hold `at` are a stretch, and the answer is where that stretch begins. That is what the walk returned.
- `inFrontOf(at)` — the last token to have ended by `at`.

Two and not one, because the questions are not the same question. An offset inside a token stands in no adjacency and still has a token in front of it; an offset past the last token has a token in front of it and no adjacency after it.

`Pairing` holds a run per code stream and answers from them. That is where the question belongs — it already reads both streams and is already handed to every family — rather than each family answering it for itself.

The second commit is why this is a search rather than a table indexed by character. A table answers in one step and is the length of the *text*; the walks it replaces were long in the number of *tokens*. Those are proportional in a source written at an even rate and not otherwise, and the difference is not small: over one four-million-character literal with ten code tokens, the table took 90ms to build and held 68.7 MiB — nine times the source and nine times the tree — where both the walk and the search take 34ms and hold 7.6 MiB. Nothing is given up for the search; the numbers below are with it.

## What goes

Nine walks. Three in `settled` and `forced` through `adjacencyAt`, one in `conditional` through `brokeInSource`, one inline in `lineStartFor`, two in `comments` through `follows`, and one in `commentLineFor` over the comments the canonical form writes. `Repair.opportunitiesOf` had both of `conditional`'s.

Two more of the same shape that are not walks of the tokens: `separates` read every break for each pair of top-level items, and `endsTheFile` copied the whole of the text after a comment to ask whether it was blank — once per comment, so the last comment of a file was as far from its end as the first.

And `aboveTheLastComment` parsed the file again to answer about its last few characters. It takes the tokens its caller has already read.

## No answer changes

`WhereAnOffsetStandsAmongTheTokensIsWhatWalkingThemSaysTest` holds both questions against the walks they replaced, at every offset of every source in the corpus and of every canonical form of one, plus a few offsets off each end. It asks it of three runs the corpus does not have — empty, one token, two tokens. It holds that the corpus reaches the offsets the two questions are told apart by: an offset inside a token, one past the last token, two tokens that touch (2442 of 5255 adjacencies) and two with something between them. And it holds that a run is written in order, which a search needs and a walk did not — so the assumption is checked rather than relied on.

Answering `adjacencyAt` from the other question turns those checks red.

## What it is worth

Two axes. The first grows a source by repeating a declaration, which holds characters per code token at 8.7. The second holds the tokens at 1662 and grows the text around them, which is the axis the first one fixes.

     chars   tokens   families ms
                      before   after
     14527     1662     16.4     2.6
     29033     3320     61.4     7.1
     58045     6636    236.4    12.4
    116069    13268    882.4    23.9

     80527     1662    123.9     5.1
    674527     1662   4232.2    26.3
   3314527     1662  89798.0    90.9

The second block is 1000, 10000 and 50000 comment lines above one declaration. The low-density shape was the walk's worst: `follows` read every code token for each comment, and `commentLineFor` every comment for each break, so 50000 comments came to 90 seconds.

The `souther-fmt` suite goes from 36.7s to 25.8s with this, which is a by-product rather than the point — the sweep that spends the rest of it is #810, and that one does not wait on this.

## What is left, and what this does not claim

Writing the canonical form, which was always linear, asked twice as the fixpoint has always asked it.

And one thing this does not make linear. `Repair.opportunitiesOf` reads *every* opportunity of the layout for each group it is asked about, and `Repair.where` evaluates the whole projection to keep its first offset, so a group's opportunities are found twice per report. That is `Θ(G·O)` in the departing groups and the opportunities, and it is what is left after this PR takes the token count out of it. It is not a regression here and is not what #809 named, and it is not #810 either — that one is about the sweep evaluating whole candidates repeatedly. Measured over a source with one departure per declaration it does not show: 4.21, 3.45, 3.74, 3.68 ms/KB across the same four sizes. I could not build an input from this corpus where the departing groups approach the opportunity count, so what I have is the reading of the code rather than a number. Filed as #814.

Full reactor green — runtime 113, syntax 114, fmt 2251, compiler 5160, build driver 10, lsp 258, cli 340, bench 13, 0 failures. `mvn -Plint -pl souther-fmt` adds no finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
