### PR TITLE
Ask a unit's question of that unit, not of the file

### DIFF
--- a/souther-bench/pom.xml
+++ b/souther-bench/pom.xml
@@ -37,6 +37,12 @@
             <groupId>net.unit8.raoh</groupId>
             <artifactId>raoh</artifactId>
         </dependency>
+        <!-- Called from here: the report measurement asks the formatter what a source has against
+             its canonical form, which is a cost this module times like any other. -->
+        <dependency>
+            <groupId>org.souther-lang</groupId>
+            <artifactId>souther-fmt</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
@@ -49,11 +55,6 @@
              so every one of them is named here — saying so as dependencies is what makes `-am`
              build them, and what makes the checks cover what they claim to whichever way the tree
              was built. -->
-        <dependency>
-            <groupId>org.souther-lang</groupId>
-            <artifactId>souther-fmt</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.souther-lang</groupId>
             <artifactId>souther-build-driver</artifactId>

--- a/souther-bench/src/main/java/souther/bench/Bench.java
+++ b/souther-bench/src/main/java/souther/bench/Bench.java
@@ -18,6 +18,7 @@ import java.util.List;
  *   run     what the generated code costs to run, per element
  *   scale   how a whole-workspace compile grows with the number of modules
  *   values  how one module's compile grows with the number of values it declares
+ *   report  how what a source has against its canonical form grows with the source
  * </pre>
  *
  * <p>Every corpus is compiled once and checked before anything is timed. A language change that
@@ -31,7 +32,7 @@ public final class Bench {
     public static void main(String[] args) {
         Report report = new Report(System.out);
         List<String> wanted = args.length == 0
-                ? List.of("cold", "warm", "phase", "edit", "run", "scale", "values")
+                ? List.of("cold", "warm", "phase", "edit", "run", "scale", "values", "report")
                 : new ArrayList<>(List.of(args));
 
         List<Corpus> corpora = Corpus.all();
@@ -78,6 +79,10 @@ public final class Bench {
         }
         if (wanted.contains("values")) {
             Values.measure(report);
+            report.blank();
+        }
+        if (wanted.contains("report")) {
+            Reporting.measure(report);
         }
     }
 }

--- a/souther-bench/src/main/java/souther/bench/Reporting.java
+++ b/souther-bench/src/main/java/souther/bench/Reporting.java
@@ -1,0 +1,131 @@
+package souther.bench;
+
+import souther.compiler.fmt.Deviations;
+
+/**
+ * How a report of what a source has against its canonical form grows with the source.
+ *
+ * <p>A report is asked round by round, and each round projects every rule's answer onto the text.
+ * Two of those projections used to read the whole file to answer about one unit — which of a group's
+ * places the source settled differently was found by sweeping every opportunity the layout has, and
+ * which lines a level writes by walking every line the canonical form has. That costs the units a
+ * source departs at multiplied by the file, and what says whether it is still there is a source that
+ * departs at all of them.
+ *
+ * <p>The corpus does not have one. Real code departs from the canonical form at a handful of its
+ * units however long it is, so the product stays inside the parse and a report over it is flat in
+ * ms/KB whether the projection reads a unit or a file. So the sources here are generated with the
+ * departure density held at every unit, and it is the size that moves — which is the axis the
+ * product is in: a file twice as long has twice the units departing and twice the file to read them
+ * from, and four times the cost if a unit's question is asked of the file.
+ *
+ * <p>Beside each is the same shape with one departure, at the same sizes. It is the control: a report
+ * that is slow because the source is long is slow in both lines, and one that is slow because the
+ * source departs everywhere is slow in the first alone. Reading the two together is what says which
+ * of the file and the departures a number is about — the figure to read is not either line but the
+ * distance between them, and whether that distance grows with the size.
+ *
+ * <p>The distance is in ms/KB rather than in ms, because a declaration written down the page is not
+ * as many characters as the same declaration on one line: the two lines of a pair hold the same
+ * declarations and not the same text, and reading their totals against each other would credit the
+ * shorter one with the characters it does not have. The character count is beside each for that.
+ *
+ * <p>Two shapes, because the two projections are asked of different things and were fixed
+ * separately. A group's is asked of a construct written down the page where the canonical form
+ * writes it on one line; a level's is asked of a construct written where the canonical form writes
+ * it and indented to the wrong column. Neither departs the other's way: the first has every line at
+ * the column the canonical form would put it at, and the second breaks exactly where it does.
+ */
+final class Reporting {
+
+    private Reporting() {}
+
+    /**
+     * Doubling, so the ratio between two lines names the exponent, and up to a size where the
+     * product is not buried in the parse.
+     *
+     * <p>Two lists, because the two products have different constants and each has to be measured
+     * where it can be seen. What a group's question costs at one opportunity is two searches of a
+     * sorted run; what a level's costs at one line is a lookup, a substring and a walk of the
+     * indent. So a level's product was four fifths of a report at two hundred declarations, and a
+     * group's was a fifth of one at four hundred, a third at sixteen hundred and over half at
+     * thirty-two hundred — each read as what the dense line has above its control, with the sweep
+     * still in place.
+     *
+     * <p>Parsing a file and laying it out is linear in it and is the rest of a report, so a run that
+     * stopped where the product is a fifth would show a ratio the noise covers.
+     */
+    private static final int[] GROUP_SIZES = {400, 800, 1600, 3200};
+
+    /** The same, up to where a level's product is already the whole of the number. */
+    private static final int[] LEVEL_SIZES = {200, 400, 800, 1600};
+
+    static void measure(Report report) {
+        for (int declarations : GROUP_SIZES) {
+            line(report, declarations, "group, every", brokenGroups(declarations, declarations));
+            line(report, declarations, "group, one", brokenGroups(declarations, 1));
+        }
+        for (int declarations : LEVEL_SIZES) {
+            line(report, declarations, "level, every", wrongIndents(declarations, declarations));
+            line(report, declarations, "level, one", wrongIndents(declarations, 1));
+        }
+    }
+
+    private static void line(Report report, int declarations, String shape, String source) {
+        Timing timing = Timing.of(2, 5, () -> Deviations.of(source));
+        report.line("REPORT n=%-4d %-14s %6d chars %8.1f ms (%6.3f ms/KB)",
+                declarations, shape, source.length(), timing.medianMillis(),
+                timing.medianMillis() / (source.length() / 1024.0));
+    }
+
+    /**
+     * {@code declarations} declarations, of which the first {@code broken} are written down the page
+     * where the canonical form writes them on one line.
+     *
+     * <p>Each is its own group, so a source with every declaration broken departs from as many
+     * decisions as it has declarations. The rest are written as the canonical form writes them, so
+     * what separates one line of this measurement from another is how many of them departed and
+     * nothing else about the file.
+     */
+    static String brokenGroups(int declarations, int broken) {
+        StringBuilder out = new StringBuilder("module m\n\nlet g (a: Int, b: Int): Int = a + b\n");
+        for (int i = 0; i < declarations; i++) {
+            if (i < broken) {
+                out.append("""
+
+                        let f%d (a: Int): Int = g(
+                            a,
+                            a
+                        )
+                        """.formatted(i));
+            } else {
+                out.append("\nlet f%d (a: Int): Int = g(a, a)\n".formatted(i));
+            }
+        }
+        return out.toString();
+    }
+
+    /**
+     * {@code declarations} record types written down the page as the canonical form writes them, of
+     * which the first {@code wrong} are indented two columns instead of four.
+     *
+     * <p>They break where the canonical form breaks, so no group decision is departed from and what
+     * is left is the column. Each declaration is its own level, so a source with every one of them
+     * indented wrongly departs at as many levels as it has declarations.
+     */
+    static String wrongIndents(int declarations, int wrong) {
+        StringBuilder out = new StringBuilder("module m\n");
+        for (int i = 0; i < declarations; i++) {
+            String indent = i < wrong ? "  " : "    ";
+            out.append("""
+
+                    data D%d =
+                    %s{ aRatherLongFieldName: Int
+                    %s, anotherRatherLongFieldName: Int
+                    %s, yetAnotherRatherLongFieldName: Int
+                    %s}
+                    """.formatted(i, indent, indent, indent, indent));
+        }
+        return out.toString();
+    }
+}

--- a/souther-bench/src/test/java/souther/bench/EveryShapeThatIsTimedStillDepartsTest.java
+++ b/souther-bench/src/test/java/souther/bench/EveryShapeThatIsTimedStillDepartsTest.java
@@ -1,0 +1,136 @@
+package souther.bench;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.fmt.Deviations;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * That the shapes {@link Reporting} is timed against still depart from the canonical form, and
+ * depart the way the measurement says they do.
+ *
+ * <p>{@link EveryShapeThatIsTimedStillCompilesTest} makes the same claim about the compile shapes,
+ * and for the same reason: a source that stopped departing is a source the report answers about
+ * faster, and nothing about a timing says that is what it timed. Here it is sharper. What the
+ * measurement varies is the departure density, and a formatter change that makes one of these
+ * sources canonical leaves two lines that differ in nothing being reported as the shape a product
+ * shows up in and its control.
+ *
+ * <p>Three things, and each of them can go wrong on its own. That every declaration of the dense
+ * shape departs — a shape whose departures thinned out measures the control twice. That exactly one
+ * declaration of the control departs — a control that departed everywhere would be the dense shape
+ * and the distance between the two lines would read as zero. And that the report is whole, because a
+ * report that gives up before it reaches the canonical form does fewer rounds and is faster for it.
+ *
+ * <p>At small sizes. Whether a shape departs is not a question the size answers, and the sizes are
+ * what the measurement varies.
+ */
+class EveryShapeThatIsTimedStillDepartsTest {
+
+    /** Enough declarations that "every" and "one" are different numbers, and few enough that the
+     *  report over them is not itself a benchmark. */
+    private static final int DECLARATIONS = 8;
+
+    /** A construct written down the page where the canonical form writes it on one line. */
+    private static final String THE_WIDTH_BREAKS =
+            "a construct whose line would exceed the width breaks";
+
+    /** A level written at a column the canonical form does not write it at. */
+    private static final String ONE_LEVEL_DEEPER = "one level deeper is one indent further in";
+
+    @Test
+    void everyDeclarationOfTheDenseGroupShapeDepartsFromItsGroup() {
+        departsAt(DECLARATIONS, THE_WIDTH_BREAKS,
+                Reporting.brokenGroups(DECLARATIONS, DECLARATIONS));
+    }
+
+    @Test
+    void andOneDeclarationOfItsControlDoes() {
+        departsAt(1, THE_WIDTH_BREAKS, Reporting.brokenGroups(DECLARATIONS, 1));
+    }
+
+    @Test
+    void everyDeclarationOfTheDenseLevelShapeDepartsAtItsLevel() {
+        departsAt(DECLARATIONS, ONE_LEVEL_DEEPER,
+                Reporting.wrongIndents(DECLARATIONS, DECLARATIONS));
+    }
+
+    @Test
+    void andOneDeclarationOfItsControlDoesToo() {
+        departsAt(1, ONE_LEVEL_DEEPER, Reporting.wrongIndents(DECLARATIONS, 1));
+    }
+
+    /**
+     * That the level shape departs at the column and at nothing else.
+     *
+     * <p>It is written down the page where the canonical form writes it down the page, so no group's
+     * decision is departed from. A shape that also broke somewhere else would be timing both
+     * projections under one name, and the two are what the measurement tells apart.
+     */
+    @Test
+    void andTheLevelShapeDepartsAtNothingButItsColumns() {
+        assertEquals(Set.of(ONE_LEVEL_DEEPER),
+                rulesNamedBy(Reporting.wrongIndents(DECLARATIONS, DECLARATIONS)));
+    }
+
+    /** And the group shape departs at nothing but its groups. */
+    @Test
+    void andTheGroupShapeDepartsAtNothingButItsGroups() {
+        assertEquals(Set.of(THE_WIDTH_BREAKS),
+                rulesNamedBy(Reporting.brokenGroups(DECLARATIONS, DECLARATIONS)));
+    }
+
+    /**
+     * That the two shapes differ in how many departed and in nothing else.
+     *
+     * <p>A dense shape and its control are read against each other, so what separates them has to be
+     * the density. Held by writing the same declaration either way: what the control declares past
+     * the first is what the dense shape declares, laid out as the canonical form lays it out.
+     */
+    @Test
+    void andADensityIsTheDeparturesAndNothingElse() {
+        for (List<String> pair : List.of(
+                List.of(Reporting.brokenGroups(DECLARATIONS, DECLARATIONS),
+                        Reporting.brokenGroups(DECLARATIONS, 1)),
+                List.of(Reporting.wrongIndents(DECLARATIONS, DECLARATIONS),
+                        Reporting.wrongIndents(DECLARATIONS, 1)))) {
+            assertEquals(canonicalFormOf(pair.get(0)), canonicalFormOf(pair.get(1)),
+                    "a shape and its control have different canonical forms, so a difference"
+                            + " between their two lines is not about the departures");
+        }
+    }
+
+    private static String canonicalFormOf(String source) {
+        return souther.compiler.fmt.Formatter.format(source);
+    }
+
+    /**
+     * That {@code source} departs at {@code expected} places, all of them named by {@code rule}, and
+     * that the report saying so is whole.
+     */
+    private static void departsAt(int expected, String rule, String source) {
+        Deviations.Report report = Deviations.of(source);
+        assertTrue(report.whole(),
+                "the report over this shape does not reach the canonical form, so it is timed"
+                        + " giving up rather than answering");
+        long named = report.deviations().stream().filter(d -> d.rule().equals(rule)).count();
+        assertEquals(expected, named,
+                "the shape departs at " + named + " place(s) under `" + rule + "` and the"
+                        + " measurement reads it as " + expected);
+    }
+
+    /** Which rules a source's report names, in the order it names them. */
+    private static Set<String> rulesNamedBy(String source) {
+        Set<String> out = new LinkedHashSet<>();
+        for (Deviations.Deviation d : Deviations.of(source).deviations()) {
+            out.add(d.rule());
+        }
+        return out;
+    }
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Deviations.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Deviations.java
@@ -71,30 +71,35 @@ public final class Deviations {
         for (int round = 0; round < ROUNDS; round++) {
             Witnesses.Pairing pairing = new Witnesses.Pairing(text, form);
             List<Witness> witnesses = all(text, form, pairing);
-            for (Witness w : witnesses) {
-                int at = Repair.where(text, form, pairing, w);
-                if (at < 0) {
-                    continue;
+            if (witnesses.isEmpty()) {
+                break;   // nothing to say about this text, and nothing to project it onto
+            }
+            // One projection for both questions this round asks of it. Where a witness lands is
+            // where the first stretch it comes to begins, so a report that asked for that on its
+            // own evaluated the whole projection to keep one number and then evaluated it again to
+            // write the text.
+            List<List<Repair.Edit>> each;
+            try {
+                each = Repair.each(text, form, pairing, witnesses);
+            } catch (Witnesses.NoCorrespondence _) {
+                return new Report(sorted(out), false);   // a family that could not answer
+            }
+            for (int w = 0; w < witnesses.size(); w++) {
+                if (each.get(w).isEmpty()) {
+                    continue;   // nothing of it is written here
                 }
-                int was = at;
+                int was = each.get(w).get(0).from();
                 for (int i = repaired.size() - 1; i >= 0; i--) {
                     was = Repair.before(repaired.get(i), was);
                 }
-                Deviation d = new Deviation(lineOf(source, was), columnOf(source, was), rule(w),
-                        canonicalSide(w), sourceSide(w));
+                Deviation d = new Deviation(lineOf(source, was), columnOf(source, was),
+                        rule(witnesses.get(w)), canonicalSide(witnesses.get(w)),
+                        sourceSide(witnesses.get(w)));
                 if (seen.add(d.line() + ":" + d.column() + ": " + d.rule())) {
                     out.add(d);
                 }
             }
-            if (witnesses.isEmpty()) {
-                break;
-            }
-            List<Repair.Edit> edits;
-            try {
-                edits = Repair.edits(text, form, pairing, witnesses);
-            } catch (Witnesses.NoCorrespondence _) {
-                return new Report(sorted(out), false);   // a family that could not answer
-            }
+            List<Repair.Edit> edits = Repair.composed(each);
             String next = Repair.apply(text, edits);
             if (next.equals(text)) {
                 break;

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Repair.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Repair.java
@@ -4,8 +4,10 @@ import souther.compiler.cst.SyntaxToken;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -31,6 +33,76 @@ final class Repair {
     record Edit(int from, int to, String text) {}
 
     /**
+     * A source and its canonical form, with what every witness of one round would ask of them read
+     * once.
+     *
+     * <p>Two of the projections ask a question the round shares, and each of them asks it of a whole
+     * file to answer about one unit. A group's witness is about the opportunities that group
+     * settles, and a layout has one at every place any group could break; a level's witness is about
+     * the lines written under that level, and the canonical form's lines are the whole file's. Asked
+     * per witness, both read everything — so a round over a source that departs at a large fraction
+     * of its groups cost the witnesses multiplied by the file, when what the round is about is one
+     * departure per witness.
+     *
+     * <p>So each is gathered under the unit that is asked about. What a witness reads is then its
+     * own unit's, and what the projection reads is the file once.
+     *
+     * <p>Both here, though only one of them could be kept beside the layout. Which opportunities a
+     * group settles is the layout's answer and nothing about a source; which lines are written under
+     * a level is the canonical form's, but where the source begins each of them is not, and a
+     * gathering holding that is about the pair. Split between the two places, a reader asking what a
+     * projection reads once would have to find the answer in both.
+     */
+    record Round(String source, Formatter.CanonicalForm canonical, Witnesses.Pairing pairing,
+            Map<Doc.GroupRef, List<Opportunity>> settling,
+            Map<Doc.NestRef, List<Witnesses.CanonicalLine>> under) {
+
+        Round(String source, Formatter.CanonicalForm canonical, Witnesses.Pairing pairing) {
+            this(source, canonical, pairing, settling(canonical.layout()),
+                    under(Witnesses.lines(source, canonical, pairing)));
+        }
+
+        /**
+         * The layout's opportunities, gathered under the group whose decision settles each.
+         *
+         * <p>By identity, which is how a group is asked for everywhere else: a {@link Doc.GroupRef}
+         * is the group and not a description of one, and two of them are the same group exactly
+         * where they are the same reference.
+         */
+        private static Map<Doc.GroupRef, List<Opportunity>> settling(Layout layout) {
+            Map<Doc.GroupRef, List<Opportunity>> out = new IdentityHashMap<>();
+            for (Opportunity o : layout.opportunities()) {
+                out.computeIfAbsent(o.settledBy(), _ -> new ArrayList<>()).add(o);
+            }
+            return out;
+        }
+
+        /**
+         * The canonical form's lines, gathered under every level each is written under and not only
+         * the innermost.
+         *
+         * <p>That is what the indentation repair asks for: a level that moves takes what is nested
+         * inside it along, so the lines it writes are the ones written anywhere under it. Each line
+         * therefore stands under as many entries as it has levels, and what a level's witness reads
+         * is its own entry rather than the file.
+         *
+         * <p>In the order the canonical form writes them, which the repair rests on: it keeps the
+         * first line it meets at each of the source's line starts, and the order it meets them in is
+         * the order they are written.
+         */
+        private static Map<Doc.NestRef, List<Witnesses.CanonicalLine>> under(
+                List<Witnesses.CanonicalLine> lines) {
+            Map<Doc.NestRef, List<Witnesses.CanonicalLine>> out = new IdentityHashMap<>();
+            for (Witnesses.CanonicalLine line : lines) {
+                for (Doc.NestRef level : line.under()) {
+                    out.computeIfAbsent(level, _ -> new ArrayList<>()).add(line);
+                }
+            }
+            return out;
+        }
+    }
+
+    /**
      * {@code source} with the expectations of {@code witnesses} written into it.
      *
      * <p>Refuses two expectations over one stretch rather than letting the later win. Two rules
@@ -54,9 +126,33 @@ final class Repair {
      */
     static List<Edit> edits(String source, Formatter.CanonicalForm canonical,
             Witnesses.Pairing pairing, List<Witness> witnesses) {
-        List<Edit> edits = new ArrayList<>();
+        return composed(each(source, canonical, pairing, witnesses));
+    }
+
+    /**
+     * The stretches each of {@code witnesses} comes to on its own, in the same order as the
+     * witnesses.
+     *
+     * <p>Kept apart from the composition so that a caller who wants both gets one projection. What
+     * a report wants of a witness besides its expectation is where in the source it lands, which is
+     * where the first stretch it comes to begins — and asked for on its own that was the whole
+     * projection evaluated to keep one number, and then evaluated again to write the text.
+     */
+    static List<List<Edit>> each(String source, Formatter.CanonicalForm canonical,
+            Witnesses.Pairing pairing, List<Witness> witnesses) {
+        Round round = new Round(source, canonical, pairing);
+        List<List<Edit>> out = new ArrayList<>();
         for (Witness w : witnesses) {
-            edits.addAll(of(source, canonical, pairing, w));
+            out.add(of(round, w));
+        }
+        return out;
+    }
+
+    /** The stretches of {@code each}, composed and in the order they are written. */
+    static List<Edit> composed(List<List<Edit>> each) {
+        List<Edit> edits = new ArrayList<>();
+        for (List<Edit> mine : each) {
+            edits.addAll(mine);
         }
         edits.sort(Comparator.comparingInt(Edit::from)
                 .thenComparing(Comparator.comparingInt(Edit::to).reversed()));
@@ -130,24 +226,20 @@ final class Repair {
      *
      * <p>Empty where what it is about is written around a comment, which the rules about comments
      * have to say before anything can be written there.
-     */
-    static List<Edit> of(String source, Formatter.CanonicalForm canonical, Witness w) {
-        return of(source, canonical, new Witnesses.Pairing(source, canonical), w);
-    }
-
-    /**
-     * The same, for a caller that has already read the two texts' tokens.
      *
-     * <p>Read once for a whole repair rather than once per witness. What a witness is about is
-     * found by pairing the two token streams, and a source with three hundred of them was parsed a
-     * thousand times to write one text.
+     * <p>Asked of a {@link Round} rather than of the two texts, so that what a witness is about is
+     * found once for a whole round rather than once per witness. The two texts' tokens were the
+     * first of those — a source with three hundred of them was parsed a thousand times to write one
+     * text — and what a unit is asked of is the second.
      */
-    static List<Edit> of(String source, Formatter.CanonicalForm canonical,
-            Witnesses.Pairing pairing, Witness w) {
+    static List<Edit> of(Round round, Witness w) {
+        String source = round.source();
+        Formatter.CanonicalForm canonical = round.canonical();
+        Witnesses.Pairing pairing = round.pairing();
         return switch (w) {
             case Witness.BetweenTwoTokens b -> List.of(spacing(pairing, b));
             case Witness.Separation s -> List.of(separation(source, canonical, s));
-            case Witness.Indentation i -> indentation(source, canonical, pairing, i);
+            case Witness.Indentation i -> indentation(round, i);
             case Witness.Forced f -> switch (f.unit().adjacency()) {
                 case -1 -> List.of(ending(source, canonical, pairing));
                 case -2 -> List.of(aboveTheLastComment(source, canonical, pairing));
@@ -157,9 +249,9 @@ final class Repair {
             // texts disagree about; what writes the canonical form is the same either way, since
             // a construct is put down the page by breaking the places it settles.
             case Witness.Conditional c -> gaps(source, canonical, pairing,
-                    opportunitiesOf(source, canonical, pairing, c.unit().group()));
+                    opportunitiesOf(round, c.unit().group()));
             case Witness.RunTogether r -> gaps(source, canonical, pairing,
-                    opportunitiesOf(source, canonical, pairing, r.unit().group()));
+                    opportunitiesOf(round, r.unit().group()));
             case Witness.Settled s ->
                     gaps(source, canonical, pairing, List.of(s.unit().adjacency()));
             case Witness.AtTheEndOfALine e -> List.of(new Edit(e.unit().at(),
@@ -173,13 +265,6 @@ final class Repair {
         };
     }
 
-    /** Where in the source a witness lands, or -1 where nothing of it is written there. */
-    static int where(String source, Formatter.CanonicalForm canonical, Witnesses.Pairing pairing,
-            Witness w) {
-        List<Edit> edits = of(source, canonical, pairing, w);
-        return edits.isEmpty() ? -1 : edits.get(0).from();
-    }
-
     /**
      * The columns the canonical form writes the lines of a level at.
      *
@@ -191,14 +276,18 @@ final class Repair {
      * <p>Every line written under the level and not only the ones written at it. A level that moves
      * takes what is nested inside it along, and those deeper levels have nothing against them —
      * their step is right and it is the column underneath that changed.
+     *
+     * <p>Asked of the level's own lines and not of the file's. {@link Round} gathers them under the
+     * levels they are written under, so a source whose every level is indented wrongly reads each
+     * level's lines once rather than the file once per level.
      */
-    private static List<Edit> indentation(String source, Formatter.CanonicalForm canonical,
-            Witnesses.Pairing pairing, Witness.Indentation witness) {
+    private static List<Edit> indentation(Round round, Witness.Indentation witness) {
+        String source = round.source();
         List<Edit> out = new ArrayList<>();
         Set<Integer> at = new LinkedHashSet<>();
-        for (Witnesses.CanonicalLine line : Witnesses.lines(source, canonical, pairing)) {
-            if (line.sourceStart() == null || !line.under().contains(witness.unit().inner())
-                    || !at.add(line.sourceStart())) {
+        for (Witnesses.CanonicalLine line
+                : round.under().getOrDefault(witness.unit().inner(), List.of())) {
+            if (line.sourceStart() == null || !at.add(line.sourceStart())) {
                 continue;
             }
             int lineStart = line.sourceStart();
@@ -253,16 +342,20 @@ final class Repair {
      * <p>In the order they stand in, so that the first is the one the witness stands at. Where the
      * report says the source departed is the first place it did, and that has to be the same
      * question as which of them this writes first.
+     *
+     * <p>Asked of the group's own opportunities and not of the layout's. A layout has one at every
+     * place any group could break, so a sweep of it per group is the whole file for one group's
+     * question — and a source that departs at a large fraction of its groups is asked that as many
+     * times as it has departed. Which opportunities a group settles is the layout's answer, and
+     * {@link Round} has it once.
      */
-    private static List<Integer> opportunitiesOf(String source, Formatter.CanonicalForm canonical,
-            Witnesses.Pairing pairing, Doc.GroupRef group) {
+    private static List<Integer> opportunitiesOf(Round round, Doc.GroupRef group) {
         List<Integer> out = new ArrayList<>();
-        for (Opportunity o : canonical.layout().opportunities()) {
-            if (o.settledBy() != group
-                    || Witnesses.brokeInSource(source, pairing, o.at()) == o.broke()) {
+        for (Opportunity o : round.settling().getOrDefault(group, List.of())) {
+            if (Witnesses.brokeInSource(round.source(), round.pairing(), o.at()) == o.broke()) {
                 continue;
             }
-            int i = pairing.adjacencyAt(o.at());
+            int i = round.pairing().adjacencyAt(o.at());
             if (i >= 0) {
                 out.add(i);
             }

--- a/souther-fmt/src/test/java/souther/compiler/fmt/AWitnessIsProjectedThroughItsOwnUnitAndNotTheWholeFileTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/AWitnessIsProjectedThroughItsOwnUnitAndNotTheWholeFileTest.java
@@ -1,0 +1,383 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.cst.CstParser;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a witness is projected through is its own unit's, gathered once, and it says what sweeping
+ * the whole file said.
+ *
+ * <p>Two of the projections used to read everything to answer about one unit. A group's witness is
+ * about the opportunities that group settles and a layout has one at every place any group could
+ * break; a level's witness is about the lines written under that level and the canonical form's
+ * lines are the whole file's. So both are gathered under the unit that is asked about, and what is
+ * held here is that gathering them changed no answer.
+ *
+ * <p>Held against the sweep rather than against a second statement of what the answers ought to be.
+ * The sweep is what the rules were written against, and a {@link Repair.Round} built from it is a
+ * round the projection cannot tell from the one it is given — so the two are handed to the same
+ * projection and the edits are compared.
+ *
+ * <p>Over the corpus, and over sources that depart at every group and every level. The corpus
+ * departs at a few of its units, which is the case where a sweep and a gathering agree by having
+ * almost nothing to disagree about; a source written down the page where the canonical form writes
+ * it flat, or indented two columns where it writes four, is the case the gathering was made for.
+ */
+class AWitnessIsProjectedThroughItsOwnUnitAndNotTheWholeFileTest {
+
+    /**
+     * A source that departs at every group it has: each declaration is written down the page where
+     * the canonical form writes it on one line.
+     */
+    private static String departingAtEveryGroup(int declarations) {
+        StringBuilder out = new StringBuilder("module m\n\nlet g (a: Int, b: Int): Int = a + b\n");
+        for (int i = 0; i < declarations; i++) {
+            out.append("""
+
+                    let f%d (a: Int): Int = g(
+                        a,
+                        a
+                    )
+                    """.formatted(i));
+        }
+        return out.toString();
+    }
+
+    /**
+     * A source that departs at every level it has: each declaration is written down the page, as the
+     * canonical form writes it, and indented two columns where it writes four.
+     */
+    private static String departingAtEveryLevel(int declarations) {
+        StringBuilder out = new StringBuilder("module m\n");
+        for (int i = 0; i < declarations; i++) {
+            out.append("""
+
+                    data D%d =
+                      { aRatherLongFieldName: Int
+                      , anotherRatherLongFieldName: Int
+                      , yetAnotherRatherLongFieldName: Int
+                      }
+                    """.formatted(i));
+        }
+        return out.toString();
+    }
+
+    /**
+     * A source that departs at a level with levels under it: the outer block is indented two
+     * columns where the canonical form writes four, and the block nested inside it is written at a
+     * column of its own.
+     *
+     * <p>The level a witness names is not always the innermost one on its lines. A level that moves
+     * takes what is nested inside it along, so the lines its repair writes include the deeper ones —
+     * and a source whose every departure is at an innermost level asks nothing about that.
+     */
+    private static String departingAtALevelWithLevelsUnderIt(int declarations) {
+        StringBuilder out = new StringBuilder("module m\n");
+        for (int i = 0; i < declarations; i++) {
+            out.append("""
+
+                    let f%d (a: Int): Int = {
+                      let b = {
+                            let c = a + 1
+                            c
+                        }
+                      b
+                    }
+                    """.formatted(i));
+        }
+        return out.toString();
+    }
+
+    /** The corpus, and the three shapes the gathering was made for. */
+    private static List<String> sources() {
+        List<String> out = new ArrayList<>(WhatGoesBetweenTwoTokensOnALineTest.corpus());
+        out.add(departingAtEveryGroup(6));
+        out.add(departingAtEveryLevel(6));
+        out.add(departingAtALevelWithLevelsUnderIt(6));
+        return out;
+    }
+
+    /** Every family's witnesses about one source, as a report asks for them. */
+    private static List<Witness> witnesses(String source, Formatter.CanonicalForm canonical,
+            Witnesses.Pairing pairing) {
+        List<Witness> out = new ArrayList<>();
+        List<Family> families = List.of(Witnesses::tokens, Witnesses::spacing,
+                Witnesses::separation, Witnesses::indentation, Witnesses::forced,
+                Witnesses::settled, Witnesses::conditional, Witnesses::comments,
+                Witnesses::lineEnds);
+        for (Family family : families) {
+            try {
+                out.addAll(family.of(source, canonical, pairing));
+            } catch (Witnesses.NoCorrespondence _) {
+                // this family has nothing to ask about this source, as a report would find
+            }
+        }
+        return out;
+    }
+
+    private interface Family {
+        List<Witness> of(String source, Formatter.CanonicalForm canonical,
+                Witnesses.Pairing pairing);
+    }
+
+    /** Which opportunities a group settles, by sweeping the layout for the ones that name it. */
+    private static List<Opportunity> sweptTo(Layout layout, Doc.GroupRef group) {
+        List<Opportunity> out = new ArrayList<>();
+        for (Opportunity o : layout.opportunities()) {
+            if (o.settledBy() == group) {
+                out.add(o);
+            }
+        }
+        return out;
+    }
+
+    /** Which lines are written under a level, by sweeping the canonical form's lines. */
+    private static List<Witnesses.CanonicalLine> sweptUnder(List<Witnesses.CanonicalLine> lines,
+            Doc.NestRef level) {
+        List<Witnesses.CanonicalLine> out = new ArrayList<>();
+        for (Witnesses.CanonicalLine line : lines) {
+            if (line.under().contains(level)) {
+                out.add(line);
+            }
+        }
+        return out;
+    }
+
+    /** Every group any opportunity of a layout names, in the order they are met. */
+    private static List<Doc.GroupRef> groupsOf(Layout layout) {
+        Set<Doc.GroupRef> seen = java.util.Collections.newSetFromMap(new IdentityHashMap<>());
+        List<Doc.GroupRef> out = new ArrayList<>();
+        for (Opportunity o : layout.opportunities()) {
+            if (seen.add(o.settledBy())) {
+                out.add(o.settledBy());
+            }
+        }
+        return out;
+    }
+
+    /** Every level any line of a canonical form is written under, in the order they are met. */
+    private static List<Doc.NestRef> levelsOf(List<Witnesses.CanonicalLine> lines) {
+        Set<Doc.NestRef> seen = java.util.Collections.newSetFromMap(new IdentityHashMap<>());
+        List<Doc.NestRef> out = new ArrayList<>();
+        for (Witnesses.CanonicalLine line : lines) {
+            for (Doc.NestRef level : line.under()) {
+                if (seen.add(level)) {
+                    out.add(level);
+                }
+            }
+        }
+        return out;
+    }
+
+    /**
+     * A group's opportunities are the ones sweeping the layout finds, in the order it finds them.
+     *
+     * <p>The gathering says which they are, and that is the whole of what it says: the repair sorts
+     * them by the adjacency they stand at before writing anything. Held in order anyway, because a
+     * gathering that met them in another order is a gathering that met other opportunities in every
+     * case this can tell apart, and reading the difference off the sequence says which.
+     */
+    @Test
+    void aGroupsOpportunitiesAreTheOnesTheSweepFinds() {
+        int settlingSeveral = 0;
+        for (String source : sources()) {
+            Formatter.CanonicalForm canonical =
+                    Formatter.canonicalize(CstParser.parse(source).root());
+            Repair.Round round = new Repair.Round(source, canonical,
+                    new Witnesses.Pairing(source, canonical));
+            for (Doc.GroupRef group : groupsOf(canonical.layout())) {
+                List<Opportunity> swept = sweptTo(canonical.layout(), group);
+                assertEquals(swept, round.settling().get(group),
+                        "the opportunities gathered under a group of " + head(source));
+                if (swept.size() > 1) {
+                    settlingSeveral++;
+                }
+            }
+        }
+        assertTrue(settlingSeveral > 0,
+                "no group of any source settles more than one opportunity, so gathering them under"
+                        + " the group is a gathering of nothing");
+    }
+
+    /**
+     * And a group that settles none of them has none, rather than the layout's.
+     *
+     * <p>Where a gathering has no entry, what a sweep found was nothing — so the projection reads
+     * nothing, and not every opportunity the file has.
+     */
+    @Test
+    void andAGroupThatSettlesNoneOfThemHasNone() {
+        String source = departingAtEveryGroup(2);
+        Formatter.CanonicalForm canonical = Formatter.canonicalize(CstParser.parse(source).root());
+        Repair.Round round = new Repair.Round(source, canonical,
+                new Witnesses.Pairing(source, canonical));
+
+        Doc.GroupRef settlingNothing = new Doc.GroupRef();
+        assertEquals(List.of(), sweptTo(canonical.layout(), settlingNothing));
+        assertNull(round.settling().get(settlingNothing));
+        assertTrue(!canonical.layout().opportunities().isEmpty(),
+                "the layout has no opportunity, so this asks nothing");
+    }
+
+    /**
+     * The lines under a level are the ones sweeping the canonical form's lines finds, in the order
+     * it finds them.
+     *
+     * <p>Every level the line is written under and not only the innermost. A level that moves takes
+     * what is nested inside it along, so a line four levels deep is under four of them and a
+     * gathering that filed it under one would leave the outer three writing nothing for it.
+     *
+     * <p>In order, which this one does rest on: the repair keeps the first line it meets at each of
+     * the source's line starts, so a level's lines met in another order are another set of edits.
+     */
+    @Test
+    void theLinesUnderALevelAreTheOnesTheSweepFinds() {
+        int underSeveral = 0;
+        int levelsWithSeveralLines = 0;
+        for (String source : sources()) {
+            Formatter.CanonicalForm canonical =
+                    Formatter.canonicalize(CstParser.parse(source).root());
+            Witnesses.Pairing pairing = new Witnesses.Pairing(source, canonical);
+            List<Witnesses.CanonicalLine> lines = Witnesses.lines(source, canonical, pairing);
+            Repair.Round round = new Repair.Round(source, canonical, pairing);
+            for (Doc.NestRef level : levelsOf(lines)) {
+                List<Witnesses.CanonicalLine> swept = sweptUnder(lines, level);
+                assertEquals(swept, round.under().get(level),
+                        "the lines gathered under a level of " + head(source));
+                if (swept.size() > 1) {
+                    levelsWithSeveralLines++;
+                }
+            }
+            for (Witnesses.CanonicalLine line : lines) {
+                if (line.under().size() > 1) {
+                    underSeveral++;
+                }
+            }
+        }
+        assertTrue(underSeveral > 0, "no line of any source is written under more than one level");
+        assertTrue(levelsWithSeveralLines > 0, "no level of any source holds more than one line");
+    }
+
+    /**
+     * And the projection says what it said when it swept.
+     *
+     * <p>The two rounds differ in nothing but how the two gatherings were built, so the edits a
+     * witness comes to are the same edits or the gathering changed an answer. Every family is
+     * projected, not only the two that read a gathering: what the round holds is read by name, and a
+     * family reading the wrong one is what this would find.
+     */
+    @Test
+    void andTheProjectionSaysWhatItSaidWhenItSwept() {
+        int conditional = 0;
+        int indentation = 0;
+        int overADeeperLine = 0;
+        int edits = 0;
+        for (String source : sources()) {
+            Formatter.CanonicalForm canonical =
+                    Formatter.canonicalize(CstParser.parse(source).root());
+            Witnesses.Pairing pairing = new Witnesses.Pairing(source, canonical);
+            List<Witnesses.CanonicalLine> lines = Witnesses.lines(source, canonical, pairing);
+
+            Map<Doc.GroupRef, List<Opportunity>> settling = new IdentityHashMap<>();
+            for (Doc.GroupRef group : groupsOf(canonical.layout())) {
+                settling.put(group, sweptTo(canonical.layout(), group));
+            }
+            Map<Doc.NestRef, List<Witnesses.CanonicalLine>> under = new IdentityHashMap<>();
+            for (Doc.NestRef level : levelsOf(lines)) {
+                under.put(level, sweptUnder(lines, level));
+            }
+            Repair.Round swept = new Repair.Round(source, canonical, pairing, settling, under);
+            Repair.Round gathered = new Repair.Round(source, canonical, pairing);
+
+            for (Witness w : witnesses(source, canonical, pairing)) {
+                List<Repair.Edit> was = Repair.of(swept, w);
+                assertEquals(was, Repair.of(gathered, w),
+                        "the stretches " + w.getClass().getSimpleName() + " comes to in "
+                                + head(source));
+                edits += was.size();
+                if (w instanceof Witness.Conditional || w instanceof Witness.RunTogether) {
+                    conditional++;
+                }
+                if (w instanceof Witness.Indentation i) {
+                    indentation++;
+                    for (Witnesses.CanonicalLine line : sweptUnder(lines, i.unit().inner())) {
+                        if (line.under().get(line.under().size() - 1) != i.unit().inner()) {
+                            overADeeperLine++;
+                        }
+                    }
+                }
+            }
+        }
+        assertTrue(conditional > 0, "no source has a witness that reads a group's opportunities");
+        assertTrue(indentation > 0, "no source has a witness that reads a level's lines");
+        assertTrue(overADeeperLine > 0,
+                "every level a witness names is the innermost one on its lines, so nothing here"
+                        + " asks whether a line is gathered under the levels above it too");
+        assertTrue(edits > 0, "the projection came to no stretch at all, so this compares nothing");
+    }
+
+    /**
+     * And a round hands back one list per witness, in the order it was asked about them.
+     *
+     * <p>What a report wants of a witness besides its expectation is where in the source it lands,
+     * which is where the first stretch it comes to begins. It reads that off the list of the witness
+     * it is about, so a round that handed back the lists in another order, or fewer of them than it
+     * was asked about, would put every deviation past that point at another rule's place.
+     */
+    @Test
+    void andARoundHandsBackOneListPerWitnessInOrder() {
+        String source = departingAtEveryGroup(3);
+        Formatter.CanonicalForm canonical = Formatter.canonicalize(CstParser.parse(source).root());
+        Witnesses.Pairing pairing = new Witnesses.Pairing(source, canonical);
+        List<Witness> witnesses = witnesses(source, canonical, pairing);
+        Repair.Round round = new Repair.Round(source, canonical, pairing);
+
+        List<List<Repair.Edit>> each = Repair.each(source, canonical, pairing, witnesses);
+        assertEquals(witnesses.size(), each.size());
+        assertTrue(witnesses.size() > 1, "one witness, so an order is not being held to anything");
+        for (int i = 0; i < witnesses.size(); i++) {
+            assertEquals(Repair.of(round, witnesses.get(i)), each.get(i),
+                    "the stretches witness " + i + " comes to");
+        }
+    }
+
+    /**
+     * And repairing what the rules say about these three sources writes their canonical form.
+     *
+     * <p>{@link RepairingWhatTheRulesSayWritesTheCanonicalFormTest} holds this of every source the
+     * repository has, and none of them departs at more than a handful of its units — which is the
+     * case a projection that reads one unit and one that reads the file agree on. So the three
+     * written here are held to it too, and {@link Deviations.Report#whole} is the statement: a source
+     * it is true of is one where the repair reached the canonical form and every difference on the
+     * way was named by a rule.
+     */
+    @Test
+    void andRepairingADenseSourceStillWritesItsCanonicalForm() {
+        for (String source : List.of(departingAtEveryGroup(6), departingAtEveryLevel(6),
+                departingAtALevelWithLevelsUnderIt(6))) {
+            Deviations.Report report = Deviations.of(source);
+            assertTrue(report.whole(),
+                    "repairing what the rules say about " + head(source)
+                            + " does not write its canonical form");
+            assertTrue(!report.deviations().isEmpty(),
+                    head(source) + " is already canonical, so nothing was projected");
+        }
+    }
+
+    /** The first line of a source, to say which one an assertion is about. */
+    private static String head(String source) {
+        int newline = source.indexOf('\n');
+        return "`" + (newline < 0 ? source : source.substring(0, newline)) + "`";
+    }
+}


### PR DESCRIPTION
Closes #814.

Two of the projections a report runs read the whole file to answer about one unit,
so a source that departs at a large fraction of its units cost the units multiplied
by the file. The issue reads that product off the code and says an input that
exercises it is the first step, since the corpus has none — real code departs at a
handful of its units however long it is.

## The input

It does not need a source collapsed onto one line, which is what the issue found
does not parse. A source departs from a group's decision as much by breaking where
the canonical form writes one line as by the other way about:

```
let f0 (a: Int): Int = g(
    a,
    a
)
```

which the canonical form writes as `let f0 (a: Int): Int = g(a, a)`. For a level, a
record type written down the page exactly where the canonical form writes it and
indented two columns instead of four departs at its level and at nothing else. Both
hold the canonical form still and move only how many units departed.

`souther-bench` grows a `report` measurement from that: two shapes at four sizes,
the departure density held at every unit, and the same shape with one departure
beside each as the control. The distance between the pair is the figure, in ms/KB —
a report that is slow because the source is long is slow in both lines.

With the sweep still in place, the dense line doubles its ms/KB with the size and
the control is flat:

```
REPORT n=200  level, every    24299 chars     78.6 ms ( 3.314 ms/KB)
REPORT n=200  level, one      25891 chars     16.9 ms ( 0.670 ms/KB)
REPORT n=400  level, every    48699 chars    304.5 ms ( 6.403 ms/KB)
REPORT n=400  level, one      51891 chars     29.2 ms ( 0.576 ms/KB)
REPORT n=800  level, every    97499 chars   1361.0 ms (14.294 ms/KB)
REPORT n=800  level, one     103891 chars     59.5 ms ( 0.586 ms/KB)
REPORT n=1600 level, every   195699 chars   6403.2 ms (33.505 ms/KB)
REPORT n=1600 level, one     208491 chars    126.0 ms ( 0.619 ms/KB)
```

## The fix

`Repair.Round` gathers each of the two under the unit that is asked about, once for
a round of witnesses. The opportunities go under the group that settles them. The
lines go under every level they are written under and not only the innermost,
because a level that moves takes what is nested inside it along — that is where the
fix was first left half-done: hoisting `Witnesses.lines` out of the loop stopped the
walk being repeated and left the sweep, and the shape stayed quadratic.

`Repair.where` goes with it. It evaluated the whole projection to keep one number,
and `Repair.edits` then evaluated it again to write the text. `edits` is now
`composed(each(...))`; `each` hands back one list per witness and the report reads
the offset off the list of the witness it is about.

| | before | after |
|---|---|---|
| `level, every` n=1600 | 6403.2 ms (33.505 ms/KB) | 220.6 ms (1.154) |
| `level, one` n=1600 | 126.0 ms (0.619) | 126.9 ms (0.623) |
| `group, every` n=3200 | 926.8 ms (6.640) | 554.4 ms (3.971) |
| `group, one` n=3200 | 399.7 ms (3.689) | 419.8 ms (3.874) |

## What holds it

`AWitnessIsProjectedThroughItsOwnUnitAndNotTheWholeFileTest` builds a second `Round`
by sweeping and hands both to the same projection, over the corpus and over three
sources written to depart at every group, at every level, and at a level with levels
under it. Every way of building the gatherings wrongly that it catches — filing a
line under its innermost level alone, gathering every opportunity under one group,
reversing either order — leaves the existing suite green, which is the corpus not
having the shape.

`EveryShapeThatIsTimedStillDepartsTest` holds the benchmark's shapes to being those
shapes: that the dense one departs at every declaration, that the control departs at
one, that neither departs the other's way, that the pair has one canonical form, and
that the report over each is whole.

Reports over the dense shapes are byte-identical before and after — line, column,
rule and both sides.

`souther-fmt` moves from `test` to compile scope in `souther-bench`, which is an
executable measurement tool rather than a test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
