### PR TITLE
Ask what a module's names mean where a scope reads them

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Denoting.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Denoting.java
@@ -1,0 +1,93 @@
+package souther.compiler.check;
+
+import souther.compiler.types.Denotation;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What the names written in a module mean, asked one question at a time.
+ *
+ * <p>The operations {@link TypeScope} performs on a module's meanings, and nothing else. Not a table
+ * and not a way of getting one: a reader handed the table decides for itself when to fetch it, and
+ * where the table is an answer of a query store that decision is what an edit costs — a reader that
+ * fetches to build a scope has depended on every name in the module before reading one of them.
+ * Kept as operations, where the meanings come from is the implementation's, and a reader cannot tell
+ * a table it was handed from one asked for as it is read.
+ *
+ * <p>Which is what lets the fetching get finer without a reader changing. {@link #of} is a question
+ * about one spelling and {@link #spellings} is the one that is genuinely about all of them, so a
+ * store-backed implementation asking for a module's meanings on first read can become one asking
+ * for a spelling at a time, and nothing above here is written in terms of either.
+ *
+ * <p>Absence is not one of the answers. A module this compilation does not have is a module in
+ * which every spelling means nothing, which is what {@link #NONE} says — so nothing that reads a
+ * scope has to know that a compilation can be missing a module.
+ */
+public interface Denoting {
+
+    /** What {@code spelling} means here — {@link Denotation.NotInScope} where nothing here is
+     * written that way. */
+    Denotation of(String spelling);
+
+    /** Every spelling written here, which is what a reader offering what a mistyped name may have
+     * meant has to have all of. A spelling standing for nothing is one of these; what it means is
+     * {@link #of}'s answer and a second question. */
+    Set<String> spellings();
+
+    /** The module an {@code import ... as} alias reaches, or null where no alias here does. */
+    String moduleOfAlias(String alias);
+
+    /** Every alias written here. */
+    Set<String> aliases();
+
+    /** Nothing is written here: the meanings of a module no compilation has, and of a signature
+     * written over primitives and type variables alone. */
+    Denoting NONE = of(Map.of(), Map.of());
+
+    /**
+     * The meanings a caller already holds.
+     *
+     * <p>What every reader outside a query store is answered from, and what a store-backed one
+     * answers from once it has asked. A {@link Denotation.NotInScope} is refused rather than kept:
+     * that is the answer for a spelling with no entry, so an entry holding it would be a spelling
+     * written here that is also not, and {@link #of} could not say which — which is the one way the
+     * table and the operations could come apart.
+     */
+    static Denoting of(Map<String, Denotation> denotations, Map<String, String> aliases) {
+        Map<String, Denotation> names =
+                Collections.unmodifiableMap(new LinkedHashMap<>(denotations));
+        Map<String, String> reached =
+                Collections.unmodifiableMap(new LinkedHashMap<>(aliases));
+        names.forEach((spelling, denotation) -> {
+            if (denotation instanceof Denotation.NotInScope) {
+                throw new IllegalArgumentException("`" + spelling + "` would be written here and "
+                        + "not written here: NotInScope is what a spelling with no entry means");
+            }
+        });
+        return new Denoting() {
+            @Override
+            public Denotation of(String spelling) {
+                Denotation denotation = names.get(spelling);
+                return denotation == null ? Denotation.NOT_IN_SCOPE : denotation;
+            }
+
+            @Override
+            public Set<String> spellings() {
+                return names.keySet();
+            }
+
+            @Override
+            public String moduleOfAlias(String alias) {
+                return reached.get(alias);
+            }
+
+            @Override
+            public Set<String> aliases() {
+                return reached.keySet();
+            }
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Prelude.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Prelude.java
@@ -396,7 +396,7 @@ public final class Prelude {
         return SyntaxSymbols.of(TypeSymbol.RUNTIME,
                 Registry.ofRead(Map.of(TypeSymbol.RUNTIME, new Registry.Declared<>(
                         declared, Registry.baseNames(m.exposing())))),
-                scope, Map.of());
+                Denoting.of(scope, Map.of()));
     }
 
     /** The runtime-backed declaration {@code name} denotes, or null when there is none. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Scoping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Scoping.java
@@ -428,6 +428,11 @@ public final class Scoping {
      * does not, because a behavior is not a type. Read as part of the whole assembly, that edit
      * arrived at every reader of what the names mean; read as this, it arrives at none of them.
      *
+     * <p>A type being declared does change this, and reaches whoever read it. Which readers those
+     * are is {@link Denoting}'s doing rather than this value's: a scope asks for these the first
+     * time it is read, so declaring a type reaches the bodies that write its spelling and the
+     * reports that are read off every name in sight, rather than everything built over a scope.
+     *
      * <p>The three parts are here together and not handed over one at a time, for the reason
      * {@link Scoped} gives: the module name, the scope and the aliases come out of one assembly and
      * mean nothing apart from each other, so a caller putting them together could pair parts of two.
@@ -445,12 +450,19 @@ public final class Scoping {
         /** What {@code Resolve} reads this module against, over the declarations as they were
          *  written. */
         public SyntaxSymbols writtenSymbols(Registry<Ast.Def> registry) {
-            return SyntaxSymbols.of(module, registry, denotations, aliases);
+            return SyntaxSymbols.of(module, registry, denoting());
         }
 
         /** The same over a stage of the declarations something has resolved. */
         public Symbols symbolsOver(Registry<Hir.Def> registry) {
-            return Symbols.of(module, registry, denotations, aliases);
+            return Symbols.of(module, registry, denoting());
+        }
+
+        /** These meanings as the operations a scope performs on them — what a reader that already
+         *  holds the answer is asked through, so that it and one asking a store as it reads are
+         *  told apart by nothing above {@link Denoting}. */
+        public Denoting denoting() {
+            return Denoting.of(denotations, aliases);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
@@ -23,15 +23,14 @@ public final class Symbols implements NameSense {
     private final TypeScope scope;
     private final Declarations<Hir.Def> declarations;
 
-    private Symbols(String module, Registry<Hir.Def> registry,
-                    Map<String, Denotation> names, Map<String, String> aliases) {
-        this.scope = new TypeScope(module, names, aliases, registry);
+    private Symbols(String module, Registry<Hir.Def> registry, Denoting names) {
+        this.scope = new TypeScope(module, names, registry);
         this.declarations = new Declarations<>(registry, Declarations.Vocabulary.ofLanguage());
     }
 
     /** No module at all — for signatures written over primitives and type variables only. */
     public static Symbols none() {
-        return new Symbols("", Registry.empty(), Map.of(), Map.of());
+        return new Symbols("", Registry.empty(), Denoting.NONE);
     }
 
     /**
@@ -57,18 +56,20 @@ public final class Symbols implements NameSense {
         return new Symbols(m.name(),
                 Registry.ofRead(Map.of(m.name(), new Registry.Declared<>(
                         declared.declarations(), Registry.baseNames(m.exposing())))),
-                names, Map.of());
+                Denoting.of(names, Map.of()));
     }
 
     /** A module compiled over a registry that reads its declarations
      * however it likes — the form a query-backed compilation uses, where a module's definitions are
      * asked for one at a time rather than held in a map.
      *
-     * <p>Reached through {@link Scoping.Scoped#symbolsOver}, for the reason
-     * {@link SyntaxSymbols#of(String, Registry, Map, Map)} is. */
-    static Symbols of(String module, Registry<Hir.Def> registry,
-                      Map<String, Denotation> names, Map<String, String> aliases) {
-        return new Symbols(module, registry, names, Map.copyOf(aliases));
+     * <p>What names mean here arrives as a {@link Denoting} rather than as the table itself, for
+     * the reason that interface gives: a reader that fetched the table to build this would have
+     * depended on every name in the module before reading one of them. The three that are one
+     * assembly — the module, its meanings and its aliases — still arrive together, because a caller
+     * free to pair them itself could pair parts of two. */
+    public static Symbols of(String module, Registry<Hir.Def> registry, Denoting names) {
+        return new Symbols(module, registry, names);
     }
 
     /** What a name written here means. */

--- a/souther-compiler/src/main/java/souther/compiler/check/SyntaxSymbols.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SyntaxSymbols.java
@@ -32,16 +32,15 @@ public final class SyntaxSymbols implements NameSense {
     private final Registry<Ast.Def> registry;
     private final Declarations<Ast.Def> declarations;
 
-    private SyntaxSymbols(String module, Registry<Ast.Def> registry,
-                          Map<String, Denotation> names, Map<String, String> aliases) {
-        this.scope = new TypeScope(module, names, aliases, registry);
+    private SyntaxSymbols(String module, Registry<Ast.Def> registry, Denoting names) {
+        this.scope = new TypeScope(module, names, registry);
         this.registry = registry;
         this.declarations = new Declarations<>(registry, Declarations.Vocabulary.ofNothing());
     }
 
     /** No module at all — for signatures written over primitives and type variables only. */
     public static SyntaxSymbols none() {
-        return new SyntaxSymbols("", Registry.empty(), Map.of(), Map.of());
+        return new SyntaxSymbols("", Registry.empty(), Denoting.NONE);
     }
 
     /**
@@ -67,7 +66,7 @@ public final class SyntaxSymbols implements NameSense {
         return new SyntaxSymbols(m.name(),
                 Registry.ofRead(Map.of(m.name(), new Registry.Declared<>(
                         declared.declarations(), Registry.baseNames(m.exposing())))),
-                names, Map.of());
+                Denoting.of(names, Map.of()));
     }
 
     /** A module resolved against a registry that reads its declarations however it likes — the form
@@ -77,9 +76,8 @@ public final class SyntaxSymbols implements NameSense {
      * one answer — the module, its scope and its aliases — come from. A caller free to pass them
      * separately could pass parts of two different assemblies, and nothing it was holding would
      * have said so. */
-    static SyntaxSymbols of(String module, Registry<Ast.Def> registry,
-                            Map<String, Denotation> names, Map<String, String> aliases) {
-        return new SyntaxSymbols(module, registry, names, Map.copyOf(aliases));
+    public static SyntaxSymbols of(String module, Registry<Ast.Def> registry, Denoting names) {
+        return new SyntaxSymbols(module, registry, names);
     }
 
     /** What a name written here means. */

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeScope.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeScope.java
@@ -37,19 +37,19 @@ import java.util.Set;
 public final class TypeScope {
 
     private final String module;
-    /** What a bare name means here: this module\'s own definitions plus the imported ones. */
-    private final Map<String, Denotation> scope;
-    /** Each {@code import ... as} alias → the module it names. A module of the compilation is also
-     * a qualifier under its own name, which {@link #moduleOfQualifier} reads off the registry
-     * rather than listing here — listing it would mean naming every module up front. */
-    private final Map<String, String> aliases;
+    /** What a name written here means: this module\'s own definitions plus the imported ones, and
+     * what each {@code import ... as} alias reaches. Asked rather than held, for the reason
+     * {@link Denoting} gives.
+     *
+     * <p>Not every qualifier is an alias. A module of the compilation is one under its own name,
+     * which {@link #moduleOfQualifier} reads off the registry — listed here instead, a scope could
+     * not be built without naming every module of the compilation up front. */
+    private final Denoting names;
     private final Registry<?> registry;
 
-    TypeScope(String module, Map<String, Denotation> scope, Map<String, String> aliases,
-              Registry<?> registry) {
+    TypeScope(String module, Denoting names, Registry<?> registry) {
         this.module = module;
-        this.scope = scope;
-        this.aliases = aliases;
+        this.names = names;
         this.registry = registry;
     }
 
@@ -90,8 +90,8 @@ public final class TypeScope {
     private Denotation resolveSpelling(String written) {
         int dot = written.lastIndexOf('.');
         if (dot < 0) {
-            Denotation name = scope.get(written);
-            if (name != null) {
+            Denotation name = names.of(written);
+            if (!(name instanceof Denotation.NotInScope)) {
                 return name;
             }
             // The prelude's runtime-backed data is nameable everywhere, on the lowest rung: a
@@ -156,24 +156,24 @@ public final class TypeScope {
      * nothing wherever it was put.
      */
     public TypeReachName reach(TypeSymbol type) {
-        if (type.isPrimitive() || type.equals(scope.get(type.name()) instanceof Denotation.Denotes d
+        if (type.isPrimitive() || type.equals(names.of(type.name()) instanceof Denotation.Denotes d
                 ? d.type() : null)) {
             return new TypeReachName.Bare(type);
         }
         if (TypeSymbol.RUNTIME.equals(type.module())) {
             // Reached bare, and only while nothing else here is: the runtime namespace is not a
             // module a qualifier names, so a module declaring the spelling leaves it with no name.
-            return scope.containsKey(type.name()) ? new TypeReachName.Unnameable(type)
+            return inScope(type.name()) ? new TypeReachName.Unnameable(type)
                     : new TypeReachName.Bare(type);
         }
         if (!exposes(type.module(), type.name())) {
             return new TypeReachName.Unnameable(type);
         }
         String alias = null;
-        for (Map.Entry<String, String> each : aliases.entrySet()) {
-            if (each.getValue().equals(type.module())
-                    && (alias == null || each.getKey().compareTo(alias) < 0)) {
-                alias = each.getKey();
+        for (String each : names.aliases()) {
+            if (type.module().equals(names.moduleOfAlias(each))
+                    && (alias == null || each.compareTo(alias) < 0)) {
+                alias = each;
             }
         }
         return alias != null ? new TypeReachName.ViaAlias(alias, type)
@@ -210,7 +210,7 @@ public final class TypeScope {
      * when it names none. Used to tell "unknown module" apart from "unknown type in a known
      * module". */
     public String moduleOfQualifier(String qualifier) {
-        String alias = aliases.get(qualifier);
+        String alias = names.moduleOfAlias(qualifier);
         if (alias != null) {
             return alias;
         }
@@ -220,18 +220,18 @@ public final class TypeScope {
     /** Every qualifier a reference may carry here — what a "did you mean" may offer for one. */
     public Set<String> qualifiers() {
         Set<String> all = new LinkedHashSet<>(registry.moduleNames());
-        all.addAll(aliases.keySet());
+        all.addAll(names.aliases());
         return all;
     }
 
     /** Whether {@code name} is reachable here as a bare name. */
     public boolean inScope(String name) {
-        return scope.containsKey(name);
+        return !(names.of(name) instanceof Denotation.NotInScope);
     }
 
     /** The bare names reachable here — what a "did you mean" suggestion may offer. */
     public Set<String> namesInScope() {
-        return scope.keySet();
+        return names.spellings();
     }
 
     /**
@@ -244,11 +244,11 @@ public final class TypeScope {
      */
     public Map<String, TypeSymbol> denotedNames() {
         Map<String, TypeSymbol> named = new LinkedHashMap<>();
-        scope.forEach((spelling, denotation) -> {
-            if (denotation instanceof Denotation.Denotes d) {
+        for (String spelling : names.spellings()) {
+            if (names.of(spelling) instanceof Denotation.Denotes d) {
                 named.put(spelling, d.type());
             }
-        });
+        }
         return named;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -71,9 +71,16 @@ import java.util.Set;
  * {@link Names.Meanings} is what a module's names mean, cut from the whole assembly they are read
  * off — so declaring a behavior, which adds a value name, stops there. {@link Bodies.CalleeSigsForBody}
  * is the signatures one body names, cut from its module's index of everything callable in it.
- * {@link Bodies.ContractsForBody} is a body's contracts asked entry by entry. A body is still
- * checked in what all of its module's names mean, so declaring a type re-checks every body of the
- * module; that is what is left of issue #829, and {@code IncrementalCompilationTest} pins it.
+ * {@link Bodies.ContractsForBody} is a body's contracts asked entry by entry.
+ *
+ * <p>A cut is one way to stop an index short of a reader. The other is to hand the reader the
+ * questions rather than the table, so that the index is asked for when it is read and not when it
+ * is built — which is what {@link souther.compiler.check.Registry} does for a module's declarations
+ * and {@link souther.compiler.check.Denoting} for what its names mean. It answers what a cut cannot
+ * here: which of a module's meanings a body needs is a question about what a body's scope is, and
+ * nothing has to decide it, because a body that reads none of them depends on none of them and the
+ * one report that reads every name in sight depends on every name in sight. That is issue #835,
+ * and {@code IncrementalCompilationTest} holds both halves.
  *
  * <p>One store is one workspace over time, not one compile. It is not thread-safe and does not need
  * to be: the work inside a compile is a graph walk, not a set of independent jobs.

--- a/souther-compiler/src/main/java/souther/compiler/query/Key.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Key.java
@@ -32,6 +32,12 @@ import java.util.List;
  * recomputed as often as it likes, and what the consumer reads stops at the cut.
  * {@link Bodies.CalleeSigsForBody} and {@link Names.Meanings} are the two.
  *
+ * <p>They meet again at a capability, and there the cut is not needed. A capability that reads this
+ * store is built inside a compute, so what it asks for is asked when the consumer reads it — a
+ * consumer that reads nothing has taken no dependency, and one that reads everything has taken the
+ * one it means. {@link souther.compiler.check.Denoting} is that for what a module's names mean, and
+ * it is why nothing had to decide which of them a body needs.
+ *
  * <p>The answer lives on the key rather than in a dispatch table somewhere, so one class is one
  * question: what it is, what it reads, and what it does when it cannot answer are in one place. A
  * key reaches everything else it needs by asking {@link Db}, which is what makes the read

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -7,6 +7,7 @@ import souther.compiler.ast.Ast;
 import souther.compiler.ast.Hir;
 import souther.compiler.ast.WrittenName;
 import souther.compiler.check.DeclarationRefusals;
+import souther.compiler.check.Denoting;
 import souther.compiler.check.DeclaredNames;
 import souther.compiler.check.ModuleUniverse;
 import souther.compiler.check.Scoping;
@@ -406,9 +407,14 @@ public final class Names {
      *
      * <p>The cutoff every reader of a scope stops at. A module is assembled once and the assembly
      * holds more than this: the value namespace, a way of asking the modules around it a further
-     * question, and what its import lines could not do. A body is checked against none of those and
-     * against this, so declaring a behavior — which adds a value name and no type name — comes out
-     * here as the answer that was already there, and nothing that reads it runs again.
+     * question, and what its import lines could not do. A scope is built over none of those and over
+     * this, so declaring a behavior — which adds a value name and no type name — comes out here as
+     * the answer that was already there, and nothing that reads it runs again.
+     *
+     * <p>Who reads it is a second question, and not this one's. A scope asks for this the first time
+     * it is read rather than to be built ({@link souther.compiler.check.Denoting}), so a reader that
+     * reads no meaning has not asked — which is why declaring a type reaches the bodies that write
+     * its spelling and the reports read off every name in sight, and no others.
      */
     public record Meanings(String name) implements Key<Scoping.Meanings> {
         @Override
@@ -435,11 +441,90 @@ public final class Names {
      * a time, and is the finer dependency this hands out.
      */
     private static Answer<Symbols> symbols(Db db, String name, Registry<Hir.Def> registry) {
-        Answer<Scoping.Meanings> meanings = db.ask(new Meanings(name));
-        if (!meanings.present()) {
+        if (!db.ask(new HasScope(name)).value()) {
             return Answer.absent();
         }
-        return Answer.of(meanings.value().symbolsOver(registry));
+        return Answer.of(Symbols.of(name, registry, asked(db, name)));
+    }
+
+    /**
+     * Whether this compilation can assemble a scope for {@code name} — which is the only thing a
+     * reader of one has to be told before it reads it.
+     *
+     * <p>A question of its own because of what its answer is. Read off {@link ModuleScope}, whose
+     * answer moves whenever anything in the module is edited, and answered as a yes or a no, which
+     * does not: a reader that took the assembly to find out whether there was one would be told
+     * every edit to the module, and every reader of it in turn. What is left to ask for is what the
+     * names mean, and {@link Denoting} is where that is asked.
+     */
+    public record HasScope(String name) implements Key<Boolean> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Boolean> compute(Db db) {
+            return Answer.of(db.ask(new ModuleScope(name)).present());
+        }
+    }
+
+    /**
+     * What a module's names mean, asked of this store as a scope reads them.
+     *
+     * <p>The other half of what {@link #symbols} hands out, and the half issue #835 is about.
+     * Handing over the table meant asking {@link Meanings} to build a scope, so every reader of a
+     * scope depended on every name in the module before reading one of them — and what a body check
+     * reads of them is almost always nothing, because the names it is checked over were resolved a
+     * representation earlier and it reads the declarations they denote one at a time. Asked here, a
+     * body that reads no meaning depends on none of them, and the report that reads every name in
+     * sight depends on every name in sight, which is what it is about.
+     * {@code IncrementalCompilationTest} holds the pair.
+     *
+     * <p>Built where it is used and never kept, for the reason {@link Key} gives: it reads this
+     * store, so two of them are the same when the store is, which says where they came from and not
+     * what they say. The reads it makes land on whichever question was being answered when it made
+     * them. What it fetched is kept for as long as it lives, because one scope is read many times
+     * while one question is being answered and the store would otherwise be asked the same thing
+     * each time.
+     *
+     * <p>Where this compilation has no such module, every spelling means nothing — the answer
+     * {@link Denoting#NONE} gives. Nothing reading a scope learns that a compilation can be missing
+     * a module, and nothing here has to hold an absence it would have to decide what to do with:
+     * {@link HasScope} is what a reader is told, before it has a scope at all.
+     */
+    private static Denoting asked(Db db, String module) {
+        return new Denoting() {
+            private Denoting fetched;
+
+            private Denoting read() {
+                if (fetched == null) {
+                    Answer<Scoping.Meanings> meanings = db.ask(new Meanings(module));
+                    fetched = meanings.present() ? meanings.value().denoting() : Denoting.NONE;
+                }
+                return fetched;
+            }
+
+            @Override
+            public Denotation of(String spelling) {
+                return read().of(spelling);
+            }
+
+            @Override
+            public Set<String> spellings() {
+                return read().spellings();
+            }
+
+            @Override
+            public String moduleOfAlias(String alias) {
+                return read().moduleOfAlias(alias);
+            }
+
+            @Override
+            public Set<String> aliases() {
+                return read().aliases();
+            }
+        };
     }
 
     /** What names mean in a module over the declarations as resolution left them — what
@@ -456,11 +541,10 @@ public final class Names {
     /** The same, over the declarations as they were written — what {@code Resolve} resolves
      * against. */
     static Answer<SyntaxSymbols> writtenSymbols(Db db, String name) {
-        Answer<Scoping.Meanings> meanings = db.ask(new Meanings(name));
-        if (!meanings.present()) {
+        if (!db.ask(new HasScope(name)).value()) {
             return Answer.absent();
         }
-        return Answer.of(meanings.value().writtenSymbols(writtenRegistry(db)));
+        return Answer.of(SyntaxSymbols.of(name, writtenRegistry(db), asked(db, name)));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -484,9 +484,14 @@ public final class Names {
      * <p>Built where it is used and never kept, for the reason {@link Key} gives: it reads this
      * store, so two of them are the same when the store is, which says where they came from and not
      * what they say. The reads it makes land on whichever question was being answered when it made
-     * them. What it fetched is kept for as long as it lives, because one scope is read many times
-     * while one question is being answered and the store would otherwise be asked the same thing
-     * each time.
+     * them.
+     *
+     * <p>The store is asked every time and not once. What is kept is the reading built over the
+     * answer, and it is kept only while the answer is the one it was built over — so a scope read
+     * after an edit answers from what the module means now, and one read many times while a single
+     * question is being answered builds the reading once. Fetched once instead, this would hold a
+     * snapshot for as long as it lived, and whether that could be read after an edit would be a
+     * fact about who kept a scope rather than one this can be sure of on its own.
      *
      * <p>Where this compilation has no such module, every spelling means nothing — the answer
      * {@link Denoting#NONE} gives. Nothing reading a scope learns that a compilation can be missing
@@ -495,14 +500,20 @@ public final class Names {
      */
     private static Denoting asked(Db db, String module) {
         return new Denoting() {
-            private Denoting fetched;
+            private Scoping.Meanings over;
+            private Denoting reading;
 
             private Denoting read() {
-                if (fetched == null) {
-                    Answer<Scoping.Meanings> meanings = db.ask(new Meanings(module));
-                    fetched = meanings.present() ? meanings.value().denoting() : Denoting.NONE;
+                Answer<Scoping.Meanings> meanings = db.ask(new Meanings(module));
+                Scoping.Meanings now = meanings.present() ? meanings.value() : null;
+                // The answer itself and not what it means: this is asking whether the reading in
+                // hand was built over what the store just handed over, which is a question about
+                // the two being the one object.
+                if (reading == null || now != over) {
+                    over = now;
+                    reading = now == null ? Denoting.NONE : now.denoting();
                 }
-                return fetched;
+                return reading;
             }
 
             @Override

--- a/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
@@ -646,17 +646,17 @@ class IncrementalCompilationTest {
     }
 
     /**
-     * Known and not narrowed: declaring a type re-checks every body of the module. A body is checked
-     * in what the names of its module mean, and a type declaration is a spelling that means
-     * something there — so unlike a behavior, this really does change what every body reads.
+     * Declaring a type is none of the business of the bodies that do not write it. What a body is
+     * checked in is still everything its module's names mean — the scope is the module's, and no
+     * narrower — and what changed is when that is asked for: {@link souther.compiler.check.Denoting}
+     * is asked as the scope is read rather than fetched to build it, so a body whose check reads no
+     * meaning depends on none of them.
      *
-     * <p>What is left of issue #829, which is issue #835. Which of a module's meanings a body needs
-     * is a question about what a body's scope is rather than a table being read whole, and answering
-     * it here would settle that by accident. Written down so that narrowing it is a change that
-     * shows.
+     * <p>Issue #835, and what was left of #829. Measured before it was built: over this suite a body
+     * check reads a module's meanings once in 5446 checks, and that once is the report below.
      */
     @Test
-    void declaringADataRechecksTheBodiesBesideIt() {
+    void declaringADataDoesNotRecheckTheBodiesBesideIt() {
         Compilation c = stating();
         Answer<?> caller = c.db().ask(new Bodies.CheckedBehavior("shop.orders", "caller"));
 
@@ -666,8 +666,92 @@ class IncrementalCompilationTest {
                 """), Set.of());
         c.answerEverything();
 
-        assertNotSame(caller, c.db().ask(new Bodies.CheckedBehavior("shop.orders", "caller")),
-                "`Discount` is a spelling `caller` does not write, and it means something here");
+        assertSame(caller, c.db().ask(new Bodies.CheckedBehavior("shop.orders", "caller")),
+                "`Discount` is a spelling `caller` does not write");
+    }
+
+    /**
+     * And the other half of it. A body that writes the spelling is checked again, because what the
+     * spelling means is what changed — it meant nothing there and now denotes a declaration. The
+     * pair is what says the dependency was narrowed and not dropped: a cut carrying only the
+     * spellings that already resolved would leave this one alone and be wrong to.
+     */
+    @Test
+    void declaringADataRechecksTheBodyThatWritesItsSpelling() {
+        Compilation c = Compilation.ofDocuments(Map.of("orders.sou", STATING + """
+
+                behavior writing : (n: Amount) -> Amount
+                    constructs Amount
+                let writing (n) = Amount(Discount(n.value).value)
+                """), Set.of(), ModulePath.EMPTY);
+        c.answerEverything();
+        assertFalse(c.db().allReports().isEmpty(), "`Discount` denotes nothing to begin with");
+        Answer<?> writing = c.db().ask(new Bodies.CheckedBehavior("shop.orders", "writing"));
+        Answer<?> caller = c.db().ask(new Bodies.CheckedBehavior("shop.orders", "caller"));
+
+        c.update(Map.of("orders.sou", STATING + """
+
+                data Discount = Int
+
+                behavior writing : (n: Amount) -> Amount
+                    constructs Amount
+                let writing (n) = Amount(Discount(n.value).value)
+                """), Set.of());
+        c.answerEverything();
+
+        assertNotSame(writing, c.db().ask(new Bodies.CheckedBehavior("shop.orders", "writing")),
+                "`writing` names `Discount`, which meant nothing here and now denotes a declaration");
+        assertSame(caller, c.db().ask(new Bodies.CheckedBehavior("shop.orders", "caller")),
+                "and `caller` beside it still does not write it");
+    }
+
+    /** A body whose report offers the sum an arm's name does belong to (E1203). What that report
+     * says is worked out from every name in sight, so this is the one body check that reads what a
+     * module's names mean. */
+    private static final String OFFERING = """
+            module shop.offering exposing ( Out, run )
+
+            data A = { n: Int }
+            data B = { n: Int }
+            data Inner = A | B
+            data Q
+            data Outer = Inner | Q
+            data Out = { n: Int }
+
+            behavior run : (i: Inner) -> Out
+                constructs Out
+            let run (i) =
+                match i with
+                    | A { n } -> Out { n = n }
+                    | Q -> Out { n = 0 }
+            """;
+
+    /**
+     * The other side of {@link #declaringADataDoesNotRecheckTheBodiesBesideIt}, and what says the
+     * dependency was moved rather than dropped. This body's report names the sum `Q` is a case of,
+     * which is read off every name in sight — so declaring a type does change what this check
+     * answers, and the check depends on it because it read it.
+     *
+     * <p>Written as a pair with the one above because either alone is passed by a mistake. A
+     * dependency taken whenever a scope is built passes the first and not this one; a dependency
+     * dropped altogether passes this one and not the first — and nothing else here would see it,
+     * because what the report says is checked where reports are read and not where an edit is
+     * costed.
+     */
+    @Test
+    void declaringADataRechecksTheBodyWhoseReportIsReadOffEveryNameInSight() {
+        Compilation c = Compilation.ofDocuments(Map.of("offering.sou", OFFERING), Set.of(),
+                ModulePath.EMPTY);
+        c.answerEverything();
+        assertFalse(c.db().allReports().isEmpty(), "`Q` is not a case of `Inner`, which is reported");
+        Answer<?> run = c.db().ask(new Bodies.CheckedBehavior("shop.offering", "run"));
+
+        c.update(Map.of("offering.sou", OFFERING + "\ndata Discount = Int\n"), Set.of());
+        c.answerEverything();
+
+        assertNotSame(run, c.db().ask(new Bodies.CheckedBehavior("shop.offering", "run")),
+                "what this body's report offers is read off every name in sight, `Discount` among "
+                        + "them");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
@@ -2,6 +2,7 @@ package souther.compiler.query;
 
 import souther.compiler.source.SourceId;
 
+import souther.compiler.check.Symbols;
 import souther.compiler.meta.ModulePath;
 
 import org.junit.jupiter.api.Test;
@@ -703,6 +704,35 @@ class IncrementalCompilationTest {
                 "`writing` names `Discount`, which meant nothing here and now denotes a declaration");
         assertSame(caller, c.db().ask(new Bodies.CheckedBehavior("shop.orders", "caller")),
                 "and `caller` beside it still does not write it");
+    }
+
+    /**
+     * A scope answers from what the module means now, however long the thing holding it has been
+     * held.
+     *
+     * <p>A scope is built inside the question that reads it and goes no further, which is the rule
+     * and not something a scope can check. What it can do is not depend on it: what a name means is
+     * asked of the store each time and the reading built over that answer is kept only while it is
+     * the answer, so a scope kept past its question is slower and not wrong. Held instead from the
+     * first read, it would answer from that read for as long as it lived, and whether that could be
+     * seen would be a fact about who kept a scope rather than one this module can be sure of.
+     *
+     * <p>So this test keeps one on purpose, which nothing in the compiler does.
+     */
+    @Test
+    void aScopeHeldPastTheQuestionItWasBuiltForStillAnswersFromWhatTheModuleMeansNow() {
+        Compilation c = stating();
+        Symbols held = Scopes.derived(c.db(), "shop.orders").value();
+        assertFalse(held.scope().inScope("Discount"), "nothing here is written that way yet");
+
+        c.update(Map.of("orders.sou", STATING + """
+
+                data Discount = Int
+                """), Set.of());
+        c.answerEverything();
+
+        assertTrue(held.scope().inScope("Discount"),
+                "the same scope, asked again after the declaration arrived");
     }
 
     /** A body whose report offers the sum an arm's name does belong to (E1203). What that report


### PR DESCRIPTION
Closes #835.

`Bodies.CheckedBehavior` depended on `Names.Meanings(module)`, so declaring a type re-checked every
body of the module. #835 reads that as a question about what a body's scope is — which of its
module's meanings a body needs — and asks for a frontier over one of the trees a body reaches type
names through.

## It is not that question

A counter on every read `TypeScope` makes of the table, taken over the whole `souther-compiler`
suite:

| | |
|---|---|
| `TypeChecker.checkBehavior` entered | 5446 |
| reads it made of the module's meanings | 1 |

The one read is `MatchElaborator.notCase`, which offers the sum an arm's name does belong to
(E1203) by walking every name in sight. A body needs none of the table otherwise: its type names
were resolved a representation earlier, and what it reads through `Symbols` is the declarations
they denote, which are already asked one at a time. The dependency was taken to **build** the
scope, not to read it.

Emptying the table and running the suite names the readers that do read it: 83 failures, all of
them the row generator writing a type back as surface text, plus the two E1203 tests. That is the
list a frontier would have degraded silently — both readers sit just before a `throw`, so every
test of a program that compiles stays green while the reports get thinner.

## What changed

`check.Denoting` is what `TypeScope` performs on a module's meanings and nothing else: one
spelling, every spelling, one alias, every alias. Two implementations answer it — one over a table
a caller already holds, and one private to `Names` that asks the store the first time it is read.
A scope cannot tell which it holds.

Nothing about what a name means changes. A body is checked in everything its module's names mean,
as before; what changed is when that is asked for. So no second notion of scope exists, and the
three things #835 says have to be settled first stop being asked rather than being settled:
absence counts because a spelling meaning nothing is an answer like any other, there is no
frontier for a tree to be read off, and what a body reads is whatever it read.

`Names.HasScope` carries whether this compilation has the module at all — read off `ModuleScope`,
answered as a yes or a no, so the assembly may move on every edit while the answer does not.
Nothing below `Denoting` learns that a compilation can be missing a module.

## Held by a pair, because either half alone is passed by a mistake

- `declaringADataDoesNotRecheckTheBodiesBesideIt`
- `declaringADataRechecksTheBodyThatWritesItsSpelling`
- `declaringADataRechecksTheBodyWhoseReportIsReadOffEveryNameInSight`

A dependency taken to build a scope passes the second and third and fails the first; a dependency
dropped altogether passes the first and fails the third. Removing the `visibleNames()` read from
`MatchElaborator` was run, and reddens the third and nothing else.

That a store-backed scope never reaches a memo is held by `EquivalentDatabasesAnswerTheSameTest`,
which compares two stores' answers and matches what cannot compare as a value against its register
exactly — putting one in an answer fails there and takes a written line to admit.

## Measured, before and after

Same probe, 160 bodies, declaring `data Discount = Int`:

| | before | after |
|---|---|---|
| bodies whose check was kept | 0/160 | 160/160 |
| asking the first body | 68.1ms | 67.8ms |
| asking the other 159 | 25.8ms | 12.0ms |

No body is checked again. What is left after the first ask is the verification walk. The 68ms is
the module-level rework any declaration causes — parse, resolve, the derived declarations — which
dominates and which this does not touch.

## Left alone

`TypeScope.moduleOfQualifier` and `qualifiers` read `Front.ModuleNames()` whole, so a body writing
a qualified type name depends on the compilation's list of modules. Same shape, one level up, not
generalised here.

`Denoting` rather than `Denotations`, which is taken: the invariant check's environment of what a
body's bindings mean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)