### PR TITLE
Separate what a fact is about from what makes two of them one, and carry an answer's guarantees to its caller

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AdmissibleReading.java
@@ -34,17 +34,17 @@ import java.util.Set;
  * the values can be written out ({@link ValueUniverse}) and is kept as a denial where they cannot,
  * so nothing reaches emptiness except through values this had in hand.
  */
-final class AdmissibleReading implements ClauseReading<AdmissibleValues<Term>> {
+final class AdmissibleReading implements ClauseReading<AdmissibleValues<FactSubject>> {
 
     private final Terms terms;
     private final Denotations at;
     /** What each position of the value is called, and what type stands there. A position is here
      * whether or not it is a number: which values a boolean has is as much an answer as which
      * values an integer has, and the reading that asked the carrier had no word for the first. */
-    private final Map<Term, Type> byName;
+    private final Map<FactSubject, Type> byName;
     private final Symbols symbols;
 
-    private AdmissibleReading(Terms terms, Denotations at, Map<Term, Type> byName,
+    private AdmissibleReading(Terms terms, Denotations at, Map<FactSubject, Type> byName,
                               Symbols symbols) {
         this.terms = terms;
         this.at = at;
@@ -53,29 +53,29 @@ final class AdmissibleReading implements ClauseReading<AdmissibleValues<Term>> {
     }
 
     /** The reading of one value's positions, for {@link StatedByClauses} to take the leaves of. */
-    static AdmissibleReading of(Terms terms, Denotations at, Map<Term, Type> byName,
+    static AdmissibleReading of(Terms terms, Denotations at, Map<FactSubject, Type> byName,
                                 Symbols symbols) {
         return new AdmissibleReading(terms, at, byName, symbols);
     }
 
     @Override
-    public AdmissibleValues<Term> nothingSaid() {
+    public AdmissibleValues<FactSubject> nothingSaid() {
         return AdmissibleValues.top();
     }
 
     @Override
-    public AdmissibleValues<Term> both(AdmissibleValues<Term> one, AdmissibleValues<Term> other) {
+    public AdmissibleValues<FactSubject> both(AdmissibleValues<FactSubject> one, AdmissibleValues<FactSubject> other) {
         return one.meet(other);
     }
 
     @Override
-    public AdmissibleValues<Term> either(AdmissibleValues<Term> one, AdmissibleValues<Term> other) {
+    public AdmissibleValues<FactSubject> either(AdmissibleValues<FactSubject> one, AdmissibleValues<FactSubject> other) {
         return one.join(other);
     }
 
     /** An equality names a value and a denial leaves the rest; nothing else here is read. */
     @Override
-    public AdmissibleValues<Term> leaf(Core e, boolean positive) {
+    public AdmissibleValues<FactSubject> leaf(Core e, boolean positive) {
         if (e instanceof Core.Binary b && (b.op() == Hir.BinOp.EQ || b.op() == Hir.BinOp.NE)) {
             // Which of the two it states, once the denials above have been counted: `/=` denied
             // states the equality, and `==` denied denies it.
@@ -85,8 +85,8 @@ final class AdmissibleReading implements ClauseReading<AdmissibleValues<Term>> {
     }
 
     /** What one comparison of a position with a value says, or nothing where it is not one. */
-    private AdmissibleValues<Term> comparison(Core.Binary b, boolean states) {
-        AdmissibleValues<Term> read = sided(b.left(), b.right(), states);
+    private AdmissibleValues<FactSubject> comparison(Core.Binary b, boolean states) {
+        AdmissibleValues<FactSubject> read = sided(b.left(), b.right(), states);
         if (read == null) {
             // `"A" == value` says what `value == "A"` says.
             read = sided(b.right(), b.left(), states);
@@ -110,7 +110,7 @@ final class AdmissibleReading implements ClauseReading<AdmissibleValues<Term>> {
      * ordering comparison and an equality answer alike — written per shape, {@code <} fell through
      * one path and {@code ==} another, and a relation came out as a form nobody could read.
      */
-    private AdmissibleValues<Term> unreadable(Core e) {
+    private AdmissibleValues<FactSubject> unreadable(Core e) {
         return AdmissibleValues.unreadable(names(e), relatesTwoPositions(e)
                 ? UnreadReason.RELATES_TWO_POSITIONS : UnreadReason.FORM_NOT_READ);
     }
@@ -127,8 +127,8 @@ final class AdmissibleReading implements ClauseReading<AdmissibleValues<Term>> {
         if (!(e instanceof Core.Binary b) || !COMPARES.contains(b.op())) {
             return false;
         }
-        Term left = positionIn(b.left());
-        Term right = positionIn(b.right());
+        FactSubject left = positionIn(b.left());
+        FactSubject right = positionIn(b.right());
         return left != null && right != null && !left.equals(right);
     }
 
@@ -140,19 +140,16 @@ final class AdmissibleReading implements ClauseReading<AdmissibleValues<Term>> {
 
     /** The same, with {@code where} read as the position and {@code what} as the value, or null
      * where they are not those. */
-    private AdmissibleValues<Term> sided(Core where, Core what, boolean states) {
-        Term position = positionIn(where);
+    private AdmissibleValues<FactSubject> sided(Core where, Core what, boolean states) {
+        FactSubject position = positionIn(where);
         Type type = position == null ? null : byName.get(position);
         Value value = type == null ? null : valueOf(what);
         return value == null ? null : AdmissibleValues.at(position, admits(value, states, type));
     }
 
     /** The position {@code e} is, or null where it is not one of the positions being read for. */
-    private Term positionIn(Core e) {
-        Term named = terms.atomOf(e, at);
-        if (named == null) {
-            named = terms.bodyKey(e, at);
-        }
+    private FactSubject positionIn(Core e) {
+        FactSubject named = terms.subjectOf(e, at);
         return named != null && byName.containsKey(named) ? named : null;
     }
 
@@ -208,17 +205,14 @@ final class AdmissibleReading implements ClauseReading<AdmissibleValues<Term>> {
      * nothing here relates one position to another, so a rule narrowing a position names it — and a
      * rule relating two of them names both and is itself one of these.
      */
-    private Set<Term> names(Core e) {
-        Set<Term> found = new LinkedHashSet<>();
+    private Set<FactSubject> names(Core e) {
+        Set<FactSubject> found = new LinkedHashSet<>();
         gather(e, found);
         return found;
     }
 
-    private void gather(Core e, Set<Term> found) {
-        Term here = terms.atomOf(e, at);
-        if (here == null) {
-            here = terms.bodyKey(e, at);
-        }
+    private void gather(Core e, Set<FactSubject> found) {
+        FactSubject here = terms.subjectOf(e, at);
         if (here != null && byName.containsKey(here)) {
             found.add(here);
             return;   // a position names itself, and nothing under it is a position of its own

--- a/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstraintState.java
@@ -54,8 +54,8 @@ import java.util.Set;
  * readers of two domains, and each of them answered that there was something wherever the domain it
  * happened to ask had nothing to say.
  */
-record ConstraintState(NumericDomain<Term> numbers, PredicateFacts facts,
-                       AdmissibleValues<Term> values, OrderedIntervals<Term> ordered,
+record ConstraintState(NumericDomain<FactSubject> numbers, PredicateFacts facts,
+                       AdmissibleValues<FactSubject> values, OrderedIntervals<FactSubject> ordered,
                        boolean shown) {
 
     /** Nothing taken in, so nothing ruled out. */
@@ -111,7 +111,7 @@ record ConstraintState(NumericDomain<Term> numbers, PredicateFacts facts,
      *                  off the state's own map, the place named would be the one whose clause was
      *                  read first, and moving a clause would move the refusal
      */
-    Optional<Emptiness> holdsNothing(SequencedMap<Term, String> positions) {
+    Optional<Emptiness> holdsNothing(SequencedMap<FactSubject, String> positions) {
         Emptiness why = isBottom() ? new Emptiness.ConflictingRules() : null;
         // A position whose ends cross, which is nearer than the general form: it says not only that
         // the rules contradict but where they leave nothing.
@@ -121,8 +121,8 @@ record ConstraintState(NumericDomain<Term> numbers, PredicateFacts facts,
         // the alternatives may fail at different positions — and the particular proof is particular
         // by naming a place. Written without one, the sentence read off it would name whatever place
         // the reader happened to be at, which is the declaration's own value.
-        Set<Term> empty = ordered.holdingNothing();
-        for (Map.Entry<Term, String> each : positions.entrySet()) {
+        Set<FactSubject> empty = ordered.holdingNothing();
+        for (Map.Entry<FactSubject, String> each : positions.entrySet()) {
             if (empty.contains(each.getKey())) {
                 why = Emptiness.preferred(why, new Emptiness.AtAField(each.getValue(),
                         new Emptiness.EmptyOrderedInterval()));
@@ -133,22 +133,22 @@ record ConstraintState(NumericDomain<Term> numbers, PredicateFacts facts,
     }
 
     /** This, with {@code f rel 0} taken as holding. */
-    ConstraintState taking(LinearForm<Term> f, Rel rel, Map<Term, Granularity> kinds) {
+    ConstraintState taking(LinearForm<FactSubject> f, Rel rel, Map<FactSubject, Granularity> kinds) {
         return new ConstraintState(numbers.assume(f, rel, kinds), facts, values, ordered, shown);
     }
 
     /** This, with the predicate {@code key} taken as holding, or as failing. */
-    ConstraintState taking(Term key, boolean positive) {
+    ConstraintState taking(FactSubject key, boolean positive) {
         return new ConstraintState(numbers, facts.assume(key, positive), values, ordered, shown);
     }
 
     /** This, with {@code admitted} taken as holding of the positions it speaks about. */
-    ConstraintState taking(AdmissibleValues<Term> admitted) {
+    ConstraintState taking(AdmissibleValues<FactSubject> admitted) {
         return new ConstraintState(numbers, facts, values.meet(admitted), ordered, shown);
     }
 
     /** This, with {@code bounded} taken as holding of the positions it bounds. */
-    ConstraintState taking(OrderedIntervals<Term> bounded) {
+    ConstraintState taking(OrderedIntervals<FactSubject> bounded) {
         return new ConstraintState(numbers, facts, values, ordered.meet(bounded), shown);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Denotes.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Denotes.java
@@ -19,12 +19,15 @@ sealed interface Denotes {
     record At(Location where) implements Denotes {}
 
     /**
-     * A value named by the expression that computes it. {@code readable} is true where there is
-     * something to say of it however it is reached — a form the numeric domain built, or a rule
-     * about how it was made; false where only a guard naming it makes a clause readable against
-     * it.
+     * A value named by the expression that computes it.
+     *
+     * <p>Whether a clause may be read against it is not held here. It was, as a flag decided when the
+     * binding was entered, and a flag is a second record of something the expression already answers:
+     * {@link Terms#intrinsicallyReadable} asks it of the expression, and what a path has said about
+     * the value is {@link Known}'s. A denotation says what a value <em>is</em>; what can be done with
+     * it is worked out from that and from what is known, and not stored beside it.
      */
-    record Computed(Term term, boolean readable) implements Denotes {}
+    record Computed(Term term) implements Denotes {}
 
     /**
      * A value written out, kept as what was written. There is no guard an author could add about

--- a/souther-compiler/src/main/java/souther/compiler/check/Derivation.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Derivation.java
@@ -5,7 +5,7 @@ import souther.compiler.numeric.NumericDomain.LinearForm;
 /** How a value the affine fragment cannot carry was computed from values it can. */
 sealed interface Derivation {
 
-    record Product(LinearForm<Term> left, LinearForm<Term> right) implements Derivation {}
+    record Product(LinearForm<FactSubject> left, LinearForm<FactSubject> right) implements Derivation {}
 
-    record Quotient(LinearForm<Term> numerator, long divisor) implements Derivation {}
+    record Quotient(LinearForm<FactSubject> numerator, long divisor) implements Derivation {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/DerivedBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DerivedBounds.java
@@ -48,7 +48,7 @@ final class DerivedBounds {
      * a reading that derived three of them answers. So the property has nowhere else to be read,
      * and one that nothing reads stops being true without anything failing.
      */
-    static List<List<Term>> WATCHING;
+    static List<List<FactSubject>> WATCHING;
 
     /**
      * {@code base} with what follows about the arithmetic outside the affine fragment that this
@@ -75,17 +75,17 @@ final class DerivedBounds {
      * graph names it, and never through a relation this domain holds between the two — which is the
      * interval reasoning that tightens under its own answers that this declines to be.
      */
-    static NumericDomain<Term> refine(NumericDomain<Term> base, Terms terms, Set<Term> asked) {
-        Map<Term, Derivation> recipes = terms.derivations();
-        Map<Term, Bounds> derived = new LinkedHashMap<>();
+    static NumericDomain<FactSubject> refine(NumericDomain<FactSubject> base, Terms terms, Set<FactSubject> asked) {
+        Map<FactSubject, Derivation> recipes = terms.derivations();
+        Map<FactSubject, Bounds> derived = new LinkedHashMap<>();
         if (!recipes.isEmpty() && !base.isBottom()) {
-            for (Term atom : roots(recipes, base, asked)) {
+            for (FactSubject atom : roots(recipes, base, asked)) {
                 derive(atom, base, terms, derived, new LinkedHashSet<>());
             }
         }
         watched(derived.keySet());
-        NumericDomain<Term> out = base;
-        for (Map.Entry<Term, Bounds> one : derived.entrySet()) {
+        NumericDomain<FactSubject> out = base;
+        for (Map.Entry<FactSubject, Bounds> one : derived.entrySet()) {
             out = taking(out, one.getKey(), one.getValue(), terms);
         }
         return out;
@@ -94,15 +94,15 @@ final class DerivedBounds {
     /** The atoms this reading is to derive from: the ones it can reach that were recorded as
      * arithmetic. Walked from the reaching side rather than from {@code recipes}, so what it costs
      * is what the question is about and not how much arithmetic the behavior contains. */
-    private static Set<Term> roots(Map<Term, Derivation> recipes, NumericDomain<Term> base,
-                                   Set<Term> asked) {
-        Set<Term> out = new LinkedHashSet<>();
-        for (Term atom : asked) {
+    private static Set<FactSubject> roots(Map<FactSubject, Derivation> recipes, NumericDomain<FactSubject> base,
+                                   Set<FactSubject> asked) {
+        Set<FactSubject> out = new LinkedHashSet<>();
+        for (FactSubject atom : asked) {
             if (recipes.containsKey(atom)) {
                 out.add(atom);
             }
         }
-        for (Term atom : base.atomsSpokenOf()) {
+        for (FactSubject atom : base.atomsSpokenOf()) {
             if (recipes.containsKey(atom)) {
                 out.add(atom);
             }
@@ -113,8 +113,8 @@ final class DerivedBounds {
     /** Records the recipes this reading evaluated, where a test is reading them. Every atom here
      * had its recipe put through {@link Intervals}: {@link #derive} answers a second ask from what
      * it remembered, so an atom is written once however many forms name it. */
-    private static void watched(Set<Term> evaluated) {
-        List<List<Term>> watching = WATCHING;
+    private static void watched(Set<FactSubject> evaluated) {
+        List<List<FactSubject>> watching = WATCHING;
         if (watching != null) {
             watching.add(List.copyOf(evaluated));
         }
@@ -128,8 +128,8 @@ final class DerivedBounds {
      * the recipes make a graph with no way back to where it started; reaching one that is already
      * being answered would mean the naming built an atom out of itself.
      */
-    private static Bounds derive(Term atom, NumericDomain<Term> base, Terms terms,
-                                 Map<Term, Bounds> done, Set<Term> deriving) {
+    private static Bounds derive(FactSubject atom, NumericDomain<FactSubject> base, Terms terms,
+                                 Map<FactSubject, Bounds> done, Set<FactSubject> deriving) {
         Bounds had = done.get(atom);
         if (had != null) {
             return had;
@@ -159,10 +159,10 @@ final class DerivedBounds {
      * atoms this form names are derived, so what is read is the expression's own structure and not
      * everything else the reading has recorded.
      */
-    private static Bounds boundsOf(LinearForm<Term> form, NumericDomain<Term> base, Terms terms,
-                                   Map<Term, Bounds> done, Set<Term> deriving) {
-        NumericDomain<Term> with = base;
-        for (Term atom : form.coefs().keySet()) {
+    private static Bounds boundsOf(LinearForm<FactSubject> form, NumericDomain<FactSubject> base, Terms terms,
+                                   Map<FactSubject, Bounds> done, Set<FactSubject> deriving) {
+        NumericDomain<FactSubject> with = base;
+        for (FactSubject atom : form.coefs().keySet()) {
             if (terms.derivations().containsKey(atom)) {
                 with = taking(with, atom, derive(atom, base, terms, done, deriving), terms);
             }
@@ -173,11 +173,11 @@ final class DerivedBounds {
     /** {@code d} with {@code atom} taken to lie between {@code bounds}. An end the range does not
      * reach is asserted as the strict comparison it is, which is what the domain reads a range's
      * ends as. */
-    private static NumericDomain<Term> taking(NumericDomain<Term> d, Term atom, Bounds bounds,
+    private static NumericDomain<FactSubject> taking(NumericDomain<FactSubject> d, FactSubject atom, Bounds bounds,
                                               Terms terms) {
-        LinearForm<Term> form = LinearForm.atom(atom);
-        Map<Term, Granularity> kinds = terms.kindsOf(form);
-        NumericDomain<Term> out = d;
+        LinearForm<FactSubject> form = LinearForm.atom(atom);
+        Map<FactSubject, Granularity> kinds = terms.kindsOf(form);
+        NumericDomain<FactSubject> out = d;
         if (bounds.min() != null) {
             out = out.assume(form.minus(LinearForm.constant(count(bounds.min()))),
                     bounds.min().inclusive() ? Rel.GE : Rel.GT, kinds);
@@ -211,7 +211,7 @@ final class DerivedBounds {
 
         private static final long serialVersionUID = 1L;
 
-        AnAtomComputedFromItself(Term atom) {
+        AnAtomComputedFromItself(FactSubject atom) {
             super("atom `" + atom.rendered() + "` is computed from itself");
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/EvaluationId.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/EvaluationId.java
@@ -1,0 +1,44 @@
+package souther.compiler.check;
+
+import souther.compiler.diag.SourcePos;
+
+/**
+ * One evaluation the check reads, told apart from every other.
+ *
+ * <p>Equality is identity, and that is the whole of it. Two of these are the same evaluation when
+ * they are the same object, so there is no way to spell one that equals another — which is what a
+ * subject for a value nothing may share has to be. A record over the position would not do it: a
+ * position says where something is written, and the same line evaluated in two places is two values
+ * ({@link Location} states the same rule for bindings, and {@code an offset is not an identity} is
+ * how it was learned).
+ *
+ * <p>Made once per occurrence and handed back, by {@link Terms#evaluationOf}. Constructed rather
+ * than worked out again at each ask: a subject recomputed from what a walk happens to hold is a
+ * subject that moves when the walk does, and a fact filed under the old one is then about nothing.
+ *
+ * <p>The position it carries is for a reader and takes no part in telling two apart.
+ */
+final class EvaluationId {
+
+    private final SourcePos where;
+    private final String what;
+
+    EvaluationId(String what, SourcePos where) {
+        this.what = what;
+        this.where = where;
+    }
+
+    SourcePos where() {
+        return where;
+    }
+
+    String rendered() {
+        return "<" + what + " at "
+                + (where == null ? "?" : where.line() + ":" + where.column()) + ">";
+    }
+
+    @Override
+    public String toString() {
+        return rendered();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/EvaluationId.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/EvaluationId.java
@@ -12,7 +12,7 @@ import souther.compiler.diag.SourcePos;
  * ({@link Location} states the same rule for bindings, and {@code an offset is not an identity} is
  * how it was learned).
  *
- * <p>Made once per occurrence and handed back, by {@link Terms#evaluationOf}. Constructed rather
+ * <p>Made once per occurrence and handed back, by {@link Terms#evaluationIdOf}. Constructed rather
  * than worked out again at each ask: a subject recomputed from what a walk happens to hold is a
  * subject that moves when the walk does, and a fact filed under the old one is then about nothing.
  *

--- a/souther-compiler/src/main/java/souther/compiler/check/FactSubject.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FactSubject.java
@@ -3,88 +3,43 @@ package souther.compiler.check;
 /**
  * What a fact is about: the subject a constraint, a predicate or a clause is read against.
  *
- * <p>Apart from {@link Term}, which is what a value is <em>built like</em>. The two were one, and
- * {@link Term} said so of itself — "the identity two writings of one value share" — which folds two
- * questions into one answer. Whether this check can name a value at all, and whether two writings of
- * it are one value, are separate: a term is equal to its twin structurally, so anything given a term
- * is thereby declared shareable, and a value that is nameable but not shareable had nowhere to be.
- * That is why a call to a {@code behavior} was named by nothing rather than named by itself — the
- * only constructor of a name for a call ({@code Term.Interner#called}) interns on the callee and the
- * arguments, so giving one a name would have claimed that two asks answer alike.
+ * <p>A {@link Term} is how a value is built. This is a term put forward as something facts may be
+ * filed under, and the two are separate types so that the second cannot be reached by accident: a
+ * key built for the symbolic domain to read is not thereby a key the fact set may speak of, and the
+ * places that had quietly used one as the other are the places this boundary is for.
  *
- * <p>So the order is: a value gets a subject because it can be pointed at, and two subjects are one
- * because something makes them one. Sharing is decided where a subject is built ({@link Terms#subjectOf})
- * and nowhere else, so no reader of a fact has a second question to ask about the subject it was
- * handed. A reader that re-decided it would be a reader that can forget to.
+ * <p>Which two values are one is decided in the algebra, not here and not by any reader. A structural
+ * term is equal to its twin, so two writings of a place, or of an operation over places, are one
+ * subject without anything being asked. An evaluation nothing may share is a {@code Term.Shape#EVALUATION}
+ * leaf, equal to itself and to nothing else — and because it is a leaf of the same algebra, what is
+ * built over it composes: {@code length(E)} written twice is one subject, and {@code length(E1)} and
+ * {@code length(E2)} are two.
+ *
+ * <p>That is the separation this type exists for, and it is a rule about constructors rather than a
+ * property of subjects. A pure operation decides its result from the identity of its operands; an
+ * evaluation that reaches outside the language decides nothing and takes a fresh atom. Asking a
+ * subject whether it is shareable would be asking the wrong thing of the wrong half — the question
+ * belongs to whoever built it, and it was answered there.
+ *
+ * <p>Held two ways before this: a subject was a term, whose equality is structural, so anything given
+ * a subject was thereby declared shareable and a value that could be named but not shared had nowhere
+ * to be. That is why a call to a {@code behavior} was named by nothing, and why a construction built
+ * from its answer was neither proved nor refuted nor reported (#819).
  */
-sealed interface FactSubject {
+record FactSubject(Term identity) {
+
+    FactSubject {
+        java.util.Objects.requireNonNull(identity, "a subject is something to point at");
+    }
+
+    /** The subject the value built like {@code identity} is. Null in, null out, so a caller with
+     * nothing to name stays a caller with nothing to name. */
+    static FactSubject of(Term identity) {
+        return identity == null ? null : new FactSubject(identity);
+    }
 
     /** What to call this where a message names it. For a reader, not for equality. */
-    String rendered();
-
-    /**
-     * A value named by the way it is built, and one with every other value built that way.
-     *
-     * <p>This is the shareable case, and it is shareable because {@link Term} is structural: a
-     * location, arithmetic over locations, a call to something referentially transparent. Two
-     * writings of it are one subject without anything being asked, which is what makes a guard on
-     * one a guard on the other.
-     */
-    record OfATerm(Term term) implements FactSubject {
-
-        public OfATerm {
-            java.util.Objects.requireNonNull(term, "a subject is something to point at");
-        }
-
-        @Override
-        public String rendered() {
-            return term.rendered();
-        }
-    }
-
-    /**
-     * One evaluation, and no other — including another evaluation written the same way.
-     *
-     * <p>For a value that can be pointed at but not shared. What an injected behavior answers is
-     * this: {@code external(id)} written twice is two asks of the outside world and so two values,
-     * and a fact taken from one of them is not a fact about the other. Under one subject apiece
-     * there is nothing wrong with saying either.
-     *
-     * <p>Which is why effects do not decide whether a value has a subject. They decide whether two
-     * subjects are one. Reading them as the first is what left a whole class of values with no
-     * subject at all, and a construction built from one of those was never checked and never
-     * reported (#819).
-     */
-    record OfAnEvaluation(EvaluationId where, java.util.List<String> path) implements FactSubject {
-
-        public OfAnEvaluation {
-            java.util.Objects.requireNonNull(where, "an evaluation is somewhere it happened");
-            path = java.util.List.copyOf(path);
-        }
-
-        /**
-         * This, with {@code field} read from it — the same rule {@link Location} carries for a place,
-         * asked of an evaluation instead.
-         *
-         * <p>What an evaluation answers has parts, and a clause is written about the parts: an
-         * {@code ensures} states {@code value.rank}, not {@code value}. Without this the answer could
-         * be pointed at and nothing in it could, which is a subject nothing would ever be about.
-         */
-        OfAnEvaluation then(String field) {
-            java.util.List<String> longer = new java.util.ArrayList<>(path);
-            longer.add(field);
-            return new OfAnEvaluation(where, longer);
-        }
-
-        @Override
-        public String rendered() {
-            return where.rendered() + String.join("", path.stream().map(f -> "." + f).toList());
-        }
-    }
-
-    /** The subject a value built like {@code term} is. Null in, null out, so a caller with nothing
-     * to name stays a caller with nothing to name. */
-    static FactSubject of(Term term) {
-        return term == null ? null : new OfATerm(term);
+    String rendered() {
+        return identity.rendered();
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/FactSubject.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FactSubject.java
@@ -1,0 +1,75 @@
+package souther.compiler.check;
+
+/**
+ * What a fact is about: the subject a constraint, a predicate or a clause is read against.
+ *
+ * <p>Apart from {@link Term}, which is what a value is <em>built like</em>. The two were one, and
+ * {@link Term} said so of itself — "the identity two writings of one value share" — which folds two
+ * questions into one answer. Whether this check can name a value at all, and whether two writings of
+ * it are one value, are separate: a term is equal to its twin structurally, so anything given a term
+ * is thereby declared shareable, and a value that is nameable but not shareable had nowhere to be.
+ * That is why a call to a {@code behavior} was named by nothing rather than named by itself — the
+ * only constructor of a name for a call ({@code Term.Interner#called}) interns on the callee and the
+ * arguments, so giving one a name would have claimed that two asks answer alike.
+ *
+ * <p>So the order is: a value gets a subject because it can be pointed at, and two subjects are one
+ * because something makes them one. Sharing is decided where a subject is built ({@link Terms#subjectOf})
+ * and nowhere else, so no reader of a fact has a second question to ask about the subject it was
+ * handed. A reader that re-decided it would be a reader that can forget to.
+ */
+sealed interface FactSubject {
+
+    /** What to call this where a message names it. For a reader, not for equality. */
+    String rendered();
+
+    /**
+     * A value named by the way it is built, and one with every other value built that way.
+     *
+     * <p>This is the shareable case, and it is shareable because {@link Term} is structural: a
+     * location, arithmetic over locations, a call to something referentially transparent. Two
+     * writings of it are one subject without anything being asked, which is what makes a guard on
+     * one a guard on the other.
+     */
+    record OfATerm(Term term) implements FactSubject {
+
+        public OfATerm {
+            java.util.Objects.requireNonNull(term, "a subject is something to point at");
+        }
+
+        @Override
+        public String rendered() {
+            return term.rendered();
+        }
+    }
+
+    /**
+     * One evaluation, and no other — including another evaluation written the same way.
+     *
+     * <p>For a value that can be pointed at but not shared. What an injected behavior answers is
+     * this: {@code external(id)} written twice is two asks of the outside world and so two values,
+     * and a fact taken from one of them is not a fact about the other. Under one subject apiece
+     * there is nothing wrong with saying either.
+     *
+     * <p>Which is why effects do not decide whether a value has a subject. They decide whether two
+     * subjects are one. Reading them as the first is what left a whole class of values with no
+     * subject at all, and a construction built from one of those was never checked and never
+     * reported (#819).
+     */
+    record OfAnEvaluation(EvaluationId where) implements FactSubject {
+
+        public OfAnEvaluation {
+            java.util.Objects.requireNonNull(where, "an evaluation is somewhere it happened");
+        }
+
+        @Override
+        public String rendered() {
+            return where.rendered();
+        }
+    }
+
+    /** The subject a value built like {@code term} is. Null in, null out, so a caller with nothing
+     * to name stays a caller with nothing to name. */
+    static FactSubject of(Term term) {
+        return term == null ? null : new OfATerm(term);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/FactSubject.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FactSubject.java
@@ -55,15 +55,30 @@ sealed interface FactSubject {
      * subject at all, and a construction built from one of those was never checked and never
      * reported (#819).
      */
-    record OfAnEvaluation(EvaluationId where) implements FactSubject {
+    record OfAnEvaluation(EvaluationId where, java.util.List<String> path) implements FactSubject {
 
         public OfAnEvaluation {
             java.util.Objects.requireNonNull(where, "an evaluation is somewhere it happened");
+            path = java.util.List.copyOf(path);
+        }
+
+        /**
+         * This, with {@code field} read from it — the same rule {@link Location} carries for a place,
+         * asked of an evaluation instead.
+         *
+         * <p>What an evaluation answers has parts, and a clause is written about the parts: an
+         * {@code ensures} states {@code value.rank}, not {@code value}. Without this the answer could
+         * be pointed at and nothing in it could, which is a subject nothing would ever be about.
+         */
+        OfAnEvaluation then(String field) {
+            java.util.List<String> longer = new java.util.ArrayList<>(path);
+            longer.add(field);
+            return new OfAnEvaluation(where, longer);
         }
 
         @Override
         public String rendered() {
-            return where.rendered();
+            return where.rendered() + String.join("", path.stream().map(f -> "." + f).toList());
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -48,7 +48,7 @@ public final class FieldDomains {
     /** No position anywhere, for the reading that reached none. Unmodifiable, as every other part
      * of {@link #NONE} is: a shared constant handing out a map anybody could add to is a value one
      * caller can change under the rest. */
-    private static final SequencedMap<Term, String> NO_POSITIONS =
+    private static final SequencedMap<FactSubject, String> NO_POSITIONS =
             java.util.Collections.unmodifiableSequencedMap(new LinkedHashMap<>());
 
     /**
@@ -90,7 +90,7 @@ public final class FieldDomains {
     private final Set<String> notGathered;
     /** Where each position of this value sits, in the order the value declares them. What a domain
      * holds is what a reading called a position; which place in the value that is, is known here. */
-    private final SequencedMap<Term, String> positions;
+    private final SequencedMap<FactSubject, String> positions;
     /** Everything the clauses were read as, kept whole. Whether any value of this exists is a
      * question about all of it and is asked of it; the numbers are read out of it where a bound is
      * what a caller is after. */
@@ -110,7 +110,7 @@ public final class FieldDomains {
                          List<InvariantChecker.Direct> directs,
                          Map<String, List<TypeSymbol>> narrowers,
                          boolean seeded, Set<String> notGathered,
-                         SequencedMap<Term, String> positions,
+                         SequencedMap<FactSubject, String> positions,
                          ConstraintState constraints, TypeSymbol named,
                          Hir.Data data, Symbols symbols, Map<String, Count> settled,
                          java.util.function.BooleanSupplier reading) {
@@ -231,13 +231,13 @@ public final class FieldDomains {
         Set<String> positions = new LinkedHashSet<>(seeded.keys().keySet());
         positions.addAll(seeded.atoms().keySet());
         positions.forEach(field -> {
-            AdmissibleValues<Term> values = seeded.constraints().values();
+            AdmissibleValues<FactSubject> values = seeded.constraints().values();
             // Both names of the position, since a number has one of each and a clause reaching it
             // is filed under whichever the reading recognised. Both are about the same values, so
             // what holds of it is what both leave.
             ValueSet here = ValueSet.ANY;
             UnreadReason why = null;
-            for (Term name : named(seeded, field)) {
+            for (FactSubject name : named(seeded, field)) {
                 here = here.meet(values.at(name));
                 // The first that stopped it. Two names of one position are two ways the same rules
                 // were filed, so a second reason is another account of a position already known to
@@ -274,7 +274,7 @@ public final class FieldDomains {
         // followed by the atoms, and that is the keys: an atom is named from a body key, so a
         // position with an atom has a key and the second pass adds nothing. A size has no key and
         // is not one of these — it is a number taken of a position rather than a position.
-        SequencedMap<Term, String> placeOf = new LinkedHashMap<>();
+        SequencedMap<FactSubject, String> placeOf = new LinkedHashMap<>();
         positions.forEach(field ->
                 named(seeded, field).forEach(term -> placeOf.putIfAbsent(term, field)));
         return new FieldDomains(Map.copyOf(out), Map.copyOf(holds), Map.copyOf(admitted),
@@ -511,13 +511,13 @@ public final class FieldDomains {
 
     /** Both names the position at {@code path} answers to. A number has one of each and everything
      * else has the second, and a clause is filed under whichever the reading recognised. */
-    private static List<Term> named(InvariantChecker.Seeded seeded, String path) {
-        List<Term> names = new ArrayList<>();
-        Term atom = seeded.atoms().get(path);
+    private static List<FactSubject> named(InvariantChecker.Seeded seeded, String path) {
+        List<FactSubject> names = new ArrayList<>();
+        FactSubject atom = seeded.atoms().get(path);
         if (atom != null) {
             names.add(atom);
         }
-        Term key = seeded.keys().get(path);
+        FactSubject key = seeded.keys().get(path);
         if (key != null) {
             names.add(key);
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1054,15 +1054,20 @@ public final class InvariantChecker {
 
     // --- the walk ------------------------------------------------------------------------------
 
-    private void walk(Core e, Known k, Denotations at, int depth) {
+    private void walk(Core e, Known given, Denotations at, int depth) {
         // Nothing reaches here, so there is nothing here to be about. Asked once, at the one door
         // every reading goes through: a branch, an arm, a departure, an attempt's success and a
         // closure's body are each walked with something further settled, and each of them is a place
         // the conditions can come to contradict. Asked at the reports instead, a reading added to
         // this walk would be one more that has to remember.
-        if (k.reachesNothing()) {
+        if (given.reachesNothing()) {
             return;
         }
+        // What the answers read here guarantee, before anything is judged against them. One door,
+        // because a construction is judged at its own step and the answers it is built from stand
+        // underneath it: taken in at each call's own step instead, the construction would be judged
+        // before the value it was handed said anything.
+        Known k = engine.answering(e, given, at);
         Core.LetIn standing = bindingInValueIn(e);
         if (standing != null) {
             // A call this analysis expanded is a binding holding what it was given, and where that

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -392,8 +392,8 @@ public final class InvariantChecker {
      *                 borrowing that answer would settle each reading's completeness by a fragment
      *                 that is not its own
      */
-    record Seeded(ConstraintState constraints, Map<String, Term> atoms, Map<String, Term> keys,
-                  Map<String, Term> held, Reading reading, boolean everyClauseRead,
+    record Seeded(ConstraintState constraints, Map<String, FactSubject> atoms, Map<String, FactSubject> keys,
+                  Map<String, FactSubject> held, Reading reading, boolean everyClauseRead,
                   Set<String> notGathered) {
 
         public Seeded {
@@ -409,7 +409,7 @@ public final class InvariantChecker {
 
         /** The numbers alone, for the readers that are about intervals. Whether a value exists is
          * asked of {@link #constraints} and is never read off this. */
-        NumericDomain<Term> numbers() {
+        NumericDomain<FactSubject> numbers() {
             return constraints.numbers();
         }
     }
@@ -542,10 +542,10 @@ public final class InvariantChecker {
             gaveUp("seedFields " + named.name(), why);
             return Seeded.nothingRead();
         }
-        Map<String, Term> atoms = new LinkedHashMap<>();
+        Map<String, FactSubject> atoms = new LinkedHashMap<>();
         Map<String, Type> typeAt = new LinkedHashMap<>();
-        Map<String, Term> held = new LinkedHashMap<>();
-        Map<String, Term> keys = new LinkedHashMap<>();
+        Map<String, FactSubject> held = new LinkedHashMap<>();
+        Map<String, FactSubject> keys = new LinkedHashMap<>();
         for (Map.Entry<String, BindingId> field : bindings.entrySet()) {
             Type type = fields.get(field.getKey());
             if (type != null) {
@@ -564,7 +564,7 @@ public final class InvariantChecker {
         // reached this value is the walk's answer and is given to both readings; what each of them
         // makes of a clause is its own, so neither can widen the other's idea of what it was handed.
         List<Core> reaching = written.stream().map(Written::clause).toList();
-        Map<Term, Type> positions = positions(atoms, keys, typeAt);
+        Map<FactSubject, Type> positions = positions(atoms, keys, typeAt);
         // And what the same clauses say about which values each position may hold and where each
         // position stops, off the same list at the same moment. One reading in two languages and
         // not two readings: the connectives belong to the clause, so an alternative nothing can
@@ -574,7 +574,7 @@ public final class InvariantChecker {
                 .taking(stated.values())
                 .taking(stated.ordered());
         for (Map.Entry<String, Count> each : settled.entrySet()) {
-            Term atom = atoms.get(each.getKey());
+            FactSubject atom = atoms.get(each.getKey());
             Type type = typeAt.get(each.getKey());
             if (atom == null || type == null) {
                 continue;
@@ -605,16 +605,16 @@ public final class InvariantChecker {
      * ask for what they left.
      */
     private void name(Core value, String path, Type type, Denotations at, Symbols symbols,
-                      int depth, Map<String, Term> atoms, Map<String, Type> typeAt,
-                      Map<String, Term> held, Map<String, Term> keys) {
-        Term atom = terms.atomOf(value, at);
+                      int depth, Map<String, FactSubject> atoms, Map<String, Type> typeAt,
+                      Map<String, FactSubject> held, Map<String, FactSubject> keys) {
+        FactSubject atom = terms.atomOf(value, at);
         if (atom != null) {
             atoms.put(path, atom);
         }
         // What the position is called, which every position has and only some are numbers. An
         // enumeration is ordered and carries no atom, so a clause bounding one is recognised by this
         // and by nothing above it.
-        Term key = terms.bodyKey(value, at);
+        FactSubject key = FactSubject.of(terms.bodyKey(value, at));
         if (key != null) {
             keys.put(path, key);
         }
@@ -624,7 +624,7 @@ public final class InvariantChecker {
         // And what a rule counting this position spoke about, which is not what the position is. A
         // list is no number and has no atom above; the count of it has one, and a reader asking how
         // much the position holds is asking about that one.
-        Term counted = terms.takenAtomOf(value, type, at);
+        FactSubject counted = terms.takenAtomOf(value, type, at);
         if (counted != null) {
             held.put(path, counted);
         }
@@ -662,15 +662,15 @@ public final class InvariantChecker {
      * both names — a number is called one thing by the interval algebra and another by everything
      * else — both are filed, since a clause reaching it may be recognised by either.
      */
-    private static Map<Term, Type> positions(Map<String, Term> atoms, Map<String, Term> keys,
+    private static Map<FactSubject, Type> positions(Map<String, FactSubject> atoms, Map<String, FactSubject> keys,
                                              Map<String, Type> typeAt) {
-        Map<Term, Type> out = new LinkedHashMap<>();
+        Map<FactSubject, Type> out = new LinkedHashMap<>();
         typeAt.forEach((path, type) -> {
-            Term key = keys.get(path);
+            FactSubject key = keys.get(path);
             if (key != null) {
                 out.put(key, type);
             }
-            Term atom = atoms.get(path);
+            FactSubject atom = atoms.get(path);
             if (atom != null) {
                 out.put(atom, type);
             }
@@ -746,14 +746,14 @@ public final class InvariantChecker {
     record Reading(List<Direct> directs, Map<String, List<TypeSymbol>> narrowers) {}
 
     private Reading directsIn(List<Written> stated, Denotations at,
-                                   Map<String, Term> atoms, Map<String, Term> keys,
-                                   Map<String, Term> held, Map<String, Type> typeAt) {
-        Map<Term, Coordinate> byName = new LinkedHashMap<>();
+                                   Map<String, FactSubject> atoms, Map<String, FactSubject> keys,
+                                   Map<String, FactSubject> held, Map<String, Type> typeAt) {
+        Map<FactSubject, Coordinate> byName = new LinkedHashMap<>();
         keys.forEach((path, key) -> {
             Carrier carrier = Carrier.ofValue(typeAt.get(path), symbols);
             if (carrier != null) {
                 byName.put(key, new Coordinate(path, false, carrier));
-                Term atom = atoms.get(path);
+                FactSubject atom = atoms.get(path);
                 if (atom != null) {
                     byName.put(atom, new Coordinate(path, false, carrier));
                 }
@@ -778,7 +778,7 @@ public final class InvariantChecker {
      * comparisons it had already accounted for.
      */
     private void direct(Core clause, TypeSymbol from, Denotations at,
-                        Map<Term, Coordinate> byName, List<Direct> out,
+                        Map<FactSubject, Coordinate> byName, List<Direct> out,
                         Map<String, List<TypeSymbol>> narrowers) {
         if (!(clause instanceof Core.Binary bin)) {
             return;
@@ -829,9 +829,9 @@ public final class InvariantChecker {
      * moved even where the number came from somewhere further off.
      */
     private void relating(Core clause, TypeSymbol from, Denotations at,
-                          Map<Term, Coordinate> byName,
+                          Map<FactSubject, Coordinate> byName,
                           Map<String, List<TypeSymbol>> narrowers) {
-        Term named = nameOf(clause, at);
+        FactSubject named = nameOf(clause, at);
         Coordinate found = named == null ? null : byName.get(named);
         if (found != null) {
             List<TypeSymbol> had = narrowers.computeIfAbsent(found.path(), _ -> new ArrayList<>());
@@ -853,9 +853,8 @@ public final class InvariantChecker {
      * <p>Then what the position is called, for the positions that are ordered and are not numbers. An
      * enumeration has no atom and a clause can still say where its values stop.
      */
-    private Term nameOf(Core e, Denotations at) {
-        Term atom = terms.atomOf(e, at);
-        return atom != null ? atom : terms.bodyKey(e, at);
+    private FactSubject nameOf(Core e, Denotations at) {
+        return terms.subjectOf(e, at);
     }
 
     /**
@@ -1260,11 +1259,11 @@ public final class InvariantChecker {
     }
 
     /** Which of the values a construction hands over is not one a clause may be read against
-     * ({@link Terms#siteKey}) — by identity, since it is these very values that stand in the clause. */
+     * ({@link Terms#reportableSite}) — by identity, since it is these very values that stand in the clause. */
     private Set<Core> unnamed(Collection<Core> given, Known k, Denotations at) {
         Set<Core> out = Collections.newSetFromMap(new IdentityHashMap<>());
         for (Core value : given) {
-            if (terms.siteKey(value, at, k) == null) {
+            if (terms.reportableSite(value, at, k) == null) {
                 out.add(value);
             }
         }
@@ -1374,11 +1373,11 @@ public final class InvariantChecker {
         if (owed.isEmpty()) {
             return new Judgment(unreadable ? Verdict.UNREPRESENTABLE : Verdict.PROVED, found);
         }
-        NumericDomain<Term> dom = readingOf(k.numbers(), owed);
+        NumericDomain<FactSubject> dom = readingOf(k.numbers(), owed);
         // The same clauses read against the same site, under what would be known here had no
         // condition on the path settled anything. What each clause states of the sizes it names holds
         // either way, so both readings take it.
-        NumericDomain<Term> alone = readingOf(k.unguarded().numbers(), owed);
+        NumericDomain<FactSubject> alone = readingOf(k.unguarded().numbers(), owed);
         // An invariant is the conjunction of its clauses, so every one of them is read before what
         // the invariant came out as is decided. A clause the values alone refute is the whole
         // invariant refuted on the values alone, whatever another clause needed to be refuted —
@@ -1426,12 +1425,12 @@ public final class InvariantChecker {
      * assumed, so it belongs to the reading and not to the value — which is why the construction's
      * two readings are built by two calls rather than sharing one domain.
      */
-    private NumericDomain<Term> readingOf(NumericDomain<Term> base, List<Owing> owed) {
-        NumericDomain<Term> out = base;
+    private NumericDomain<FactSubject> readingOf(NumericDomain<FactSubject> base, List<Owing> owed) {
+        NumericDomain<FactSubject> out = base;
         // What the clauses are decided by, which is one half of what the derivation can reach. The
         // other half is what the domain speaks of, and that is the domain's own to answer — asked
         // after this loop, since assuming a clause's statements is what puts its atoms there.
-        Set<Term> asked = new LinkedHashSet<>();
+        Set<FactSubject> asked = new LinkedHashSet<>();
         for (Owing owing : owed) {
             Predicates.Clause c = owing.owed();
             for (Predicates.Constraint known : c.known()) {
@@ -1451,7 +1450,7 @@ public final class InvariantChecker {
      * two questions were answered against a reading that proves everything, and a check that filed
      * it under either answer would report a clause the value does not fail, or leave one it does.
      */
-    private static ClauseStatus statusOf(Predicates.Clause owed, NumericDomain<Term> dom, Known k,
+    private static ClauseStatus statusOf(Predicates.Clause owed, NumericDomain<FactSubject> dom, Known k,
                                          Clause clause) {
         boolean established = owed.dischargedBy(dom, k.facts());
         boolean refused = owed.refutedBy(dom, k.facts());
@@ -1740,17 +1739,11 @@ public final class InvariantChecker {
         }
     }
 
-    /** What each node a rewrite built stands for, so a construction keeps its identity through one. */
-    private final Map<Core, Core> rebuilt = new IdentityHashMap<>();
-
-    /** The node {@code e} was built from, however many rewrites ago. */
+    /** The node {@code e} was built from, however many rewrites ago. Asked of {@link Terms}, which
+     * is where which-occurrence-is-this is answered: a construction and an evaluation are told apart
+     * by the same rewrites, and two records of that would be two things to keep agreeing. */
     private Core asWritten(Core e) {
-        Core from = e;
-        Core next;
-        while ((next = rebuilt.get(from)) != null) {
-            from = next;
-        }
-        return from;
+        return terms.asWritten(e);
     }
 
     /**
@@ -1972,14 +1965,14 @@ public final class InvariantChecker {
         }
         Core made = Core.mapAll(e, child -> without(child, was, becomes), name -> name);
         if (made != e) {
-            rebuilt.put(made, e);
+            terms.rebuilt(made, e);
             // What an attempt tries to build is rebuilt through the construction slot, which does not
             // come back through here, so its rebuild is recorded here instead. Unrecorded, the two
             // readings key one construction under two occurrences, and the branch that refutes it is
             // said on its own rather than answered by the branch that proves it.
             if (made instanceof Core.IfConstructed x && e instanceof Core.IfConstructed from
                     && x.construct() != from.construct()) {
-                rebuilt.put(x.construct(), from.construct());
+                terms.rebuilt(x.construct(), from.construct());
             }
         }
         return made;

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -614,7 +614,7 @@ public final class InvariantChecker {
         // What the position is called, which every position has and only some are numbers. An
         // enumeration is ordered and carries no atom, so a clause bounding one is recognised by this
         // and by nothing above it.
-        FactSubject key = FactSubject.of(terms.bodyKey(value, at));
+        FactSubject key = terms.subjectOf(value, at);
         if (key != null) {
             keys.put(path, key);
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/Known.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Known.java
@@ -26,22 +26,22 @@ import java.util.Set;
  * it is not claimed either.
  */
 record Known(ConstraintState constraints, List<Quantified> quantified,
-                     Set<Term> spoken, Unguarded unguarded) {
+                     Set<FactSubject> spoken, Unguarded unguarded) {
 
     /** What holds of the values here whatever the path did — what a type guarantees of a value and
      * what a name was given. It carries no quantifiers and no spoken terms: those decide which
      * clauses are read at all, and both readings are asked about the same clauses. */
     record Unguarded(ConstraintState constraints) {
 
-        Unguarded taking(LinearForm<Term> f, Rel rel, Map<Term, Granularity> kinds) {
+        Unguarded taking(LinearForm<FactSubject> f, Rel rel, Map<FactSubject, Granularity> kinds) {
             return new Unguarded(constraints.taking(f, rel, kinds));
         }
 
-        Unguarded taking(Term key, boolean positive) {
+        Unguarded taking(FactSubject key, boolean positive) {
             return new Unguarded(constraints.taking(key, positive));
         }
 
-        NumericDomain<Term> numbers() {
+        NumericDomain<FactSubject> numbers() {
             return constraints.numbers();
         }
 
@@ -54,7 +54,7 @@ record Known(ConstraintState constraints, List<Quantified> quantified,
      * answer — a bound is read off one and off nothing else — and for nothing about the state as a
      * whole. Whether a value exists and whether a path is reached are both
      * {@link ConstraintState#isBottom}, and neither is assembled from this. */
-    NumericDomain<Term> numbers() {
+    NumericDomain<FactSubject> numbers() {
         return constraints.numbers();
     }
 
@@ -90,14 +90,14 @@ record Known(ConstraintState constraints, List<Quantified> quantified,
     }
 
     /** This, with {@code f rel 0} taken as holding as far as {@code held} reaches. */
-    Known taking(LinearForm<Term> f, Rel rel, Held held, Map<Term, Granularity> kinds) {
+    Known taking(LinearForm<FactSubject> f, Rel rel, Held held, Map<FactSubject, Granularity> kinds) {
         return new Known(constraints.taking(f, rel, kinds), quantified, spoken,
                 held == Held.OF_THE_VALUE ? unguarded.taking(f, rel, kinds) : unguarded);
     }
 
     /** This, with the predicate {@code key} taken as holding — or as failing, where {@code positive}
      * is false — as far as {@code held} reaches. */
-    Known taking(Term key, boolean positive, Held held) {
+    Known taking(FactSubject key, boolean positive, Held held) {
         return new Known(constraints.taking(key, positive), quantified, spoken,
                 held == Held.OF_THE_VALUE ? unguarded.taking(key, positive) : unguarded);
     }
@@ -121,17 +121,17 @@ record Known(ConstraintState constraints, List<Quantified> quantified,
      * spoke about is known exactly then, and reading it back out of a domain would mean matching
      * key text, which is how a term that merely reads like another gets mistaken for it.
      */
-    Known speaking(Collection<Term> terms) {
+    Known speaking(Collection<FactSubject> terms) {
         if (terms.isEmpty()) {
             return this;
         }
-        Set<Term> all = new HashSet<>(spoken);
+        Set<FactSubject> all = new HashSet<>(spoken);
         all.addAll(terms);
         return new Known(constraints, quantified, all, unguarded);
     }
 
     /** Whether an assumption on this path named {@code term}. */
-    boolean speaksOf(Term term) {
+    boolean speaksOf(FactSubject term) {
         return spoken.contains(term);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/OccurrenceCounts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OccurrenceCounts.java
@@ -93,7 +93,7 @@ public final class OccurrenceCounts {
         if (seeded == null) {
             return 0;
         }
-        Term counted = seeded.held().get(path);
+        FactSubject counted = seeded.held().get(path);
         return counted == null ? 0
                 : CountDomain.leastFrom(seeded.numbers().boundsOf(counted).min());
     }
@@ -102,11 +102,11 @@ public final class OccurrenceCounts {
         if (seeded == null) {
             return true;
         }
-        Term counted = seeded.held().get(path);
+        FactSubject counted = seeded.held().get(path);
         if (counted == null) {
             return true;   // nothing counts what is there, so no rule here is about how much it holds
         }
-        NumericDomain.LinearForm<Term> from = NumericDomain.LinearForm.atom(counted)
+        NumericDomain.LinearForm<FactSubject> from = NumericDomain.LinearForm.atom(counted)
                 .minus(NumericDomain.LinearForm.constant(BigDecimal.valueOf(count)));
         return !seeded.numbers()
                 .assume(from, against, Map.of(counted, Granularity.DISCRETE))

--- a/souther-compiler/src/main/java/souther/compiler/check/OccurrenceValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OccurrenceValues.java
@@ -70,7 +70,7 @@ public final class OccurrenceValues {
         if (seeded == null) {
             return Cardinality.UNKNOWN;
         }
-        Term atom = seeded.atoms().get(path);
+        FactSubject atom = seeded.atoms().get(path);
         if (atom == null) {
             return Cardinality.UNKNOWN;
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/OrderedReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OrderedReading.java
@@ -49,22 +49,22 @@ import java.util.Map;
  * end, and the values a denial leaves are a set rather than a range. Under a denial the two swap
  * places, which is the same rule read once.
  */
-final class OrderedReading implements ClauseReading<OrderedIntervals<Term>> {
+final class OrderedReading implements ClauseReading<OrderedIntervals<FactSubject>> {
 
     private final Terms terms;
     private final Denotations at;
     /** What each position's values are ordered on, for the positions that are ordered at all. */
-    private final Map<Term, OrderScale> scales;
+    private final Map<FactSubject, OrderScale> scales;
 
-    private OrderedReading(Terms terms, Denotations at, Map<Term, OrderScale> scales) {
+    private OrderedReading(Terms terms, Denotations at, Map<FactSubject, OrderScale> scales) {
         this.terms = terms;
         this.at = at;
         this.scales = scales;
     }
 
     /** The reading of one value's positions, for {@link StatedByClauses} to take the leaves of. */
-    static OrderedReading of(Terms terms, Denotations at, Map<Term, Type> byName, Symbols symbols) {
-        Map<Term, OrderScale> scales = new LinkedHashMap<>();
+    static OrderedReading of(Terms terms, Denotations at, Map<FactSubject, Type> byName, Symbols symbols) {
+        Map<FactSubject, OrderScale> scales = new LinkedHashMap<>();
         byName.forEach((name, type) -> {
             OrderScale scale = OrderScale.ofValue(type, symbols);
             if (scale != null) {
@@ -75,17 +75,17 @@ final class OrderedReading implements ClauseReading<OrderedIntervals<Term>> {
     }
 
     @Override
-    public OrderedIntervals<Term> nothingSaid() {
+    public OrderedIntervals<FactSubject> nothingSaid() {
         return OrderedIntervals.top();
     }
 
     @Override
-    public OrderedIntervals<Term> both(OrderedIntervals<Term> one, OrderedIntervals<Term> other) {
+    public OrderedIntervals<FactSubject> both(OrderedIntervals<FactSubject> one, OrderedIntervals<FactSubject> other) {
         return one.meet(other);
     }
 
     @Override
-    public OrderedIntervals<Term> either(OrderedIntervals<Term> one, OrderedIntervals<Term> other) {
+    public OrderedIntervals<FactSubject> either(OrderedIntervals<FactSubject> one, OrderedIntervals<FactSubject> other) {
         return one.join(other);
     }
 
@@ -98,15 +98,15 @@ final class OrderedReading implements ClauseReading<OrderedIntervals<Term>> {
      * step.
      */
     @Override
-    public OrderedIntervals<Term> leaf(Core e, boolean positive) {
+    public OrderedIntervals<FactSubject> leaf(Core e, boolean positive) {
         return e instanceof Core.Binary bin ? comparison(bin, positive) : OrderedIntervals.top();
     }
 
     /** Where one comparison leaves the position it names, or nothing where it names none. */
-    private OrderedIntervals<Term> comparison(Core.Binary bin, boolean positive) {
+    private OrderedIntervals<FactSubject> comparison(Core.Binary bin, boolean positive) {
         // The position-bearing side read as the left one, as `0 <= value` says what `value >= 0`
         // says.
-        Term position = positionIn(bin.left());
+        FactSubject position = positionIn(bin.left());
         Core bound = bin.right();
         Hir.BinOp op = bin.op();
         if (position == null) {
@@ -152,7 +152,7 @@ final class OrderedReading implements ClauseReading<OrderedIntervals<Term>> {
      * every answer rather than something applied once at the end. A reader adding a second such
      * place has to remember the extent; this one cannot forget it.
      */
-    private static OrderedIntervals<Term> leaves(Term position, OrderScale scale,
+    private static OrderedIntervals<FactSubject> leaves(FactSubject position, OrderScale scale,
                                                  OrderedInterval range) {
         return OrderedIntervals.at(position, scale.extent().meet(range));
     }
@@ -173,11 +173,8 @@ final class OrderedReading implements ClauseReading<OrderedIntervals<Term>> {
     }
 
     /** The position {@code e} is, or null where it is not one this is reading for. */
-    private Term positionIn(Core e) {
-        Term named = terms.atomOf(e, at);
-        if (named == null) {
-            named = terms.bodyKey(e, at);
-        }
+    private FactSubject positionIn(Core e) {
+        FactSubject named = terms.subjectOf(e, at);
         return named != null && scales.containsKey(named) ? named : null;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -354,6 +354,58 @@ final class PathEngine {
     // --- seeding -------------------------------------------------------------------------------
 
     /**
+     * {@code k} with what every answer read here guarantees taken as holding of it: what its type
+     * states of any value of that type, and what its behavior declared of every answer it gives.
+     *
+     * <p>An answer is a value of its type, built through that type's checked constructor — the same
+     * argument {@link #enter} rests on for a parameter, for what a {@code match} arm binds, and for
+     * what a combinator hands its closure. It was not asked of an answer only because an answer had
+     * nothing to be asked about: no subject, so nothing to write the guarantee under. It has one now.
+     *
+     * <p>What makes an answer one of these is not the shape of the node. It is that whoever produced
+     * it had already established what its type states before handing it over — a boundary this check
+     * read on its own, or one another compile read and published. A call to a behavior is that today,
+     * and if another way of invoking one turns out to carry the same guarantee it belongs here too. A
+     * construction written here is not: it is the very thing being judged, and seeding it assumes
+     * what the judgement is about. Written that way first, a construction over a value nothing was
+     * known of came out proved — and came out proved with the clause meant to establish it taken
+     * away, which is the shape of a check that has stopped checking.
+     *
+     * <p>Only what holds of every answer. A rule under a case is about an answer that is that case,
+     * and nothing here has opened one; that rule is taken in where the case is known, which is at the
+     * arm ({@link #enteringArm}). A rule under no case holds of whatever the behavior answered, so
+     * the call is where it is known.
+     *
+     * <p>Sound for a behavior that reaches outside the language, and for the same reason it is sound
+     * for one that does not. Two writings of such a call are two evaluations and so two subjects, but
+     * each invocation answers something its own declaration holds of it. What the effect decides is
+     * whether the two may be identified, not whether either of them was declared about.
+     *
+     * <p>Held of the value and not of the path. What is guaranteed of a value is true wherever that
+     * value is named, and an evaluation is named at one place, so there is no branch on which it is
+     * less true.
+     *
+     * <p>Read over the expression rather than at each call's own step in the walk, because a
+     * construction is judged when the walk reaches it and the answers it is built from stand
+     * underneath it. Not through a block: what a closure's body answers is decided where the closure
+     * is applied, and what a binding inside one holds is not settled from out here.
+     */
+    Known answering(Core e, Known k, Denotations at) {
+        if (e instanceof Core.Block) {
+            return k;
+        }
+        Known out = k;
+        if (e instanceof Core.Call && terms.subjectOf(e, at) instanceof FactSubject.OfAnEvaluation) {
+            out = seedAt(e, out, at, 0);
+            out = assuming(answeredBy(e, at), e, guard -> guard instanceof Guard.Always,
+                    new Entered(out, at)).known();
+        }
+        Known[] threaded = {out};
+        Core.forEachChild(e, child -> threaded[0] = answering(child, threaded[0], at));
+        return threaded[0];
+    }
+
+    /**
      * Seeds a reading with what the type of the value at {@code root} guarantees: a numeric
      * newtype's own invariant on its value, a predicate its invariant states of it, or a product
      * data's invariant over its fields (and one level of fields), each read at that very value.

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -387,22 +387,64 @@ final class PathEngine {
      *
      * <p>Read over the expression rather than at each call's own step in the walk, because a
      * construction is judged when the walk reaches it and the answers it is built from stand
-     * underneath it. Not through a block: what a closure's body answers is decided where the closure
-     * is applied, and what a binding inside one holds is not settled from out here.
+     * underneath it.
+     *
+     * <p>As far as the expression is <em>reached</em>, and no further. Standing in the subtree is not
+     * standing where the walk is: a branch is read under the condition that chose it, and a call in
+     * the arm beside it is one this path never evaluates. Taken in from there, what that call
+     * guarantees is a fact about a value that was never produced — and since a guarantee constrains
+     * the arguments it relates the answer to, it lands on the very values the condition is about. One
+     * arm's answer then contradicts the other arm's condition, the reading comes out reaching
+     * nothing, and the arm is walked no further: its constructions are not judged and nothing is
+     * said. So this stops where the walk branches, and each branch's own reading seeds what stands in
+     * it. Blocks stop it too — what a closure's body answers is decided where the closure is applied,
+     * and what a binding inside one holds is not settled from out here.
      */
     Known answering(Core e, Known k, Denotations at) {
         if (e instanceof Core.Block) {
             return k;
         }
         Known out = k;
-        if (e instanceof Core.Call && terms.subjectOf(e, at) instanceof FactSubject.OfAnEvaluation) {
+        if (isACheckedProducer(e)) {
             out = seedAt(e, out, at, 0);
-            out = assuming(answeredBy(e, at), e, guard -> guard instanceof Guard.Always,
-                    new Entered(out, at)).known();
         }
-        Known[] threaded = {out};
-        Core.forEachChild(e, child -> threaded[0] = answering(child, threaded[0], at));
-        return threaded[0];
+        out = assuming(answeredBy(e, at), e, guard -> guard instanceof Guard.Always,
+                new Entered(out, at)).known();
+        // Only what is evaluated by reaching here. What each branch holds is that branch's to read.
+        return switch (e) {
+            case Core.If x -> answering(x.cond(), out, at);
+            case Core.Match x -> answering(x.scrutinee(), out, at);
+            case Core.IfConstructed x -> answering(x.construct(), out, at);
+            // A binding's body is read once the binding is entered, and not from out here: what its
+            // initializer denotes is not settled until `bindLet` has run, so an answer read through a
+            // name from here would be given a subject the name does not have yet.
+            case Core.LetIn x -> answering(x.value(), out, at);
+            default -> {
+                Known[] threaded = {out};
+                Core.forEachChild(e, child -> threaded[0] = answering(child, threaded[0], at));
+                yield threaded[0];
+            }
+        };
+    }
+
+    /**
+     * Whether reaching {@code e} means reaching a value whose type's invariant something already
+     * established.
+     *
+     * <p>Asked of what produced the value, and of nothing else. Not of the subject it was given: what
+     * kind of subject a value has says whether two writings of it may be identified, which is a
+     * different question with a different answer, and reading one as the other would take the
+     * guarantee away from any answer that turned out to be shareable. Not of whether a contract was
+     * declared either — that is what an {@code ensures} is, and a behavior with none still answers a
+     * value of its type.
+     *
+     * <p>A call to a behavior is one: its implementation is a body this check read, or one another
+     * compile read and published, and either way the construction was checked there. A construction
+     * written here is not — it is the very thing being judged.
+     */
+    private boolean isACheckedProducer(Core e) {
+        return e instanceof Core.Call call && call.fn() instanceof Core.Reached reached
+                && reached.denotes() instanceof ValueName.Behavior;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -159,7 +159,7 @@ final class PathEngine {
         if (at.valueOf(li.binder().id()) == li.value()) {
             return new Entered(k, at);
         }
-        Denotes what = terms.denotationOf(li.value(), at, k);
+        Denotes what = terms.denotationOf(li.value(), at);
         return new Entered(k, at.binding(li.binder().id(), li.value(), what));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
@@ -409,9 +409,14 @@ public final class PathReachability {
      * read to no effect is the ordinary state of a branch nobody built a value for, and no widening
      * touches it. Told apart by asking the reading, not by comparing the state it answered with to
      * the state it was given — that comparison says whether anything changed, which is neither.
+     *
+     * <p>The shape and not what was taken in. Since every value has an identity, a condition this
+     * could not read still narrows the state through the subject it names — so "something was taken
+     * in" stopped telling the two apart, and what an author is owed here is whether the reading
+     * reached what the condition says.
      */
     private static WhyUnsettled whyNot(Predicates.Assumed taken, Core cond) {
-        return taken.read() ? WhyUnsettled.noWitness()
+        return taken.shapeRead() ? WhyUnsettled.noWitness()
                 : WhyUnsettled.aConditionWasNotRead(cond.pos());
     }
 
@@ -419,13 +424,18 @@ public final class PathReachability {
      * The conditions on the way here, with this one — where it was taken in at all.
      *
      * <p>The only way one of these is made, so that a proof cannot name a condition the domains
-     * never read. A condition of a shape no rule here reads narrowed nothing: what came out is what
-     * went in, and listing it among the reasons would say a line was holding when nothing here
-     * could tell whether it was.
+     * never took in. A condition nothing was taken from narrowed nothing: what came out is what went
+     * in, and listing it among the reasons would say a line was holding when nothing here could tell
+     * whether it was.
+     *
+     * <p>What was taken in, and not what was read. A condition whose shape ran out still narrows the
+     * state through the subject it names, and it may be the whole of why nothing stands here — left
+     * out, this proof would name the conditions that <em>were</em> read and say they cannot all hold
+     * when they plainly can, which is a claim about the model made out of a limit of this compiler.
      */
     private static List<PathDecision> with(List<PathDecision> decided, Predicates.Assumed taken,
                                            SourcePos at, boolean held) {
-        if (!taken.read()) {
+        if (!taken.taken()) {
             return decided;
         }
         List<PathDecision> out = new ArrayList<>(decided);

--- a/souther-compiler/src/main/java/souther/compiler/check/PredicateFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PredicateFacts.java
@@ -20,10 +20,10 @@ final class PredicateFacts {
     private static final PredicateFacts BOTTOM = new PredicateFacts(true, Set.of(), Set.of());
 
     private final boolean bottom;    // contradictory guards — this path is not taken
-    private final Set<Term> holds;
-    private final Set<Term> fails;
+    private final Set<FactSubject> holds;
+    private final Set<FactSubject> fails;
 
-    private PredicateFacts(boolean bottom, Set<Term> holds, Set<Term> fails) {
+    private PredicateFacts(boolean bottom, Set<FactSubject> holds, Set<FactSubject> fails) {
         this.bottom = bottom;
         this.holds = holds;
         this.fails = fails;
@@ -47,14 +47,14 @@ final class PredicateFacts {
     }
 
     /** The facts with {@code key} settled. Settling it both ways makes the path infeasible. */
-    PredicateFacts assume(Term key, boolean positive) {
+    PredicateFacts assume(FactSubject key, boolean positive) {
         if (bottom) {
             return this;
         }
         if ((positive ? fails : holds).contains(key)) {
             return BOTTOM;
         }
-        Set<Term> next = new HashSet<>(positive ? holds : fails);
+        Set<FactSubject> next = new HashSet<>(positive ? holds : fails);
         next.add(key);
         return positive
                 ? new PredicateFacts(false, Set.copyOf(next), fails)
@@ -62,12 +62,12 @@ final class PredicateFacts {
     }
 
     /** Whether the guards prove {@code key} (or its negation, when {@code positive} is false). */
-    boolean entails(Term key, boolean positive) {
+    boolean entails(FactSubject key, boolean positive) {
         return bottom || (positive ? holds : fails).contains(key);
     }
 
     /** Whether the guards prove the opposite of what {@code positive} asks of {@code key}. */
-    boolean refutes(Term key, boolean positive) {
+    boolean refutes(FactSubject key, boolean positive) {
         return !bottom && (positive ? fails : holds).contains(key);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -547,16 +547,23 @@ final class Predicates {
      *
      * @param read whether any of these domains took the condition in
      */
-    record Assumed(Known known, boolean read) {
+    record Assumed(Known known, boolean taken, boolean shapeRead) {
 
-        Assumed alsoRead(boolean more) {
-            return more && !read ? new Assumed(known, true) : this;
+        Assumed alsoRead(boolean moreTaken, boolean moreShape) {
+            return moreTaken && !taken || moreShape && !shapeRead
+                    ? new Assumed(known, taken || moreTaken, shapeRead || moreShape) : this;
         }
     }
 
     Assumed assumeCond(Core rawCond, Known k, Denotations at, boolean positive) {
         Core cond = asSizeComparison(rawCond);
-        boolean read = false;
+        // Two answers, and they were one until a condition could name something without this having
+        // read what it says. What was taken in is what a proof about this path may rest on; what was
+        // read is what an unsettled arm may be explained by. A condition whose shape ran out still
+        // narrows the state through the subject it names, and a proof that left it out would name a
+        // set of conditions that can all hold and say they cannot.
+        boolean taken = false;
+        boolean shapeRead = false;
         Core ordered = asOrderComparison(cond, at);
         if (ordered != cond) {
             // Both hold of the same values: the order the call decides, and the bound on the sign
@@ -564,7 +571,8 @@ final class Predicates {
             // read, so a guard states each of them rather than choosing here.
             Assumed first = assumeCond(ordered, k, at, positive);
             k = first.known();
-            read = first.read();
+            taken = first.taken();
+            shapeRead = first.shapeRead();
         }
         // `&&` asserted true gives both sides; `||` asserted false gives both sides negated.
         if (cond instanceof Core.Binary b
@@ -574,11 +582,11 @@ final class Predicates {
             // is not one nothing was read of, and calling it that would name this compiler's limit
             // where the limit was reached on one operand only.
             return assumeCond(b.right(), left.known(), at, positive)
-                    .alsoRead(left.read() || read);
+                    .alsoRead(left.taken() || taken, left.shapeRead() || shapeRead);
         }
         Core under = negated(cond);
         if (under != null) {
-            return assumeCond(under, k, at, !positive).alsoRead(read);
+            return assumeCond(under, k, at, !positive).alsoRead(taken, shapeRead);
         }
         Known out = k;
         // What holds of the sizes the condition names, and of what the operations in it answer,
@@ -599,9 +607,10 @@ final class Predicates {
         // which is handed the same facts, would not.
         if (noCaseSatisfies(cond, out, at, positive)) {
             // Read, and read to the end: what it comes to is that nothing enters here.
-            return new Assumed(out.reachingNothing(), true);
+            return new Assumed(out.reachingNothing(), true, true);
         }
-        read |= !known.isEmpty();
+        taken |= !known.isEmpty();
+        shapeRead |= !known.isEmpty();
         if (cond instanceof Core.Binary b) {
             Rel rel = relOf(b.op());
             Rel eff = rel == null ? null : positive ? rel : negateRel(rel);
@@ -610,7 +619,8 @@ final class Predicates {
             if (la != null && ra != null) {
                 LinearForm compared = la.minus(ra);
                 out = out.taking(compared, eff, Known.Held.ON_THE_PATH, terms.kindsOf(compared));
-                read |= readsItsShape(b.left(), at) && readsItsShape(b.right(), at);
+                taken = true;
+                shapeRead |= readsItsShape(b.left(), at) && readsItsShape(b.right(), at);
             }
             // What the comparison named, recorded as spoken about: a construction from one of these
             // is one the author has said something about, whichever route ends up carrying it.
@@ -621,14 +631,15 @@ final class Predicates {
         List<Quantified> quantified = new ArrayList<>();
         quantifiedBy(cond, at, positive, quantified);
         out = out.and(quantified);
-        read |= !quantified.isEmpty();
+        taken |= !quantified.isEmpty();
+        shapeRead |= !quantified.isEmpty();
         // Both routes, always: which one carries a clause is decided where the clause is read, and a
         // guard does not know which that will be.
         Polar polar = polar(cond, positive);
         FactSubject key = terms.subjectOf(polar.expr(), at);
-        return key == null ? new Assumed(out, read)
-                : new Assumed(out.taking(key, polar.positive(), Known.Held.ON_THE_PATH),
-                        read || readsItsShape(polar.expr(), at));
+        return key == null ? new Assumed(out, taken, shapeRead)
+                : new Assumed(out.taking(key, polar.positive(), Known.Held.ON_THE_PATH), true,
+                        shapeRead || readsItsShape(polar.expr(), at));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -382,14 +382,40 @@ final class Predicates {
      * elsewhere, and that check names the clause that failed rather than only saying one did, so it
      * is left to say it. */
     Owed obligations(Core inv, Known k, Denotations at, boolean decidesFalse) {
-        return obligations(inv, k, at, Set.of(), true, decidesFalse);
+        return obligations(inv, k, at, Set.of(), true, decidesFalse, Read.AN_ASSUMPTION);
+    }
+
+    /**
+     * Whether a clause is being read as something that makes knowledge or as something that spends
+     * it. Not a direction of travel: the two read one expression through one reader, which is what
+     * keeps them from drifting, and this is the single thing they cannot share.
+     *
+     * <p>An assumption produces. A guard holds because the branch was taken, an {@code ensures}
+     * holds because the callee established it, and an invariant holds because the value was built
+     * through a checked constructor — none of them needs anything to have been said about the value
+     * beforehand, and each is how something first comes to be said about it.
+     *
+     * <p>An obligation spends. It asks the author to account for a value, and asking that about a
+     * value nothing has ever said anything of is asking for something no guard they could write
+     * would settle; the run-time check stands for such a clause instead.
+     *
+     * <p>Requiring an assumption to spend what it produces is the circle it looks like: to be spoken
+     * of, a value would have to already be spoken of. It is not a theoretical worry — written that
+     * way, a declaration that refutes a construction stopped refusing it, because the declaration was
+     * turned away for want of the knowledge it was carrying.
+     */
+    enum Read {
+        /** Knowledge being made: a guard, an invariant, a declared guarantee. */
+        AN_ASSUMPTION,
+        /** Knowledge being spent: a clause this construction has to account for. */
+        AN_OBLIGATION
     }
 
     /** The same, where {@code unnamed} holds the values the site hands over that no clause may be
      * read against. */
     Owed obligations(Core inv, Known k, Denotations at, Set<Core> unnamed,
                      boolean decidesFalse) {
-        return obligations(inv, k, at, unnamed, true, decidesFalse);
+        return obligations(inv, k, at, unnamed, true, decidesFalse, Read.AN_OBLIGATION);
     }
 
     /**
@@ -400,29 +426,29 @@ final class Predicates {
      * taken. Reading a predicate never takes a reading away.
      */
     private Owed obligations(Core rawInv, Known k, Denotations at, Set<Core> unnamed,
-                             boolean positive, boolean decidesFalse) {
+                             boolean positive, boolean decidesFalse, Read way) {
         Core sized = asSizeComparison(rawInv);
         Core ordered = asOrderComparison(sized, at);
-        Owed read = read(ordered, k, at, unnamed, positive, decidesFalse);
+        Owed read = read(ordered, k, at, unnamed, positive, decidesFalse, way);
         return ordered != sized && read.unreadable()
-                ? read(sized, k, at, unnamed, positive, decidesFalse) : read;
+                ? read(sized, k, at, unnamed, positive, decidesFalse, way) : read;
     }
 
     /** What {@code inv} owes, read as it stands. Its parts are read through {@link #obligations},
      * which is where each of them is taken as the comparison it states. */
     private Owed read(Core inv, Known k, Denotations at, Set<Core> unnamed,
-                      boolean positive, boolean decidesFalse) {
+                      boolean positive, boolean decidesFalse, Read way) {
         if (inv instanceof Core.Binary b && b.op() == Hir.BinOp.AND && positive) {
             // Each conjunct on its own: an invariant is a set of things that hold, and one the check
             // cannot read leaves its own run-time check standing without costing the others theirs.
             // That it stands is carried rather than dropped — the other conjunct being discharged is
             // not the invariant proven.
-            return obligations(b.left(), k, at, unnamed, true, decidesFalse)
-                    .and(obligations(b.right(), k, at, unnamed, true, decidesFalse));
+            return obligations(b.left(), k, at, unnamed, true, decidesFalse, way)
+                    .and(obligations(b.right(), k, at, unnamed, true, decidesFalse, way));
         }
         Core under = negated(inv);
         if (under != null) {
-            return obligations(under, k, at, unnamed, !positive, decidesFalse);
+            return obligations(under, k, at, unnamed, !positive, decidesFalse, way);
         }
         Boolean folded = decidedAt(inv);
         if (folded != null) {
@@ -443,8 +469,13 @@ final class Predicates {
             Rel eff = positive ? relOf(b.op()) : negateRel(relOf(b.op()));
             LinearForm<FactSubject> la = eff == null ? null : terms.affineOf(b.left(), at);
             LinearForm<FactSubject> ra = eff == null ? null : terms.affineOf(b.right(), at);
-            if (la != null && ra != null) {
-                numeric = new Constraint(la.minus(ra), eff);
+            // Asked of the relation, not of its two sides. An atom on both sides cancels, and one
+            // that is not in the relation is not something the relation depends on — turning a clause
+            // away for a value it does not actually rest on would report nothing about a value the
+            // author was never asked about.
+            LinearForm<FactSubject> between = la == null || ra == null ? null : la.minus(ra);
+            if (between != null && canBeDischargedFrom(between, k, way)) {
+                numeric = new Constraint(between, eff);
                 // The same clause read as the cases of whatever chooses inside it. Both readings are
                 // kept: a guard may name the call itself, which the clause as it stands is what
                 // settles, and reading it case by case never takes that away.
@@ -466,6 +497,28 @@ final class Predicates {
         sizeFacts(inv, at, known);
         resultFacts(inv, at, known);
         return Owed.of(new Clause(numeric, fact, known, piecewise));
+    }
+
+    /**
+     * Whether there is anything for a clause written over {@code form} to be discharged from.
+     *
+     * <p>The same question {@link Terms#reportableSite} asks of a value, asked here of the atoms a
+     * clause is written over — and it has to be asked here as well, because a clause reaches atoms
+     * the site's own value never mentions. An atom is either one the check writes about of its own
+     * accord, which is what a place is, or one something on this path has spoken of. There is no
+     * third kind, and for an atom the first reduces to a single test: only an atom standing on one
+     * evaluation is outside what the seeding writes about.
+     *
+     * <p>Asked at all only because identity closed. A form being built used to be evidence that
+     * something was known, because a value nothing could be said of could not be composed into a form
+     * either; now every value has an identity and arithmetic composes over any of them, so the
+     * coincidence is gone and the rule it stood for has to be stated. Left unstated, a clause over a
+     * value nothing has ever mentioned would be owed here, and owing it would mean reporting a
+     * construction no guard an author could write would ever settle.
+     */
+    private static boolean canBeDischargedFrom(LinearForm<FactSubject> form, Known k, Read way) {
+        return way == Read.AN_ASSUMPTION || form.coefs().keySet().stream()
+                .allMatch(atom -> !atom.identity().standsOnAnEvaluation() || k.speaksOf(atom));
     }
 
     /** Whether {@code inv} is decided outright: the clause, with the construction's own values
@@ -636,10 +689,6 @@ final class Predicates {
     }
 
 
-    /** {@code k} with everything {@code owed} states taken as holding, as far as {@code held}
-     * reaches. What a clause owes at a construction is what it guarantees where it is already
-     * established, so the two read the same clauses through the same rule and differ only in
-     * direction. */
     /** Every subject the clauses in {@code owed} say something about. */
     private static Set<FactSubject> subjectsIn(Owed owed) {
         Set<FactSubject> named = new LinkedHashSet<>();
@@ -657,6 +706,10 @@ final class Predicates {
         return named;
     }
 
+    /** {@code k} with everything {@code owed} states taken as holding, as far as {@code held}
+     * reaches. What a clause owes at a construction is what it guarantees where it is already
+     * established, so the two read the same clauses through the same rule and differ only in
+     * direction. */
     Known assume(Owed owed, Known k, Known.Held held) {
         Known out = k;
         // Every subject this takes something in about is one something has been said about. Recorded

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -57,7 +57,7 @@ final class Predicates {
         Set<Shape> crossed = EnumSet.noneOf(Shape.class);
         Core source = container;
         while (true) {
-            Term key = terms.bodyKey(source, at);
+            FactSubject key = FactSubject.of(terms.bodyKey(source, at));
             if (key != null) {
                 for (Quantified q : k.quantified()) {
                     if (key.equals(q.container()) && q.through().containsAll(crossed)) {
@@ -122,7 +122,7 @@ final class Predicates {
         // The container is the carrying rule's, which is the one argument this predicate is about.
         // What the operation hands its closure answers the same question about the same argument, and
         // is asked here only for the closure.
-        Term container = terms.bodyKey(carried.container(), at);
+        FactSubject container = FactSubject.of(terms.bodyKey(carried.container(), at));
         if (container == null) {
             return;
         }
@@ -139,10 +139,10 @@ final class Predicates {
         return found[0];
     }
 
-    record Constraint(LinearForm<Term> form, Rel rel) {
+    record Constraint(LinearForm<FactSubject> form, Rel rel) {
 
         /** The atoms this relation is written over. */
-        Set<Term> atoms() {
+        Set<FactSubject> atoms() {
             return form.coefs().keySet();
         }
     }
@@ -154,10 +154,10 @@ final class Predicates {
      * about a list built from it. {@code positive} is false for a clause written under a negation,
      * and such a clause carries nowhere, since the implication runs the other way.
      */
-    record Fact(List<Term> keys, boolean positive) {
+    record Fact(List<FactSubject> keys, boolean positive) {
 
         boolean entailedBy(PredicateFacts facts) {
-            for (Term key : keys) {
+            for (FactSubject key : keys) {
                 if (facts.entails(key, positive)) {
                     return true;
                 }
@@ -177,7 +177,7 @@ final class Predicates {
      * @param kinds how the values of every atom either of them names are spaced, so that a case can
      *              be taken into a domain without asking anything further of the caller
      */
-    record Case(Constraint numeric, List<Constraint> given, Map<Term, Granularity> kinds) {
+    record Case(Constraint numeric, List<Constraint> given, Map<FactSubject, Granularity> kinds) {
 
         /**
          * Every atom this case is decided by.
@@ -189,13 +189,13 @@ final class Predicates {
          * a condition names and never answers is an atom of this case all the same, and today no
          * operation in the table has such an argument.
          */
-        Set<Term> atomsItIsDecidedBy() {
+        Set<FactSubject> atomsItIsDecidedBy() {
             return kinds.keySet();
         }
 
         /** {@code d} with this case's conditions on the arguments taken as holding. */
-        private NumericDomain<Term> in(NumericDomain<Term> d) {
-            NumericDomain<Term> out = d;
+        private NumericDomain<FactSubject> in(NumericDomain<FactSubject> d) {
+            NumericDomain<FactSubject> out = d;
             for (Constraint one : given) {
                 out = out.assume(one.form(), one.rel(), kinds);
             }
@@ -233,18 +233,18 @@ final class Predicates {
         /** Every atom any case of this is decided by. A case that is never reached is one the
          * conditions rule out, and which those are is what the domain answers — so every case is
          * counted here, including the ones a reading will drop. */
-        Set<Term> atomsItIsDecidedBy() {
-            Set<Term> out = new LinkedHashSet<>();
+        Set<FactSubject> atomsItIsDecidedBy() {
+            Set<FactSubject> out = new LinkedHashSet<>();
             for (Case one : cases) {
                 out.addAll(one.atomsItIsDecidedBy());
             }
             return out;
         }
 
-        boolean entailedBy(NumericDomain<Term> d) {
+        boolean entailedBy(NumericDomain<FactSubject> d) {
             boolean reached = false;
             for (Case one : cases) {
-                NumericDomain<Term> here = one.in(d);
+                NumericDomain<FactSubject> here = one.in(d);
                 if (here.isBottom()) {
                     continue;
                 }
@@ -256,10 +256,10 @@ final class Predicates {
             return reached;
         }
 
-        boolean refutedBy(NumericDomain<Term> d) {
+        boolean refutedBy(NumericDomain<FactSubject> d) {
             boolean reached = false;
             for (Case one : cases) {
-                NumericDomain<Term> here = one.in(d);
+                NumericDomain<FactSubject> here = one.in(d);
                 if (here.isBottom()) {
                     continue;
                 }
@@ -303,8 +303,8 @@ final class Predicates {
          * about the caller, and answering by what some caller does is how the answer comes to be
          * wrong for the next one.
          */
-        Set<Term> atomsItIsDecidedBy() {
-            Set<Term> out = new LinkedHashSet<>();
+        Set<FactSubject> atomsItIsDecidedBy() {
+            Set<FactSubject> out = new LinkedHashSet<>();
             if (numeric != null) {
                 out.addAll(numeric.atoms());
             }
@@ -317,13 +317,13 @@ final class Predicates {
             return out;
         }
 
-        boolean dischargedBy(NumericDomain<Term> d, PredicateFacts facts) {
+        boolean dischargedBy(NumericDomain<FactSubject> d, PredicateFacts facts) {
             return numeric != null && d.entails(numeric.form(), numeric.rel())
                     || fact != null && fact.entailedBy(facts)
                     || piecewise != null && !decidedAsWritten(d, facts) && piecewise.entailedBy(d);
         }
 
-        boolean refutedBy(NumericDomain<Term> d, PredicateFacts facts) {
+        boolean refutedBy(NumericDomain<FactSubject> d, PredicateFacts facts) {
             return numeric != null && d.refutes(numeric.form(), numeric.rel())
                     || fact != null && fact.refutedBy(facts)
                     || piecewise != null && !decidedAsWritten(d, facts) && piecewise.refutedBy(d);
@@ -340,7 +340,7 @@ final class Predicates {
          * contradicting itself rather than an answer. What the cases are for is a clause the reading
          * that takes the call as an unknown cannot settle, and that is untouched.
          */
-        private boolean decidedAsWritten(NumericDomain<Term> d, PredicateFacts facts) {
+        private boolean decidedAsWritten(NumericDomain<FactSubject> d, PredicateFacts facts) {
             return numeric != null
                     && (d.entails(numeric.form(), numeric.rel())
                             || d.refutes(numeric.form(), numeric.rel()))
@@ -441,8 +441,8 @@ final class Predicates {
         Piecewise piecewise = null;
         if (inv instanceof Core.Binary b && relOf(b.op()) != null) {
             Rel eff = positive ? relOf(b.op()) : negateRel(relOf(b.op()));
-            LinearForm<Term> la = eff == null ? null : terms.affineOf(b.left(), at);
-            LinearForm<Term> ra = eff == null ? null : terms.affineOf(b.right(), at);
+            LinearForm<FactSubject> la = eff == null ? null : terms.affineOf(b.left(), at);
+            LinearForm<FactSubject> ra = eff == null ? null : terms.affineOf(b.right(), at);
             if (la != null && ra != null) {
                 numeric = new Constraint(la.minus(ra), eff);
                 // The same clause read as the cases of whatever chooses inside it. Both readings are
@@ -455,7 +455,7 @@ final class Predicates {
         // A predicate over a value no guard could be written about is not a predicate a guard will
         // settle, so it is not owed as one — where the domain can say something of that value it has
         // already said it above, and where it cannot the run-time check stands for the clause.
-        List<Term> keys = !unnamed.isEmpty() && names(polar.expr(), unnamed)
+        List<FactSubject> keys = !unnamed.isEmpty() && names(polar.expr(), unnamed)
                 ? List.of() : factKeys(polar.expr(), at);
         boolean stated = polar.positive();
         Fact fact = keys.isEmpty() ? null : new Fact(stated ? keys : firstOnly(keys), stated);
@@ -476,7 +476,7 @@ final class Predicates {
         return folded instanceof Boolean b ? b : null;
     }
 
-    static List<Term> firstOnly(List<Term> keys) {
+    static List<FactSubject> firstOnly(List<FactSubject> keys) {
         return keys.isEmpty() ? keys : List.of(keys.get(0));
     }
 
@@ -552,8 +552,8 @@ final class Predicates {
         if (cond instanceof Core.Binary b) {
             Rel rel = relOf(b.op());
             Rel eff = rel == null ? null : positive ? rel : negateRel(rel);
-            LinearForm<Term> la = eff == null ? null : terms.affineOf(b.left(), at);
-            LinearForm<Term> ra = eff == null ? null : terms.affineOf(b.right(), at);
+            LinearForm<FactSubject> la = eff == null ? null : terms.affineOf(b.left(), at);
+            LinearForm<FactSubject> ra = eff == null ? null : terms.affineOf(b.right(), at);
             if (la != null && ra != null) {
                 LinearForm compared = la.minus(ra);
                 out = out.taking(compared, eff, Known.Held.ON_THE_PATH, terms.kindsOf(compared));
@@ -561,7 +561,7 @@ final class Predicates {
             }
             // What the comparison named, recorded as spoken about: a construction from one of these
             // is one the author has said something about, whichever route ends up carrying it.
-            Set<Term> named = new HashSet<>(spokenOf(b.left(), at, la));
+            Set<FactSubject> named = new HashSet<>(spokenOf(b.left(), at, la));
             named.addAll(spokenOf(b.right(), at, ra));
             out = out.speaking(named);
         }
@@ -572,16 +572,16 @@ final class Predicates {
         // Both routes, always: which one carries a clause is decided where the clause is read, and a
         // guard does not know which that will be.
         Polar polar = polar(cond, positive);
-        Term key = terms.bodyKey(polar.expr(), at);
+        FactSubject key = FactSubject.of(terms.bodyKey(polar.expr(), at));
         return key == null ? new Assumed(out, read)
                 : new Assumed(out.taking(key, polar.positive(), Known.Held.ON_THE_PATH), true);
     }
 
     /** The terms one side of a compared pair names: the expression itself, and each atom of the form it
      * reduced to — {@code leftover + 1} says something about {@code leftover}. */
-    Collection<Term> spokenOf(Core side, Denotations at, LinearForm<Term> form) {
-        Set<Term> named = new HashSet<>(form == null ? Set.of() : form.coefs().keySet());
-        Term written = terms.bodyKey(side, at);
+    Collection<FactSubject> spokenOf(Core side, Denotations at, LinearForm<FactSubject> form) {
+        Set<FactSubject> named = new HashSet<>(form == null ? Set.of() : form.coefs().keySet());
+        FactSubject written = FactSubject.of(terms.bodyKey(side, at));
         if (written != null) {
             named.add(written);
         }
@@ -681,7 +681,7 @@ final class Predicates {
         }
         Core container = DischargeRules.sizeArgOf(call);
         if (container != null) {
-            Term atom = terms.sizeAtomOf(call, arg -> terms.bodyKey(arg, at));
+            FactSubject atom = terms.sizeAtomOf(call, arg -> terms.bodyKey(arg, at));
             if (atom != null) {
                 out.add(new Constraint(LinearForm.atom(atom), Rel.GE));   // a size is never negative
                 bounds(call.operation(), DischargeRules.sizeSource(container), at, out);
@@ -713,11 +713,11 @@ final class Predicates {
             Core.forEachChild(e, child -> resultFacts(child, at, out));
             return;
         }
-        Term result = terms.atomOf(call, at);
+        FactSubject result = terms.atomOf(call, at);
         if (result != null) {
             for (DischargeRules.ResultBound bound
                     : DischargeRules.boundsOn(call, arg -> constantOf(arg, at))) {
-                LinearForm<Term> against = bound.against() == null
+                LinearForm<FactSubject> against = bound.against() == null
                         ? LinearForm.constant(bound.offset())
                         : addTo(terms.affineOf(bound.against().of(call), at), bound.offset());
                 if (against != null) {
@@ -746,8 +746,8 @@ final class Predicates {
             return false;
         }
         Rel stated = positive ? relOf(b.op()) : negateRel(relOf(b.op()));
-        LinearForm<Term> la = stated == null ? null : terms.affineOf(b.left(), at);
-        LinearForm<Term> ra = stated == null ? null : terms.affineOf(b.right(), at);
+        LinearForm<FactSubject> la = stated == null ? null : terms.affineOf(b.left(), at);
+        LinearForm<FactSubject> ra = stated == null ? null : terms.affineOf(b.right(), at);
         if (la == null || ra == null) {
             return false;
         }
@@ -766,39 +766,39 @@ final class Predicates {
      * first and leave the second saying nothing.
      */
     private Piecewise piecewiseOf(Constraint owed, Core inv, Denotations at) {
-        Map<Term, Core.PreservedCall> choosing = new LinkedHashMap<>();
+        Map<FactSubject, Core.PreservedCall> choosing = new LinkedHashMap<>();
         chosenCalls(inv, at, choosing);
         choosing.keySet().retainAll(owed.form().coefs().keySet());
         if (choosing.size() != 1) {
             return null;
         }
-        Term atom = choosing.keySet().iterator().next();
+        FactSubject atom = choosing.keySet().iterator().next();
         Core.PreservedCall call = choosing.get(atom);
         BigDecimal coefficient = owed.form().coefs().get(atom);
         List<Case> cases = new ArrayList<>();
         for (DischargeRules.Choice one : DischargeRules.chosenBy(call).cases()) {
-            LinearForm<Term> answered = terms.affineOf(one.answers().of(call), at);
+            LinearForm<FactSubject> answered = terms.affineOf(one.answers().of(call), at);
             if (answered == null) {
                 return null;
             }
-            LinearForm<Term> instead = owed.form()
+            LinearForm<FactSubject> instead = owed.form()
                     .minus(LinearForm.atom(atom).times(coefficient))
                     .plus(answered.times(coefficient));
             List<Constraint> given = new ArrayList<>(one.given().size() + 1);
-            Map<Term, Granularity> kinds = new HashMap<>(terms.kindsOf(instead));
+            Map<FactSubject, Granularity> kinds = new HashMap<>(terms.kindsOf(instead));
             // What the call answers here, said of the call itself: in this case the two are one
             // value. Without it a guard written about the call would stand outside the cases, and a
             // clause could come out established by these and refused by that.
-            LinearForm<Term> answeredHere = LinearForm.atom(atom).minus(answered);
+            LinearForm<FactSubject> answeredHere = LinearForm.atom(atom).minus(answered);
             given.add(new Constraint(answeredHere, Rel.EQ));
             kinds.putAll(terms.kindsOf(answeredHere));
             for (DischargeRules.ArgumentsStand stands : one.given()) {
-                LinearForm<Term> left = terms.affineOf(stands.left().of(call), at);
-                LinearForm<Term> right = terms.affineOf(stands.right().of(call), at);
+                LinearForm<FactSubject> left = terms.affineOf(stands.left().of(call), at);
+                LinearForm<FactSubject> right = terms.affineOf(stands.right().of(call), at);
                 if (left == null || right == null) {
                     return null;
                 }
-                LinearForm<Term> between = left.minus(right);
+                LinearForm<FactSubject> between = left.minus(right);
                 given.add(new Constraint(between, stands.rel()));
                 kinds.putAll(terms.kindsOf(between));
             }
@@ -810,13 +810,13 @@ final class Predicates {
 
     /** Every call inside {@code e} that answers one of the values it was given, by the atom it keys
      * as. A name is what it was given, as everywhere else a value is read. */
-    private void chosenCalls(Core e, Denotations at, Map<Term, Core.PreservedCall> out) {
+    private void chosenCalls(Core e, Denotations at, Map<FactSubject, Core.PreservedCall> out) {
         if (e instanceof Core.Read r && at.valueOf(r.binding()) != null) {
             chosenCalls(at.valueOf(r.binding()), at, out);
             return;
         }
         if (e instanceof Core.PreservedCall call && DischargeRules.chosenBy(call) != null) {
-            Term atom = terms.atomOf(call, at);
+            FactSubject atom = terms.atomOf(call, at);
             if (atom != null) {
                 out.put(atom, call);
             }
@@ -839,7 +839,7 @@ final class Predicates {
         }
         Term from = terms.bodyKey(shift.of().of(call), at);
         Term to = terms.bodyKey(call, at);
-        LinearForm<Term> amount = terms.affineOf(shift.amount().of(call), at);
+        LinearForm<FactSubject> amount = terms.affineOf(shift.amount().of(call), at);
         if (from == null || to == null || amount == null) {
             return;
         }
@@ -850,13 +850,13 @@ final class Predicates {
     }
 
     /** {@code form} with {@code offset} added, or null where the form could not be read. */
-    private static LinearForm<Term> addTo(LinearForm<Term> form, BigDecimal offset) {
+    private static LinearForm<FactSubject> addTo(LinearForm<FactSubject> form, BigDecimal offset) {
         return form == null ? null : form.plus(LinearForm.constant(offset));
     }
 
     /** The constant {@code e} reads as, or null where it reads as none. */
     private BigDecimal constantOf(Core e, Denotations at) {
-        LinearForm<Term> form = terms.affineOf(e, at);
+        LinearForm<FactSubject> form = terms.affineOf(e, at);
         return form == null || !form.coefs().isEmpty() ? null : form.constant();
     }
 
@@ -911,12 +911,12 @@ final class Predicates {
     /** The keys a guard could have settled to establish this clause: the predicate as written, and
      * the same predicate of each container the written one was built from by a construction that
      * carries it. Stating {@code List.all(p, xs)} is stating it of every sublist of {@code xs}. */
-    List<Term> factKeys(Core inv, Denotations at) {
-        Term written = terms.bodyKey(inv, at);
+    List<FactSubject> factKeys(Core inv, Denotations at) {
+        FactSubject written = FactSubject.of(terms.bodyKey(inv, at));
         if (written == null) {
             return List.of();
         }
-        List<Term> keys = new ArrayList<>();
+        List<FactSubject> keys = new ArrayList<>();
         keys.add(written);
         if (!(inv instanceof Core.PreservedCall call)) {
             return keys;
@@ -939,7 +939,7 @@ final class Predicates {
                 break;
             }
             Core source = built.container();
-            Term key = terms.bodyKey(carried.over(next, source), at);
+            FactSubject key = FactSubject.of(terms.bodyKey(carried.over(next, source), at));
             if (key == null) {
                 break;
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -57,7 +57,7 @@ final class Predicates {
         Set<Shape> crossed = EnumSet.noneOf(Shape.class);
         Core source = container;
         while (true) {
-            FactSubject key = FactSubject.of(terms.bodyKey(source, at));
+            FactSubject key = terms.subjectOf(source, at);
             if (key != null) {
                 for (Quantified q : k.quantified()) {
                     if (key.equals(q.container()) && q.through().containsAll(crossed)) {
@@ -122,7 +122,7 @@ final class Predicates {
         // The container is the carrying rule's, which is the one argument this predicate is about.
         // What the operation hands its closure answers the same question about the same argument, and
         // is asked here only for the closure.
-        FactSubject container = FactSubject.of(terms.bodyKey(carried.container(), at));
+        FactSubject container = terms.subjectOf(carried.container(), at);
         if (container == null) {
             return;
         }
@@ -610,7 +610,7 @@ final class Predicates {
             if (la != null && ra != null) {
                 LinearForm compared = la.minus(ra);
                 out = out.taking(compared, eff, Known.Held.ON_THE_PATH, terms.kindsOf(compared));
-                read = true;
+                read |= readsItsShape(b.left(), at) && readsItsShape(b.right(), at);
             }
             // What the comparison named, recorded as spoken about: a construction from one of these
             // is one the author has said something about, whichever route ends up carrying it.
@@ -625,16 +625,41 @@ final class Predicates {
         // Both routes, always: which one carries a clause is decided where the clause is read, and a
         // guard does not know which that will be.
         Polar polar = polar(cond, positive);
-        FactSubject key = FactSubject.of(terms.bodyKey(polar.expr(), at));
+        FactSubject key = terms.subjectOf(polar.expr(), at);
         return key == null ? new Assumed(out, read)
-                : new Assumed(out.taking(key, polar.positive(), Known.Held.ON_THE_PATH), true);
+                : new Assumed(out.taking(key, polar.positive(), Known.Held.ON_THE_PATH),
+                        read || readsItsShape(polar.expr(), at));
+    }
+
+    /**
+     * Whether a rule here read the shape {@code e} is written in.
+     *
+     * <p>Not what a fact about {@code e} is filed under, which is {@link Terms#subjectOf}'s and is
+     * now an answer for every expression there is. This is the other question, and the only place
+     * the symbolic reading is the right one to ask: whether the check reached what the condition
+     * <em>says</em>, or only which value it says it of.
+     *
+     * <p>What it decides is what an unsettled arm is explained by. A condition of a shape no rule
+     * reads is this compiler's limit and widening the reading removes it; a condition read to no
+     * effect is the ordinary state of a branch nobody built a value for, and no widening touches it.
+     * Since identity closed, every condition names something and a fact about that something is
+     * always recorded — so answering this from whether anything was recorded made the first kind
+     * vanish, and every limit of this compiler was reported as a fact about the model. Measured:
+     * over the whole suite the first kind stopped occurring at all.
+     *
+     * <p>The knowledge is taken in either way. What a guard says about a value is true whether or not
+     * this check could read the shape it was written in, and a clause naming that value is still
+     * discharged by it. This says only what may be claimed about the reading.
+     */
+    private boolean readsItsShape(Core e, Denotations at) {
+        return terms.bodyKey(e, at) != null;
     }
 
     /** The terms one side of a compared pair names: the expression itself, and each atom of the form it
      * reduced to — {@code leftover + 1} says something about {@code leftover}. */
     Collection<FactSubject> spokenOf(Core side, Denotations at, LinearForm<FactSubject> form) {
         Set<FactSubject> named = new HashSet<>(form == null ? Set.of() : form.coefs().keySet());
-        FactSubject written = FactSubject.of(terms.bodyKey(side, at));
+        FactSubject written = terms.subjectOf(side, at);
         if (written != null) {
             named.add(written);
         }
@@ -758,7 +783,9 @@ final class Predicates {
         }
         Core container = DischargeRules.sizeArgOf(call);
         if (container != null) {
-            FactSubject atom = terms.sizeAtomOf(call, arg -> terms.bodyKey(arg, at));
+            // The subject and not the symbolic key: a size is never negative whatever it is taken
+            // of, and a count over something the term grammar cannot read is still a count.
+            FactSubject atom = terms.subjectOf(call, at);
             if (atom != null) {
                 out.add(new Constraint(LinearForm.atom(atom), Rel.GE));   // a size is never negative
                 bounds(call.operation(), DischargeRules.sizeSource(container), at, out);
@@ -989,7 +1016,7 @@ final class Predicates {
      * the same predicate of each container the written one was built from by a construction that
      * carries it. Stating {@code List.all(p, xs)} is stating it of every sublist of {@code xs}. */
     List<FactSubject> factKeys(Core inv, Denotations at) {
-        FactSubject written = FactSubject.of(terms.bodyKey(inv, at));
+        FactSubject written = terms.subjectOf(inv, at);
         if (written == null) {
             return List.of();
         }
@@ -1016,7 +1043,7 @@ final class Predicates {
                 break;
             }
             Core source = built.container();
-            FactSubject key = FactSubject.of(terms.bodyKey(carried.over(next, source), at));
+            FactSubject key = terms.subjectOf(carried.over(next, source), at);
             if (key == null) {
                 break;
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -640,8 +640,32 @@ final class Predicates {
      * reaches. What a clause owes at a construction is what it guarantees where it is already
      * established, so the two read the same clauses through the same rule and differ only in
      * direction. */
+    /** Every subject the clauses in {@code owed} say something about. */
+    private static Set<FactSubject> subjectsIn(Owed owed) {
+        Set<FactSubject> named = new LinkedHashSet<>();
+        for (Clause c : owed.clauses()) {
+            for (Constraint known : c.known()) {
+                named.addAll(known.form().coefs().keySet());
+            }
+            if (c.numeric() != null) {
+                named.addAll(c.numeric().form().coefs().keySet());
+            }
+            if (c.fact() != null) {
+                named.addAll(c.fact().keys());
+            }
+        }
+        return named;
+    }
+
     Known assume(Owed owed, Known k, Known.Held held) {
         Known out = k;
+        // Every subject this takes something in about is one something has been said about. Recorded
+        // for the same reason a guard's subjects are: what makes a clause readable against a value is
+        // that something speaks of it, and the seeding speaks. A place did not need it — the seeding
+        // writes about places, which is a rule of its own — but an evaluation has no such rule, and
+        // saying nothing here would leave a value its own type guarantees something about looking
+        // like one nothing is known of.
+        out = out.speaking(subjectsIn(owed));
         // What could not be read says nothing here: a clause left to the run-time check is not one
         // the seeding may assume, and the flag saying so is the construction site's to act on.
         for (Clause c : owed.clauses()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Quantified.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Quantified.java
@@ -16,4 +16,4 @@ import java.util.Set;
  * them. The predicate is kept as the block it is, already read where the relation was stated, so
  * every name in it means there what it meant there.
  */
-record Quantified(Term container, Set<Shape> through, Core.Block predicate) {}
+record Quantified(FactSubject container, Set<Shape> through, Core.Block predicate) {}

--- a/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StatedByClauses.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * A branch impossible only by an arithmetic relation between two positions is one nothing here can
  * drop, and giving those two a reading of alternatives is its own change with its own reason.
  */
-record StatedByClauses(AdmissibleValues<Term> values, OrderedIntervals<Term> ordered) {
+record StatedByClauses(AdmissibleValues<FactSubject> values, OrderedIntervals<FactSubject> ordered) {
 
     /** Nothing read, so nothing ruled out. */
     static StatedByClauses top() {
@@ -45,7 +45,7 @@ record StatedByClauses(AdmissibleValues<Term> values, OrderedIntervals<Term> ord
      * @param byName the type at each position, keyed by what that position is called
      */
     static StatedByClauses of(List<Core> clauses, Terms terms, Denotations at,
-                              Map<Term, Type> byName, Symbols symbols) {
+                              Map<FactSubject, Type> byName, Symbols symbols) {
         Reading reading = new Reading(AdmissibleReading.of(terms, at, byName, symbols),
                 OrderedReading.of(terms, at, byName, symbols));
         StatedByClauses out = top();

--- a/souther-compiler/src/main/java/souther/compiler/check/Term.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Term.java
@@ -68,6 +68,17 @@ final class Term {
         BUILT,
         /** A call, over its arguments. */
         CALLED,
+        /**
+         * One evaluation, told apart from every other by the { EvaluationId} it holds and not by
+         * anything about its shape.
+         *
+         * <p>The one nominal atom. Everything else here is structural all the way down, which is what
+         * makes two writings of one value one term; a value nothing may share needs a leaf that is
+         * equal to nothing but itself, and it needs to be a leaf of this same algebra so that what is
+         * built over it composes. { length(E)} written twice is one term because { CALLED}
+         * interns over its children and the child is the one atom both times.
+         */
+        EVALUATION,
         /** A value given to an optional position. */
         SOME,
         /** The empty optional, at the type of the position it fills. */
@@ -150,10 +161,28 @@ final class Term {
      * one term, and nothing here reads a rendering back: that is what the string form of this was,
      * and it is why an escaping bug in it could make one value out of two.
      */
+    /**
+     * Whether this stands on one evaluation and nothing else this check can read — the atom itself,
+     * or a field read off one.
+     *
+     * <p>Such a term names a value, which is what lets a guard or a declaration speak about it; it
+     * says nothing at all on its own. The two used to be one answer, because a value with no
+     * structure to read had no name either, and a reader could take having a name as evidence that
+     * something was readable. Now it is not evidence, and the readers that used it that way ask this.
+     */
+    boolean standsOnAnEvaluation() {
+        return switch (shape) {
+            case EVALUATION -> true;
+            case ON -> parts.get(0).standsOnAnEvaluation();
+            default -> false;
+        };
+    }
+
     String rendered() {
         StringBuilder sb = new StringBuilder();
         switch (shape) {
             case AT, BOUND -> sb.append(of);
+            case EVALUATION -> sb.append(of);
             case ON -> sb.append(parts.get(0).rendered()).append(path());
             case INT, DECIMAL, BOOL -> sb.append(of);
             case STRING -> sb.append('"').append(of).append('"');
@@ -365,6 +394,12 @@ final class Term {
          * that have to keep agreeing. */
         Term called(ValueName operation, List<Term> args) {
             return of(Shape.CALLED, operation, args);
+        }
+
+        /** The value one evaluation answered. Equal to itself and to nothing else, because an
+         * { EvaluationId} is. */
+        Term evaluated(EvaluationId where) {
+            return of(Shape.EVALUATION, where, List.of());
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -49,7 +49,7 @@ final class Terms {
     /** How the values of each atom this has named are spaced. Kept here because this is where an
      * atom's name is made: the key and the kind of number behind it are decided in one step, and
      * anywhere else would be a second place that has to agree about which is which. */
-    private final Map<Term, Granularity> atomKinds = new HashMap<>();
+    private final Map<FactSubject, Granularity> atomKinds = new HashMap<>();
     /**
      * The terms this reading has built, each held under the one instance standing for it.
      *
@@ -61,10 +61,18 @@ final class Terms {
      */
     private final Term.Interner interned = new Term.Interner();
     /** How each atom outside the affine fragment was computed. */
-    private final Map<Term, Derivation> derivations = new HashMap<>();
+    private final Map<FactSubject, Derivation> derivations = new HashMap<>();
+
+    /** The subject each evaluation this could not name is, made once per occurrence. Identity-keyed:
+     * an occurrence is a node, and two nodes are two evaluations however alike they are written. */
+    private final java.util.IdentityHashMap<Core, EvaluationId> evaluations =
+            new java.util.IdentityHashMap<>();
+
+    /** What each node a rewrite built stands for, so an occurrence keeps its identity through one. */
+    private final java.util.IdentityHashMap<Core, Core> builtFrom = new java.util.IdentityHashMap<>();
 
     /** What each atom this named outside the affine fragment was computed from. */
-    Map<Term, Derivation> derivations() {
+    Map<FactSubject, Derivation> derivations() {
         return derivations;
     }
 
@@ -135,7 +143,7 @@ final class Terms {
      * what made {@code a * b} name nothing where it is written and something where it is bound —
      * which is a name changing what can be said of an expression.
      */
-    LinearForm<Term> affine(Core raw, Denotations at, java.util.function.Function<Core, LinearForm<Term>> leaf) {
+    LinearForm<FactSubject> affine(Core raw, Denotations at, java.util.function.Function<Core, LinearForm<FactSubject>> leaf) {
         Core e = asOperator(raw);
         if (e instanceof Core.PreservedCall) {
             // A call that folds is the number it folds to. `String.length("1A")` is 2, and a clause
@@ -147,14 +155,14 @@ final class Terms {
                 return LinearForm.constant(folded);
             }
         }
-        LinearForm<Term> composed = composed(e, at, leaf);
+        LinearForm<FactSubject> composed = composed(e, at, leaf);
         return composed != null ? composed : leaf.apply(e);
     }
 
     /** {@code e} read as arithmetic over what {@code leaf} answers, or {@code null} where this has no
      * rule for it or the rule it has does not compose. */
-    private LinearForm<Term> composed(Core e, Denotations at,
-                                java.util.function.Function<Core, LinearForm<Term>> leaf) {
+    private LinearForm<FactSubject> composed(Core e, Denotations at,
+                                java.util.function.Function<Core, LinearForm<FactSubject>> leaf) {
         return switch (e) {
             case Core.Int i -> LinearForm.constant(BigDecimal.valueOf(i.value()));
             case Core.Decimal d -> LinearForm.constant(d.value());
@@ -185,7 +193,7 @@ final class Terms {
             // arithmetic helper becomes, so reading through it is reading the arithmetic the author
             // wrote.
             case Core.LetIn li -> {
-                LinearForm<Term> bound = affine(li.value(), at, leaf);
+                LinearForm<FactSubject> bound = affine(li.value(), at, leaf);
                 yield bound == null ? null : affine(li.body(), at,
                         n -> n instanceof Core.Read r && r.binding().equals(li.binder().id())
                                 ? bound : leaf.apply(n));
@@ -224,7 +232,7 @@ final class Terms {
 
     /** The affine form of an expression: a numeric atom, a newtype construct's wrapped value, or
      * {@code null}. */
-    LinearForm<Term> affineOf(Core e, Denotations at) {
+    LinearForm<FactSubject> affineOf(Core e, Denotations at) {
         return affine(e, at, n -> {
             // A newtype built around a number is that number here. What makes it one is the
             // declaration, which `affineScalarBase` asks; a construction of it has the one field the
@@ -254,11 +262,11 @@ final class Terms {
             // §invariant-discharge-terms). Read through it, as the `let` node above is read through:
             // the name and the expression it was given are one value, and reading one as an atom of
             // its own leaves a guard on the name saying nothing about the value it was built from.
-            LinearForm<Term> given = givenForm(n, at);
+            LinearForm<FactSubject> given = givenForm(n, at);
             if (given != null) {
                 return given;
             }
-            Term atom = atomOf(n, at);
+            FactSubject atom = atomOf(n, at);
             return atom == null ? null : LinearForm.atom(atom);
         });
     }
@@ -268,7 +276,7 @@ final class Terms {
      * given is arithmetic this can read. A name given a location is not this — {@link #atomOf}
      * answers that with the location, which is what the seeding wrote about.
      */
-    private LinearForm<Term> givenForm(Core e, Denotations at) {
+    private LinearForm<FactSubject> givenForm(Core e, Denotations at) {
         if (!(e instanceof Core.Read r) || !(at.of(r.binding()) instanceof Denotes.Computed)
                 || affineScalarBase(e.type()) == null) {
             return null;
@@ -331,15 +339,15 @@ final class Terms {
      * have been said before a value could be an atom made the first guard about a value the one that
      * could not be read, since it was read to decide whether that value had a name at all.
      */
-    Term atomOf(Core e, Denotations at) {
-        Term size = sizeAtomOf(e, arg -> bodyKey(arg, at));
+    FactSubject atomOf(Core e, Denotations at) {
+        FactSubject size = sizeAtomOf(e, arg -> bodyKey(arg, at));
         if (size != null) {
             return size;
         }
         if (affineScalarBase(e.type()) == null) {
             return null;
         }
-        Term atom = named(bodyKey(e, at), granularityOf(e.type()));
+        FactSubject atom = named(bodyKey(e, at), granularityOf(e.type()));
         if (atom != null) {
             recording(atom, e, at);
         }
@@ -359,7 +367,7 @@ final class Terms {
      * between depends on what the path assumed, and the path is not something the naming of an
      * expression knows — which is why the walk that reads the operands is not handed one.
      */
-    private void recording(Term atom, Core e, Denotations at) {
+    private void recording(FactSubject atom, Core e, Denotations at) {
         if (!(asOperator(e) instanceof Core.Binary b)) {
             return;
         }
@@ -382,8 +390,8 @@ final class Terms {
      * factor that is a written constant is not this: that product is a scalar multiply and the
      * fragment carries it ({@link #scale}). */
     private Derivation product(Core.Binary b, Denotations at) {
-        LinearForm<Term> left = affineOf(b.left(), at);
-        LinearForm<Term> right = affineOf(b.right(), at);
+        LinearForm<FactSubject> left = affineOf(b.left(), at);
+        LinearForm<FactSubject> right = affineOf(b.right(), at);
         return left == null || right == null ? null : new Derivation.Product(left, right);
     }
 
@@ -407,8 +415,8 @@ final class Terms {
         if (granularityOf(b.type()) != Granularity.DISCRETE) {
             return null;
         }
-        LinearForm<Term> numerator = affineOf(b.left(), at);
-        LinearForm<Term> divisor = affineOf(b.right(), at);
+        LinearForm<FactSubject> numerator = affineOf(b.left(), at);
+        LinearForm<FactSubject> divisor = affineOf(b.right(), at);
         if (numerator == null || divisor == null || !divisor.coefs().isEmpty()) {
             return null;
         }
@@ -445,7 +453,7 @@ final class Terms {
         };
     }
 
-    private static boolean sameForm(LinearForm<Term> a, LinearForm<Term> b) {
+    private static boolean sameForm(LinearForm<FactSubject> a, LinearForm<FactSubject> b) {
         if (a.constant().compareTo(b.constant()) != 0 || !a.coefs().keySet().equals(b.coefs().keySet())) {
             return false;
         }
@@ -470,7 +478,7 @@ final class Terms {
 
     /** The atom of the size {@code e} takes of a container {@code key} can name, or null where it
      * takes none or names none. */
-    Term sizeAtomOf(Core e, java.util.function.Function<Core, Term> key) {
+    FactSubject sizeAtomOf(Core e, java.util.function.Function<Core, Term> key) {
         Core container = DischargeRules.sizeArgOf(e);
         if (container == null) {
             return null;
@@ -484,7 +492,7 @@ final class Terms {
      * that takes it and nothing besides, which is the term a clause reading one builds and the term a
      * guard stating one builds — so the two are one value rather than two writings that have to keep
      * spelling each other alike. */
-    Term sizeKeyOf(ValueName size, Term container) {
+    FactSubject sizeKeyOf(ValueName size, Term container) {
         return named(interned.called(size, List.of(container)), Granularity.DISCRETE);
     }
 
@@ -496,7 +504,7 @@ final class Terms {
      * the measure to answer, which is what a clause reading the call is named with too — a count of
      * whole days is one thing wherever it is written.
      */
-    Term measureKeyOf(ValueName.Stdlib measure, Term from, Term to) {
+    FactSubject measureKeyOf(ValueName.Stdlib measure, Term from, Term to) {
         Prelude.PreludeEntry counts = Prelude.entry(measure.qualified());
         return named(interned.called(measure, List.of(from, to)),
                 granularityOf(counts.signature().result()));
@@ -517,13 +525,13 @@ final class Terms {
      * a field wants the name a clause already gave it, and answering with a fresh one would put an
      * atom nothing bounds into the domain and call that an answer.
      */
-    Term takenAtomOf(Core e, Type type, Denotations at) {
+    FactSubject takenAtomOf(Core e, Type type, Denotations at) {
         ValueName.Stdlib counts = NumericMeasures.takenOf(type, symbols);
         if (counts == null) {
             return null;
         }
         Term container = bodyKey(e, at);
-        return container == null ? null : interned.calledIfBuilt(counts, List.of(container));
+        return container == null ? null : FactSubject.of(interned.calledIfBuilt(counts, List.of(container)));
     }
 
     /**
@@ -551,15 +559,22 @@ final class Terms {
     /** {@code key}, with how its values are spaced recorded against it. A key is what a value is
      * called and a kind is what the value is, so one key is one kind: two would mean this named two
      * values alike, and everything recorded under the name would be about neither of them. */
-    private Term named(Term key, Granularity g) {
-        if (key == null) {
+    private FactSubject named(Term key, Granularity g) {
+        return key == null ? null : named(FactSubject.of(key), g);
+    }
+
+    /** The same, of a subject already made. Both spellings record here, so an atom reached by either
+     * is held to the one kind. */
+    private FactSubject named(FactSubject subject, Granularity g) {
+        if (subject == null) {
             return null;
         }
-        Granularity had = atomKinds.putIfAbsent(key, g);
+        Granularity had = atomKinds.putIfAbsent(subject, g);
         if (had != null && had != g) {
-            throw new OneTermTwoKinds("atom `" + key.rendered() + "` is " + had + " and " + g);
+            throw new OneTermTwoKinds("atom `" + subject.rendered() + "` is " + had
+                    + " and " + g);
         }
-        return key;
+        return subject;
     }
 
     /** How the values of a numeric type are spaced. */
@@ -576,23 +591,23 @@ final class Terms {
 
     /** The spacing of every atom {@code f} is written over, for the domain to record. Every one of
      * them was named here, so one that is not is a form built somewhere this cannot answer for. */
-    Map<Term, Granularity> kindsOf(LinearForm<Term> f) {
+    Map<FactSubject, Granularity> kindsOf(LinearForm<FactSubject> f) {
         return kindsOfAtoms(f.coefs().keySet());
     }
 
     /** The same, for a name being given a form: the name is an atom too, and its own type says how
      * its values are spaced. */
-    Map<Term, Granularity> kindsOf(LinearForm<Term> f, Term atom, Type type) {
-        Map<Term, Granularity> out = new HashMap<>(kindsOf(f));
+    Map<FactSubject, Granularity> kindsOf(LinearForm<FactSubject> f, FactSubject atom, Type type) {
+        Map<FactSubject, Granularity> out = new HashMap<>(kindsOf(f));
         Granularity g = granularityOf(type);
         named(atom, g);
         out.put(atom, g);
         return out;
     }
 
-    private Map<Term, Granularity> kindsOfAtoms(Set<Term> atoms) {
-        Map<Term, Granularity> out = new HashMap<>();
-        for (Term atom : atoms) {
+    private Map<FactSubject, Granularity> kindsOfAtoms(Set<FactSubject> atoms) {
+        Map<FactSubject, Granularity> out = new HashMap<>();
+        for (FactSubject atom : atoms) {
             Granularity g = atomKinds.get(atom);
             if (g == null) {
                 throw new IllegalStateException("atom `" + atom.rendered() + "` was not named here");
@@ -606,6 +621,85 @@ final class Terms {
      * structurally. */
     Term bodyKey(Core e, Denotations at) {
         return termKey(e, at, Map.of(), 0);
+    }
+
+    /**
+     * The subject a fact about {@code e} is about: the atom where the numeric domain carries one, and
+     * the canonical key of the expression otherwise.
+     *
+     * <p>One place answers it. Three readers worked the same fallback out for themselves, and a
+     * reader that decides for itself which of the two a value is named by is a reader that can decide
+     * it differently from the one beside it.
+     */
+    FactSubject subjectOf(Core e, Denotations at) {
+        FactSubject atom = atomOf(e, at);
+        if (atom != null) {
+            return atom;
+        }
+        Term key = bodyKey(e, at);
+        if (key != null) {
+            return FactSubject.of(key);
+        }
+        // Nothing the term grammar can name. That is a value this cannot share, not a value it
+        // cannot point at, so the evaluation itself is the subject.
+        return evaluationOf(e);
+    }
+
+    /**
+     * The subject one evaluation of {@code e} is — the same one every time this occurrence is asked
+     * about, and one no other occurrence can be given.
+     *
+     * <p>Kept in a table rather than made afresh, because a subject made twice is two subjects and a
+     * fact filed under the first is then about neither. The table is keyed by the node, which is what
+     * an occurrence is here: two writings of one call are two nodes and so two evaluations, which is
+     * the answer for a value nothing may share and the safe answer for one that may.
+     */
+    FactSubject evaluationOf(Core e) {
+        if (e == null) {
+            return null;
+        }
+        return new FactSubject.OfAnEvaluation(evaluations.computeIfAbsent(asWritten(e),
+                node -> new EvaluationId(shapeOf(node), node.pos())));
+    }
+
+    /**
+     * Records that {@code made} is {@code from} built again — the same evaluation, reached through a
+     * tree this check rewrote rather than through the one the author wrote.
+     *
+     * <p>Held here because which occurrence a node is, is an identity question, and identity has one
+     * authority. A reading that replaces a conditional rebuilds every node on the way to it
+     * ({@code Core.mapAll} makes a new parent whenever a child changed), so the very same call
+     * arrives as a different object in each reading. Left unrecorded, each reading would give it an
+     * evaluation of its own, and a fact taken in one would be about nothing in the next.
+     *
+     * <p>A rebuild is not a second evaluation. Something that really does evaluate twice — two calls
+     * written out, one call inside a fold — is two nodes and never comes through here, so the two
+     * stay apart.
+     */
+    void rebuilt(Core made, Core from) {
+        if (made != from) {
+            builtFrom.put(made, from);
+        }
+    }
+
+    /** The node {@code e} was built from, however many rewrites ago — and {@code e} itself where it
+     * is the one that was written. */
+    Core asWritten(Core e) {
+        Core from = e;
+        Core next;
+        while ((next = builtFrom.get(from)) != null) {
+            from = next;
+        }
+        return from;
+    }
+
+    /** What to call an evaluation in a message: the kind of expression it is. */
+    private static String shapeOf(Core e) {
+        return switch (e) {
+            case Core.Call _ -> "an answer";
+            case Core.Apply _ -> "what a function value answered";
+            default -> "a value";
+        };
     }
 
     /**
@@ -626,13 +720,42 @@ final class Terms {
      * this check's flagging policy rather than a proof: the run-time check stands for the whole of
      * such an invariant. Widening it is a matter of naming more values here.
      */
-    Term siteKey(Core e, Denotations at, Known k) {
-        // A value written out is not something a guard can be written about: there is nothing to
-        // state of `"xyz"` that the text does not already say. Where a clause reading it folds it is
-        // decided before this is asked, and where it does not fold there is no guard that would
-        // discharge it, so naming it here would only report what the author cannot answer.
-        Denotes d = denotationOf(e, at, k);
-        return readable(d, k) ? termOf(d) : null;
+    FactSubject reportableSite(Core e, Denotations at, Known k) {
+        Denotes d = denotationOf(e, at);
+        // A value written out is not a site at all. There is nothing to state of `"xyz"` that the
+        // text does not already say, so there is no guard an author could add — and this is a rule
+        // about what is worth reporting, not about what is known. Kept out of the judgment below
+        // rather than answered as "not readable": a written value's key is one a guard naming a
+        // literal puts in `spoken` (`x == "xyz"` speaks of both sides), so folded into the judgment
+        // it would come back readable through the second half of it.
+        if (d instanceof Denotes.Written) {
+            return null;
+        }
+        FactSubject subject = FactSubject.of(termOf(d));
+        if (subject == null) {
+            return null;
+        }
+        return intrinsicallyReadable(d, e, at) || k.speaksOf(subject) ? subject : null;
+    }
+
+    /**
+     * Whether the check's own semantics make {@code e} something a clause can be read against, before
+     * anything a path has said.
+     *
+     * <p>A place is: the seeding writes about places, whatever their type states. A computed value is
+     * where the numeric domain built a form for it or a rule says how it was made. Anything else is
+     * not, and stays not until a guard on the path speaks of it — which is the other half of the
+     * question and is asked of {@link Known}, not here.
+     *
+     * <p>Asked of the expression, so a name for it answers the same. That is what makes naming an
+     * expression not change what is known of it.
+     */
+    boolean intrinsicallyReadable(Denotes d, Core e, Denotations at) {
+        return switch (d) {
+            case Denotes.At _ -> true;
+            case Denotes.Computed _ -> affineOf(e, at) != null || namedByRule(e, at);
+            case Denotes.Written _, Denotes.Nothing _ -> false;
+        };
     }
 
     /** What {@code d} is named by, or null where it is named by nothing. Said here because a place is
@@ -923,7 +1046,7 @@ final class Terms {
      * that decides it, so an expression answers the same whether it was written where it is used or
      * given a name first.
      */
-    Denotes denotationOf(Core e, Denotations at, Known k) {
+    Denotes denotationOf(Core e, Denotations at) {
         Core written = writtenValue(e, at);
         if (written != null) {
             return new Denotes.Written(bodyKey(written, at), written);
@@ -937,26 +1060,7 @@ final class Terms {
             return new Denotes.Nothing(absent);
         }
         Term term = named.term();
-        // Readable where there is something to say of it: a form the numeric domain built, or a rule
-        // about how it was made. This is asked of the expression, so a name for it answers the same.
-        return new Denotes.Computed(term, affineOf(e, at) != null || namedByRule(e, at));
-    }
-
-    /**
-     * Whether a clause may be read against what {@code d} denotes. A location always may: the seeding
-     * writes about locations. A computed term may where something can be said of it, or where a guard
-     * on this path has said something. Nothing never may.
-     *
-     * <p>Every question of the form "is this value one a clause can be read against" asks this, and
-     * asking it of a name gives the same answer as asking it of the expression the name was bound to.
-     * That is what makes naming an expression not change what is known of it.
-     */
-    static boolean readable(Denotes d, Known k) {
-        return switch (d) {
-            case Denotes.At _ -> true;
-            case Denotes.Computed computed -> computed.readable() || k.speaksOf(computed.term());
-            case Denotes.Written _, Denotes.Nothing _ -> false;
-        };
+        return new Denotes.Computed(term);
     }
 
     /** What {@code e} is written as, where it is a written value or a name given one — and
@@ -1025,7 +1129,12 @@ final class Terms {
             return true;
         }
         if (e instanceof Core.Read r) {
-            return at.of(r.binding()) instanceof Denotes.Computed t && t.readable();
+            // The name is the expression it was given, so the question is asked of that expression.
+            // It was a flag recorded when the binding was entered, which is a second record of what
+            // the initializer already answers.
+            Core given = at.valueOf(r.binding());
+            return at.of(r.binding()) instanceof Denotes.Computed && given != null && given != e
+                    && (affineOf(given, at) != null || namedByRule(given, at));
         }
         Core read = asOperator(e);
         if (read instanceof Core.PreservedCall call

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -731,7 +731,7 @@ final class Terms {
         if (d instanceof Denotes.Written) {
             return null;
         }
-        FactSubject subject = FactSubject.of(termOf(d));
+        FactSubject subject = subjectOf(e, at);
         if (subject == null) {
             return null;
         }
@@ -760,7 +760,7 @@ final class Terms {
 
     /** What {@code d} is named by, or null where it is named by nothing. Said here because a place is
      * named by the term it is, and only this holds the terms. */
-    Term termOf(Denotes d) {
+    private Term termOf(Denotes d) {
         return switch (d) {
             case Denotes.At located -> interned.at(located.where());
             case Denotes.Computed computed -> computed.term();

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -347,33 +347,16 @@ final class Terms {
         if (affineScalarBase(e.type()) == null) {
             return null;
         }
-        Term key = bodyKey(e, at);
-        // A number the term grammar cannot name is still a number, and it is still one value. Where
-        // it is a part of an evaluation — `findIt(id).rank` — the evaluation is what it is a part of,
-        // and that is what a clause about the answer is read against.
-        FactSubject atom = named(key != null ? FactSubject.of(key) : partOfAnEvaluation(e, at),
-                granularityOf(e.type()));
+        // A number the term grammar cannot read is still a number, and still one value: it takes an
+        // atom of its own, and what is built over it composes with that atom rather than starting
+        // again. Which is why this asks for the identity and not for the symbolic key.
+        FactSubject atom = named(FactSubject.of(identityOf(e, at)), granularityOf(e.type()));
         if (atom != null) {
             recording(atom, e, at);
         }
         return atom;
     }
 
-    /**
-     * The part of an evaluation {@code e} is, or null where it is not read off one.
-     *
-     * <p>A field read off something the term grammar cannot name is a part of that evaluation rather
-     * than an evaluation of its own — the rule {@link Location} carries for a place, asked here of an
-     * evaluation. Nothing else is: an evaluation reached no other way is left to {@link #evaluationOf},
-     * which is where an occurrence is given its identity.
-     */
-    private FactSubject partOfAnEvaluation(Core e, Denotations at) {
-        if (!(e instanceof Core.FieldAccess fa)
-                || !(subjectOf(fa.target(), at) instanceof FactSubject.OfAnEvaluation base)) {
-            return null;
-        }
-        return Location.isStep(fa.target().type(), fa.field(), symbols) ? base.then(fa.field()) : base;
-    }
 
     /**
      * Records how {@code atom} was computed, where it stands for arithmetic the affine fragment
@@ -641,7 +624,13 @@ final class Terms {
     /** An expression's canonical key: a location names itself, and everything else is read
      * structurally. */
     Term bodyKey(Core e, Denotations at) {
-        return termKey(e, at, Map.of(), 0);
+        return termKey(e, at, Map.of(), 0, Leaf.SYMBOLIC);
+    }
+
+    /** The identity a fact about {@code e} is filed under: the same algebra, taking an atom of its
+     * own where the grammar runs out rather than answering nothing. */
+    private Term identityOf(Core e, Denotations at) {
+        return termKey(e, at, Map.of(), 0, Leaf.AN_EVALUATION);
     }
 
     /**
@@ -653,31 +642,7 @@ final class Terms {
      * it differently from the one beside it.
      */
     FactSubject subjectOf(Core e, Denotations at) {
-        FactSubject atom = atomOf(e, at);
-        if (atom != null) {
-            return atom;
-        }
-        Term key = bodyKey(e, at);
-        if (key != null) {
-            return FactSubject.of(key);
-        }
-        // Nothing the term grammar can name. That is a value this cannot share, not a value it
-        // cannot point at, so the evaluation itself is the subject — and a field read off one is a
-        // part of that evaluation rather than an evaluation of its own.
-        FactSubject part = partOfAnEvaluation(e, at);
-        if (part != null) {
-            return part;
-        }
-        // A name is the expression it was given. Answering it with an evaluation of its own would
-        // make naming an answer change which value a fact is about — the seeding speaks at the call,
-        // and every reading of the name would look elsewhere.
-        if (e instanceof Core.Read r) {
-            Core given = at.valueOf(r.binding());
-            if (given != null && given != e) {
-                return subjectOf(given, at);
-            }
-        }
-        return evaluationOf(e);
+        return FactSubject.of(identityOf(e, at));
     }
 
     /**
@@ -689,12 +654,12 @@ final class Terms {
      * an occurrence is here: two writings of one call are two nodes and so two evaluations, which is
      * the answer for a value nothing may share and the safe answer for one that may.
      */
-    FactSubject evaluationOf(Core e) {
+    private EvaluationId evaluationIdOf(Core e) {
         if (e == null) {
             return null;
         }
-        return new FactSubject.OfAnEvaluation(evaluations.computeIfAbsent(asWritten(e),
-                node -> new EvaluationId(shapeOf(node), node.pos())), java.util.List.of());
+        return evaluations.computeIfAbsent(asWritten(e),
+                node -> new EvaluationId(shapeOf(node), node.pos()));
     }
 
     /**
@@ -815,8 +780,9 @@ final class Terms {
      * still the value it is and so is part of the term. Anything outside this grammar keys as
      * {@code null}, and the clause reading it is left opaque.
      */
-    private Term termKey(Core raw, Denotations at, Map<BindingId, Term> bound, int depth) {
-        return naming(raw, at, bound, depth).term();
+    private Term termKey(Core raw, Denotations at, Map<BindingId, Term> bound, int depth,
+                         Leaf leaf) {
+        return naming(raw, at, bound, depth, leaf).term();
     }
 
     /**
@@ -834,54 +800,87 @@ final class Terms {
      * not. That a call is still standing here is not one of the questions — whether a helper was
      * expanded into this body is a fact about the reading, not about the value it answers.
      */
-    private Naming naming(Core raw, Denotations at, Map<BindingId, Term> bound, int depth) {
+    /**
+     * What a walk over an expression does where the term grammar runs out.
+     *
+     * <p>Two readings, one walk. The symbolic domain wants to know whether it can read a value's
+     * structure, and an answer of "no" is what leaves a clause over it opaque. Asking what a fact
+     * about that value would be filed under is a different question with a different right answer:
+     * the value is still one value, and it takes an atom equal to itself and to nothing else. Written
+     * as two walks they would be two structural rules to keep agreeing, which is what a second
+     * identity algebra would have been.
+     */
+    enum Leaf {
+        /** Runs out: the shape has no term, and neither has anything built from it. */
+        SYMBOLIC,
+        /** Takes an atom of its own, so that what is built over it composes. */
+        AN_EVALUATION
+    }
+
+    /** {@code c}'s arguments, with a size call's container peeled back to the one whose size it is.
+     * Only where an identity is being built: what the symbolic reader keys a size as is its own
+     * question, and answering it here would move a key nothing asked to be moved. */
+    private List<Core> sizedOver(Core.PreservedCall c, Leaf leaf) {
+        Core container = leaf == Leaf.AN_EVALUATION ? DischargeRules.sizeArgOf(c) : null;
+        return container == null ? c.args() : List.of(DischargeRules.sizeSource(container));
+    }
+
+    /** The naming to answer with where the grammar runs out, which is nothing or the evaluation
+     * itself. */
+    private Naming ranOut(Core raw, Leaf leaf, Naming absent) {
+        return leaf == Leaf.AN_EVALUATION
+                ? new Naming.Named(interned.evaluated(evaluationIdOf(raw))) : absent;
+    }
+
+    private Naming naming(Core raw, Denotations at, Map<BindingId, Term> bound, int depth,
+                          Leaf leaf) {
         Core e = asOperator(raw);
         BindingId root = rootBinding(e);
         if (root != null) {
             Term here = bound.get(root);
             return here != null ? new Naming.Named(interned.on(here, chainOf(e)))
-                    : Naming.of(pathKey(e, at), Naming.Reason.A_BINDING_STANDS_FOR_NOTHING);
+                    : Naming.of(pathKey(e, at, leaf), Naming.Reason.A_BINDING_STANDS_FOR_NOTHING);
         }
         return switch (e) {
             case Core.Read _, Core.FieldAccess _ ->
-                    Naming.of(pathKey(e, at), Naming.Reason.A_BINDING_STANDS_FOR_NOTHING);
+                    Naming.of(pathKey(e, at, leaf), Naming.Reason.A_BINDING_STANDS_FOR_NOTHING);
             case Core.Int i -> new Naming.Named(interned.written(i.value()));
             case Core.Decimal d -> new Naming.Named(interned.written(d.value()));
             case Core.Str str -> new Naming.Named(interned.written(str.value()));
             case Core.Bool b -> new Naming.Named(interned.written(b.value()));
             case Core.UnitValue u -> new Naming.Named(interned.unit(u.data()));
-            case Core.Neg n -> over(List.of(n.operand()), at, bound, depth,
+            case Core.Neg n -> over(List.of(n.operand()), at, bound, depth, leaf,
                     ps -> interned.negated(ps.get(0)));
-            case Core.Binary b -> over(List.of(b.left(), b.right()), at, bound, depth,
+            case Core.Binary b -> over(List.of(b.left(), b.right()), at, bound, depth, leaf,
                     ps -> interned.operator(b.op(), ps.get(0), ps.get(1)));
-            case Core.ListLit l -> over(l.elements(), at, bound, depth, interned::list);
-            case Core.Tuple t -> over(t.elements(), at, bound, depth, interned::tuple);
-            case Core.TupleGet g -> over(List.of(g.tuple()), at, bound, depth,
+            case Core.ListLit l -> over(l.elements(), at, bound, depth, leaf, interned::list);
+            case Core.Tuple t -> over(t.elements(), at, bound, depth, leaf, interned::tuple);
+            case Core.TupleGet g -> over(List.of(g.tuple()), at, bound, depth, leaf,
                     ps -> interned.part(ps.get(0), g.index()));
-            case Core.If iff -> over(List.of(iff.cond(), iff.then(), iff.els()), at, bound, depth,
+            case Core.If iff -> over(List.of(iff.cond(), iff.then(), iff.els()), at, bound, depth, leaf,
                     ps -> interned.choice(ps.get(0), ps.get(1), ps.get(2)));
-            case Core.OptionSome s -> over(List.of(s.value()), at, bound, depth,
+            case Core.OptionSome s -> over(List.of(s.value()), at, bound, depth, leaf,
                     ps -> interned.some(ps.get(0)));
             case Core.OptionNone none -> new Naming.Named(interned.none(none.type()));
             case Core.Block b -> {
                 Map<BindingId, Term> inner = binding(bound, b.params(), depth);
-                yield named(naming(b.body(), at, inner, depth + 1),
+                yield named(naming(b.body(), at, inner, depth + 1, leaf),
                         body -> interned.closure(b.params().size(), body));
             }
             case Core.LetIn li -> {
-                Naming value = naming(li.value(), at, bound, depth);
+                Naming value = naming(li.value(), at, bound, depth, leaf);
                 if (value instanceof Naming.Unnamed absent) {
                     yield absent;
                 }
                 Map<BindingId, Term> inner = binding(bound, List.of(li.binder()), depth);
-                yield named(naming(li.body(), at, inner, depth + 1),
+                yield named(naming(li.body(), at, inner, depth + 1, leaf),
                         body -> interned.let(value.term(), body));
             }
             // A construction is a pure function of its fields, and a closure that builds one is what a
             // mapping usually is. The fields are held in declaration order, so two sites writing them
             // in different orders — or one of them through a spread — write one term.
             case Core.Construct nd -> over(nd.values().stream().map(Core.FieldValue::value).toList(),
-                    at, bound, depth,
+                    at, bound, depth, leaf,
                     ps -> interned.built(nd.typeName(),
                             nd.values().stream().map(Core.FieldValue::field).toList(), ps));
             case Core.Match m -> {
@@ -892,21 +891,21 @@ final class Terms {
                 for (Core.Case arm : m.cases()) {
                     Map<BindingId, Term> inner = arm.binding() == null ? outer
                             : binding(outer, List.of(arm.binding()), depth);
-                    answers.add(naming(arm.body(), at, inner, depth + 1));
+                    answers.add(naming(arm.body(), at, inner, depth + 1, leaf));
                 }
-                Naming scrutinee = naming(m.scrutinee(), at, bound, depth);
+                Naming scrutinee = naming(m.scrutinee(), at, bound, depth, leaf);
                 yield joined(scrutinee, answers,
                         parts -> interned.matched(parts.get(0),
                                 m.cases().stream().map(Core.Case::caseTypes).toList(),
                                 parts.subList(1, parts.size())));
             }
             case Core.IfConstructed ic -> {
-                Naming built = naming(ic.construct(), at, bound, depth);
+                Naming built = naming(ic.construct(), at, bound, depth, leaf);
                 Map<BindingId, Term> inner = binding(bound, List.of(ic.binder()), depth);
                 List<Naming> answers = new ArrayList<>();
-                answers.add(naming(ic.then(), at, inner, depth + 1));
+                answers.add(naming(ic.then(), at, inner, depth + 1, leaf));
                 for (Core.ElseArm arm : ic.els()) {
-                    answers.add(naming(arm.body(), at, bound, depth));
+                    answers.add(naming(arm.body(), at, bound, depth, leaf));
                 }
                 yield joined(built, answers,
                         parts -> interned.attempted(parts.get(0),
@@ -917,20 +916,26 @@ final class Terms {
             // functions of what they were given: the first because the language defines them, the
             // second because a helper is pure (spec §fn-rules). What an injected behavior answers is
             // neither, and a call to one is named by nothing.
-            case Core.PreservedCall c -> over(c.args(), at, bound, depth,
+            // A size is keyed over the container it is really the size of. An operation that answers
+            // exactly as many as it was given does not change the number, which the discharge table
+            // states as a relation between the two values (`Cardinality.SAME`) rather than as
+            // something this check happens to follow — so it is an equality identity may read.
+            case Core.PreservedCall c -> over(sizedOver(c, leaf), at, bound, depth, leaf,
                     ps -> interned.called(c.operation(), ps));
             case Core.Call c -> switch (c.fn()) {
                 case Core.Reached reached -> switch (answersOf(reached.denotes())) {
-                    case Naming.OfAName.AnswersNothing none -> new Naming.Opaque(none.reason());
-                    case Naming.OfAName.Answers ignored -> over(c.args(), at, bound, depth,
+                    case Naming.OfAName.AnswersNothing none ->
+                            ranOut(raw, leaf, new Naming.Opaque(none.reason()));
+                    case Naming.OfAName.Answers ignored -> over(c.args(), at, bound, depth, leaf,
                             ps -> interned.called(reached.denotes(), ps));
                 };
                 // A walk this compiler minted for a shape the backend lowers as a whole. The reading
                 // this check is given keeps no such call, so one arriving is a pass having run over a
                 // tree it was not written for rather than a value nothing can be said of.
-                case Core.Emitted emitted -> unsupported(emitted.rendered());
+                case Core.Emitted emitted -> ranOut(raw, leaf, unsupported(emitted.rendered()));
             };
-            case Core.Apply _ -> new Naming.Opaque(Naming.Reason.A_FUNCTION_VALUE_WAS_APPLIED);
+            case Core.Apply _ -> ranOut(raw, leaf,
+                    new Naming.Opaque(Naming.Reason.A_FUNCTION_VALUE_WAS_APPLIED));
             case Core.Unreachable _ -> new Naming.Opaque(Naming.Reason.NOTHING_IS_ANSWERED);
         };
     }
@@ -997,10 +1002,10 @@ final class Terms {
 
     /** {@code made} of the terms {@code parts} are, or null where any of them is named by nothing. */
     private Naming over(List<Core> parts, Denotations at, Map<BindingId, Term> bound, int depth,
-                        java.util.function.Function<List<Term>, Term> made) {
+                        Leaf leaf, java.util.function.Function<List<Term>, Term> made) {
         List<Term> terms = new ArrayList<>();
         for (Core part : parts) {
-            Naming one = naming(part, at, bound, depth);
+            Naming one = naming(part, at, bound, depth, leaf);
             if (one instanceof Naming.Unnamed absent) {
                 return absent;
             }
@@ -1051,21 +1056,31 @@ final class Terms {
      * rule and is read here of a term too, so a value keyed one way through a binding and the other
      * way through a field is one value.
      */
-    Term pathKey(Core e, Denotations at) {
+    Term pathKey(Core e, Denotations at, Leaf leaf) {
         Location located = locationOf(e, at);
         if (located != null) {
             return interned.at(located);
         }
         return switch (e) {
-            case Core.Read r -> termOf(at.of(r.binding()));
+            case Core.Read r -> {
+                Term named = termOf(at.of(r.binding()));
+                if (named != null || leaf == Leaf.SYMBOLIC) {
+                    yield named;
+                }
+                // A name is the expression it was given, so it is that expression's identity and not
+                // one of its own. Given nothing, the name is all there is, and it takes an atom.
+                Core given = at.valueOf(r.binding());
+                yield given != null && given != e ? termKey(given, at, Map.of(), 0, leaf)
+                        : interned.evaluated(evaluationIdOf(e));
+            }
             case Core.FieldAccess fa -> {
                 if (!Location.isStep(fa.target().type(), fa.field(), symbols)) {
-                    yield pathKey(fa.target(), at);
+                    yield pathKey(fa.target(), at, leaf);
                 }
-                Term base = pathKey(fa.target(), at);
+                Term base = pathKey(fa.target(), at, leaf);
                 yield base == null ? null : interned.on(base, List.of(fa.field()));
             }
-            default -> null;
+            default -> leaf == Leaf.AN_EVALUATION ? interned.evaluated(evaluationIdOf(e)) : null;
         };
     }
 
@@ -1090,7 +1105,7 @@ final class Terms {
         if (located != null) {
             return new Denotes.At(located);
         }
-        Naming named = naming(e, at, Map.of(), 0);
+        Naming named = naming(e, at, Map.of(), 0, Leaf.SYMBOLIC);
         if (named instanceof Naming.Unnamed absent) {
             return new Denotes.Nothing(absent);
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -347,11 +347,32 @@ final class Terms {
         if (affineScalarBase(e.type()) == null) {
             return null;
         }
-        FactSubject atom = named(bodyKey(e, at), granularityOf(e.type()));
+        Term key = bodyKey(e, at);
+        // A number the term grammar cannot name is still a number, and it is still one value. Where
+        // it is a part of an evaluation — `findIt(id).rank` — the evaluation is what it is a part of,
+        // and that is what a clause about the answer is read against.
+        FactSubject atom = named(key != null ? FactSubject.of(key) : partOfAnEvaluation(e, at),
+                granularityOf(e.type()));
         if (atom != null) {
             recording(atom, e, at);
         }
         return atom;
+    }
+
+    /**
+     * The part of an evaluation {@code e} is, or null where it is not read off one.
+     *
+     * <p>A field read off something the term grammar cannot name is a part of that evaluation rather
+     * than an evaluation of its own — the rule {@link Location} carries for a place, asked here of an
+     * evaluation. Nothing else is: an evaluation reached no other way is left to {@link #evaluationOf},
+     * which is where an occurrence is given its identity.
+     */
+    private FactSubject partOfAnEvaluation(Core e, Denotations at) {
+        if (!(e instanceof Core.FieldAccess fa)
+                || !(subjectOf(fa.target(), at) instanceof FactSubject.OfAnEvaluation base)) {
+            return null;
+        }
+        return Location.isStep(fa.target().type(), fa.field(), symbols) ? base.then(fa.field()) : base;
     }
 
     /**
@@ -641,7 +662,21 @@ final class Terms {
             return FactSubject.of(key);
         }
         // Nothing the term grammar can name. That is a value this cannot share, not a value it
-        // cannot point at, so the evaluation itself is the subject.
+        // cannot point at, so the evaluation itself is the subject — and a field read off one is a
+        // part of that evaluation rather than an evaluation of its own.
+        FactSubject part = partOfAnEvaluation(e, at);
+        if (part != null) {
+            return part;
+        }
+        // A name is the expression it was given. Answering it with an evaluation of its own would
+        // make naming an answer change which value a fact is about — the seeding speaks at the call,
+        // and every reading of the name would look elsewhere.
+        if (e instanceof Core.Read r) {
+            Core given = at.valueOf(r.binding());
+            if (given != null && given != e) {
+                return subjectOf(given, at);
+            }
+        }
         return evaluationOf(e);
     }
 
@@ -659,7 +694,7 @@ final class Terms {
             return null;
         }
         return new FactSubject.OfAnEvaluation(evaluations.computeIfAbsent(asWritten(e),
-                node -> new EvaluationId(shapeOf(node), node.pos())));
+                node -> new EvaluationId(shapeOf(node), node.pos())), java.util.List.of());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/ACallerMayAssumeWhatTheAnswerWasDeclaredToBeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACallerMayAssumeWhatTheAnswerWasDeclaredToBeTest.java
@@ -153,6 +153,11 @@ class ACallerMayAssumeWhatTheAnswerWasDeclaredToBeTest {
 
         assertEquals(List.of(), unproven(source),
                 "`value.rank > id.value` was read, whatever became of the half beside it");
+        assertEquals(1, unproven(source.replace(
+                        "    ensures String.startsWith(value.tag, \"x\") && value.rank > id.value\n",
+                        "")).size(),
+                "and with the rule taken away the construction is unproven — without this, the "
+                        + "silence above is also what a rule reaching nobody looks like (#819)");
     }
 
 

--- a/souther-compiler/src/test/java/souther/compiler/ACallerMayAssumeWhatTheAnswerWasDeclaredToBeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACallerMayAssumeWhatTheAnswerWasDeclaredToBeTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * What a behavior declared about its answer is what a caller that reached the case may assume.
@@ -153,11 +154,15 @@ class ACallerMayAssumeWhatTheAnswerWasDeclaredToBeTest {
 
         assertEquals(List.of(), unproven(source),
                 "`value.rank > id.value` was read, whatever became of the half beside it");
-        assertEquals(1, unproven(source.replace(
-                        "    ensures String.startsWith(value.tag, \"x\") && value.rank > id.value\n",
-                        "")).size(),
-                "and with the rule taken away the construction is unproven — without this, the "
-                        + "silence above is also what a rule reaching nobody looks like (#819)");
+        // The control cannot be the rule taken away. Say nothing about an answer and there is
+        // nothing for a clause about it to be discharged from, so the construction is one the
+        // run-time check stands for and this is silent either way. A rule that refutes it is the
+        // control that works: it can only refuse by having reached the construction, which is what
+        // the silence above needs saying about it.
+        assertThrows(souther.compiler.diag.CompileException.class,
+                () -> unproven(source.replace("value.rank > id.value",
+                        "value.rank + id.value < 0")),
+                "a rule that refutes the construction refuses it, so the rule reached it");
     }
 
 

--- a/souther-compiler/src/test/java/souther/compiler/ACardinalityPreservingBuildAndItsSourceAreOneSizeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACardinalityPreservingBuildAndItsSourceAreOneSizeTest.java
@@ -1,0 +1,90 @@
+package souther.compiler;
+
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * How many a build has and how many its source has are one value where the operation says so.
+ *
+ * <p>{@code List.reverse} and {@code List.map} answer exactly as many as they were given, which
+ * {@code DischargeRules.Cardinality.SAME} states — and it is stated as a relation between the two
+ * values, not as a fact about either. So the size of the build and the size of the source are one
+ * subject rather than two that have to be kept saying the same thing, and a guard written about
+ * either is a guard about both.
+ *
+ * <p>Held here because that identification is about to become the answer everywhere. It is read from
+ * the table that already declares the relation, and reading it there is right exactly while the
+ * declaration is a semantic equality: {@code AT_MOST} is the same table's word for an operation that
+ * may answer fewer, and the second half of this holds that such an operation is <em>not</em>
+ * identified — a subject built from what an analysis merely happens to follow would tie what this
+ * check can name to what it can currently prove.
+ */
+class ACardinalityPreservingBuildAndItsSourceAreOneSizeTest {
+
+    private static final String DECLARES = """
+            module m exposing ( Sized, use )
+
+            data Sized = Int
+                invariant value > 0
+
+            behavior use : (xs: List<Int>) -> Sized
+                constructs Sized
+            """;
+
+    private static List<Diagnostic> unproven(String source) {
+        return Compiler.compileWithWarnings(source).warnings().stream()
+                .filter(d -> d.severity() == Severity.WARNING)
+                .filter(d -> d.code().equals("E2011")).toList();
+    }
+
+    /**
+     * A guard on the source settles a clause about the build.
+     *
+     * <p>Which is only true if the two sizes are one subject. Were they two, the guard would have
+     * spoken about one of them and the construction would be read against the other, and nothing
+     * would carry across.
+     */
+    @Test
+    void aGuardOnTheSourceSettlesAConstructionOverACardinalityPreservingBuild() {
+        assertEquals(List.of(), unproven(DECLARES + """
+                let use (xs) = {
+                    guard List.length(xs) > 0
+                        else Sized(1)
+                    Sized(List.length(List.reverse(xs)))
+                }
+                """), "`reverse` answers exactly as many, so both sizes are the one value");
+
+        assertEquals(List.of(), unproven(DECLARES + """
+                let use (xs) = {
+                    guard List.length(xs) > 0
+                        else Sized(1)
+                    Sized(List.length(List.map(x -> x + 1, xs)))
+                }
+                """), "and so does `map`, whatever it does to the elements");
+    }
+
+    /**
+     * And an operation that may answer fewer is not identified with its source.
+     *
+     * <p>The control the first half needs: silence there would look the same if nothing were being
+     * read at all. {@code filter} is declared {@code AT_MOST} by the same table, and a guard saying
+     * the source is non-empty says nothing about how many survive it — so this construction stays the
+     * unproven one it is.
+     */
+    @Test
+    void aBuildThatMayAnswerFewerIsNotTheSameSizeAsItsSource() {
+        assertEquals(1, unproven(DECLARES + """
+                let use (xs) = {
+                    guard List.length(xs) > 0
+                        else Sized(1)
+                    Sized(List.length(List.filter(x -> x > 0, xs)))
+                }
+                """).size(), "`filter` may answer fewer, so the source's size settles nothing");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/WhatABehaviorGuaranteesOfItsAnswerReachesTheCallerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatABehaviorGuaranteesOfItsAnswerReachesTheCallerTest.java
@@ -1,0 +1,130 @@
+package souther.compiler;
+
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What a behavior guarantees of its answer is what a caller may assume of it — including where no
+ * arm ever opens that answer.
+ *
+ * <p>A behavior whose output has no cases is never matched, so until here its answer was named by
+ * nothing: no subject, and so nothing for either its type's invariant or its {@code ensures} to be
+ * written under. A construction downstream of such a call was then not proved, not refuted, and not
+ * reported (#819). The silence was the whole of the problem, and silence is also what a check that
+ * never ran looks like — so every test here says what the same program is like with the guarantee
+ * taken away, and expects the construction to be an unproven one (E2011) there.
+ *
+ * <p>Both spellings of the same program, because they are the same program. Naming a call and
+ * writing it where it is used differ in nothing an author means, and a check that answered them
+ * differently would be one where naming a value changes what is known of it.
+ */
+class WhatABehaviorGuaranteesOfItsAnswerReachesTheCallerTest {
+
+    private static List<Diagnostic> unproven(String source) {
+        return Compiler.compileWithWarnings(source).warnings().stream()
+                .filter(d -> d.severity() == Severity.WARNING)
+                .filter(d -> d.code().equals("E2011")).toList();
+    }
+
+    private static final String ENSURES = "    ensures value.rank > id.value\n";
+
+    /** A caseless answer, its behavior stating a relation between what it was given and what it
+     * answered. `id.value >= 0` and `rank > id.value` give `rank > 0`, which is `Ranked`'s. */
+    private static String statingARelation(String body) {
+        return """
+                module m.a exposing ( Id, Found, Ranked, findIt, use )
+
+                data Id     = Int
+                data Found  = { rank: Int }
+                data Ranked = Int
+                    invariant value > 0
+
+                behavior findIt : (id: Id) -> Found
+                    constructs Found
+                """ + ENSURES + """
+
+                let findIt (id) = Found { rank = id.value + 1 }
+
+                behavior use : (id: Id) -> Ranked
+                    constructs Ranked
+                """ + body;
+    }
+
+    private static final String NAMED = """
+            let use (id) = {
+                guard id.value >= 0
+                    else Ranked(1)
+                let answer = findIt(id)
+                Ranked(answer.rank)
+            }
+            """;
+
+    private static final String WRITTEN_WHERE_IT_IS_USED = """
+            let use (id) = {
+                guard id.value >= 0
+                    else Ranked(1)
+                Ranked(findIt(id).rank)
+            }
+            """;
+
+    @Test
+    void anEnsuresOnAnAnswerNoArmOpensReachesTheCaller() {
+        assertEquals(List.of(), unproven(statingARelation(NAMED)),
+                "declared of every answer, so it holds of this one");
+        assertEquals(1, unproven(statingARelation(NAMED).replace(ENSURES, "")).size(),
+                "and with nothing declared it is the unproven construction it always was");
+    }
+
+    /** The same, with the call written where its name stood. */
+    @Test
+    void theSameWhereTheCallIsWrittenWhereItIsUsed() {
+        assertEquals(List.of(), unproven(statingARelation(WRITTEN_WHERE_IT_IS_USED)),
+                "naming the answer is not what carries the relation");
+        assertEquals(1,
+                unproven(statingARelation(WRITTEN_WHERE_IT_IS_USED).replace(ENSURES, "")).size(),
+                "and taking the relation away leaves this spelling unproven too");
+    }
+
+    /**
+     * And what the answer's own type states, which needs nothing declared at the behavior.
+     *
+     * <p>The same value handed in as a parameter carried its type's invariant all along; handed back
+     * as an answer it carried nothing, which is the asymmetry underneath #819. An answer is a value
+     * of its type built through that type's checked constructor, exactly as a parameter is.
+     */
+    @Test
+    void theInvariantOfTheAnswersOwnTypeReachesTheCaller() {
+        String source = """
+                module m.e exposing ( Id, Found, Ranked, findIt, use )
+
+                data Id     = Int
+                data Found  = { rank: Int }
+                    invariant rank > 0
+                data Ranked = Int
+                    invariant value > 0
+
+                behavior findIt : (id: Id) -> Found
+                    constructs Found
+
+                let findIt (id) = Found { rank = 1 }
+
+                behavior use : (id: Id) -> Ranked
+                    constructs Ranked
+                let use (id) = {
+                    let answer = findIt(id)
+                    Ranked(answer.rank)
+                }
+                """;
+
+        assertEquals(List.of(), unproven(source),
+                "`Found` guarantees `rank > 0` of every value of it, this one included");
+        assertEquals(1, unproven(source.replace("    invariant rank > 0\n", "")).size(),
+                "and a `Found` that guarantees nothing leaves the construction unproven");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/WhatABehaviorGuaranteesOfItsAnswerReachesTheCallerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatABehaviorGuaranteesOfItsAnswerReachesTheCallerTest.java
@@ -18,12 +18,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * nothing: no subject, and so nothing for either its type's invariant or its {@code ensures} to be
  * written under. A construction downstream of such a call was then not proved, not refuted, and not
  * reported (#819). The silence was the whole of the problem, and silence is also what a check that
- * never ran looks like — so every test here says what the same program is like with the guarantee
- * taken away, and expects the construction to be an unproven one (E2011) there.
+ * never ran looks like, so nothing here rests on it alone.
  *
  * <p>Both spellings of the same program, because they are the same program. Naming a call and
  * writing it where it is used differ in nothing an author means, and a check that answered them
  * differently would be one where naming a value changes what is known of it.
+ *
+ * <p>The control is never the guarantee taken away. Declare nothing about an answer and there is
+ * nothing for a clause about it to be discharged from, so the construction is one the run-time check
+ * stands for and the compile is silent — correctly, and as it was before any of this. Silence is
+ * therefore the wrong control for silence. A guarantee that <em>refutes</em> the construction is the
+ * right one: it can only refuse by having reached it.
  */
 class WhatABehaviorGuaranteesOfItsAnswerReachesTheCallerTest {
 
@@ -231,5 +236,51 @@ class WhatABehaviorGuaranteesOfItsAnswerReachesTheCallerTest {
 
         assertThrows(souther.compiler.diag.CompileException.class, () -> unproven(source),
                 "`n` cancels and `a - b` is -1, which the invariant rejects however opaque `n` is");
+    }
+
+    /**
+     * A guarantee that is a predicate reaches the caller too, and not only one that is a number.
+     *
+     * <p>The half that closing identity for the numeric domain alone would have left behind. A
+     * relation between numbers reaches a caller through the affine reading, which composes over
+     * whatever atom the answer is; a predicate reaches it through the key a fact is filed under, and
+     * that key was still being built the symbolic way — which runs out at an answer exactly as it did
+     * before any of this. So {@code ensures value.rank > 0} would arrive and {@code ensures value.ok}
+     * would not, which is one guarantee kept and one quietly dropped for no reason an author could
+     * see.
+     *
+     * <p>Read through the refutation, for the reason every control here is: with nothing declared the
+     * construction is silent, so silence proves nothing on its own. A guarantee that contradicts the
+     * invariant can only refuse by having reached it.
+     */
+    @Test
+    void aGuaranteeThatIsAPredicateReachesTheCallerAsWell() {
+        String source = """
+                module m.d exposing ( Id, Found, Checked, findIt, use )
+
+                data Id      = Int
+                data Found   = { ok: Bool }
+                data Checked = { ok: Bool }
+                    invariant ok
+
+                behavior findIt : (id: Id) -> Found
+                    constructs Found
+                    ensures id.value > 0 && value.ok
+
+                let findIt (id) = Found { ok = id.value > 0 }
+
+                behavior use : (id: Id) -> Checked
+                    constructs Checked
+                let use (id) = {
+                    let answer = findIt(id)
+                    Checked { ok = answer.ok }
+                }
+                """;
+
+        assertEquals(List.of(), unproven(source), "`value.ok` holds of the answer, so this is built");
+        assertThrows(souther.compiler.diag.CompileException.class,
+                () -> unproven(source.replace("&& value.ok", "&& Bool.not(value.ok)")),
+                "and a predicate that contradicts the invariant refuses the construction, which it "
+                        + "can only do by having reached it");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/WhatABehaviorGuaranteesOfItsAnswerReachesTheCallerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatABehaviorGuaranteesOfItsAnswerReachesTheCallerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * What a behavior guarantees of its answer is what a caller may assume of it — including where no
@@ -30,6 +31,28 @@ class WhatABehaviorGuaranteesOfItsAnswerReachesTheCallerTest {
         return Compiler.compileWithWarnings(source).warnings().stream()
                 .filter(d -> d.severity() == Severity.WARNING)
                 .filter(d -> d.code().equals("E2011")).toList();
+    }
+
+    /**
+     * The code the compile refused this source with, or {@code null} where it compiled.
+     *
+     * <p>The control every test here needs, and it cannot be the guarantee taken away. Say nothing
+     * about an answer and there is nothing to read a clause against, so the construction is one the
+     * run-time check stands for and the compile is silent — which is what it was before any of this,
+     * and is correct: an answer having an identity is not a reason to start reporting on it. Silence
+     * is therefore the wrong control for silence. A guarantee that <em>refutes</em> the construction
+     * is the right one: it can only be refuted if the rule reached, so the refusal is the evidence
+     * the passing case cannot give on its own.
+     */
+    private static String refusedWith(String source) {
+        try {
+            Compiler.compileWithWarnings(source);
+            return null;
+        } catch (souther.compiler.diag.CompileException refused) {
+            String said = refused.getMessage();
+            int at = said.indexOf("E2");
+            return at < 0 ? said : said.substring(at, at + 5);
+        }
     }
 
     private static final String ENSURES = "    ensures value.rank > id.value\n";
@@ -77,8 +100,10 @@ class WhatABehaviorGuaranteesOfItsAnswerReachesTheCallerTest {
     void anEnsuresOnAnAnswerNoArmOpensReachesTheCaller() {
         assertEquals(List.of(), unproven(statingARelation(NAMED)),
                 "declared of every answer, so it holds of this one");
-        assertEquals(1, unproven(statingARelation(NAMED).replace(ENSURES, "")).size(),
-                "and with nothing declared it is the unproven construction it always was");
+        assertEquals("E2010", refusedWith(statingARelation(NAMED)
+                        .replace(ENSURES, "    ensures value.rank + id.value < 0\n")),
+                "and a relation that refutes the construction refuses it, which it can only do "
+                        + "by having reached it");
     }
 
     /** The same, with the call written where its name stood. */
@@ -86,9 +111,9 @@ class WhatABehaviorGuaranteesOfItsAnswerReachesTheCallerTest {
     void theSameWhereTheCallIsWrittenWhereItIsUsed() {
         assertEquals(List.of(), unproven(statingARelation(WRITTEN_WHERE_IT_IS_USED)),
                 "naming the answer is not what carries the relation");
-        assertEquals(1,
-                unproven(statingARelation(WRITTEN_WHERE_IT_IS_USED).replace(ENSURES, "")).size(),
-                "and taking the relation away leaves this spelling unproven too");
+        assertEquals("E2010", refusedWith(statingARelation(WRITTEN_WHERE_IT_IS_USED)
+                        .replace(ENSURES, "    ensures value.rank + id.value < 0\n")),
+                "and this spelling is refused by a refuting relation just the same");
     }
 
     /**
@@ -124,7 +149,87 @@ class WhatABehaviorGuaranteesOfItsAnswerReachesTheCallerTest {
 
         assertEquals(List.of(), unproven(source),
                 "`Found` guarantees `rank > 0` of every value of it, this one included");
-        assertEquals(1, unproven(source.replace("    invariant rank > 0\n", "")).size(),
-                "and a `Found` that guarantees nothing leaves the construction unproven");
+        assertEquals("E2010", refusedWith(source.replace("    invariant rank > 0\n",
+                        "    invariant rank < 0\n")),
+                "and a `Found` whose invariant refutes the construction refuses it");
+    }
+
+    /**
+     * What an answer guarantees is taken in where that answer is reached, and not in the branch
+     * beside it.
+     *
+     * <p>Standing in the subtree is not standing where the walk is. A guarantee relates the answer to
+     * the arguments it was given, so taken in from an arm this path never evaluates it lands on the
+     * very values the condition is about — one arm's answer then contradicts the other arm's
+     * condition, that arm comes out reaching nothing, and its constructions are never judged. The
+     * loss is silent, which is the failure this whole issue is about, so it is held here.
+     *
+     * <p>Read as the count and not as one report: the construction in the {@code then} arm is
+     * unproven whatever the {@code else} arm calls, and the two arms answer for themselves.
+     */
+    @Test
+    void whatAnAnswerGuaranteesDoesNotReachTheBranchBesideIt() {
+        String source = """
+                module m.b exposing ( Id, Found, Ranked, findIt, use )
+
+                data Id     = Int
+                data Found  = { rank: Int }
+                    invariant rank <= 0
+                data Ranked = Int
+                    invariant value > 0
+
+                behavior findIt : (id: Id) -> Found
+                    constructs Found
+                    ensures value.rank > id.value
+
+                let findIt (id) = Found { rank = 0 - id.value - 1 }
+
+                behavior use : (id: Id) -> Ranked
+                    constructs Ranked
+                let use (id) =
+                    if id.value >= 0 then
+                        Ranked(id.value)
+                    else
+                        Ranked(0 - findIt(id).rank)
+                """;
+
+        assertEquals(unproven(source.replace("    ensures value.rank > id.value\n", "")).size(),
+                unproven(source).size(),
+                "the `else` arm's answer says nothing about the `then` arm, so the same "
+                        + "constructions are unproven either way");
+    }
+
+    /**
+     * A value a clause does not actually rest on does not stop the clause being asked about.
+     *
+     * <p>Whether the author can be asked to account for a construction is decided from the values the
+     * clause depends on. An opaque value that appears on both sides of the relation is not one of
+     * them — it cancels, and what is left is arithmetic the check could read all along. Asked of the
+     * two sides separately instead of the relation between them, this clause would be turned away
+     * for a value it does not mention, and a construction the invariant plainly rejects would compile
+     * in silence.
+     */
+    @Test
+    void aValueThatCancelsOutOfAClauseDoesNotSilenceIt() {
+        String source = """
+                module m.c exposing ( Id, Rising, opaque, use )
+
+                data Id     = Int
+                data Rising = { a: Int, b: Int }
+                    invariant a > b
+
+                behavior opaque : (id: Id) -> Int
+
+                behavior use : (id: Id) -> Rising
+                    constructs Rising
+                    depends on opaque
+                let use (id, opaque) = {
+                    let n = opaque(id)
+                    Rising { a = n, b = n + 1 }
+                }
+                """;
+
+        assertThrows(souther.compiler.diag.CompileException.class, () -> unproven(source),
+                "`n` cancels and `a - b` is -1, which the invariant rejects however opaque `n` is");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/AGuardTheGuardsAboveItRuleOutIsProvenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AGuardTheGuardsAboveItRuleOutIsProvenTest.java
@@ -5,6 +5,7 @@ import souther.compiler.coverage.ControlPointId;
 import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
+import souther.compiler.reach.PathDecision;
 import souther.compiler.reach.Proof;
 import souther.compiler.reach.Reachability;
 
@@ -351,5 +352,56 @@ class AGuardTheGuardsAboveItRuleOutIsProvenTest {
                         "this reading proves nothing arrives, never that something does");
             }
         }
+    }
+
+    /**
+     * A condition whose shape this could not read may still be the whole of why nothing stands here,
+     * and where it is, the proof names it.
+     *
+     * <p>The two questions this reading answers came apart when every value got an identity. A guard
+     * over an answer nothing may share is a condition whose shape runs out — there is no reading of
+     * what {@code opaque()} computes — and it narrows the state all the same, through the subject the
+     * answer is. So it is not among the reasons and among them at once: not read, and taken in.
+     *
+     * <p>Answered from the wrong one of the two, this proof said the readable guard cannot hold, and
+     * that guard can hold perfectly well. A proof is a claim about the program; a limit of this
+     * compiler is not, and the one must not be written out of the other.
+     */
+    @Test
+    void aProofRestsOnAConditionWhoseShapeWasNotRead() {
+        String source = """
+                module d
+
+                data Amount = Int invariant value >= 0 && value <= 1000
+                data Free
+                data Charged = { yen: Int }
+
+                behavior opaque : () -> Int
+
+                behavior charge : (a: Amount) -> Free | Charged
+                    constructs Free, Charged
+                    depends on opaque
+                let charge (a, opaque) = {
+                    let x = opaque()
+                    guard a.value < 900 else Free
+                    guard x < 5 else Free
+                    guard x < 6 else Free
+                    Charged { yen = 1 }
+                }
+                """;
+
+        List<Proof> proven = provenIn(source, "charge");
+        assertEquals(1, proven.size(), "nothing under five is six or more, whatever `x` is");
+        List<PathDecision> why = WhatAnAnswerSays.conditionsIn(proven.get(0));
+        assertEquals(3, why.size(),
+                () -> "the guard over the answer is what rules this out, so it is named: " + why);
+
+        // And the other half: the same guard is still one this reading did not read, which is what
+        // an arm it leaves unsettled is owed as an explanation.
+        assertTrue(armsOf(source, "charge").stream()
+                        .filter(Reachability.Unsettled.class::isInstance)
+                        .map(each -> ((Reachability.Unsettled) each).why())
+                        .anyMatch(WhatAnAnswerSays::isAConditionNotRead),
+                "its shape ran out, and an arm left unsettled by it says so");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/AHelperCallIsNameableWhetherOrNotItWasExpandedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AHelperCallIsNameableWhetherOrNotItWasExpandedTest.java
@@ -88,13 +88,23 @@ class AHelperCallIsNameableWhetherOrNotItWasExpandedTest {
     }
 
     /**
-     * What a behavior answers is named by nothing, whichever way it is reached.
+     * A behavior's answer having a subject is not a reason to report on it.
      *
-     * <p>Held beside the helper because the two used to differ by which of them this reading had
-     * expanded. They differ by what was called.
+     * <p>This once held that such an answer was named by nothing, which was one sentence doing two
+     * jobs: it had no symbolic name, and so nothing was said of a construction over it. The first
+     * stopped being true when identity closed — every value can be pointed at now, and an injected
+     * behavior's answer is pointed at by an atom equal to itself and nothing else. The second is
+     * still true and is what this holds.
+     *
+     * <p>Which is the whole separation, read at a construction: {@code step} declares nothing, no
+     * guard mentions its answer, and the type it answers guarantees nothing of it. So there is
+     * nothing for {@code NonNeg}'s clause to be discharged from, the run-time check stands for it,
+     * and the compile says nothing — exactly as before. Having somewhere to file a fact is not
+     * having one. The identity half is held in
+     * {@code WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest}.
      */
     @Test
-    void aBehaviorsAnswerIsNamedByNothing() {
+    void aBehaviorAnswerHavingASubjectDoesNotMakeItAReportableSite() {
         reads(Verdict.UNREPRESENTABLE, TYPES + """
 
                 behavior step : (n: Int) -> Int

--- a/souther-compiler/src/test/java/souther/compiler/check/AHelperCallIsNameableWhetherOrNotItWasExpandedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AHelperCallIsNameableWhetherOrNotItWasExpandedTest.java
@@ -26,10 +26,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * over a helper that happens not to recurse was reported. Recursion is a fact about the helper's own
  * body; the value it answers is a function of what it was given either way.
  *
- * <p>What makes it nameable is what the name was resolved to: a module's own helper is pure and
+ * <p>What makes it shareable is what the name was resolved to: a module's own helper is pure and
  * total (spec §fn-rules), so two writings of one call with the same arguments are one value. What a
- * behavior answers is named by nothing, and that is here too — both spellings of it, so that the
- * rule is read as being about the callee rather than about which of them was expanded.
+ * behavior answers is not shareable and takes an atom of its own, and that is here too — both
+ * spellings of it, so that the rule is read as being about the callee rather than about which of
+ * them was expanded.
+ *
+ * <p>Having an atom is not having anything said about it, which is the other half and is held below.
  */
 class AHelperCallIsNameableWhetherOrNotItWasExpandedTest {
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AProductIsHeldToWhatThePathKnowsOfItsFactorsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AProductIsHeldToWhatThePathKnowsOfItsFactorsTest.java
@@ -55,15 +55,15 @@ class AProductIsHeldToWhatThePathKnowsOfItsFactorsTest {
         return new Core.Binary(op, left, right, CoverageOrigin.unwritten(), Type.INT, POS);
     }
 
-    private static LinearForm<Term> num(long n) {
+    private static LinearForm<FactSubject> num(long n) {
         return LinearForm.constant(BigDecimal.valueOf(n));
     }
 
     /** A domain in which each of {@code atoms} is at or above zero. */
-    private static NumericDomain<Term> atOrAboveZero(Terms terms, Term... atoms) {
-        NumericDomain<Term> d = NumericDomain.top();
-        for (Term atom : atoms) {
-            LinearForm<Term> form = LinearForm.atom(atom);
+    private static NumericDomain<FactSubject> atOrAboveZero(Terms terms, FactSubject... atoms) {
+        NumericDomain<FactSubject> d = NumericDomain.top();
+        for (FactSubject atom : atoms) {
+            LinearForm<FactSubject> form = LinearForm.atom(atom);
             d = d.assume(form, Rel.GE, terms.kindsOf(form));
         }
         return d;
@@ -80,17 +80,18 @@ class AProductIsHeldToWhatThePathKnowsOfItsFactorsTest {
         BindingId b = binding(1);
         Denotations at = Denotations.none().location(a).location(b);
 
-        LinearForm<Term> product = terms.affineOf(
+        LinearForm<FactSubject> product = terms.affineOf(
                 arithmetic(Hir.BinOp.MUL, read("a", a), read("b", b)), at);
 
         assertNotNull(product, "a product is one value, whatever is known of it");
-        Term atom = product.coefs().keySet().iterator().next();
-        NumericDomain<Term> guarded = atOrAboveZero(terms,
-                terms.bodyKey(read("a", a), at), terms.bodyKey(read("b", b), at));
+        FactSubject atom = product.coefs().keySet().iterator().next();
+        NumericDomain<FactSubject> guarded = atOrAboveZero(terms,
+                FactSubject.of(terms.bodyKey(read("a", a), at)),
+                FactSubject.of(terms.bodyKey(read("b", b), at)));
         assertTrue(guarded.boundsOf(atom).isEmpty(),
                 "nothing was said about the product itself");
 
-        NumericDomain<Term> derived = DerivedBounds.refine(guarded, terms, Set.of(atom));
+        NumericDomain<FactSubject> derived = DerivedBounds.refine(guarded, terms, Set.of(atom));
 
         assertEquals(Endpoint.inclusive(Count.of(0)), derived.boundsOf(atom).min());
         assertNull(derived.boundsOf(atom).max(), "nothing bounds either factor above");
@@ -111,11 +112,11 @@ class AProductIsHeldToWhatThePathKnowsOfItsFactorsTest {
         BindingId b = binding(1);
         Denotations at = Denotations.none().location(a).location(b);
 
-        LinearForm<Term> product = terms.affineOf(
+        LinearForm<FactSubject> product = terms.affineOf(
                 arithmetic(Hir.BinOp.MUL, read("a", a), read("b", b)), at);
-        Term atom = product.coefs().keySet().iterator().next();
+        FactSubject atom = product.coefs().keySet().iterator().next();
 
-        NumericDomain<Term> derived = DerivedBounds.refine(NumericDomain.top(), terms, Set.of(atom));
+        NumericDomain<FactSubject> derived = DerivedBounds.refine(NumericDomain.top(), terms, Set.of(atom));
 
         assertTrue(derived.boundsOf(atom).isEmpty());
     }
@@ -136,13 +137,13 @@ class AProductIsHeldToWhatThePathKnowsOfItsFactorsTest {
         Core scaled = arithmetic(Hir.BinOp.MUL, read("x", x), new Core.Int(30, Type.INT, POS));
         Core quotient = arithmetic(Hir.BinOp.DIV, scaled, new Core.Int(100, Type.INT, POS));
 
-        LinearForm<Term> form = terms.affineOf(quotient, at);
+        LinearForm<FactSubject> form = terms.affineOf(quotient, at);
 
         assertNotNull(form);
-        Term atom = form.coefs().keySet().iterator().next();
-        NumericDomain<Term> guarded = atOrAboveZero(terms, terms.bodyKey(read("x", x), at));
+        FactSubject atom = form.coefs().keySet().iterator().next();
+        NumericDomain<FactSubject> guarded = atOrAboveZero(terms, FactSubject.of(terms.bodyKey(read("x", x), at)));
 
-        NumericDomain<Term> derived = DerivedBounds.refine(guarded, terms, Set.of(atom));
+        NumericDomain<FactSubject> derived = DerivedBounds.refine(guarded, terms, Set.of(atom));
 
         assertEquals(Endpoint.inclusive(Count.of(0)), derived.boundsOf(atom).min());
     }
@@ -160,11 +161,11 @@ class AProductIsHeldToWhatThePathKnowsOfItsFactorsTest {
         Core product = arithmetic(Hir.BinOp.MUL, read("a", a), read("b", b));
         Core quotient = arithmetic(Hir.BinOp.DIV, product, new Core.Int(100, Type.INT, POS));
 
-        LinearForm<Term> form = terms.affineOf(quotient, at);
-        Term atom = form.coefs().keySet().iterator().next();
-        Term factorA = terms.bodyKey(read("a", a), at);
-        Term factorB = terms.bodyKey(read("b", b), at);
-        NumericDomain<Term> guarded = NumericDomain.<Term>top()
+        LinearForm<FactSubject> form = terms.affineOf(quotient, at);
+        FactSubject atom = form.coefs().keySet().iterator().next();
+        FactSubject factorA = FactSubject.of(terms.bodyKey(read("a", a), at));
+        FactSubject factorB = FactSubject.of(terms.bodyKey(read("b", b), at));
+        NumericDomain<FactSubject> guarded = NumericDomain.<FactSubject>top()
                 .assume(LinearForm.atom(factorA), Rel.GE,
                         terms.kindsOf(LinearForm.atom(factorA)))
                 .assume(LinearForm.atom(factorA).minus(num(10)), Rel.LE,
@@ -174,7 +175,7 @@ class AProductIsHeldToWhatThePathKnowsOfItsFactorsTest {
                 .assume(LinearForm.atom(factorB).minus(num(1000)), Rel.LE,
                         terms.kindsOf(LinearForm.atom(factorB)));
 
-        NumericDomain<Term> derived = DerivedBounds.refine(guarded, terms, Set.of(atom));
+        NumericDomain<FactSubject> derived = DerivedBounds.refine(guarded, terms, Set.of(atom));
 
         assertEquals(Endpoint.inclusive(Count.of(0)), derived.boundsOf(atom).min());
         assertEquals(Endpoint.inclusive(Count.of(100)), derived.boundsOf(atom).max(),
@@ -190,8 +191,8 @@ class AProductIsHeldToWhatThePathKnowsOfItsFactorsTest {
         BindingId b = binding(1);
         Denotations at = Denotations.none().location(a).location(b);
 
-        Term first = terms.affineOf(arithmetic(Hir.BinOp.MUL, read("a", a), read("b", b)), at).coefs().keySet().iterator().next();
-        Term second = terms.affineOf(arithmetic(Hir.BinOp.MUL, read("a", a), read("b", b)), at).coefs().keySet().iterator().next();
+        FactSubject first = terms.affineOf(arithmetic(Hir.BinOp.MUL, read("a", a), read("b", b)), at).coefs().keySet().iterator().next();
+        FactSubject second = terms.affineOf(arithmetic(Hir.BinOp.MUL, read("a", a), read("b", b)), at).coefs().keySet().iterator().next();
 
         assertEquals(first, second);
         assertEquals(1, terms.derivations().size());
@@ -205,9 +206,9 @@ class AProductIsHeldToWhatThePathKnowsOfItsFactorsTest {
         BindingId b = binding(1);
         Denotations at = Denotations.none().location(a).location(b);
 
-        LinearForm<Term> product = terms.affineOf(
+        LinearForm<FactSubject> product = terms.affineOf(
                 arithmetic(Hir.BinOp.MUL, read("a", a), read("b", b)), at);
-        Term atom = product.coefs().keySet().iterator().next();
+        FactSubject atom = product.coefs().keySet().iterator().next();
 
         assertEquals(Map.of(atom, Granularity.DISCRETE), terms.kindsOf(product));
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest.java
@@ -57,7 +57,7 @@ class ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest {
         along.add(term);
         for (int i = 0; i < links; i++) {
             BindingId id = new BindingId(OWNER, i);
-            at = at.binding(id, value, new Denotes.Computed(term, true));
+            at = at.binding(id, value, new Denotes.Computed(term));
             Core read = new Core.Read("v" + i, id, Type.INT, NOWHERE);
             value = new Core.Binary(Hir.BinOp.ADD, read, read, CoverageOrigin.unwritten(),
                     Type.INT, NOWHERE);

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryForkIsReadUnderWhatItsBindingCarriesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryForkIsReadUnderWhatItsBindingCarriesTest.java
@@ -199,14 +199,24 @@ class EveryForkIsReadUnderWhatItsBindingCarriesTest {
     }
 
     /**
-     * A condition the reading could not take in is not among the reasons a proof gives.
+     * A proof names every condition the reading took something from, and not only the ones whose
+     * shape it read.
      *
-     * <p>The proof says which conditions leave nothing together. One that narrowed nothing did no
-     * part of that, and naming it says a line was holding where nothing here could tell whether it
-     * was.
+     * <p>{@code Proof.conditionsThatCannotAllHold} says these cannot all hold. That is a claim about
+     * the program, so it has to name everything the contradiction rests on — including a condition
+     * whose shape ran out, which still narrows the state through the subject it names. Left out, the
+     * proof would name the conditions it happened to read and say they cannot all hold when they
+     * plainly can, turning a limit of this compiler into a claim about the model.
+     *
+     * <p>Not a smallest such set. Cutting these down to the ones that actually did the ruling out is
+     * a different job, and one nothing here asks for.
+     *
+     * <p>Whether the reading understood a condition is the other question, and it is not this one.
+     * It has its own answer ({@code WhyUnsettled.aConditionWasNotRead}) and its own test, beside the
+     * guards it explains.
      */
     @Test
-    void aConditionNothingCouldReadIsNotAReasonForAnything() {
+    void aProofNamesEveryConditionItRestsOn() {
         List<Proof> proven = provenIn("""
                 module demo
 
@@ -227,7 +237,8 @@ class EveryForkIsReadUnderWhatItsBindingCarriesTest {
         assertEquals(1, proven.size(),
                 "nothing under fifty is eighty or more, and the guard above is what says so");
         List<PathDecision> why = WhatAnAnswerSays.conditionsIn(proven.get(0));
-        assertEquals(2, why.size(),
-                () -> "the two guards that were read, and not the one through a fold: " + why);
+        assertEquals(3, why.size(),
+                () -> "every guard the contradiction rests on, the one through a fold included: "
+                        + why);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryForkIsReadUnderWhatItsBindingCarriesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryForkIsReadUnderWhatItsBindingCarriesTest.java
@@ -199,14 +199,22 @@ class EveryForkIsReadUnderWhatItsBindingCarriesTest {
     }
 
     /**
-     * A condition the reading could not take in is not among the reasons a proof gives.
+     * A proof carries every condition the reading took in on the way to it.
      *
-     * <p>The proof says which conditions leave nothing together. One that narrowed nothing did no
-     * part of that, and naming it says a line was holding where nothing here could tell whether it
-     * was.
+     * <p>Not the fewest that would do. {@code conditionsThatCannotAllHold} promises the conditions
+     * assumed on the way here and says so; cutting them down to the ones that actually did the ruling
+     * out is a different job, and one nothing here has asked for.
+     *
+     * <p>This held two before, and the third was the first guard: a size taken over a list nothing
+     * could name was a condition the reading passed over. It is read now. A value the term grammar
+     * cannot name still has an identity, so the size of it composes over that identity, and a guard
+     * about it is a guard the reading takes in — which is the whole of what closing the identity
+     * algebra was for. What the older test held beside this — that a condition nothing could read is
+     * not among a proof's reasons — is still true and no longer has a fixture here, since this one
+     * stopped being an example of it.
      */
     @Test
-    void aConditionNothingCouldReadIsNotAReasonForAnything() {
+    void everyConditionTheReadingTookInIsCarriedByTheProof() {
         List<Proof> proven = provenIn("""
                 module demo
 
@@ -227,7 +235,8 @@ class EveryForkIsReadUnderWhatItsBindingCarriesTest {
         assertEquals(1, proven.size(),
                 "nothing under fifty is eighty or more, and the guard above is what says so");
         List<PathDecision> why = WhatAnAnswerSays.conditionsIn(proven.get(0));
-        assertEquals(2, why.size(),
-                () -> "the two guards that were read, and not the one through a fold: " + why);
+        assertEquals(3, why.size(),
+                () -> "every guard the reading assumed on the way here, and not a smaller set of "
+                        + "them that would have done: " + why);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryForkIsReadUnderWhatItsBindingCarriesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryForkIsReadUnderWhatItsBindingCarriesTest.java
@@ -199,22 +199,14 @@ class EveryForkIsReadUnderWhatItsBindingCarriesTest {
     }
 
     /**
-     * A proof carries every condition the reading took in on the way to it.
+     * A condition the reading could not take in is not among the reasons a proof gives.
      *
-     * <p>Not the fewest that would do. {@code conditionsThatCannotAllHold} promises the conditions
-     * assumed on the way here and says so; cutting them down to the ones that actually did the ruling
-     * out is a different job, and one nothing here has asked for.
-     *
-     * <p>This held two before, and the third was the first guard: a size taken over a list nothing
-     * could name was a condition the reading passed over. It is read now. A value the term grammar
-     * cannot name still has an identity, so the size of it composes over that identity, and a guard
-     * about it is a guard the reading takes in — which is the whole of what closing the identity
-     * algebra was for. What the older test held beside this — that a condition nothing could read is
-     * not among a proof's reasons — is still true and no longer has a fixture here, since this one
-     * stopped being an example of it.
+     * <p>The proof says which conditions leave nothing together. One that narrowed nothing did no
+     * part of that, and naming it says a line was holding where nothing here could tell whether it
+     * was.
      */
     @Test
-    void everyConditionTheReadingTookInIsCarriedByTheProof() {
+    void aConditionNothingCouldReadIsNotAReasonForAnything() {
         List<Proof> proven = provenIn("""
                 module demo
 
@@ -235,8 +227,7 @@ class EveryForkIsReadUnderWhatItsBindingCarriesTest {
         assertEquals(1, proven.size(),
                 "nothing under fifty is eighty or more, and the guard above is what says so");
         List<PathDecision> why = WhatAnAnswerSays.conditionsIn(proven.get(0));
-        assertEquals(3, why.size(),
-                () -> "every guard the reading assumed on the way here, and not a smaller set of "
-                        + "them that would have done: " + why);
+        assertEquals(2, why.size(),
+                () -> "the two guards that were read, and not the one through a fold: " + why);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/OneNameIsOneValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneNameIsOneValueTest.java
@@ -41,7 +41,7 @@ class OneNameIsOneValueTest {
         Terms terms = new Terms(Symbols.none());
         BindingId binding = binding();
         Denotations at = Denotations.none().location(binding);
-        Term whole = terms.atomOf(new Core.Read("n", binding, Type.INT, POS), at);
+        FactSubject whole = terms.atomOf(new Core.Read("n", binding, Type.INT, POS), at);
         assertNotNull(whole, "a location is an atom");
         Terms.OneTermTwoKinds refused = assertThrows(Terms.OneTermTwoKinds.class,
                 () -> terms.atomOf(new Core.Read("n", binding, Type.DECIMAL, POS), at),

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAReadingDerivesIsWhatItsQuestionReachesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAReadingDerivesIsWhatItsQuestionReachesTest.java
@@ -47,7 +47,7 @@ class WhatAReadingDerivesIsWhatItsQuestionReachesTest {
 
     /** The recipes each reading of the module evaluated, by the name each atom renders as. */
     private static List<Set<String>> derivedWhileCompiling(String module) {
-        List<List<Term>> watching = new ArrayList<>();
+        List<List<FactSubject>> watching = new ArrayList<>();
         DerivedBounds.WATCHING = watching;
         try {
             Compiler.compileWithWarnings(module);
@@ -55,7 +55,7 @@ class WhatAReadingDerivesIsWhatItsQuestionReachesTest {
             DerivedBounds.WATCHING = null;
         }
         return watching.stream()
-                .map(one -> one.stream().map(Term::rendered)
+                .map(one -> one.stream().map(FactSubject::rendered)
                         .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new)))
                 .map(one -> (Set<String>) one)
                 .toList();

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest.java
@@ -9,7 +9,6 @@ import souther.compiler.types.Type;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -46,7 +45,7 @@ class WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest {
         FactSubject first = terms.subjectOf(new Core.Read("n", n, Type.INT, POS), at);
         FactSubject second = terms.subjectOf(new Core.Read("n", n, Type.INT, POS), at);
 
-        assertInstanceOf(FactSubject.OfATerm.class, first, "a place is named by the way it is built");
+        assertNotNull(first, "a place is something to point at");
         assertEquals(first, second, "so two writings of it are one subject");
     }
 
@@ -69,9 +68,89 @@ class WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest {
         FactSubject second = terms.subjectOf(other, at);
 
         assertNotNull(first, "an evaluation can be pointed at even where it cannot be named");
-        assertInstanceOf(FactSubject.OfAnEvaluation.class, first,
-                "and pointing at it is what it is given");
         assertNotEquals(first, second, "two occurrences are two evaluations");
+    }
+
+    /**
+     * A referentially transparent operation over one evaluation answers one subject.
+     *
+     * <p>The closure the whole separation is for. An evaluation gets a subject because it can be
+     * pointed at; whether two writings of something built <em>over</em> it are one value is then the
+     * operation's to decide, and {@code List.length} decides it the way every pure operation does —
+     * same operation, same arguments, same value. If a subject could only be composed out of things
+     * the term grammar already named, an answer would be nameable and everything built from it would
+     * not, and a fact about {@code length(xs)} would be about nothing by the second reading of it.
+     */
+    @Test
+    void onePureApplicationToOneEvaluationHasOneSubject() {
+        Terms terms = new Terms(Symbols.none());
+        Denotations at = Denotations.none();
+        Core answer = unnameable();
+
+        assertEquals(terms.subjectOf(length(answer), at), terms.subjectOf(length(answer), at),
+                "one operation over one evaluation is one value, however often it is written");
+    }
+
+    /** And over two evaluations it is two, because the arguments are two values. The control for the
+     * law above: equality there must come from the operation composing, not from everything being
+     * lumped together. */
+    @Test
+    void onePureApplicationToTwoEvaluationsHasTwoSubjects() {
+        Terms terms = new Terms(Symbols.none());
+        Denotations at = Denotations.none();
+
+        assertNotEquals(terms.subjectOf(length(unnameable()), at),
+                terms.subjectOf(length(unnameable()), at),
+                "two evaluations are two values, so the sizes of them are two values");
+    }
+
+    /**
+     * A part of an evaluation composes the same way anything else reads a field.
+     *
+     * <p>Not a projection machinery of its own. A place has one and a term has one, and an evaluation
+     * having a third would be three rules to keep saying the same thing — {@code E.rank} is the field
+     * {@code rank} read off whatever {@code E} is, which is what reading a field means everywhere.
+     */
+    @Test
+    void aFieldReadOffAnEvaluationComposesWithIt() {
+        Terms terms = new Terms(Symbols.none());
+        Denotations at = Denotations.none();
+        Core answer = unnameable();
+
+        assertEquals(terms.subjectOf(field(answer, "rank"), at),
+                terms.subjectOf(field(answer, "rank"), at),
+                "one field of one evaluation is one value");
+        assertNotEquals(terms.subjectOf(field(answer, "rank"), at),
+                terms.subjectOf(answer, at),
+                "and it is not the evaluation it is read off");
+    }
+
+    /**
+     * An evaluation that reaches outside the language has a subject, and every ask of it has its own.
+     *
+     * <p>The half that used to be missing. What such a behavior answers cannot be shared — two asks
+     * are two answers — and the only way to give a value a name was to declare it shared, so it was
+     * given none. Having none is what left a construction over it neither proved nor refuted nor
+     * reported (#819).
+     *
+     * <p>Having one is not the same as anything being known of it, and nothing here says it is: what
+     * a construction over such an answer comes out as is held at
+     * {@code AHelperCallIsNameableWhetherOrNotItWasExpandedTest}, and it is still silence.
+     */
+    @Test
+    void anAnswerFromOutsideTheLanguageHasASubjectAndEachAskHasItsOwn() {
+        Terms terms = new Terms(Symbols.none());
+        Denotations at = Denotations.none();
+
+        assertNotNull(terms.subjectOf(unnameable(), at),
+                "two asks are two answers, which is a reason to keep them apart, not to refuse "
+                        + "both a name");
+        assertNotEquals(terms.subjectOf(unnameable(), at), terms.subjectOf(unnameable(), at),
+                "and each ask is its own");
+    }
+
+    private static Core field(Core of, String name) {
+        return new Core.FieldAccess(of, name, Type.INT, POS);
     }
 
     /** And the same occurrence asked twice is one subject, or a fact filed under the first ask would
@@ -189,11 +268,11 @@ class WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest {
         FactSubject part = terms.subjectOf(
                 new Core.FieldAccess(answer, "rank", Type.INT, POS), at);
 
-        assertInstanceOf(FactSubject.OfAnEvaluation.class, part, "a part of an evaluation");
-        assertEquals(((FactSubject.OfAnEvaluation) whole).where(),
-                ((FactSubject.OfAnEvaluation) part).where(),
-                "and of that evaluation, not of one of its own");
+        assertNotNull(part, "a part of an evaluation is something to point at");
         assertNotEquals(whole, part, "the answer and the field read off it are two values");
+        assertEquals(part, terms.subjectOf(
+                new Core.FieldAccess(answer, "rank", Type.INT, POS), at),
+                "and one field of one evaluation is one value");
     }
 
     private static Core length(Core of) {
@@ -215,6 +294,6 @@ class WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest {
      * injected from outside. */
     private static Core unnameable() {
         return new Core.Apply(new Core.Read("f", binding(1), Type.INT, POS), java.util.List.of(),
-                Type.INT, POS);
+                Type.list(Type.INT), POS);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest.java
@@ -171,6 +171,31 @@ class WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest {
                 "`distinct` may answer fewer, so its size is a value of its own");
     }
 
+    /**
+     * A part of an evaluation is a part of that evaluation, not an evaluation of its own.
+     *
+     * <p>A clause is written about the parts — an {@code ensures} states {@code value.rank}, not
+     * {@code value} — so an answer that could be pointed at while nothing inside it could would be a
+     * subject nothing is ever about. The same rule {@link Location} carries for a place, asked here of
+     * an evaluation.
+     */
+    @Test
+    void aFieldReadOffAnEvaluationIsAPartOfIt() {
+        Terms terms = new Terms(Symbols.none());
+        Denotations at = Denotations.none();
+        Core answer = unnameable();
+
+        FactSubject whole = terms.subjectOf(answer, at);
+        FactSubject part = terms.subjectOf(
+                new Core.FieldAccess(answer, "rank", Type.INT, POS), at);
+
+        assertInstanceOf(FactSubject.OfAnEvaluation.class, part, "a part of an evaluation");
+        assertEquals(((FactSubject.OfAnEvaluation) whole).where(),
+                ((FactSubject.OfAnEvaluation) part).where(),
+                "and of that evaluation, not of one of its own");
+        assertNotEquals(whole, part, "the answer and the field read off it are two values");
+    }
+
     private static Core length(Core of) {
         return new Core.PreservedCall(new souther.compiler.types.ValueName.Stdlib("List", "length"),
                 java.util.List.of(of), Type.INT, POS);

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest.java
@@ -1,0 +1,140 @@
+package souther.compiler.check;
+
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Whether a value can be pointed at, and whether two writings of it are one value, are two questions.
+ *
+ * <p>They were one. A subject was a {@link Term}, whose equality is structural, so anything given a
+ * subject was thereby declared shareable — and a value that could be named but not shared had nowhere
+ * to be. What that cost is written in #819: a call to a {@code behavior} was given no subject at all,
+ * because the only way to give it one would have claimed that two asks of it answer alike. A
+ * construction built from such an answer was then not checked and not reported.
+ *
+ * <p>So the order is fixed here: a subject exists because there is something to point at, and two
+ * subjects are one because the way they are built makes them one. Both answers are settled where the
+ * subject is built ({@link Terms#subjectOf}), so a reader handed a subject has no second question to
+ * ask — and no way to answer it differently from the reader beside it.
+ */
+class WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    private static BindingId binding(int index) {
+        return new BindingId(new BindingOwner.OfValue("demo", "f"), index);
+    }
+
+    /** A place is shareable, and two readings of it are one subject. That is what makes a guard on
+     * one writing of a name a guard on the next. */
+    @Test
+    void twoWritingsOfAPlaceAreOneSubject() {
+        Terms terms = new Terms(Symbols.none());
+        BindingId n = binding(0);
+        Denotations at = Denotations.none().location(n);
+
+        FactSubject first = terms.subjectOf(new Core.Read("n", n, Type.INT, POS), at);
+        FactSubject second = terms.subjectOf(new Core.Read("n", n, Type.INT, POS), at);
+
+        assertInstanceOf(FactSubject.OfATerm.class, first, "a place is named by the way it is built");
+        assertEquals(first, second, "so two writings of it are one subject");
+    }
+
+    /**
+     * An evaluation the term grammar cannot name is one subject per occurrence.
+     *
+     * <p>Two of them written the same way are two subjects, which is the answer a value nothing may
+     * share needs — what an injected behavior answers is a different value each time it is asked. It
+     * is also the safe answer for a value that may be shared: two subjects say less than one, and
+     * saying less is not saying something false.
+     */
+    @Test
+    void twoOccurrencesOfAnUnnameableEvaluationAreTwoSubjects() {
+        Terms terms = new Terms(Symbols.none());
+        Denotations at = Denotations.none();
+        Core one = unnameable();
+        Core other = unnameable();
+
+        FactSubject first = terms.subjectOf(one, at);
+        FactSubject second = terms.subjectOf(other, at);
+
+        assertNotNull(first, "an evaluation can be pointed at even where it cannot be named");
+        assertInstanceOf(FactSubject.OfAnEvaluation.class, first,
+                "and pointing at it is what it is given");
+        assertNotEquals(first, second, "two occurrences are two evaluations");
+    }
+
+    /** And the same occurrence asked twice is one subject, or a fact filed under the first ask would
+     * be about nothing by the second. */
+    @Test
+    void oneOccurrenceAskedTwiceIsOneSubject() {
+        Terms terms = new Terms(Symbols.none());
+        Denotations at = Denotations.none();
+        Core once = unnameable();
+
+        assertEquals(terms.subjectOf(once, at), terms.subjectOf(once, at),
+                "an occurrence is asked about more than once, and it is one evaluation");
+    }
+
+    /**
+     * Rewriting does not create an evaluation.
+     *
+     * <p>A reading that replaces a conditional rebuilds every node on the way to it, so the very same
+     * call arrives as a different object in each reading. That is the check reconstructing a tree, not
+     * the program evaluating anything twice, and an occurrence that came through one is the occurrence
+     * it was built from.
+     *
+     * <p>Held as a law rather than left to the rewrite that happens to record it: what a fact is about
+     * has to survive the analysis rearranging its own input, and a reading that gave one call two
+     * evaluations would take a fact in under the first and read it back under the second — finding
+     * nothing, and reporting a construction it had already settled.
+     */
+    @Test
+    void rebuildingAnOccurrenceDoesNotMakeASecondEvaluation() {
+        Terms terms = new Terms(Symbols.none());
+        Denotations at = Denotations.none();
+        Core written = unnameable();
+        FactSubject before = terms.subjectOf(written, at);
+
+        Core rebuilt = unnameable();          // the same expression, built again by a rewrite
+        terms.rebuilt(rebuilt, written);
+
+        assertEquals(before, terms.subjectOf(rebuilt, at),
+                "a node a rewrite built is the occurrence it was built from");
+    }
+
+    /**
+     * And the pair of it: a second evaluation is a second subject.
+     *
+     * <p>The two are told apart by where they come from rather than by what they look like. Something
+     * a rewrite built is recorded as built from what it replaced; something the program evaluates
+     * again was never recorded, so it keeps the fresh identity it was given. Deciding it by how the
+     * two are written would be the mistake this whole model exists to avoid — two writings alike is
+     * exactly what a shareable value and an unshareable one have in common.
+     */
+    @Test
+    void anEvaluationNoRewriteAccountsForIsASecondEvaluation() {
+        Terms terms = new Terms(Symbols.none());
+        Denotations at = Denotations.none();
+
+        assertNotEquals(terms.subjectOf(unnameable(), at), terms.subjectOf(unnameable(), at),
+                "nothing said these were one occurrence, so they are two");
+    }
+
+    /** A value of a shape no term covers: applying whatever a binding holds, which may be a behavior
+     * injected from outside. */
+    private static Core unnameable() {
+        return new Core.Apply(new Core.Read("f", binding(1), Type.INT, POS), java.util.List.of(),
+                Type.INT, POS);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest.java
@@ -131,6 +131,61 @@ class WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest {
                 "nothing said these were one occurrence, so they are two");
     }
 
+    /**
+     * A build that answers exactly as many as its source, and that source, have one size subject.
+     *
+     * <p>This is the one place equivalence is strengthened by making {@link Terms#subjectOf} the only
+     * authority: read through the old one, {@code length(reverse(ns))} and {@code length(ns)} were two
+     * subjects. They are one value, and the table already says so — {@code Cardinality.SAME} is a
+     * statement about how many the result has, not about what this check happens to be able to
+     * follow, which is what makes it something identity may read.
+     *
+     * <p>Held as a unit rather than through a program, because no program tells the two apart today:
+     * the caller of {@code reportableSite} reads only whether it answered, so which subject it
+     * answered with reaches nothing yet. That is what makes this safe to unify now, and it is also why
+     * the rule needs holding here — nothing downstream would notice it going away.
+     */
+    @Test
+    void aSizeAndTheSizeOfWhatItWasBuiltFromAreOneSubject() {
+        Terms terms = new Terms(Symbols.none());
+        BindingId ns = binding(2);
+        Denotations at = Denotations.none().location(ns);
+        Core list = new Core.Read("ns", ns, Type.list(Type.INT), POS);
+
+        FactSubject ofTheSource = terms.subjectOf(length(list), at);
+        assertNotNull(ofTheSource, "a size is a value this names, or the two below are one nothing");
+        assertEquals(ofTheSource, terms.subjectOf(length(reverse(list)), at),
+                "`reverse` answers exactly as many, so the two sizes are the one value");
+    }
+
+    /** And an operation the same table says may answer fewer is not identified with its source. */
+    @Test
+    void aSizeOfABuildThatMayAnswerFewerIsItsOwnSubject() {
+        Terms terms = new Terms(Symbols.none());
+        BindingId ns = binding(3);
+        Denotations at = Denotations.none().location(ns);
+        Core list = new Core.Read("ns", ns, Type.list(Type.INT), POS);
+
+        assertNotEquals(terms.subjectOf(length(list), at),
+                terms.subjectOf(length(distinct(list)), at),
+                "`distinct` may answer fewer, so its size is a value of its own");
+    }
+
+    private static Core length(Core of) {
+        return new Core.PreservedCall(new souther.compiler.types.ValueName.Stdlib("List", "length"),
+                java.util.List.of(of), Type.INT, POS);
+    }
+
+    private static Core reverse(Core of) {
+        return new Core.PreservedCall(new souther.compiler.types.ValueName.Stdlib("List", "reverse"),
+                java.util.List.of(of), of.type(), POS);
+    }
+
+    private static Core distinct(Core of) {
+        return new Core.PreservedCall(new souther.compiler.types.ValueName.Stdlib("List", "distinct"),
+                java.util.List.of(of), of.type(), POS);
+    }
+
     /** A value of a shape no term covers: applying whatever a binding holds, which may be a behavior
      * injected from outside. */
     private static Core unnameable() {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest.java
@@ -149,6 +149,33 @@ class WhatMakesTwoSubjectsOneIsAskedWhereASubjectIsBuiltTest {
                 "and each ask is its own");
     }
 
+    /**
+     * A size taken over a part of an evaluation composes with it, like anything else built over one.
+     *
+     * <p>Held because this is where a closure that only went one level deep would show: the size rule
+     * keys a count over the container it is really the size of, and that container is here a field of
+     * something the term grammar cannot name. Were the composition to stop at either step, one
+     * writing of this in a guard and another in a clause would be two values, and the guard could
+     * never discharge the clause.
+     */
+    @Test
+    void aSizeOverAPartOfAnEvaluationComposesWithIt() {
+        Terms terms = new Terms(Symbols.none());
+        Denotations at = Denotations.none();
+        Core answer = unnameable();
+
+        assertEquals(terms.subjectOf(length(items(answer)), at),
+                terms.subjectOf(length(items(answer)), at),
+                "one count of one field of one evaluation is one value");
+        assertNotEquals(terms.subjectOf(length(items(answer)), at),
+                terms.subjectOf(length(items(unnameable())), at),
+                "and over another evaluation it is another value");
+    }
+
+    private static Core items(Core of) {
+        return new Core.FieldAccess(of, "items", Type.list(Type.INT), POS);
+    }
+
     private static Core field(Core of, String name) {
         return new Core.FieldAccess(of, name, Type.INT, POS);
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatTheCheckWillNotGiveUpOnIsAskedByItsKindTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatTheCheckWillNotGiveUpOnIsAskedByItsKindTest.java
@@ -74,10 +74,10 @@ class WhatTheCheckWillNotGiveUpOnIsAskedByItsKindTest {
         Denotations at = Denotations.none().location(a).location(b);
         Core.Read left = new Core.Read("a", a, Type.INT, POS);
         Core.Read right = new Core.Read("b", b, Type.INT, POS);
-        NumericDomain.LinearForm<Term> product = terms.affineOf(
+        NumericDomain.LinearForm<FactSubject> product = terms.affineOf(
                 new Core.Binary(Hir.BinOp.MUL, left, right, CoverageOrigin.unwritten(), Type.INT,
                         POS), at);
-        Term atom = product.coefs().keySet().iterator().next();
+        FactSubject atom = product.coefs().keySet().iterator().next();
 
         assertThrows(Terms.OneTermTwoDerivations.class, () -> InvariantChecker.gaveUp("a test",
                 new Terms.OneTermTwoDerivations("atom `" + atom.rendered() + "` two ways")));
@@ -90,7 +90,7 @@ class WhatTheCheckWillNotGiveUpOnIsAskedByItsKindTest {
         Terms terms = new Terms(Symbols.none());
         BindingId a = binding(0);
         Denotations at = Denotations.none().location(a);
-        Term atom = terms.atomOf(new Core.Read("a", a, Type.INT, POS), at);
+        FactSubject atom = terms.atomOf(new Core.Read("a", a, Type.INT, POS), at);
 
         assertThrows(DerivedBounds.AnAtomComputedFromItself.class,
                 () -> InvariantChecker.gaveUp("a test",

--- a/souther-compiler/src/test/java/souther/compiler/check/WhetherAPathIsReachedIsAskedOfEveryDomainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhetherAPathIsReachedIsAskedOfEveryDomainTest.java
@@ -119,8 +119,8 @@ class WhetherAPathIsReachedIsAskedOfEveryDomainTest {
     // --- the question itself -------------------------------------------------------------------
 
     private static final Term.Interner NAMES = new Term.Interner();
-    private static final Term A_PREDICATE = NAMES.written("some predicate");
-    private static final Term A_POSITION = NAMES.written("some position");
+    private static final FactSubject A_PREDICATE = FactSubject.of(NAMES.written("some predicate"));
+    private static final FactSubject A_POSITION = FactSubject.of(NAMES.written("some position"));
 
     /**
      * Each domain at its own bottom, asked of the walk's own question.

--- a/souther-compiler/src/test/java/souther/compiler/check/WhetherAValueExistsIsAskedOfEveryDomainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhetherAValueExistsIsAskedOfEveryDomainTest.java
@@ -44,8 +44,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class WhetherAValueExistsIsAskedOfEveryDomainTest {
 
     private static final Term.Interner NAMES = new Term.Interner();
-    private static final Term A_PREDICATE = NAMES.written("some predicate");
-    private static final Term A_POSITION = NAMES.written("some position");
+    private static final FactSubject A_PREDICATE = FactSubject.of(NAMES.written("some predicate"));
+    private static final FactSubject A_POSITION = FactSubject.of(NAMES.written("some position"));
 
     /** Nothing taken in leaves every value there was. */
     @Test
@@ -157,6 +157,6 @@ class WhetherAValueExistsIsAskedOfEveryDomainTest {
      * domain in it has nothing to say. */
     @Test
     void aDomainWithNothingToSayIsNotADomainThatHoldsNothing() {
-        assertFalse(NumericDomain.<Term>top().isBottom());
+        assertFalse(NumericDomain.<FactSubject>top().isBottom());
     }
 }


### PR DESCRIPTION
Closes #819.

A behavior whose output has no cases is never matched, so its answer was named by nothing. A
construction downstream of such a call was not proved, not refuted, and not reported — the same
`Found` handed *in* as a parameter carried its type's invariant all along, and handed *back* as an
answer carried nothing. The issue reads as a gap about cases. It is not: it is what happens when a
value can be pointed at but not shared, and the model had nowhere to put one.

`Term` said of itself that it was "the identity two writings of one value share". That is two
questions given one answer, and the only constructor of a name for a call interns on the callee and
the arguments — so naming a behavior's answer would have claimed that two asks answer alike, which
is false for one that reaches outside the language. Refused a name, it got no subject at all.

Four axes come out of it, and most of this branch is keeping them apart.

    Identity      what a fact is about            FactSubject over one Term algebra
    Equivalence   which two are one value         decided where a subject is built
    Knowledge     what holds of it here           Known
    Reporting     what the author is asked        reportableSite, and the obligation gate

## What each commit does

**Tell apart what a fact is about from what makes two of them one.** `FactSubject` is the identity.
Readability stops being carried on a denotation. `siteKey` becomes `reportableSite`, with the
written-value suppression kept out of the judgment on purpose: a literal's key is one a guard naming
it puts in `spoken`, so folded in it would come back readable through the wrong half. `asWritten`
moves to `Terms`, held by two laws — rewriting does not create an evaluation, and an evaluation no
rewrite accounts for is a second one.

**Ask one thing what a fact is about.** `termOf` and `subjectOf` both answered it; `subjectOf` is the
one, and `termOf` is private and builds terms.

**Carry what a behavior guarantees of its answer to whoever called it.** An answer has a subject, so
its type's invariant and its `ensures` have somewhere to go. What makes an answer one of these is
that whoever produced it had already established what its type states — not the shape of the node,
and not what kind of subject it has. A construction written here is not: seeded as one, a
construction over a value nothing was known of came out proved, and came out proved with the very
clause meant to establish it taken away.

**Close identity under composition.** `length(xs)` over an answer was a fresh occurrence every time
it was written. `Term` gains one nominal leaf whose payload is identity-equal, and everything else
stays structural, so composition over it interns like anything else — which deletes the second
projection machinery rather than adding one. Closing it broke a coincidence the readability rule
rested on, so the rule is stated: a clause may be owed here when every atom it rests on is a place or
is one something on this path has spoken of. Asked of the relation rather than its two sides, and
asked only of an obligation — an assumption is where knowledge comes from, so requiring one to spend
what it produces is the circle it looks like.

**Make one thing the authority everywhere.** Seven places still built a subject from the symbolic
key, so a numeric guarantee over an answer reached its caller and a predicate one did not. There is
no `FactSubject.of(bodyKey(...))` left in production. That made a second thing vacuous — `read` said
whether a rule read a condition, and once every condition names something it was always true, so 852
occasions of this compiler not reaching a fold were reported as facts about the model. It is decided
from the symbolic reading now, which is the question it was always asking.

**Say what a proof rests on, and separately what the reading understood.** Splitting that flag left
one caller using it for the other meaning: `Proof.conditionsThatCannotAllHold` dropped a guard over
an answer and named the guards it had read, saying those cannot all hold when they plainly can.
`Assumed` carries both now — what was taken in is what a proof may rest on, what was read is what an
unsettled arm is owed.

## What moved

Against `origin/develop`, over every construction site the two share:

    UNREPRESENTABLE -> PROVED               3
    UNREPRESENTABLE -> PROVED, REFUTED      1
    anything leaving PROVED or REFUTED      0

Nothing that was proved stopped being proved and nothing that was refuted stopped being refused. No
new warning: what moved was silence, into the domain.

## Controls

Declaring nothing about an answer leaves nothing for a clause to be discharged from, so the
construction is silent — correctly, and as it was before any of this. Silence is therefore the wrong
control for silence, and every test here pairs the passing case with a guarantee that *refutes* the
construction, which can only refuse by having reached it. That covers the numeric guarantee, the
predicate one, and the answer's own type invariant.

## What is left

#824 — a `match` creates a subject for the answer rather than refining the one it has, and `Denotes`
still carries more than one thing. #826 — the seeding walk re-reads the subtree at every node.
Neither is a defect a program can show; both are measured in the issues.

## Verification

Full reactor green under `CI=1 mvn -Plint` on `origin/develop` (5e4de6b2) — compiler 5237, syntax
2257, lsp 267, cli 340, 0 failures. Conformance snapshots unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)