### PR TITLE
Let a caller assume what the answer was declared to be

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
@@ -48,33 +48,21 @@ public record ContractDischarge(List<RuleDischarge> rules,
     public record RuleDischarge(BehaviorContract.RuleId rule, ClauseDischarge capability) {}
 
     /**
-     * What the check can read of {@code contract}, whose rules are as their author wrote them. Each
-     * is expanded into the representation the check reads ({@link InliningPolicy#DISCHARGE}) as it is
-     * classified, so what comes back is placed and split where it is written.
+     * What the check can read of what {@code stated} states, rule by rule.
      *
-     * <p>Handed a contract rather than a declaration. What a rule is about, what {@code value} is
-     * there and which rule it is are the reading's answers ({@link BehaviorChecker}), and this asks
-     * one question of them. The contract handed here is the same declaration that reading reads for
-     * the tree that runs, so its {@link BehaviorContract.RuleId}s are the ids of the rules that run —
-     * a reader holding both is not left matching them up.
+     * <p>Handed the rules as the analysis holds them rather than the declaration they came from.
+     * Which case a rule is about, what {@code value} is there, where each conjunct was written and
+     * what it types to are all settled by the one reading ({@link StatedContract}), and this asks one
+     * question of it — the same reading the check at a call takes what it may assume from, so what an
+     * author is shown and what a caller is given cannot drift apart.
      *
-     * @param expansion what turns a piece of what was written into the tree the check reads. Applied
-     *                  here, one conjunct at a time, rather than to the declaration before it was
-     *                  read: an expansion carries the positions of the body it copies in, so a rule
-     *                  expanded first would be placed inside the helper it names and split where that
-     *                  helper's author split it
-     * @param helpers the signatures a rule may reach without a binding, as the check that holds a
-     *                rule to its declaration reads them
      */
-    public static ContractDischarge of(BehaviorContract contract, ClausesForDischarge declaring,
-                                       Symbols symbols, Map<String, Type> helpers) {
+    public static ContractDischarge of(StatedContract stated, Symbols symbols) {
         List<RuleDischarge> classified = new ArrayList<>();
-        for (Clause clause : contract.clauses()) {
-            for (Rule rule : clause.rules()) {
-                classified.addAll(of(contract, clause, rule, declaring, symbols, helpers));
-            }
+        for (StatedContract.StatedRule rule : stated.rules()) {
+            classified.addAll(of(stated, rule, symbols));
         }
-        return new ContractDischarge(classified, unstatedCases(contract, symbols));
+        return new ContractDischarge(classified, unstatedCases(stated, symbols));
     }
 
     /**
@@ -84,17 +72,9 @@ public record ContractDischarge(List<RuleDischarge> rules,
      * what discharges the other, and an author acts on the half. The name the clause was declared
      * with goes on each of them, because a violation is reported by the clause however many conjuncts
      * it was written as.
-     *
-     * <p>Split where the author wrote the {@code &&} and not where an expansion put one. A rule
-     * naming a helper whose body is a conjunction is one thing the author wrote, so it is one answer;
-     * splitting the expanded tree would hand back two answers to a rule nobody wrote as two, each
-     * placed inside the helper.
      */
-    private static List<RuleDischarge> of(BehaviorContract contract, Clause clause, Rule rule,
-                                          ClausesForDischarge declaring, Symbols symbols,
-                                          Map<String, Type> helpers) {
-        Scope scope = BehaviorChecker.scopeOf(contract, rule).reaching(helpers);
-        CheckContext ctx = CheckContext.of(symbols).forDischarge();
+    private static List<RuleDischarge> of(StatedContract contract, StatedContract.StatedRule rule,
+                                          Symbols symbols) {
         // The parameters and `value` stand for themselves. A caller hands one value per parameter and
         // the behavior answers one value, so a rule naming either names something wherever it is read
         // — entered as locations, and nothing is seeded of them, since what the rule states is the
@@ -106,14 +86,11 @@ public record ContractDischarge(List<RuleDischarge> rules,
         named.add(rule.value());
         Denotations locations = Denotations.none().locations(named);
 
-        BindingOwner owner = BehaviorContract.ownerOf(contract.behavior());
         List<RuleDischarge> out = new ArrayList<>();
-        for (ClausesForDischarge.ClauseReading written
-                : declaring.conjunctsOf(rule.statement(), owner)) {
-            for (ClauseDischarge read : InvariantChecker.capabilitiesOf(written,
-                    toRead -> Elaborator.elaborate(toRead, scope, ctx, Type.BOOL), locations,
-                    symbols, contract.behavior().name())) {
-                out.add(new RuleDischarge(rule.id(), read.named(clause.name())));
+        for (StatedContract.Conjunct conjunct : rule.conjuncts()) {
+            for (ClauseDischarge read : InvariantChecker.capabilitiesOf(conjunct, locations, symbols,
+                    contract.behavior().name())) {
+                out.add(new RuleDischarge(rule.id(), read.named(rule.clause())));
             }
         }
         return out;
@@ -127,9 +104,9 @@ public record ContractDischarge(List<RuleDischarge> rules,
      * Answered here rather than reported, because a correct model may say nothing about most of what
      * it answers, and a reader wanting to know asks.
      */
-    private static List<TypeSymbol> unstatedCases(BehaviorContract contract, Symbols symbols) {
+    private static List<TypeSymbol> unstatedCases(StatedContract contract, Symbols symbols) {
         Set<TypeSymbol> stated = new LinkedHashSet<>();
-        for (Rule rule : contract.rules()) {
+        for (StatedContract.StatedRule rule : contract.rules()) {
             if (rule.guard() instanceof Guard.Case(CaseSelector selector)) {
                 stated.add(selector.name());
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -15,6 +15,7 @@ import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -144,7 +145,13 @@ public final class InvariantChecker {
      * author wrote, so where a declaration was written does not decide what can be discharged
      * against it (spec §invariant-discharge-representation).
      */
-    public record Source(Hir.Expr body, Map<TypeSymbol, List<Hir.InvariantClause>> invariants) {}
+    public record Source(Hir.Expr body, Map<TypeSymbol, List<Hir.InvariantClause>> invariants,
+                         Map<ValueName.Behavior, StatedContract> contracts) {
+
+        public Source {
+            contracts = Map.copyOf(contracts);
+        }
+    }
 
     /** How many conditionals a construction opens before the rest is left to the run-time check.
      * Each one doubles the paths, and a value written over three of them is not what the bound is
@@ -168,7 +175,13 @@ public final class InvariantChecker {
 
     private InvariantChecker(Symbols symbols,
                              Map<TypeSymbol, List<Hir.InvariantClause>> dischargeInvariants) {
-        this.engine = new PathEngine(symbols, dischargeInvariants);
+        this(symbols, dischargeInvariants, Map.of());
+    }
+
+    private InvariantChecker(Symbols symbols,
+                             Map<TypeSymbol, List<Hir.InvariantClause>> dischargeInvariants,
+                             Map<ValueName.Behavior, StatedContract> contracts) {
+        this.engine = new PathEngine(symbols, dischargeInvariants, contracts);
         // Named here because this check reads them directly and often. They are the engine's, not a
         // second copy: one engine builds them once and everything below sees those.
         this.symbols = engine.symbols();
@@ -225,11 +238,10 @@ public final class InvariantChecker {
      * @param locations the names it may read, each standing for itself
      * @param describing what is being read, for the record a fail-open leaves behind
      */
-    static List<ClauseDischarge> capabilitiesOf(ClausesForDischarge.ClauseReading clause,
-                                        Typing typing, Denotations locations, Symbols symbols,
-                                        String describing) {
+    static List<ClauseDischarge> capabilitiesOf(StatedContract.Conjunct conjunct,
+                                        Denotations locations, Symbols symbols, String describing) {
         return new InvariantChecker(symbols, Map.of())
-                .capabilitiesOf(clause, typing, locations, describing);
+                .capabilitiesOf(conjunct.stated(), conjunct.at(), locations, describing);
     }
 
     /** What turns the read form of a clause into the tree this check walks, which is the reader's to
@@ -991,8 +1003,9 @@ public final class InvariantChecker {
      * the analysis representation could not be built or typed for, and is not analyzed at all.
      */
     static Findings analyze(Core body, Map<TypeSymbol, List<Hir.InvariantClause>> invariants,
+                            Map<ValueName.Behavior, StatedContract> contracts,
                             Scope params, Symbols symbols) {
-        InvariantChecker c = new InvariantChecker(symbols, invariants);
+        InvariantChecker c = new InvariantChecker(symbols, invariants, contracts);
         if (body == null) {
             return new Findings(c.errors, c.warnings, Status.ABANDONED);
         }
@@ -1139,7 +1152,10 @@ public final class InvariantChecker {
                     // could have named — the case's value names only itself. What the arm binds is a
                     // value of the case's type, reached only here, so it is a location this arm
                     // introduces and it carries what that type guarantees.
-                    Entered in = engine.enteringArm(c, k, at);
+                    // The scrutinee travels with the arm: what a caller may assume of an answer is
+                    // decided by which behavior answered and which case this arm opened, and the
+                    // first of those is a question about what is being matched.
+                    Entered in = engine.enteringArm(c, m.scrutinee(), k, at);
                     walk(c.body(), in.known(), in.at(), depth);
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -1,10 +1,13 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Hir;
+import souther.compiler.check.BehaviorContract.Guard;
 import souther.compiler.core.Core;
 import souther.compiler.types.BindingId;
+import souther.compiler.types.CaseSelector;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -12,6 +15,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * What holds where a walk stands, and the three acts that move it.
@@ -46,9 +50,16 @@ final class PathEngine {
     private final Terms terms;
     /** What a clause owes and what a guard settles. */
     private final Predicates predicates;
+    /** What each behavior a body may call states about its answer, by the name it is called under. */
+    private final Map<ValueName.Behavior, StatedContract> contracts;
 
     PathEngine(Symbols symbols, Map<TypeSymbol, List<Hir.InvariantClause>> dischargeInvariants) {
-        this(symbols, dischargeInvariants, Terms.Of.THE_DISCHARGE_TREE);
+        this(symbols, dischargeInvariants, Map.of(), Terms.Of.THE_DISCHARGE_TREE);
+    }
+
+    PathEngine(Symbols symbols, Map<TypeSymbol, List<Hir.InvariantClause>> dischargeInvariants,
+               Map<ValueName.Behavior, StatedContract> contracts) {
+        this(symbols, dischargeInvariants, contracts, Terms.Of.THE_DISCHARGE_TREE);
     }
 
     /**
@@ -61,10 +72,16 @@ final class PathEngine {
      */
     PathEngine(Symbols symbols, Map<TypeSymbol, List<Hir.InvariantClause>> dischargeInvariants,
                Terms.Of reading) {
+        this(symbols, dischargeInvariants, Map.of(), reading);
+    }
+
+    PathEngine(Symbols symbols, Map<TypeSymbol, List<Hir.InvariantClause>> dischargeInvariants,
+               Map<ValueName.Behavior, StatedContract> contracts, Terms.Of reading) {
         this.symbols = symbols;
         this.clauses = new Clauses(symbols, dischargeInvariants);
         this.terms = new Terms(symbols, reading);
         this.predicates = new Predicates(terms);
+        this.contracts = Map.copyOf(contracts);
     }
 
     Symbols symbols() {
@@ -171,10 +188,150 @@ final class PathEngine {
      * here rather than at each walk: two readings deciding it apart is two chances to forget, and
      * the one that forgot fell over on every ordinary unit case.
      */
-    Entered enteringArm(Core.Case arm, Known k, Denotations at) {
-        return arm.binding() == null || arm.bindType() == null
+    Entered enteringArm(Core.Case arm, Core scrutinee, Known k, Denotations at) {
+        Entered in = arm.binding() == null || arm.bindType() == null
                 ? new Entered(k, at)
                 : enter(Terms.read(arm.binding(), arm.bindType(), arm.pos()), k, at);
+        return assuming(answeredBy(scrutinee, in.at()), answered(arm, scrutinee),
+                guard -> impliedBy(guard, arm.pattern()), in);
+    }
+
+    /**
+     * The same arm, where the answer it is opening came from nowhere this can name.
+     *
+     * <p>Kept as the shorter question a caller with no scrutinee to hand asks — a conditional lifted
+     * out of a body is read where it stood, and what it stood in front of is not being re-decided
+     * here.
+     */
+    Entered enteringArm(Core.Case arm, Known k, Denotations at) {
+        return enteringArm(arm, null, k, at);
+    }
+
+    // --- what a call's answer was declared to be ------------------------------------------------
+
+    /**
+     * What the behavior that produced {@code value} states about its answer, or null where nothing
+     * did.
+     *
+     * <p>The call is followed through the names it was given. {@code let r = findTodo(id)} and
+     * {@code match findTodo(id)} are the same program to an author, and asking whether the scrutinee
+     * <em>is</em> a call answers only the second — the binding it went through is not a step away
+     * from the call, it is a name for it. Derived from what the walk already recorded rather than
+     * remembered beside it: {@link Denotations} holds what each binding was given, and holding an
+     * origin as well would be two records of one fact to keep agreeing.
+     */
+    private Answered answeredBy(Core value, Denotations at) {
+        Core.Call call = value == null ? null : originatingCall(value, at, new HashSet<>());
+        if (call == null || !(call.fn() instanceof Core.Reached reached)
+                || !(reached.denotes() instanceof ValueName.Behavior behavior)) {
+            return null;
+        }
+        StatedContract stated = contracts.get(behavior);
+        return stated == null ? null : new Answered(stated, call);
+    }
+
+    /** An answer and what was declared about it: the rules, and the call they are read at — a rule
+     * names the behavior's own parameters, and what those are here is what this call handed over. */
+    private record Answered(StatedContract stated, Core.Call call) {}
+
+    /** The call {@code value} came from, through however many names it was given, or null where it
+     * came from something else. {@code seen} stops a binding given itself. */
+    private Core.Call originatingCall(Core value, Denotations at, Set<BindingId> seen) {
+        if (value instanceof Core.Call call) {
+            return call;
+        }
+        if (value instanceof Core.Read read && seen.add(read.binding())) {
+            Core given = at.valueOf(read.binding());
+            return given == null ? null : originatingCall(given, at, seen);
+        }
+        return null;
+    }
+
+    /**
+     * Whether an arm's pattern says the answer is what {@code guard} is about.
+     *
+     * <p>Read off the pattern, which is the proof the checker already has: an arm is taken because
+     * the value is one of the cases it names, so an arm naming one case says the answer is that case
+     * and an arm naming several says only that it is one of them. A rule about one of several is a
+     * rule about a value this arm may not have.
+     *
+     * <p>A rule under no case applies to every answer, so any arm reaching it is an arm it holds of.
+     */
+    private static boolean impliedBy(Guard guard, Core.ResolvedPattern pattern) {
+        if (guard instanceof Guard.Always) {
+            return true;
+        }
+        if (!(guard instanceof Guard.Case(CaseSelector selector))
+                || !(pattern instanceof Core.ResolvedPattern.Single single)) {
+            return false;
+        }
+        return single.selector().name().equals(selector.name());
+    }
+
+    /** What the arm holds of the answer: what it binds where it binds one, and the answer itself
+     * where it does not — an arm may state a relation about a case that carries nothing. */
+    private static Core answered(Core.Case arm, Core scrutinee) {
+        return arm.binding() == null || arm.bindType() == null ? scrutinee
+                : Terms.read(arm.binding(), arm.bindType(), arm.pos());
+    }
+
+    /**
+     * {@code in} with every rule the arm's pattern implies taken as holding of the answer.
+     *
+     * <p>Conjunct by conjunct, as everything else about a clause is. A rule one half of which names
+     * something this cannot read still says the other half: dropping the rule for the half that got
+     * away would leave a caller with less than the declaration gives them, and taking the half that
+     * was read is what the seeding does everywhere else.
+     */
+    private Entered assuming(Answered answered, Core answer, Predicate<Guard> reached, Entered in) {
+        if (answered == null || answer == null) {
+            return in;
+        }
+        Known out = in.known();
+        for (StatedContract.StatedRule rule : answered.stated().rules()) {
+            if (!reached.test(rule.guard())) {
+                continue;
+            }
+            Map<BindingId, Core> given = handedOver(answered, rule, answer);
+            if (given == null) {
+                continue;
+            }
+            for (StatedContract.Conjunct conjunct : rule.conjuncts()) {
+                if (conjunct.stated() == null) {
+                    continue;
+                }
+                Core here = Clauses.substituted(conjunct.stated(), given);
+                out = predicates.assume(predicates.obligations(here, out, in.at(), false), out,
+                        Known.Held.OF_THE_VALUE);
+            }
+        }
+        return new Entered(out, in.at());
+    }
+
+    /**
+     * What each name a rule reads stands for here: the parameters as this call handed them over, and
+     * {@code value} as what the arm holds.
+     *
+     * <p>A rule is written in the declaration's names and read at the caller's values, so the two are
+     * put together before anything is read of it — which is the same substitution a declaration's
+     * clause gets where a value is built ({@link Clauses#statedAt}).
+     *
+     * <p>Null where the call and the declaration disagree about how many values were handed over.
+     * That is a program this compiler is refusing elsewhere, and a rule read against the wrong
+     * argument would be a relation nobody declared.
+     */
+    private static Map<BindingId, Core> handedOver(Answered answered,
+                                                   StatedContract.StatedRule rule, Core answer) {
+        List<Core> args = answered.call().args();
+        if (args.size() != answered.stated().params().size()) {
+            return null;
+        }
+        Map<BindingId, Core> given = new HashMap<>();
+        for (BehaviorContract.ContractParam param : answered.stated().params()) {
+            given.put(param.binding(), args.get(param.index()));
+        }
+        given.put(rule.value(), answer);
+        return given;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -436,7 +436,8 @@ public final class SpecChecker {
                         new CheckContext(symbols, null, reqSigs).withCallees(calleeSigs)
                                 .withDependencies(dependsOn).forDischarge(), output);
         InvariantChecker.Findings inv = InvariantChecker.analyze(dischargeBody,
-                discharge == null ? Map.of() : discharge.invariants(), env, symbols);
+                discharge == null ? Map.of() : discharge.invariants(),
+                discharge == null ? Map.of() : discharge.contracts(), env, symbols);
         warnings.addAll(inv.warnings());
         if (!inv.errors().isEmpty()) {
             throw inv.errors().get(0);

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedContract.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedContract.java
@@ -1,0 +1,112 @@
+package souther.compiler.check;
+
+import souther.compiler.check.BehaviorContract.ContractParam;
+import souther.compiler.check.BehaviorContract.Guard;
+import souther.compiler.check.BehaviorContract.Rule;
+import souther.compiler.check.BehaviorContract.RuleId;
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * What a behavior states about its answer, read into the representation the analysis has rules
+ * about and typed there.
+ *
+ * <p>Two readers want this and they want the same thing of it. The editor asks how much of each rule
+ * the check can read; the check at a call asks what of it may be taken as holding. Both are questions
+ * about the rule as a term — which case it is about, which names it reads, what it comes to — so it
+ * is read once, here, and each of them takes what it needs. Read twice, the answer shown to an author
+ * and the answer a caller is given would be two readings that have to be kept agreeing.
+ *
+ * <p>Every conjunct arrives placed and typed together ({@link Conjunct}). The rest of this package
+ * has been got wrong twice by carrying those apart.
+ */
+public record StatedContract(ValueName.Behavior behavior, List<ContractParam> params, Type output,
+                             List<StatedRule> rules) {
+
+    public StatedContract {
+        params = List.copyOf(params);
+        rules = List.copyOf(rules);
+    }
+
+    /**
+     * One rule: when it applies, what {@code value} is where it does, and what it states.
+     *
+     * <p>The clause's name travels with it because a violation is reported by the clause, and a
+     * reader of one rule has no way back to the clause it was written under.
+     */
+    public record StatedRule(RuleId id, Guard guard, BindingId value, Optional<String> clause,
+                             List<Conjunct> conjuncts) {
+
+        public StatedRule {
+            conjuncts = List.copyOf(conjuncts);
+        }
+    }
+
+    /**
+     * One conjunct the author wrote: where they wrote it, and what it types to for the analysis.
+     *
+     * @param stated null where this compiler could not type it in that representation, which is an
+     *               answer and not a failure — a rule the check cannot read is not a rule an author
+     *               wrote wrongly
+     */
+    public record Conjunct(SourcePos at, Core stated) {}
+
+    /**
+     * {@code contract} read as the analysis reads it.
+     *
+     * <p>Types each conjunct over the behavior's own names: the parameters as the contract says they
+     * are bound, and {@code value} as what the case the rule is about holds. Which is what a caller
+     * substitutes into — the names are the declaration's, and the values are the call's.
+     *
+     * @param declaring the module's clauses as the analysis reads them, which is what turns a
+     *                  conjunct into the tree that has rules about it
+     * @param helpers the signatures a rule may reach without a binding
+     */
+    public static StatedContract of(BehaviorContract contract, ClausesForDischarge declaring,
+                                    Symbols symbols, Map<String, Type> helpers) {
+        CheckContext ctx = CheckContext.of(symbols).forDischarge();
+        List<StatedRule> rules = new ArrayList<>();
+        for (BehaviorContract.Clause clause : contract.clauses()) {
+            for (Rule rule : clause.rules()) {
+                Scope scope = BehaviorChecker.scopeOf(contract, rule).reaching(helpers);
+                List<Conjunct> conjuncts = new ArrayList<>();
+                for (ClausesForDischarge.ClauseReading written : declaring.conjunctsOf(
+                        rule.statement(), BehaviorContract.ownerOf(contract.behavior()))) {
+                    conjuncts.add(new Conjunct(written.at(),
+                            typed(written.read(), scope, ctx, contract.behavior())));
+                }
+                rules.add(new StatedRule(rule.id(), rule.guard(), rule.value(), clause.name(),
+                        conjuncts));
+            }
+        }
+        return new StatedContract(contract.behavior(), contract.params(), contract.output(), rules);
+    }
+
+    /** {@code read} as the check holds it, or null where this compiler could not type it there. */
+    private static Core typed(souther.compiler.ast.Hir.Expr read, Scope scope, CheckContext ctx,
+                              ValueName.Behavior behavior) {
+        try {
+            return Elaborator.elaborate(read, scope, ctx, Type.BOOL);
+        } catch (RuntimeException why) {
+            // Fail-open, as every reading of a clause is, and recorded: a rule this compiler could
+            // not type and an analysis that fell over typing it come out alike, and only one of them
+            // is something the model says.
+            InvariantChecker.gaveUp("typing " + behavior.name(), why);
+            return null;
+        }
+    }
+
+    /** Where a rule states nothing this can read, so a reader asking what to assume has nothing to
+     * take from it. */
+    public boolean isEmpty() {
+        return rules.isEmpty();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -6,6 +6,7 @@ import souther.compiler.check.BehaviorChecker;
 import souther.compiler.check.BehaviorContract;
 import souther.compiler.check.BehaviorRequirement;
 import souther.compiler.check.ClausesForDischarge;
+import souther.compiler.check.StatedContract;
 import souther.compiler.check.ContractDischarge;
 import souther.compiler.check.DataChecker;
 import souther.compiler.check.HelperInliner;
@@ -393,6 +394,85 @@ public final class Bodies {
 
         @Override
         public Answer<Map<String, ContractDischarge>> compute(Db db) {
+            Answer<Map<String, StatedContract>> stated = db.ask(new StatedContracts(name));
+            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            if (!stated.present() || !scope.present()) {
+                return Answer.absent();
+            }
+            Map<String, ContractDischarge> out = new LinkedHashMap<>();
+            stated.value().forEach((behavior, rules) ->
+                    out.put(behavior, ContractDischarge.of(rules, scope.value())));
+            return Answer.of(Ordered.map(out));
+        }
+    }
+
+    /**
+     * What every behavior a body of this module may call states about its answer, by the name it is
+     * called under — this module's own and the ones it borrows.
+     *
+     * <p>What a caller may assume of an answer is what the module that declared the behavior said,
+     * so a borrowed one is read from the module that declares it and not from anything this one
+     * holds. A module reached through its published classes answers the same question: the
+     * declaration it published is read back by this front end, and what its author wrote is what
+     * comes back (spec §published-modules).
+     *
+     * <p>A behavior that states nothing is not here, and neither is one whose module could not be
+     * read. Absence is what a caller wanting to know "is there anything to assume" is asking, and an
+     * empty contract would be a second way to say it.
+     */
+    public record ContractsInSight(String name)
+            implements Key<Map<ValueName.Behavior, StatedContract>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<ValueName.Behavior, StatedContract>> compute(Db db) {
+            Answer<Map<String, StatedContract>> own = db.ask(new StatedContracts(name));
+            if (!own.present()) {
+                return Answer.absent();
+            }
+            Map<ValueName.Behavior, StatedContract> out = new LinkedHashMap<>();
+            own.value().forEach((behavior, stated) ->
+                    out.put(new ValueName.Behavior(name, behavior), stated));
+            for (ValueName.Behavior each : borrowed(db, name)) {
+                if (each.module().equals(name)) {
+                    continue;
+                }
+                Map<String, StatedContract> theirs =
+                        db.ask(new StatedContracts(each.module())).value();
+                StatedContract stated = theirs == null ? null : theirs.get(each.name());
+                if (stated != null) {
+                    out.put(each, stated);
+                }
+            }
+            return Answer.of(Ordered.map(out));
+        }
+    }
+
+    /**
+     * What each behavior of a module states about its answer, read into the representation the
+     * analysis has rules about and typed there, by the name the behavior is declared under.
+     *
+     * <p>The one reading of a rule as a term. Two readers want it — the editor, which shows how much
+     * of each rule the check can read, and the check at a call, which takes what it may assume — and
+     * both want the same thing of it: the rule as the analysis holds it, placed where its author
+     * wrote it. Read twice, what an author is shown and what a caller is given would be two answers
+     * to keep agreeing.
+     *
+     * <p>Nothing is reported from here. Whether a clause is well formed was decided by
+     * {@link Contracts}, which owns both the contracts and what reading them found; a behavior whose
+     * declaration cannot be read is left out of this rather than refused a second time.
+     */
+    public record StatedContracts(String name) implements Key<Map<String, StatedContract>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, StatedContract>> compute(Db db) {
             Answer<souther.compiler.check.Expandable> expandable = db.ask(new Shapes.Expandable(name));
             Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
             Answer<Map<String, Sig>> signatures = db.ask(new Signatures(name));
@@ -403,7 +483,7 @@ public final class Bodies {
             }
             Answer<Map<String, Hir.FnDef>> imported = db.ask(new ImportedDefinitions(name));
             Map<String, Hir.FnDef> published = imported.present() ? imported.value() : Map.of();
-            Map<String, ContractDischarge> out = new LinkedHashMap<>();
+            Map<String, StatedContract> out = new LinkedHashMap<>();
             try {
                 ClausesForDischarge declaring =
                         ClausesForDischarge.of(expandable.value(), scope.value(), published);
@@ -412,12 +492,12 @@ public final class Bodies {
                     try {
                         BehaviorContract contract = BehaviorChecker.contractAsRead(each.getValue(),
                                 name, signatures.value().get(each.getKey()), scope.value());
-                        out.put(each.getKey(), ContractDischarge.of(contract, declaring,
-                                scope.value(), helpers.value()));
+                        out.put(each.getKey(), StatedContract.of(contract, declaring, scope.value(),
+                                helpers.value()));
                     } catch (Unanswerable | CompileException _) {
                         // The declaration could not be read, which is said where it is held to its
-                        // rules. There is nothing to classify, and a behavior that cannot be read
-                        // leaves the rest of the module's readable.
+                        // rules. There is nothing to read into a term, and a behavior that cannot be
+                        // read leaves the rest of the module's readable.
                     }
                 }
             } catch (CompileException e) {
@@ -1323,6 +1403,11 @@ public final class Bodies {
             Answer<Hir.FnDef> discharge = db.ask(new BodyForInvariantDischarge(module, behavior));
             Answer<Map<TypeSymbol, List<Hir.InvariantClause>>> dischargeInvariants =
                     db.ask(new Shapes.InvariantsForDischarge(module));
+            // What the behaviors this body may call state about their answers. A caller that has
+            // matched a case may take the rules about that case as holding, which is what a declared
+            // relation is for (spec §ensures).
+            Answer<Map<ValueName.Behavior, StatedContract>> contracts =
+                    db.ask(new ContractsInSight(module));
             if (!spec.present() || !fn.present() || !body.present() || !scope.present()
                     || !calleeSigs.present() || !reqSigs.present() || !inliner.present()
                     || !sigs.present() || !constructs.present()) {
@@ -1333,7 +1418,8 @@ public final class Bodies {
             // rather than run against the emitted tree, whose operations are no longer operations.
             InvariantChecker.Source dischargeSource = discharge.present()
                     ? new InvariantChecker.Source(discharge.value().writtenBody(),
-                            dischargeInvariants.present() ? dischargeInvariants.value() : Map.of())
+                            dischargeInvariants.present() ? dischargeInvariants.value() : Map.of(),
+                            contracts.present() ? contracts.value() : Map.of())
                     : null;
             List<Diagnostic> warnings = new ArrayList<>();
             try {

--- a/souther-compiler/src/test/java/souther/compiler/ACallerMayAssumeWhatTheAnswerWasDeclaredToBeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACallerMayAssumeWhatTheAnswerWasDeclaredToBeTest.java
@@ -1,0 +1,211 @@
+package souther.compiler;
+
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What a behavior declared about its answer is what a caller that reached the case may assume.
+ *
+ * <p>This is what an {@code ensures} is for, and until here it was a run-time check and nothing
+ * else. A relation between what a behavior was given and what it answered fits on neither type — the
+ * answer does not hold the input — so a caller had to establish it again with a {@code guard} it
+ * could not derive, and the declaration cost something and paid nothing.
+ *
+ * <p>Measured by a construction downstream of the call: the seeding either carries the relation to
+ * it, in which case nothing is reported, or it does not, in which case the construction is an
+ * unproven one (E2011). Every test that asserts silence says what the same program is like with the
+ * clause taken away, because silence on its own is what a check that never ran also looks like.
+ */
+class ACallerMayAssumeWhatTheAnswerWasDeclaredToBeTest {
+
+    private static final String CLAUSE = "    ensures Found -> value.rank > id.value\n";
+
+    private static final String DECLARES = """
+            module m.a exposing ( Id, Found, Missing, Ranked, findIt, use )
+
+            data Id      = Int
+            data Found   = { rank: Int }
+            data Missing = { asked: Id }
+            data Ranked  = Int
+                invariant value > 0
+
+            behavior findIt : (id: Id) -> Found | Missing
+                constructs Found, Missing
+            """ + CLAUSE + """
+
+            let findIt (id) =
+                if id.value > 0 then Found { rank = id.value } else Missing { asked = id }
+
+            behavior use : (id: Id) -> Ranked | Missing
+                constructs Ranked, Missing
+            """;
+
+    private static final String THROUGH_A_MATCH = """
+            let use (id) = {
+                guard id.value >= 0
+                    else Missing { asked = id }
+                match findIt(id) with
+                    | Found as found -> Ranked(found.rank)
+                    | Missing as missing -> missing
+            }
+            """;
+
+    private static List<Diagnostic> unproven(String source) {
+        return Compiler.compileWithWarnings(source).warnings().stream()
+                .filter(d -> d.severity() == Severity.WARNING)
+                .filter(d -> d.code().equals("E2011")).toList();
+    }
+
+    private static String withoutTheClause(String source) {
+        return source.replace(CLAUSE, "");
+    }
+
+    @Test
+    void aRelationDeclaredOnTheAnswerReachesAConstructionAfterTheMatch() {
+        // `value.rank > id.value` and the guard `id.value >= 0` give `rank > 0`, which is `Ranked`'s
+        assertEquals(List.of(), unproven(DECLARES + THROUGH_A_MATCH),
+                "declared, matched, assumed — so the construction is settled");
+        assertEquals(1, unproven(withoutTheClause(DECLARES + THROUGH_A_MATCH)).size(),
+                "and with nothing declared it is the unproven construction it always was");
+    }
+
+    /**
+     * The call is reached through the name it was given.
+     *
+     * <p>{@code let r = findIt(id)} and {@code match findIt(id)} are one program to an author. A
+     * reader asking whether the scrutinee <em>is</em> a call answers only the second, and the first
+     * is how anybody writes it who wants to name the answer.
+     */
+    @Test
+    void theCallIsFollowedThroughTheNameItWasGiven() {
+        String throughALet = """
+                let use (id) = {
+                    guard id.value >= 0
+                        else Missing { asked = id }
+                    let answer = findIt(id)
+                    match answer with
+                        | Found as found -> Ranked(found.rank)
+                        | Missing as missing -> missing
+                }
+                """;
+
+        assertEquals(List.of(), unproven(DECLARES + throughALet));
+        assertEquals(1, unproven(withoutTheClause(DECLARES + throughALet)).size());
+    }
+
+    /**
+     * An arm answering for several cases says the answer is one of them, which is not that it is any
+     * one of them. A rule about {@code Found} is a rule about a value this arm may not have.
+     */
+    @Test
+    void anArmAnsweringForSeveralCasesAssumesNothingAboutOneOfThem() {
+        String orPattern = """
+                let use (id) = {
+                    guard id.value >= 0
+                        else Missing { asked = id }
+                    match findIt(id) with
+                        | Found | Missing as either -> Ranked(id.value)
+                }
+                """;
+
+        assertEquals(1, unproven(DECLARES + orPattern).size(),
+                "`Found`'s rule says nothing here, so this construction is as unproven as ever");
+    }
+
+    /**
+     * A rule with a part this cannot read still says the part it can.
+     *
+     * <p>The unit is the conjunct everywhere else a clause is read, and dropping a rule for the half
+     * that got away would leave a caller with less than the declaration gives them.
+     */
+    @Test
+    void aRuleHalfOfWhichCannotBeReadStillSaysTheOtherHalf() {
+        String source = """
+                module m.b exposing ( Id, Found, Ranked, findIt, use )
+
+                data Id     = Int
+                data Found  = { rank: Int, tag: String }
+                data Ranked = Int
+                    invariant value > 0
+
+                behavior findIt : (id: Id) -> Found
+                    constructs Found
+                    ensures String.startsWith(value.tag, "x") && value.rank > id.value
+
+                let findIt (id) = Found { rank = id.value + 1, tag = "x" }
+
+                behavior use : (id: Id) -> Ranked
+                    constructs Ranked
+                let use (id) = {
+                    guard id.value >= 0
+                        else Ranked(1)
+                    let answer = findIt(id)
+                    Ranked(answer.rank)
+                }
+                """;
+
+        assertEquals(List.of(), unproven(source),
+                "`value.rank > id.value` was read, whatever became of the half beside it");
+    }
+
+
+    /**
+     * What another module declared is what a caller in this one may assume.
+     *
+     * <p>The relation belongs to the behavior, so it is read from the module that declares it —
+     * which is where an author reading the call would look for it, and the only place it is written.
+     */
+    @Test
+    void aRelationDeclaredInAnotherModuleReachesItsCallerHere() {
+        String declaring = """
+                module up exposing ( Id, Found, Missing, findIt )
+
+                data Id      = Int
+                data Found   = { rank: Int }
+                data Missing = { asked: Id }
+
+                behavior findIt : (id: Id) -> Found | Missing
+                    constructs Found, Missing
+                    ensures Found -> value.rank > id.value
+
+                let findIt (id) =
+                    if id.value > 0 then Found { rank = id.value } else Missing { asked = id }
+                """;
+        String calling = """
+                module down exposing ( Ranked, use )
+
+                import up ( Id, Found, Missing, findIt )
+
+                data Ranked = Int
+                    invariant value > 0
+
+                behavior use : (id: Id) -> Ranked | Missing
+                    constructs Ranked, Missing
+                let use (id) = {
+                    guard id.value >= 0
+                        else Missing { asked = id }
+                    match findIt(id) with
+                        | Found as found -> Ranked(found.rank)
+                        | Missing as missing -> missing
+                }
+                """;
+
+        assertEquals(List.of(), unprovenAcross(List.of(declaring, calling)));
+        assertEquals(1, unprovenAcross(List.of(
+                declaring.replace("    ensures Found -> value.rank > id.value\n", ""),
+                calling)).size(),
+                "and with nothing declared up there, the construction down here is unproven");
+    }
+
+    private static List<Diagnostic> unprovenAcross(List<String> sources) {
+        return Compiler.compileModulesWithWarnings(sources).warnings().stream()
+                .filter(d -> d.severity() == Severity.WARNING)
+                .filter(d -> d.code().equals("E2011")).toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/ACallerMayAssumeWhatTheAnswerWasDeclaredToBeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACallerMayAssumeWhatTheAnswerWasDeclaredToBeTest.java
@@ -6,6 +6,7 @@ import souther.compiler.diag.Severity;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -206,6 +207,65 @@ class ACallerMayAssumeWhatTheAnswerWasDeclaredToBeTest {
     private static List<Diagnostic> unprovenAcross(List<String> sources) {
         return Compiler.compileModulesWithWarnings(sources).warnings().stream()
                 .filter(d -> d.severity() == Severity.WARNING)
+                .filter(d -> d.code().equals("E2011")).toList();
+    }
+
+    /**
+     * And what the module published, not only what this compile happened to hold.
+     *
+     * <p>A module reached through its classes is a different path to the same question: what its
+     * author wrote travels as the declaration it published and is read back by this front end
+     * (ADR-0063), and nothing of the module that declared it is compiled here. A caller assuming a
+     * relation is a language guarantee across that boundary or it is a guarantee only inside one
+     * build.
+     */
+    @Test
+    void aRelationPublishedByAnotherProjectReachesItsCallerHere() {
+        String library = """
+                module shared.finding exposing ( Id, Found, Missing, findIt )
+
+                data Id      = Int
+                data Found   = { rank: Int }
+                data Missing = { asked: Id }
+
+                behavior findIt : (id: Id) -> Found | Missing
+                    constructs Found, Missing
+                    ensures Found -> value.rank > id.value
+
+                let findIt (id) =
+                    if id.value > 0 then Found { rank = id.value } else Missing { asked = id }
+                """;
+        String consumer = """
+                module app.ranking exposing ( Ranked, use )
+
+                import shared.finding ( Id, Found, Missing, findIt )
+
+                data Ranked = Int
+                    invariant value > 0
+
+                behavior use : (id: Id) -> Ranked | Missing
+                    constructs Ranked, Missing
+                let use (id) = {
+                    guard id.value >= 0
+                        else Missing { asked = id }
+                    match findIt(id) with
+                        | Found as found -> Ranked(found.rank)
+                        | Missing as missing -> missing
+                }
+                """;
+
+        assertEquals(List.of(), unprovenAgainst(consumer, library),
+                "the relation was read back off the published declaration and assumed here");
+        assertEquals(1, unprovenAgainst(consumer,
+                        library.replace("    ensures Found -> value.rank > id.value\n", "")).size(),
+                "and a library that declares nothing leaves the construction unproven, as before");
+    }
+
+    /** The consumer compiled on its own, against the library's classes and none of its source. */
+    private static List<Diagnostic> unprovenAgainst(String consumer, String library) {
+        Map<String, byte[]> classes = Compiler.compile(library);
+        return Compiler.compileModulesWithWarnings(List.of(consumer), classes::get).warnings()
+                .stream().filter(d -> d.severity() == Severity.WARNING)
                 .filter(d -> d.code().equals("E2011")).toList();
     }
 }

--- a/specification.adoc
+++ b/specification.adoc
@@ -2355,6 +2355,16 @@ A clause MAY be named. [[ensures-clause-names-are-distinct]]Named clauses are di
 
 A clause travels with the published declaration, as a data's does and for the same reason: a reader that cannot read it cannot assume it.
 
+==== What a caller may assume
+
+Where a caller has reached the case a rule is about, that rule holds of the answer, and the checker takes it as holding — the same seeding an input's type gives (<<invariant-discharge>>). This is what declaring a relation buys: the answer does not carry the input, so before it a caller could only re-establish the relation with a `+guard+` it had no way to derive.
+
+It is reached by matching that case and by nothing weaker. An arm answering for several cases says the answer is one of them, which is not that it is any one of them, so a rule about one of those cases is a rule about a value that arm may not have. A rule under no case applies to every answer and is reached wherever the answer is.
+
+What is taken in is what the checker can read of the rule, conjunct by conjunct, as everywhere else a clause is read (<<ensures-discharge-capability>>). A rule one part of which it cannot read still says the part it can.
+
+The answer has to be a value the checker can name, which a matched case's binding is. An answer no arm opens — a behavior whose output has no cases — is named by nothing the checker reasons about, so what is stated about such an answer is held when the behavior answers and reaches no caller.
+
 [#ensures-discharge-capability]
 ==== A rule says how much of it the check reads
 


### PR DESCRIPTION
Commit 5 of #803: what a behavior declares about its answer is now what a caller that reached the case may assume.

## What it does

Until here an `ensures` was a run-time check and nothing else. The relation it declares fits on neither type — the answer does not carry the input — so a caller had to re-establish it with a guard it had no way to derive.

```souther
behavior findIt : (id: Id) -> Found | Missing
    ensures Found -> value.rank > id.value

let use (id) = {
    guard id.value >= 0
        else Missing { asked = id }
    match findIt(id) with
        | Found as found -> Ranked(found.rank)   -- `Ranked`'s `value > 0` is settled here
        | Missing as missing -> missing
}
```

Take the clause away and that construction is the unproven one (E2011) it always was. Every test asserting silence carries that control, since silence is also what a check that never ran looks like.

## How

- **One reading.** `StatedContract` reads a behavior's rules into the representation the analysis has rules about and types them there, once. The editor's classification (commit 4) is now derived from that same reading, so what an author is shown and what a caller is given cannot drift apart.
- **Contracts in sight.** `Bodies.ContractsInSight` puts that answer under the name each behavior is called by — this module's own and the ones it borrows, each read from the module that declares it.
- **In `PathEngine`, not in the check.** PR#804 removed the second reader of path semantics; putting this in the checker would have grown it back. `InvariantChecker` holds no policy about it.
- **Which rules a caller reaches is read off the arm's pattern.** One case named → that case; several → only that it is one of them, so a rule about one of them is a rule about a value the arm may not have. No new abstract domain: the pattern is the proof the checker already holds.
- **The call is followed through the names it was given**, so `let r = findIt(id)` then `match r` works. Derived from what the walk recorded (`Denotations` already holds what each binding was given) rather than remembered beside it.
- **Conjunct by conjunct**, as everything else about a clause: a rule one half of which names something unreadable still says the other half.

## What does not reach a caller yet

A behavior whose answer has no cases is never matched, so its answer is named only by a `let` — and a name for a call is not a location, so there is no term to read a rule against. I tried making it one: it takes away the record that lets the match path follow the call, because a binding is either an alias for its initializer or a location and `Denotations` holds one of the two. That is a change to what a name for an answer means, and it belongs in its own piece of work. The specification says so rather than leaving it to be discovered.

## Verification

Full reactor green under `CI=1 mvn -Plint` — compiler 5197, lsp 267, cli 340, syntax 114, fmt 2251, build driver 10, runtime 113, bench 13, 0 failures.

Five new tests: through a match, through a name, an or-pattern assuming nothing about one of its cases, a rule half of which is unreadable, and a relation declared in another module reaching its caller here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)