### PR TITLE
Answer with what a module's names mean, and check a body against what it names

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Scoping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Scoping.java
@@ -90,7 +90,7 @@ public final class Scoping {
         Resolve.Values values = new Resolve.Values(
                 reachable(universe, subject, imports), new OfTheUniverse(universe));
         refused.addAll(oneSpellingTwice(subject, ownData));
-        return new Scoped(m.name(), denotations, aliases, values, imports, refused);
+        return new Scoped(new Meanings(m.name(), denotations, aliases), values, imports, refused);
     }
 
     /**
@@ -371,32 +371,39 @@ public final class Scoping {
      * universe, leaving what an import brought in decided by one and what a qualifier names by the
      * other. The declaration registry is handed over at the point of use for the opposite reason:
      * one compilation genuinely reads one scope against three stages of its declarations.
+     *
+     * <p>{@link Meanings} is the part of it that is a value on its own, and a reader wanting only
+     * to know what a name means here is handed that rather than this.
      */
-    public record Scoped(String module, Map<String, Denotation> denotations,
-                         Map<String, String> aliases, Resolve.Values values,
+    public record Scoped(Meanings meanings, Resolve.Values values,
                          ResolvedImports imports, List<Refusal> refused) {
 
-        /** Copied, for the reason {@link Exposing.Checked} is: this is an answer a compilation
-         *  remembers, and an answer it remembers is a value. */
+        /**
+         * Copied, for the reason {@link Exposing.Checked} is: this is an answer a compilation
+         * remembers, and an answer it remembers is a value.
+         *
+         * <p>This one is not one yet. Two of these assembled from one input are unequal, because
+         * the way of asking the universe a further question holds the store it asks — which is a
+         * capability in an answer, and is on the register
+         * {@code EquivalentDatabasesAnswerTheSameTest} keeps.
+         */
         public Scoped {
-            denotations = Collections.unmodifiableMap(new LinkedHashMap<>(denotations));
-            aliases = Collections.unmodifiableMap(new LinkedHashMap<>(aliases));
             refused = List.copyOf(refused);
         }
 
-        /**
-         * What {@code Resolve} reads this module against, over the declarations as they were
-         * written.
-         *
-         * <p>Made here and not by a caller holding the parts. The scope, the aliases and the module
-         * name come out of one assembly and mean nothing apart from each other; passed separately
-         * they could be paired with parts of another, and nothing in what a caller was holding
-         * would have said so. The registry is the one thing left to hand over, because it really is
-         * a free axis: one compilation reads the same scope against its written, its resolved and
-         * its derived declarations.
-         */
-        public SyntaxSymbols writtenSymbols(Registry<Ast.Def> registry) {
-            return SyntaxSymbols.of(module, registry, denotations, aliases);
+        /** The module being scoped. */
+        public String module() {
+            return meanings.module();
+        }
+
+        /** What each type spelling written here denotes. */
+        public Map<String, Denotation> denotations() {
+            return meanings.denotations();
+        }
+
+        /** What each {@code import ... as} alias reaches. */
+        public Map<String, String> aliases() {
+            return meanings.aliases();
         }
 
         /** What this module can name in the value namespace, on its own. What a reader wanting to
@@ -404,7 +411,42 @@ public final class Scoping {
         public Resolve.Reachable reachable() {
             return values.reachable();
         }
+    }
 
+    /**
+     * What the names written in a module mean: what each type spelling denotes, and what each alias
+     * reaches.
+     *
+     * <p>Apart from {@link Scoped} because it is the part of a scope that is a value and nothing
+     * else. What a module is resolved against is this together with the value namespace and a way
+     * of asking the universe a further question, and those two are not values of this kind — one
+     * carries a way of reading the modules around this one, which is a thing to do rather than a
+     * thing to compare. A reader that only wants to know what a name means here is handed this, and
+     * two of them coming out the same is what lets everything below stop.
+     *
+     * <p>Which is what a behavior being declared shows: the value namespace gains a name and this
+     * does not, because a behavior is not a type. Read as part of the whole assembly, that edit
+     * arrived at every reader of what the names mean; read as this, it arrives at none of them.
+     *
+     * <p>The three parts are here together and not handed over one at a time, for the reason
+     * {@link Scoped} gives: the module name, the scope and the aliases come out of one assembly and
+     * mean nothing apart from each other, so a caller putting them together could pair parts of two.
+     * The declaration registry is the one axis that stays free, because one compilation genuinely
+     * reads one set of meanings against its written, its resolved and its derived declarations.
+     */
+    public record Meanings(String module, Map<String, Denotation> denotations,
+                           Map<String, String> aliases) {
+
+        public Meanings {
+            denotations = Collections.unmodifiableMap(new LinkedHashMap<>(denotations));
+            aliases = Collections.unmodifiableMap(new LinkedHashMap<>(aliases));
+        }
+
+        /** What {@code Resolve} reads this module against, over the declarations as they were
+         *  written. */
+        public SyntaxSymbols writtenSymbols(Registry<Ast.Def> registry) {
+            return SyntaxSymbols.of(module, registry, denotations, aliases);
+        }
 
         /** The same over a stage of the declarations something has resolved. */
         public Symbols symbolsOver(Registry<Hir.Def> registry) {

--- a/souther-compiler/src/main/java/souther/compiler/meta/PublishedUniverse.java
+++ b/souther-compiler/src/main/java/souther/compiler/meta/PublishedUniverse.java
@@ -248,7 +248,7 @@ public final class PublishedUniverse {
                     ScopeRefusals.of(scoped.refused()));
         }
         Resolve.Resolution resolution = Resolve.resolving(readable.module(),
-                scoped.writtenSymbols(registry), scoped.values());
+                scoped.meanings().writtenSymbols(registry), scoped.values());
         if (!resolution.unresolved().isEmpty()) {
             // What resolution has for each of them is a report, written for an author holding the
             // file and quoting the line — a line of the text this reading assembled. So what

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -191,7 +191,7 @@ public final class Adequacy {
         @Override
         public Answer<Map<String, InputDomain>> compute(Db db) {
             Answer<souther.compiler.check.Prepared> prepared = db.ask(new Shapes.Prepared(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(name));
             Answer<Hir.Module> settled = db.ask(new Bodies.Settled(name));
             if (!prepared.present() || !scope.present() || !sigs.present() || !settled.present()) {
@@ -277,7 +277,7 @@ public final class Adequacy {
         @Override
         public Answer<Map<String, souther.compiler.check.PathReachability.Answers>> compute(Db db) {
             Answer<souther.compiler.check.Prepared> prepared = db.ask(new Shapes.Prepared(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             if (!prepared.present() || !scope.present()) {
                 return Answer.absent();
             }
@@ -535,7 +535,7 @@ public final class Adequacy {
         @Override
         public Answer<Map<String, SignatureEvidence>> compute(Db db) {
             Answer<souther.compiler.check.Prepared> prepared = db.ask(new Shapes.Prepared(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(name));
             if (!prepared.present() || !scope.present() || !sigs.present()) {
                 return Answer.absent();
@@ -588,7 +588,7 @@ public final class Adequacy {
         @Override
         public Answer<Map<String, PartitionEvidence>> compute(Db db) {
             Answer<souther.compiler.check.Prepared> prepared = db.ask(new Shapes.Prepared(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(name));
             if (!prepared.present() || !scope.present() || !sigs.present()) {
                 return Answer.absent();
@@ -662,7 +662,7 @@ public final class Adequacy {
         @Override
         public Answer<Map<String, List<BoundaryAssessment>>> compute(Db db) {
             Answer<souther.compiler.check.Prepared> prepared = db.ask(new Shapes.Prepared(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(name));
             if (!prepared.present() || !scope.present() || !sigs.present()) {
                 return Answer.absent();
@@ -1257,7 +1257,7 @@ public final class Adequacy {
         @Override
         public Answer<Map<String, Filling>> compute(Db db) {
             Answer<souther.compiler.check.Prepared> prepared = db.ask(new Shapes.Prepared(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(name));
             if (!prepared.present() || !scope.present() || !sigs.present()) {
                 return Answer.absent();

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -297,7 +297,7 @@ public final class Bodies {
         public Answer<Map<ValueName.Behavior, Sig>> compute(Db db) {
             Answer<souther.compiler.check.Desugared.Module> desugared =
                     db.ask(new Shapes.Desugared(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             Answer<Map<ValueName.Behavior, Sig>> imported = db.ask(new Imported(name));
             if (!desugared.present() || !scope.present() || !imported.present()) {
                 return Answer.absent();
@@ -340,7 +340,7 @@ public final class Bodies {
         @Override
         public Answer<Map<String, BehaviorContract>> compute(Db db) {
             Answer<Lower.Lowered> lowering = db.ask(new Lowering(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             Answer<Map<String, Sig>> signatures = db.ask(new Signatures(name));
             Answer<Map<String, Type>> helpers = db.ask(new RecursiveHelperSigs(name));
             if (!lowering.present() || !scope.present() || !signatures.present()
@@ -397,7 +397,7 @@ public final class Bodies {
         @Override
         public Answer<Map<String, ContractDischarge>> compute(Db db) {
             Answer<Map<String, StatedContract>> stated = db.ask(new StatedContracts(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             if (!stated.present() || !scope.present()) {
                 return Answer.absent();
             }
@@ -587,7 +587,7 @@ public final class Bodies {
         @Override
         public Answer<Map<String, StatedContract>> compute(Db db) {
             Answer<souther.compiler.check.Expandable> expandable = db.ask(new Shapes.Expandable(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             Answer<Map<String, Sig>> signatures = db.ask(new Signatures(name));
             Answer<Map<String, Type>> helpers = db.ask(new RecursiveHelperSigs(name));
             if (!expandable.present() || !scope.present() || !signatures.present()
@@ -759,7 +759,7 @@ public final class Bodies {
         @Override
         public Answer<Map<ValueName.Behavior, ReqSig>> compute(Db db) {
             Answer<souther.compiler.check.Prepared> prepared = db.ask(new Shapes.Prepared(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             Answer<Map<ValueName.Behavior, Sig>> imported = db.ask(new Imported(name));
             Answer<Set<String>> own = db.ask(new Dependencies(name));
             Answer<Set<ValueName.Behavior>> borrowed = db.ask(new ImportedDependencies(name));
@@ -793,7 +793,7 @@ public final class Bodies {
         @Override
         public Answer<Map<ValueName.Behavior, ReqSig>> compute(Db db) {
             Answer<souther.compiler.check.Prepared> prepared = db.ask(new Shapes.Prepared(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             Answer<Map<ValueName.Behavior, Sig>> imported = db.ask(new Imported(name));
             Answer<Set<String>> own = db.ask(new Callable(name));
             Answer<Set<ValueName.Behavior>> borrowed = db.ask(new ImportedCallable(name));
@@ -849,7 +849,7 @@ public final class Bodies {
         @Override
         public Answer<Hir.Module> compute(Db db) {
             Answer<souther.compiler.check.Prepared> prepared = db.ask(new Shapes.Prepared(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             Answer<Map<ValueName.Behavior, ReqSig>> reqSigs = db.ask(new ReqSigs(name));
             if (!prepared.present() || !scope.present() || !reqSigs.present()) {
                 return Answer.absent();
@@ -1392,7 +1392,7 @@ public final class Bodies {
         @Override
         public Answer<Map<String, Type>> compute(Db db) {
             Answer<HelperInliner> inliner = expanding(db, name, InliningPolicy.FULL);
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             if (!inliner.present() || !scope.present()) {
                 return Answer.absent();
             }
@@ -1419,7 +1419,7 @@ public final class Bodies {
         public Answer<Map<String, DataChecker.Constructs>> compute(Db db) {
             Answer<HelperInliner> inliner = expanding(db, name, InliningPolicy.FULL);
             Answer<Map<String, Type>> sigs = db.ask(new RecursiveHelperSigs(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             if (!inliner.present() || !sigs.present() || !scope.present()) {
                 return Answer.absent();
             }
@@ -1506,7 +1506,7 @@ public final class Bodies {
             Answer<Hir.SpecBehavior> spec = db.ask(new Spec(module, behavior));
             Answer<Hir.FnDef> fn = db.ask(new SettledFn(module, behavior));
             Answer<Hir.FnDef> body = db.ask(new LoweredBody(module, behavior));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(module));
+            Answer<Symbols> scope = Names.derivedSymbols(db, module);
             Answer<Map<ValueName.Behavior, ReqSig>> calleeSigs = db.ask(new CalleeSigs(module));
             Answer<Map<ValueName.Behavior, ReqSig>> reqSigs = db.ask(new ReqSigs(module));
             Answer<HelperInliner> inliner = expanding(db, module, InliningPolicy.FULL);
@@ -1571,7 +1571,7 @@ public final class Bodies {
      */
     private static Map<String, souther.compiler.claims.Claims> judged(
             Db db, String module, Hir.Module settled, Map<String, Core> bodies) {
-        Answer<Symbols> scope = db.ask(new Shapes.Scope(module));
+        Answer<Symbols> scope = Names.derivedSymbols(db, module);
         Answer<Map<String, souther.compiler.inputs.InputDomain>> inputs =
                 db.ask(new souther.compiler.query.Adequacy.Inputs(module));
         if (!scope.present() || !inputs.present()) {
@@ -1649,7 +1649,7 @@ public final class Bodies {
         @Override
         public Answer<Of> compute(Db db) {
             Answer<Lower.Lowered> lowering = db.ask(new Lowering(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             // The signatures the check reads are the ones every other reader reads. Asked for here
             // rather than built here: a second construction would answer the boundary's question a
             // second time, and what a phase below the check is handed would be a different answer

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -565,6 +565,47 @@ public final class Bodies {
     }
 
     /**
+     * What the behaviors one body names take, by the name each is called under.
+     *
+     * <p>{@link CalleeSigs} is the module's index of everything callable in it, and a body wants the
+     * entries for what it calls. Read whole, it hands this body the module's identity: declaring a
+     * behavior no body calls changes the index, and every body of the module is checked again
+     * against signatures none of them names differently. Read here and projected, the index is still
+     * built once and what comes out of this is the same answer until one of these signatures moves.
+     *
+     * <p>Over what the body reaches rather than what it applies, which is the frontier
+     * {@link BehaviorsReached} draws and the same one a body's contracts are read at. That frontier
+     * is taken over the representation the discharge analysis reads, and this is handed to a check
+     * that reads the fully expanded one — which is the same set of names, because a helper cannot
+     * reach a behavior at all (E1818), so expanding one into a body brings no name the other tree
+     * has not got.
+     *
+     * <p>One lookup by name is all the check does with it, so a body that named something not in
+     * here would be told there is no such behavior — which is what a body naming something outside
+     * its own frontier would have to be. Nothing iterates it, so nothing sees a smaller module.
+     */
+    public record CalleeSigsForBody(String module, String behavior)
+            implements Key<Map<ValueName.Behavior, ReqSig>> {
+
+        @Override
+        public Answer<Map<ValueName.Behavior, ReqSig>> compute(Db db) {
+            Answer<Set<ValueName.Behavior>> targets = db.ask(new BehaviorsReached(module, behavior));
+            Answer<Map<ValueName.Behavior, ReqSig>> callable = db.ask(new CalleeSigs(module));
+            if (!targets.present() || !callable.present()) {
+                return Answer.absent();
+            }
+            Map<ValueName.Behavior, ReqSig> out = new LinkedHashMap<>();
+            for (ValueName.Behavior each : targets.value()) {
+                ReqSig sig = callable.value().get(each);
+                if (sig != null) {
+                    out.put(each, sig);
+                }
+            }
+            return Answer.of(Ordered.map(out));
+        }
+    }
+
+    /**
      * What each behavior of a module states about its answer, read into the representation the
      * analysis has rules about and typed there, by the name the behavior is declared under.
      *
@@ -1507,7 +1548,11 @@ public final class Bodies {
             Answer<Hir.FnDef> fn = db.ask(new SettledFn(module, behavior));
             Answer<Hir.FnDef> body = db.ask(new LoweredBody(module, behavior));
             Answer<Symbols> scope = Names.derivedSymbols(db, module);
-            Answer<Map<ValueName.Behavior, ReqSig>> calleeSigs = db.ask(new CalleeSigs(module));
+            // What this body names, and not what its module happens to have callable in it: a
+            // signature it never names is no part of what it is checked against, and depending on
+            // the module's index would re-check this body whenever a behavior beside it was declared.
+            Answer<Map<ValueName.Behavior, ReqSig>> calleeSigs =
+                    db.ask(new CalleeSigsForBody(module, behavior));
             Answer<Map<ValueName.Behavior, ReqSig>> reqSigs = db.ask(new ReqSigs(module));
             Answer<HelperInliner> inliner = expanding(db, module, InliningPolicy.FULL);
             Answer<Map<String, Type>> sigs = db.ask(new RecursiveHelperSigs(module));

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -4,7 +4,6 @@ import souther.compiler.source.SourceId;
 
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
-import souther.compiler.check.Symbols;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.LabeledRegion;
@@ -225,11 +224,6 @@ public final class Compilation {
      * recursive prelude helpers it reaches. Null where it did not get that far. */
     public Prepared module(String name) {
         return db.ask(new Shapes.Prepared(name)).value();
-    }
-
-    /** What the names in {@code module} denote — the table a question about a type is asked against. */
-    public Symbols symbols(String module) {
-        return db.ask(new Shapes.Scope(module)).value();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -52,9 +52,9 @@ import java.util.Set;
  * and no test of what the compiler answers can see the difference. Keeping the index is fine, and
  * so is reading one to answer a question about a single entry — {@link Bodies.Stated} does exactly
  * that. What a per-definition question may not do is take the index as its own dependency.
- * {@link Bodies.ContractsForBody} is a body's contracts asked entry by entry. Checking a body still reads its module's
- * {@link Shapes.Scope} and {@link Bodies.CalleeSigs} whole, so declaring a behavior re-checks every
- * body of the module; that is issue #829, and {@code IncrementalCompilationTest} pins both sides.
+ * {@link Bodies.ContractsForBody} is a body's contracts asked entry by entry. Checking a body still
+ * reads its module's {@link Bodies.CalleeSigs} whole, so declaring a behavior re-checks every body
+ * of the module; that is issue #829, and {@code IncrementalCompilationTest} pins it.
  *
  * <p>One store is one workspace over time, not one compile. It is not thread-safe and does not need
  * to be: the work inside a compile is a graph walk, not a set of independent jobs.

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -45,16 +45,35 @@ import java.util.Set;
  * What would is for an example to depend on the classes it reaches rather than on all of them,
  * which is per-definition work and not here.
  *
- * <p>Which is one case of the rule the rest of them are cases of. A collection gathered per module
- * is an index, and a question asked per definition depends on the entries it reaches rather than on
- * the index. Read whole, an index hands the finer question the coarser one's identity: an edit
- * anywhere in the module — or in a module it imports — arrives as an edit to every definition in it,
- * and no test of what the compiler answers can see the difference. Keeping the index is fine, and
- * so is reading one to answer a question about a single entry — {@link Bodies.Stated} does exactly
- * that. What a per-definition question may not do is take the index as its own dependency.
- * {@link Bodies.ContractsForBody} is a body's contracts asked entry by entry. Checking a body still
- * reads its module's {@link Bodies.CalleeSigs} whole, so declaring a behavior re-checks every body
- * of the module; that is issue #829, and {@code IncrementalCompilationTest} pins it.
+ * <p>Two rules run through the rest of them, and an answer can break either one.
+ *
+ * <p>A node is a value. What {@code equals} says is what stops work, so an answer says what it
+ * means and not where it came from; an answer that never equals the one it replaces leaves nothing
+ * downstream of it ever kept, while every test of what the compiler says stays green. That rules
+ * out a kind of thing and not a missing method: an object that reads this store when it is asked —
+ * a registry, a scope over one, a loader — is the same as another when the store is, which is where
+ * it came from. Those are built inside a {@code compute} and used there, which is also what makes
+ * their reads land on the question being answered. {@link Names#derivedSymbols} is one, handed out
+ * and not kept, and {@code EquivalentDatabasesAnswerTheSameTest} is what says which answers still
+ * break the rule.
+ *
+ * <p>An edge is what its consumer means. A collection gathered per module is an index, and a
+ * question asked per definition depends on the entries it reaches rather than on the index. Read
+ * whole, an index hands the finer question the coarser one's identity: an edit anywhere in the
+ * module — or in a module it imports — arrives as an edit to every definition in it, and again no
+ * test of what the compiler answers can see the difference. Keeping the index is fine, and so is
+ * reading one to answer a question about a single entry — {@link Bodies.Stated} does exactly that.
+ * What a per-definition question may not do is take the index as its own dependency.
+ *
+ * <p>Which does not mean every producer has to be split. What the consumer reads has to stop where
+ * its meaning stops, and a key between the two is where that happens: the broad answer is
+ * recomputed as often as its own inputs move, and the cut is what the consumer depends on.
+ * {@link Names.Meanings} is what a module's names mean, cut from the whole assembly they are read
+ * off — so declaring a behavior, which adds a value name, stops there. {@link Bodies.CalleeSigsForBody}
+ * is the signatures one body names, cut from its module's index of everything callable in it.
+ * {@link Bodies.ContractsForBody} is a body's contracts asked entry by entry. A body is still
+ * checked in what all of its module's names mean, so declaring a type re-checks every body of the
+ * module; that is what is left of issue #829, and {@code IncrementalCompilationTest} pins it.
  *
  * <p>One store is one workspace over time, not one compile. It is not thread-safe and does not need
  * to be: the work inside a compile is a graph walk, not a set of independent jobs.

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -286,6 +286,20 @@ public final class Db {
     }
 
     /**
+     * Every answer being kept, by the question it answers.
+     *
+     * <p>For the one reader that is about the store rather than about a compile: whether the answers
+     * it keeps are values is a question about all of them at once, and there is no question to ask
+     * that would enumerate them. Nothing in a compile reads this — a pass wanting an answer asks for
+     * the one it wants.
+     */
+    Map<Key<?>, Answer<?>> everyAnswer() {
+        Map<Key<?>, Answer<?>> out = new LinkedHashMap<>();
+        memos.forEach((key, memo) -> out.put(key, memo.answer()));
+        return out;
+    }
+
+    /**
      * A report, the module it is about, and the source the key that found it names — either of which
      * may be null.
      *

--- a/souther-compiler/src/main/java/souther/compiler/query/Key.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Key.java
@@ -12,6 +12,26 @@ import java.util.List;
  * free — and a key holds only what identifies the question, never a compilation, a registry or a
  * position, because anything held here would be part of the question's identity.
  *
+ * <p>The answer is a value too, and for a reason of the same kind. An edit is absorbed by an answer
+ * coming out equal to the one it replaces, so what {@code equals} says here is the whole of what
+ * stops work: an answer that never equals its predecessor makes everything that read it run again
+ * for as long as the compilation lives, and no test of what the compiler says can see it. So an
+ * answer says what it is, not where it came from — two of them are equal when they mean the same
+ * thing, and a value that compares by identity or by which store built it is not one of these.
+ *
+ * <p>Which rules out a kind of thing rather than a missing method. An object that reads {@link Db}
+ * when it is asked — a registry, a scope over one, a loader — has no such equality to give: two of
+ * them are the same when the store is, which says where they came from. These are what a
+ * {@code compute} builds and uses while it runs, never what one answers with, and building one
+ * inside the compute that reads it is also what makes its reads land on the question being answered
+ * rather than on nothing. {@link Names#derivedSymbols} is one, handed out and not kept.
+ *
+ * <p>A question asked per definition depends on what it reaches and not on the index its module
+ * gathered, which {@link Db} states. Those two rules meet at a projection: a broad answer read
+ * whole, cut down to what one consumer means, is a key of its own — the coarse answer may be
+ * recomputed as often as it likes, and what the consumer reads stops at the cut.
+ * {@link Bodies.CalleeSigsForBody} and {@link Names.Meanings} are the two.
+ *
  * <p>The answer lives on the key rather than in a dispatch table somewhere, so one class is one
  * question: what it is, what it reads, and what it does when it cannot answer are in one place. A
  * key reaches everything else it needs by asking {@link Db}, which is what makes the read

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -444,12 +444,12 @@ public final class Names {
 
     /** What names mean in a module over the declarations as resolution left them — what
      * {@link Resolved} is resolved against. */
-    public static Answer<Symbols> resolvedSymbols(Db db, String name) {
+    static Answer<Symbols> resolvedSymbols(Db db, String name) {
         return symbols(db, name, resolvedRegistry(db));
     }
 
     /** The same over the derived declarations — what everything below the check reads. */
-    public static Answer<Symbols> derivedSymbols(Db db, String name) {
+    static Answer<Symbols> derivedSymbols(Db db, String name) {
         return symbols(db, name, derivedRegistry(db));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -71,10 +71,10 @@ public final class Names {
      * A registry over this compilation, reading each module's declarations as resolution left them.
      *
      * <p>One of the two declaration worlds a module can be read against, and which one a reader gets
-     * is which question it asked: this one answers {@link NameScope}, and the derived one answers
-     * {@link Shapes.Scope}. Neither is chosen by a value handed in — a reader that could pass which
-     * world it wanted is a reader that could pass the wrong one, and nothing in what it was holding
-     * would say so.
+     * is which question it asked: this one answers {@link #resolvedSymbols}, and the derived one
+     * answers {@link #derivedSymbols}. Neither is chosen by a value handed in — a reader that could
+     * pass which world it wanted is a reader that could pass the wrong one, and nothing in what it
+     * was holding would say so.
      */
     static Registry<Hir.Def> resolvedRegistry(Db db) {
         return new Registry<Hir.Def>() {
@@ -150,8 +150,9 @@ public final class Names {
      * answers an identity from this registry and from the language's own vocabulary, and the
      * prelude's declarations are loaded resolved and kept out of derivation — so there is no derived
      * declaration for the second source to hand over, and the representation both can be in is the
-     * node. What says a reader is at the derived world is which query it asked: {@code Shapes.Scope}
-     * is built over this one and {@code Names.NameScope} over the resolved one.
+     * node. What says a reader is at the derived world is which of the two it asked for:
+     * {@link #derivedSymbols} is built over this one and {@link #resolvedSymbols} over the
+     * resolved one.
      */
     static Registry<Hir.Def> derivedRegistry(Db db) {
         return new Registry<Hir.Def>() {
@@ -400,47 +401,88 @@ public final class Names {
         };
     }
 
-    /** What names mean in a module, over the declaration world {@code registry} reads. */
-    private static Answer<Symbols> symbols(Db db, String name, Registry<Hir.Def> registry) {
-        Answer<Scoping.Scoped> scoped = db.ask(new ModuleScope(name));
-        if (!scoped.present()) {
-            return Answer.absent();
-        }
-        return Answer.of(scoped.value().symbolsOver(registry));
-    }
-
-    /** What names mean in a module over the declarations as resolution left them — what
-     * {@link NameScope} answers with, and what a reader asks for by asking that. */
-    static Answer<Symbols> resolvedSymbols(Db db, String name) {
-        return symbols(db, name, resolvedRegistry(db));
-    }
-
-    /** The same over the derived declarations — {@link Shapes.Scope}'s answer. */
-    static Answer<Symbols> derivedSymbols(Db db, String name) {
-        return symbols(db, name, derivedRegistry(db));
-    }
-
-    /** The same, over the declarations as they were written — what {@code Resolve} resolves
-     * against. */
-    static Answer<SyntaxSymbols> writtenSymbols(Db db, String name) {
-        Answer<Scoping.Scoped> scoped = db.ask(new ModuleScope(name));
-        if (!scoped.present()) {
-            return Answer.absent();
-        }
-        return Answer.of(scoped.value().writtenSymbols(writtenRegistry(db)));
-    }
-
-    /** What names mean in a module before anything is derived from it — what {@link Resolved}
-     * resolves against. */
-    public record NameScope(String name) implements Key<Symbols> {
+    /**
+     * What the names written in a module mean — the part of its scope that is a value.
+     *
+     * <p>The cutoff every reader of a scope stops at. A module is assembled once and the assembly
+     * holds more than this: the value namespace, a way of asking the modules around it a further
+     * question, and what its import lines could not do. A body is checked against none of those and
+     * against this, so declaring a behavior — which adds a value name and no type name — comes out
+     * here as the answer that was already there, and nothing that reads it runs again.
+     */
+    public record Meanings(String name) implements Key<Scoping.Meanings> {
         @Override
         public String module() {
             return name;
         }
 
         @Override
-        public Answer<Symbols> compute(Db db) {
-            return resolvedSymbols(db, name);
+        public Answer<Scoping.Meanings> compute(Db db) {
+            Answer<Scoping.Scoped> scoped = db.ask(new ModuleScope(name));
+            return scoped.present() ? Answer.of(scoped.value().meanings()) : Answer.absent();
+        }
+    }
+
+    /**
+     * What names mean in a module, over the declaration world {@code registry} reads.
+     *
+     * <p>Built where it is used and never kept. What comes back reads declarations by asking this
+     * store, so it is a way of asking rather than an answer: two of them are the same when the
+     * store is, which says where they came from and not what they say. Kept as an answer, it would
+     * be an answer that never equals the one it replaces, and everything that read it would run
+     * again for as long as the compilation lived. Built here, the reads it makes are recorded
+     * against whichever question was being answered when it made them — which is one declaration at
+     * a time, and is the finer dependency this hands out.
+     */
+    private static Answer<Symbols> symbols(Db db, String name, Registry<Hir.Def> registry) {
+        Answer<Scoping.Meanings> meanings = db.ask(new Meanings(name));
+        if (!meanings.present()) {
+            return Answer.absent();
+        }
+        return Answer.of(meanings.value().symbolsOver(registry));
+    }
+
+    /** What names mean in a module over the declarations as resolution left them — what
+     * {@link Resolved} is resolved against. */
+    public static Answer<Symbols> resolvedSymbols(Db db, String name) {
+        return symbols(db, name, resolvedRegistry(db));
+    }
+
+    /** The same over the derived declarations — what everything below the check reads. */
+    public static Answer<Symbols> derivedSymbols(Db db, String name) {
+        return symbols(db, name, derivedRegistry(db));
+    }
+
+    /** The same, over the declarations as they were written — what {@code Resolve} resolves
+     * against. */
+    static Answer<SyntaxSymbols> writtenSymbols(Db db, String name) {
+        Answer<Scoping.Meanings> meanings = db.ask(new Meanings(name));
+        if (!meanings.present()) {
+            return Answer.absent();
+        }
+        return Answer.of(meanings.value().writtenSymbols(writtenRegistry(db)));
+    }
+
+    /**
+     * Every bare spelling that reaches a definition in a module, and the definition it reaches —
+     * this module's own plus the ones it imported.
+     *
+     * <p>The one question a scope answers that needs both of its halves, asked here so that what a
+     * reader outside the compile gets is the answer and not the way of reading it. What a scope
+     * hands out reads declarations by asking this store, and a reader holding one past the question
+     * it was built for makes reads nothing records; the answer is a map of declarations, which is a
+     * value, so there is nothing left to hold.
+     */
+    public record Reachable(String name) implements Key<Map<String, Hir.Def>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, Hir.Def>> compute(Db db) {
+            Answer<Symbols> symbols = resolvedSymbols(db, name);
+            return symbols.present() ? Answer.of(symbols.value().reachable()) : Answer.absent();
         }
     }
 
@@ -470,7 +512,7 @@ public final class Names {
             Resolve.Resolution resolution;
             try {
                 resolution = Resolve.resolving(available.value(),
-                        scoped.value().writtenSymbols(writtenRegistry(db)),
+                        scoped.value().meanings().writtenSymbols(writtenRegistry(db)),
                         scoped.value().values());
             } catch (CompileException e) {
                 return Answer.absent(e);

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -128,7 +128,7 @@ public final class Output {
         static Inputs inputs(Db db, String name) {
             Answer<Bodies.Elaborated> checked = db.ask(new Bodies.Checked(name));
             Answer<Lower.Lowered> lowering = db.ask(new Bodies.Lowering(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             // The same answer the check read. The backend replays the composition walk and emits
             // the codecs a signature says are needed, so building its own would be the boundary's
             // question answered a third time.
@@ -592,7 +592,7 @@ public final class Output {
         @Override
         public Answer<Boolean> compute(Db db) {
             Answer<souther.compiler.check.Prepared> prepared = db.ask(new Shapes.Prepared(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             if (!prepared.present() || !scope.present()) {
                 return Answer.absent();
             }
@@ -646,7 +646,7 @@ public final class Output {
          */
         private String failingClause(Db db, DataChecker.ConstCheck check, Class<?> ctfe) {
             Answer<souther.compiler.check.Prepared> declaring = db.ask(new Shapes.Prepared(check.type().module()));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(check.type().module()));
+            Answer<Symbols> scope = Names.derivedSymbols(db, check.type().module());
             if (!declaring.present() || !scope.present()) {
                 return null;
             }
@@ -709,7 +709,7 @@ public final class Output {
         @Override
         public Answer<souther.compiler.examples.ExampleStatements.Readings> compute(Db db) {
             Answer<souther.compiler.check.Prepared> prepared = db.ask(new Shapes.Prepared(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(name));
             if (!prepared.present() || !scope.present() || !sigs.present()) {
                 return Answer.absent();
@@ -941,7 +941,7 @@ public final class Output {
          */
         private static List<Diagnostic> fakeTables(Db db, String name, SourceId sourceId) {
             Answer<souther.compiler.check.Prepared> prepared = db.ask(new Shapes.Prepared(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(name));
             if (!prepared.present() || !scope.present() || !sigs.present()) {
                 return List.of();
@@ -982,7 +982,7 @@ public final class Output {
         static Answer<Of> evaluate(Db db, String name, SourceId sourceId, EvaluationArtifact artifact,
                                    CoverageMode coverage) {
             Answer<souther.compiler.check.Prepared> prepared = db.ask(new Shapes.Prepared(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(name));
             if (!prepared.present() || !scope.present() || !sigs.present()) {
                 return Answer.absent();

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -71,7 +71,7 @@ public final class Shapes {
             if (!expandable.present()) {
                 return Answer.absent();
             }
-            Answer<Symbols> scope = db.ask(new Names.NameScope(name));
+            Answer<Symbols> scope = Names.resolvedSymbols(db, name);
             if (!scope.present()) {
                 return Answer.absent();
             }
@@ -189,7 +189,7 @@ public final class Shapes {
         @Override
         public Answer<Map<String, souther.compiler.check.Derived.Def>> compute(Db db) {
             Answer<InvariantSettled> settling = db.ask(new Settling(name));
-            Answer<Symbols> scope = db.ask(new Names.NameScope(name));
+            Answer<Symbols> scope = Names.resolvedSymbols(db, name);
             if (!settling.present() || !scope.present()) {
                 return Answer.absent();
             }
@@ -281,7 +281,7 @@ public final class Shapes {
         @Override
         public Answer<Map<String, souther.compiler.check.Desugared.Fn>> compute(Db db) {
             Answer<InvariantSettled> settling = db.ask(new Settling(name));
-            Answer<Symbols> scope = db.ask(new Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             if (!settling.present() || !scope.present()) {
                 return Answer.absent();
             }
@@ -346,7 +346,7 @@ public final class Shapes {
         @Override
         public Answer<souther.compiler.check.Prepared> compute(Db db) {
             Answer<souther.compiler.check.Desugared.Module> desugared = db.ask(new Desugared(name));
-            Answer<Symbols> scope = db.ask(new Scope(name));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
             Answer<Map<String, Hir.FnDef>> imported = db.ask(new Bodies.ImportedDefinitions(name));
             // What each behavior takes and answers with, from the one place that settles it: a
             // composition's shape is worked out there and nowhere else, and a dependency another
@@ -370,19 +370,6 @@ public final class Shapes {
         }
     }
 
-    /** What names mean in a module once everything is derived — the scope a check runs in. */
-    public record Scope(String name) implements Key<Symbols> {
-        @Override
-        public String module() {
-            return name;
-        }
-
-        @Override
-        public Answer<Symbols> compute(Db db) {
-            return Names.derivedSymbols(db, name);
-        }
-    }
-
     /**
      * How each clause of each invariant this module declares can be discharged at compile time (spec
      * §invariant-discharge-capability), in the order the clauses are written.
@@ -400,7 +387,7 @@ public final class Shapes {
         @Override
         public Answer<Map<TypeSymbol, List<ClauseDischarge>>> compute(Db db) {
             Answer<souther.compiler.check.Expandable> expandable = db.ask(new Expandable(name));
-            Answer<Symbols> scope = db.ask(new Names.NameScope(name));
+            Answer<Symbols> scope = Names.resolvedSymbols(db, name);
             if (!expandable.present() || !scope.present()) {
                 return Answer.absent();
             }
@@ -461,7 +448,7 @@ public final class Shapes {
         @Override
         public Answer<Map<TypeSymbol, List<Hir.InvariantClause>>> compute(Db db) {
             Answer<souther.compiler.check.Expandable> expandable = db.ask(new Expandable(name));
-            Answer<Symbols> scope = db.ask(new Names.NameScope(name));
+            Answer<Symbols> scope = Names.resolvedSymbols(db, name);
             if (!expandable.present() || !scope.present()) {
                 return Answer.absent();
             }

--- a/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
@@ -2,6 +2,7 @@ package souther.compiler;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
@@ -15,7 +16,6 @@ import souther.compiler.partition.AxisId;
 import souther.compiler.partition.GenerationReason;
 import souther.compiler.partition.Generator;
 import souther.compiler.partition.Partitions;
-import souther.compiler.query.Names;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
@@ -69,7 +69,7 @@ class AGenerationThatWentOnDoesNotSayItStoppedTest {
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
                 .filter(b -> b.name().equals("submit")).findFirst().orElseThrow();
         Sig sig = sigs.get("submit");

--- a/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
@@ -15,6 +15,7 @@ import souther.compiler.partition.AxisId;
 import souther.compiler.partition.GenerationReason;
 import souther.compiler.partition.Generator;
 import souther.compiler.partition.Partitions;
+import souther.compiler.query.Names;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
@@ -68,7 +69,7 @@ class AGenerationThatWentOnDoesNotSayItStoppedTest {
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
                 .filter(b -> b.name().equals("submit")).findFirst().orElseThrow();
         Sig sig = sigs.get("submit");

--- a/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
@@ -452,7 +452,7 @@ class CompileFakeExampleDisagreementTest {
                 c.db().ask(new souther.compiler.query.Shapes.Prepared(name)).value();
         return ExampleStatements.disagreements(
                 prepared.forExamples(),
-                c.db().ask(new souther.compiler.query.Shapes.Scope(name)).value(),
+                souther.compiler.query.Names.derivedSymbols(c.db(), name).value(),
                 c.db().ask(new souther.compiler.query.Bodies.Signatures(name)).value(),
                 c.db().ask(new souther.compiler.query.Output.EvaluationLinked(
                         name, souther.compiler.query.Output.CoverageMode.NONE)).value().classes(),

--- a/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
@@ -452,7 +452,7 @@ class CompileFakeExampleDisagreementTest {
                 c.db().ask(new souther.compiler.query.Shapes.Prepared(name)).value();
         return ExampleStatements.disagreements(
                 prepared.forExamples(),
-                souther.compiler.query.Names.derivedSymbols(c.db(), name).value(),
+                souther.compiler.query.Scopes.derived(c.db(), name).value(),
                 c.db().ask(new souther.compiler.query.Bodies.Signatures(name)).value(),
                 c.db().ask(new souther.compiler.query.Output.EvaluationLinked(
                         name, souther.compiler.query.Output.CoverageMode.NONE)).value().classes(),

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldIsBoundByTheDeclarationThatWroteItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldIsBoundByTheDeclarationThatWroteItTest.java
@@ -94,7 +94,7 @@ class AFieldIsBoundByTheDeclarationThatWroteItTest {
 
     /** The clauses as the module named {@code reading} reads them. */
     private static Clauses readBy(Compilation c, String reading) {
-        return new Clauses(c.db().ask(new Names.NameScope(reading)).value(), Map.of());
+        return new Clauses(Names.resolvedSymbols(c.db(), reading).value(), Map.of());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldIsBoundByTheDeclarationThatWroteItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldIsBoundByTheDeclarationThatWroteItTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.check;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.Compiler;
 import org.junit.jupiter.api.Test;
 
@@ -94,7 +95,7 @@ class AFieldIsBoundByTheDeclarationThatWroteItTest {
 
     /** The clauses as the module named {@code reading} reads them. */
     private static Clauses readBy(Compilation c, String reading) {
-        return new Clauses(Names.resolvedSymbols(c.db(), reading).value(), Map.of());
+        return new Clauses(Scopes.resolved(c.db(), reading).value(), Map.of());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldsFloorIsTheRecordsRuleAboutWhatItHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldsFloorIsTheRecordsRuleAboutWhatItHoldsTest.java
@@ -2,8 +2,8 @@ package souther.compiler.check;
 
 import souther.compiler.ast.Hir;
 import souther.compiler.numeric.Count;
+import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
-import souther.compiler.query.Shapes;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
 import souther.compiler.types.TypeSymbol;
@@ -36,7 +36,7 @@ class AFieldsFloorIsTheRecordsRuleAboutWhatItHoldsTest {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         String module = compilation.modules().get(0);
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         assertNotNull(symbols, "the model did not compile");
         TypeSymbol named = TypeSymbols.declared(new TypeKey(module, type));
         Hir.Data data = (Hir.Data) symbols.declarations().declaration(named.key());

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldsFloorIsTheRecordsRuleAboutWhatItHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldsFloorIsTheRecordsRuleAboutWhatItHoldsTest.java
@@ -1,8 +1,8 @@
 package souther.compiler.check;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.numeric.Count;
-import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
@@ -36,7 +36,7 @@ class AFieldsFloorIsTheRecordsRuleAboutWhatItHoldsTest {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         String module = compilation.modules().get(0);
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(symbols, "the model did not compile");
         TypeSymbol named = TypeSymbols.declared(new TypeKey(module, type));
         Hir.Data data = (Hir.Data) symbols.declarations().declaration(named.key());

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldsRangeIsTheRecordsRuleProjectedOntoItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldsRangeIsTheRecordsRuleProjectedOntoItTest.java
@@ -1,8 +1,8 @@
 package souther.compiler.check;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.numeric.NumericDomain;
-import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
@@ -33,7 +33,7 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         String module = compilation.modules().get(0);
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(symbols, "the model did not compile");
         TypeSymbol named = TypeSymbols.declared(new TypeKey(module, type));
         Hir.Data data = (Hir.Data) symbols.declarations().declaration(named.key());
@@ -297,7 +297,7 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
                 data Forecast = { total: Amount }
                 """), souther.compiler.meta.ModulePath.EMPTY);
         compilation.answerEverything();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), "example.report").value();
+        Symbols symbols = Scopes.derived(compilation.db(), "example.report").value();
         assertNotNull(symbols, "the model did not compile");
         TypeSymbol named = TypeSymbols.declared(new TypeKey("example.report", "Forecast"));
         FieldDomains domains = FieldDomains.of(named, (Hir.Data) symbols.declarations().declaration(named.key()), symbols);
@@ -364,7 +364,7 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
                     invariant ordered = a < b
                 """), souther.compiler.meta.ModulePath.EMPTY);
         compilation.answerEverything();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), "example.pair").value();
+        Symbols symbols = Scopes.derived(compilation.db(), "example.pair").value();
         TypeSymbol named = TypeSymbols.declared(new TypeKey("example.pair", "Pair"));
         FieldDomains domains = FieldDomains.of(named, (Hir.Data) symbols.declarations().declaration(named.key()), symbols);
 
@@ -465,7 +465,7 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
                     invariant ordered = a < b
                 """), souther.compiler.meta.ModulePath.EMPTY);
         compilation.answerEverything();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), "example.report").value();
+        Symbols symbols = Scopes.derived(compilation.db(), "example.report").value();
         TypeSymbol named = TypeSymbols.declared(new TypeKey("example.report", "Pair"));
         FieldDomains domains = FieldDomains.of(named, (Hir.Data) symbols.declarations().declaration(named.key()), symbols);
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldsRangeIsTheRecordsRuleProjectedOntoItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldsRangeIsTheRecordsRuleProjectedOntoItTest.java
@@ -2,8 +2,8 @@ package souther.compiler.check;
 
 import souther.compiler.ast.Hir;
 import souther.compiler.numeric.NumericDomain;
+import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
-import souther.compiler.query.Shapes;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
 import souther.compiler.types.TypeSymbol;
@@ -33,7 +33,7 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         String module = compilation.modules().get(0);
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         assertNotNull(symbols, "the model did not compile");
         TypeSymbol named = TypeSymbols.declared(new TypeKey(module, type));
         Hir.Data data = (Hir.Data) symbols.declarations().declaration(named.key());
@@ -297,7 +297,7 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
                 data Forecast = { total: Amount }
                 """), souther.compiler.meta.ModulePath.EMPTY);
         compilation.answerEverything();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope("example.report")).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), "example.report").value();
         assertNotNull(symbols, "the model did not compile");
         TypeSymbol named = TypeSymbols.declared(new TypeKey("example.report", "Forecast"));
         FieldDomains domains = FieldDomains.of(named, (Hir.Data) symbols.declarations().declaration(named.key()), symbols);
@@ -364,7 +364,7 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
                     invariant ordered = a < b
                 """), souther.compiler.meta.ModulePath.EMPTY);
         compilation.answerEverything();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope("example.pair")).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), "example.pair").value();
         TypeSymbol named = TypeSymbols.declared(new TypeKey("example.pair", "Pair"));
         FieldDomains domains = FieldDomains.of(named, (Hir.Data) symbols.declarations().declaration(named.key()), symbols);
 
@@ -465,7 +465,7 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
                     invariant ordered = a < b
                 """), souther.compiler.meta.ModulePath.EMPTY);
         compilation.answerEverything();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope("example.report")).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), "example.report").value();
         TypeSymbol named = TypeSymbols.declared(new TypeKey("example.report", "Pair"));
         FieldDomains domains = FieldDomains.of(named, (Hir.Data) symbols.declarations().declaration(named.key()), symbols);
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AGrantedNameIsReadAsGrantedWhereverItIsReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AGrantedNameIsReadAsGrantedWhereverItIsReachedTest.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
@@ -49,7 +50,7 @@ class AGrantedNameIsReadAsGrantedWhereverItIsReachedTest {
                         .flatMap(List::stream).map(each -> each.diagnostic().code().toString())
                         .filter(each -> !each.equals("E1013")).toList(),
                 "the model this reads has to be one somebody could write");
-        Symbols symbols = compilation.symbols("demo");
+        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
         TypeCardinality.Cardinalities solved =
                 TypeCardinality.solve(compilation.module("demo").defs().stream().map(Derived.Def::read).toList(), symbols);
         assertTrue(solved.of(TypeSymbols.declared(new TypeKey(symbols.module(), reader))).none(),
@@ -133,7 +134,7 @@ class AGrantedNameIsReadAsGrantedWhereverItIsReachedTest {
 
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
-        Symbols symbols = compilation.symbols("demo");
+        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
         assertTrue(TypeCardinality.solve(compilation.module("demo").defs().stream().map(Derived.Def::read).toList(), symbols)
                         .granting(Set.of(TypeSymbols.declared(new TypeKey(symbols.module(), "Granted")))).get(TypeSymbols.declared(new TypeKey(symbols.module(), "Bad"))).none(),
                 "and what it wraps was not granted anything");
@@ -165,7 +166,7 @@ class AGrantedNameIsReadAsGrantedWhereverItIsReachedTest {
                 data B = { a: A }
                 """, "Main");
         compilation.answerEverything();
-        Symbols symbols = compilation.symbols("demo");
+        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
         TypeCardinality.Cardinalities solved =
                 TypeCardinality.solve(compilation.module("demo").defs().stream().map(Derived.Def::read).toList(), symbols);
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AGrantedNameIsReadAsGrantedWhereverItIsReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AGrantedNameIsReadAsGrantedWhereverItIsReachedTest.java
@@ -2,7 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.query.Names;
+import souther.compiler.query.Scopes;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
@@ -50,7 +50,7 @@ class AGrantedNameIsReadAsGrantedWhereverItIsReachedTest {
                         .flatMap(List::stream).map(each -> each.diagnostic().code().toString())
                         .filter(each -> !each.equals("E1013")).toList(),
                 "the model this reads has to be one somebody could write");
-        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         TypeCardinality.Cardinalities solved =
                 TypeCardinality.solve(compilation.module("demo").defs().stream().map(Derived.Def::read).toList(), symbols);
         assertTrue(solved.of(TypeSymbols.declared(new TypeKey(symbols.module(), reader))).none(),
@@ -134,7 +134,7 @@ class AGrantedNameIsReadAsGrantedWhereverItIsReachedTest {
 
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         assertTrue(TypeCardinality.solve(compilation.module("demo").defs().stream().map(Derived.Def::read).toList(), symbols)
                         .granting(Set.of(TypeSymbols.declared(new TypeKey(symbols.module(), "Granted")))).get(TypeSymbols.declared(new TypeKey(symbols.module(), "Bad"))).none(),
                 "and what it wraps was not granted anything");
@@ -166,7 +166,7 @@ class AGrantedNameIsReadAsGrantedWhereverItIsReachedTest {
                 data B = { a: A }
                 """, "Main");
         compilation.answerEverything();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         TypeCardinality.Cardinalities solved =
                 TypeCardinality.solve(compilation.module("demo").defs().stream().map(Derived.Def::read).toList(), symbols);
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AGroupIsNamedForItsOwnLackAndNotAnotherGroupsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AGroupIsNamedForItsOwnLackAndNotAnotherGroupsTest.java
@@ -2,7 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.query.Names;
+import souther.compiler.query.Scopes;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeSymbol;
 
@@ -33,7 +33,7 @@ class AGroupIsNamedForItsOwnLackAndNotAnotherGroupsTest {
                 "the model this reads has to be one somebody could write");
         return UninhabitableTypes.withNoValueOfTheirOwn(compilation.module("demo").defs().stream().map(Derived.Def::read).toList(),
                         TypeCardinality.solve(compilation.module("demo").defs().stream().map(Derived.Def::read).toList(),
-                                Names.derivedSymbols(compilation.db(), "demo").value()))
+                                Scopes.derived(compilation.db(), "demo").value()))
                 .stream().map(each -> each.members().stream().map(TypeSymbol::name).toList()).toList();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AGroupIsNamedForItsOwnLackAndNotAnotherGroupsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AGroupIsNamedForItsOwnLackAndNotAnotherGroupsTest.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeSymbol;
 
@@ -32,7 +33,7 @@ class AGroupIsNamedForItsOwnLackAndNotAnotherGroupsTest {
                 "the model this reads has to be one somebody could write");
         return UninhabitableTypes.withNoValueOfTheirOwn(compilation.module("demo").defs().stream().map(Derived.Def::read).toList(),
                         TypeCardinality.solve(compilation.module("demo").defs().stream().map(Derived.Def::read).toList(),
-                                compilation.symbols("demo")))
+                                Names.derivedSymbols(compilation.db(), "demo").value()))
                 .stream().map(each -> each.members().stream().map(TypeSymbol::name).toList()).toList();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AReachedNameResolvesBackToWhatItWasAskedAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AReachedNameResolvesBackToWhatItWasAskedAboutTest.java
@@ -2,8 +2,8 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.meta.ModulePath;
-import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
 import souther.compiler.ast.WrittenName;
 import souther.compiler.types.Denotation;
@@ -71,7 +71,7 @@ class AReachedNameResolvesBackToWhatItWasAskedAboutTest {
     private static Symbols scopeOf(String module, String... sources) {
         Compilation compilation = Compilation.ofSources(List.of(sources), ModulePath.EMPTY);
         compilation.answerEverything();
-        return Names.derivedSymbols(compilation.db(), module).value();
+        return Scopes.derived(compilation.db(), module).value();
     }
 
     /** Every declaration this compilation has, which is what a position here may turn out to be. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AReachedNameResolvesBackToWhatItWasAskedAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AReachedNameResolvesBackToWhatItWasAskedAboutTest.java
@@ -3,8 +3,8 @@ package souther.compiler.check;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
-import souther.compiler.query.Shapes;
 import souther.compiler.ast.WrittenName;
 import souther.compiler.types.Denotation;
 import souther.compiler.types.TypeKey;
@@ -71,7 +71,7 @@ class AReachedNameResolvesBackToWhatItWasAskedAboutTest {
     private static Symbols scopeOf(String module, String... sources) {
         Compilation compilation = Compilation.ofSources(List.of(sources), ModulePath.EMPTY);
         compilation.answerEverything();
-        return compilation.db().ask(new Shapes.Scope(module)).value();
+        return Names.derivedSymbols(compilation.db(), module).value();
     }
 
     /** Every declaration this compilation has, which is what a position here may turn out to be. */

--- a/souther-compiler/src/test/java/souther/compiler/check/ARefusalCarriesTheProofItsCountCameToNoneByTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARefusalCarriesTheProofItsCountCameToNoneByTest.java
@@ -2,7 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.query.Names;
+import souther.compiler.query.Scopes;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeSymbol;
 
@@ -35,7 +35,7 @@ class ARefusalCarriesTheProofItsCountCameToNoneByTest {
         List<souther.compiler.ast.Hir.Def> defs =
                 compilation.module("demo").defs().stream().map(Derived.Def::read).toList();
         return UninhabitableTypes.withNoValueOfTheirOwn(defs,
-                TypeCardinality.solve(defs, Names.derivedSymbols(compilation.db(), "demo").value()));
+                TypeCardinality.solve(defs, Scopes.derived(compilation.db(), "demo").value()));
     }
 
     private static Emptiness only(String source) {
@@ -50,7 +50,7 @@ class ARefusalCarriesTheProofItsCountCameToNoneByTest {
         compilation.answerEverything();
         List<souther.compiler.ast.Hir.Def> defs =
                 compilation.module("demo").defs().stream().map(Derived.Def::read).toList();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         return shape(TypeCardinality.solve(defs, symbols).of(
                 souther.compiler.types.TypeSymbols.declared(
                         new souther.compiler.types.TypeKey(symbols.module(), name))).why());

--- a/souther-compiler/src/test/java/souther/compiler/check/ARefusalCarriesTheProofItsCountCameToNoneByTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARefusalCarriesTheProofItsCountCameToNoneByTest.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeSymbol;
 
@@ -34,7 +35,7 @@ class ARefusalCarriesTheProofItsCountCameToNoneByTest {
         List<souther.compiler.ast.Hir.Def> defs =
                 compilation.module("demo").defs().stream().map(Derived.Def::read).toList();
         return UninhabitableTypes.withNoValueOfTheirOwn(defs,
-                TypeCardinality.solve(defs, compilation.symbols("demo")));
+                TypeCardinality.solve(defs, Names.derivedSymbols(compilation.db(), "demo").value()));
     }
 
     private static Emptiness only(String source) {
@@ -49,7 +50,7 @@ class ARefusalCarriesTheProofItsCountCameToNoneByTest {
         compilation.answerEverything();
         List<souther.compiler.ast.Hir.Def> defs =
                 compilation.module("demo").defs().stream().map(Derived.Def::read).toList();
-        Symbols symbols = compilation.symbols("demo");
+        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
         return shape(TypeCardinality.solve(defs, symbols).of(
                 souther.compiler.types.TypeSymbols.declared(
                         new souther.compiler.types.TypeKey(symbols.module(), name))).why());

--- a/souther-compiler/src/test/java/souther/compiler/check/ATypeIsGrantedAValueOnlyWhereOneIsShownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ATypeIsGrantedAValueOnlyWhereOneIsShownTest.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeSymbol;
 
@@ -36,7 +37,7 @@ class ATypeIsGrantedAValueOnlyWhereOneIsShownTest {
                         .filter(each -> !each.equals("E1013")).toList(),
                 "the model this reads has to be one somebody could write");
         Map<TypeSymbol, Cardinality> solution =
-                TypeCardinality.solve(compilation.module("demo").defs().stream().map(Derived.Def::read).toList(), compilation.symbols("demo")).all();
+                TypeCardinality.solve(compilation.module("demo").defs().stream().map(Derived.Def::read).toList(), Names.derivedSymbols(compilation.db(), "demo").value()).all();
         Map<String, Cardinality> byName = new LinkedHashMap<>();
         solution.forEach((name, each) -> byName.put(name.name(), each));
         return byName;

--- a/souther-compiler/src/test/java/souther/compiler/check/ATypeIsGrantedAValueOnlyWhereOneIsShownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ATypeIsGrantedAValueOnlyWhereOneIsShownTest.java
@@ -2,7 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.query.Names;
+import souther.compiler.query.Scopes;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeSymbol;
 
@@ -37,7 +37,7 @@ class ATypeIsGrantedAValueOnlyWhereOneIsShownTest {
                         .filter(each -> !each.equals("E1013")).toList(),
                 "the model this reads has to be one somebody could write");
         Map<TypeSymbol, Cardinality> solution =
-                TypeCardinality.solve(compilation.module("demo").defs().stream().map(Derived.Def::read).toList(), Names.derivedSymbols(compilation.db(), "demo").value()).all();
+                TypeCardinality.solve(compilation.module("demo").defs().stream().map(Derived.Def::read).toList(), Scopes.derived(compilation.db(), "demo").value()).all();
         Map<String, Cardinality> byName = new LinkedHashMap<>();
         solution.forEach((name, each) -> byName.put(name.name(), each));
         return byName;

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest.java
@@ -1,8 +1,8 @@
 package souther.compiler.check;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.Compiler;
 import souther.compiler.ast.Hir;
-import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
 import souther.compiler.types.TypeKey;
@@ -106,7 +106,7 @@ class EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest {
             compilation.answerEverything();
 
             String module = compilation.modules().get(0);
-            Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+            Symbols symbols = Scopes.derived(compilation.db(), module).value();
             Map<TypeSymbol, List<Hir.InvariantClause>> declared =
                     compilation.db().ask(new Shapes.InvariantsForDischarge(module)).value();
             Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import souther.compiler.Compiler;
 import souther.compiler.ast.Hir;
+import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
 import souther.compiler.types.TypeKey;
@@ -105,7 +106,7 @@ class EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest {
             compilation.answerEverything();
 
             String module = compilation.modules().get(0);
-            Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+            Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
             Map<TypeSymbol, List<Hir.InvariantClause>> declared =
                     compilation.db().ask(new Shapes.InvariantsForDischarge(module)).value();
             Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();

--- a/souther-compiler/src/test/java/souther/compiler/check/HowManyValuesAPositionHasIsNotHowMuchItHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/HowManyValuesAPositionHasIsNotHowMuchItHoldsTest.java
@@ -2,7 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.query.Names;
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeKey;
@@ -39,7 +39,7 @@ class HowManyValuesAPositionHasIsNotHowMuchItHoldsTest {
                         .flatMap(java.util.List::stream)
                         .map(each -> each.diagnostic().code().toString()).toList(),
                 "the model this reads has to be one somebody could write");
-        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         return OccurrenceValues.of(TypeSymbols.declared(new TypeKey(symbols.module(), name)), data(compilation, name), symbols)
                 .wholeValuesAt(path);
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/HowManyValuesAPositionHasIsNotHowMuchItHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/HowManyValuesAPositionHasIsNotHowMuchItHoldsTest.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Names;
 import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeKey;
@@ -38,7 +39,7 @@ class HowManyValuesAPositionHasIsNotHowMuchItHoldsTest {
                         .flatMap(java.util.List::stream)
                         .map(each -> each.diagnostic().code().toString()).toList(),
                 "the model this reads has to be one somebody could write");
-        Symbols symbols = compilation.symbols("demo");
+        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
         return OccurrenceValues.of(TypeSymbols.declared(new TypeKey(symbols.module(), name)), data(compilation, name), symbols)
                 .wholeValuesAt(path);
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/ReadingARuleNeedsLessOfATypeThanWritingAValueDoesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ReadingARuleNeedsLessOfATypeThanWritingAValueDoesTest.java
@@ -7,8 +7,8 @@ import souther.compiler.numeric.DateTimes;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.OrderedInterval;
 import souther.compiler.numeric.Text;
+import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
-import souther.compiler.query.Shapes;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
@@ -52,7 +52,7 @@ class ReadingARuleNeedsLessOfATypeThanWritingAValueDoesTest {
     private static Symbols symbols() {
         Compilation compilation = Compilation.ofSource(MODEL, "Main");
         compilation.answerEverything();
-        return compilation.db().ask(new Shapes.Scope(compilation.modules().get(0))).value();
+        return Names.derivedSymbols(compilation.db(), compilation.modules().get(0)).value();
     }
 
     private static Type colour() {

--- a/souther-compiler/src/test/java/souther/compiler/check/ReadingARuleNeedsLessOfATypeThanWritingAValueDoesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ReadingARuleNeedsLessOfATypeThanWritingAValueDoesTest.java
@@ -2,12 +2,12 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.DateTimes;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.OrderedInterval;
 import souther.compiler.numeric.Text;
-import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
@@ -52,7 +52,7 @@ class ReadingARuleNeedsLessOfATypeThanWritingAValueDoesTest {
     private static Symbols symbols() {
         Compilation compilation = Compilation.ofSource(MODEL, "Main");
         compilation.answerEverything();
-        return Names.derivedSymbols(compilation.db(), compilation.modules().get(0)).value();
+        return Scopes.derived(compilation.db(), compilation.modules().get(0)).value();
     }
 
     private static Type colour() {

--- a/souther-compiler/src/test/java/souther/compiler/check/ThreeQuestionsAboutANumberAndThreeAnswersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ThreeQuestionsAboutANumberAndThreeAnswersTest.java
@@ -1,6 +1,6 @@
 package souther.compiler.check;
 
-import souther.compiler.query.Names;
+import souther.compiler.query.Scopes;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
@@ -48,7 +48,7 @@ class ThreeQuestionsAboutANumberAndThreeAnswersTest {
         Compilation compilation = Compilation.ofSource(TYPES, "Main");
         compilation.answerEverything();
         String module = compilation.modules().get(0);
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(symbols, "the model did not compile");
         Type t = switch (type) {
             case "Int" -> Type.INT;

--- a/souther-compiler/src/test/java/souther/compiler/check/ThreeQuestionsAboutANumberAndThreeAnswersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ThreeQuestionsAboutANumberAndThreeAnswersTest.java
@@ -1,7 +1,7 @@
 package souther.compiler.check;
 
+import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
-import souther.compiler.query.Shapes;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
@@ -48,7 +48,7 @@ class ThreeQuestionsAboutANumberAndThreeAnswersTest {
         Compilation compilation = Compilation.ofSource(TYPES, "Main");
         compilation.answerEverything();
         String module = compilation.modules().get(0);
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         assertNotNull(symbols, "the model did not compile");
         Type t = switch (type) {
             case "Int" -> Type.INT;

--- a/souther-compiler/src/test/java/souther/compiler/check/UnsupportedInformationNeverShrinksTheModelSetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/UnsupportedInformationNeverShrinksTheModelSetTest.java
@@ -2,7 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.query.Names;
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeKey;
@@ -41,14 +41,14 @@ class UnsupportedInformationNeverShrinksTheModelSetTest {
     private static FieldDomains domainsOf(String source, String name) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         return FieldDomains.of(TypeSymbols.declared(new TypeKey(symbols.module(), name)), data(compilation, name), symbols);
     }
 
     private static OccurrenceCounts countsOf(String source, String name) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         return OccurrenceCounts.of(TypeSymbols.declared(new TypeKey(symbols.module(), name)), data(compilation, name), symbols);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/UnsupportedInformationNeverShrinksTheModelSetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/UnsupportedInformationNeverShrinksTheModelSetTest.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Names;
 import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeKey;
@@ -40,14 +41,14 @@ class UnsupportedInformationNeverShrinksTheModelSetTest {
     private static FieldDomains domainsOf(String source, String name) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
-        Symbols symbols = compilation.symbols("demo");
+        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
         return FieldDomains.of(TypeSymbols.declared(new TypeKey(symbols.module(), name)), data(compilation, name), symbols);
     }
 
     private static OccurrenceCounts countsOf(String source, String name) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
-        Symbols symbols = compilation.symbols("demo");
+        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
         return OccurrenceCounts.of(TypeSymbols.declared(new TypeKey(symbols.module(), name)), data(compilation, name), symbols);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatANameMeansDoesNotDependOnWhichUniverseAnsweredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatANameMeansDoesNotDependOnWhichUniverseAnsweredTest.java
@@ -119,7 +119,7 @@ class WhatANameMeansDoesNotDependOnWhichUniverseAnsweredTest {
         assertEquals(java.util.List.of(), scoped.refused(),
                 "nothing about this model is refused");
         Resolve.Resolution answered = Resolve.resolving(subject.module(),
-                scoped.writtenSymbols(declaredBy(db, readings)), scoped.values());
+                scoped.meanings().writtenSymbols(declaredBy(db, readings)), scoped.values());
         assertEquals(java.util.List.of(), answered.unresolved(),
                 () -> "every name was answered: " + answered.unresolved());
         return answered.module();
@@ -190,7 +190,7 @@ class WhatANameMeansDoesNotDependOnWhichUniverseAnsweredTest {
         Scoping.Scoped scoped =
                 Scoping.of(new ModuleUniverse.OfWhatIsRead(readings), withoutTheTable);
         Resolve.Resolution answered = Resolve.resolving(withoutTheTable.module(),
-                scoped.writtenSymbols(declaredBy(db, readings)), scoped.values());
+                scoped.meanings().writtenSymbols(declaredBy(db, readings)), scoped.values());
 
         assertTrue(answered.unresolved().stream()
                         .anyMatch(e -> e.getMessage().contains("length")),

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Names;
 import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeKey;
@@ -50,7 +51,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
                 .flatMap(List::stream)
                 .map(each -> each.diagnostic().code())
                 .toList(), "the model this reads has to be one somebody could write");
-        Symbols symbols = compilation.symbols("demo");
+        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
         TypeSymbol name = TypeSymbols.declared(new TypeKey(symbols.module(), named));
         return new Read(FieldDomains.of(name,
                 (Hir.Data) symbols.declarations().declaration(name.key()), symbols), symbols);
@@ -67,7 +68,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
         compilation.answerEverything();
         assertFalse(compilation.diagnostics().values().stream().flatMap(List::stream).toList()
                 .isEmpty(), "this model is meant to be refused");
-        Symbols symbols = compilation.symbols("demo");
+        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
         TypeSymbol name = TypeSymbols.declared(new TypeKey(symbols.module(), named));
         return FieldDomains.of(name,
                 (Hir.Data) symbols.declarations().declaration(name.key()), symbols);

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
@@ -2,7 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.query.Names;
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeKey;
@@ -51,7 +51,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
                 .flatMap(List::stream)
                 .map(each -> each.diagnostic().code())
                 .toList(), "the model this reads has to be one somebody could write");
-        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         TypeSymbol name = TypeSymbols.declared(new TypeKey(symbols.module(), named));
         return new Read(FieldDomains.of(name,
                 (Hir.Data) symbols.declarations().declaration(name.key()), symbols), symbols);
@@ -68,7 +68,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
         compilation.answerEverything();
         assertFalse(compilation.diagnostics().values().stream().flatMap(List::stream).toList()
                 .isEmpty(), "this model is meant to be refused");
-        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         TypeSymbol name = TypeSymbols.declared(new TypeKey(symbols.module(), named));
         return FieldDomains.of(name,
                 (Hir.Data) symbols.declarations().declaration(name.key()), symbols);

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatOneDeclarationComesToUnderWhatIsKnownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatOneDeclarationComesToUnderWhatIsKnownTest.java
@@ -2,7 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.query.Names;
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeKey;
@@ -55,7 +55,7 @@ class WhatOneDeclarationComesToUnderWhatIsKnownTest {
                         .map(each -> each.diagnostic().code().toString())
                         .filter(each -> !each.equals("E1013")).toList(),
                 "the model this reads has to be one somebody could write");
-        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
+        Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
         Map<TypeSymbol, Cardinality> solution = new HashMap<>();
         for (int each = 0; each < assumed.length; each += 2) {
             solution.put(TypeSymbols.declared(new TypeKey(symbols.module(), (String) assumed[each])), (Cardinality) assumed[each + 1]);

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatOneDeclarationComesToUnderWhatIsKnownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatOneDeclarationComesToUnderWhatIsKnownTest.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Names;
 import souther.compiler.ast.Hir;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeKey;
@@ -54,7 +55,7 @@ class WhatOneDeclarationComesToUnderWhatIsKnownTest {
                         .map(each -> each.diagnostic().code().toString())
                         .filter(each -> !each.equals("E1013")).toList(),
                 "the model this reads has to be one somebody could write");
-        Symbols symbols = compilation.symbols("demo");
+        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
         Map<TypeSymbol, Cardinality> solution = new HashMap<>();
         for (int each = 0; each < assumed.length; each += 2) {
             solution.put(TypeSymbols.declared(new TypeKey(symbols.module(), (String) assumed[each])), (Cardinality) assumed[each + 1]);

--- a/souther-compiler/src/test/java/souther/compiler/check/WhichTypesHaveValuesThatCanBeWrittenOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhichTypesHaveValuesThatCanBeWrittenOutTest.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
@@ -35,7 +36,7 @@ class WhichTypesHaveValuesThatCanBeWrittenOutTest {
                 .flatMap(List::stream)
                 .map(each -> each.diagnostic().code())
                 .toList(), "the model this reads has to be one somebody could write");
-        return compilation.symbols("demo");
+        return Names.derivedSymbols(compilation.db(), "demo").value();
     }
 
     private static List<Value> of(String source, String named) {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhichTypesHaveValuesThatCanBeWrittenOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhichTypesHaveValuesThatCanBeWrittenOutTest.java
@@ -2,7 +2,7 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.query.Names;
+import souther.compiler.query.Scopes;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
@@ -36,7 +36,7 @@ class WhichTypesHaveValuesThatCanBeWrittenOutTest {
                 .flatMap(List::stream)
                 .map(each -> each.diagnostic().code())
                 .toList(), "the model this reads has to be one somebody could write");
-        return Names.derivedSymbols(compilation.db(), "demo").value();
+        return Scopes.derived(compilation.db(), "demo").value();
     }
 
     private static List<Value> of(String source, String named) {

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARowIsNotHandedToAnAnswerFromAnotherBuildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARowIsNotHandedToAnAnswerFromAnotherBuildTest.java
@@ -2,6 +2,7 @@ package souther.compiler.examples;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.generated.EvaluationArtifact;
 import souther.compiler.meta.ClassFileDeclarations;
 import souther.compiler.meta.PublishedClasses;
@@ -11,7 +12,6 @@ import souther.compiler.observe.FailurePhase;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.RowOutcome;
 import souther.compiler.observe.Stage;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
@@ -306,7 +306,7 @@ class ARowIsNotHandedToAnAnswerFromAnotherBuildTest {
                 "the model whose rows are run compiles");
         return ExampleVerifier.check(
                 c.db().ask(new Shapes.Prepared(name)).value().forExamples(),
-                Names.derivedSymbols(c.db(), name).value(),
+                Scopes.derived(c.db(), name).value(),
                 c.db().ask(new Bodies.Signatures(name)).value(),
                 artifact,
                 declared,

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARowIsNotHandedToAnAnswerFromAnotherBuildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARowIsNotHandedToAnAnswerFromAnotherBuildTest.java
@@ -11,6 +11,7 @@ import souther.compiler.observe.FailurePhase;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.RowOutcome;
 import souther.compiler.observe.Stage;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
@@ -305,7 +306,7 @@ class ARowIsNotHandedToAnAnswerFromAnotherBuildTest {
                 "the model whose rows are run compiles");
         return ExampleVerifier.check(
                 c.db().ask(new Shapes.Prepared(name)).value().forExamples(),
-                c.db().ask(new Shapes.Scope(name)).value(),
+                Names.derivedSymbols(c.db(), name).value(),
                 c.db().ask(new Bodies.Signatures(name)).value(),
                 artifact,
                 declared,

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARunIsToldWhichModuleAnAnswersClassesAreShortOfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARunIsToldWhichModuleAnAnswersClassesAreShortOfTest.java
@@ -2,6 +2,7 @@ package souther.compiler.examples;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.Note;
 import souther.compiler.diag.msg.ExampleMessage;
@@ -11,7 +12,6 @@ import souther.compiler.generated.EvaluationArtifact;
 import souther.compiler.meta.ClassFileDeclarations;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.meta.PublishedClasses;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
@@ -210,7 +210,7 @@ class ARunIsToldWhichModuleAnAnswersClassesAreShortOfTest {
                 "the model whose rows are run compiles");
         return ExampleVerifier.check(
                 c.db().ask(new Shapes.Prepared(name)).value().forExamples(),
-                Names.derivedSymbols(c.db(), name).value(),
+                Scopes.derived(c.db(), name).value(),
                 c.db().ask(new Bodies.Signatures(name)).value(),
                 artifact,
                 () -> declarationsOf(List.of(SHARED, ROOT)),

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARunIsToldWhichModuleAnAnswersClassesAreShortOfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARunIsToldWhichModuleAnAnswersClassesAreShortOfTest.java
@@ -11,6 +11,7 @@ import souther.compiler.generated.EvaluationArtifact;
 import souther.compiler.meta.ClassFileDeclarations;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.meta.PublishedClasses;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
@@ -209,7 +210,7 @@ class ARunIsToldWhichModuleAnAnswersClassesAreShortOfTest {
                 "the model whose rows are run compiles");
         return ExampleVerifier.check(
                 c.db().ask(new Shapes.Prepared(name)).value().forExamples(),
-                c.db().ask(new Shapes.Scope(name)).value(),
+                Names.derivedSymbols(c.db(), name).value(),
                 c.db().ask(new Bodies.Signatures(name)).value(),
                 artifact,
                 () -> declarationsOf(List.of(SHARED, ROOT)),

--- a/souther-compiler/src/test/java/souther/compiler/examples/AValueWearsTheEnvelopeThePositionReadsItThroughTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AValueWearsTheEnvelopeThePositionReadsItThroughTest.java
@@ -6,7 +6,7 @@ import net.unit8.raoh.decode.Decoder;
 
 import org.junit.jupiter.api.Test;
 
-import souther.compiler.query.Names;
+import souther.compiler.query.Scopes;
 import souther.compiler.check.Symbols;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.Type;
@@ -65,7 +65,7 @@ class AValueWearsTheEnvelopeThePositionReadsItThroughTest {
             """;
 
     private final Compilation compilation = compiled(MODULE);
-    private final Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
+    private final Symbols symbols = Scopes.derived(compilation.db(), "demo").value();
     private final NeutralForm neutral = new NeutralForm(symbols);
 
     private static Compilation compiled(String module) {
@@ -190,7 +190,7 @@ class AValueWearsTheEnvelopeThePositionReadsItThroughTest {
     @Test
     void anotherSumListingTheCaseDoesNotMoveWhatAPlaceNothingReadsWrites() throws Exception {
         Compilation with = compiled(AND_ANOTHER_SUM);
-        Symbols theirs = Names.derivedSymbols(with.db(), "demo").value();
+        Symbols theirs = Scopes.derived(with.db(), "demo").value();
         NeutralForm and = new NeutralForm(theirs);
         assertEquals(Map.of(), neutral.of(unit("Filed"), Position.UNREAD, "h"));
         assertEquals(Map.of(), and.of(value(with, "Filed", Map.of()), Position.UNREAD, "h"));

--- a/souther-compiler/src/test/java/souther/compiler/examples/AValueWearsTheEnvelopeThePositionReadsItThroughTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AValueWearsTheEnvelopeThePositionReadsItThroughTest.java
@@ -6,6 +6,7 @@ import net.unit8.raoh.decode.Decoder;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Names;
 import souther.compiler.check.Symbols;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.Type;
@@ -64,7 +65,7 @@ class AValueWearsTheEnvelopeThePositionReadsItThroughTest {
             """;
 
     private final Compilation compilation = compiled(MODULE);
-    private final Symbols symbols = compilation.symbols("demo");
+    private final Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
     private final NeutralForm neutral = new NeutralForm(symbols);
 
     private static Compilation compiled(String module) {
@@ -189,7 +190,7 @@ class AValueWearsTheEnvelopeThePositionReadsItThroughTest {
     @Test
     void anotherSumListingTheCaseDoesNotMoveWhatAPlaceNothingReadsWrites() throws Exception {
         Compilation with = compiled(AND_ANOTHER_SUM);
-        Symbols theirs = with.symbols("demo");
+        Symbols theirs = Names.derivedSymbols(with.db(), "demo").value();
         NeutralForm and = new NeutralForm(theirs);
         assertEquals(Map.of(), neutral.of(unit("Filed"), Position.UNREAD, "h"));
         assertEquals(Map.of(), and.of(value(with, "Filed", Map.of()), Position.UNREAD, "h"));

--- a/souther-compiler/src/test/java/souther/compiler/examples/AnAnswererInAnotherLoaderRunsARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AnAnswererInAnotherLoaderRunsARowTest.java
@@ -13,6 +13,7 @@ import souther.compiler.observe.Applied;
 import souther.compiler.observe.Disposition;
 import souther.compiler.observe.RowOutcome;
 import souther.compiler.observe.Stage;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
@@ -223,7 +224,7 @@ class AnAnswererInAnotherLoaderRunsARowTest {
         answerer.hereLoaded = loaded(new MemoryClassLoader(classes, parent), answerer.hereNamed);
         return ExampleVerifier.check(
                 c.db().ask(new Shapes.Prepared(name)).value().forExamples(),
-                c.db().ask(new Shapes.Scope(name)).value(),
+                Names.derivedSymbols(c.db(), name).value(),
                 c.db().ask(new Bodies.Signatures(name)).value(),
                 artifact,
                 // The crossing here is between two loaders of one build, so what the answerer reads

--- a/souther-compiler/src/test/java/souther/compiler/examples/AnAnswererInAnotherLoaderRunsARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AnAnswererInAnotherLoaderRunsARowTest.java
@@ -6,6 +6,7 @@ import net.unit8.raoh.decode.Decoder;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.generated.MemoryClassLoader;
 import souther.compiler.jvm.GeneratedClass;
 import souther.compiler.jvm.GeneratedClasses;
@@ -13,7 +14,6 @@ import souther.compiler.observe.Applied;
 import souther.compiler.observe.Disposition;
 import souther.compiler.observe.RowOutcome;
 import souther.compiler.observe.Stage;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
@@ -224,7 +224,7 @@ class AnAnswererInAnotherLoaderRunsARowTest {
         answerer.hereLoaded = loaded(new MemoryClassLoader(classes, parent), answerer.hereNamed);
         return ExampleVerifier.check(
                 c.db().ask(new Shapes.Prepared(name)).value().forExamples(),
-                Names.derivedSymbols(c.db(), name).value(),
+                Scopes.derived(c.db(), name).value(),
                 c.db().ask(new Bodies.Signatures(name)).value(),
                 artifact,
                 // The crossing here is between two loaders of one build, so what the answerer reads

--- a/souther-compiler/src/test/java/souther/compiler/examples/WhereARowStopsIsDecidedByWhichHalfOfTheSeamItReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/WhereARowStopsIsDecidedByWhichHalfOfTheSeamItReachedTest.java
@@ -2,13 +2,13 @@ package souther.compiler.examples;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.diag.msg.ExampleMessage;
 import souther.compiler.observe.Applied;
 import souther.compiler.observe.Disposition;
 import souther.compiler.observe.FailurePhase;
 import souther.compiler.observe.RowOutcome;
 import souther.compiler.observe.Stage;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
@@ -300,7 +300,7 @@ class WhereARowStopsIsDecidedByWhichHalfOfTheSeamItReachedTest {
                 .ask(new Output.EvaluationLinked(name, Output.CoverageMode.NONE)).value();
         return ExampleVerifier.check(
                 c.db().ask(new Shapes.Prepared(name)).value().forExamples(),
-                Names.derivedSymbols(c.db(), name).value(),
+                Scopes.derived(c.db(), name).value(),
                 c.db().ask(new Bodies.Signatures(name)).value(),
                 artifact,
                 // The answerers here apply this compile's own classes, so there is no second set of

--- a/souther-compiler/src/test/java/souther/compiler/examples/WhereARowStopsIsDecidedByWhichHalfOfTheSeamItReachedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/WhereARowStopsIsDecidedByWhichHalfOfTheSeamItReachedTest.java
@@ -8,6 +8,7 @@ import souther.compiler.observe.Disposition;
 import souther.compiler.observe.FailurePhase;
 import souther.compiler.observe.RowOutcome;
 import souther.compiler.observe.Stage;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
@@ -299,7 +300,7 @@ class WhereARowStopsIsDecidedByWhichHalfOfTheSeamItReachedTest {
                 .ask(new Output.EvaluationLinked(name, Output.CoverageMode.NONE)).value();
         return ExampleVerifier.check(
                 c.db().ask(new Shapes.Prepared(name)).value().forExamples(),
-                c.db().ask(new Shapes.Scope(name)).value(),
+                Names.derivedSymbols(c.db(), name).value(),
                 c.db().ask(new Bodies.Signatures(name)).value(),
                 artifact,
                 // The answerers here apply this compile's own classes, so there is no second set of

--- a/souther-compiler/src/test/java/souther/compiler/examples/WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest.java
@@ -2,6 +2,7 @@ package souther.compiler.examples;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.generated.EvaluationArtifact;
 import souther.compiler.generated.GeneratedImplementations;
 import souther.compiler.generated.MemoryClassLoader;
@@ -10,7 +11,6 @@ import souther.compiler.observe.Disposition;
 import souther.compiler.observe.FailurePhase;
 import souther.compiler.observe.RowOutcome;
 import souther.compiler.observe.Stage;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
@@ -213,7 +213,7 @@ class WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest {
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
                 () -> ExampleVerifier.check(
                         mine.db().ask(new Shapes.Prepared(name)).value().forExamples(),
-                        Names.derivedSymbols(mine.db(), name).value(),
+                        Scopes.derived(mine.db(), name).value(),
                         mine.db().ask(new Bodies.Signatures(name)).value(),
                         artifactOf(other, "example.elsewhere"),
                         () -> {
@@ -305,7 +305,7 @@ class WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest {
         String name = c.modules().get(0);
         return ExampleVerifier.check(
                 c.db().ask(new Shapes.Prepared(name)).value().forExamples(),
-                Names.derivedSymbols(c.db(), name).value(),
+                Scopes.derived(c.db(), name).value(),
                 c.db().ask(new Bodies.Signatures(name)).value(),
                 artifactOf(c, name),
                 // Every answer here applies this compile's own classes, so nothing is held against

--- a/souther-compiler/src/test/java/souther/compiler/examples/WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest.java
@@ -10,6 +10,7 @@ import souther.compiler.observe.Disposition;
 import souther.compiler.observe.FailurePhase;
 import souther.compiler.observe.RowOutcome;
 import souther.compiler.observe.Stage;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
@@ -212,7 +213,7 @@ class WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest {
         IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
                 () -> ExampleVerifier.check(
                         mine.db().ask(new Shapes.Prepared(name)).value().forExamples(),
-                        mine.db().ask(new Shapes.Scope(name)).value(),
+                        Names.derivedSymbols(mine.db(), name).value(),
                         mine.db().ask(new Bodies.Signatures(name)).value(),
                         artifactOf(other, "example.elsewhere"),
                         () -> {
@@ -304,7 +305,7 @@ class WhetherAnythingAppliesABehaviorIsTheRunsAnswerTest {
         String name = c.modules().get(0);
         return ExampleVerifier.check(
                 c.db().ask(new Shapes.Prepared(name)).value().forExamples(),
-                c.db().ask(new Shapes.Scope(name)).value(),
+                Names.derivedSymbols(c.db(), name).value(),
                 c.db().ask(new Bodies.Signatures(name)).value(),
                 artifactOf(c, name),
                 // Every answer here applies this compile's own classes, so nothing is held against

--- a/souther-compiler/src/test/java/souther/compiler/frontend/AFrontEndDoesNotDropWhatTheIrCannotHoldTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/frontend/AFrontEndDoesNotDropWhatTheIrCannotHoldTest.java
@@ -2,11 +2,11 @@ package souther.compiler.frontend;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.Compiler;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Symbols;
 import souther.compiler.diag.CompileException;
-import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.TypeKey;
 
@@ -150,7 +150,7 @@ class AFrontEndDoesNotDropWhatTheIrCannotHoldTest {
             return new Read(said, false);
         }
         String module = compilation.modules().get(0);
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         if (symbols == null) {
             return new Read(said, false);
         }

--- a/souther-compiler/src/test/java/souther/compiler/frontend/AFrontEndDoesNotDropWhatTheIrCannotHoldTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/frontend/AFrontEndDoesNotDropWhatTheIrCannotHoldTest.java
@@ -6,8 +6,8 @@ import souther.compiler.Compiler;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Symbols;
 import souther.compiler.diag.CompileException;
+import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
-import souther.compiler.query.Shapes;
 import souther.compiler.types.TypeKey;
 
 import java.lang.reflect.RecordComponent;
@@ -150,7 +150,7 @@ class AFrontEndDoesNotDropWhatTheIrCannotHoldTest {
             return new Read(said, false);
         }
         String module = compilation.modules().get(0);
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         if (symbols == null) {
             return new Read(said, false);
         }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABoundaryRowWearsEveryNameThePositionDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABoundaryRowWearsEveryNameThePositionDeclaresTest.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
@@ -10,7 +11,6 @@ import souther.compiler.check.TypeChecker;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.inputs.InputDomain;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -85,7 +85,7 @@ class ABoundaryRowWearsEveryNameThePositionDeclaresTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, "the model under test compiles");

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABoundaryRowWearsEveryNameThePositionDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABoundaryRowWearsEveryNameThePositionDeclaresTest.java
@@ -10,6 +10,7 @@ import souther.compiler.check.TypeChecker;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.inputs.InputDomain;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -84,7 +85,7 @@ class ABoundaryRowWearsEveryNameThePositionDeclaresTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, "the model under test compiles");

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACarrierNothingReadsUnmeasuresItsSiblingsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACarrierNothingReadsUnmeasuresItsSiblingsTest.java
@@ -2,12 +2,12 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.inputs.InputDomain;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -118,7 +118,7 @@ class ACarrierNothingReadsUnmeasuresItsSiblingsTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
                 .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACarrierNothingReadsUnmeasuresItsSiblingsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACarrierNothingReadsUnmeasuresItsSiblingsTest.java
@@ -7,6 +7,7 @@ import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.inputs.InputDomain;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -117,7 +118,7 @@ class ACarrierNothingReadsUnmeasuresItsSiblingsTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
                 .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClassIsOneThePositionCanHoldAndNothingTakesItAwayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClassIsOneThePositionCanHoldAndNothingTakesItAwayTest.java
@@ -9,6 +9,7 @@ import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.inputs.InputDomain;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -57,7 +58,7 @@ class AClassIsOneThePositionCanHoldAndNothingTakesItAwayTest {
         String module = compilation.modules().get(nth);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
                 .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
         return new Read(compilation, module, spec, sigs.get(behavior), symbols);

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClassIsOneThePositionCanHoldAndNothingTakesItAwayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClassIsOneThePositionCanHoldAndNothingTakesItAwayTest.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
@@ -9,7 +10,6 @@ import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.inputs.InputDomain;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -58,7 +58,7 @@ class AClassIsOneThePositionCanHoldAndNothingTakesItAwayTest {
         String module = compilation.modules().get(nth);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
                 .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
         return new Read(compilation, module, spec, sigs.get(behavior), symbols);

--- a/souther-compiler/src/test/java/souther/compiler/partition/AComparisonThisDoesNotReadIsStillNoticedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AComparisonThisDoesNotReadIsStillNoticedTest.java
@@ -11,6 +11,7 @@ import souther.compiler.coverage.CoverageSites;
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.inputs.UnreadRule;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -64,7 +65,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, () -> "the model under test compiles: " + condition);
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()

--- a/souther-compiler/src/test/java/souther/compiler/partition/AComparisonThisDoesNotReadIsStillNoticedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AComparisonThisDoesNotReadIsStillNoticedTest.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Symbols;
@@ -11,7 +12,6 @@ import souther.compiler.coverage.CoverageSites;
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.inputs.UnreadRule;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -65,7 +65,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, () -> "the model under test compiles: " + condition);
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACountTheCarrierDoesNotHoldIsNotAnEndTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACountTheCarrierDoesNotHoldIsNotAnEndTest.java
@@ -10,6 +10,7 @@ import souther.compiler.check.Symbols;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.DateTimes;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -196,7 +197,7 @@ class ACountTheCarrierDoesNotHoldIsNotAnEndTest {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         String module = compilation.modules().get(0);
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         return Partitions.representativesOf(
                         souther.compiler.types.Type.ref(
                                 souther.compiler.types.TypeSymbols.declared(new souther.compiler.types.TypeKey(module, name))), symbols)
@@ -209,7 +210,7 @@ class ACountTheCarrierDoesNotHoldIsNotAnEndTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().get(0);
         assertNotNull(sigs.get(spec.name()), "the model under test compiles");

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACountTheCarrierDoesNotHoldIsNotAnEndTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACountTheCarrierDoesNotHoldIsNotAnEndTest.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Carrier;
@@ -10,7 +11,6 @@ import souther.compiler.check.Symbols;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.DateTimes;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -197,7 +197,7 @@ class ACountTheCarrierDoesNotHoldIsNotAnEndTest {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         String module = compilation.modules().get(0);
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         return Partitions.representativesOf(
                         souther.compiler.types.Type.ref(
                                 souther.compiler.types.TypeSymbols.declared(new souther.compiler.types.TypeKey(module, name))), symbols)
@@ -210,7 +210,7 @@ class ACountTheCarrierDoesNotHoldIsNotAnEndTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().get(0);
         assertNotNull(sigs.get(spec.name()), "the model under test compiles");

--- a/souther-compiler/src/test/java/souther/compiler/partition/ADistinctionIsMeasuredHoweverItIsSpelledTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ADistinctionIsMeasuredHoweverItIsSpelledTest.java
@@ -2,12 +2,12 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.inputs.InputDomain;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -47,7 +47,7 @@ class ADistinctionIsMeasuredHoweverItIsSpelledTest {
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
                 .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         return Partitions.of(spec.name(), InputDomain.of(spec, sigs.get(behavior), symbols),
                 symbols);
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ADistinctionIsMeasuredHoweverItIsSpelledTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ADistinctionIsMeasuredHoweverItIsSpelledTest.java
@@ -7,6 +7,7 @@ import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.inputs.InputDomain;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -46,7 +47,7 @@ class ADistinctionIsMeasuredHoweverItIsSpelledTest {
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
                 .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         return Partitions.of(spec.name(), InputDomain.of(spec, sigs.get(behavior), symbols),
                 symbols);
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AFloorHoldsWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AFloorHoldsWhereverItIsWrittenTest.java
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.FieldDomains;
 import souther.compiler.check.Symbols;
+import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
-import souther.compiler.query.Shapes;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
@@ -48,7 +48,7 @@ class AFloorHoldsWhereverItIsWrittenTest {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         String module = compilation.modules().get(0);
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         assertNotNull(symbols, "the model did not compile");
         assertEquals(List.of(), compilation.diagnostics().values().stream()
                         .flatMap(List::stream).map(each -> each.diagnostic().code()).toList(),

--- a/souther-compiler/src/test/java/souther/compiler/partition/AFloorHoldsWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AFloorHoldsWhereverItIsWrittenTest.java
@@ -2,10 +2,10 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.FieldDomains;
 import souther.compiler.check.Symbols;
-import souther.compiler.query.Names;
 import souther.compiler.query.Compilation;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
@@ -48,7 +48,7 @@ class AFloorHoldsWhereverItIsWrittenTest {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         String module = compilation.modules().get(0);
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(symbols, "the model did not compile");
         assertEquals(List.of(), compilation.diagnostics().values().stream()
                         .flatMap(List::stream).map(each -> each.diagnostic().code()).toList(),

--- a/souther-compiler/src/test/java/souther/compiler/partition/AFloorNothingBuildsIsSaidTheSameWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AFloorNothingBuildsIsSaidTheSameWhereverItIsWrittenTest.java
@@ -7,6 +7,7 @@ import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.inputs.InputDomain;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -46,7 +47,7 @@ class AFloorNothingBuildsIsSaidTheSameWhereverItIsWrittenTest {
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         assertNotNull(prepared, "the model did not compile");
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
                 .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();

--- a/souther-compiler/src/test/java/souther/compiler/partition/AFloorNothingBuildsIsSaidTheSameWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AFloorNothingBuildsIsSaidTheSameWhereverItIsWrittenTest.java
@@ -2,12 +2,12 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.inputs.InputDomain;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -47,7 +47,7 @@ class AFloorNothingBuildsIsSaidTheSameWhereverItIsWrittenTest {
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(prepared, "the model did not compile");
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
                 .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionWithAFloorIsOfferedAValueThatMeetsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionWithAFloorIsOfferedAValueThatMeetsItTest.java
@@ -7,6 +7,7 @@ import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.inputs.InputDomain;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -32,7 +33,7 @@ class APositionWithAFloorIsOfferedAValueThatMeetsItTest {
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         assertNotNull(prepared, "the model did not compile");
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
                 .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionWithAFloorIsOfferedAValueThatMeetsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionWithAFloorIsOfferedAValueThatMeetsItTest.java
@@ -2,12 +2,12 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.inputs.InputDomain;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -33,7 +33,7 @@ class APositionWithAFloorIsOfferedAValueThatMeetsItTest {
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(prepared, "the model did not compile");
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
                 .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnObservationSaysTheSameThingWhereverThePathMeetsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnObservationSaysTheSameThingWhereverThePathMeetsItTest.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
@@ -15,7 +16,6 @@ import souther.compiler.observe.Classification;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.observe.RowOutcome;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
@@ -78,7 +78,7 @@ class AnObservationSaysTheSameThingWhereverThePathMeetsItTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, "the model under test compiles");

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnObservationSaysTheSameThingWhereverThePathMeetsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnObservationSaysTheSameThingWhereverThePathMeetsItTest.java
@@ -15,6 +15,7 @@ import souther.compiler.observe.Classification;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.observe.RowOutcome;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
@@ -77,7 +78,7 @@ class AnObservationSaysTheSameThingWhereverThePathMeetsItTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, "the model under test compiles");

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnOrdinalIsNeverWhatAnEnumerationIsWrittenAsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnOrdinalIsNeverWhatAnEnumerationIsWrittenAsTest.java
@@ -116,7 +116,7 @@ class AnOrdinalIsNeverWhatAnEnumerationIsWrittenAsTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         souther.compiler.check.Symbols symbols =
-                souther.compiler.query.Names.derivedSymbols(compilation.db(), module).value();
+                souther.compiler.query.Scopes.derived(compilation.db(), module).value();
 
         assertNull(Carrier.ofValue(
                 souther.compiler.types.Type.ref(TypeSymbols.declared(new TypeKey("example.onecase", "Qualified"))),

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnOrdinalIsNeverWhatAnEnumerationIsWrittenAsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnOrdinalIsNeverWhatAnEnumerationIsWrittenAsTest.java
@@ -116,7 +116,7 @@ class AnOrdinalIsNeverWhatAnEnumerationIsWrittenAsTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         souther.compiler.check.Symbols symbols =
-                compilation.db().ask(new souther.compiler.query.Shapes.Scope(module)).value();
+                souther.compiler.query.Names.derivedSymbols(compilation.db(), module).value();
 
         assertNull(Carrier.ofValue(
                 souther.compiler.types.Type.ref(TypeSymbols.declared(new TypeKey("example.onecase", "Qualified"))),

--- a/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
@@ -11,7 +12,6 @@ import souther.compiler.inputs.Membership;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.observe.Classification;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -102,7 +102,7 @@ class GeneratorTest {
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         assertNotNull(prepared);
         assertNotNull(sigs);
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()

--- a/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
@@ -11,6 +11,7 @@ import souther.compiler.inputs.Membership;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.observe.Classification;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -101,7 +102,7 @@ class GeneratorTest {
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         assertNotNull(prepared);
         assertNotNull(sigs);
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()

--- a/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
@@ -9,6 +9,7 @@ import souther.compiler.check.Symbols;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.Membership;
 import souther.compiler.observe.ObservedValue;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -43,7 +44,7 @@ class PartitionsTest {
         assertNotNull(sigs);
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
                 .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         return Partitions.of(spec.name(), InputDomain.of(spec, sigs.get(behavior), symbols),
                 symbols);
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
@@ -9,7 +10,6 @@ import souther.compiler.check.Symbols;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.Membership;
 import souther.compiler.observe.ObservedValue;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -44,7 +44,7 @@ class PartitionsTest {
         assertNotNull(sigs);
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
                 .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         return Partitions.of(spec.name(), InputDomain.of(spec, sigs.get(behavior), symbols),
                 symbols);
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/RowClassesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/RowClassesTest.java
@@ -14,6 +14,7 @@ import souther.compiler.observe.Classification;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.observe.RowOutcome;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
@@ -66,7 +67,7 @@ class RowClassesTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, "the model under test compiles");

--- a/souther-compiler/src/test/java/souther/compiler/partition/RowClassesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/RowClassesTest.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
@@ -14,7 +15,6 @@ import souther.compiler.observe.Classification;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.observe.RowOutcome;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
@@ -67,7 +67,7 @@ class RowClassesTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, "the model under test compiles");

--- a/souther-compiler/src/test/java/souther/compiler/partition/ThresholdNormalizationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ThresholdNormalizationTest.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
@@ -12,7 +13,6 @@ import souther.compiler.coverage.CoverageSites;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.observe.ObservedValue;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -48,7 +48,7 @@ class ThresholdNormalizationTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, "the model under test compiles");

--- a/souther-compiler/src/test/java/souther/compiler/partition/ThresholdNormalizationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ThresholdNormalizationTest.java
@@ -12,6 +12,7 @@ import souther.compiler.coverage.CoverageSites;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.observe.ObservedValue;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -47,7 +48,7 @@ class ThresholdNormalizationTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, "the model under test compiles");

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAClassMeansDoesNotTurnOnWhoIsReadingItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAClassMeansDoesNotTurnOnWhoIsReadingItTest.java
@@ -9,6 +9,7 @@ import souther.compiler.check.Symbols;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.observe.ObservedValue;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -72,7 +73,7 @@ class WhatAClassMeansDoesNotTurnOnWhoIsReadingItTest {
         String module = compilation.modules().get(nth);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
                 .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
         return Partitions.of(spec.name(), InputDomain.of(spec, sigs.get(behavior), symbols), symbols).axes().stream()

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAClassMeansDoesNotTurnOnWhoIsReadingItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAClassMeansDoesNotTurnOnWhoIsReadingItTest.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
@@ -9,7 +10,6 @@ import souther.compiler.check.Symbols;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.observe.ObservedValue;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -73,7 +73,7 @@ class WhatAClassMeansDoesNotTurnOnWhoIsReadingItTest {
         String module = compilation.modules().get(nth);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
                 .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
         return Partitions.of(spec.name(), InputDomain.of(spec, sigs.get(behavior), symbols), symbols).axes().stream()

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAClauseDrawsALineOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAClauseDrawsALineOnTest.java
@@ -2,13 +2,13 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.StatedContract;
 import souther.compiler.check.Symbols;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.NumericTerm;
-import souther.compiler.query.Names;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
@@ -39,7 +39,7 @@ class WhatAClauseDrawsALineOnTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         Map<String, StatedContract> stated =
                 compilation.db().ask(new Bodies.StatedContracts(module)).value();
         InputDomain inputs =

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAClauseDrawsALineOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAClauseDrawsALineOnTest.java
@@ -8,6 +8,7 @@ import souther.compiler.check.StatedContract;
 import souther.compiler.check.Symbols;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.NumericTerm;
+import souther.compiler.query.Names;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
@@ -38,7 +39,7 @@ class WhatAClauseDrawsALineOnTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         Map<String, StatedContract> stated =
                 compilation.db().ask(new Bodies.StatedContracts(module)).value();
         InputDomain inputs =

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatARuleOnAStringIsMeasuredAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatARuleOnAStringIsMeasuredAtTest.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
@@ -10,7 +11,6 @@ import souther.compiler.check.TypeChecker;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.inputs.InputDomain;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -156,7 +156,7 @@ class WhatARuleOnAStringIsMeasuredAtTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, "the model under test compiles: " + guard);

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatARuleOnAStringIsMeasuredAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatARuleOnAStringIsMeasuredAtTest.java
@@ -10,6 +10,7 @@ import souther.compiler.check.TypeChecker;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.inputs.InputDomain;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -155,7 +156,7 @@ class WhatARuleOnAStringIsMeasuredAtTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, "the model under test compiles: " + guard);

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhichArmWitnessesAComparisonIsPerComparisonTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhichArmWitnessesAComparisonIsPerComparisonTest.java
@@ -8,6 +8,7 @@ import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeChecker;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -53,7 +54,7 @@ class WhichArmWitnessesAComparisonIsPerComparisonTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, () -> "the model under test compiles: " + condition);
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhichArmWitnessesAComparisonIsPerComparisonTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhichArmWitnessesAComparisonIsPerComparisonTest.java
@@ -2,13 +2,13 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeChecker;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -54,7 +54,7 @@ class WhichArmWitnessesAComparisonIsPerComparisonTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, () -> "the model under test compiles: " + condition);
         Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest.java
@@ -15,6 +15,7 @@ import souther.compiler.observe.Classification;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.observe.RowOutcome;
+import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
@@ -78,7 +79,7 @@ class WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, "the model under test compiles");

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
@@ -15,7 +16,6 @@ import souther.compiler.observe.Classification;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.observe.RowOutcome;
-import souther.compiler.query.Names;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
@@ -79,7 +79,7 @@ class WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest {
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
-        Symbols symbols = Names.derivedSymbols(compilation.db(), module).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
         Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
         assertNotNull(checked, "the model under test compiles");

--- a/souther-compiler/src/test/java/souther/compiler/query/Divergence.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/Divergence.java
@@ -4,7 +4,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.IdentityHashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -49,9 +49,16 @@ record Divergence(String path, String cause, Divergence.Kind kind) {
 
     private static final class Walk {
 
-        /** Pairs already walked, so a graph that loops is walked once. */
-        private final Set<Object> seen =
-                java.util.Collections.newSetFromMap(new IdentityHashMap<>());
+        /**
+         * Pairs already walked, so a graph that loops is walked once.
+         *
+         * <p>A set that compares its members and not their addresses, because a pair is made where
+         * it is asked about and is never the same object twice. What is compared is what
+         * {@link Pair} says: the two sides by address, which is the question — whether these two
+         * objects have been walked together — and not whether two objects are equal, which is what
+         * the walk is here to find out.
+         */
+        private final Set<Pair> seen = new HashSet<>();
         private final List<Divergence> out;
         /** A walk of two whole answers is bounded, so a graph nobody meant to walk stops. */
         private int budget = 400_000;

--- a/souther-compiler/src/test/java/souther/compiler/query/Divergence.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/Divergence.java
@@ -1,0 +1,169 @@
+package souther.compiler.query;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Where two answers to one question stop being the same thing, and why.
+ *
+ * <p>A pair walk and not a scan of one of them. What makes an answer fail to compare is not always
+ * something with no {@code equals}: a record whose component is a way of reading a store has an
+ * {@code equals} of its own and still says no, because the two stores are two objects. Only holding
+ * the two side by side says which is which.
+ *
+ * @param path where in the answer the two came apart, as field names from the answer down
+ * @param cause the class the two are of at that point, or the array type
+ * @param kind whether the two say the same thing there, or different things
+ */
+record Divergence(String path, String cause, Divergence.Kind kind) {
+
+    /** What a divergence means. */
+    enum Kind {
+        /**
+         * The two are the same thing said twice and compare unequal anyway — an array, a class with
+         * no {@code equals} of its own, or one whose {@code equals} rests on something that is one
+         * object per store. Nothing downstream of it can ever be kept.
+         */
+        THE_SAME_THING_TWICE,
+        /**
+         * The two say different things. One compile of one input answered differently from another,
+         * which is not about equality at all.
+         */
+        DIFFERENT_THINGS
+    }
+
+    /** Where {@code a} and {@code b} come apart, empty where nothing downstream can tell them
+     *  apart. */
+    static List<Divergence> between(Object a, Object b) {
+        List<Divergence> out = new ArrayList<>();
+        new Walk(out).at(a, b, "");
+        return out;
+    }
+
+    private static final class Walk {
+
+        /** Pairs already walked, so a graph that loops is walked once. */
+        private final Set<Object> seen =
+                java.util.Collections.newSetFromMap(new IdentityHashMap<>());
+        private final List<Divergence> out;
+        /** A walk of two whole answers is bounded, so a graph nobody meant to walk stops. */
+        private int budget = 400_000;
+
+        Walk(List<Divergence> out) {
+            this.out = out;
+        }
+
+        private static boolean opaque(Class<?> c) {
+            return c == String.class || Number.class.isAssignableFrom(c) || c == Boolean.class
+                    || c == Character.class || c.isEnum();
+        }
+
+        private void say(String path, Class<?> c, Kind kind) {
+            out.add(new Divergence(path, c.isArray() ? c.getSimpleName() : c.getName(), kind));
+        }
+
+        void at(Object a, Object b, String path) {
+            if (a == b || budget-- <= 0) {
+                return;
+            }
+            if (a == null || b == null || a.getClass() != b.getClass()) {
+                say(path, (a == null ? b : a).getClass(), Kind.DIFFERENT_THINGS);
+                return;
+            }
+            Class<?> c = a.getClass();
+            if (opaque(c)) {
+                if (!a.equals(b)) {
+                    say(path, c, Kind.DIFFERENT_THINGS);
+                }
+                return;
+            }
+            // The store itself is where a walk stops. Every answer in it is being compared already,
+            // and an answer that holds it holds one object per store however deep the walk goes.
+            if (a instanceof Db) {
+                say(path, c, Kind.THE_SAME_THING_TWICE);
+                return;
+            }
+            if (!seen.add(new Pair(a, b))) {
+                return;
+            }
+            int before = out.size();
+            descend(a, b, c, path);
+            if (out.size() == before && !a.equals(b)) {
+                say(path, c, Kind.THE_SAME_THING_TWICE);
+            }
+        }
+
+        private void descend(Object a, Object b, Class<?> c, String path) {
+            if (c.isArray()) {
+                int length = java.lang.reflect.Array.getLength(a);
+                if (length != java.lang.reflect.Array.getLength(b)) {
+                    say(path, c, Kind.DIFFERENT_THINGS);
+                    return;
+                }
+                for (int i = 0; i < length; i++) {
+                    at(java.lang.reflect.Array.get(a, i), java.lang.reflect.Array.get(b, i),
+                            path + "[]");
+                }
+                // An array compares by identity, so where the elements agree the caller's own
+                // check is what names it.
+                return;
+            }
+            if (a instanceof Map<?, ?> left && b instanceof Map<?, ?> right) {
+                if (!left.keySet().equals(right.keySet())) {
+                    say(path, c, Kind.DIFFERENT_THINGS);
+                    return;
+                }
+                left.forEach((key, value) -> at(value, right.get(key), path + ".value"));
+                return;
+            }
+            if (a instanceof Collection<?> left && b instanceof Collection<?> right) {
+                if (left.size() != right.size()) {
+                    say(path, c, Kind.DIFFERENT_THINGS);
+                    return;
+                }
+                Iterator<?> theirs = right.iterator();
+                for (Object each : left) {
+                    at(each, theirs.next(), path + "[]");
+                }
+                return;
+            }
+            if (a.equals(b)) {
+                return;
+            }
+            for (Class<?> k = c; k != null && k != Object.class; k = k.getSuperclass()) {
+                for (Field f : k.getDeclaredFields()) {
+                    if (Modifier.isStatic(f.getModifiers())) {
+                        continue;
+                    }
+                    try {
+                        f.setAccessible(true);
+                        at(f.get(a), f.get(b), path + "." + f.getName());
+                    } catch (ReflectiveOperationException | RuntimeException | Error _) {
+                        // Nothing this can say about a field it cannot read. The class itself is
+                        // still reported where the descent finds nothing.
+                    }
+                }
+            }
+        }
+    }
+
+    /** Two objects walked together, by identity. */
+    private record Pair(Object left, Object right) {
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof Pair pair && pair.left == left && pair.right == right;
+        }
+
+        @Override
+        public int hashCode() {
+            return System.identityHashCode(left) * 31 + System.identityHashCode(right);
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/EquivalentDatabasesAnswerTheSameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EquivalentDatabasesAnswerTheSameTest.java
@@ -1,0 +1,103 @@
+package souther.compiler.query;
+
+import souther.compiler.conformance.ConformanceCorpus;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Two stores given the same sources answer the same.
+ *
+ * <p>What an edit costs rests on an answer that means what the last one meant coming out equal to
+ * it. That is a property of the answers and not of the engine, and nothing else here can see it
+ * fail: a value that compares by identity leaves every check green and every reader of it running
+ * again forever. So it is asked of two compilations of one input, where anything that compares by
+ * where it came from has to say no.
+ *
+ * <p>Two things are asked at once and told apart. An answer that is the same thing said twice and
+ * compares unequal anyway is a value that is not one — an array, or something holding a way of
+ * reading a store. An answer that says something different is a compile that did not reproduce,
+ * which is a different fault with the same symptom, and there is no reason for one of those to
+ * exist at all.
+ *
+ * <p>What it sees is what the corpora reach. An answer no question about them asks for is not
+ * compared here, and what the corpora reach is
+ * {@code AConformanceCorpusReachesEveryConstructTheLanguageDeclaresTest}'s to say.
+ *
+ * <p>What is known and not fixed is written out below by what causes it, not by which question it
+ * reaches. A cause is one thing to fix; the questions it arrives at are however many happen to read
+ * it today, and restructuring what an answer holds would rewrite that list without changing what is
+ * wrong. Exactly the causes below, so fixing one is a failure until it is struck off, and so is
+ * adding one.
+ */
+class EquivalentDatabasesAnswerTheSameTest {
+
+    /**
+     * A thing kept in an answer that cannot compare as a value, and where it is being dealt with.
+     *
+     * <p>Two ways out and no third. Something that says what it is becomes a value — that is
+     * {@code byte[]}, which means what its bytes mean and is compared as an address. Something that
+     * does something is a capability, and a capability is built where it is used and never answered
+     * with. Which of the two each of these is is written here because it is the fix, and a note
+     * saying only that it is known would leave the next reader to decide it again.
+     */
+    private record Known(String cause, String fix) {}
+
+    private static final List<Known> KNOWN = List.of(
+            new Known("byte[]",
+                    "a value: what a class is is its bytes, so a wrapper comparing them is what "
+                            + "lets a module whose classes came out the same leave its readers "
+                            + "alone. Reached from Output.All, .Classes, .Linked, .Evaluated and "
+                            + ".EvaluationLinked, which are one thing to fix and not five"),
+            new Known("souther.compiler.query.Db",
+                    "a capability: Scoping.Scoped carries a way of asking the modules around this "
+                            + "one a further question, and it holds this store to ask with. Where "
+                            + "a scope has been taken apart already, that is the half of the "
+                            + "assembly nobody has yet — it belongs inside the compute that asks"),
+            new Known("souther.compiler.inputs.InputDomain",
+                    "unclassified: whether it is something that says what it is or something that "
+                            + "does something has to be read before it is either, so the fix is to "
+                            + "read it"),
+            new Known("souther.compiler.query.Bodies$Elaborated",
+                    "unclassified: as above"));
+
+    @Test
+    void everyAnswerMeansTheSameThingInBothStores() {
+        Map<String, Set<String>> sameThingTwice = new TreeMap<>();
+        Map<String, Set<String>> differentThings = new TreeMap<>();
+        for (ConformanceCorpus corpus : ConformanceCorpus.all()) {
+            Map<Key<?>, Answer<?>> one = corpus.analyse().compilation().db().everyAnswer();
+            Map<Key<?>, Answer<?>> other = corpus.analyse().compilation().db().everyAnswer();
+            Set<Key<?>> asked = new HashSet<>(one.keySet());
+            asked.retainAll(other.keySet());
+            for (Key<?> key : asked) {
+                Answer<?> a = one.get(key);
+                Answer<?> b = other.get(key);
+                if (a.equals(b)) {
+                    continue;
+                }
+                for (Divergence each : Divergence.between(a, b)) {
+                    Map<String, Set<String>> into =
+                            each.kind() == Divergence.Kind.THE_SAME_THING_TWICE
+                                    ? sameThingTwice : differentThings;
+                    into.computeIfAbsent(each.cause(), _ -> new TreeSet<>())
+                            .add(key.getClass().getSimpleName() + each.path());
+                }
+            }
+        }
+
+        assertEquals(Map.of(), differentThings,
+                "one input compiled twice answered two different things, which no equality can fix");
+        assertEquals(new TreeSet<>(KNOWN.stream().map(Known::cause).toList()),
+                new TreeSet<>(sameThingTwice.keySet()),
+                "what is kept in an answer and cannot compare as a value, reached at "
+                        + sameThingTwice);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/EquivalentDatabasesAnswerTheSameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EquivalentDatabasesAnswerTheSameTest.java
@@ -13,7 +13,7 @@ import java.util.TreeSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Two stores given the same sources answer the same.
+ * Two stores given the same sources are asked the same questions and answer them the same.
  *
  * <p>What an edit costs rests on an answer that means what the last one meant coming out equal to
  * it. That is a property of the answers and not of the engine, and nothing else here can see it
@@ -40,7 +40,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class EquivalentDatabasesAnswerTheSameTest {
 
     /**
-     * A thing kept in an answer that cannot compare as a value, and where it is being dealt with.
+     * A thing kept in an answer that cannot compare as a value, the questions it is reached from,
+     * and where it is being dealt with.
+     *
+     * <p>The questions and not the paths. A cause is one thing to fix wherever it turns up, so
+     * moving what an answer holds around inside itself is not news; a cause turning up under a
+     * question that did not have it is a new place the debt has reached, and that is. Which is what
+     * makes this a register and not a list of what to overlook: putting a {@code byte[]} in some new
+     * answer fails here, and the line to add says which of the two things it has to become.
      *
      * <p>Two ways out and no third. Something that says what it is becomes a value — that is
      * {@code byte[]}, which means what its bytes mean and is compared as an address. Something that
@@ -48,30 +55,57 @@ class EquivalentDatabasesAnswerTheSameTest {
      * with. Which of the two each of these is is written here because it is the fix, and a note
      * saying only that it is known would leave the next reader to decide it again.
      */
-    private record Known(String cause, String fix) {}
+    private record Known(String cause, Set<String> asked, String fix) {}
 
     private static final List<Known> KNOWN = List.of(
             new Known("byte[]",
+                    Set.of("All", "Classes", "Linked", "Evaluated", "EvaluationLinked"),
                     "a value: what a class is is its bytes, so a wrapper comparing them is what "
                             + "lets a module whose classes came out the same leave its readers "
-                            + "alone. Reached from Output.All, .Classes, .Linked, .Evaluated and "
-                            + ".EvaluationLinked, which are one thing to fix and not five"),
+                            + "alone. Five questions and one thing to fix"),
             new Known("souther.compiler.query.Db",
+                    Set.of("ModuleScope"),
                     "a capability: Scoping.Scoped carries a way of asking the modules around this "
                             + "one a further question, and it holds this store to ask with. Where "
                             + "a scope has been taken apart already, that is the half of the "
                             + "assembly nobody has yet — it belongs inside the compute that asks"),
             new Known("souther.compiler.inputs.InputDomain",
+                    Set.of("Inputs"),
                     "unclassified: whether it is something that says what it is or something that "
                             + "does something has to be read before it is either, so the fix is to "
                             + "read it"),
             new Known("souther.compiler.query.Bodies$Elaborated",
+                    Set.of("Checked"),
                     "unclassified: as above"));
+
+    /**
+     * And they are asked the same questions. What an answer was built from is what an edit is
+     * absorbed by, so which questions a compile reaches is as much what it did as what it said: two
+     * stores over one input reaching different graphs would mean the dependencies recorded in one
+     * are not the ones the other would keep.
+     *
+     * <p>Its own sentence rather than a line of the one below, which is about what the two kept
+     * where they were asked the same thing.
+     */
+    @Test
+    void bothStoresAreAskedTheSameQuestions() {
+        for (ConformanceCorpus corpus : ConformanceCorpus.all()) {
+            Set<Key<?>> one = corpus.analyse().compilation().db().everyAnswer().keySet();
+            Set<Key<?>> other = corpus.analyse().compilation().db().everyAnswer().keySet();
+            Set<String> onlyOne = new TreeSet<>();
+            one.stream().filter(key -> !other.contains(key)).forEach(key -> onlyOne.add(key.toString()));
+            Set<String> onlyOther = new TreeSet<>();
+            other.stream().filter(key -> !one.contains(key)).forEach(key -> onlyOther.add(key.toString()));
+            assertEquals(Set.of(), onlyOne, "asked only the first time, of " + corpus);
+            assertEquals(Set.of(), onlyOther, "asked only the second time, of " + corpus);
+        }
+    }
 
     @Test
     void everyAnswerMeansTheSameThingInBothStores() {
         Map<String, Set<String>> sameThingTwice = new TreeMap<>();
         Map<String, Set<String>> differentThings = new TreeMap<>();
+        Map<String, Set<String>> where = new TreeMap<>();
         for (ConformanceCorpus corpus : ConformanceCorpus.all()) {
             Map<Key<?>, Answer<?>> one = corpus.analyse().compilation().db().everyAnswer();
             Map<Key<?>, Answer<?>> other = corpus.analyse().compilation().db().everyAnswer();
@@ -88,6 +122,8 @@ class EquivalentDatabasesAnswerTheSameTest {
                             each.kind() == Divergence.Kind.THE_SAME_THING_TWICE
                                     ? sameThingTwice : differentThings;
                     into.computeIfAbsent(each.cause(), _ -> new TreeSet<>())
+                            .add(key.getClass().getSimpleName());
+                    where.computeIfAbsent(each.cause(), _ -> new TreeSet<>())
                             .add(key.getClass().getSimpleName() + each.path());
                 }
             }
@@ -95,9 +131,10 @@ class EquivalentDatabasesAnswerTheSameTest {
 
         assertEquals(Map.of(), differentThings,
                 "one input compiled twice answered two different things, which no equality can fix");
-        assertEquals(new TreeSet<>(KNOWN.stream().map(Known::cause).toList()),
-                new TreeSet<>(sameThingTwice.keySet()),
-                "what is kept in an answer and cannot compare as a value, reached at "
-                        + sameThingTwice);
+        Map<String, Set<String>> known = new TreeMap<>();
+        KNOWN.forEach(each -> known.put(each.cause(), new TreeSet<>(each.asked())));
+        assertEquals(known, sameThingTwice,
+                "what is kept in an answer and cannot compare as a value, by the questions it is "
+                        + "reached from. Found at " + where);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -592,13 +593,42 @@ class IncrementalCompilationTest {
     }
 
     /**
-     * Known and not narrowed: declaring a behavior re-checks every body of the module. A body reads
-     * its module's scope and the signatures of everything callable there as whole tables, so adding
-     * one changes both and reaches all of them — issue #829.
+     * What the names written in a module mean is what a body is checked in, and declaring a behavior
+     * does not change it: a behavior is a value and not a type, so no spelling here means anything
+     * it did not mean before.
      *
-     * <p>Written down so that narrowing either of them is a change that shows, and so that the
-     * contract dependency above is not read as having made an edit to a declaration local. It did
-     * not: it made an edit to an `ensures` local, which is a different edit.
+     * <p>The whole assembly does change — the value namespace gains a name — and reading a scope off
+     * the assembly is what made that edit arrive at every reader of what the names mean. What is
+     * asked for here is the part of it that answers this question.
+     */
+    @Test
+    void declaringABehaviorDoesNotChangeWhatTheNamesOfTheModuleMean() {
+        Compilation c = stating();
+        Answer<?> meant = c.db().ask(new Names.Meanings("shop.orders"));
+        Answer<?> assembled = c.db().ask(new Names.ModuleScope("shop.orders"));
+
+        c.update(Map.of("orders.sou", STATING + """
+
+                behavior added : (n: Amount) -> Amount
+                    constructs Amount
+                let added (n) = Amount(n.value * 4)
+                """), Set.of());
+        c.answerEverything();
+
+        assertEquals(meant, c.db().ask(new Names.Meanings("shop.orders")),
+                "`added` is a name in the value namespace and no type is spelled differently");
+        assertNotEquals(assembled, c.db().ask(new Names.ModuleScope("shop.orders")),
+                "and the assembly it is read off did change, which is why it is not read off it");
+    }
+
+    /**
+     * Known and not narrowed: declaring a behavior re-checks every body of the module. A body reads
+     * the signatures of everything callable in its module as a whole table, so adding one changes it
+     * and reaches all of them — issue #829.
+     *
+     * <p>Written down so that narrowing it is a change that shows, and so that the contract
+     * dependency above is not read as having made an edit to a declaration local. It did not: it
+     * made an edit to an `ensures` local, which is a different edit.
      */
     @Test
     void declaringABehaviorRechecksTheBodiesBesideIt() {

--- a/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
@@ -622,16 +622,14 @@ class IncrementalCompilationTest {
     }
 
     /**
-     * Known and not narrowed: declaring a behavior re-checks every body of the module. A body reads
-     * the signatures of everything callable in its module as a whole table, so adding one changes it
-     * and reaches all of them — issue #829.
-     *
-     * <p>Written down so that narrowing it is a change that shows, and so that the contract
-     * dependency above is not read as having made an edit to a declaration local. It did not: it
-     * made an edit to an `ensures` local, which is a different edit.
+     * Declaring a behavior is none of the business of the bodies beside it. A body reads what the
+     * names of its module mean and the signatures of what it calls; the first does not change when a
+     * value name is added, and the second is what this body names rather than what the module has
+     * callable in it. Both were read as whole tables, so adding a behavior nothing calls reached
+     * every body in the file — issue #829.
      */
     @Test
-    void declaringABehaviorRechecksTheBodiesBesideIt() {
+    void declaringABehaviorDoesNotRecheckTheBodiesBesideIt() {
         Compilation c = stating();
         Answer<?> caller = c.db().ask(new Bodies.CheckedBehavior("shop.orders", "caller"));
 
@@ -643,7 +641,85 @@ class IncrementalCompilationTest {
                 """), Set.of());
         c.answerEverything();
 
-        assertNotSame(caller, c.db().ask(new Bodies.CheckedBehavior("shop.orders", "caller")),
+        assertSame(caller, c.db().ask(new Bodies.CheckedBehavior("shop.orders", "caller")),
                 "`caller` neither calls `added` nor names anything of it");
+    }
+
+    /**
+     * Known and not narrowed: declaring a type re-checks every body of the module. A body is checked
+     * in what the names of its module mean, and a type declaration is a spelling that means
+     * something there — so unlike a behavior, this really does change what every body reads.
+     *
+     * <p>What is left of issue #829, which is issue #835. Which of a module's meanings a body needs
+     * is a question about what a body's scope is rather than a table being read whole, and answering
+     * it here would settle that by accident. Written down so that narrowing it is a change that
+     * shows.
+     */
+    @Test
+    void declaringADataRechecksTheBodiesBesideIt() {
+        Compilation c = stating();
+        Answer<?> caller = c.db().ask(new Bodies.CheckedBehavior("shop.orders", "caller"));
+
+        c.update(Map.of("orders.sou", STATING + """
+
+                data Discount = Int
+                """), Set.of());
+        c.answerEverything();
+
+        assertNotSame(caller, c.db().ask(new Bodies.CheckedBehavior("shop.orders", "caller")),
+                "`Discount` is a spelling `caller` does not write, and it means something here");
+    }
+
+    /**
+     * And moving one. What a body is checked against is what the declarations say, so the order they
+     * are written in is not part of it — a signature that arrived at a caller carrying where it was
+     * written, or the position its module numbered it at, would reach every caller on an edit above
+     * it.
+     */
+    @Test
+    void reorderingTheDeclarationsDoesNotRecheckTheBodiesBesideThem() {
+        Compilation c = stating();
+        Answer<?> caller = c.db().ask(new Bodies.CheckedBehavior("shop.orders", "caller"));
+
+        String uncalled = """
+                behavior uncalled : (n: Amount) -> Amount
+                    constructs Amount
+                    ensures value.value > n.value - 1
+                let uncalled (n) = Amount(n.value * 3)
+
+                """;
+        String called = """
+                behavior called : (n: Amount) -> Amount
+                    constructs Amount
+                    ensures value.value >= n.value
+                let called (n) = Amount(n.value * 2)
+                """;
+        assertTrue(STATING.contains(uncalled) && STATING.endsWith(called),
+                "the fixture is the two declarations in this order");
+        c.update(Map.of("orders.sou",
+                STATING.replace(uncalled, "").replace(called, called + "\n" + uncalled.strip() + "\n")),
+                Set.of());
+        c.answerEverything();
+
+        assertSame(caller, c.db().ask(new Bodies.CheckedBehavior("shop.orders", "caller")),
+                "`called` takes what it took, wherever in the file it is written");
+    }
+
+    /** And the other way round: editing what a called behavior takes is what its callers read. */
+    @Test
+    void changingWhatACalledBehaviorTakesRechecksTheBodiesThatCallIt() {
+        Compilation c = stating();
+        Answer<?> caller = c.db().ask(new Bodies.CheckedBehavior("shop.orders", "caller"));
+
+        c.update(Map.of("orders.sou", STATING.replace(
+                "behavior called : (n: Amount) -> Amount",
+                "behavior called : (n: Amount, m: Amount) -> Amount").replace(
+                "let called (n) = Amount(n.value * 2)",
+                "let called (n, m) = Amount(n.value * 2 + m.value)").replace(
+                "let caller (n) = called(n)", "let caller (n) = called(n, n)")), Set.of());
+        c.answerEverything();
+
+        assertNotSame(caller, c.db().ask(new Bodies.CheckedBehavior("shop.orders", "caller")),
+                "`caller` calls `called`, so what `called` takes is what it is typed against");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/Scopes.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/Scopes.java
@@ -1,0 +1,30 @@
+package souther.compiler.query;
+
+import souther.compiler.check.Symbols;
+
+/**
+ * A scope, for a test standing where a compute stands.
+ *
+ * <p>Here and not on {@link Names} because of what a scope is. It reads declarations by asking the
+ * store, so it is a way of asking rather than an answer, and what keeps that honest is that one is
+ * built inside the {@code compute} that reads it and goes no further — a public way of getting one
+ * is a way of keeping one, which is what {@code Compilation.symbols} was and why it is gone.
+ *
+ * <p>A test is not a compute and does not have to be. What it may not do is make the production API
+ * wider than the rule allows so that it can reach one; so it reaches over the package boundary from
+ * inside the package, which is a thing only a test source can do.
+ */
+public final class Scopes {
+
+    private Scopes() {}
+
+    /** What names mean in {@code module}, over the declarations as they were derived. */
+    public static Answer<Symbols> derived(Db db, String module) {
+        return Names.derivedSymbols(db, module);
+    }
+
+    /** The same, over the declarations as resolution left them. */
+    public static Answer<Symbols> resolved(Db db, String module) {
+        return Names.resolvedSymbols(db, module);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/WhichDeclarationWorldAReaderGetsIsWhichQuestionItAskedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhichDeclarationWorldAReaderGetsIsWhichQuestionItAskedTest.java
@@ -53,8 +53,8 @@ class WhichDeclarationWorldAReaderGetsIsWhichQuestionItAskedTest {
     void theResolvedWorldAndTheDerivedWorldAnswerDifferently() {
         Db db = db();
 
-        Hir.Expr resolved = clauseOf(db.ask(new Names.NameScope("m")).value());
-        Hir.Expr derived = clauseOf(db.ask(new Shapes.Scope("m")).value());
+        Hir.Expr resolved = clauseOf(Names.resolvedSymbols(db, "m").value());
+        Hir.Expr derived = clauseOf(Names.derivedSymbols(db, "m").value());
 
         assertEquals(1, applications(resolved),
                 "the resolved world holds the clause as written: a call to the helper");
@@ -69,8 +69,8 @@ class WhichDeclarationWorldAReaderGetsIsWhichQuestionItAskedTest {
     void neitherScopeCarriesWhichWorldItCameFrom() {
         Db db = db();
 
-        assertInstanceOf(Symbols.class, db.ask(new Names.NameScope("m")).value());
-        assertInstanceOf(Symbols.class, db.ask(new Shapes.Scope("m")).value());
+        assertInstanceOf(Symbols.class, Names.resolvedSymbols(db, "m").value());
+        assertInstanceOf(Symbols.class, Names.derivedSymbols(db, "m").value());
     }
 
     private static int applications(Hir.Expr e) {

--- a/souther-lsp/src/main/java/souther/lsp/analysis/NamesFromElsewhere.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/NamesFromElsewhere.java
@@ -2,7 +2,6 @@ package souther.lsp.analysis;
 
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Scoping;
-import souther.compiler.check.Symbols;
 import souther.compiler.query.Answer;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Names;
@@ -12,13 +11,14 @@ import souther.lsp.protocol.CompletionItem;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
  * What a document may write that it does not declare itself, as the compiler last answered it.
  *
  * <p>Which bare spelling reaches what is the compiler's, and both namespaces are asked of it every
- * time it can answer: {@link Names.NameScope} for the declarations a name reaches, which carry what
+ * time it can answer: {@link Names.Reachable} for the declarations a name reaches, which carry what
  * kind of declaration each is, and {@link Names.ModuleScope} for the value namespace. Nothing here
  * reads an import line. What one brings in is {@code Scoping}'s to say, and a second reader of those
  * lines would be that rule written twice, to go out of agreement the first time either moved.
@@ -83,7 +83,7 @@ final class NamesFromElsewhere {
         if (module == null) {
             return null;
         }
-        Answer<Symbols> types = compilation.db().ask(new Names.NameScope(module));
+        Answer<Map<String, Hir.Def>> types = compilation.db().ask(new Names.Reachable(module));
         Answer<Scoping.Scoped> scope = compilation.db().ask(new Names.ModuleScope(module));
         if (!types.present() || !scope.present()) {
             return null;
@@ -91,7 +91,7 @@ final class NamesFromElsewhere {
         List<CompletionItem> found = new ArrayList<>();
         // The type namespace first, as a bare name in a value position is answered: a data written
         // as a value is its construction, and the value table is read after that.
-        types.value().reachable().forEach((spelling, def) -> {
+        types.value().forEach((spelling, def) -> {
             if (!declaredHere.contains(spelling)) {
                 found.add(new CompletionItem(spelling, kindOf(def), def.declaredIn()));
             }


### PR DESCRIPTION
Closes #829.

Adding a behavior to a module re-checked every body in it. Two inputs of
`Bodies.CheckedBehavior` changed, and they were not the same fault.

`Bodies.CalleeSigs` changed because the map really did gain an entry — the module's index of
everything callable in it, read whole by a question asked per body.

`Shapes.Scope` changed while saying the same thing. Its answer, `Symbols`, reads declarations by
asking the store, so two of them are the same when the store is and never when one replaces the
other. Measured over that edit: `denotedNames`, `namesInScope` and `reachable` all came out equal,
and of the six parts of the assembly the scope is built from, the one that moved was the value
namespace — which nothing building a scope reads.

## What the commits do

**Build a scope where it is read.** `Scoping.Meanings` — the module name, what each type spelling
denotes, what each alias reaches — is what `Names.Meanings` answers, cut out of the whole assembly.
A scope is built inside whichever compute reads it, through `Names.derivedSymbols`. That is also
what makes the declarations it fetches dependencies of the asker, one declaration at a time.
`Shapes.Scope`, `Names.NameScope` and `Compilation.symbols` are gone; the LSP wanted what a
spelling reaches, which `Names.Reachable` answers as a map of declarations.

**Check a body against the signatures it names.** `Bodies.CalleeSigsForBody` projects the module's
index over `BehaviorsReached`. The two trees involved name the same behaviors because a helper
cannot reach a behavior at all (E1818).

**Say the rule on `Key`.** An answer is a value; an object that reads the store is not an answer.
A coarse producer does not have to be split — what a consumer reads has to stop where its meaning
stops, and a key between the two is where that happens.

**Ask two stores the same input.** `EquivalentDatabasesAnswerTheSameTest` compiles each conformance
corpus into two fresh stores and compares what they kept. It separates an answer that is the same
thing said twice and compares unequal anyway from one that says something different; the second is
required to be empty. Finding which takes a walk of the pair, because a record holding a way of
reading a store declares an `equals` and still says no.

Known and not fixed, by cause, with what each has to become:

| cause | |
|---|---|
| `byte[]` | a value — reached from five questions, one thing to fix |
| the store, through `Scoping.Scoped`'s way of asking the modules around a module | a capability, out of the answer |
| `souther.compiler.inputs.InputDomain` | unclassified, so read it first |
| `souther.compiler.query.Bodies$Elaborated` | unclassified |

Exactly those: fixing one without striking it off fails, and so does adding one.

## What is left

Declaring a type still re-checks every body of the module, because it really does change what the
names of the module mean. That is #835, and `declaringADataRechecksTheBodiesBesideIt` pins it.

## Checked

`CI=1 mvn -o -Plint verify` green across every module. Each new check was made to fail on purpose
first: making `Scoping.Meanings` compare by identity turns the incremental tests red with two
identical-looking values, and it turns up in the register test named with its path; putting a value
that does not reproduce into a scope turns up under the other assertion instead.
