### PR TITLE
Say how much of a rule the check reads, and show it where the rule is written

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/BehaviorChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BehaviorChecker.java
@@ -47,8 +47,11 @@ public final class BehaviorChecker {
      */
     public static BehaviorContract contractOf(Hir.SpecBehavior behavior, String module, Sig sig,
                                        Symbols symbols, Map<String, Type> helpers) {
-        List<Diagnostic> found = new ArrayList<>();
-        BehaviorContract contract = read(behavior, module, sig, symbols, found);
+        Reading reading = read(behavior, module, sig, symbols);
+        BehaviorContract contract = reading.contract();
+        // The rules it did read, held to what a rule has to be. Two mistakes in one declaration are
+        // two things for an author to fix, and this is the reading that reports them.
+        List<Diagnostic> found = new ArrayList<>(reading.unread());
         for (Rule rule : contract.rules()) {
             collect(found, () -> checkRule(behavior, contract, rule, helpers, symbols));
         }
@@ -83,17 +86,38 @@ public final class BehaviorChecker {
      */
     public static BehaviorContract contractAsRead(Hir.SpecBehavior behavior, String module, Sig sig,
                                                   Symbols symbols) {
-        List<Diagnostic> unread = new ArrayList<>();
-        BehaviorContract contract = read(behavior, module, sig, symbols, unread);
-        if (!unread.isEmpty()) {
-            throw CompileException.of(unread.get(0));
-        }
-        return contract;
+        return read(behavior, module, sig, symbols).whole();
     }
 
-    /** The declaration as rules, with what could not be read of it collected into {@code found}. */
-    private static BehaviorContract read(Hir.SpecBehavior behavior, String module, Sig sig,
-                                         Symbols symbols, List<Diagnostic> found) {
+    /**
+     * What reading a declaration came to: the rules it made, and what it could not read.
+     *
+     * <p>The two are one value because the contract alone does not say it is short of anything. A
+     * declaration whose arm could not be read makes a contract that states nothing about the cases
+     * that arm named, which is indistinguishable from a declaration that said nothing about them —
+     * and a reader deriving what is left unstated would report the opposite of what the author wrote.
+     * So what was lost arrives with what was kept, and a caller says which it is asking for.
+     */
+    private record Reading(BehaviorContract contract, List<Diagnostic> unread) {
+
+        /**
+         * The contract where the whole declaration was read.
+         *
+         * @throws CompileException where any of it was not, which is reported by the reading that
+         *     holds the declaration to its rules rather than said twice
+         */
+        BehaviorContract whole() {
+            if (!unread.isEmpty()) {
+                throw CompileException.of(unread.get(0));
+            }
+            return contract;
+        }
+    }
+
+    /** The declaration as rules, beside what could not be read of it. */
+    private static Reading read(Hir.SpecBehavior behavior, String module, Sig sig,
+                                Symbols symbols) {
+        List<Diagnostic> found = new ArrayList<>();
         ValueName.Behavior name = new ValueName.Behavior(module, behavior.name());
         if (sig == null) {
             // The signature could not be made, which is reported where that failed. A rule is
@@ -138,7 +162,7 @@ public final class BehaviorChecker {
             }
             clauses.add(new Clause(written.name(), rules, written.pos(), written.region()));
         }
-        return new BehaviorContract(name, params, sig.outputType(), clauses);
+        return new Reading(new BehaviorContract(name, params, sig.outputType(), clauses), found);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/BehaviorChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BehaviorChecker.java
@@ -47,6 +47,43 @@ public final class BehaviorChecker {
      */
     public static BehaviorContract contractOf(Hir.SpecBehavior behavior, String module, Sig sig,
                                        Symbols symbols, Map<String, Type> helpers) {
+        List<Diagnostic> found = new ArrayList<>();
+        BehaviorContract contract = read(behavior, module, sig, symbols, found);
+        for (Rule rule : contract.rules()) {
+            collect(found, () -> checkRule(behavior, contract, rule, helpers, symbols));
+        }
+        if (found.size() == 1) {
+            throw CompileException.of(found.get(0));
+        }
+        if (!found.isEmpty()) {
+            throw CompileException.ofAll(found, DiagnosticRenderer.legacyBody(found.get(0)));
+        }
+        return contract;
+    }
+
+    /**
+     * The same declaration read again, in whatever representation {@code behavior} is written in, and
+     * held to nothing.
+     *
+     * <p>What the rules are — which case each applies to, what {@code value} is there, which rule is
+     * which — is a property of the declaration and not of the representation, so this reads the same
+     * rules under the same {@link RuleId}s as {@link #contractOf} does of the tree that runs. What is
+     * not done again is the holding: a clause that is not well formed is one mistake, and the reading
+     * that reports it is the one the author's build is made of. An arm this cannot read contributes
+     * no rule, as it does there.
+     *
+     * @throws Unanswerable where there is no signature to read the rules against
+     * @throws CompileException where the declaration cannot be read at all, which the executable
+     *     reading of it reports as well
+     */
+    public static BehaviorContract contractAsRead(Hir.SpecBehavior behavior, String module, Sig sig,
+                                                  Symbols symbols) {
+        return read(behavior, module, sig, symbols, new ArrayList<>());
+    }
+
+    /** The declaration as rules, with what could not be read of it collected into {@code found}. */
+    private static BehaviorContract read(Hir.SpecBehavior behavior, String module, Sig sig,
+                                         Symbols symbols, List<Diagnostic> found) {
         ValueName.Behavior name = new ValueName.Behavior(module, behavior.name());
         if (sig == null) {
             // The signature could not be made, which is reported where that failed. A rule is
@@ -65,7 +102,8 @@ public final class BehaviorChecker {
         BindingOwner owner = BehaviorContract.ownerOf(name);
         List<ContractParam> params = new ArrayList<>();
         for (int i = 0; i < behavior.params().size(); i++) {
-            params.add(new ContractParam(new BindingId(owner, i), sig.inputTypes().get(i), i));
+            params.add(new ContractParam(new BindingId(owner, i), behavior.params().get(i).name(),
+                    sig.inputTypes().get(i), i));
         }
 
         // Which cases the answer can be, and what `value` is in each, come from the same place a
@@ -77,7 +115,6 @@ public final class BehaviorChecker {
         // one pass — what a rule states is which case it applies to and what holds there, and every
         // refusal here is this not having been able to read that — so an arm that fails contributes
         // no rule and stops nothing else.
-        List<Diagnostic> found = new ArrayList<>();
         List<Clause> clauses = new ArrayList<>();
         int armOrdinal = 0;
         for (int c = 0; c < behavior.ensures().size(); c++) {
@@ -91,18 +128,7 @@ public final class BehaviorChecker {
             }
             clauses.add(new Clause(written.name(), rules, written.pos(), written.region()));
         }
-        BehaviorContract contract =
-                new BehaviorContract(name, params, sig.outputType(), clauses);
-        for (Rule rule : contract.rules()) {
-            collect(found, () -> checkRule(behavior, contract, rule, helpers, symbols));
-        }
-        if (found.size() == 1) {
-            throw CompileException.of(found.get(0));
-        }
-        if (!found.isEmpty()) {
-            throw CompileException.ofAll(found, DiagnosticRenderer.legacyBody(found.get(0)));
-        }
-        return contract;
+        return new BehaviorContract(name, params, sig.outputType(), clauses);
     }
 
     /**
@@ -172,21 +198,31 @@ public final class BehaviorChecker {
     /** One rule: what its expression comes to, and that it states a relation. */
     private static void checkRule(Hir.SpecBehavior behavior, BehaviorContract contract, Rule rule,
                                   Map<String, Type> helpers, Symbols symbols) {
-        Map<BindingId, Scope.Binding> bindings = new LinkedHashMap<>();
-        for (ContractParam param : contract.params()) {
-            bindings.put(param.binding(),
-                    new Scope.Binding(behavior.params().get(param.index()).name(), param.type()));
-        }
-        bindings.put(rule.value(),
-                new Scope.Binding("value", rule.valueType(contract.output())));
-        Type actual = Elaborator.typeOf(rule.statement(), Scope.of(bindings).reaching(helpers),
-                CheckContext.of(symbols));
+        Type actual = Elaborator.typeOf(rule.statement(),
+                scopeOf(contract, rule).reaching(helpers), CheckContext.of(symbols));
         if (actual != Type.BOOL) {
             throw CompileException.of(Diagnostic.at(rule.statement().pos())
                     .say(new BehaviorMessage.AnEnsuresExpressionIsNotBool(
                             behavior.name(), Type.show(actual))).build());
         }
         requireBothSides(behavior, contract, rule);
+    }
+
+    /**
+     * What a rule may name: the behavior's parameters, and {@code value} as the case it is written
+     * under holds it.
+     *
+     * <p>Everything it takes is the contract's. A rule is read here, where it is checked, and there
+     * where it is classified, and the two would be two scopes to keep saying the same thing if
+     * either built it from the declaration instead.
+     */
+    static Scope scopeOf(BehaviorContract contract, Rule rule) {
+        Map<BindingId, Scope.Binding> bindings = new LinkedHashMap<>();
+        for (ContractParam param : contract.params()) {
+            bindings.put(param.binding(), new Scope.Binding(param.name(), param.type()));
+        }
+        bindings.put(rule.value(), new Scope.Binding("value", rule.valueType(contract.output())));
+        return Scope.of(bindings);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/BehaviorChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BehaviorChecker.java
@@ -69,16 +69,26 @@ public final class BehaviorChecker {
      * which — is a property of the declaration and not of the representation, so this reads the same
      * rules under the same {@link RuleId}s as {@link #contractOf} does of the tree that runs. What is
      * not done again is the holding: a clause that is not well formed is one mistake, and the reading
-     * that reports it is the one the author's build is made of. An arm this cannot read contributes
-     * no rule, as it does there.
+     * that reports it is the one the author's build is made of.
+     *
+     * <p>All of the declaration or none of it. An arm that cannot be read contributes no rule, and a
+     * contract missing one is a contract that says the author stated nothing about the cases that arm
+     * named — which is the opposite of what they wrote, and is what a reader of it would be told. The
+     * refusal is already being reported by the reading that holds the declaration to its rules, so
+     * there is nothing to say here beyond declining to answer.
      *
      * @throws Unanswerable where there is no signature to read the rules against
-     * @throws CompileException where the declaration cannot be read at all, which the executable
+     * @throws CompileException where any of the declaration could not be read, which the executable
      *     reading of it reports as well
      */
     public static BehaviorContract contractAsRead(Hir.SpecBehavior behavior, String module, Sig sig,
                                                   Symbols symbols) {
-        return read(behavior, module, sig, symbols, new ArrayList<>());
+        List<Diagnostic> unread = new ArrayList<>();
+        BehaviorContract contract = read(behavior, module, sig, symbols, unread);
+        if (!unread.isEmpty()) {
+            throw CompileException.of(unread.get(0));
+        }
+        return contract;
     }
 
     /** The declaration as rules, with what could not be read of it collected into {@code found}. */

--- a/souther-compiler/src/main/java/souther/compiler/check/BehaviorContract.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BehaviorContract.java
@@ -39,8 +39,16 @@ public record BehaviorContract(ValueName.Behavior behavior, List<ContractParam> 
         clauses = List.copyOf(clauses);
     }
 
-    /** A parameter as a rule names it: where it is bound, what it holds, and which one it is. */
-    public record ContractParam(BindingId binding, Type type, int index) {}
+    /**
+     * A parameter as a rule names it: where it is bound, what the author calls it, what it holds, and
+     * which one it is.
+     *
+     * <p>A rule names it by its binding and never by the spelling. The spelling is carried for a
+     * reader — a diagnostic quoting the parameter a rule could not be read against, and an editor
+     * showing what a behavior states — which is the reason it is here rather than looked up on the
+     * declaration by whoever needs to show one.
+     */
+    public record ContractParam(BindingId binding, String name, Type type, int index) {}
 
     /** One `ensures`, with the rules its arms state. A violation is reported by the clause, so this
      *  is what carries the name a reader is given. */
@@ -85,11 +93,18 @@ public record BehaviorContract(ValueName.Behavior behavior, List<ContractParam> 
     }
 
     /**
-     * Which rule this is, stably.
+     * Which rule this is: where in the declaration it is written, and which case it is about.
      *
-     * <p>Written down rather than counted off a walk. The emitter, the classification, the editor
-     * and a report all have to agree that they are talking about the same rule, and an identity that
-     * came from the order something was visited in would move when an unrelated declaration moved.
+     * <p>Coordinates in the declaration and not steps of a walk. Which clause, which arm of it, and
+     * which case that arm names is what the author wrote; nothing here comes from the order some
+     * reader happened to visit things in, so two readings of one declaration — the tree that runs and
+     * the tree the analysis reads — answer with the same ids without having to be matched up
+     * afterwards.
+     *
+     * <p>{@code arm} is needed and {@code (clause, selector)} would not do: two arms of one clause may
+     * name the same case, and {@code Found -> p | Found -> q} is two rules. It moves when arms are
+     * added, removed or reordered, which is the declaration changing shape — not something else in the
+     * module moving.
      */
     public record RuleId(ValueName.Behavior behavior, int clause, int arm, TypeSymbol selector) {}
 

--- a/souther-compiler/src/main/java/souther/compiler/check/BehaviorContract.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BehaviorContract.java
@@ -105,6 +105,10 @@ public record BehaviorContract(ValueName.Behavior behavior, List<ContractParam> 
      * name the same case, and {@code Found -> p | Found -> q} is two rules. It moves when arms are
      * added, removed or reordered, which is the declaration changing shape — not something else in the
      * module moving.
+     *
+     * <p>It counts the arms of the whole behavior and not of its clause, so the arms of the second
+     * clause carry on from where the first left off. That is what the binding {@code value} is is
+     * numbered by, and one number for both is one thing to keep true instead of two.
      */
     public record RuleId(ValueName.Behavior behavior, int clause, int arm, TypeSymbol selector) {}
 

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseDischarge.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseDischarge.java
@@ -99,16 +99,32 @@ public record ClauseDischarge(SourcePos clause, Kind kind, Optional<String> reas
     public static List<ClauseDischarge> readings(boolean asABound, boolean asATerm, boolean unread,
                                                  SourcePos clause, Supplier<String> why) {
         List<ClauseDischarge> found = new ArrayList<>();
+        for (Kind read : kindsRead(asABound, asATerm, unread)) {
+            found.add(read == Kind.RUNTIME_ONLY ? runtimeOnly(clause, why.get())
+                    : new ClauseDischarge(clause, read, Optional.empty()));
+        }
+        return List.copyOf(found);
+    }
+
+    /**
+     * The same rule, for a reader with nowhere to say it.
+     *
+     * <p>A caller that only wants to know whether a clause was read as a bound has no author in front
+     * of it and so no position to be right or wrong about — asked for one it would have to invent
+     * one, and an invented position is the thing this classification has been got wrong by twice.
+     */
+    public static List<Kind> kindsRead(boolean asABound, boolean asATerm, boolean unread) {
+        List<Kind> found = new ArrayList<>();
         if (asABound) {
-            found.add(derivable(clause));
+            found.add(Kind.DERIVABLE);
         }
         if (asATerm) {
-            found.add(exactMatch(clause));
+            found.add(Kind.EXACT_MATCH);
         }
         // A clause nothing was found of is one nothing can be asked of, which is the same answer as a
         // clause the check read no part of.
         if (unread || found.isEmpty()) {
-            found.add(runtimeOnly(clause, why.get()));
+            found.add(Kind.RUNTIME_ONLY);
         }
         return List.copyOf(found);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseDischarge.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseDischarge.java
@@ -2,7 +2,10 @@ package souther.compiler.check;
 
 import souther.compiler.diag.SourcePos;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * How much of one clause of the model the check reads: a data's {@code invariant} (spec
@@ -69,6 +72,45 @@ public record ClauseDischarge(SourcePos clause, Kind kind, Optional<String> reas
      * be outside the fragment, and which one it is decides what the author can do about it. */
     public static ClauseDischarge runtimeOnly(SourcePos clause, String reason) {
         return new ClauseDischarge(clause, Kind.RUNTIME_ONLY, Optional.of(reason));
+    }
+
+    /**
+     * Every reading one clause got, from what the check found of it — one where it is read one way,
+     * and more where it is read more than one way.
+     *
+     * <p>What is written as one thing need not be read as one thing. A clause naming a helper is one
+     * thing to its author and is whatever that helper states to the check, and the parts of it can be
+     * read differently: a bound and a term that can only be compared for identity are discharged by
+     * different guards, and something being one says nothing about whether the rest is. Answering
+     * with one of them is choosing which part of a clause to describe — and if the choice is "the
+     * strongest", what an author is shown is the part that will not surprise them.
+     *
+     * <p>{@code unread} is the part of it the check made nothing of, which is said even where the
+     * rest was read. Left out, a clause half of which is outside the fragment would be described
+     * entirely by the half inside it: an author reading "a guard discharges this" would write one and
+     * find the construction still refused.
+     *
+     * <p>Written here as what it is — a function of what was found — so that it can be held to for
+     * shapes a program does not take today. Every reader of a clause reaches this, and the day the
+     * check reads further into what a clause names is the day a clause states two of these at once.
+     *
+     * @param why what the check could not read, asked for only where there is something to say
+     */
+    public static List<ClauseDischarge> readings(boolean asABound, boolean asATerm, boolean unread,
+                                                 SourcePos clause, Supplier<String> why) {
+        List<ClauseDischarge> found = new ArrayList<>();
+        if (asABound) {
+            found.add(derivable(clause));
+        }
+        if (asATerm) {
+            found.add(exactMatch(clause));
+        }
+        // A clause nothing was found of is one nothing can be asked of, which is the same answer as a
+        // clause the check read no part of.
+        if (unread || found.isEmpty()) {
+            found.add(runtimeOnly(clause, why.get()));
+        }
+        return List.copyOf(found);
     }
 
     /** Whether a construction of this type can be judged safe from this clause at all. */

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseDischarge.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseDischarge.java
@@ -5,8 +5,9 @@ import souther.compiler.diag.SourcePos;
 import java.util.Optional;
 
 /**
- * How one clause of an invariant can be discharged at compile time (spec
- * §invariant-discharge-capability).
+ * How much of one clause of the model the check reads: a data's {@code invariant} (spec
+ * §invariant-discharge-capability) or a behavior's {@code ensures} (spec
+ * §ensures-discharge-capability).
  *
  * <p>Once some clauses are statically dischargeable and others are not, the same {@code invariant}
  * keyword means two different things to a reader: one shape reports an unguarded construction and the
@@ -14,8 +15,13 @@ import java.util.Optional;
  * This is the answer, per clause, so the classification is a property of the language and not of
  * whatever the checker happens to manage.
  *
- * <p>It is the clause's own capability, read with the construction assumed to name what it is given.
- * A construction that names nothing the check can name discharges nothing whatever its clauses say —
+ * <p>One record for both kinds because it is one question — whether what is written is a relation the
+ * numeric domain reasons over, a term the check can name, or neither. What follows from the answer is
+ * the reader's: for an invariant it says what discharges a construction, for a rule how much of the
+ * relation there is to read. Answering it twice would be two classifications to keep agreeing.
+ *
+ * <p>It is the clause's own capability, read with what it names assumed to stand for itself. A
+ * construction that names nothing the check can name discharges nothing whatever its clauses say —
  * that is a fact about the construction, and belongs where the construction is.
  */
 public record ClauseDischarge(SourcePos clause, Kind kind, Optional<String> reason,

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseHelpers.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseHelpers.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Hir;
+import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.TypeSymbol;
 
@@ -84,6 +85,30 @@ public final class ClauseHelpers {
         return out;
     }
 
+    /**
+     * Each behavior's {@code ensures} in the representation the discharge analysis reads, by the name
+     * the behavior is declared under. A behavior stating nothing is not here.
+     *
+     * <p>The same reading {@link #invariantsForDischarge} gives a declaration's clauses, of the other
+     * kind of clause. The whole declaration and not its clauses alone, because what a rule is read
+     * against — which cases the answer has, what each parameter holds — is read off the same node,
+     * and a reader handed the clauses would go back to the module for the rest.
+     */
+    public static Map<String, Hir.SpecBehavior> ensuresForDischarge(
+            Expandable expandable, Symbols symbols, Map<String, Hir.FnDef> published) {
+        Hir.Module m = expandable.module();
+        Hir.Module settled = settled(m, symbols);
+        HelperInliner inliner = HelperInliner.forHelpers(m.name(), HelperInliner.helpersOf(settled),
+                published, InliningPolicy.DISCHARGE);
+        Map<String, Hir.SpecBehavior> out = new LinkedHashMap<>();
+        for (Hir.BehaviorDef behavior : settled.behaviors()) {
+            if (behavior instanceof Hir.SpecBehavior spec && !spec.ensures().isEmpty()) {
+                out.put(spec.name(), withInlinedEnsures(inliner, settled.name(), spec));
+            }
+        }
+        return out;
+    }
+
     /** {@code m} with its helper parameter types settled and the names in its invariants written
      * qualified — what both representations are expanded from, so neither reads a table the other
      * would key differently. */
@@ -110,25 +135,51 @@ public final class ClauseHelpers {
         }
         List<Hir.BehaviorDef> behaviors = new ArrayList<>();
         for (Hir.BehaviorDef behavior : m.behaviors()) {
-            if (behavior instanceof Hir.SpecBehavior spec && !spec.ensures().isEmpty()) {
-                BindingOwner owner = new BindingOwner.OfSignature(
-                        new souther.compiler.types.ValueName.Behavior(m.name(), spec.name()));
-                List<Hir.EnsuresClause> clauses = new ArrayList<>();
-                for (Hir.EnsuresClause clause : spec.ensures()) {
-                    List<Hir.EnsuresArm> arms = new ArrayList<>();
-                    for (Hir.EnsuresArm arm : clause.arms()) {
-                        arms.add(arm.with(inliner.inline(arm.expr(), owner)));
-                    }
-                    clauses.add(new Hir.EnsuresClause(clause.name(), List.copyOf(arms),
-                            clause.pos(), clause.region()));
-                }
-                behaviors.add(new Hir.SpecBehavior(spec.written(), spec.params(), spec.ret(),
-                        spec.constructs(), spec.dependsOn(), List.copyOf(clauses), spec.pos()));
-            } else {
-                behaviors.add(behavior);
-            }
+            behaviors.add(behavior instanceof Hir.SpecBehavior spec && !spec.ensures().isEmpty()
+                    ? withInlinedEnsures(inliner, m.name(), spec) : behavior);
         }
         return m.withDefs(defs).withBehaviors(behaviors);
+    }
+
+    /** {@code spec} with the helper calls in its {@code ensures} expanded as {@code inliner} expands
+     * them — which representation that leaves is the inliner's to say, and the same walk gives
+     * either. */
+    private static Hir.SpecBehavior withInlinedEnsures(HelperInliner inliner, String module,
+                                                       Hir.SpecBehavior spec) {
+        BindingOwner owner = new BindingOwner.OfSignature(
+                new souther.compiler.types.ValueName.Behavior(module, spec.name()));
+        List<Hir.EnsuresClause> clauses = new ArrayList<>();
+        for (Hir.EnsuresClause clause : spec.ensures()) {
+            List<Hir.EnsuresArm> arms = new ArrayList<>();
+            for (Hir.EnsuresArm arm : clause.arms()) {
+                arms.add(arm.with(inliner.inline(arm.expr(), owner)));
+            }
+            clauses.add(new Hir.EnsuresClause(clause.name(), List.copyOf(arms),
+                    clause.pos(), clause.region()));
+        }
+        return new Hir.SpecBehavior(spec.written(), spec.params(), spec.ret(),
+                spec.constructs(), spec.dependsOn(), List.copyOf(clauses), spec.pos());
+    }
+
+    /**
+     * Where a written clause begins: the earliest position anything in it carries.
+     *
+     * <p>A node's own position is where its operator is written, so the position of {@code a && b} is
+     * the {@code &&}. A reader is pointed at the clause, which starts at whatever of it comes first.
+     */
+    public static SourcePos beginsAt(Hir.Expr e) {
+        SourcePos[] found = {e.pos()};
+        Hir.forEachChild(e, child -> {
+            SourcePos inner = beginsAt(child);
+            if (inner != null && (found[0] == null || earlier(inner, found[0]))) {
+                found[0] = inner;
+            }
+        });
+        return found[0];
+    }
+
+    private static boolean earlier(SourcePos a, SourcePos b) {
+        return a.line() != b.line() ? a.line() < b.line() : a.column() < b.column();
     }
 
     /** The conjuncts of a clause, flattened, in the order they are written — what a reader sees as

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseHelpers.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseHelpers.java
@@ -185,10 +185,51 @@ public final class ClauseHelpers {
     }
 
     /**
+     * A clause as a reader of it sees it: one entry per conjunct the author wrote, each placed where
+     * they wrote it and expanded into the representation that reads it.
+     *
+     * <p>The three steps are here together because their order is the whole of the correctness. An
+     * expansion carries the positions of the body it copies in and splices in whatever that body is
+     * made of, so a clause expanded first is placed inside the helper it names and split where that
+     * helper's author put an {@code &&} — and what comes back is an answer about a rule nobody wrote,
+     * pointing at a line they did not write it on. Split and placed first, then expanded, none of
+     * that can happen; done in either other order, all of it does.
+     *
+     * <p>Both kinds of clause read this. Having said the order once, there is nowhere left to say it
+     * differently — which is what it cost to have it written twice: the invariant reader had it right
+     * and the rule reader had it backwards, and nothing in either of them said which was which.
+     *
+     * @param written the clause as its author wrote it, before anything is expanded
+     * @param owner what the names in an expansion of it belong to — a declaration or a signature
+     * @param expansion what turns one conjunct into the tree its reader has rules about
+     */
+    public static List<Conjunct> conjunctsToRead(Hir.Expr written, BindingOwner owner,
+                                                 HelperInliner expansion) {
+        List<Conjunct> out = new ArrayList<>();
+        for (Hir.Expr each : conjunctsOf(written)) {
+            out.add(new Conjunct(beginsAt(each), expansion.inline(each, owner)));
+        }
+        return out;
+    }
+
+    /**
+     * One conjunct of a clause: where the author wrote it, and what it comes to for the reader that
+     * asked.
+     *
+     * <p>The two travel together because the answer is about both — what a reader works out has to be
+     * said at a place, and the place is not a property of what they worked it out from.
+     */
+    public record Conjunct(SourcePos at, Hir.Expr read) {}
+
+    /**
      * Where a written clause begins: the earliest position anything in it carries.
      *
      * <p>A node's own position is where its operator is written, so the position of {@code a && b} is
      * the {@code &&}. A reader is pointed at the clause, which starts at whatever of it comes first.
+     *
+     * <p>Of what was written. Asked of an expanded tree it answers with a position inside whatever
+     * was expanded into it, which is why a reader wanting both this and the expansion asks
+     * {@link #conjunctsToRead} for the two at once.
      */
     public static SourcePos beginsAt(Hir.Expr e) {
         SourcePos[] found = {e.pos()};

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseHelpers.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseHelpers.java
@@ -85,57 +85,10 @@ public final class ClauseHelpers {
         return out;
     }
 
-    /**
-     * The behaviors of a module that state something, as their author wrote them, beside the
-     * expansion the discharge analysis reads them under.
-     *
-     * <p>Not expanded here, which is the difference from {@link #invariantsForDischarge} and the
-     * reason this hands over the expansion instead. A rule is shown to whoever wrote it, so what a
-     * reader is given has to be said at the position it is written at and split where the author
-     * split it — and an expansion carries the positions of the body it copied in
-     * ({@link HelperInliner}), so a rule expanded before it is read would be reported inside the
-     * helper it names. The clauses are split and placed against what is written, and each piece is
-     * expanded after that (spec §ensures-discharge-capability).
-     *
-     * <p>The whole declaration and not its clauses alone, because what a rule is read against —
-     * which cases the answer has, what each parameter holds — is read off the same node, and a
-     * reader handed the clauses would go back to the module for the rest.
-     */
-    public static WrittenEnsures ensuresForDischarge(
-            Expandable expandable, Symbols symbols, Map<String, Hir.FnDef> published) {
-        Hir.Module m = expandable.module();
-        Hir.Module settled = settled(m, symbols);
-        Map<String, Hir.SpecBehavior> out = new LinkedHashMap<>();
-        for (Hir.BehaviorDef behavior : settled.behaviors()) {
-            if (behavior instanceof Hir.SpecBehavior spec && !spec.ensures().isEmpty()) {
-                out.put(spec.name(), spec);
-            }
-        }
-        return new WrittenEnsures(out, HelperInliner.forHelpers(m.name(),
-                HelperInliner.helpersOf(settled), published, InliningPolicy.DISCHARGE));
-    }
-
-    /**
-     * What a module states about its answers as it is written, and what expands a piece of it into
-     * the representation the discharge analysis reads.
-     *
-     * <p>The two travel together because neither is usable alone: the written form is what a reader
-     * is shown and is not what the analysis has rules about, and the expansion says nothing about
-     * which behavior or which clause is being expanded.
-     */
-    public record WrittenEnsures(Map<String, Hir.SpecBehavior> behaviors, HelperInliner expansion) {
-
-        public WrittenEnsures {
-            // Kept in the order the module declares them, so that what a reader is handed does not
-            // depend on how a map happened to hash the names.
-            behaviors = java.util.Collections.unmodifiableMap(new LinkedHashMap<>(behaviors));
-        }
-    }
-
     /** {@code m} with its helper parameter types settled and the names in its invariants written
      * qualified — what both representations are expanded from, so neither reads a table the other
      * would key differently. */
-    private static Hir.Module settled(Hir.Module m, Symbols symbols) {
+    static Hir.Module settled(Hir.Module m, Symbols symbols) {
         return HelperNames.withQualifiedInvariants(HelperParams.settle(m, symbols, Map.of()));
     }
 
@@ -185,53 +138,16 @@ public final class ClauseHelpers {
     }
 
     /**
-     * A clause as a reader of it sees it: one entry per conjunct the author wrote, each placed where
-     * they wrote it and expanded into the representation that reads it.
-     *
-     * <p>The three steps are here together because their order is the whole of the correctness. An
-     * expansion carries the positions of the body it copies in and splices in whatever that body is
-     * made of, so a clause expanded first is placed inside the helper it names and split where that
-     * helper's author put an {@code &&} — and what comes back is an answer about a rule nobody wrote,
-     * pointing at a line they did not write it on. Split and placed first, then expanded, none of
-     * that can happen; done in either other order, all of it does.
-     *
-     * <p>Both kinds of clause read this. Having said the order once, there is nowhere left to say it
-     * differently — which is what it cost to have it written twice: the invariant reader had it right
-     * and the rule reader had it backwards, and nothing in either of them said which was which.
-     *
-     * @param written the clause as its author wrote it, before anything is expanded
-     * @param owner what the names in an expansion of it belong to — a declaration or a signature
-     * @param expansion what turns one conjunct into the tree its reader has rules about
-     */
-    public static List<Conjunct> conjunctsToRead(Hir.Expr written, BindingOwner owner,
-                                                 HelperInliner expansion) {
-        List<Conjunct> out = new ArrayList<>();
-        for (Hir.Expr each : conjunctsOf(written)) {
-            out.add(new Conjunct(beginsAt(each), expansion.inline(each, owner)));
-        }
-        return out;
-    }
-
-    /**
-     * One conjunct of a clause: where the author wrote it, and what it comes to for the reader that
-     * asked.
-     *
-     * <p>The two travel together because the answer is about both — what a reader works out has to be
-     * said at a place, and the place is not a property of what they worked it out from.
-     */
-    public record Conjunct(SourcePos at, Hir.Expr read) {}
-
-    /**
      * Where a written clause begins: the earliest position anything in it carries.
      *
      * <p>A node's own position is where its operator is written, so the position of {@code a && b} is
      * the {@code &&}. A reader is pointed at the clause, which starts at whatever of it comes first.
      *
      * <p>Of what was written. Asked of an expanded tree it answers with a position inside whatever
-     * was expanded into it, which is why a reader wanting both this and the expansion asks
-     * {@link #conjunctsToRead} for the two at once.
+     * was expanded into it, which is why the reader that wants both this and the expansion gets them
+     * made together ({@link ClausesForDischarge}).
      */
-    public static SourcePos beginsAt(Hir.Expr e) {
+    static SourcePos beginsAt(Hir.Expr e) {
         SourcePos[] found = {e.pos()};
         Hir.forEachChild(e, child -> {
             SourcePos inner = beginsAt(child);

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseHelpers.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseHelpers.java
@@ -86,27 +86,50 @@ public final class ClauseHelpers {
     }
 
     /**
-     * Each behavior's {@code ensures} in the representation the discharge analysis reads, by the name
-     * the behavior is declared under. A behavior stating nothing is not here.
+     * The behaviors of a module that state something, as their author wrote them, beside the
+     * expansion the discharge analysis reads them under.
      *
-     * <p>The same reading {@link #invariantsForDischarge} gives a declaration's clauses, of the other
-     * kind of clause. The whole declaration and not its clauses alone, because what a rule is read
-     * against — which cases the answer has, what each parameter holds — is read off the same node,
-     * and a reader handed the clauses would go back to the module for the rest.
+     * <p>Not expanded here, which is the difference from {@link #invariantsForDischarge} and the
+     * reason this hands over the expansion instead. A rule is shown to whoever wrote it, so what a
+     * reader is given has to be said at the position it is written at and split where the author
+     * split it — and an expansion carries the positions of the body it copied in
+     * ({@link HelperInliner}), so a rule expanded before it is read would be reported inside the
+     * helper it names. The clauses are split and placed against what is written, and each piece is
+     * expanded after that (spec §ensures-discharge-capability).
+     *
+     * <p>The whole declaration and not its clauses alone, because what a rule is read against —
+     * which cases the answer has, what each parameter holds — is read off the same node, and a
+     * reader handed the clauses would go back to the module for the rest.
      */
-    public static Map<String, Hir.SpecBehavior> ensuresForDischarge(
+    public static WrittenEnsures ensuresForDischarge(
             Expandable expandable, Symbols symbols, Map<String, Hir.FnDef> published) {
         Hir.Module m = expandable.module();
         Hir.Module settled = settled(m, symbols);
-        HelperInliner inliner = HelperInliner.forHelpers(m.name(), HelperInliner.helpersOf(settled),
-                published, InliningPolicy.DISCHARGE);
         Map<String, Hir.SpecBehavior> out = new LinkedHashMap<>();
         for (Hir.BehaviorDef behavior : settled.behaviors()) {
             if (behavior instanceof Hir.SpecBehavior spec && !spec.ensures().isEmpty()) {
-                out.put(spec.name(), withInlinedEnsures(inliner, settled.name(), spec));
+                out.put(spec.name(), spec);
             }
         }
-        return out;
+        return new WrittenEnsures(out, HelperInliner.forHelpers(m.name(),
+                HelperInliner.helpersOf(settled), published, InliningPolicy.DISCHARGE));
+    }
+
+    /**
+     * What a module states about its answers as it is written, and what expands a piece of it into
+     * the representation the discharge analysis reads.
+     *
+     * <p>The two travel together because neither is usable alone: the written form is what a reader
+     * is shown and is not what the analysis has rules about, and the expansion says nothing about
+     * which behavior or which clause is being expanded.
+     */
+    public record WrittenEnsures(Map<String, Hir.SpecBehavior> behaviors, HelperInliner expansion) {
+
+        public WrittenEnsures {
+            // Kept in the order the module declares them, so that what a reader is handed does not
+            // depend on how a map happened to hash the names.
+            behaviors = java.util.Collections.unmodifiableMap(new LinkedHashMap<>(behaviors));
+        }
     }
 
     /** {@code m} with its helper parameter types settled and the names in its invariants written

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseHelpers.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseHelpers.java
@@ -10,9 +10,10 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * A declaration's {@code invariant} with the helpers it names expanded.
+ * The clauses a module declares — a data's {@code invariant} and a behavior's {@code ensures} — with
+ * the helpers they name expanded.
  *
- * <p>An invariant is expanded well before a body is. An importer reads an included data's invariant
+ * <p>A clause is expanded well before a body is. An importer reads an included data's invariant
  * through the symbol table, so it has to be expanded by the time the table is built, and the settling
  * of the helper parameter types it reaches has to happen first — expanding a call carries the
  * parameter's type onto the binding the call becomes, so a type settled afterwards would never reach
@@ -22,10 +23,14 @@ import java.util.Map;
  * <p>There are two, and they are read by different things. The settled form is what travels to an
  * importer and what the backend emits; the discharge form leaves the language's own operations
  * standing, because the analysis has rules about them ({@link InliningPolicy}).
+ *
+ * <p>Both kinds of clause are here because the expansion is one rule. What a helper call comes to
+ * does not depend on whether the clause it stands in is written of a value or of an answer, and the
+ * two representations are the same two either way.
  */
-public final class HelperInvariants {
+public final class ClauseHelpers {
 
-    private HelperInvariants() {}
+    private ClauseHelpers() {}
 
     /**
      * Settles the helper parameter types the author left unwritten, then inlines the helper calls in
@@ -126,8 +131,8 @@ public final class HelperInvariants {
         return m.withDefs(defs).withBehaviors(behaviors);
     }
 
-    /** The conjuncts of an invariant expression, flattened, in the order they are written — what a
-     * reader sees as separate clauses. */
+    /** The conjuncts of a clause, flattened, in the order they are written — what a reader sees as
+     * separate clauses. */
     public static List<Hir.Expr> conjunctsOf(Hir.Expr e) {
         if (e instanceof Hir.Binary b && b.op() == Hir.BinOp.AND) {
             List<Hir.Expr> out = new ArrayList<>(conjunctsOf(b.left()));

--- a/souther-compiler/src/main/java/souther/compiler/check/ClausesForDischarge.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClausesForDischarge.java
@@ -1,0 +1,125 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.diag.Region;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingOwner;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A module's clauses as the discharge analysis reads them — the one thing that hands a reader a
+ * clause to classify.
+ *
+ * <p>Reading a clause is four facts, and every one of them has been got wrong by somebody deriving
+ * it for themselves: <em>what the author wrote</em>, <em>where they wrote it</em>, <em>which
+ * representation the analysis reads it in</em>, and <em>whether all of it was read</em>. They are not
+ * independent — the position belongs to the written form, the analysis wants the expanded one, and an
+ * expansion carries the positions of the body it copies in — so a reader holding some of them and
+ * working out the rest is a reader that can hold a matched set or a mismatched one with nothing to
+ * tell them apart. Both kinds of clause had a reader of their own doing exactly that, and they
+ * disagreed: the data reader placed its answers on what was written and the rule reader placed them
+ * on what it had expanded.
+ *
+ * <p>So the facts arrive together or not at all. This owns the expansion and never hands it out, and
+ * what it gives back is a {@link ClauseReading} — a written conjunct that knows where it is and what
+ * it comes to. There is no argument anywhere below for a reader to pass a position in, which is what
+ * makes the wrong position unwritable rather than merely wrong.
+ *
+ * <p>What is <em>not</em> here is the reading the check itself does of a whole clause
+ * ({@link ClauseHelpers#invariantsForDischarge}). That answers a different question — what a
+ * construction owes — and is read against the values a construction hands over rather than placed in
+ * front of an author.
+ */
+public final class ClausesForDischarge {
+
+    private final Hir.Module settled;
+    /** Kept and not handed out. A caller given the expansion could expand a clause before splitting
+     *  or placing it, which is the one order that loses both the author's units and their
+     *  positions. */
+    private final HelperInliner expansion;
+
+    private ClausesForDischarge(Hir.Module settled, HelperInliner expansion) {
+        this.settled = settled;
+        this.expansion = expansion;
+    }
+
+    /**
+     * The clauses {@code expandable} declares, ready to be read.
+     *
+     * <p>{@code published} is what the modules this one imports offer it: a clause names what is in
+     * scope where it is written, and an imported definition is in scope there as it is in a body.
+     */
+    public static ClausesForDischarge of(Expandable expandable, Symbols symbols,
+                                         Map<String, Hir.FnDef> published) {
+        Hir.Module settled = ClauseHelpers.settled(expandable.module(), symbols);
+        return new ClausesForDischarge(settled, HelperInliner.forHelpers(settled.name(),
+                HelperInliner.helpersOf(settled), published, InliningPolicy.DISCHARGE));
+    }
+
+    /** The declarations that state an {@code invariant}, as their authors wrote them. */
+    public List<Hir.Data> declarationsThatState() {
+        List<Hir.Data> out = new ArrayList<>();
+        for (Hir.Def def : settled.defs()) {
+            if (def instanceof Hir.Data data && !data.invariants().isEmpty()) {
+                out.add(data);
+            }
+        }
+        return out;
+    }
+
+    /** The behaviors that state an {@code ensures}, as their authors wrote them, by the name each is
+     *  declared under. */
+    public Map<String, Hir.SpecBehavior> behaviorsThatState() {
+        Map<String, Hir.SpecBehavior> out = new LinkedHashMap<>();
+        for (Hir.BehaviorDef behavior : settled.behaviors()) {
+            if (behavior instanceof Hir.SpecBehavior spec && !spec.ensures().isEmpty()) {
+                out.put(spec.name(), spec);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * A clause as a reader of it gets it: one reading per conjunct the author wrote, each knowing
+     * where it is written and what it comes to for the analysis.
+     *
+     * <p>Split first, placed from what was written, expanded last. That order is the whole of the
+     * correctness and it is said here once — an expansion carries the positions of the body it copies
+     * in and splices in whatever that body is made of, so a clause expanded any earlier is placed
+     * inside the helper it names and split where that helper's author put an {@code &&}.
+     *
+     * @param owner what the names in an expansion belong to — a declaration or a signature
+     */
+    public List<ClauseReading> conjunctsOf(Hir.Expr written, BindingOwner owner) {
+        List<ClauseReading> out = new ArrayList<>();
+        for (Hir.Expr each : ClauseHelpers.conjunctsOf(written)) {
+            out.add(new ClauseReading(each, expansion.inline(each, owner)));
+        }
+        return out;
+    }
+
+    /**
+     * One conjunct of a clause, as written and as read.
+     *
+     * <p>Where it is comes from what was written and from nothing else, so it is asked of this rather
+     * than carried beside it: a position that can be passed is a position that can be passed wrongly,
+     * and the one thing every reader of this got wrong was which tree they took it from.
+     */
+    public record ClauseReading(Hir.Expr written, Hir.Expr read) {
+
+        /** Where the author wrote it — the earliest position anything written carries. */
+        public SourcePos at() {
+            return ClauseHelpers.beginsAt(written);
+        }
+
+        /** The stretch of source it is written over, for a reader holding it against the clause it
+         *  came from. */
+        public Region region() {
+            return written.region();
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
@@ -66,12 +66,12 @@ public record ContractDischarge(List<RuleDischarge> rules,
      * @param helpers the signatures a rule may reach without a binding, as the check that holds a
      *                rule to its declaration reads them
      */
-    public static ContractDischarge of(BehaviorContract contract, HelperInliner expansion,
+    public static ContractDischarge of(BehaviorContract contract, ClausesForDischarge declaring,
                                        Symbols symbols, Map<String, Type> helpers) {
         List<RuleDischarge> classified = new ArrayList<>();
         for (Clause clause : contract.clauses()) {
             for (Rule rule : clause.rules()) {
-                classified.addAll(of(contract, clause, rule, expansion, symbols, helpers));
+                classified.addAll(of(contract, clause, rule, declaring, symbols, helpers));
             }
         }
         return new ContractDischarge(classified, unstatedCases(contract, symbols));
@@ -91,7 +91,7 @@ public record ContractDischarge(List<RuleDischarge> rules,
      * placed inside the helper.
      */
     private static List<RuleDischarge> of(BehaviorContract contract, Clause clause, Rule rule,
-                                          HelperInliner expansion, Symbols symbols,
+                                          ClausesForDischarge declaring, Symbols symbols,
                                           Map<String, Type> helpers) {
         Scope scope = BehaviorChecker.scopeOf(contract, rule).reaching(helpers);
         CheckContext ctx = CheckContext.of(symbols).forDischarge();
@@ -108,30 +108,15 @@ public record ContractDischarge(List<RuleDischarge> rules,
 
         BindingOwner owner = BehaviorContract.ownerOf(contract.behavior());
         List<RuleDischarge> out = new ArrayList<>();
-        for (ClauseHelpers.Conjunct written
-                : ClauseHelpers.conjunctsToRead(rule.statement(), owner, expansion)) {
-            for (ClauseDischarge read : InvariantChecker.capabilitiesOf(
-                    typed(written.read(), scope, ctx), written.at(), locations, symbols,
-                    contract.behavior().name())) {
+        for (ClausesForDischarge.ClauseReading written
+                : declaring.conjunctsOf(rule.statement(), owner)) {
+            for (ClauseDischarge read : InvariantChecker.capabilitiesOf(written,
+                    toRead -> Elaborator.elaborate(toRead, scope, ctx, Type.BOOL), locations,
+                    symbols, contract.behavior().name())) {
                 out.add(new RuleDischarge(rule.id(), read.named(clause.name())));
             }
         }
         return out;
-    }
-
-    /**
-     * {@code conjunct} as the check reads it, or null where this compiler could not type it there.
-     *
-     * <p>Null is an answer and not a failure, as it is for a data's clause: a rule the check cannot
-     * read is not a rule an author wrote wrongly, and whether it is well formed was settled where the
-     * declaration was held to its rules.
-     */
-    private static Core typed(Hir.Expr conjunct, Scope scope, CheckContext ctx) {
-        try {
-            return Elaborator.elaborate(conjunct, scope, ctx, Type.BOOL);
-        } catch (RuntimeException _) {
-            return null;
-        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
@@ -1,0 +1,144 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.BehaviorContract.Clause;
+import souther.compiler.check.BehaviorContract.ContractParam;
+import souther.compiler.check.BehaviorContract.Guard;
+import souther.compiler.check.BehaviorContract.Rule;
+import souther.compiler.core.Core;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.CaseSelector;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * How much of what a behavior declares the check can read, rule by rule, and which of the answer's
+ * cases nothing is said about.
+ *
+ * <p>The same classification a data's clause gets ({@link ClauseDischarge}), asked of the other kind
+ * of clause. It is the same question: whether what is written is a relation the numeric domain
+ * reasons over, a term the check can name and compare, or something it cannot represent at all. What
+ * follows from the answer differs — an invariant's classification says what discharges a
+ * construction, a rule's says how much of the relation is there to be read at a call — but what is
+ * being asked of the expression is one thing, and asking it twice would be two answers to keep
+ * agreeing.
+ *
+ * <p>The unit is the rule, and under it the conjunct. A rule is already specialized to one case, so
+ * {@code ensures Todo | NotFound -> value.id == id} is classified once for {@code Todo} and once for
+ * {@code NotFound} and the two may differ — what {@code value} is differs between them, and what the
+ * check can make of a statement about it follows. A flat list per behavior would put the two under
+ * one entry and leave a reader to work out which case it was looking at.
+ */
+public record ContractDischarge(List<RuleDischarge> rules,
+                                List<TypeSymbol> casesNothingIsSaidAbout) {
+
+    public ContractDischarge {
+        rules = List.copyOf(rules);
+        casesNothingIsSaidAbout = List.copyOf(casesNothingIsSaidAbout);
+    }
+
+    /** One conjunct of one rule, and what the check can make of it. */
+    public record RuleDischarge(BehaviorContract.RuleId rule, ClauseDischarge capability) {}
+
+    /**
+     * What the check can read of {@code contract}, which is written in the representation the check
+     * reads ({@link InliningPolicy#DISCHARGE}).
+     *
+     * <p>Handed a contract rather than a declaration. What a rule is about, what {@code value} is
+     * there and which rule it is are the reading's answers ({@link BehaviorChecker}), and this asks
+     * one question of them. The contract handed here is the same declaration read by that same
+     * reading into the tree the check has rules about, so its {@link BehaviorContract.RuleId}s are the
+     * ids of the rules that run — a reader holding both is not left matching them up.
+     *
+     * @param helpers the signatures a rule may reach without a binding, as the check that holds a
+     *                rule to its declaration reads them
+     */
+    public static ContractDischarge of(BehaviorContract contract, Symbols symbols,
+                                       Map<String, Type> helpers) {
+        List<RuleDischarge> classified = new ArrayList<>();
+        for (Clause clause : contract.clauses()) {
+            for (Rule rule : clause.rules()) {
+                classified.addAll(of(contract, clause, rule, symbols, helpers));
+            }
+        }
+        return new ContractDischarge(classified, unstatedCases(contract, symbols));
+    }
+
+    /**
+     * One rule, conjunct by conjunct.
+     *
+     * <p>Each conjunct on its own, as a data's are: what discharges one half of {@code a && b} is not
+     * what discharges the other, and an author acts on the half. The name the clause was declared
+     * with goes on each of them, because a violation is reported by the clause however many conjuncts
+     * it was written as.
+     */
+    private static List<RuleDischarge> of(BehaviorContract contract, Clause clause, Rule rule,
+                                          Symbols symbols, Map<String, Type> helpers) {
+        Scope scope = BehaviorChecker.scopeOf(contract, rule).reaching(helpers);
+        CheckContext ctx = CheckContext.of(symbols).forDischarge();
+        // The parameters and `value` stand for themselves. A caller hands one value per parameter and
+        // the behavior answers one value, so a rule naming either names something wherever it is read
+        // — entered as locations, and nothing is seeded of them, since what the rule states is the
+        // question.
+        Set<BindingId> named = new LinkedHashSet<>();
+        for (ContractParam param : contract.params()) {
+            named.add(param.binding());
+        }
+        named.add(rule.value());
+        Denotations locations = Denotations.none().locations(named);
+
+        List<RuleDischarge> out = new ArrayList<>();
+        for (Hir.Expr conjunct : ClauseHelpers.conjunctsOf(rule.statement())) {
+            out.add(new RuleDischarge(rule.id(),
+                    InvariantChecker.capabilityOf(typed(conjunct, scope, ctx),
+                            ClauseHelpers.beginsAt(conjunct), locations, symbols,
+                            contract.behavior().name()).named(clause.name())));
+        }
+        return out;
+    }
+
+    /**
+     * {@code conjunct} as the check reads it, or null where this compiler could not type it there.
+     *
+     * <p>Null is an answer and not a failure, as it is for a data's clause: a rule the check cannot
+     * read is not a rule an author wrote wrongly, and whether it is well formed was settled where the
+     * declaration was held to its rules.
+     */
+    private static Core typed(Hir.Expr conjunct, Scope scope, CheckContext ctx) {
+        try {
+            return Elaborator.elaborate(conjunct, scope, ctx, Type.BOOL);
+        } catch (RuntimeException _) {
+            return null;
+        }
+    }
+
+    /**
+     * The cases of the answer no rule names.
+     *
+     * <p>Nothing is stated about them, which is what the declaration says and not a mistake in it:
+     * there is no wildcard arm, so a case left unnamed is a case the behavior promises nothing of.
+     * Answered here rather than reported, because a correct model may say nothing about most of what
+     * it answers, and a reader wanting to know asks.
+     */
+    private static List<TypeSymbol> unstatedCases(BehaviorContract contract, Symbols symbols) {
+        Set<TypeSymbol> stated = new LinkedHashSet<>();
+        for (Rule rule : contract.rules()) {
+            if (rule.guard() instanceof Guard.Case(CaseSelector selector)) {
+                stated.add(selector.name());
+            }
+        }
+        List<TypeSymbol> unstated = new ArrayList<>();
+        for (CaseSelector selector : CaseSpace.of(contract.output(), symbols).selectors()) {
+            if (!stated.contains(selector.name())) {
+                unstated.add(selector.name());
+            }
+        }
+        return unstated;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
@@ -7,6 +7,7 @@ import souther.compiler.check.BehaviorContract.Guard;
 import souther.compiler.check.BehaviorContract.Rule;
 import souther.compiler.core.Core;
 import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
 import souther.compiler.types.CaseSelector;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
@@ -47,24 +48,30 @@ public record ContractDischarge(List<RuleDischarge> rules,
     public record RuleDischarge(BehaviorContract.RuleId rule, ClauseDischarge capability) {}
 
     /**
-     * What the check can read of {@code contract}, which is written in the representation the check
-     * reads ({@link InliningPolicy#DISCHARGE}).
+     * What the check can read of {@code contract}, whose rules are as their author wrote them. Each
+     * is expanded into the representation the check reads ({@link InliningPolicy#DISCHARGE}) as it is
+     * classified, so what comes back is placed and split where it is written.
      *
      * <p>Handed a contract rather than a declaration. What a rule is about, what {@code value} is
      * there and which rule it is are the reading's answers ({@link BehaviorChecker}), and this asks
-     * one question of them. The contract handed here is the same declaration read by that same
-     * reading into the tree the check has rules about, so its {@link BehaviorContract.RuleId}s are the
-     * ids of the rules that run — a reader holding both is not left matching them up.
+     * one question of them. The contract handed here is the same declaration that reading reads for
+     * the tree that runs, so its {@link BehaviorContract.RuleId}s are the ids of the rules that run —
+     * a reader holding both is not left matching them up.
      *
+     * @param expansion what turns a piece of what was written into the tree the check reads. Applied
+     *                  here, one conjunct at a time, rather than to the declaration before it was
+     *                  read: an expansion carries the positions of the body it copies in, so a rule
+     *                  expanded first would be placed inside the helper it names and split where that
+     *                  helper's author split it
      * @param helpers the signatures a rule may reach without a binding, as the check that holds a
      *                rule to its declaration reads them
      */
-    public static ContractDischarge of(BehaviorContract contract, Symbols symbols,
-                                       Map<String, Type> helpers) {
+    public static ContractDischarge of(BehaviorContract contract, HelperInliner expansion,
+                                       Symbols symbols, Map<String, Type> helpers) {
         List<RuleDischarge> classified = new ArrayList<>();
         for (Clause clause : contract.clauses()) {
             for (Rule rule : clause.rules()) {
-                classified.addAll(of(contract, clause, rule, symbols, helpers));
+                classified.addAll(of(contract, clause, rule, expansion, symbols, helpers));
             }
         }
         return new ContractDischarge(classified, unstatedCases(contract, symbols));
@@ -77,9 +84,15 @@ public record ContractDischarge(List<RuleDischarge> rules,
      * what discharges the other, and an author acts on the half. The name the clause was declared
      * with goes on each of them, because a violation is reported by the clause however many conjuncts
      * it was written as.
+     *
+     * <p>Split where the author wrote the {@code &&} and not where an expansion put one. A rule
+     * naming a helper whose body is a conjunction is one thing the author wrote, so it is one answer;
+     * splitting the expanded tree would hand back two answers to a rule nobody wrote as two, each
+     * placed inside the helper.
      */
     private static List<RuleDischarge> of(BehaviorContract contract, Clause clause, Rule rule,
-                                          Symbols symbols, Map<String, Type> helpers) {
+                                          HelperInliner expansion, Symbols symbols,
+                                          Map<String, Type> helpers) {
         Scope scope = BehaviorChecker.scopeOf(contract, rule).reaching(helpers);
         CheckContext ctx = CheckContext.of(symbols).forDischarge();
         // The parameters and `value` stand for themselves. A caller hands one value per parameter and
@@ -93,11 +106,13 @@ public record ContractDischarge(List<RuleDischarge> rules,
         named.add(rule.value());
         Denotations locations = Denotations.none().locations(named);
 
+        BindingOwner owner = BehaviorContract.ownerOf(contract.behavior());
         List<RuleDischarge> out = new ArrayList<>();
-        for (Hir.Expr conjunct : ClauseHelpers.conjunctsOf(rule.statement())) {
+        for (Hir.Expr written : ClauseHelpers.conjunctsOf(rule.statement())) {
             out.add(new RuleDischarge(rule.id(),
-                    InvariantChecker.capabilityOf(typed(conjunct, scope, ctx),
-                            ClauseHelpers.beginsAt(conjunct), locations, symbols,
+                    InvariantChecker.capabilityOf(
+                            typed(expansion.inline(written, owner), scope, ctx),
+                            ClauseHelpers.beginsAt(written), locations, symbols,
                             contract.behavior().name()).named(clause.name())));
         }
         return out;

--- a/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
@@ -108,12 +108,13 @@ public record ContractDischarge(List<RuleDischarge> rules,
 
         BindingOwner owner = BehaviorContract.ownerOf(contract.behavior());
         List<RuleDischarge> out = new ArrayList<>();
-        for (Hir.Expr written : ClauseHelpers.conjunctsOf(rule.statement())) {
-            out.add(new RuleDischarge(rule.id(),
-                    InvariantChecker.capabilityOf(
-                            typed(expansion.inline(written, owner), scope, ctx),
-                            ClauseHelpers.beginsAt(written), locations, symbols,
-                            contract.behavior().name()).named(clause.name())));
+        for (ClauseHelpers.Conjunct written
+                : ClauseHelpers.conjunctsToRead(rule.statement(), owner, expansion)) {
+            for (ClauseDischarge read : InvariantChecker.capabilitiesOf(
+                    typed(written.read(), scope, ctx), written.at(), locations, symbols,
+                    contract.behavior().name())) {
+                out.add(new RuleDischarge(rule.id(), read.named(clause.name())));
+            }
         }
         return out;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
@@ -106,7 +106,7 @@ public final class DeclaredBounds {
         // and every layer that put an end where it is is kept, because each is a rule a row is owed.
         for (TypeOps.Layer layer : TypeOps.newtypeChain(type, symbols)) {
             for (Hir.InvariantClause clause : TypeOps.effectiveInvariants(layer.data(), symbols)) {
-                for (Hir.Expr each : HelperInvariants.conjunctsOf(clause.expr())) {
+                for (Hir.Expr each : ClauseHelpers.conjunctsOf(clause.expr())) {
                     // An end and nothing else. A rule this reads no end from narrows nothing here,
                     // and a rule stepping past the last value of the order states an end no value is
                     // at — which is a declaration with no value, answered where counts are and not

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -183,15 +183,15 @@ public final class InvariantChecker {
      * where the clause is written, which is the pre-expansion position; {@code clause} is that clause
      * in the representation the check reads.
      */
-    public static List<ClauseDischarge> capabilitiesOf(Hir.Expr clause, SourcePos at, TypeSymbol named,
-                                               Hir.Data data, Symbols symbols) {
+    public static List<ClauseDischarge> capabilitiesOf(ClausesForDischarge.ClauseReading clause,
+                                               TypeSymbol named, Hir.Data data, Symbols symbols) {
         InvariantChecker c = new InvariantChecker(symbols, Map.of());
         // Read over the declaration's own fields, each standing for itself: a construction hands one
         // value per field, so a clause naming a field names something wherever it is built. These
         // stand for a value rather than holding one, so they are entered as locations and nothing is
         // seeded of them — what a clause owes is the question, and answering it here would be
         // assuming it.
-        return c.capabilitiesOf(c.clauses.typed(clause, named, data), at,
+        return c.capabilitiesOf(clause, read -> c.clauses.typed(read, named, data),
                 Denotations.none().locations(c.clauses.bindingsOf(named, data).values()),
                 data.name());
     }
@@ -213,20 +213,59 @@ public final class InvariantChecker {
      * Answering with one of them would be picking which half of a clause to describe, and the half not
      * picked is the one an author is about to be surprised by.
      *
-     * @param stated the statement in the representation this check reads, or null where the front end
-     *               could not type it there
-     * @param at where it is written, which is the pre-expansion position an author is looking at
+     * <p>Where the answers are said is the clause's and is not passed in. A position that can be
+     * passed can be passed from the wrong tree — which is what an expansion of the clause is, and
+     * what every reader of this had to be told not to take it from. Handed the clause itself, there
+     * is nothing left to get wrong: it says where it was written and what it comes to, and the two
+     * were made together ({@link ClausesForDischarge}).
+     *
+     * @param clause the conjunct, as written and as this check reads it
+     * @param typing what types the read form here — a declaration's fields, a signature's names —
+     *               answering null where this compiler could not type it
      * @param locations the names it may read, each standing for itself
      * @param describing what is being read, for the record a fail-open leaves behind
      */
-    static List<ClauseDischarge> capabilitiesOf(Core stated, SourcePos at, Denotations locations,
-                                        Symbols symbols, String describing) {
+    static List<ClauseDischarge> capabilitiesOf(ClausesForDischarge.ClauseReading clause,
+                                        Typing typing, Denotations locations, Symbols symbols,
+                                        String describing) {
         return new InvariantChecker(symbols, Map.of())
-                .capabilitiesOf(stated, at, locations, describing);
+                .capabilitiesOf(clause, typing, locations, describing);
+    }
+
+    /** What turns the read form of a clause into the tree this check walks, which is the reader's to
+     * say: a declaration's clause is typed over its fields and a behavior's rule over its signature. */
+    @FunctionalInterface
+    interface Typing {
+        Core type(Hir.Expr read);
+    }
+
+    private List<ClauseDischarge> capabilitiesOf(ClausesForDischarge.ClauseReading clause,
+                                         Typing typing, Denotations locations, String describing) {
+        SourcePos at = clause.at();
+        Core stated;
+        try {
+            stated = typing.type(clause.read());
+        } catch (RuntimeException _) {
+            stated = null;
+        }
+        return capabilitiesOf(stated, at, locations, describing);
     }
 
     private List<ClauseDischarge> capabilitiesOf(Core stated, SourcePos at, Denotations locations,
                                          String describing) {
+        List<ClauseDischarge> found = new ArrayList<>();
+        for (ClauseDischarge.Kind read : kindsRead(stated, locations, describing)) {
+            found.add(read == ClauseDischarge.Kind.RUNTIME_ONLY
+                    ? ClauseDischarge.runtimeOnly(at, whyUnreadable(stated, locations))
+                    : new ClauseDischarge(at, read, java.util.Optional.empty()));
+        }
+        return List.copyOf(found);
+    }
+
+    /** What the check made of {@code stated}, said as the readings it got and nothing about where
+     * they belong. */
+    private List<ClauseDischarge.Kind> kindsRead(Core stated, Denotations locations,
+                                                 String describing) {
         Predicates.Owed owed;
         try {
             owed = stated == null ? Predicates.Owed.UNREADABLE
@@ -252,9 +291,7 @@ public final class InvariantChecker {
         }
         // What was not read at all is said even where something else was: a clause half of which
         // could not be read would otherwise be described entirely by the half that was.
-        Core read = stated;
-        return ClauseDischarge.readings(asABound, asATerm, owed.unreadable(), at,
-                () -> whyUnreadable(read, locations));
+        return ClauseDischarge.kindsRead(asABound, asATerm, owed.unreadable());
     }
 
     /** What in {@code clause} the check cannot read, said so an author can act on it. */
@@ -821,6 +858,27 @@ public final class InvariantChecker {
      * empty, so a rule inside it is a rule about a value the construction need not make. A type
      * already met is not entered again, which is what stops a record that holds itself.
      */
+    /**
+     * Whether every reading of {@code clause} is a bound.
+     *
+     * <p>Nothing here is shown to anybody, so nothing here is placed: this asks what the check made
+     * of a clause and not where to say it, and a reader with no author in front of it has no position
+     * to be right or wrong about. What it reads is the clause as this checker holds it, which is the
+     * representation the rest of this walk is written against.
+     */
+    private static boolean readOnlyAsBounds(Hir.Expr clause, TypeSymbol named, Hir.Data data,
+                                            Symbols symbols) {
+        InvariantChecker c = new InvariantChecker(symbols, Map.of());
+        for (ClauseDischarge.Kind read : c.kindsRead(c.clauses.typed(clause, named, data),
+                Denotations.none().locations(c.clauses.bindingsOf(named, data).values()),
+                data.name())) {
+            if (read != ClauseDischarge.Kind.DERIVABLE) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     static boolean everyRuleRead(TypeSymbol named, Hir.Data data, Symbols symbols) {
         return everyRuleRead(named, data, symbols, new HashSet<>());
     }
@@ -838,11 +896,8 @@ public final class InvariantChecker {
             for (Hir.InvariantClause clause : TypeOps.effectiveInvariants(data, symbols)) {
                 // Every reading of it, and not one of them: a clause read as a bound and as
                 // something else besides is a clause part of which no bound expresses.
-                for (ClauseDischarge read
-                        : capabilitiesOf(clause.expr(), clause.pos(), named, data, symbols)) {
-                    if (read.kind() != ClauseDischarge.Kind.DERIVABLE) {
-                        return false;
-                    }
+                if (!readOnlyAsBounds(clause.expr(), named, data, symbols)) {
+                    return false;
                 }
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -191,25 +191,51 @@ public final class InvariantChecker {
         // stand for a value rather than holding one, so they are entered as locations and nothing is
         // seeded of them — what a clause owes is the question, and answering it here would be
         // assuming it.
-        Core stated = c.clauses.typed(clause, named, data);
-        Denotations fields = Denotations.none()
-                .locations(c.clauses.bindingsOf(named, data).values());
+        return c.capabilityOf(c.clauses.typed(clause, named, data), at,
+                Denotations.none().locations(c.clauses.bindingsOf(named, data).values()),
+                data.name());
+    }
+
+    /**
+     * How a statement of the model can be discharged, read on its own: what the check can make of it
+     * where the names in it stand for themselves.
+     *
+     * <p>Not a question about invariants. A data's clause and a behavior's rule are the same
+     * expression fragment read the same way, and what tells them apart — which names stand for what,
+     * and where those names come from — is settled by {@code locations} before this is asked. Held
+     * here because the answer is what this check can read, and a second reader working that out from
+     * the outside would be deciding it by what it happened to manage.
+     *
+     * @param stated the statement in the representation this check reads, or null where the front end
+     *               could not type it there
+     * @param at where it is written, which is the pre-expansion position an author is looking at
+     * @param locations the names it may read, each standing for itself
+     * @param describing what is being read, for the record a fail-open leaves behind
+     */
+    static ClauseDischarge capabilityOf(Core stated, SourcePos at, Denotations locations,
+                                        Symbols symbols, String describing) {
+        return new InvariantChecker(symbols, Map.of())
+                .capabilityOf(stated, at, locations, describing);
+    }
+
+    private ClauseDischarge capabilityOf(Core stated, SourcePos at, Denotations locations,
+                                         String describing) {
         Predicates.Owed owed;
         try {
             owed = stated == null ? Predicates.Owed.UNREADABLE
-                    : c.predicates.obligations(stated, Known.top(), fields, false);
+                    : predicates.obligations(stated, Known.top(), locations, false);
         } catch (RuntimeException why) {
             // Fail-open, as the walk is — and recorded, because a clause this could not read and an
             // analysis that fell over reading it both come out `runtimeOnly`, and only one of them
             // is something the model says.
-            gaveUp("capabilityOf " + data.name(), why);
+            gaveUp("capabilityOf " + describing, why);
             owed = Predicates.Owed.UNREADABLE;
         }
         // A clause owing nothing is answered here as one nothing can be asked of. What it is instead
         // — a clause that holds wherever it is built — is a fourth answer this classification does
         // not have, and giving it one is a change to what the language states about a clause.
         if (owed.clauses().isEmpty()) {
-            return ClauseDischarge.runtimeOnly(at, c.whyUnreadable(stated, fields));
+            return ClauseDischarge.runtimeOnly(at, whyUnreadable(stated, locations));
         }
         for (Predicates.Clause owe : owed.clauses()) {
             if (owe.numeric() != null) {

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -844,7 +844,7 @@ public final class InvariantChecker {
         // declares rather than against what carries the value makes every such rule unreadable.
         for (TypeOps.Layer layer : TypeOps.newtypeChain(Type.ref(named), symbols)) {
             for (Hir.InvariantClause clause : TypeOps.effectiveInvariants(layer.data(), symbols)) {
-                for (Hir.Expr each : HelperInvariants.conjunctsOf(clause.expr())) {
+                for (Hir.Expr each : ClauseHelpers.conjunctsOf(clause.expr())) {
                     // A `String` is the one type two measures answer for — its own order, and the
                     // length of it — so a rule about either is a rule that was read, and both are
                     // asked. Every other carrier is measured one way, and asking the second reader

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -241,14 +241,24 @@ public final class InvariantChecker {
 
     private List<ClauseDischarge> capabilitiesOf(ClausesForDischarge.ClauseReading clause,
                                          Typing typing, Denotations locations, String describing) {
-        SourcePos at = clause.at();
-        Core stated;
+        return capabilitiesOf(typed(typing, clause.read(), describing), clause.at(), locations,
+                describing);
+    }
+
+    /**
+     * {@code read} as its reader types it, or null where it could not be typed there.
+     *
+     * <p>Fail-open, as the walk is, and recorded for the reason the reading below is: a clause this
+     * compiler could not type and an analysis that fell over typing it both come out
+     * {@code runtimeOnly}, and only one of them is something the model says.
+     */
+    private Core typed(Typing typing, Hir.Expr read, String describing) {
         try {
-            stated = typing.type(clause.read());
-        } catch (RuntimeException _) {
-            stated = null;
+            return typing.type(read);
+        } catch (RuntimeException why) {
+            gaveUp("typing " + describing, why);
+            return null;
         }
-        return capabilitiesOf(stated, at, locations, describing);
     }
 
     private List<ClauseDischarge> capabilitiesOf(Core stated, SourcePos at, Denotations locations,
@@ -837,17 +847,13 @@ public final class InvariantChecker {
     }
 
     /**
-     * Whether every rule reaching a value of {@code data} is one the numeric domain reasons over.
+     * Whether every rule that can refuse a value of {@code data} was read as a bound.
      *
      * <p>{@link ClauseDischarge.Kind#DERIVABLE} is the same classification a construction is judged
      * by, asked here of the declaration rather than of a site. A clause that is only nameable — a
      * pattern, a membership — narrows no bound, and a clause outside the fragment narrows none
-     * either; both leave a way the record refuses a value that the bounds do not express.
-     *
-     * <p>The same reach the seeding has, so what this classifies is what that took in.
-     */
-    /**
-     * Whether every rule that can refuse a value of {@code data} was read as a bound.
+     * either; both leave a way the record refuses a value that the bounds do not express. The same
+     * reach the seeding has, so what this classifies is what that took in.
      *
      * <p>Asked over the values a construction has to produce, which is not the depth a report takes a
      * value apart to. {@code FIELDS_SEEDED} and {@code MAX_DEPTH} are limits on how far a measurement
@@ -858,6 +864,10 @@ public final class InvariantChecker {
      * empty, so a rule inside it is a rule about a value the construction need not make. A type
      * already met is not entered again, which is what stops a record that holds itself.
      */
+    static boolean everyRuleRead(TypeSymbol named, Hir.Data data, Symbols symbols) {
+        return everyRuleRead(named, data, symbols, new HashSet<>());
+    }
+
     /**
      * Whether every reading of {@code clause} is a bound.
      *
@@ -869,7 +879,8 @@ public final class InvariantChecker {
     private static boolean readOnlyAsBounds(Hir.Expr clause, TypeSymbol named, Hir.Data data,
                                             Symbols symbols) {
         InvariantChecker c = new InvariantChecker(symbols, Map.of());
-        for (ClauseDischarge.Kind read : c.kindsRead(c.clauses.typed(clause, named, data),
+        Core stated = c.typed(read -> c.clauses.typed(read, named, data), clause, data.name());
+        for (ClauseDischarge.Kind read : c.kindsRead(stated,
                 Denotations.none().locations(c.clauses.bindingsOf(named, data).values()),
                 data.name())) {
             if (read != ClauseDischarge.Kind.DERIVABLE) {
@@ -877,10 +888,6 @@ public final class InvariantChecker {
             }
         }
         return true;
-    }
-
-    static boolean everyRuleRead(TypeSymbol named, Hir.Data data, Symbols symbols) {
-        return everyRuleRead(named, data, symbols, new HashSet<>());
     }
 
     private static boolean everyRuleRead(TypeSymbol named, Hir.Data data, Symbols symbols,

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -183,7 +183,7 @@ public final class InvariantChecker {
      * where the clause is written, which is the pre-expansion position; {@code clause} is that clause
      * in the representation the check reads.
      */
-    public static ClauseDischarge capabilityOf(Hir.Expr clause, SourcePos at, TypeSymbol named,
+    public static List<ClauseDischarge> capabilitiesOf(Hir.Expr clause, SourcePos at, TypeSymbol named,
                                                Hir.Data data, Symbols symbols) {
         InvariantChecker c = new InvariantChecker(symbols, Map.of());
         // Read over the declaration's own fields, each standing for itself: a construction hands one
@@ -191,7 +191,7 @@ public final class InvariantChecker {
         // stand for a value rather than holding one, so they are entered as locations and nothing is
         // seeded of them — what a clause owes is the question, and answering it here would be
         // assuming it.
-        return c.capabilityOf(c.clauses.typed(clause, named, data), at,
+        return c.capabilitiesOf(c.clauses.typed(clause, named, data), at,
                 Denotations.none().locations(c.clauses.bindingsOf(named, data).values()),
                 data.name());
     }
@@ -206,19 +206,26 @@ public final class InvariantChecker {
      * here because the answer is what this check can read, and a second reader working that out from
      * the outside would be deciding it by what it happened to manage.
      *
+     * <p>More than one where more than one is true of it. What is written as one thing can be read as
+     * several — a rule that names a helper is one thing to its author and is whatever that helper
+     * states to this — and the readings need not agree: a bound and a term the check can only compare
+     * are discharged by different guards, and one of them being there says nothing about the other.
+     * Answering with one of them would be picking which half of a clause to describe, and the half not
+     * picked is the one an author is about to be surprised by.
+     *
      * @param stated the statement in the representation this check reads, or null where the front end
      *               could not type it there
      * @param at where it is written, which is the pre-expansion position an author is looking at
      * @param locations the names it may read, each standing for itself
      * @param describing what is being read, for the record a fail-open leaves behind
      */
-    static ClauseDischarge capabilityOf(Core stated, SourcePos at, Denotations locations,
+    static List<ClauseDischarge> capabilitiesOf(Core stated, SourcePos at, Denotations locations,
                                         Symbols symbols, String describing) {
         return new InvariantChecker(symbols, Map.of())
-                .capabilityOf(stated, at, locations, describing);
+                .capabilitiesOf(stated, at, locations, describing);
     }
 
-    private ClauseDischarge capabilityOf(Core stated, SourcePos at, Denotations locations,
+    private List<ClauseDischarge> capabilitiesOf(Core stated, SourcePos at, Denotations locations,
                                          String describing) {
         Predicates.Owed owed;
         try {
@@ -228,21 +235,26 @@ public final class InvariantChecker {
             // Fail-open, as the walk is — and recorded, because a clause this could not read and an
             // analysis that fell over reading it both come out `runtimeOnly`, and only one of them
             // is something the model says.
-            gaveUp("capabilityOf " + describing, why);
+            gaveUp("capabilitiesOf " + describing, why);
             owed = Predicates.Owed.UNREADABLE;
         }
-        // A clause owing nothing is answered here as one nothing can be asked of. What it is instead
-        // — a clause that holds wherever it is built — is a fourth answer this classification does
-        // not have, and giving it one is a change to what the language states about a clause.
-        if (owed.clauses().isEmpty()) {
-            return ClauseDischarge.runtimeOnly(at, whyUnreadable(stated, locations));
-        }
+        boolean asABound = false;
+        boolean asATerm = false;
         for (Predicates.Clause owe : owed.clauses()) {
+            // A clause read both ways is one obligation with two readings of it, not two obligations
+            // — the bound is the stronger of them, and any guard implying it discharges the clause,
+            // so that is what it is here.
             if (owe.numeric() != null) {
-                return ClauseDischarge.derivable(at);
+                asABound = true;
+            } else {
+                asATerm = true;
             }
         }
-        return ClauseDischarge.exactMatch(at);
+        // What was not read at all is said even where something else was: a clause half of which
+        // could not be read would otherwise be described entirely by the half that was.
+        Core read = stated;
+        return ClauseDischarge.readings(asABound, asATerm, owed.unreadable(), at,
+                () -> whyUnreadable(read, locations));
     }
 
     /** What in {@code clause} the check cannot read, said so an author can act on it. */
@@ -824,9 +836,13 @@ public final class InvariantChecker {
             }
         } else {
             for (Hir.InvariantClause clause : TypeOps.effectiveInvariants(data, symbols)) {
-                if (capabilityOf(clause.expr(), clause.pos(), named, data, symbols).kind()
-                        != ClauseDischarge.Kind.DERIVABLE) {
-                    return false;
+                // Every reading of it, and not one of them: a clause read as a bound and as
+                // something else besides is a clause part of which no bound expresses.
+                for (ClauseDischarge read
+                        : capabilitiesOf(clause.expr(), clause.pos(), named, data, symbols)) {
+                    if (read.kind() != ClauseDischarge.Kind.DERIVABLE) {
+                        return false;
+                    }
                 }
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantSettled.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantSettled.java
@@ -67,7 +67,7 @@ public final class InvariantSettled {
                                           Map<String, Hir.FnDef> published) {
         Hir.Module derived = Deriver.derive(expandable.module(), scope);
         return new InvariantSettled(
-                HelperInvariants.withSettledInvariants(derived, scope, published));
+                ClauseHelpers.withSettledInvariants(derived, scope, published));
     }
 
 

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
@@ -2,7 +2,7 @@ package souther.compiler.codegen;
 
 import souther.compiler.check.MatchElaborator;
 import souther.compiler.check.Symbols;
-import souther.compiler.check.HelperInvariants;
+import souther.compiler.check.ClauseHelpers;
 import souther.compiler.ast.Hir;
 import souther.compiler.types.MapKeyRepresentation;
 import souther.compiler.types.CaseShape;
@@ -668,7 +668,7 @@ final class CodecGen {
             boolean refine = true;
             if (!refining) {
                 refine = false;
-                for (Hir.Expr conjunct : HelperInvariants.conjunctsOf(declared.get(i).expr())) {
+                for (Hir.Expr conjunct : ClauseHelpers.conjunctsOf(declared.get(i).expr())) {
                     Optional<InvariantConstraints.Constraint> c =
                             InvariantConstraints.of(conjunct, base);
                     if (c.isPresent()) {

--- a/souther-compiler/src/main/java/souther/compiler/codegen/EnsuresGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/EnsuresGen.java
@@ -88,7 +88,7 @@ final class EnsuresGen {
             code.aload(param.index());
             int slot = gen.slot(param.type());
             unbox(code, param.type(), slot, ctx);
-            gen.bind(param.binding(), slotLabel(param), slot, param.type());
+            gen.bind(param.binding(), param.name(), slot, param.type());
         }
         for (Rule rule : contract.rules()) {
             emitRule(code, gen, contract, rule, answer);
@@ -161,16 +161,4 @@ final class EnsuresGen {
         }
     }
 
-    /**
-     * What the binding table calls a parameter's slot.
-     *
-     * <p>Not the name the author wrote, and nothing reads it: a rule names a parameter by its
-     * binding, and no local variable table is emitted for this method for a name to be quoted from.
-     * Written as the position it is, so that it does not read as a spelling somebody could be shown
-     * — the day one is shown, what has to arrive is the declared name, which the contract would
-     * carry rather than this inventing one.
-     */
-    private static String slotLabel(ContractParam param) {
-        return "in" + param.index();
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -4,7 +4,7 @@ import souther.compiler.ast.Hir;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.DeclaredBounds;
 import souther.compiler.check.FieldDomains;
-import souther.compiler.check.HelperInvariants;
+import souther.compiler.check.ClauseHelpers;
 import souther.compiler.check.InvariantBound;
 import souther.compiler.check.NumericMeasures;
 import souther.compiler.check.Sig;
@@ -343,7 +343,7 @@ public final class InputDomain {
         List<UnreadRule> out = new ArrayList<>();
         for (TypeOps.Layer layer : TypeOps.newtypeChain(type, symbols)) {
             for (Hir.InvariantClause clause : TypeOps.effectiveInvariants(layer.data(), symbols)) {
-                for (Hir.Expr each : HelperInvariants.conjunctsOf(clause.expr())) {
+                for (Hir.Expr each : ClauseHelpers.conjunctsOf(clause.expr())) {
                     BlockReason why = whyUnread(each, carried, measure);
                     // Once per position, as a comparison is: what a reader has to lift is the first
                     // limit in the way, and a second clause behind it says nothing further.

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -3,7 +3,7 @@ package souther.compiler.partition;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.DeclaredBounds;
-import souther.compiler.check.HelperInvariants;
+import souther.compiler.check.ClauseHelpers;
 import souther.compiler.check.Shape;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
@@ -1104,7 +1104,7 @@ public final class Partitions {
         }
         if (base == Type.STRING && symbols.declarations().declaration(newtype.key()) instanceof Hir.Data data) {
             for (Hir.InvariantClause clause : TypeOps.effectiveInvariants(data, symbols)) {
-                for (Hir.Expr each : HelperInvariants.conjunctsOf(clause.expr())) {
+                for (Hir.Expr each : ClauseHelpers.conjunctsOf(clause.expr())) {
                     if (InvariantConstraints.of(each, base).orElse(null)
                             instanceof InvariantConstraints.Pattern format) {
                         PatternValues.shortestAccepted(format.regex())

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -405,14 +405,14 @@ public final class Bodies {
             Map<String, Hir.FnDef> published = imported.present() ? imported.value() : Map.of();
             Map<String, ContractDischarge> out = new LinkedHashMap<>();
             try {
-                Map<String, Hir.SpecBehavior> declaring = ClauseHelpers.ensuresForDischarge(
+                ClauseHelpers.WrittenEnsures declaring = ClauseHelpers.ensuresForDischarge(
                         expandable.value(), scope.value(), published);
-                for (Map.Entry<String, Hir.SpecBehavior> each : declaring.entrySet()) {
+                for (Map.Entry<String, Hir.SpecBehavior> each : declaring.behaviors().entrySet()) {
                     try {
                         BehaviorContract contract = BehaviorChecker.contractAsRead(each.getValue(),
                                 name, signatures.value().get(each.getKey()), scope.value());
-                        out.put(each.getKey(),
-                                ContractDischarge.of(contract, scope.value(), helpers.value()));
+                        out.put(each.getKey(), ContractDischarge.of(contract, declaring.expansion(),
+                                scope.value(), helpers.value()));
                     } catch (Unanswerable | CompileException _) {
                         // The declaration could not be read, which is said where it is held to its
                         // rules. There is nothing to classify, and a behavior that cannot be read

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -5,7 +5,7 @@ import souther.compiler.ast.Hir;
 import souther.compiler.check.BehaviorChecker;
 import souther.compiler.check.BehaviorContract;
 import souther.compiler.check.BehaviorRequirement;
-import souther.compiler.check.ClauseHelpers;
+import souther.compiler.check.ClausesForDischarge;
 import souther.compiler.check.ContractDischarge;
 import souther.compiler.check.DataChecker;
 import souther.compiler.check.HelperInliner;
@@ -405,13 +405,14 @@ public final class Bodies {
             Map<String, Hir.FnDef> published = imported.present() ? imported.value() : Map.of();
             Map<String, ContractDischarge> out = new LinkedHashMap<>();
             try {
-                ClauseHelpers.WrittenEnsures declaring = ClauseHelpers.ensuresForDischarge(
-                        expandable.value(), scope.value(), published);
-                for (Map.Entry<String, Hir.SpecBehavior> each : declaring.behaviors().entrySet()) {
+                ClausesForDischarge declaring =
+                        ClausesForDischarge.of(expandable.value(), scope.value(), published);
+                for (Map.Entry<String, Hir.SpecBehavior> each
+                        : declaring.behaviorsThatState().entrySet()) {
                     try {
                         BehaviorContract contract = BehaviorChecker.contractAsRead(each.getValue(),
                                 name, signatures.value().get(each.getKey()), scope.value());
-                        out.put(each.getKey(), ContractDischarge.of(contract, declaring.expansion(),
+                        out.put(each.getKey(), ContractDischarge.of(contract, declaring,
                                 scope.value(), helpers.value()));
                     } catch (Unanswerable | CompileException _) {
                         // The declaration could not be read, which is said where it is held to its

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -5,6 +5,8 @@ import souther.compiler.ast.Hir;
 import souther.compiler.check.BehaviorChecker;
 import souther.compiler.check.BehaviorContract;
 import souther.compiler.check.BehaviorRequirement;
+import souther.compiler.check.ClauseHelpers;
+import souther.compiler.check.ContractDischarge;
 import souther.compiler.check.DataChecker;
 import souther.compiler.check.HelperInliner;
 import souther.compiler.check.HelperGraph;
@@ -362,6 +364,65 @@ public final class Bodies {
                 }
             }
             return Answer.of(Ordered.map(contracts), reports);
+        }
+    }
+
+    /**
+     * How much of what each behavior of a module declares the check can read, by the name the
+     * behavior is declared under (spec §ensures-discharge-capability).
+     *
+     * <p>Read in the representation the discharge analysis reads ({@link InliningPolicy#DISCHARGE}),
+     * which is not the one that runs: an operation the language defines the meaning of stays an
+     * operation here, and the classification is of what the author wrote rather than of the algorithm
+     * it becomes. That is the same reading a data's clauses are classified in
+     * ({@link Shapes.InvariantCapabilities}).
+     *
+     * <p>Only this module's own behaviors. The classification is the declaration's, and a reader in
+     * another module asks that module.
+     *
+     * <p>Nothing is reported from here. Whether a clause is well formed was decided by
+     * {@link Contracts}, which owns both the contracts and what reading them found; a behavior whose
+     * declaration cannot be read is left out of this rather than refused a second time.
+     */
+    public record ContractCapabilities(String name)
+            implements Key<Map<String, ContractDischarge>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, ContractDischarge>> compute(Db db) {
+            Answer<souther.compiler.check.Expandable> expandable = db.ask(new Shapes.Expandable(name));
+            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Map<String, Sig>> signatures = db.ask(new Signatures(name));
+            Answer<Map<String, Type>> helpers = db.ask(new RecursiveHelperSigs(name));
+            if (!expandable.present() || !scope.present() || !signatures.present()
+                    || !helpers.present()) {
+                return Answer.absent();
+            }
+            Answer<Map<String, Hir.FnDef>> imported = db.ask(new ImportedDefinitions(name));
+            Map<String, Hir.FnDef> published = imported.present() ? imported.value() : Map.of();
+            Map<String, ContractDischarge> out = new LinkedHashMap<>();
+            try {
+                Map<String, Hir.SpecBehavior> declaring = ClauseHelpers.ensuresForDischarge(
+                        expandable.value(), scope.value(), published);
+                for (Map.Entry<String, Hir.SpecBehavior> each : declaring.entrySet()) {
+                    try {
+                        BehaviorContract contract = BehaviorChecker.contractAsRead(each.getValue(),
+                                name, signatures.value().get(each.getKey()), scope.value());
+                        out.put(each.getKey(),
+                                ContractDischarge.of(contract, scope.value(), helpers.value()));
+                    } catch (Unanswerable | CompileException _) {
+                        // The declaration could not be read, which is said where it is held to its
+                        // rules. There is nothing to classify, and a behavior that cannot be read
+                        // leaves the rest of the module's readable.
+                    }
+                }
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+            return Answer.of(Ordered.map(out));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -426,11 +426,12 @@ public final class Shapes {
                     // discharge, so `a && b` under one name is classified twice under that name: what
                     // discharges each half is what an author needs, and the name is what a caller reads.
                     for (Hir.InvariantClause declared : data.invariants()) {
-                        for (Hir.Expr written : ClauseHelpers.conjunctsOf(declared.expr())) {
-                            clauses.add(InvariantChecker.capabilityOf(
-                                    inliner.inline(written, new BindingOwner.OfData(named)),
-                                    ClauseHelpers.beginsAt(written), named, data, scope.value())
-                                    .named(declared.name()));
+                        for (ClauseHelpers.Conjunct written : ClauseHelpers.conjunctsToRead(
+                                declared.expr(), new BindingOwner.OfData(named), inliner)) {
+                            for (ClauseDischarge read : InvariantChecker.capabilitiesOf(
+                                    written.read(), written.at(), named, data, scope.value())) {
+                                clauses.add(read.named(declared.name()));
+                            }
                         }
                     }
                     out.put(named, List.copyOf(clauses));

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -5,6 +5,7 @@ import souther.compiler.check.ClauseDischarge;
 import souther.compiler.check.InvariantSettled;
 import souther.compiler.check.HelperInliner;
 import souther.compiler.check.ClauseHelpers;
+import souther.compiler.check.ClausesForDischarge;
 import souther.compiler.check.HelperNames;
 import souther.compiler.check.InliningPolicy;
 import souther.compiler.check.InvariantChecker;
@@ -408,28 +409,24 @@ public final class Shapes {
             // What the clause says is what the check reads, so an imported bound is substituted here
             // as it is where the invariant is settled. A clause left naming it would be classified as
             // a rule this analysis cannot read, and a construction the bound rejects would compile.
-            Hir.Module declaring = expandable.value().withQualifiedInvariants();
             try {
+                // The one reader of a clause: it holds the expansion, and what it hands back is a
+                // conjunct that knows where it was written and what it comes to. Nothing here places
+                // an answer, so nothing here can place one wrongly.
+                ClausesForDischarge declaring =
+                        ClausesForDischarge.of(expandable.value(), scope.value(), published);
                 Map<TypeSymbol, List<ClauseDischarge>> out = new LinkedHashMap<>();
-                for (Hir.Def def : declaring.defs()) {
-                    if (!(def instanceof Hir.Data data) || data.invariants().isEmpty()) {
-                        continue;
-                    }
-                    // The clause is classified in the representation the check reads, and reported at
-                    // the position it is written — an expansion carries positions of its own, and the
-                    // author is looking at the source.
-                    HelperInliner inliner = HelperInliner.forHelpers(name,
-                            HelperInliner.helpersOf(declaring), published, InliningPolicy.DISCHARGE);
+                for (Hir.Data data : declaring.declarationsThatState()) {
                     List<ClauseDischarge> clauses = new ArrayList<>();
                     TypeSymbol named = data.declares();
                     // A declared clause is one rule to depart by and may still be several conjuncts to
                     // discharge, so `a && b` under one name is classified twice under that name: what
                     // discharges each half is what an author needs, and the name is what a caller reads.
                     for (Hir.InvariantClause declared : data.invariants()) {
-                        for (ClauseHelpers.Conjunct written : ClauseHelpers.conjunctsToRead(
-                                declared.expr(), new BindingOwner.OfData(named), inliner)) {
+                        for (ClausesForDischarge.ClauseReading written
+                                : declaring.conjunctsOf(declared.expr(), new BindingOwner.OfData(named))) {
                             for (ClauseDischarge read : InvariantChecker.capabilitiesOf(
-                                    written.read(), written.at(), named, data, scope.value())) {
+                                    written, named, data, scope.value())) {
                                 clauses.add(read.named(declared.name()));
                             }
                         }

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -14,7 +14,6 @@ import souther.compiler.check.ValueCycles;
 import souther.compiler.check.Symbols;
 import souther.compiler.derive.Deriver;
 import souther.compiler.diag.CompileException;
-import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
@@ -430,7 +429,7 @@ public final class Shapes {
                         for (Hir.Expr written : ClauseHelpers.conjunctsOf(declared.expr())) {
                             clauses.add(InvariantChecker.capabilityOf(
                                     inliner.inline(written, new BindingOwner.OfData(named)),
-                                    leftmost(written), named, data, scope.value())
+                                    ClauseHelpers.beginsAt(written), named, data, scope.value())
                                     .named(declared.name()));
                         }
                     }
@@ -441,23 +440,6 @@ public final class Shapes {
                 return Answer.absent(e);
             }
         }
-    }
-
-    /** Where a clause begins: the earliest position anything in it carries. A node's own position is
-     * where its operator is written, and a reader points at the clause. */
-    private static SourcePos leftmost(Hir.Expr e) {
-        SourcePos[] found = {e.pos()};
-        Hir.forEachChild(e, child -> {
-            SourcePos inner = leftmost(child);
-            if (inner != null && (found[0] == null || earlier(inner, found[0]))) {
-                found[0] = inner;
-            }
-        });
-        return found[0];
-    }
-
-    private static boolean earlier(SourcePos a, SourcePos b) {
-        return a.line() != b.line() ? a.line() < b.line() : a.column() < b.column();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -4,7 +4,7 @@ import souther.compiler.ast.Hir;
 import souther.compiler.check.ClauseDischarge;
 import souther.compiler.check.InvariantSettled;
 import souther.compiler.check.HelperInliner;
-import souther.compiler.check.HelperInvariants;
+import souther.compiler.check.ClauseHelpers;
 import souther.compiler.check.HelperNames;
 import souther.compiler.check.InliningPolicy;
 import souther.compiler.check.InvariantChecker;
@@ -427,7 +427,7 @@ public final class Shapes {
                     // discharge, so `a && b` under one name is classified twice under that name: what
                     // discharges each half is what an author needs, and the name is what a caller reads.
                     for (Hir.InvariantClause declared : data.invariants()) {
-                        for (Hir.Expr written : HelperInvariants.conjunctsOf(declared.expr())) {
+                        for (Hir.Expr written : ClauseHelpers.conjunctsOf(declared.expr())) {
                             clauses.add(InvariantChecker.capabilityOf(
                                     inliner.inline(written, new BindingOwner.OfData(named)),
                                     leftmost(written), named, data, scope.value())
@@ -488,7 +488,7 @@ public final class Shapes {
             Answer<Map<String, Hir.FnDef>> imported = db.ask(new Bodies.ImportedDefinitions(name));
             Map<String, Hir.FnDef> published = imported.present() ? imported.value() : Map.of();
             try {
-                return Answer.of(HelperInvariants.invariantsForDischarge(
+                return Answer.of(ClauseHelpers.invariantsForDischarge(
                         expandable.value(), scope.value(), published));
             } catch (CompileException e) {
                 return Answer.absent(e);

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryReadingOfAClauseIsAnsweredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryReadingOfAClauseIsAnsweredTest.java
@@ -1,0 +1,94 @@
+package souther.compiler.check;
+
+import souther.compiler.diag.SourcePos;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A clause read more than one way is answered more than one way.
+ *
+ * <p>What is written as one thing need not be read as one thing: a clause naming a helper is one
+ * thing to its author and is whatever that helper states to the check, and its parts can be read
+ * differently. Answered with one of the readings, an author is told what discharges half of their
+ * clause and left to find out about the other half from a construction that is still refused.
+ *
+ * <p>Held here rather than through a program, because no program takes these shapes today — a clause
+ * that names a helper is read as one term and states one thing to the check. It is the day the check
+ * reads further into what a clause names that a clause states two of these at once, and a mechanism
+ * whose data never takes a shape it is written for is a mechanism nothing has run.
+ */
+class EveryReadingOfAClauseIsAnsweredTest {
+
+    private static final SourcePos AT = new SourcePos(3, 5);
+
+    private static List<ClauseDischarge.Kind> kinds(boolean asABound, boolean asATerm,
+                                                    boolean unread) {
+        List<ClauseDischarge.Kind> out = new ArrayList<>();
+        for (ClauseDischarge each
+                : ClauseDischarge.readings(asABound, asATerm, unread, AT, () -> "why")) {
+            assertEquals(AT, each.clause(), "every reading is of the clause that was read");
+            out.add(each.kind());
+        }
+        return out;
+    }
+
+    @Test
+    void aClauseReadOneWayIsAnsweredOnce() {
+        assertEquals(List.of(ClauseDischarge.Kind.DERIVABLE), kinds(true, false, false));
+        assertEquals(List.of(ClauseDischarge.Kind.EXACT_MATCH), kinds(false, true, false));
+    }
+
+    /** The reason a single answer is wrong: neither reading describes the other's half, and which of
+     *  them a reader is handed decides what they believe a guard will do. */
+    @Test
+    void aClauseReadAsABoundAndAsATermIsAnsweredAsBoth() {
+        assertEquals(List.of(ClauseDischarge.Kind.DERIVABLE, ClauseDischarge.Kind.EXACT_MATCH),
+                kinds(true, true, false));
+    }
+
+    /**
+     * What was not read is said even where something else was.
+     *
+     * <p>This is the one that decides a program: a clause part of which is outside the fragment is a
+     * clause no guard discharges, and answering it by the part that was read tells an author their
+     * construction can be judged safe when it cannot.
+     */
+    @Test
+    void whatWasNotReadIsSaidBesideWhatWas() {
+        assertTrue(kinds(true, false, true).contains(ClauseDischarge.Kind.RUNTIME_ONLY),
+                "a bound and a part nothing was made of");
+        assertTrue(kinds(false, true, true).contains(ClauseDischarge.Kind.RUNTIME_ONLY),
+                "a term and a part nothing was made of");
+        assertTrue(kinds(true, true, true).contains(ClauseDischarge.Kind.RUNTIME_ONLY));
+    }
+
+    @Test
+    void aClauseNothingWasMadeOfIsAnsweredOnce() {
+        assertEquals(List.of(ClauseDischarge.Kind.RUNTIME_ONLY), kinds(false, false, true));
+        assertEquals(List.of(ClauseDischarge.Kind.RUNTIME_ONLY), kinds(false, false, false));
+    }
+
+    /** The reason is what an author acts on, and it is only asked for where there is something to
+     *  say — reading a clause to find out what it is missing costs a walk of it. */
+    @Test
+    void whyIsAskedOnlyWhereSomethingWasNotRead() {
+        boolean[] asked = {false};
+        ClauseDischarge.readings(true, false, false, AT, () -> {
+            asked[0] = true;
+            return "why";
+        });
+        assertTrue(!asked[0], "nothing was left unread, so there is nothing to explain");
+
+        ClauseDischarge.readings(true, false, true, AT, () -> {
+            asked[0] = true;
+            return "why";
+        });
+        assertTrue(asked[0], "and it is asked where there is");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/AClassificationIsPlacedInsideTheClauseItIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AClassificationIsPlacedInsideTheClauseItIsAboutTest.java
@@ -1,0 +1,131 @@
+package souther.compiler.query;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.BehaviorContract;
+import souther.compiler.check.ClauseDischarge;
+import souther.compiler.check.ContractDischarge;
+import souther.compiler.check.ContractDischarge.RuleDischarge;
+import souther.compiler.diag.Region;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.types.TypeSymbol;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What the compiler says about a clause is said where that clause is written.
+ *
+ * <p>Both kinds of clause are classified by asking the same check about an expression, and an
+ * expression reaches it expanded — a helper the clause names is substituted first, because the
+ * analysis has rules about what a clause states and none about a call. An expansion carries the
+ * positions of the body it copies in, so a classification worked out from one and then placed by
+ * what it was worked out from lands inside the helper, in a definition the author was not looking at.
+ * The editor keeps the answers whose position falls inside the clause the cursor is in, so what an
+ * author sees is a clause the compiler has nothing to say about.
+ *
+ * <p>This holds the property rather than the arrangement that keeps it. Where the split and the
+ * placing happen relative to the expansion is a thing a reader can get wrong once per kind of clause
+ * — it was written twice and was wrong in one of them — and every future reader of a clause has the
+ * same order to get right.
+ */
+class AClassificationIsPlacedInsideTheClauseItIsAboutTest {
+
+    /**
+     * Clauses of both kinds that name helpers, with a helper written before the declaration that
+     * names it and one written after, and a helper body that is itself a conjunction — which is what
+     * splits one rule the author wrote into two answers where the splitting is done after expanding.
+     */
+    private static final String SOURCE = """
+            module m.a exposing ( Amount, Id, Found, findIt )
+
+            let positive (n: Int): Bool = n > 0
+            let ranked (rank: Int, floor: Int): Bool = rank > 0 && rank > floor
+
+            data Amount = Int
+                invariant positive(value)
+                invariant isSmall = value < 1000 && positive(value)
+
+            data Id    = { n: Int }
+            data Found = { rank: Int }
+
+            behavior findIt : (id: Id) -> Found
+                constructs Found
+                ensures ranked(value.rank, id.n)
+                ensures alsoPositive = positive(value.rank) && value.rank > id.n
+
+            let findIt (id) = Found { rank = 1 }
+
+            let atLeast (n: Int, floor: Int): Bool = n >= floor
+            """;
+
+    private static Compilation compiled() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("a.sou", SOURCE);
+        return Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+    }
+
+    /** A position is inside a region, said so that neither being absent passes for agreement —
+     *  {@link Region#encloses} is vacuously true where either side is nowhere. */
+    private static void enclosedBy(Region clause, ClauseDischarge answer, String what) {
+        assertNotNull(clause, what + ": the clause knows where it is written");
+        assertNotNull(answer.clause(), what + ": the answer says where it is about");
+        assertTrue(Region.encloses(clause, Region.point(answer.clause())),
+                what + ": answered at " + answer.clause() + ", which is not inside " + clause);
+    }
+
+    @Test
+    void everyRuleIsPlacedInsideTheEnsuresItIsWrittenUnder() {
+        Compilation c = compiled();
+        Map<String, BehaviorContract> contracts = c.db().ask(new Bodies.Contracts("m.a")).value();
+        Map<String, ContractDischarge> classified =
+                c.db().ask(new Bodies.ContractCapabilities("m.a")).value();
+        assertNotNull(contracts);
+        assertNotNull(classified);
+
+        ContractDischarge discharge = classified.get("findIt");
+        assertNotNull(discharge, "the behavior states something, so it is classified");
+        assertEquals(3, discharge.rules().size(),
+                "one answer per conjunct the author wrote: the helper's own `&&` is not theirs");
+        for (RuleDischarge rule : discharge.rules()) {
+            BehaviorContract.Clause clause =
+                    contracts.get("findIt").clauses().get(rule.rule().clause());
+            enclosedBy(clause.region(), rule.capability(), "rule of clause " + rule.rule().clause());
+        }
+    }
+
+    @Test
+    void everyClauseIsPlacedInsideTheInvariantItIsWrittenUnder() {
+        Compilation c = compiled();
+        Map<TypeSymbol, List<Hir.InvariantClause>> declared =
+                c.db().ask(new Shapes.InvariantsForDischarge("m.a")).value();
+        Map<TypeSymbol, List<ClauseDischarge>> classified =
+                c.db().ask(new Shapes.InvariantCapabilities("m.a")).value();
+        assertNotNull(declared);
+        assertNotNull(classified);
+        assertEquals(1, classified.size(), "one declaration writes invariants here");
+
+        classified.forEach((named, answers) -> {
+            assertEquals(3, answers.size(),
+                    "one answer per conjunct written: `positive(value)`, and the two of `isSmall`");
+            for (ClauseDischarge answer : answers) {
+                // Which of the declaration's clauses each answer is about is not carried, so what is
+                // held is that it is inside one of them — a position inside the helper is inside none.
+                boolean inside = false;
+                for (Hir.InvariantClause clause : declared.get(named)) {
+                    assertNotNull(clause.region(), "the clause knows where it is written");
+                    inside = inside || Region.encloses(clause.region(), Region.point(answer.clause()));
+                }
+                assertTrue(inside, "answered at " + answer.clause()
+                        + ", which is inside no clause of " + named);
+            }
+        });
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/HowMuchOfARuleTheCheckReadsIsAskedPerCaseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/HowMuchOfARuleTheCheckReadsIsAskedPerCaseTest.java
@@ -152,6 +152,37 @@ class HowMuchOfARuleTheCheckReadsIsAskedPerCaseTest {
     }
 
     /**
+     * A rule naming a helper is answered where the rule is written, not where the helper is.
+     *
+     * <p>The helper is expanded before the rule is read, and an expansion of a module's own helper
+     * carries the positions its body has. Answered from the expanded tree, the rule would be placed
+     * inside the {@code let} — which for the reader that asks this is a rule belonging to no clause
+     * of the behavior at all.
+     */
+    @Test
+    void aRuleThroughAHelperIsAnsweredWhereItIsWritten() {
+        ContractDischarge discharge = of("""
+                module m.a exposing ( Id, Found, findIt )
+
+                let ranked (rank: Int, id: Id): Bool = rank > 0 && rank > id.value
+
+                data Id    = Int
+                data Found = { id: Id, rank: Int }
+
+                behavior findIt : (id: Id) -> Found
+                    constructs Found
+                    ensures ranked(value.rank, id)
+
+                let findIt (id) = Found { id = id, rank = 1 }
+                """, "findIt");
+
+        assertEquals(1, discharge.rules().size(),
+                "one rule, because the author wrote one — the `&&` is the helper's, not theirs");
+        assertEquals(10, discharge.rules().get(0).capability().clause().line(),
+                "the `ensures` line, not the `let` on line 3");
+    }
+
+    /**
      * A case no rule names carries no stated relation, and that is the declaration speaking rather
      * than a mistake in it. It is answered here so a reader can be shown it, not reported.
      */
@@ -167,6 +198,42 @@ class HowMuchOfARuleTheCheckReadsIsAskedPerCaseTest {
     @Test
     void aBehaviorWhoseEveryCaseIsSpokenForHasNoneLeft() {
         assertEquals(List.of(), of(FINDS, "findIt").casesNothingIsSaidAbout());
+    }
+
+    /**
+     * A declaration with an arm that cannot be read is not classified at all.
+     *
+     * <p>The arm contributes no rule, so what is left says nothing about the cases that arm named —
+     * and a reader of it would be told that the author stated nothing about them, which is the
+     * opposite of what they wrote. The refusal is reported where the declaration is held to its
+     * rules; here there is simply no answer.
+     */
+    @Test
+    void aDeclarationOneArmOfWhichCannotBeReadIsNotClassified() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("a.sou", """
+                module m.a exposing ( Id, Found, Missing, Other, findIt )
+
+                data Id      = Int
+                data Found   = { id: Id }
+                data Missing = { asked: Id }
+                data Other   = { x: Int }
+
+                behavior findIt : (id: Id) -> Found | Missing
+                    constructs Found, Missing
+                    ensures Found | Other -> value.id == id
+
+                let findIt (id) = if id.value > 0 then Found { id = id } else Missing { asked = id }
+                """);
+        Compilation c = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+
+        Map<String, ContractDischarge> byName =
+                c.db().ask(new Bodies.ContractCapabilities("m.a")).value();
+
+        assertNotNull(byName);
+        assertFalse(byName.containsKey("findIt"),
+                "`Other` is not a case of the answer, so the arm naming `Found` beside it was not "
+                        + "read — and nothing here may say `Found` was left unspoken for");
     }
 
     /** A behavior stating nothing has no classification: there is nothing to classify, and an empty

--- a/souther-compiler/src/test/java/souther/compiler/query/HowMuchOfARuleTheCheckReadsIsAskedPerCaseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/HowMuchOfARuleTheCheckReadsIsAskedPerCaseTest.java
@@ -1,0 +1,192 @@
+package souther.compiler.query;
+
+import souther.compiler.check.ClauseDischarge;
+import souther.compiler.check.ContractDischarge;
+import souther.compiler.check.ContractDischarge.RuleDischarge;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * What the compiler can make of what a behavior declares, asked rule by rule.
+ *
+ * <p>The classification a data's clause gets ({@link Shapes.InvariantCapabilities}), asked of the
+ * other kind of clause. A rule is already about one case, and what {@code value} is differs between
+ * cases, so two arms written under one arrow can be read to different depths — an answer per clause
+ * would put them under one entry and leave a reader to guess which case it was told about.
+ */
+class HowMuchOfARuleTheCheckReadsIsAskedPerCaseTest {
+
+    private static ContractDischarge of(String source, String behavior) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("a.sou", source);
+        Compilation c = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+        Map<String, ContractDischarge> byName =
+                c.db().ask(new Bodies.ContractCapabilities("m.a")).value();
+        assertNotNull(byName, "the module reads, so its declarations are classified");
+        return byName.get(behavior);
+    }
+
+    private static TypeSymbol named(String type) {
+        return TypeSymbols.declared(new TypeKey("m.a", type));
+    }
+
+    private static List<TypeSymbol> casesOf(ContractDischarge discharge) {
+        List<TypeSymbol> cases = new ArrayList<>();
+        for (RuleDischarge rule : discharge.rules()) {
+            cases.add(rule.rule().selector());
+        }
+        return cases;
+    }
+
+    private static final String FINDS = """
+            module m.a exposing ( Id, Found, Missing, findIt )
+
+            data Id      = Int
+            data Found   = { id: Id }
+            data Missing = { asked: Id }
+
+            behavior findIt : (id: Id) -> Found | Missing
+                constructs Found, Missing
+                ensures answersTheRequest = Found   -> value.id == id
+                                          | Missing -> value.asked == id
+
+            let findIt (id) = if id.value > 0 then Found { id = id } else Missing { asked = id }
+            """;
+
+    @Test
+    void aRuleIsClassifiedUnderTheCaseItIsAbout() {
+        ContractDischarge discharge = of(FINDS, "findIt");
+
+        assertEquals(List.of(named("Found"), named("Missing")),
+                casesOf(discharge), "one answer per rule, named by the case the rule is about");
+        for (RuleDischarge rule : discharge.rules()) {
+            assertEquals("answersTheRequest", rule.capability().name().orElse(null),
+                    "under the name a violation of it is reported by");
+        }
+    }
+
+    /** Two cases sharing one expression are two rules, and each is read for the case it is about —
+     *  what `value` holds differs between them, so what the check can make of the same words can. */
+    @Test
+    void twoCasesUnderOneArrowAreTwoAnswers() {
+        ContractDischarge discharge = of("""
+                module m.a exposing ( Id, Found, Missing, findIt )
+
+                data Id      = Int
+                data Found   = { id: Id }
+                data Missing = { id: Id }
+
+                behavior findIt : (id: Id) -> Found | Missing
+                    constructs Found, Missing
+                    ensures Found | Missing -> value.id == id
+
+                let findIt (id) = if id.value > 0 then Found { id = id } else Missing { id = id }
+                """, "findIt");
+
+        assertEquals(List.of(named("Found"), named("Missing")),
+                casesOf(discharge));
+    }
+
+    /** The unit under the rule is the conjunct, as it is for a data's clause: what the check makes of
+     *  one half of `a && b` is not what it makes of the other, and the half is what an author acts on. */
+    @Test
+    void eachConjunctOfARuleIsAnsweredOnItsOwn() {
+        ContractDischarge discharge = of("""
+                module m.a exposing ( Id, Found, findIt )
+
+                data Id    = Int
+                data Found = { id: Id, rank: Int }
+
+                behavior findIt : (id: Id) -> Found
+                    constructs Found
+                    ensures value.id == id && value.rank >= 0
+
+                let findIt (id) = Found { id = id, rank = 0 }
+                """, "findIt");
+
+        assertEquals(2, discharge.rules().size(), "one answer per conjunct");
+        assertEquals(ClauseDischarge.Kind.DERIVABLE, discharge.rules().get(1).capability().kind(),
+                "`value.rank >= 0` is a relation the numeric domain reasons over");
+    }
+
+    /**
+     * A rule is read in the representation the check has rules about, not in the one that runs.
+     *
+     * <p>An operation the language defines the meaning of stands here as the operation it is written
+     * as. Read from the tree that runs, {@code List.allDistinctBy} would be the fold it becomes, and
+     * the check has nothing to say about a fold.
+     */
+    @Test
+    void aRuleIsReadAsWhatItIsWrittenAs() {
+        ContractDischarge discharge = of("""
+                module m.a exposing ( Id, Row, Rows, findIt )
+
+                data Id   = Int
+                data Row  = { name: String }
+                data Rows = List<Row>
+
+                behavior findIt : (id: Id) -> Rows
+                    constructs Rows
+                    ensures List.allDistinctBy(.name, value.value) && id.value > 0
+
+                let findIt (id) = Rows { value = [] }
+                """, "findIt");
+
+        assertEquals(ClauseDischarge.Kind.EXACT_MATCH, discharge.rules().get(0).capability().kind(),
+                "a term the check can name and compare, and nothing weaker states it");
+        assertEquals(ClauseDischarge.Kind.DERIVABLE, discharge.rules().get(1).capability().kind());
+    }
+
+    /**
+     * A case no rule names carries no stated relation, and that is the declaration speaking rather
+     * than a mistake in it. It is answered here so a reader can be shown it, not reported.
+     */
+    @Test
+    void theCasesNothingIsSaidAboutAreAnswered() {
+        ContractDischarge discharge = of(FINDS
+                .replace("                              | Missing -> value.asked == id\n", ""), "findIt");
+
+        assertEquals(List.of(named("Missing")),
+                discharge.casesNothingIsSaidAbout());
+    }
+
+    @Test
+    void aBehaviorWhoseEveryCaseIsSpokenForHasNoneLeft() {
+        assertEquals(List.of(), of(FINDS, "findIt").casesNothingIsSaidAbout());
+    }
+
+    /** A behavior stating nothing has no classification: there is nothing to classify, and an empty
+     *  answer would be a second way to say what absence says. */
+    @Test
+    void aBehaviorThatDeclaresNothingIsNotThere() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("a.sou", """
+                module m.a exposing ( Id, echo )
+
+                data Id = Int
+
+                behavior echo : (id: Id) -> Id
+                let echo (id) = id
+                """);
+        Compilation c = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+        Map<String, ContractDischarge> byName =
+                c.db().ask(new Bodies.ContractCapabilities("m.a")).value();
+
+        assertNotNull(byName);
+        assertFalse(byName.containsKey("echo"));
+    }
+}

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -1871,7 +1871,7 @@ public final class Analyzer {
         SyntaxToken declares = def == null ? null : nameToken(def);
         ContractDischarge discharge = def != null && def.kind() == SyntaxKind.BEHAVIOR_DEF
                 && declares != null && declares.start() == ident.start()
-                ? contractOf(uri, graph, nameOf(ident)) : null;
+                ? contractOf(uri, graph, ident) : null;
         if (discharge == null || discharge.casesNothingIsSaidAbout().isEmpty()) {
             return shown;
         }
@@ -1902,7 +1902,7 @@ public final class Analyzer {
         if (clause == null || name == null) {
             return Optional.empty();
         }
-        ContractDischarge discharge = contractOf(uri, graph, nameOf(name));
+        ContractDischarge discharge = contractOf(uri, graph, name);
         if (discharge == null) {
             return Optional.empty();
         }
@@ -1920,17 +1920,25 @@ public final class Analyzer {
                 : Optional.of(new Hover(ruleContents(here), nodeRange(lines, clause)));
     }
 
-    /** What the compiler says about the behavior {@code named} declares, or null where the document
-     * belongs to no module this compile has, or the behavior states nothing. */
-    private ContractDischarge contractOf(String uri, ModuleGraph graph, String named) {
+    /**
+     * What the compiler says about the behavior the token {@code named} spells, or null where the
+     * document belongs to no module this compile has, or the behavior states nothing.
+     *
+     * <p>A token and not a spelling. The compiler files its answer under the canonical name, and a
+     * cursor is characters; handed a {@link String}, a caller has already decided which of the two
+     * it is passing, and both call sites here had that decision to make. Canonically equivalent
+     * spellings are one name ({@link #nameOf}), and which of them an author's cursor happens to be
+     * on is not a thing an editor may answer differently.
+     */
+    private ContractDischarge contractOf(String uri, ModuleGraph graph, SyntaxToken named) {
         Compilation compilation = compileOf(graph);
         String module = moduleOf(compilation, graph, uri);
-        if (module == null) {
+        if (module == null || named == null) {
             return null;
         }
         Map<String, ContractDischarge> byName =
                 compilation.db().ask(new Bodies.ContractCapabilities(module)).value();
-        return byName == null ? null : byName.get(named);
+        return byName == null ? null : byName.get(nameOf(named));
     }
 
     /**
@@ -1991,16 +1999,24 @@ public final class Analyzer {
         }
         // The clauses are in the order they are written, so the one the cursor is in is the last that
         // starts at or before it.
-        ClauseDischarge found = null;
+        SourcePos found = null;
         for (ClauseDischarge c : clauses) {
             if (lines.offsetOf(c.clause().line() - 1, c.clause().column() - 1) <= offset) {
-                found = c;
+                found = c.clause();
             }
         }
         if (found == null) {
             return Optional.empty();
         }
-        return Optional.of(new Hover(dischargeContents(found), nodeRange(lines, clause)));
+        // Every reading of that clause, which may be more than one: what is written once can be read
+        // as a bound and as a term besides, and showing whichever came last would describe half of it.
+        List<String> said = new ArrayList<>();
+        for (ClauseDischarge c : clauses) {
+            if (c.clause().equals(found)) {
+                said.add(dischargeContents(c));
+            }
+        }
+        return Optional.of(new Hover(String.join("\n\n", said), nodeRange(lines, clause)));
     }
 
     /** What a clause's classification says, in the terms an author acts on. */

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -1862,12 +1862,16 @@ public final class Analyzer {
         SyntaxNode root = CstParser.parse(text).root();
         SyntaxToken ident = identAt(meaningfulTokens(root), lines,
                 lines.offsetOf(pos.line(), pos.character()));
-        // The name of a behavior this document declares, and nothing else. What a behavior states is
-        // asked of it by name, so a name that declares something else would be asked about under a
-        // spelling that means something else here.
+        // The cursor on the name a behavior is declared under, and nowhere else. `declaringDef` finds
+        // a definition by the characters of a name, so a parameter or a local spelled like a behavior
+        // of this module finds that behavior — and what is said here would be said about a value that
+        // states nothing. Which token the cursor is on tells the declaration from anything spelled
+        // like it.
         SyntaxNode def = ident == null ? null : declaringDef(root, nameOf(ident));
+        SyntaxToken declares = def == null ? null : nameToken(def);
         ContractDischarge discharge = def != null && def.kind() == SyntaxKind.BEHAVIOR_DEF
-                ? contractOf(uri, graph, ident.text()) : null;
+                && declares != null && declares.start() == ident.start()
+                ? contractOf(uri, graph, nameOf(ident)) : null;
         if (discharge == null || discharge.casesNothingIsSaidAbout().isEmpty()) {
             return shown;
         }
@@ -1898,7 +1902,7 @@ public final class Analyzer {
         if (clause == null || name == null) {
             return Optional.empty();
         }
-        ContractDischarge discharge = contractOf(uri, graph, name.text());
+        ContractDischarge discharge = contractOf(uri, graph, nameOf(name));
         if (discharge == null) {
             return Optional.empty();
         }

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -16,6 +16,8 @@ import souther.compiler.query.Compilation;
 import souther.compiler.query.Names;
 import souther.compiler.query.Shapes;
 import souther.compiler.check.ClauseDischarge;
+import souther.compiler.check.ContractDischarge;
+import souther.compiler.check.ContractDischarge.RuleDischarge;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
 import souther.compiler.Reserved;
@@ -1838,7 +1840,119 @@ public final class Analyzer {
      */
     public Optional<Hover> hover(String uri, String text, Position pos, ModuleGraph graph) {
         Optional<Hover> clause = invariantClauseHover(uri, text, pos, graph);
-        return clause.isPresent() ? clause : hover(text, pos);
+        if (clause.isPresent()) {
+            return clause;
+        }
+        Optional<Hover> rule = ensuresClauseHover(uri, text, pos, graph);
+        return rule.isPresent() ? rule
+                : hover(text, pos).map(shown -> withWhatIsNotStated(shown, uri, text, pos, graph));
+    }
+
+    /**
+     * The same hover, and on a behavior that states something, which of its cases nothing is said
+     * about.
+     *
+     * <p>There is no wildcard arm, so a case no rule names is one the behavior promises nothing of.
+     * That is the declaration speaking and not a mistake in it, which is why a reader is shown it
+     * where they are reading the declaration rather than told about it as a problem.
+     */
+    private Hover withWhatIsNotStated(Hover shown, String uri, String text, Position pos,
+                                      ModuleGraph graph) {
+        LineIndex lines = new LineIndex(text);
+        SyntaxNode root = CstParser.parse(text).root();
+        SyntaxToken ident = identAt(meaningfulTokens(root), lines,
+                lines.offsetOf(pos.line(), pos.character()));
+        // The name of a behavior this document declares, and nothing else. What a behavior states is
+        // asked of it by name, so a name that declares something else would be asked about under a
+        // spelling that means something else here.
+        SyntaxNode def = ident == null ? null : declaringDef(root, nameOf(ident));
+        ContractDischarge discharge = def != null && def.kind() == SyntaxKind.BEHAVIOR_DEF
+                ? contractOf(uri, graph, ident.text()) : null;
+        if (discharge == null || discharge.casesNothingIsSaidAbout().isEmpty()) {
+            return shown;
+        }
+        List<String> unstated = new ArrayList<>();
+        for (TypeSymbol each : discharge.casesNothingIsSaidAbout()) {
+            unstated.add("`" + each.name() + "`");
+        }
+        return new Hover(shown.contents() + "\n\nNothing is stated about "
+                + String.join(", ", unstated) + ".", shown.range());
+    }
+
+    /**
+     * What the check reads of the {@code ensures} clause the cursor is in, rule by rule, or empty
+     * when it is not in one.
+     *
+     * <p>Rule by rule and not clause by clause. One arrow may be written over several cases, and what
+     * {@code value} is differs between them, so the same words can be read to different depths — a
+     * single answer on the clause would be one of those readings shown as if it were the clause's.
+     */
+    private Optional<Hover> ensuresClauseHover(String uri, String text, Position pos,
+                                               ModuleGraph graph) {
+        LineIndex lines = new LineIndex(text);
+        SyntaxNode root = CstParser.parse(text).root();
+        int offset = lines.offsetOf(pos.line(), pos.character());
+        SyntaxNode clause = enclosing(root, offset, SyntaxKind.ENSURES_CLAUSE);
+        SyntaxNode behavior = enclosing(root, offset, SyntaxKind.BEHAVIOR_DEF);
+        SyntaxToken name = behavior == null ? null : nameToken(behavior);
+        if (clause == null || name == null) {
+            return Optional.empty();
+        }
+        ContractDischarge discharge = contractOf(uri, graph, name.text());
+        if (discharge == null) {
+            return Optional.empty();
+        }
+        // The rules of this clause are the ones written inside it. A behavior may carry several
+        // clauses, and each of them is classified on its own.
+        List<RuleDischarge> here = new ArrayList<>();
+        for (RuleDischarge rule : discharge.rules()) {
+            int at = lines.offsetOf(rule.capability().clause().line() - 1,
+                    rule.capability().clause().column() - 1);
+            if (at >= clause.start() && at < clause.end()) {
+                here.add(rule);
+            }
+        }
+        return here.isEmpty() ? Optional.empty()
+                : Optional.of(new Hover(ruleContents(here), nodeRange(lines, clause)));
+    }
+
+    /** What the compiler says about the behavior {@code named} declares, or null where the document
+     * belongs to no module this compile has, or the behavior states nothing. */
+    private ContractDischarge contractOf(String uri, ModuleGraph graph, String named) {
+        Compilation compilation = compileOf(graph);
+        String module = moduleOf(compilation, graph, uri);
+        if (module == null) {
+            return null;
+        }
+        Map<String, ContractDischarge> byName =
+                compilation.db().ask(new Bodies.ContractCapabilities(module)).value();
+        return byName == null ? null : byName.get(named);
+    }
+
+    /**
+     * What the check reads of each rule, in the terms an author acts on.
+     *
+     * <p>What the check reads is not what the run-time check holds. Every rule is held when the
+     * behavior answers, whatever this says; what this says is how much of the relation is written in
+     * a form the check can carry.
+     */
+    private String ruleContents(List<RuleDischarge> rules) {
+        StringBuilder out = new StringBuilder("**What the check reads of this**\n");
+        for (RuleDischarge rule : rules) {
+            ClauseDischarge capability = rule.capability();
+            String read = switch (capability.kind()) {
+                case DERIVABLE -> "**derivable** — read as a relation the numeric domain reasons over";
+                case EXACT_MATCH -> "**exact match** — read as a term the check can name and compare, "
+                        + "and nothing weaker states it";
+                case RUNTIME_ONLY -> "**runtime only** — not read at all, so the check the behavior "
+                        + "runs on its answer is the whole of it";
+            };
+            String about = rule.rule().selector() == null ? ""
+                    : "`" + rule.rule().selector().name() + "`: ";
+            out.append("\n- ").append(about).append(read)
+                    .append(capability.reason().map(why -> "; " + why).orElse("")).append(".");
+        }
+        return out.toString();
     }
 
     /** The discharge classification of the invariant clause the cursor is in, or empty when it is not

--- a/souther-lsp/src/test/java/souther/lsp/analysis/WhatAnEnsuresClauseSaysIsShownPerCaseTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/WhatAnEnsuresClauseSaysIsShownPerCaseTest.java
@@ -1,0 +1,127 @@
+package souther.lsp.analysis;
+
+import souther.lsp.protocol.Hover;
+import souther.lsp.protocol.Position;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What an editor is shown on an {@code ensures} clause.
+ *
+ * <p>A rule is about one case, and what {@code value} is differs between cases, so what the check can
+ * make of a clause is not one answer. Shown per rule, an author reading the clause reads which of its
+ * cases the check carries and which of them it only holds when the behavior answers; shown as one, a
+ * clause whose cases are read to different depths would say the wrong thing about one of them.
+ *
+ * <p>And a case no rule names is shown on the behavior. There is no wildcard arm, so nothing being
+ * stated about a case is the declaration speaking — which a reader can only see by reading every
+ * clause and comparing it against the answer's cases.
+ */
+class WhatAnEnsuresClauseSaysIsShownPerCaseTest {
+
+    private final Analyzer analyzer = new Analyzer();
+
+    private static final String SRC = """
+            module demo exposing ( Id, Found, Missing, findIt )
+
+            data Id      = { n: Int, label: String }
+            data Found   = { n: Int }
+            data Missing = { asked: String }
+
+            behavior findIt : (id: Id) -> Found | Missing
+                constructs Found, Missing
+                ensures Found   -> value.n == id.n
+                      | Missing -> String.startsWith(id.label, value.asked)
+
+            let findIt (id) =
+                if id.n > 0 then Found { n = id.n } else Missing { asked = id.label }
+            """;
+
+    private Optional<Hover> hover(String source, int line, int character) {
+        ModuleGraph graph = ModuleGraph.of(Map.of("file:///demo.sou", source));
+        return analyzer.hover("file:///demo.sou", source, new Position(line, character), graph);
+    }
+
+    @Test
+    void aClauseSaysWhatTheCheckReadsOfEachOfItsCases() {
+        // inside the clause, on the arm for `Found`
+        Optional<Hover> hover = hover(SRC, 8, 20);
+
+        assertTrue(hover.isPresent());
+        String shown = hover.get().contents();
+        assertTrue(shown.contains("`Found`") && shown.contains("derivable"), shown);
+        assertTrue(shown.contains("`Missing`") && shown.contains("exact match"), shown);
+    }
+
+    /** The same clause read from its other arm is the same clause: a hover is about what is written
+     *  there, and both arms are written under one {@code ensures}. */
+    @Test
+    void theOtherArmOfOneClauseSaysTheSame() {
+        assertTrue(hover(SRC, 9, 20).map(Hover::contents)
+                .filter(shown -> shown.contains("`Found`") && shown.contains("`Missing`"))
+                .isPresent());
+    }
+
+    /** Two cases under one arrow are two rules, and both are shown. The words are the same and what
+     *  they are read of is not, so a reader is told about each case rather than about the arrow. */
+    @Test
+    void twoCasesUnderOneArrowAreBothShown() {
+        String source = """
+                module demo exposing ( Id, Found, Missing, findIt )
+
+                data Id      = { n: Int }
+                data Found   = { n: Int }
+                data Missing = { n: Int }
+
+                behavior findIt : (id: Id) -> Found | Missing
+                    constructs Found, Missing
+                    ensures Found | Missing -> value.n == id.n
+
+                let findIt (id) =
+                    if id.n > 0 then Found { n = id.n } else Missing { n = id.n }
+                """;
+
+        Optional<Hover> hover = hover(source, 8, 30);
+
+        assertTrue(hover.isPresent());
+        String shown = hover.get().contents();
+        assertTrue(shown.contains("`Found`") && shown.contains("`Missing`"), shown);
+    }
+
+    @Test
+    void aBehaviorSaysWhichOfItsCasesNothingIsStatedAbout() {
+        String source = SRC.replace(
+                "      | Missing -> String.startsWith(id.label, value.asked)\n", "");
+
+        // over the behavior's name
+        Optional<Hover> hover = hover(source, 6, 10);
+
+        assertTrue(hover.isPresent());
+        assertTrue(hover.get().contents().contains("Nothing is stated about `Missing`"),
+                hover.get().contents());
+    }
+
+    @Test
+    void aBehaviorEveryCaseOfWhichIsSpokenForSaysNothingOfTheKind() {
+        Optional<Hover> hover = hover(SRC, 6, 10);
+
+        assertTrue(hover.isPresent());
+        assertFalse(hover.get().contents().contains("Nothing is stated about"),
+                hover.get().contents());
+    }
+
+    /** Outside a clause the hover is what it was: this one has something semantic to say only where
+     *  a rule is written. */
+    @Test
+    void hoverOutsideAClauseStillShowsTheSignature() {
+        Optional<Hover> hover = hover(SRC, 3, 5);   // over `Found`
+
+        assertTrue(hover.isPresent());
+        assertTrue(hover.get().contents().contains("data Found"), hover.get().contents());
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/analysis/WhatAnEnsuresClauseSaysIsShownPerCaseTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/WhatAnEnsuresClauseSaysIsShownPerCaseTest.java
@@ -115,6 +115,91 @@ class WhatAnEnsuresClauseSaysIsShownPerCaseTest {
                 hover.get().contents());
     }
 
+    /**
+     * A rule written through a helper is still answered on the clause.
+     *
+     * <p>The helper is expanded before the rule is classified, and an expansion of a module's own
+     * helper carries the positions its body has. Placed by those, the answer falls outside the
+     * clause the cursor is in and this shows nothing — which reads as a rule the compiler has nothing
+     * to say about.
+     */
+    @Test
+    void aRuleWrittenThroughAHelperIsStillShown() {
+        String source = """
+                module demo exposing ( Id, Found, findIt )
+
+                let ranked (rank: Int, id: Id): Bool = rank > 0 && rank > id.n
+
+                data Id    = { n: Int }
+                data Found = { rank: Int }
+
+                behavior findIt : (id: Id) -> Found
+                    constructs Found
+                    ensures ranked(value.rank, id)
+
+                let findIt (id) = Found { rank = 1 }
+                """;
+
+        Optional<Hover> hover = hover(source, 9, 20);
+
+        assertTrue(hover.isPresent());
+        assertTrue(hover.get().contents().contains("What the check reads of this"),
+                hover.get().contents());
+    }
+
+    /**
+     * The note about unstated cases is for the behavior's declaration, and a name is not a
+     * declaration.
+     *
+     * <p>A definition is found here by the characters of a name, so a parameter spelled like a
+     * behavior of the module finds that behavior. What would be shown then is what a behavior states,
+     * on a value that states nothing.
+     */
+    @Test
+    void aParameterSpelledLikeABehaviorIsNotThatBehavior() {
+        String source = SRC.replace(
+                "      | Missing -> String.startsWith(id.label, value.asked)\n", "")
+                + "\nlet echo (findIt: Id): Int = findIt.n\n";
+
+        // over the parameter `findIt`, not over the behavior's name
+        Optional<Hover> hover = hover(source, 13, 11);
+
+        assertTrue(hover.isPresent());
+        assertFalse(hover.get().contents().contains("Nothing is stated about"),
+                hover.get().contents());
+    }
+
+    /**
+     * A behavior whose name is written decomposed is the same behavior.
+     *
+     * <p>What the compiler filed the answer under is the canonical name, and a cursor is characters.
+     * Which spelling an author's cursor happens to be on is not a thing an editor may answer
+     * differently.
+     */
+    @Test
+    void aDecomposedlyNamedBehaviorStillSaysWhatIsNotStated() {
+        String kana = new String(new int[] {0x304b, 0x3099}, 0, 2);
+        String source = """
+                module demo exposing ( Id, Found, Missing, %s )
+
+                data Id      = { n: Int }
+                data Found   = { n: Int }
+                data Missing = { asked: String }
+
+                behavior %s : (id: Id) -> Found | Missing
+                    constructs Found, Missing
+                    ensures Found -> value.n == id.n
+
+                let %s (id) = Found { n = id.n }
+                """.formatted(kana, kana, kana);
+
+        Optional<Hover> hover = hover(source, 6, 9);
+
+        assertTrue(hover.isPresent());
+        assertTrue(hover.get().contents().contains("Nothing is stated about `Missing`"),
+                hover.get().contents());
+    }
+
     /** Outside a clause the hover is what it was: this one has something semantic to say only where
      *  a rule is written. */
     @Test

--- a/specification.adoc
+++ b/specification.adoc
@@ -2353,6 +2353,17 @@ A clause MAY be named. [[ensures-clause-names-are-distinct]]Named clauses are di
 
 A clause travels with the published declaration, as a data's does and for the same reason: a reader that cannot read it cannot assume it.
 
+[#ensures-discharge-capability]
+==== A rule says how much of it the check reads
+
+A rule is classified as a data's clause is (<<invariant-discharge-capability>>), by the same three answers and for the same reason: what is written decides how much of it the checker can carry, and nothing in the source tells the two apart. The unit is the *rule* and, under a rule, the conjunct. A rule is already about one case — `+ensures Found | Missing -> value.id == id+` is a rule for `+Found+` and a rule for `+Missing+` — and what `+value+` is differs between them, so the same words can be read to different depths. One answer for the clause would be one of those readings shown as if it were the other's.
+
+The classification says nothing about whether the rule is enforced. Every rule holds when the behavior answers, whatever this says of it; what it says is how much of the relation is written in a form the checker reads — `+derivable+` a relation the numeric domain reasons over, `+exact match+` a term it can name and compare and nothing weaker, `+runtime only+` nothing it can represent.
+
+The rule is read as it is written. An operation whose meaning the language defines stands as that operation, as a data's clause is read (<<invariant-discharge-representation>>), so a rule naming one is classified by what the language says of it and not by the algorithm it is emitted as.
+
+It is a query rather than a diagnostic, again as a data's is, and the LSP surfaces it on the clause. So is which of the answer's cases no rule names: nothing being stated about a case is what the declaration says (<<ensures>>), and a reader who wants to know asks rather than being told.
+
 [#calling-a-behavior]
 === Calling a behavior
 

--- a/specification.adoc
+++ b/specification.adoc
@@ -1708,6 +1708,8 @@ The classification is the clause's own, read with the construction assumed to na
 
 The answer carries the clause's name where it has one (<<invariant-clause-name>>), so what the LSP shows on a clause says both how it can be discharged and what an attempt departs by. The unit is the conjunct, as it is for the rest of the check, so a named clause written as `+a && b+` is classified twice under that one name — what discharges each half is what an author acts on, and the name is what a caller reads.
 
+One conjunct is answered as many times as it is read. What is written as one thing need not be read as one thing: a conjunct naming a helper is one thing to its author and is whatever that helper states to the checker, and the parts of it may be read differently. Each answer says what discharges the part it is about, and all of them are given at the one place the conjunct is written — the parts have no places of their own, having been written as one. A part the checker made nothing of is `+runtime only+` and is said beside the parts it read, since a clause is discharged only where every part of it is.
+
 [#invariant-reify]
 ==== Reifying a cross-behavior relation
 
@@ -2357,6 +2359,8 @@ A clause travels with the published declaration, as a data's does and for the sa
 ==== A rule says how much of it the check reads
 
 A rule is classified as a data's clause is (<<invariant-discharge-capability>>), by the same three answers and for the same reason: what is written decides how much of it the checker can carry, and nothing in the source tells the two apart. The unit is the *rule* and, under a rule, the conjunct. A rule is already about one case — `+ensures Found | Missing -> value.id == id+` is a rule for `+Found+` and a rule for `+Missing+` — and what `+value+` is differs between them, so the same words can be read to different depths. One answer for the clause would be one of those readings shown as if it were the other's.
+
+A rule is answered as many times as it is read, as a data's conjunct is (<<invariant-discharge-capability>>), at the one place it is written.
 
 The classification says nothing about whether the rule is enforced. Every rule holds when the behavior answers, whatever this says of it; what it says is how much of the relation is written in a form the checker reads — `+derivable+` a relation the numeric domain reasons over, `+exact match+` a term it can name and compare and nothing weaker, `+runtime only+` nothing it can represent.
 


### PR DESCRIPTION
Commit 4 of #803: the classification and the editor become consumers of the contract IR.

## What it does

A data's clause is classified — derivable / exact match / runtime only — and shown to whoever is writing it. A behavior's rule was not, and it is the same question asked of the same expression fragment. Now it is asked once and answered per rule.

- `InvariantChecker.capabilityOf` splits into the data entry it had and a reading over a typed statement plus the names that stand for themselves. Which names those are is what tells the two kinds of clause apart, and it is settled before the classification rather than inside it.
- `check/ContractDischarge` holds the answers under the rule ids they belong to, plus which of the answer's cases no rule names. The unit is the rule and, under a rule, the conjunct: `ensures Found | Missing -> value.id == id` is classified once for `Found` and once for `Missing`, because what `value` is differs between them.
- `query/Bodies.ContractCapabilities` is the key. It reports nothing — whether a clause is well formed was decided by `Contracts`, which owns the contracts and what reading them found.
- The LSP hover on an `ensures` clause lists what the check reads of each of its cases, under the case's own name; the hover on a behavior's name says which of its cases nothing is stated about.
- `HelperInvariants` becomes `ClauseHelpers`: it has expanded both kinds of clause for two commits.

The hover says what is **read**, not what a caller is given. Nothing assumes a rule at a call yet — that is commit 5 — and a hover claiming otherwise would promise a guarantee that is not there.

## The representation, and why the contract is read twice

A rule is classified in the tree the analysis has rules about (`InliningPolicy.DISCHARGE`), as a data's clause is. The contract the emitter runs on is expanded the other way and cannot be read back into this one, so the declaration is read again into the analysis tree — by the same reading, which `BehaviorChecker` now splits from the holding. The rules that come out carry the same `RuleId`s, because an id is a coordinate in the declaration and both readings walk the same declaration. Nothing matches the two lists up afterwards.

That is the one deviation from the plan, which had a `contract.forDischarge()` view. A view over the executable contract cannot recover an operation that its expansion already turned into a fold.

`RuleId`'s comment claimed its ids were not counted off a walk, and `arm` is. It now says what the coordinates are and what moves them; `(clause, selector)` cannot be the identity, because two arms of one clause may name the same case.

## Verification

Full reactor green under `CI=1 mvn -Plint` — syntax 114, fmt 2251, compiler 5184, build driver 10, lsp 264, cli 340, runtime 113, bench 13, 0 failures.

New: 7 tests on the query (one answer per case, per conjunct, the clause's name on each, the cases nothing is said about, a behavior that states nothing) and 6 on the hover (both cases of one arrow shown, arms read to different depths shown apart, the unstated case on the behavior, and hovering elsewhere unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)