### PR TITLE
Name a fork by the construct written, not by the one it lowered to

### DIFF
--- a/souther-cli/src/test/java/souther/cli/AComparisonInAnEnsuresIsOfferedARowTest.java
+++ b/souther-cli/src/test/java/souther/cli/AComparisonInAnEnsuresIsOfferedARowTest.java
@@ -60,20 +60,24 @@ class AComparisonInAnEnsuresIsOfferedARowTest {
     }
 
     /**
-     * A clause's line is met by writing the value; a guard's at the same value is not.
+     * A clause's line is met by writing the value; a fork's at the same value is not.
      *
      * <p>The distinction the whole thing turns on, in one report. The row hands the behavior a
      * hundred and takes the branch above the comparison, so it never reaches
-     * {@code a.n.value > 100} — the guard's line at a hundred is unmet, and the clause's is met,
+     * {@code a.n.value > 100} — the fork's line at a hundred is unmet, and the clause's is met,
      * because every rule of a declaration runs whenever the behavior answers.
+     *
+     * <p>The fork is named {@code if} because that is what this body writes. Matched on the word so
+     * that the two rules are told apart by what drew each of them; a report naming every fork
+     * {@code guard} would have this pass while sending a reader after a construct that is not there.
      */
     @Test
-    void aClausesLineIsMetByWritingTheValueAndAGuardsIsNot() throws Exception {
+    void aClausesLineIsMetByWritingTheValueAndAForksIsNot() throws Exception {
         List<String> gaps = boundaryGaps(reportOf(REACHED_BY_ONE_RULE_ONLY));
 
         assertTrue(gaps.stream().anyMatch(line -> line.contains("charge/a.n = 100")
-                        && line.contains("guard")),
-                () -> "no row got the guard's comparison to answer at a hundred: " + gaps);
+                        && line.contains("if@")),
+                () -> "no row got the fork's comparison to answer at a hundred: " + gaps);
         assertFalse(gaps.stream().anyMatch(line -> line.contains("charge/a.n = 100")
                         && line.contains("ensures")),
                 () -> "the row writes a hundred, which is the whole of what the clause wants: "
@@ -107,7 +111,7 @@ class AComparisonInAnEnsuresIsOfferedARowTest {
      * <p>A clause comparing one input against another draws a line where the two hold one count. It
      * is on neither of them, so it has no axis and no class either side — and what meeting it takes
      * is the same answer the clause's other lines get: the row that puts one count in both
-     * positions has met it. The guard drawing the same line is not met, because the row takes the
+     * positions has met it. The fork drawing the same line is not met, because the row takes the
      * branch above the comparison.
      */
     @Test
@@ -115,8 +119,8 @@ class AComparisonInAnEnsuresIsOfferedARowTest {
         List<String> gaps = boundaryGaps(reportOf(A_LINE_BETWEEN_TWO_POSITIONS));
 
         assertTrue(gaps.stream().anyMatch(line -> line.contains("book/from = to")
-                        && line.contains("guard")),
-                () -> "no row got the guard's comparison to answer on the line: " + gaps);
+                        && line.contains("if@")),
+                () -> "no row got the fork's comparison to answer on the line: " + gaps);
         assertFalse(gaps.stream().anyMatch(line -> line.contains("book/from = to")
                         && line.contains("ensures")),
                 () -> "the row puts one count in both positions, which is what the clause wants: "

--- a/souther-cli/src/test/java/souther/cli/AnArmNothingReachesIsNotOwedARowTest.java
+++ b/souther-cli/src/test/java/souther/cli/AnArmNothingReachesIsNotOwedARowTest.java
@@ -305,9 +305,13 @@ class AnArmNothingReachesIsNotOwedARowTest {
     // --- what happens if the proof is wrong -------------------------------------------------------
 
     private static CoverageSites.Site arm(int index) {
-        return new CoverageSites.Site("classify", CoverageSites.Site.Kind.THEN, "then", null,
-                index, index,
-                new CoverageSites.Obligation("classify", CoverageOrigin.written("t", index), 0));
+        return new CoverageSites.Site("classify",
+                new souther.compiler.coverage.SourceOutcome.Held(
+                        new souther.compiler.coverage.SourceOutcome.HeldBy.Condition()),
+                null, index, index,
+                new CoverageSites.Obligation("classify",
+                        CoverageOrigin.written("t", index,
+                                souther.compiler.types.CoverageConstruct.IF), 0));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -4,6 +4,7 @@ import souther.compiler.ast.Hir;
 import souther.compiler.core.Core;
 import souther.compiler.diag.Citation;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.CoverageConstruct;
 import souther.compiler.types.CoverageOrigin;
 import souther.compiler.types.TypeSymbol;
 
@@ -32,8 +33,15 @@ import java.util.Map;
  * invariant clause gets none either: it is a property of a type, not a fork in this body, and whether
  * the rows reach its edges is a different measure asked another way.
  *
- * <p>A {@code guard … else} is an {@code if} by the time it gets here, so it needs no case of its own.
- * Helper bodies are not walked: a non-recursive helper is already inlined into the body that uses it,
+ * <p>A {@code guard … else} and a comprehension's condition are both an {@code if} by the time they
+ * get here, so the walk has one case for the three of them — and what they are is not read off that
+ * case. Which construct the author wrote is carried from where the source was read
+ * ({@link souther.compiler.types.CoverageConstruct}), and what one way through it means is a
+ * {@link SourceOutcome} beside it. Deciding either from the shape of the lowered node is answering a
+ * question about the source out of the tree that runs, which is how a comprehension came to be
+ * reported as a {@code guard} with a {@code then} arm.
+ *
+ * <p>Helper bodies are not walked: a non-recursive helper is already inlined into the body that uses it,
  * and a recursive one is a shared method rather than a fork in any one behavior.
  */
 public final class CoverageSites {
@@ -68,8 +76,15 @@ public final class CoverageSites {
     public record Obligation(String behavior, CoverageOrigin origin, int part) {}
 
     /**
-     * One arm, as it stands in the tree that runs.
+     * One outcome of one construct, as it stands in the tree that runs.
      *
+     * <p>Two halves and one meaning. {@link #obligation} carries the construct the source wrote, and
+     * {@link #outcome} what this way through it means; neither says the other, so nothing here can
+     * hold two answers about one construct. What a reader is told is {@link #name}, and it is the
+     * pair that settles it — a condition holding is a {@code then} under an {@code if} and the rest
+     * of the block under a {@code guard}.
+     *
+     * @param outcome     what this way through the construct means, in the source's terms
      * @param at          where the arm is written, as a report may say it. A {@link Citation} and
      *                    not a place, because an arm of a body spliced in from out of sight is at a
      *                    call in the caller's file and is not written there — a report handed the
@@ -80,42 +95,87 @@ public final class CoverageSites {
      * @param ordinal     where it comes in its behavior, for display
      * @param obligation  what a row would be owed for, which several occurrences share
      */
-    public record Site(String behavior, Kind kind, String label, Citation at,
+    public record Site(String behavior, SourceOutcome outcome, Citation at,
                        int index, int ordinal, Obligation obligation) {
 
-        public enum Kind {
-            /** The arm an {@code if} takes when its condition holds. */
-            THEN,
-            /** The arm it takes when the condition does not hold — a {@code guard}'s departure. */
-            ELSE,
-            /** One arm of a {@code match}. Cases written together on one arm are one site: they are
-             * one run of code, and a row takes it or does not. */
-            CASE,
-            /** The arm an attempted construction takes when the value was built. */
-            CONSTRUCTED,
-            /** An arm it takes when a clause refused. */
-            DEPARTURE,
-            /**
-             * One comparison of a guard's condition, recorded where it produced its boolean value.
-             *
-             * <p>Not an arm, and counted as one nowhere. A condition stops as soon as its answer is
-             * settled, so which arm a row landed in does not say which of the condition's comparisons
-             * ran: under {@code A && B} the arm where the condition failed is where a row that made
-             * {@code B} false lands and where a row that never reached {@code B} lands. Only an
-             * observation at the comparison separates them.
-             */
-            COMPARISON;
+        public Site {
+            // The pair is what carries the meaning, so the pair is what is checked. Not every
+            // combination is a construct of the language — a comprehension attempts no construction,
+            // a `match` settles no condition — and a walk that put an outcome on the wrong construct
+            // is the defect this whole value exists to make impossible.
+            OutcomeName.of(obligation.origin().kind(), outcome);
+        }
 
-            /** Whether a site of this kind is one of the arms a branch measure counts, and so one a
-             * report can name as an arm no row goes through. */
-            public boolean isArm() {
-                return this != COMPARISON;
-            }
+        /** What the author wrote this an outcome of. */
+        public CoverageConstruct construct() {
+            return obligation.origin().kind();
+        }
+
+        /** What a reader is told this is, which the two halves settle together. */
+        public OutcomeName name() {
+            return OutcomeName.of(construct(), outcome);
         }
 
         /** Whether this is one of the arms a branch measure counts. */
         public boolean isArm() {
-            return kind.isArm();
+            return outcome.isArm();
+        }
+
+        /**
+         * What a sentence in the reader's language calls this arm.
+         *
+         * <p>A key and what goes in it, chosen from the pair and not from either half: a condition
+         * holding is a {@code then} to quote under an {@code if} and the rest of the block under a
+         * {@code guard}, and the words for both are the catalog's.
+         */
+        public souther.compiler.diag.Localizable said() {
+            return switch (outcome) {
+                case SourceOutcome.Matched(List<TypeSymbol> cases) ->
+                        souther.compiler.diag.Localizable.of("arm.case", namesOf(cases));
+                case SourceOutcome.Failed(SourceOutcome.FailedBy.Construction(var clause)) ->
+                        clause.map(c -> souther.compiler.diag.Localizable.of(
+                                        "arm.departure.clause", c))
+                                .orElseGet(() -> souther.compiler.diag.Localizable.of(
+                                        "arm.departure"));
+                case SourceOutcome.Held _, SourceOutcome.Failed _, SourceOutcome.Compared _ ->
+                        switch (name()) {
+                            case THEN -> souther.compiler.diag.Localizable.of("arm.then");
+                            case ELSE -> souther.compiler.diag.Localizable.of("arm.else");
+                            case CONTINUED ->
+                                    souther.compiler.diag.Localizable.of("arm.continued");
+                            case KEPT -> souther.compiler.diag.Localizable.of("arm.kept");
+                            case DROPPED -> souther.compiler.diag.Localizable.of("arm.dropped");
+                            case CONSTRUCTED ->
+                                    souther.compiler.diag.Localizable.of("arm.constructed");
+                            // Neither is reachable here — a `case` and a departure are answered
+                            // above, and a comparison is not an arm, so nothing asks a sentence
+                            // about one.
+                            case CASE, DEPARTURE, COMPARISON -> throw new IllegalStateException(
+                                    "no sentence names this: " + name());
+                        };
+            };
+        }
+
+        /**
+         * The same, as the reports that are written in one language spell it.
+         *
+         * <p>Short where {@link #said} is a phrase: this goes in a field a consumer joins on and in a
+         * line of a table, and neither is a sentence.
+         */
+        public String label() {
+            return switch (outcome) {
+                case SourceOutcome.Matched(List<TypeSymbol> cases) -> "case " + namesOf(cases);
+                case SourceOutcome.Failed(SourceOutcome.FailedBy.Construction(var clause)) ->
+                        clause.map(c -> "else " + c).orElse("else");
+                case SourceOutcome.Compared(Hir.BinOp op) -> op.toString();
+                case SourceOutcome.Held _, SourceOutcome.Failed _ ->
+                        name().name().toLowerCase(java.util.Locale.ROOT);
+            };
+        }
+
+        private static String namesOf(List<TypeSymbol> cases) {
+            return cases.stream().map(TypeSymbol::name)
+                    .collect(java.util.stream.Collectors.joining(" | "));
         }
     }
 
@@ -281,6 +341,14 @@ public final class CoverageSites {
                 new IdentityHashMap<>();
         private final IdentityHashMap<Core, Integer> controlByComparison = new IdentityHashMap<>();
         private final IdentityHashMap<Core, Boolean> answering = new IdentityHashMap<>();
+        /** The outcomes that carry nothing of their own. What each of them means is settled with
+         *  the construct beside it, so one instance stands for every occurrence. */
+        private static final SourceOutcome HELD =
+                new SourceOutcome.Held(new SourceOutcome.HeldBy.Condition());
+        private static final SourceOutcome FAILED =
+                new SourceOutcome.Failed(new SourceOutcome.FailedBy.Condition());
+        private static final SourceOutcome BUILT =
+                new SourceOutcome.Held(new SourceOutcome.HeldBy.Construction());
         private String behavior;
         private int ordinal;
         /** Numbered across the whole plan and never reused, so that one number names one place
@@ -305,14 +373,14 @@ public final class CoverageSites {
          * an {@code unreachable} is E1911 and states nothing, so an arm only such a row could go
          * through is an arm no row will ever be recorded in.
          */
-        private ControlPointId.ArmOccurrence armOf(Site.Kind kind, String label, Core owner,
+        private ControlPointId.ArmOccurrence armOf(SourceOutcome outcome, Core owner,
                                                    CoverageOrigin origin, int part, Core arm,
                                                    boolean reachable) {
             // The arm is made either way. Whether a run through it can be recorded is the second
             // question and only the probe turns on it — an arm nothing could record is still an arm,
             // and the readings that judge one need to be able to name it.
             int probe = reachable && NormalReturn.of(arm)
-                    ? site(kind, label, owner, origin, part) : NO_SITE;
+                    ? site(outcome, owner, origin, part) : NO_SITE;
             return new ControlPointId.ArmOccurrence(controls++,
                     probe == NO_SITE ? OptionalInt.empty() : OptionalInt.of(probe),
                     // The fork's own coordinate, as a site takes it: an arm's body is what lowering
@@ -361,13 +429,13 @@ public final class CoverageSites {
          * @param owner the {@code if}, {@code match} or attempted construction the arm is one of
          * @param arm   the arm's body, which says what the arm is made of and not where it is
          */
-        private int site(Site.Kind kind, String label, Core owner, CoverageOrigin origin, int part) {
+        private int site(SourceOutcome outcome, Core owner, CoverageOrigin origin, int part) {
             int index = sites.size();
             // Of the node's own coordinate. This walk is over one module and an arm of a
             // helper another module of this compile wrote is in that module's file, so a
             // source carried here beside the position would be the wrong half of two
             // answers about one place. The walk holds none for that reason.
-            sites.add(new Site(behavior, kind, label, Citation.of(owner.pos()),
+            sites.add(new Site(behavior, outcome, Citation.of(owner.pos()),
                     index, ordinal++, new Obligation(behavior, origin, part)));
             return index;
         }
@@ -425,10 +493,10 @@ public final class CoverageSites {
                 case Core.If iff -> {
                     walk(iff.cond(), inside);
                     ControlPointId.ArmOccurrence then =
-                            armOf(Site.Kind.THEN, "then", iff, iff.origin(), 0, iff.then(), inside);
+                            armOf(HELD, iff, iff.origin(), 0, iff.then(), inside);
                     walk(iff.then(), inside);
                     ControlPointId.ArmOccurrence els =
-                            armOf(Site.Kind.ELSE, "else", iff, iff.origin(), 1, iff.els(), inside);
+                            armOf(FAILED, iff, iff.origin(), 1, iff.els(), inside);
                     walk(iff.els(), inside);
                     byNode.put(iff, probesOf(then, els));
                     armsByNode.put(iff, new ControlPointId.ArmOccurrence[] {then, els});
@@ -445,8 +513,7 @@ public final class CoverageSites {
                             new ControlPointId.ArmOccurrence[m.cases().size()];
                     for (int i = 0; i < m.cases().size(); i++) {
                         Core.Case arm = m.cases().get(i);
-                        arms[i] = armOf(Site.Kind.CASE, label(arm), m, m.origin(), i, arm.body(),
-                                inside);
+                        arms[i] = armOf(matched(arm), m, m.origin(), i, arm.body(), inside);
                         walk(arm.body(), inside);
                     }
                     byNode.put(m, probesOf(arms));
@@ -456,12 +523,12 @@ public final class CoverageSites {
                     ic.construct().values().forEach(given -> walk(given.value(), inside));
                     ControlPointId.ArmOccurrence[] arms =
                             new ControlPointId.ArmOccurrence[1 + ic.els().size()];
-                    arms[0] = armOf(Site.Kind.CONSTRUCTED, "constructed", ic, ic.origin(), 0,
+                    arms[0] = armOf(BUILT, ic, ic.origin(), 0,
                             ic.then(), inside);
                     walk(ic.then(), inside);
                     for (int i = 0; i < ic.els().size(); i++) {
                         Core.ElseArm arm = ic.els().get(i);
-                        arms[i + 1] = armOf(Site.Kind.DEPARTURE, label(arm), ic, ic.origin(), i + 1,
+                        arms[i + 1] = armOf(refused(arm), ic, ic.origin(), i + 1,
                                 arm.body(), inside);
                         walk(arm.body(), inside);
                     }
@@ -508,19 +575,19 @@ public final class CoverageSites {
                             + "; a tree rebuilt for an analysis is not the tree that runs");
                 }
                 byComparison.put(comparison,
-                        site(Site.Kind.COMPARISON, comparison.op().toString(), comparison,
+                        site(new SourceOutcome.Compared(comparison.op()), comparison,
                                 comparison.origin(), 0));
                 controlByComparison.put(comparison, controls++);
             }
         }
 
-        private static String label(Core.Case arm) {
-            List<String> names = arm.caseTypes().stream().map(TypeSymbol::name).toList();
-            return "case " + String.join(" | ", names);
+        private static SourceOutcome matched(Core.Case arm) {
+            return new SourceOutcome.Matched(arm.caseTypes());
         }
 
-        private static String label(Core.ElseArm arm) {
-            return arm.clause().map(c -> "else " + c).orElse("else");
+        private static SourceOutcome refused(Core.ElseArm arm) {
+            return new SourceOutcome.Failed(
+                    new SourceOutcome.FailedBy.Construction(arm.clause()));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -373,6 +373,16 @@ public final class CoverageSites {
          * @param arm   the arm's body, which says what the arm is made of and not where it is
          */
         private int site(SourceOutcome outcome, Core owner, CoverageOrigin origin, int part) {
+            // Said here because this is where anything is numbered, and the rule is about numbering
+            // rather than about comparisons: an arm of a fork nothing wrote is as much a row nobody
+            // can be owed as a comparison of one. Stated for the comparisons alone, it left the arms
+            // to be refused further down by whatever noticed first — which was the pair check on
+            // `Site`, saying something true about the pair and nothing about the tree.
+            if (!origin.isWritten()) {
+                throw new IllegalStateException("a construct with no source wrote it is being "
+                        + "numbered at " + owner.pos()
+                        + "; a tree rebuilt for an analysis is not the tree that runs");
+            }
             int index = sites.size();
             // Of the node's own coordinate. This walk is over one module and an arm of a
             // helper another module of this compile wrote is in that module's file, so a
@@ -512,11 +522,6 @@ public final class CoverageSites {
                 // condition can be an application of a function parameter, and then the comparison is
                 // the caller's: two predicates written separately are two lines, and one predicate
                 // handed to two calls is one, neither of which the fork can say.
-                if (!comparison.origin().isWritten()) {
-                    throw new IllegalStateException("a comparison with no source wrote it is being "
-                            + "numbered at " + comparison.pos()
-                            + "; a tree rebuilt for an analysis is not the tree that runs");
-                }
                 byComparison.put(comparison,
                         site(new SourceOutcome.Compared(comparison.op()), comparison,
                                 comparison.origin(), 0));

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -6,7 +6,6 @@ import souther.compiler.diag.Citation;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.CoverageConstruct;
 import souther.compiler.types.CoverageOrigin;
-import souther.compiler.types.TypeSymbol;
 
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
@@ -80,9 +79,10 @@ public final class CoverageSites {
      *
      * <p>Two halves and one meaning. {@link #obligation} carries the construct the source wrote, and
      * {@link #outcome} what this way through it means; neither says the other, so nothing here can
-     * hold two answers about one construct. What a reader is told is {@link #name}, and it is the
-     * pair that settles it — a condition holding is a {@code then} under an {@code if} and the rest
-     * of the block under a {@code guard}.
+     * hold two answers about one construct. Which of them the pair comes to is {@link #name}, and
+     * that is as far as this goes — a condition holding is a {@code then} under an {@code if} and the
+     * rest of the block under a {@code guard}, and both of those are said in a language, by whoever
+     * has a reader in front of them.
      *
      * @param outcome     what this way through the construct means, in the source's terms
      * @param at          where the arm is written, as a report may say it. A {@link Citation} and
@@ -119,63 +119,6 @@ public final class CoverageSites {
         /** Whether this is one of the arms a branch measure counts. */
         public boolean isArm() {
             return outcome.isArm();
-        }
-
-        /**
-         * What a sentence in the reader's language calls this arm.
-         *
-         * <p>A key and what goes in it, chosen from the pair and not from either half: a condition
-         * holding is a {@code then} to quote under an {@code if} and the rest of the block under a
-         * {@code guard}, and the words for both are the catalog's.
-         */
-        public souther.compiler.diag.Localizable said() {
-            return switch (outcome) {
-                case SourceOutcome.Matched(List<TypeSymbol> cases) ->
-                        souther.compiler.diag.Localizable.of("arm.case", namesOf(cases));
-                case SourceOutcome.Failed(SourceOutcome.FailedBy.Construction(var clause)) ->
-                        clause.map(c -> souther.compiler.diag.Localizable.of(
-                                        "arm.departure.clause", c))
-                                .orElseGet(() -> souther.compiler.diag.Localizable.of(
-                                        "arm.departure"));
-                case SourceOutcome.Held _, SourceOutcome.Failed _, SourceOutcome.Compared _ ->
-                        switch (name()) {
-                            case THEN -> souther.compiler.diag.Localizable.of("arm.then");
-                            case ELSE -> souther.compiler.diag.Localizable.of("arm.else");
-                            case CONTINUED ->
-                                    souther.compiler.diag.Localizable.of("arm.continued");
-                            case KEPT -> souther.compiler.diag.Localizable.of("arm.kept");
-                            case DROPPED -> souther.compiler.diag.Localizable.of("arm.dropped");
-                            case CONSTRUCTED ->
-                                    souther.compiler.diag.Localizable.of("arm.constructed");
-                            // Neither is reachable here — a `case` and a departure are answered
-                            // above, and a comparison is not an arm, so nothing asks a sentence
-                            // about one.
-                            case CASE, DEPARTURE, COMPARISON -> throw new IllegalStateException(
-                                    "no sentence names this: " + name());
-                        };
-            };
-        }
-
-        /**
-         * The same, as the reports that are written in one language spell it.
-         *
-         * <p>Short where {@link #said} is a phrase: this goes in a field a consumer joins on and in a
-         * line of a table, and neither is a sentence.
-         */
-        public String label() {
-            return switch (outcome) {
-                case SourceOutcome.Matched(List<TypeSymbol> cases) -> "case " + namesOf(cases);
-                case SourceOutcome.Failed(SourceOutcome.FailedBy.Construction(var clause)) ->
-                        clause.map(c -> "else " + c).orElse("else");
-                case SourceOutcome.Compared(Hir.BinOp op) -> op.toString();
-                case SourceOutcome.Held _, SourceOutcome.Failed _ ->
-                        name().name().toLowerCase(java.util.Locale.ROOT);
-            };
-        }
-
-        private static String namesOf(List<TypeSymbol> cases) {
-            return cases.stream().map(TypeSymbol::name)
-                    .collect(java.util.stream.Collectors.joining(" | "));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/coverage/OutcomeName.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/OutcomeName.java
@@ -1,0 +1,109 @@
+package souther.compiler.coverage;
+
+import souther.compiler.types.CoverageConstruct;
+
+/**
+ * What a reader is told one outcome of one construct is.
+ *
+ * <p>The projection of the pair — the construct a source wrote, and what one way through it means —
+ * onto the vocabulary the reports share. A distinction and not a word: what a document spells it and
+ * what a sentence in the reader's language calls it are two renderings of this, and both are chosen
+ * where the reader is.
+ *
+ * <p>Every pair passes through {@link #of}, which is the one place the admissible pairs are written
+ * down. A construct or an outcome added later stops there rather than falling into a default and
+ * arriving at a reader named after whichever arm the code was written next to.
+ */
+public enum OutcomeName {
+
+    /** The arm an {@code if} takes when its condition holds. */
+    THEN,
+
+    /** The arm the author wrote {@code else} on — an {@code if}'s, and a {@code guard}'s departure. */
+    ELSE,
+
+    /**
+     * The body past a {@code guard} whose condition held.
+     *
+     * <p>Not a {@code then}. The author wrote one arm of the fork and the compiler supplied this one
+     * out of the rest of the block, so there is no word in the source to quote.
+     */
+    CONTINUED,
+
+    /** The element a comprehension yields when its condition holds. */
+    KEPT,
+
+    /** The empty list a comprehension yields when it does not. */
+    DROPPED,
+
+    /** One arm of a {@code match}. */
+    CASE,
+
+    /** The way taken when an attempted construction built its value. */
+    CONSTRUCTED,
+
+    /** The way taken when a clause refused it. */
+    DEPARTURE,
+
+    /** One comparison of a condition, which is a site and not an arm. */
+    COMPARISON;
+
+    /**
+     * Whether a document names this among the arms a branch measure counts.
+     *
+     * <p>The image of {@link SourceOutcome#isArm()} under this projection, and held to it by
+     * {@code AnOutcomeIsNamedByWhatWasWrittenTest}, which walks the admissible pairs and asks both.
+     */
+    public boolean isArm() {
+        return this != COMPARISON;
+    }
+
+    /**
+     * What to call {@code outcome} under {@code construct}.
+     *
+     * @throws IllegalArgumentException where no construct of the language has that outcome — a
+     *                                  comprehension attempting a construction, a {@code match}
+     *                                  settling a condition. The pair is what carries the meaning, so
+     *                                  a pair nothing can be written as is a walk that has put an
+     *                                  outcome on the wrong construct
+     */
+    public static OutcomeName of(CoverageConstruct construct, SourceOutcome outcome) {
+        return switch (outcome) {
+            case SourceOutcome.Held(SourceOutcome.HeldBy.Condition _) -> switch (construct) {
+                case IF -> THEN;
+                case GUARD -> CONTINUED;
+                case COMPREHENSION -> KEPT;
+                case MATCH, COMPARISON, NOT_WRITTEN -> refuse(construct, outcome);
+            };
+            case SourceOutcome.Failed(SourceOutcome.FailedBy.Condition _) -> switch (construct) {
+                case IF, GUARD -> ELSE;
+                case COMPREHENSION -> DROPPED;
+                case MATCH, COMPARISON, NOT_WRITTEN -> refuse(construct, outcome);
+            };
+            // An attempted construction is a shape either of the two conditionals may be written in,
+            // and no other construct has one. What the value was attempted under is said by the
+            // construct beside this rather than by a second word here.
+            case SourceOutcome.Held(SourceOutcome.HeldBy.Construction _) -> switch (construct) {
+                case IF, GUARD -> CONSTRUCTED;
+                case COMPREHENSION, MATCH, COMPARISON, NOT_WRITTEN -> refuse(construct, outcome);
+            };
+            case SourceOutcome.Failed(SourceOutcome.FailedBy.Construction _) -> switch (construct) {
+                case IF, GUARD -> DEPARTURE;
+                case COMPREHENSION, MATCH, COMPARISON, NOT_WRITTEN -> refuse(construct, outcome);
+            };
+            case SourceOutcome.Matched _ -> switch (construct) {
+                case MATCH -> CASE;
+                case IF, GUARD, COMPREHENSION, COMPARISON, NOT_WRITTEN -> refuse(construct, outcome);
+            };
+            case SourceOutcome.Compared _ -> switch (construct) {
+                case COMPARISON -> COMPARISON;
+                case IF, GUARD, COMPREHENSION, MATCH, NOT_WRITTEN -> refuse(construct, outcome);
+            };
+        };
+    }
+
+    private static OutcomeName refuse(CoverageConstruct construct, SourceOutcome outcome) {
+        throw new IllegalArgumentException(
+                "no construct of the language has this outcome: " + construct + " with " + outcome);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/OutcomeName.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/OutcomeName.java
@@ -73,30 +73,33 @@ public enum OutcomeName {
                 case IF -> THEN;
                 case GUARD -> CONTINUED;
                 case COMPREHENSION -> KEPT;
-                case MATCH, COMPARISON, NOT_WRITTEN -> refuse(construct, outcome);
+                case MATCH, BINARY, NOT_WRITTEN -> refuse(construct, outcome);
             };
             case SourceOutcome.Failed(SourceOutcome.FailedBy.Condition _) -> switch (construct) {
                 case IF, GUARD -> ELSE;
                 case COMPREHENSION -> DROPPED;
-                case MATCH, COMPARISON, NOT_WRITTEN -> refuse(construct, outcome);
+                case MATCH, BINARY, NOT_WRITTEN -> refuse(construct, outcome);
             };
             // An attempted construction is a shape either of the two conditionals may be written in,
             // and no other construct has one. What the value was attempted under is said by the
             // construct beside this rather than by a second word here.
             case SourceOutcome.Held(SourceOutcome.HeldBy.Construction _) -> switch (construct) {
                 case IF, GUARD -> CONSTRUCTED;
-                case COMPREHENSION, MATCH, COMPARISON, NOT_WRITTEN -> refuse(construct, outcome);
+                case COMPREHENSION, MATCH, BINARY, NOT_WRITTEN -> refuse(construct, outcome);
             };
             case SourceOutcome.Failed(SourceOutcome.FailedBy.Construction _) -> switch (construct) {
                 case IF, GUARD -> DEPARTURE;
-                case COMPREHENSION, MATCH, COMPARISON, NOT_WRITTEN -> refuse(construct, outcome);
+                case COMPREHENSION, MATCH, BINARY, NOT_WRITTEN -> refuse(construct, outcome);
             };
             case SourceOutcome.Matched _ -> switch (construct) {
                 case MATCH -> CASE;
-                case IF, GUARD, COMPREHENSION, COMPARISON, NOT_WRITTEN -> refuse(construct, outcome);
+                case IF, GUARD, COMPREHENSION, BINARY, NOT_WRITTEN -> refuse(construct, outcome);
             };
+            // The one place the two axes meet without naming each other: what was written is a
+            // binary expression, and being read as a comparison a row can reach is what happened to
+            // it. Every other binary expression the source wrote has no outcome at all.
             case SourceOutcome.Compared _ -> switch (construct) {
-                case COMPARISON -> COMPARISON;
+                case BINARY -> COMPARISON;
                 case IF, GUARD, COMPREHENSION, MATCH, NOT_WRITTEN -> refuse(construct, outcome);
             };
         };

--- a/souther-compiler/src/main/java/souther/compiler/coverage/SourceOutcome.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/SourceOutcome.java
@@ -1,0 +1,102 @@
+package souther.compiler.coverage;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * What one way through a coverage construct means, said in the source's own terms.
+ *
+ * <p>Half of an answer. Which construct this is an outcome of is {@link CoverageSites.Site}'s other
+ * half, read off the {@link souther.compiler.types.CoverageOrigin} its obligation carries, and the
+ * meaning is the two together: a condition holding is {@code then} under an {@code if}, the rest of
+ * the block under a {@code guard}, and an element kept under a comprehension. The construct is not
+ * repeated here, so nothing can say one construct in one component and another in the next.
+ *
+ * <p>Data and not words. What a report calls an outcome is a rendering, chosen where a reader is and
+ * in the language they asked for; deciding it while the tree is being walked freezes one language's
+ * word into the analysis, which is how {@code then} came to be printed for constructs that have no
+ * {@code then} in them.
+ */
+public sealed interface SourceOutcome {
+
+    /**
+     * The way taken because the decision held.
+     *
+     * <p>Not always an arm the author wrote. A {@code guard}'s is the rest of the block and a
+     * comprehension's is the element it yields, and what says which of those this is, is the
+     * construct beside it.
+     */
+    record Held(HeldBy by) implements SourceOutcome {}
+
+    /** The way taken because the decision did not hold. */
+    record Failed(FailedBy by) implements SourceOutcome {}
+
+    /**
+     * What held.
+     *
+     * <p>Beside the construct rather than inside it, because the two vary on their own: an
+     * {@code if} and a {@code guard} each come in both shapes, and a comprehension only ever
+     * decides on a condition.
+     */
+    sealed interface HeldBy {
+
+        /** A condition came out true. */
+        record Condition() implements HeldBy {}
+
+        /** A value was built, so its invariant is what held. Nothing to name: a construction that
+         *  succeeded broke no clause. */
+        record Construction() implements HeldBy {}
+    }
+
+    /** What did not hold, which has one thing to say that {@link HeldBy} does not. */
+    sealed interface FailedBy {
+
+        /** A condition came out false. */
+        record Condition() implements FailedBy {}
+
+        /**
+         * A value was refused by its invariant.
+         *
+         * @param clause which clause this departure answers, where the source named one, and empty
+         *               where it takes any failure
+         */
+        record Construction(Optional<String> clause) implements FailedBy {
+
+            public Construction {
+                clause = clause == null ? Optional.empty() : clause;
+            }
+        }
+    }
+
+    /**
+     * One arm of a {@code match}.
+     *
+     * @param cases the cases written on the arm. Several where the source wrote them together, which
+     *              is one run of code and so one arm
+     */
+    record Matched(List<TypeSymbol> cases) implements SourceOutcome {
+
+        public Matched {
+            cases = List.copyOf(cases);
+        }
+    }
+
+    /**
+     * One comparison of a condition, recorded where it produced its answer.
+     *
+     * <p>Not an arm and counted as one nowhere. A condition stops as soon as it is settled, so which
+     * arm a row landed in does not say which comparison ran.
+     */
+    record Compared(Hir.BinOp op) implements SourceOutcome {}
+
+    /** Whether this is one of the arms a branch measure counts. */
+    default boolean isArm() {
+        return switch (this) {
+            case Compared _ -> false;
+            case Held _, Failed _, Matched _ -> true;
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -833,7 +833,7 @@ public final class AstBuilder {
         // Anchored at the operator, which is what a report about the operation is about, and written
         // over both operands, which is what the operation is.
         return new Ast.Binary(binOp(op.kind()), expr(operands.get(0)), expr(operands.get(1)),
-                construct(CoverageConstruct.COMPARISON), posOf(op), region(n));
+                construct(CoverageConstruct.BINARY), posOf(op), region(n));
     }
 
     private static Ast.BinOp binOp(SyntaxKind k) {

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -3,6 +3,7 @@ package souther.compiler.frontend;
 import souther.compiler.diag.msg.Reported;
 import souther.compiler.diag.msg.Supporting;
 import souther.compiler.ast.Ast;
+import souther.compiler.types.CoverageConstruct;
 import souther.compiler.types.CoverageOrigin;
 import souther.compiler.ast.StructuralCost;
 import souther.compiler.ast.WrittenName;
@@ -99,8 +100,15 @@ public final class AstBuilder {
 
     /** The next construct of this source a coverage obligation can be about. Called once where a
      * construct is recognised, never per node the construct is built as. */
-    private CoverageOrigin construct() {
-        return CoverageOrigin.written(moduleName, constructCounter++);
+    /**
+     * The next construct of this source, said as what the author wrote it as.
+     *
+     * <p>The kind is taken here and nowhere else. This is the one place that has the syntax in front
+     * of it — every stage below reads a tree that has already been lowered, where a {@code guard},
+     * an {@code if} and a comprehension's condition are the same node.
+     */
+    private CoverageOrigin construct(CoverageConstruct kind) {
+        return CoverageOrigin.written(moduleName, constructCounter++, kind);
     }
 
     // --- module ---
@@ -825,7 +833,7 @@ public final class AstBuilder {
         // Anchored at the operator, which is what a report about the operation is about, and written
         // over both operands, which is what the operation is.
         return new Ast.Binary(binOp(op.kind()), expr(operands.get(0)), expr(operands.get(1)),
-                construct(), posOf(op), region(n));
+                construct(CoverageConstruct.COMPARISON), posOf(op), region(n));
     }
 
     private static Ast.BinOp binOp(SyntaxKind k) {
@@ -883,7 +891,8 @@ public final class AstBuilder {
         for (int i = 1; i < exprs.size(); i++) {
             guards.add(expr(exprs.get(i)));
         }
-        return new Ast.ListComp(element, guards, construct(), pos(n), region(n));
+        return new Ast.ListComp(element, guards, construct(CoverageConstruct.COMPREHENSION),
+                pos(n), region(n));
     }
 
     private Ast.Expr ifExpr(SyntaxNode n) {
@@ -892,7 +901,7 @@ public final class AstBuilder {
         String binder = as == null ? null : ident(as);
         List<Ast.ElseArm> arms = elseArms(n, binder);
         // One construct, so one origin whichever of the three shapes it is written as.
-        CoverageOrigin origin = construct();
+        CoverageOrigin origin = construct(CoverageConstruct.IF);
         if (arms != null) {
             return new Ast.IfConstructed(expr(exprs.get(0)),
                     binderOf(as), expr(exprs.get(1)), arms, origin, pos(n), region(n));
@@ -1049,7 +1058,8 @@ public final class AstBuilder {
         for (SyntaxNode c : childNodes(n, SyntaxKind.MATCH_CASE)) {
             cases.add(matchCase(c));
         }
-        return new Ast.Match(scrutinee, cases, construct(), pos(n), region(n));
+        return new Ast.Match(scrutinee, cases, construct(CoverageConstruct.MATCH), pos(n),
+                region(n));
     }
 
     /** A name as the source wrote it — bare, or qualified through a module or an import alias — read
@@ -1353,7 +1363,7 @@ public final class AstBuilder {
                 Ast.Expr rest = foldStatements(stmts, index + 1, result);
                 List<Ast.ElseArm> arms = elseArms(s, binder);
                 // One construct, so one origin whichever of the three shapes it is written as.
-                CoverageOrigin origin = construct();
+                CoverageOrigin origin = construct(CoverageConstruct.GUARD);
                 if (arms != null) {
                     yield new Ast.IfConstructed(expr(exprs.get(0)), binderOf(as), rest, arms, origin,
                             pos, held);

--- a/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
@@ -198,6 +198,11 @@ public sealed interface OriginRef {
      * from the place instead, one compile reported a guard of {@code Int.abs} as {@code guard@7:22}
      * two lines under an arm of that same body saying where it was.
      *
+     * <p>Which word the place is written under is the construct the author wrote, taken off the
+     * origin the fork carries rather than off the lowered node. Three constructs draw a line this way
+     * and one of them is spelled {@code guard}, so a report that called all three that sent two of
+     * their readers looking for a form that is not there.
+     *
      * <p>A type and an invariant have names, and a name is the same wherever it is read, so they take
      * no resolver and are given one only because this is one question.
      */
@@ -208,12 +213,31 @@ public sealed interface OriginRef {
             case EnsuresOrigin e -> nameOf(e);
             case GuardOrigin g -> switch (g.at()) {
                 case Citation.Written _, Citation.Unplaced _ ->
-                        "guard@" + g.at().said(names, sectionSource);
-                case Citation.Elsewhere _ -> "guard in " + g.at().said(names, sectionSource);
+                        wordFor(g) + "@" + g.at().said(names, sectionSource);
+                case Citation.Elsewhere _ -> wordFor(g) + " in " + g.at().said(names, sectionSource);
             };
             case NarrowedOrigin n -> n.bound().describe(names, sectionSource) + " within "
                     + n.within().stream().map(TypeSymbol::name)
                             .collect(java.util.stream.Collectors.joining(" or "));
+        };
+    }
+
+    /**
+     * What a report calls the construct a line was drawn in.
+     *
+     * <p>English, like every other word this method writes. What a diagnostic says instead is chosen
+     * in the reader's language, from the same construct.
+     */
+    private static String wordFor(GuardOrigin g) {
+        return switch (g.constructThatDrewIt()) {
+            case IF -> "if";
+            case GUARD -> "guard";
+            case COMPREHENSION -> "comprehension";
+            // A line is read off a fork's condition, and these are not forks. Reaching one is this
+            // reader and the walk that numbered the fork disagreeing about what drew the line.
+            case MATCH, COMPARISON, NOT_WRITTEN -> throw new IllegalStateException(
+                    "a line was drawn in something that is not a fork: "
+                            + g.guard().origin().kind());
         };
     }
 
@@ -232,8 +256,10 @@ public sealed interface OriginRef {
             case EnsuresOrigin e -> nameOf(e);
             // Never rendered to a reader: a rule with no name gets a sentence of its own, so the
             // catalog holds those words in every language rather than this building them in one.
-            // What reaches this is a caller that wanted something to call the rule anyway.
-            case GuardOrigin _ -> "a guard";
+            // What reaches this is a caller that wanted something to call the rule anyway, and what
+            // it gets is the construct the source wrote rather than one of the three standing for
+            // all of them.
+            case GuardOrigin g -> "the " + wordFor(g);
             case NarrowedOrigin n -> n.bound().named() + " within "
                     + n.within().stream().map(TypeSymbol::name)
                             .collect(java.util.stream.Collectors.joining(" or "));
@@ -262,6 +288,27 @@ public sealed interface OriginRef {
             case GuardOrigin _ -> true;
             case NarrowedOrigin n -> n.bound().isAGuard();
             case TypeOrigin _, InvariantOrigin _, EnsuresOrigin _ -> false;
+        };
+    }
+
+    /**
+     * Which construct of the language drew this line, through however many narrowings.
+     *
+     * <p>Asked of the rule rather than worked out from the shape the fork was lowered to. Three
+     * constructs draw a line off a condition and one of them is spelled {@code guard}; the tree that
+     * runs holds one node for all three, and the answer travels with the fork's origin from where the
+     * source was read.
+     *
+     * @throws IllegalStateException where no fork drew the line. An invariant, a type and a clause
+     *                               have names rather than places, and {@link #isAGuard} is what
+     *                               tells them apart from this
+     */
+    default souther.compiler.types.CoverageConstruct constructThatDrewIt() {
+        return switch (this) {
+            case GuardOrigin g -> g.guard().origin().kind();
+            case NarrowedOrigin n -> n.bound().constructThatDrewIt();
+            case TypeOrigin _, InvariantOrigin _, EnsuresOrigin _ -> throw new IllegalStateException(
+                    "no fork of a body drew this line: " + named());
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
@@ -235,7 +235,7 @@ public sealed interface OriginRef {
             case COMPREHENSION -> "comprehension";
             // A line is read off a fork's condition, and these are not forks. Reaching one is this
             // reader and the walk that numbered the fork disagreeing about what drew the line.
-            case MATCH, COMPARISON, NOT_WRITTEN -> throw new IllegalStateException(
+            case MATCH, BINARY, NOT_WRITTEN -> throw new IllegalStateException(
                     "a line was drawn in something that is not a fork: "
                             + g.guard().origin().kind());
         };
@@ -281,12 +281,22 @@ public sealed interface OriginRef {
                 + (e.clause().isEmpty() ? "" : " (" + e.clause() + ")");
     }
 
-    /** Whether a guard drew this line, through however many narrowings. Asked rather than matched
-     *  on the text: what a rule is called is a rendering, and two of them read the same word. */
-    default boolean isAGuard() {
+    /**
+     * Whether a fork of a body drew this line, through however many narrowings.
+     *
+     * <p>Not whether the author wrote {@code guard}. Three constructs put a line on a condition and
+     * one of them is spelled that way, so a predicate reading as the keyword would be answered
+     * {@code true} about an {@code if} — and the next reader to notice the mismatch would repair the
+     * name into a test of the construct and break the other two. What this separates is a rule with a
+     * place from a rule with a name, which is what every caller wants of it.
+     *
+     * <p>Asked rather than matched on the text: what a rule is called is a rendering, and two of them
+     * read the same word.
+     */
+    default boolean wasDrawnInABodyFork() {
         return switch (this) {
             case GuardOrigin _ -> true;
-            case NarrowedOrigin n -> n.bound().isAGuard();
+            case NarrowedOrigin n -> n.bound().wasDrawnInABodyFork();
             case TypeOrigin _, InvariantOrigin _, EnsuresOrigin _ -> false;
         };
     }
@@ -300,8 +310,8 @@ public sealed interface OriginRef {
      * source was read.
      *
      * @throws IllegalStateException where no fork drew the line. An invariant, a type and a clause
-     *                               have names rather than places, and {@link #isAGuard} is what
-     *                               tells them apart from this
+     *                               have names rather than places, and {@link #wasDrawnInABodyFork}
+     *                               is what tells them apart from this
      */
     default souther.compiler.types.CoverageConstruct constructThatDrewIt() {
         return switch (this) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1930,8 +1930,12 @@ public final class Adequacy {
                 return;
             }
             for (souther.compiler.coverage.CoverageSites.Site arm : branch.unreached()) {
+                // The arm itself and not words about it. What to call one differs between a report,
+                // which is written in one language, and a diagnostic, which is written in the
+                // reader's — and the two readings ask the same arm rather than one of them being
+                // handed the other's answer.
                 out.add(new Finding(Kind.ARM_UNREACHED, behavior.name(), branch.status(),
-                        arm.at(), List.of(arm.label(), arm.behavior())));
+                        arm.at(), List.of(arm, arm.behavior())));
             }
         }
     }
@@ -1996,15 +2000,16 @@ public final class Adequacy {
                                 text(said, 0), text(said, 1), text(said, 2));
                         // The rule named without a place. Nothing here knows what to call a
                         // source, so a line and a column written into the sentence would be read
-                        // against whichever file the reader has in mind. Where the rule is a
-                        // guard, the place is pointed at rather than said.
+                        // against whichever file the reader has in mind. Where a fork of a body
+                        // drew the line, the place is pointed at rather than said, and which
+                        // construct it was is a phrase the catalog holds in every language.
                         case BOUNDARY_UNMET -> rule(said).isAGuard()
-                                ? new ExampleMessage.NoRowIsAtTheLineAGuardDrew(
-                                        text(said, 0), text(said, 1))
+                                ? new ExampleMessage.NoRowIsAtTheLineAConstructDrew(
+                                        text(said, 0), text(said, 1), constructOf(said))
                                 : new ExampleMessage.NoRowIsAtThatBoundary(
                                         text(said, 0), text(said, 1), rule(said).named());
                         case ARM_UNREACHED -> new ExampleMessage.NoRowGoesThroughThatArm(
-                                text(said, 0), text(said, 1));
+                                arm(said).said(), text(said, 1));
                         default -> throw new IllegalArgumentException(
                                 "no message for " + finding.kind());
                     });
@@ -2026,10 +2031,12 @@ public final class Adequacy {
                         switch (cited) {
                             case souther.compiler.diag.Citation.Written w ->
                                     built.secondary(souther.compiler.diag.Region.point(w.at()),
-                                            new ExampleMessage.TheGuardThatDrawsTheLine());
+                                            new ExampleMessage.TheConstructThatDrawsTheLine(
+                                                    constructOf(said)));
                             case souther.compiler.diag.Citation.Reached r ->
                                     built.secondary(souther.compiler.diag.Region.point(r.at()),
-                                            new ExampleMessage.TheGuardThatDrawsTheLine());
+                                            new ExampleMessage.TheConstructThatDrawsTheLine(
+                                                    constructOf(said)));
                             // Nowhere this compilation can put a marker. Where the guard is written
                             // out of sight the label says so instead; where it is in a text the
                             // caller handed over there is no declaration to name and nothing to say,
@@ -2037,7 +2044,8 @@ public final class Adequacy {
                             // a place a reader is sent to names its source, and this one cannot.
                             case souther.compiler.diag.Citation.Elsewhere e ->
                                     built.secondaryOutOfSight(e.provenance(),
-                                            new ExampleMessage.TheGuardThatDrawsTheLine());
+                                            new ExampleMessage.TheConstructThatDrawsTheLine(
+                                                    constructOf(said)));
                             case souther.compiler.diag.Citation.Unplaced _ -> { }
                         }
                     });
@@ -2078,6 +2086,18 @@ public final class Adequacy {
          *  which cannot. */
         private static souther.compiler.partition.OriginRef rule(List<Object> said) {
             return (souther.compiler.partition.OriginRef) said.get(2);
+        }
+
+        /** The arm an arm finding is about, which it carries as itself for the same reason a
+         *  boundary finding carries its rule: what to call it is the reader's question. */
+        private static souther.compiler.coverage.CoverageSites.Site arm(List<Object> said) {
+            return (souther.compiler.coverage.CoverageSites.Site) said.get(0);
+        }
+
+        /** Which construct of the language drew a boundary's line, as a phrase the reader's
+         *  language supplies. Asked of the rule, which is where the source's own answer is. */
+        private static souther.compiler.diag.Localizable constructOf(List<Object> said) {
+            return rule(said).constructThatDrewIt().said();
         }
 
         /** What a finding put at {@code at}, as the text a message carries. */

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -2003,13 +2003,13 @@ public final class Adequacy {
                         // against whichever file the reader has in mind. Where a fork of a body
                         // drew the line, the place is pointed at rather than said, and which
                         // construct it was is a phrase the catalog holds in every language.
-                        case BOUNDARY_UNMET -> rule(said).isAGuard()
+                        case BOUNDARY_UNMET -> rule(said).wasDrawnInABodyFork()
                                 ? new ExampleMessage.NoRowIsAtTheLineAConstructDrew(
                                         text(said, 0), text(said, 1), constructOf(said))
                                 : new ExampleMessage.NoRowIsAtThatBoundary(
                                         text(said, 0), text(said, 1), rule(said).named());
                         case ARM_UNREACHED -> new ExampleMessage.NoRowGoesThroughThatArm(
-                                arm(said).said(), text(said, 1));
+                                phraseFor(arm(said)), text(said, 1));
                         default -> throw new IllegalArgumentException(
                                 "no message for " + finding.kind());
                     });
@@ -2098,6 +2098,51 @@ public final class Adequacy {
          *  language supplies. Asked of the rule, which is where the source's own answer is. */
         private static souther.compiler.diag.Localizable constructOf(List<Object> said) {
             return rule(said).constructThatDrewIt().said();
+        }
+
+        /**
+         * What a sentence calls one arm, as a phrase the catalog holds in every language.
+         *
+         * <p>Chosen here and not where the arm was found. The measurement answers what the arm is —
+         * a construct and a way through it — and what to call one is a question only a sentence with
+         * a reader has; the report writes a short word for the same arm and this writes a phrase, and
+         * neither is the other's to decide. Written off the name the pair already settles, so a
+         * construct added to the language arrives here as a case with no phrase rather than as one
+         * quietly answered with a neighbour's.
+         */
+        private static souther.compiler.diag.Localizable phraseFor(
+                souther.compiler.coverage.CoverageSites.Site arm) {
+            return switch (arm.name()) {
+                case THEN -> souther.compiler.diag.Localizable.of("arm.then");
+                case ELSE -> souther.compiler.diag.Localizable.of("arm.else");
+                case CONTINUED -> souther.compiler.diag.Localizable.of("arm.continued");
+                case KEPT -> souther.compiler.diag.Localizable.of("arm.kept");
+                case DROPPED -> souther.compiler.diag.Localizable.of("arm.dropped");
+                case CONSTRUCTED -> souther.compiler.diag.Localizable.of("arm.constructed");
+                case CASE -> souther.compiler.diag.Localizable.of("arm.case", casesOf(arm));
+                case DEPARTURE -> clauseOf(arm)
+                        .map(c -> souther.compiler.diag.Localizable.of("arm.departure.clause", c))
+                        .orElseGet(() -> souther.compiler.diag.Localizable.of("arm.departure"));
+                // Not an arm, so no warning is about one. Reaching this is the branch measure and
+                // this sentence disagreeing about what it counts.
+                case COMPARISON -> throw new IllegalStateException(
+                        "no arm was unreached here: " + arm);
+            };
+        }
+
+        private static String casesOf(souther.compiler.coverage.CoverageSites.Site arm) {
+            return arm.outcome() instanceof souther.compiler.coverage.SourceOutcome.Matched matched
+                    ? matched.cases().stream()
+                            .map(souther.compiler.types.TypeSymbol::name)
+                            .collect(java.util.stream.Collectors.joining(" | "))
+                    : "";
+        }
+
+        private static java.util.Optional<String> clauseOf(
+                souther.compiler.coverage.CoverageSites.Site arm) {
+            return arm.outcome() instanceof souther.compiler.coverage.SourceOutcome.Failed(
+                    souther.compiler.coverage.SourceOutcome.FailedBy.Construction(var clause))
+                    ? clause : java.util.Optional.empty();
         }
 
         /** What a finding put at {@code at}, as the text a message carries. */

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -795,7 +795,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         }
         for (Adequacy.Finding f : behavior.of(Adequacy.Kind.ARM_UNREACHED)) {
             out.append(String.format("      %s no row goes through `%s` (%s)%n",
-                    mark(f), f.args().get(0), f.at().said(names, declaredIn)));
+                    mark(f), armOf(f).label(), f.at().said(names, declaredIn)));
         }
     }
 
@@ -1228,7 +1228,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         for (souther.compiler.coverage.CoverageSites.Site arm : named) {
             ObjectNode a = unreached.addObject();
             a.put("label", arm.label());
-            a.put("kind", word(arm.kind()));
+            a.put("kind", word(arm.name()));
+            // What the arm is an outcome of. Two fields because the meaning is the pair: an `else`
+            // an author wrote under an `if` and one written under a `guard` are the same outcome of
+            // two constructs, and a consumer told only the outcome cannot tell them apart.
+            a.put("construct", word(arm.construct()));
             at(a, arm.at(), sources);
         }
     }
@@ -1314,14 +1318,24 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     private static String subject(Adequacy.Finding finding) {
         List<Object> args = finding.args();
         return switch (finding.kind()) {
+            // The label and not the arm, and the same label `branch.unreached` writes: this field
+            // exists to join to that entry, and a value spelled a second way here would join to
+            // nothing.
+            case ARM_UNREACHED -> armOf(finding).label();
             case OUTPUT_CASE_UNSPECIFIED, OUTPUT_CASE_UNVERIFIED, AXIS_CLASS_UNCOVERED,
-                    ARM_UNREACHED, PARTITION_NOT_DERIVABLE, PARTITION_NOT_READ,
+                    PARTITION_NOT_DERIVABLE, PARTITION_NOT_READ,
                     PARTITION_READ_IN_PART, PARTITION_OMITTED ->
                     String.valueOf(args.get(0));
             case INPUT_CASE_UNSPECIFIED ->
                     String.valueOf(args.get(0)) + " (in #" + args.get(1) + ")";
             case BOUNDARY_UNMET -> args.get(0) + " = " + args.get(1);
         };
+    }
+
+    /** The arm an arm finding carries, which it holds as itself so that each reader names it its
+     *  own way. */
+    private static souther.compiler.coverage.CoverageSites.Site armOf(Adequacy.Finding finding) {
+        return (souther.compiler.coverage.CoverageSites.Site) finding.args().get(0);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -795,7 +795,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         }
         for (Adequacy.Finding f : behavior.of(Adequacy.Kind.ARM_UNREACHED)) {
             out.append(String.format("      %s no row goes through `%s` (%s)%n",
-                    mark(f), armOf(f).label(), f.at().said(names, declaredIn)));
+                    mark(f), ArmVocabulary.label(armOf(f)), f.at().said(names, declaredIn)));
         }
     }
 
@@ -1227,7 +1227,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 branch.status() == MeasurementStatus.COMPLETE ? branch.unreached() : List.of();
         for (souther.compiler.coverage.CoverageSites.Site arm : named) {
             ObjectNode a = unreached.addObject();
-            a.put("label", arm.label());
+            a.put("label", ArmVocabulary.label(arm));
             a.put("kind", word(arm.name()));
             // What the arm is an outcome of. Two fields because the meaning is the pair: an `else`
             // an author wrote under an `if` and one written under a `guard` are the same outcome of
@@ -1321,7 +1321,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // The label and not the arm, and the same label `branch.unreached` writes: this field
             // exists to join to that entry, and a value spelled a second way here would join to
             // nothing.
-            case ARM_UNREACHED -> armOf(finding).label();
+            case ARM_UNREACHED -> ArmVocabulary.label(armOf(finding));
             case OUTPUT_CASE_UNSPECIFIED, OUTPUT_CASE_UNVERIFIED, AXIS_CLASS_UNCOVERED,
                     PARTITION_NOT_DERIVABLE, PARTITION_NOT_READ,
                     PARTITION_READ_IN_PART, PARTITION_OMITTED ->

--- a/souther-compiler/src/main/java/souther/compiler/report/ArmVocabulary.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/ArmVocabulary.java
@@ -1,0 +1,52 @@
+package souther.compiler.report;
+
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.coverage.SourceOutcome;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * What the reports written in one language call one way through a construct.
+ *
+ * <p>Here rather than beside the measurement. What a way through a construct <em>is</em> is a
+ * construct and a {@link SourceOutcome}, and both of those are the same however they are asked
+ * about; what to call one is a question only somebody with a reader in front of them has, and there
+ * are two such readers with different needs — a table and a document that join on a short word, and
+ * a diagnostic that says a phrase in whatever language it was asked in. The second is the catalog's.
+ *
+ * <p>Written off {@link souther.compiler.coverage.OutcomeName}, which is the pair already settled, so
+ * a construct or an outcome added to the language reaches this as a name it has to be given a word
+ * for rather than as a case that falls through.
+ */
+public final class ArmVocabulary {
+
+    /**
+     * The short word a table prints and a document writes under {@code label}.
+     *
+     * <p>One function for both, because the document's {@code subject} joins a finding to the entry
+     * in {@code branch.unreached} that names the same arm: spelled twice, the two would join to
+     * nothing the day one of them was reworded.
+     */
+    public static String label(CoverageSites.Site arm) {
+        return switch (arm.outcome()) {
+            case SourceOutcome.Matched(List<TypeSymbol> cases) -> "case " + namesOf(cases);
+            // The word the author put the departure under, and the clause where they named one. The
+            // name of this outcome is `departure`, which says what happened rather than what is
+            // written there; a reader of a table is looking at the file.
+            case SourceOutcome.Failed(SourceOutcome.FailedBy.Construction(var clause)) ->
+                    clause.map(c -> "else " + c).orElse("else");
+            case SourceOutcome.Compared(var op) -> op.toString();
+            case SourceOutcome.Held _, SourceOutcome.Failed _ ->
+                    arm.name().name().toLowerCase(Locale.ROOT);
+        };
+    }
+
+    private static String namesOf(List<TypeSymbol> cases) {
+        return cases.stream().map(TypeSymbol::name)
+                .collect(java.util.stream.Collectors.joining(" | "));
+    }
+
+    private ArmVocabulary() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -402,8 +402,8 @@ public final class GeneratedRows {
             // `subject` joins on. The finding carries the arm rather than words about it, so that
             // the sentence a diagnostic says in the reader's language and the words written here
             // are two readings of one arm rather than one of them being handed the other's.
-            case ARM_UNREACHED -> ((souther.compiler.coverage.CoverageSites.Site)
-                    gap.args().get(0)).label();
+            case ARM_UNREACHED -> ArmVocabulary.label(
+                    (souther.compiler.coverage.CoverageSites.Site) gap.args().get(0));
             case INPUT_CASE_UNSPECIFIED, OUTPUT_CASE_UNSPECIFIED ->
                     String.valueOf(gap.args().get(0));
             // Not gaps a build refuses, and a disposition is not held for one. Listed rather than

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -398,7 +398,13 @@ public final class GeneratedRows {
     private static String about(Adequacy.Finding gap) {
         return switch (gap.kind()) {
             case BOUNDARY_UNMET -> gap.args().get(0) + " = " + gap.args().get(1);
-            case ARM_UNREACHED, INPUT_CASE_UNSPECIFIED, OUTPUT_CASE_UNSPECIFIED ->
+            // The arm's own short name, which is what the report writes and what the document's
+            // `subject` joins on. The finding carries the arm rather than words about it, so that
+            // the sentence a diagnostic says in the reader's language and the words written here
+            // are two readings of one arm rather than one of them being handed the other's.
+            case ARM_UNREACHED -> ((souther.compiler.coverage.CoverageSites.Site)
+                    gap.args().get(0)).label();
+            case INPUT_CASE_UNSPECIFIED, OUTPUT_CASE_UNSPECIFIED ->
                     String.valueOf(gap.args().get(0));
             // Not gaps a build refuses, and a disposition is not held for one. Listed rather than
             // defaulted so that a kind added later has to be given words here.

--- a/souther-compiler/src/main/java/souther/compiler/types/CoverageConstruct.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/CoverageConstruct.java
@@ -1,0 +1,75 @@
+package souther.compiler.types;
+
+/**
+ * Which construct of the language a coverage obligation was written as.
+ *
+ * <p>The other half of {@link CoverageOrigin}. That says which construct this is, so that copies of
+ * one fork stay one obligation; this says what the author wrote there. Both are answers about the
+ * source, and neither can be read off the tree that runs: {@code guard} is sugar for {@code if}
+ * (ADR-0020), a list comprehension is rewritten before Core exists, and by the time coverage is
+ * numbered one node stands for all three. A reader asking what to call the construct, or what one of
+ * its outcomes means, is asking about the source, so the answer travels from where the source was
+ * read rather than being worked out again from the shape it was lowered to.
+ *
+ * <p>Settled where the construct is read and carried from there. Nothing derives one later — every
+ * rewrite between the AST and Core copies the origin it was given, so this arrives at a report
+ * unchanged however many times a helper holding the construct was expanded.
+ */
+public enum CoverageConstruct {
+
+    /** {@code if c then a else b}, and {@code if T(v) as x then a else …}. */
+    IF,
+
+    /**
+     * {@code guard c else x}, and {@code guard T(v) as x else …}.
+     *
+     * <p>An {@code if} by the time anything runs, and not one to a reader: the author wrote one arm
+     * of it and the compiler supplied the other, which is the rest of the block.
+     */
+    GUARD,
+
+    /**
+     * A list comprehension's guard — {@code [e | c]}.
+     *
+     * <p>One construct however many conditions it lists. Each becomes a fork of its own, derived
+     * from this one by {@link CoverageOrigin#lowered}, so the guards of one comprehension are told
+     * apart without any of them being taken for a construct the author wrote separately.
+     */
+    COMPREHENSION,
+
+    /** {@code match}. */
+    MATCH,
+
+    /** One comparison, which is where a row's answer to it is recorded rather than an arm. */
+    COMPARISON,
+
+    /**
+     * No source wrote it.
+     *
+     * <p>What {@link CoverageOrigin#unwritten} carries. A comparison rebuilt for an analysis is a
+     * comparison, and giving it {@link #COMPARISON} would make it a value that passes for a coverage
+     * obligation — which is the thing that origin exists not to be. Named here so that a switch
+     * needing a construct the author wrote has somewhere to refuse it.
+     */
+    NOT_WRITTEN;
+
+    /**
+     * What a sentence in the reader's language calls this.
+     *
+     * <p>A key and not a word. The walk that found the construct has no reader, so it has no language
+     * to name one in; what it can say is which construct it was, and the catalog says the rest.
+     *
+     * @throws IllegalStateException where the construct is not one a fork of a body is written as.
+     *                               A {@code match} has arms rather than a line, a comparison is
+     *                               inside a fork rather than being one, and nothing wrote the last
+     */
+    public souther.compiler.diag.Localizable said() {
+        return switch (this) {
+            case IF -> souther.compiler.diag.Localizable.of("construct.if");
+            case GUARD -> souther.compiler.diag.Localizable.of("construct.guard");
+            case COMPREHENSION -> souther.compiler.diag.Localizable.of("construct.comprehension");
+            case MATCH, COMPARISON, NOT_WRITTEN -> throw new IllegalStateException(
+                    "not a fork of a body: " + this);
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/types/CoverageConstruct.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/CoverageConstruct.java
@@ -40,16 +40,24 @@ public enum CoverageConstruct {
     /** {@code match}. */
     MATCH,
 
-    /** One comparison, which is where a row's answer to it is recorded rather than an arm. */
-    COMPARISON,
+    /**
+     * A binary expression — a comparison, a conjunction, an arithmetic operation, a concatenation.
+     *
+     * <p>What was written, and not what was made of it. Only a comparison inside a fork's condition
+     * is ever numbered, and whether this one was is {@link souther.compiler.coverage.SourceOutcome}'s
+     * answer rather than this one's: {@code a + b} is as much a binary expression the source wrote as
+     * {@code a > b} is, and naming the construct after the use the analysis puts a few of them to
+     * would make this value say something untrue of every arithmetic node in every body.
+     */
+    BINARY,
 
     /**
      * No source wrote it.
      *
      * <p>What {@link CoverageOrigin#unwritten} carries. A comparison rebuilt for an analysis is a
-     * comparison, and giving it {@link #COMPARISON} would make it a value that passes for a coverage
-     * obligation — which is the thing that origin exists not to be. Named here so that a switch
-     * needing a construct the author wrote has somewhere to refuse it.
+     * binary expression, and giving it {@link #BINARY} would make it a value that passes for a
+     * coverage obligation — which is the thing that origin exists not to be. Named here so that a
+     * switch needing a construct the author wrote has somewhere to refuse it.
      */
     NOT_WRITTEN;
 
@@ -68,7 +76,7 @@ public enum CoverageConstruct {
             case IF -> souther.compiler.diag.Localizable.of("construct.if");
             case GUARD -> souther.compiler.diag.Localizable.of("construct.guard");
             case COMPREHENSION -> souther.compiler.diag.Localizable.of("construct.comprehension");
-            case MATCH, COMPARISON, NOT_WRITTEN -> throw new IllegalStateException(
+            case MATCH, BINARY, NOT_WRITTEN -> throw new IllegalStateException(
                     "not a fork of a body: " + this);
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/types/CoverageOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/CoverageOrigin.java
@@ -27,12 +27,27 @@ package souther.compiler.types;
  * @param ordinal which construct of that source, by the builder's own count over it
  * @param lowered which fork of that construct, where a lowering makes more than one out of it. Zero
  *                is the construct's own fork, which is every fork an author writes as one
+ * @param kind    what the author wrote there. Not part of what tells one construct from another —
+ *                the builder takes a fresh ordinal for every construct it reads, so no two origins
+ *                share one and nothing here can disagree about a construct two values name. It is
+ *                the answer a report needs and the tree that runs no longer holds
  */
-public record CoverageOrigin(String module, int ordinal, int lowered) {
+public record CoverageOrigin(String module, int ordinal, int lowered, CoverageConstruct kind) {
 
-    /** The construct a source wrote. */
-    public static CoverageOrigin written(String module, int ordinal) {
-        return new CoverageOrigin(module, ordinal, 0);
+    public CoverageOrigin {
+        // Two spellings of one fact, held together rather than left to agree. `isWritten` is asked
+        // by readers that have no use for the kind, and a value answering it one way and carrying a
+        // construct the other way is one either reader can be right about.
+        if ((ordinal < 0) != (kind == CoverageConstruct.NOT_WRITTEN)) {
+            throw new IllegalArgumentException(
+                    "an origin says both whether a source wrote it and what was written: "
+                            + ordinal + " with " + kind);
+        }
+    }
+
+    /** The construct a source wrote, said as {@code kind}. */
+    public static CoverageOrigin written(String module, int ordinal, CoverageConstruct kind) {
+        return new CoverageOrigin(module, ordinal, 0, kind);
     }
 
     /**
@@ -47,7 +62,8 @@ public record CoverageOrigin(String module, int ordinal, int lowered) {
         return UNWRITTEN;
     }
 
-    private static final CoverageOrigin UNWRITTEN = new CoverageOrigin("", -1, 0);
+    private static final CoverageOrigin UNWRITTEN =
+            new CoverageOrigin("", -1, 0, CoverageConstruct.NOT_WRITTEN);
 
     /** Whether a source wrote the construct this names. False only for {@link #unwritten}. */
     public boolean isWritten() {
@@ -70,6 +86,9 @@ public record CoverageOrigin(String module, int ordinal, int lowered) {
             throw new IllegalStateException(
                     "a lowered fork cannot be lowered again: " + this + " part " + part);
         }
-        return new CoverageOrigin(module, ordinal, part + 1);
+        // The kind comes along. A guard of a comprehension is a fork of that comprehension, and a
+        // fork that arrived saying it was written as something else would be the construct this
+        // whole value exists to keep hold of, lost one lowering in.
+        return new CoverageOrigin(module, ordinal, part + 1, kind);
     }
 }

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-1.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-1.json
@@ -140,7 +140,14 @@
             "additionalProperties": false,
             "properties": {
               "label": { "type": "string" },
-              "kind": { "enum": ["then", "else", "case", "constructed", "departure"] },
+              "kind": {
+                "description": "What this way through the construct is. `then` and `else` are the arms of an `if`; `continued` is the body past a `guard` whose condition held, which the author writes no word for; `kept` and `dropped` are the element a comprehension yields and the empty list it yields instead; `case` is an arm of a `match`; `constructed` and `departure` are the two ways out of an attempted construction. Read beside `construct`: the same outcome under two constructs is two things, and an `else` written under a `guard` is not the `else` of an `if`.",
+                "enum": ["then", "else", "case", "constructed", "departure", "continued", "kept", "dropped"]
+              },
+              "construct": {
+                "description": "What the author wrote this an outcome of. Not in `required`: a document written before this key existed is still a document of this version, and in one of those `then` and `else` were written for a `guard` and a comprehension as well as for an `if`.",
+                "enum": ["if", "guard", "comprehension", "match"]
+              },
               "at": { "$ref": "#/$defs/at" }
             }
           }
@@ -255,7 +262,7 @@
             "additionalProperties": false,
             "properties": {
               "axis": { "type": "string" },
-              "origin": { "type": "string", "description": "The rule that drew this line — a type's invariant, or a guard." },
+              "origin": { "type": "string", "description": "The rule that drew this line — a type's invariant, a behavior's `ensures`, or the fork of a body a condition was written in, named by the construct the author wrote it as (`if`, `guard` or `comprehension`) and where. Prose rather than a word list: which rules there are is the model's question, not this document's." },
               "side": { "enum": ["below", "at", "above"] },
               "kind": {
                 "enum": ["at_value", "between_positions"],

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -576,6 +576,23 @@ tok.decimal=a decimal
 tok.string=a string
 tok.typevar=a type variable
 tok.eof=the end of input
+
+# The construct a fork was written as, and what one way through it is, dropped into the sentences
+# above. Words and not rules: which of them a sentence takes is decided by what the source wrote,
+# and the sentence itself is one wording. Localized here because the walk that found the construct
+# has no reader and so no language to name it in.
+construct.if=the `if`
+construct.guard=the `guard`
+construct.comprehension=the comprehension
+arm.then=the `then` arm
+arm.else=the `else` arm
+arm.continued=the body past the guard
+arm.kept=the element the comprehension keeps
+arm.dropped=the empty list the comprehension yields
+arm.case=the `case {0}` arm
+arm.constructed=the arm the value is built in
+arm.departure=the `else` arm
+arm.departure.clause=the `else {0}` arm
 declaration.the-right-side-of-a-value-pipe-is-a-call=The right side of `|>` must be a function call or a function name.
 declaration.it-nests-deeper-than-is-read=This nests deeper than I read. Break it into parts that have names, so each one is read on its own and says what it is: a binding for a value, a declaration for a type. What those parts add up to is bounded too, and far above this.
 
@@ -604,10 +621,10 @@ example.no-row-expects-that-case=No row expects `{caseName}`, so nothing says `{
 example.write-a-row-expecting-that-case=Write a row whose expected value is a `{caseName}`, or drop the case from the signature.
 example.no-row-applies-it-to-that-case=No row applies `{behavior}` to a `{caseName}`, so input #{at} has a case nothing was tried with.
 example.no-row-is-at-that-boundary=No row is at {at} = {value}, which is where {rule} draws its line.
-example.no-row-is-at-the-line-a-guard-drew=No row is at {at} = {value}, which is where a guard draws its line.
-example.the-guard-that-draws-the-line=The guard that draws that line.
+example.no-row-is-at-the-line-a-construct-drew=No row is at {at} = {value}, which is where {construct} draws its line.
+example.the-construct-that-draws-the-line=Where {construct} draws that line.
 example.a-row-on-the-line-tells-two-rules-apart=A row on the line is what tells a rule written `<=` from one written `<`.
-example.no-row-goes-through-that-arm=No row goes through the `{arm}` arm of `{behavior}`.
+example.no-row-goes-through-that-arm=No row goes through {arm} in `{behavior}`.
 example.either-a-row-is-missing-or-nothing-reaches-it=Either a row is missing for what this arm answers, or nothing reaches it — which an `unreachable` states.
 
 # --- totality (E2001, size-change termination) ---

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -571,6 +571,21 @@ tok.decimal=小数
 tok.string=文字列
 tok.typevar=型変数
 tok.eof=入力の終わり
+
+# 分岐が何として書かれたか、そのどの道かを、上の文に差し込む語。規則ではなく語で、どれを取るかは
+# ソースが書いたもので決まる。分岐を見つけた走査には読み手がいないので、言語もここで決める。
+construct.if=`if`
+construct.guard=`guard`
+construct.comprehension=内包表記
+arm.then=`then` の腕
+arm.else=`else` の腕
+arm.continued=guard を通過した先の本体
+arm.kept=内包表記が要素を返す側
+arm.dropped=内包表記が空リストを返す側
+arm.case=`case {0}` の腕
+arm.constructed=値が構築される側の腕
+arm.departure=`else` の腕
+arm.departure.clause=`else {0}` の腕
 declaration.the-right-side-of-a-value-pipe-is-a-call=`|>` の右辺は関数呼び出しか関数名でなければなりません。
 declaration.it-nests-deeper-than-is-read=ここは読み取れる深さを超えて入れ子になっています。名前の付いた部分に分け、それぞれを単独で読めるようにしてください。値なら束縛に、型なら宣言に切り出します。分けた部分の合計にも上限がありますが、こちらよりはるかに大きい値です。
 
@@ -599,10 +614,10 @@ example.no-row-expects-that-case=`{caseName}` を期待する行がないので�
 example.write-a-row-expecting-that-case=期待値が `{caseName}` の行を書くか、シグネチャからそのケースを外してください。
 example.no-row-applies-it-to-that-case=`{caseName}` を `{behavior}` に渡す行がないので、入力 #{at} に一度も試していないケースがあります。
 example.no-row-is-at-that-boundary={at} = {value} を書いた行がありません。{rule} が線を引いているのはそこです。
-example.no-row-is-at-the-line-a-guard-drew={at} = {value} を書いた行がありません。guard が線を引いているのはそこです。
-example.the-guard-that-draws-the-line=その線を引いている guard です。
+example.no-row-is-at-the-line-a-construct-drew={at} = {value} を書いた行がありません。{construct}が線を引いているのはそこです。
+example.the-construct-that-draws-the-line=その線を引いている{construct}です。
 example.a-row-on-the-line-tells-two-rules-apart=線上の行があって初めて、`<=` で書かれた規則と `<` で書かれた規則が区別できます。
-example.no-row-goes-through-that-arm=`{behavior}` の `{arm}` の腕を、どの行も通りません。
+example.no-row-goes-through-that-arm={arm}を通る行が、`{behavior}` にありません。
 example.either-a-row-is-missing-or-nothing-reaches-it=この腕が返すもののための行が無いか、そもそも到達しないかのどちらかです。到達しないことは `unreachable` で述べます。
 
 # --- totality (E2001, サイズ変化停止性) ---

--- a/souther-compiler/src/test/java/souther/compiler/ACaseTheModelRulesOutIsNotOwedARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACaseTheModelRulesOutIsNotOwedARowTest.java
@@ -731,7 +731,8 @@ class ACaseTheModelRulesOutIsNotOwedARowTest {
      * this is about which case was named. */
     private static List<String> messages(String source) {
         return reported(source).stream()
-                .map(d -> d.values().values().stream().map(String::valueOf)
+                .map(d -> d.values().values().stream()
+                        .map(v -> souther.compiler.diag.Messages.text(v, java.util.Locale.ENGLISH))
                         .collect(java.util.stream.Collectors.joining(" ")))
                 .toList();
     }

--- a/souther-compiler/src/test/java/souther/compiler/AnArmDoesNotSayWhetherAComparisonRanTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnArmDoesNotSayWhetherAComparisonRanTest.java
@@ -145,6 +145,6 @@ class AnArmDoesNotSayWhetherAComparisonRanTest {
 
         assertEquals(List.of("then", "else"),
                 branches.get("gate").all().stream()
-                        .map(souther.compiler.coverage.CoverageSites.Site::label).toList());
+                        .map(souther.compiler.report.ArmVocabulary::label).toList());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/AnEdgeIsWritableBecauseSomethingSaidSoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEdgeIsWritableBecauseSomethingSaidSoTest.java
@@ -287,7 +287,7 @@ class AnEdgeIsWritableBecauseSomethingSaidSoTest {
                 compilation.db().ask(new Adequacy.Boundaries("example.waiting")).value();
 
         List<BoundaryAssessment> guards = boundaries.get("f").stream()
-                .filter(b -> b.rule().isAGuard()).toList();
+                .filter(b -> b.rule().wasDrawnInABodyFork()).toList();
         assertFalse(guards.isEmpty(), "the comparison draws lines: " + boundaries.get("f"));
         for (BoundaryAssessment at : guards) {
             assertEquals(BoundaryAssessment.Coverage.Reason.ARMS_NOT_ASKED,

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleBoundaryTest.java
@@ -121,7 +121,7 @@ class CompileExampleBoundaryTest {
         BoundaryAssessment hundred = at(evidence, "100").get(0);
         assertEquals(MeasurementStatus.COMPLETE, hundred.status());
         assertTrue(hundred.coverage().hit(), "the row wrote 100 and the guard compared it");
-        assertTrue(hundred.rule().isAGuard(), hundred.rule().named());
+        assertTrue(hundred.rule().wasDrawnInABodyFork(), hundred.rule().named());
     }
 
     /**
@@ -158,7 +158,7 @@ class CompileExampleBoundaryTest {
                 """);
 
         BoundaryAssessment first = at(evidence, "0").stream()
-                .filter(b -> b.rule().isAGuard()).findFirst().orElseThrow();
+                .filter(b -> b.rule().wasDrawnInABodyFork()).findFirst().orElseThrow();
         BoundaryAssessment second = at(evidence, "100").get(0);
 
         assertEquals(MeasurementStatus.COMPLETE, second.status(), "the arms were measured");

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleCoverageTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleCoverageTest.java
@@ -57,7 +57,7 @@ class CompileExampleCoverageTest {
 
     private static List<String> unreached(Adequacy.BranchEvidence branch) {
         return branch.unreached().stream()
-                .map(souther.compiler.coverage.CoverageSites.Site::label).toList();
+                .map(souther.compiler.report.ArmVocabulary::label).toList();
     }
 
     /** One row through the guard leaves the other arm with nothing going through it. */
@@ -178,7 +178,7 @@ class CompileExampleCoverageTest {
                 """, "pick");
 
         assertEquals(List.of("case Off"),
-                branch.all().stream().map(site -> site.label()).toList());
+                branch.all().stream().map(site -> souther.compiler.report.ArmVocabulary.label(site)).toList());
         assertEquals(List.of(), unreached(branch), "the row went through the arm that is left");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleCoverageTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleCoverageTest.java
@@ -377,7 +377,9 @@ class CompileExampleCoverageTest {
         Adequacy.SignatureEvidence signature = compilation.db()
                 .ask(new Adequacy.Witnesses(module)).value().get("submit");
 
-        assertEquals(List.of("then"), unreached(branch));
+        // The `guard` passes into the rest of the block, and the author wrote no `then` for it
+        // to be called after.
+        assertEquals(List.of("continued"), unreached(branch));
         assertEquals(1, signature.output().verified().size());
         assertFalse(signature.output().verified().isEmpty(),
                 "the arm that ran is the case that was verified");

--- a/souther-compiler/src/test/java/souther/compiler/EveryPlaceAReportNamesSaysWhereTheCodeIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryPlaceAReportNamesSaysWhereTheCodeIsTest.java
@@ -244,8 +244,8 @@ class EveryPlaceAReportNamesSaysWhereTheCodeIsTest {
 
         assertFalse(said.boundaryLines().isEmpty(), "the comparison drew lines");
         for (String line : said.boundaryLines()) {
-            assertTrue(line.contains("guard@up.sou:"),
-                    () -> "the line names the file the guard is written in: " + line);
+            assertTrue(line.contains("if@up.sou:"),
+                    () -> "the line names the file the fork is written in: " + line);
         }
     }
 
@@ -293,15 +293,15 @@ class EveryPlaceAReportNamesSaysWhereTheCodeIsTest {
     /**
      * A rule with no name gets a sentence of its own rather than a phrase built for its slot.
      *
-     * <p>A type and an invariant have names, which read the same in every language. A guard has none,
-     * and what filled the slot for it was English assembled in Java — so the Japanese warning said
-     * "a guard が線を引いているのはそこです". The words belong to the catalog, where every language
-     * has its own.
+     * <p>A type and an invariant have names, which read the same in every language. A fork of a body
+     * has none, and what filled the slot for it was English assembled in Java — so the Japanese
+     * warning said "a guard が線を引いているのはそこです". The words belong to the catalog, where
+     * every language has its own, and which construct it was is one of them.
      */
     @Test
-    void aLineAGuardDrewIsSaidInEveryLanguageItIsAskedIn() {
+    void aLineAForkDrewIsSaidInEveryLanguageItIsAskedIn() {
         Diagnostic edge = saidAbout(IN_SIGHT).edge();
-        assertInstanceOf(ExampleMessage.NoRowIsAtTheLineAGuardDrew.class, edge.said(),
+        assertInstanceOf(ExampleMessage.NoRowIsAtTheLineAConstructDrew.class, edge.said(),
                 "a rule with no name reports its own message");
         assertFalse(DiagnosticRenderer.body(edge, Locale.JAPANESE).contains("a guard"),
                 () -> "no English is assembled into a Japanese sentence: "
@@ -335,12 +335,12 @@ class EveryPlaceAReportNamesSaysWhereTheCodeIsTest {
     }
 
     @Test
-    void aGuardWrittenHereGainsNoneOfIt() {
+    void aForkWrittenHereGainsNoneOfIt() {
         Said said = saidAbout(IN_SIGHT);
         assertFalse(said.boundaryOrigins().isEmpty(), "the comparison drew lines");
         for (String origin : said.boundaryOrigins()) {
-            assertTrue(origin.startsWith("guard@"),
-                    () -> "the guard is where the report says it is: " + origin);
+            assertTrue(origin.startsWith("if@"),
+                    () -> "the fork is where the report says it is: " + origin);
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
@@ -101,11 +101,11 @@ class EverySchemaWordIsAccountedForTest {
                 .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
     }
 
-    /** The constructs an arm can be an outcome of. Fewer than the kinds an origin carries: a
-     *  comparison is inside a fork rather than being one, and nothing wrote the last. */
+    /** The constructs an arm can be an outcome of. Fewer than the kinds an origin carries: a binary
+     *  expression is inside a fork rather than being one, and nothing wrote the last. */
     private static Set<String> constructWords() {
         return Arrays.stream(souther.compiler.types.CoverageConstruct.values())
-                .filter(c -> c != souther.compiler.types.CoverageConstruct.COMPARISON
+                .filter(c -> c != souther.compiler.types.CoverageConstruct.BINARY
                         && c != souther.compiler.types.CoverageConstruct.NOT_WRITTEN)
                 .map(AdequacyReport::word)
                 .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));

--- a/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
@@ -93,10 +93,20 @@ class EverySchemaWordIsAccountedForTest {
         }
     }
 
-    /** The kinds of site a branch measure counts, spelled by the writer's own encoder. */
+    /** The names a branch measure can give an arm, spelled by the writer's own encoder. */
     private static Set<String> armWords() {
-        return Arrays.stream(CoverageSites.Site.Kind.values())
-                .filter(CoverageSites.Site.Kind::isArm)
+        return Arrays.stream(souther.compiler.coverage.OutcomeName.values())
+                .filter(souther.compiler.coverage.OutcomeName::isArm)
+                .map(AdequacyReport::word)
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    /** The constructs an arm can be an outcome of. Fewer than the kinds an origin carries: a
+     *  comparison is inside a fork rather than being one, and nothing wrote the last. */
+    private static Set<String> constructWords() {
+        return Arrays.stream(souther.compiler.types.CoverageConstruct.values())
+                .filter(c -> c != souther.compiler.types.CoverageConstruct.COMPARISON
+                        && c != souther.compiler.types.CoverageConstruct.NOT_WRITTEN)
                 .map(AdequacyReport::word)
                 .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
     }
@@ -154,7 +164,14 @@ class EverySchemaWordIsAccountedForTest {
             new Vocabulary("branch.unreached[].kind",
                     List.of("$defs", "branch", "properties", "unreached", "items", "properties",
                             "kind"),
-                    CoverageSites.Site.Kind.class, armWords(), Set.of()),
+                    souther.compiler.coverage.OutcomeName.class, armWords(), Set.of()),
+            // The other half of what an arm is. Held apart from the outcome because they vary on
+            // their own: an `else` is written under an `if` and under a `guard`, and a construct
+            // added to the language does not add an outcome.
+            new Vocabulary("branch.unreached[].construct",
+                    List.of("$defs", "branch", "properties", "unreached", "items", "properties",
+                            "construct"),
+                    souther.compiler.types.CoverageConstruct.class, constructWords(), Set.of()),
             new Vocabulary("partition.axesMeasure.reason",
                     List.of("$defs", "partition", "properties", "axesMeasure", "properties",
                             "reason"),

--- a/souther-compiler/src/test/java/souther/compiler/core/EverySlotIsAChildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/core/EverySlotIsAChildTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class EverySlotIsAChildTest {
 
     private static final SourcePos POS = new SourcePos(1, 1);
-    private static final CoverageOrigin ORIGIN = CoverageOrigin.written("t", 0);
+    private static final CoverageOrigin ORIGIN = CoverageOrigin.written("t", 0, souther.compiler.types.CoverageConstruct.IF);
     private static final BindingOwner OWNER = new BindingOwner.OfValue("demo", "go");
 
     private static final Hir.Binders BINDERS = new Hir.Binders(OWNER);

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonBelongsToWhoWroteItNotToTheForkTestingItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonBelongsToWhoWroteItNotToTheForkTestingItTest.java
@@ -107,7 +107,7 @@ class AComparisonBelongsToWhoWroteItNotToTheForkTestingItTest {
         Map<String, Core> bodies = checked.behaviorBodies();
         CoverageSites.Plan plan = CoverageSites.of(bodies);
         return plan.sites().stream()
-                .filter(site -> site.kind() == CoverageSites.Site.Kind.COMPARISON)
+                .filter(site -> site.outcome() instanceof SourceOutcome.Compared)
                 .map(CoverageSites.Site::obligation)
                 .toList();
     }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AnOutcomeIsNamedByWhatWasWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AnOutcomeIsNamedByWhatWasWrittenTest.java
@@ -134,7 +134,7 @@ class AnOutcomeIsNamedByWhatWasWrittenTest {
         assertEquals(List.of("constructed", "else"),
                 planOf(AN_ATTEMPTED_GUARD).sites().stream()
                         .filter(CoverageSites.Site::isArm)
-                        .map(CoverageSites.Site::label).toList());
+                        .map(souther.compiler.report.ArmVocabulary::label).toList());
     }
 
     /**
@@ -169,6 +169,39 @@ class AnOutcomeIsNamedByWhatWasWrittenTest {
         assertEquals(CoverageConstruct.COMPREHENSION, written.lowered(1).kind());
     }
 
+    /**
+     * A binary expression is what the source wrote; being read as a comparison a row can reach is
+     * what happened to some of them.
+     *
+     * <p>{@code a + b} is minted exactly the way {@code a >= b} is — one call of the builder, one
+     * ordinal — so naming the construct after the use the analysis puts a few of them to would put a
+     * word on every arithmetic node in every body that is untrue of it. Only the comparisons of a
+     * fork's condition become sites, and a {@code &&} is descended through rather than numbered, so
+     * what a construct is and what was made of it have to be two answers.
+     */
+    @Test
+    void everyBinaryTheSourceWroteIsABinaryAndOnlySomeAreSites() {
+        String source = """
+                module demo
+
+                behavior total : (a: Int, b: Int) -> Int
+                let total (a, b) = if a + b >= 10 && a > 0 then a * b else a - b
+                """;
+
+        List<CoverageConstruct> written = binariesIn(source);
+        assertEquals(6, written.size(), () -> "four arithmetic, two comparisons, one `&&`: "
+                + written);
+        assertTrue(written.stream().allMatch(k -> k == CoverageConstruct.BINARY),
+                () -> "what the source wrote is a binary expression, whichever operator: " + written);
+
+        // And two of the six are sites: the comparisons the fork's condition settles on. The `&&`
+        // is walked into rather than numbered, and nothing outside a condition is numbered at all.
+        assertEquals(2, planOf(source).sites().stream()
+                        .filter(site -> site.outcome() instanceof SourceOutcome.Compared)
+                        .count(),
+                "a comparison of the condition is a site; a binary expression is not");
+    }
+
     // --- what the pair admits -----------------------------------------------------------------------
 
     /**
@@ -192,7 +225,7 @@ class AnOutcomeIsNamedByWhatWasWrittenTest {
         assertEquals(OutcomeName.DEPARTURE, OutcomeName.of(CoverageConstruct.GUARD, refused()));
         assertEquals(OutcomeName.CASE, OutcomeName.of(CoverageConstruct.MATCH,
                 new SourceOutcome.Matched(List.of())));
-        assertEquals(OutcomeName.COMPARISON, OutcomeName.of(CoverageConstruct.COMPARISON,
+        assertEquals(OutcomeName.COMPARISON, OutcomeName.of(CoverageConstruct.BINARY,
                 new SourceOutcome.Compared(souther.compiler.ast.Hir.BinOp.GE)));
     }
 
@@ -204,7 +237,7 @@ class AnOutcomeIsNamedByWhatWasWrittenTest {
         assertThrows(IllegalArgumentException.class,
                 () -> OutcomeName.of(CoverageConstruct.MATCH, held()));
         assertThrows(IllegalArgumentException.class,
-                () -> OutcomeName.of(CoverageConstruct.COMPARISON, failed()));
+                () -> OutcomeName.of(CoverageConstruct.BINARY, failed()));
         assertThrows(IllegalArgumentException.class,
                 () -> OutcomeName.of(CoverageConstruct.NOT_WRITTEN, held()));
     }
@@ -286,13 +319,30 @@ class AnOutcomeIsNamedByWhatWasWrittenTest {
         return guards.get(0).origin().kind();
     }
 
-    private static CoverageSites.Plan planOf(String source) {
+    /** The construct every binary expression of this body was written as. */
+    private static List<CoverageConstruct> binariesIn(String source) {
+        List<CoverageConstruct> out = new java.util.ArrayList<>();
+        bodiesOf(source).values().forEach(body -> collectBinaries(body, out));
+        return out;
+    }
+
+    private static void collectBinaries(Core e, List<CoverageConstruct> out) {
+        if (e instanceof Core.Binary binary) {
+            out.add(binary.origin().kind());
+        }
+        Core.forEachChild(e, child -> collectBinaries(child, out));
+    }
+
+    private static Map<String, Core> bodiesOf(String source) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         Bodies.Elaborated checked = compilation.db()
                 .ask(new Bodies.Checked(compilation.modules().get(0))).value();
         assertNotNull(checked, "the model under test compiles");
-        Map<String, Core> bodies = checked.behaviorBodies();
-        return CoverageSites.of(bodies);
+        return checked.behaviorBodies();
+    }
+
+    private static CoverageSites.Plan planOf(String source) {
+        return CoverageSites.of(bodiesOf(source));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AnOutcomeIsNamedByWhatWasWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AnOutcomeIsNamedByWhatWasWrittenTest.java
@@ -1,0 +1,298 @@
+package souther.compiler.coverage;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.core.Core;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.types.CoverageConstruct;
+import souther.compiler.types.CoverageOrigin;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a coverage report calls a construct, and what it calls one way through it.
+ *
+ * <p>Three constructs of the language become one {@code if} before anything runs — an {@code if}, a
+ * {@code guard}, and a comprehension's condition — and the tree that runs is where the report used
+ * to read the answer off. It named all three {@code guard}, and named the ways through them
+ * {@code then} and {@code else} however the source wrote them, so two of every three readers were
+ * sent looking for a form that is not in the file.
+ *
+ * <p>Held as the pair, because that is where the meaning is. The construct comes from the origin the
+ * fork carries, the way through it is a {@link SourceOutcome}, and neither says the other.
+ */
+class AnOutcomeIsNamedByWhatWasWrittenTest {
+
+    private static final String AN_IF = """
+            module demo
+
+            behavior price : (temp: Int) -> Int
+            let price (temp) = if temp >= 240 then 1 else 2
+            """;
+
+    private static final String A_GUARD = """
+            module demo
+
+            data Hot = { at: Int }
+            data Low
+
+            behavior price : (temp: Int) -> Hot | Low
+                constructs Hot, Low
+            let price (temp) = {
+                guard temp >= 240 else Low
+                Hot { at = temp }
+            }
+            """;
+
+    private static final String A_COMPREHENSION = """
+            module demo
+
+            behavior pick : (temp: Int) -> List<Int>
+            let pick (temp) = [ temp | temp >= 240 ]
+            """;
+
+    private static final String AN_ATTEMPTED_IF = """
+            module demo
+
+            data Warm = Int invariant hot = value >= 240
+            data Low
+
+            behavior price : (temp: Int) -> Warm | Low
+                constructs Warm, Low
+            let price (temp) = if Warm(temp) as w then w else Low
+            """;
+
+    private static final String AN_ATTEMPTED_GUARD = """
+            module demo
+
+            data Warm = Int invariant hot = value >= 240
+            data Low
+
+            behavior price : (temp: Int) -> Warm | Low
+                constructs Warm, Low
+            let price (temp) = {
+                guard Warm(temp) as w else Low
+                w
+            }
+            """;
+
+    /**
+     * A comprehension inside a non-recursive helper, which is spliced into the body that calls it.
+     *
+     * <p>Two guards, so the lowering makes two forks out of one construct; called twice, so an
+     * expansion makes two copies of each of those.
+     */
+    private static final String THROUGH_A_HELPER = """
+            module demo
+
+            let picked (n: Int): List<Int> = [ n | n >= 240, n <= 300 ]
+
+            behavior price : (a: Int, b: Int) -> List<Int>
+            let price (a, b) = picked(a) ++ picked(b)
+            """;
+
+    // --- the matrix ---------------------------------------------------------------------------------
+
+    @Test
+    void anIfHasTheTwoArmsItsAuthorWrote() {
+        assertEquals(List.of("IF then", "IF else"), namesIn(AN_IF));
+    }
+
+    /** The `else` is the author's word; the other way is the rest of the block, which they wrote no
+     *  word for at all. */
+    @Test
+    void aGuardHasAnElseAndTheRestOfTheBlock() {
+        assertEquals(List.of("GUARD continued", "GUARD else"), namesIn(A_GUARD));
+    }
+
+    /** Neither way through this one has a word in the source, so neither is quoted as one. */
+    @Test
+    void aComprehensionHasNeitherWord() {
+        assertEquals(List.of("COMPREHENSION kept", "COMPREHENSION dropped"),
+                namesIn(A_COMPREHENSION));
+    }
+
+    /** The shape varies on its own: either conditional may be written as an attempt, and what the
+     *  decision was is then the invariant's rather than a condition's. */
+    @Test
+    void anAttemptCarriesTheConstructItWasWrittenUnder() {
+        assertEquals(List.of("IF constructed", "IF departure"), namesIn(AN_ATTEMPTED_IF));
+        assertEquals(List.of("GUARD constructed", "GUARD departure"),
+                namesIn(AN_ATTEMPTED_GUARD));
+
+        // The short name a report and a document write is the `else` the author put the departure
+        // under, which is a word here where the two conditionals have one and the ways through a
+        // comprehension have none.
+        assertEquals(List.of("constructed", "else"),
+                planOf(AN_ATTEMPTED_GUARD).sites().stream()
+                        .filter(CoverageSites.Site::isArm)
+                        .map(CoverageSites.Site::label).toList());
+    }
+
+    /**
+     * Copying does not change what was written.
+     *
+     * <p>Both halves of the answer come along: the helper's comprehension is a comprehension in each
+     * body it was spliced into, and each of its two conditions is still one of that comprehension's
+     * forks rather than a construct of its own. Held over the copies as a set — what the expansion
+     * makes more of is occurrences, and what an author wrote is what this is about.
+     */
+    @Test
+    void anExpansionAndALoweringBothKeepWhatWasWritten() {
+        List<String> names = namesIn(THROUGH_A_HELPER);
+
+        assertEquals(8, names.size(), () -> "two guards, lowered and then copied twice: " + names);
+        assertTrue(names.stream().allMatch(n -> n.startsWith("COMPREHENSION ")),
+                () -> "a copy of a comprehension is a comprehension: " + names);
+
+        // And the two conditions stay apart, which is what `lowered` is for. Four obligations and
+        // not two: each condition owes a row through each of its ways.
+        assertEquals(4, planOf(THROUGH_A_HELPER).sites().stream()
+                        .filter(CoverageSites.Site::isArm)
+                        .map(CoverageSites.Site::obligation).distinct().count(),
+                "two forks of the one comprehension, two ways each");
+    }
+
+    /** A guard of a comprehension is a fork of that comprehension, and not of something else. */
+    @Test
+    void aLoweredForkKeepsTheConstructItWasLoweredFrom() {
+        CoverageOrigin written = CoverageOrigin.written("m", 3, CoverageConstruct.COMPREHENSION);
+
+        assertEquals(CoverageConstruct.COMPREHENSION, written.lowered(1).kind());
+    }
+
+    // --- what the pair admits -----------------------------------------------------------------------
+
+    /**
+     * Every pair passes through one projection, and it is total over what the language has.
+     *
+     * <p>Written out because the pair is what carries the meaning: a table here and a switch there
+     * is how {@code then} came to be said of a construct that has no {@code then}, and this is what
+     * either of them would have to be checked against.
+     */
+    @Test
+    void everyPairTheLanguageHasIsNamed() {
+        assertEquals(OutcomeName.THEN, OutcomeName.of(CoverageConstruct.IF, held()));
+        assertEquals(OutcomeName.ELSE, OutcomeName.of(CoverageConstruct.IF, failed()));
+        assertEquals(OutcomeName.CONTINUED, OutcomeName.of(CoverageConstruct.GUARD, held()));
+        assertEquals(OutcomeName.ELSE, OutcomeName.of(CoverageConstruct.GUARD, failed()));
+        assertEquals(OutcomeName.KEPT, OutcomeName.of(CoverageConstruct.COMPREHENSION, held()));
+        assertEquals(OutcomeName.DROPPED, OutcomeName.of(CoverageConstruct.COMPREHENSION, failed()));
+        assertEquals(OutcomeName.CONSTRUCTED, OutcomeName.of(CoverageConstruct.IF, built()));
+        assertEquals(OutcomeName.DEPARTURE, OutcomeName.of(CoverageConstruct.IF, refused()));
+        assertEquals(OutcomeName.CONSTRUCTED, OutcomeName.of(CoverageConstruct.GUARD, built()));
+        assertEquals(OutcomeName.DEPARTURE, OutcomeName.of(CoverageConstruct.GUARD, refused()));
+        assertEquals(OutcomeName.CASE, OutcomeName.of(CoverageConstruct.MATCH,
+                new SourceOutcome.Matched(List.of())));
+        assertEquals(OutcomeName.COMPARISON, OutcomeName.of(CoverageConstruct.COMPARISON,
+                new SourceOutcome.Compared(souther.compiler.ast.Hir.BinOp.GE)));
+    }
+
+    /** A comprehension attempts no construction, and a {@code match} settles no condition. */
+    @Test
+    void aPairTheLanguageDoesNotHaveIsRefused() {
+        assertThrows(IllegalArgumentException.class,
+                () -> OutcomeName.of(CoverageConstruct.COMPREHENSION, built()));
+        assertThrows(IllegalArgumentException.class,
+                () -> OutcomeName.of(CoverageConstruct.MATCH, held()));
+        assertThrows(IllegalArgumentException.class,
+                () -> OutcomeName.of(CoverageConstruct.COMPARISON, failed()));
+        assertThrows(IllegalArgumentException.class,
+                () -> OutcomeName.of(CoverageConstruct.NOT_WRITTEN, held()));
+    }
+
+    /** And a site cannot be made holding one, which is where the two halves are first put together. */
+    @Test
+    void aSiteCannotHoldAPairTheLanguageDoesNotHave() {
+        assertThrows(IllegalArgumentException.class, () -> new CoverageSites.Site("b", built(), null,
+                0, 0, new CoverageSites.Obligation("b",
+                        CoverageOrigin.written("m", 0, CoverageConstruct.COMPREHENSION), 0)));
+    }
+
+    /**
+     * What a document lists among the arms is what the measure counts as one.
+     *
+     * <p>Two predicates over one question — the projection has its own, because the schema's word
+     * list is read off it — and this is what holds them to the same answer.
+     */
+    @Test
+    void whatIsAnArmIsTheSameQuestionOnBothSidesOfTheProjection() {
+        for (CoverageConstruct construct : CoverageConstruct.values()) {
+            for (SourceOutcome outcome : List.of(held(), failed(), built(), refused(),
+                    new SourceOutcome.Matched(List.of()),
+                    new SourceOutcome.Compared(souther.compiler.ast.Hir.BinOp.GE))) {
+                OutcomeName name;
+                try {
+                    name = OutcomeName.of(construct, outcome);
+                } catch (IllegalArgumentException _) {
+                    continue;   // not a pair the language has, so nothing to agree about
+                }
+                assertEquals(outcome.isArm(), name.isArm(),
+                        () -> construct + " with " + outcome + " is named " + name);
+            }
+        }
+    }
+
+    // --- what the origin says a line was drawn in ---------------------------------------------------
+
+    @Test
+    void anOriginSaysWhichConstructDrewTheLine() {
+        assertEquals(CoverageConstruct.IF, drewTheLine(AN_IF));
+        assertEquals(CoverageConstruct.GUARD, drewTheLine(A_GUARD));
+        assertEquals(CoverageConstruct.COMPREHENSION, drewTheLine(A_COMPREHENSION));
+    }
+
+    // --- helpers ------------------------------------------------------------------------------------
+
+    private static SourceOutcome held() {
+        return new SourceOutcome.Held(new SourceOutcome.HeldBy.Condition());
+    }
+
+    private static SourceOutcome failed() {
+        return new SourceOutcome.Failed(new SourceOutcome.FailedBy.Condition());
+    }
+
+    private static SourceOutcome built() {
+        return new SourceOutcome.Held(new SourceOutcome.HeldBy.Construction());
+    }
+
+    private static SourceOutcome refused() {
+        return new SourceOutcome.Failed(
+                new SourceOutcome.FailedBy.Construction(Optional.empty()));
+    }
+
+    /** Each arm as the pair that says what it is: what the author wrote, and which way through it. */
+    private static List<String> namesIn(String source) {
+        return planOf(source).sites().stream()
+                .filter(CoverageSites.Site::isArm)
+                .map(site -> site.construct() + " "
+                        + site.name().name().toLowerCase(java.util.Locale.ROOT))
+                .toList();
+    }
+
+    /** Which construct the line on this body's only fork was drawn in. */
+    private static CoverageConstruct drewTheLine(String source) {
+        CoverageSites.Plan plan = planOf(source);
+        List<CoverageSites.GuardRef> guards = plan.guards();
+        assertEquals(1, guards.size(), () -> "one fork, so one reference: " + guards);
+        return guards.get(0).origin().kind();
+    }
+
+    private static CoverageSites.Plan planOf(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        Bodies.Elaborated checked = compilation.db()
+                .ask(new Bodies.Checked(compilation.modules().get(0))).value();
+        assertNotNull(checked, "the model under test compiles");
+        Map<String, Core> bodies = checked.behaviorBodies();
+        return CoverageSites.of(bodies);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AnOutcomeIsNamedByWhatWasWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AnOutcomeIsNamedByWhatWasWrittenTest.java
@@ -274,6 +274,30 @@ class AnOutcomeIsNamedByWhatWasWrittenTest {
         }
     }
 
+    /**
+     * A tree nothing wrote is refused wherever it is numbered, and not only at a comparison.
+     *
+     * <p>The invariant-discharge reader rebuilds comparisons so it can read them as such, and that
+     * tree is not the tree that runs; the walk said so of a condition's comparisons and left a fork's
+     * arms to be turned away by whatever noticed first. Held over a fork because a fork is the half
+     * the rule was not written for — the arms are where a row would be owed, and nobody can be owed
+     * one for code no source wrote.
+     */
+    @Test
+    void anArmOfSomethingNoSourceWroteIsRefusedWhereItWouldBeNumbered() {
+        souther.compiler.diag.SourcePos at = new souther.compiler.diag.SourcePos(1, 1);
+        Core answer = new Core.Int(1, souther.compiler.types.Type.INT, at);
+        Core fork = new Core.If(new Core.Bool(true, souther.compiler.types.Type.BOOL, at),
+                answer, new Core.Int(2, souther.compiler.types.Type.INT, at),
+                CoverageOrigin.unwritten(), souther.compiler.types.Type.INT, at);
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> CoverageSites.of(Map.of("b", fork)));
+
+        assertTrue(refused.getMessage().contains("no source wrote it"),
+                () -> "the walk says what is wrong with the tree: " + refused.getMessage());
+    }
+
     // --- what the origin says a line was drawn in ---------------------------------------------------
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/coverage/CoverageSitesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/CoverageSitesTest.java
@@ -68,9 +68,8 @@ class CoverageSitesTest {
         CoverageSites.Plan plan = planOf(MODEL);
 
         assertEquals(List.of("case UnderThirty", "then", "else"), labels(plan));
-        assertEquals(List.of(CoverageSites.Site.Kind.CASE, CoverageSites.Site.Kind.THEN,
-                        CoverageSites.Site.Kind.ELSE),
-                plan.sites().stream().map(CoverageSites.Site::kind).toList());
+        assertEquals(List.of(OutcomeName.CASE, OutcomeName.THEN, OutcomeName.ELSE),
+                plan.sites().stream().map(CoverageSites.Site::name).toList());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/coverage/CoverageSitesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/CoverageSitesTest.java
@@ -60,7 +60,7 @@ class CoverageSitesTest {
     }
 
     private static List<String> labels(CoverageSites.Plan plan) {
-        return plan.sites().stream().map(CoverageSites.Site::label).toList();
+        return plan.sites().stream().map(souther.compiler.report.ArmVocabulary::label).toList();
     }
 
     @Test
@@ -295,8 +295,8 @@ class CoverageSitesTest {
 
         assertEquals(1, plan.guards().size());
         CoverageSites.GuardRef guard = plan.guards().get(0);
-        assertEquals("then", plan.site(guard.siteIndexThen()).label());
-        assertEquals("else", plan.site(guard.siteIndexElse()).label());
+        assertEquals("then", souther.compiler.report.ArmVocabulary.label(plan.site(guard.siteIndexThen())));
+        assertEquals("else", souther.compiler.report.ArmVocabulary.label(plan.site(guard.siteIndexElse())));
     }
 
     /** The comparison was evaluated to reach the arm that is left, so the line it draws is still one
@@ -309,7 +309,7 @@ class CoverageSitesTest {
         assertEquals(1, plan.guards().size());
         CoverageSites.GuardRef guard = plan.guards().get(0);
         assertEquals(CoverageSites.NO_SITE, guard.siteIndexThen());
-        assertEquals("else", plan.site(guard.siteIndexElse()).label());
+        assertEquals("else", souther.compiler.report.ArmVocabulary.label(plan.site(guard.siteIndexElse())));
     }
 
     /**
@@ -357,7 +357,7 @@ class CoverageSitesTest {
         int[] arms = plan.probesOf(match);
         assertNotNull(arms, "the plan is keyed by the instances it was built from");
         assertEquals(2, arms.length);
-        assertEquals("case UnderThirty", plan.site(arms[0]).label());
+        assertEquals("case UnderThirty", souther.compiler.report.ArmVocabulary.label(plan.site(arms[0])));
 
         Core.Match copy = new Core.Match(match.scrutinee(), match.cases(), match.origin(),
                 match.type(), match.pos());
@@ -417,7 +417,7 @@ class CoverageSitesTest {
                 """);
 
         List<CoverageSites.Obligation> inner = plan.sites().stream()
-                .filter(s -> s.label().equals("case Yes"))
+                .filter(s -> souther.compiler.report.ArmVocabulary.label(s).equals("case Yes"))
                 .map(CoverageSites.Site::obligation).toList();
         assertEquals(inner.size(), inner.stream().distinct().count(),
                 "the two inner `case Yes` arms are two arms the author wrote");

--- a/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
@@ -89,7 +89,7 @@ class ProbeMappingTest {
         // The same plan with one more arm in it than any body will emit.
         CoverageSites.Site extra = real.sites().get(0);
         List<CoverageSites.Site> longer = new java.util.ArrayList<>(real.sites());
-        longer.add(new CoverageSites.Site(extra.behavior(), extra.kind(), "phantom", extra.at(),
+        longer.add(new CoverageSites.Site(extra.behavior(), extra.outcome(), extra.at(),
                 real.sites().size(), real.sites().size(), extra.obligation()));
         CoverageSites.Plan overcounted =
                 new CoverageSites.Plan(longer, real.guards(), real.byNode(), real.byComparison());

--- a/souther-syntax/src/main/java/souther/compiler/diag/msg/ExampleMessage.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/msg/ExampleMessage.java
@@ -244,29 +244,45 @@ public sealed interface ExampleMessage extends Message {
     record NoRowIsAtThatBoundary(String at, String value, String rule) implements ExampleMessage, Reported {}
 
     /**
-     * The same, where a guard drew the line.
+     * The same, where a fork of a body drew the line.
      *
-     * <p>A rule of its own because a guard has no name to put in the other one's slot. What went
+     * <p>A rule of its own because a fork has no name to put in the other one's slot. What went
      * there was a phrase built in Java — `a guard` — which is a rendering, so it read as English in
-     * every language the rest of the sentence was written in. A type and an invariant have names,
-     * and a name is the same in every language; this has none, so the words are the catalog's.
+     * every language the rest of the sentence was written in, and it named one construct where three
+     * draw a line this way. A type and an invariant have names, and a name is the same in every
+     * language; this has none, so the words are the catalog's.
      *
-     * <p>Where the guard is written is not here either. It is a place, and a place is pointed at.
+     * <p>Which construct it was is a {@link souther.compiler.diag.Localizable}, and not three rules
+     * of this one. What the sentence says does not turn on it — the phrase is a noun dropped into one
+     * wording, which is what a token category already is — so what varies is a catalog entry rather
+     * than a sentence written twice.
+     *
+     * <p>Where the construct is written is not here either. It is a place, and a place is pointed at.
      */
     @Code(DiagnosticCode.E1916)
-    record NoRowIsAtTheLineAGuardDrew(String at, String value)
+    record NoRowIsAtTheLineAConstructDrew(String at, String value,
+                                          souther.compiler.diag.Localizable construct)
             implements ExampleMessage, Reported {}
 
-    /** Said beside the guard a line was drawn by, the sentence naming the rule without a place —
-     *  a guard has no name, and where it is written is a place a renderer resolves a file for. */
-    record TheGuardThatDrawsTheLine() implements ExampleMessage, Supporting {}
+    /** Said beside the construct a line was drawn in, the sentence naming the rule without a place —
+     *  a fork has no name, and where it is written is a place a renderer resolves a file for. */
+    record TheConstructThatDrawsTheLine(souther.compiler.diag.Localizable construct)
+            implements ExampleMessage, Supporting {}
 
     /** What a row on the line tells apart. */
     record ARowOnTheLineTellsTwoRulesApart() implements ExampleMessage, Supporting {}
 
-    /** No row goes through an arm of the body. */
+    /**
+     * No row goes through an arm of the body.
+     *
+     * <p>{@code arm} is localized where the sentence is. What an outcome is called depends on the
+     * construct it belongs to — an {@code if} has a {@code then} to quote, a {@code guard} has the
+     * rest of its block and no word for it — and the analysis that found the arm has no reader and
+     * so no language to name it in.
+     */
     @Code(DiagnosticCode.E1918)
-    record NoRowGoesThroughThatArm(String arm, String behavior) implements ExampleMessage, Reported {}
+    record NoRowGoesThroughThatArm(souther.compiler.diag.Localizable arm, String behavior)
+            implements ExampleMessage, Reported {}
 
     /** Which of the two that is. */
     record EitherARowIsMissingOrNothingReachesIt() implements ExampleMessage, Supporting {}

--- a/specification.adoc
+++ b/specification.adoc
@@ -5846,23 +5846,29 @@ Not warned about for a case the model's own rules refuse (<<a-case-the-rules-ref
 
 [,text]
 ----
-No row is at submit/cost = 100, which is where guard@14:5 draws its line.
+No row is at submit/cost = 100, which is where the `guard` draws its line.
 Hint: A row on the line is what tells a rule written `<=` from one written `<`.
 ----
 
-A warning, and one that needs the arms measured where the line was drawn by a `+guard+` (<<example-branch-coverage>>): meeting such a line takes reaching the comparison, not writing the value. A line an invariant drew is decided without that. The rule that drew it is named, because the same value can be a boundary of several and reaching it through one leaves the others unmet.
+A warning, and one that needs the arms measured where the line was drawn by a fork of the body (<<example-branch-coverage>>): meeting such a line takes reaching the comparison, not writing the value. A line an invariant drew is decided without that. The rule that drew it is named, because the same value can be a boundary of several and reaching it through one leaves the others unmet.
+
+The fork is named by the construct it was written as — an `+if+`, a `+guard+`, or a guard comprehension (<<stdlib-list>>) — and where it is written is pointed at rather than said, a place being something only a reader's own files give a name to. All three lower to one form before anything runs, so the word comes from where the source was read and not from the shape it was lowered to.
 
 [#e1918]
 === No row goes through an arm
 
 [,text]
 ----
-No row goes through the `else` arm of `submit`.
+No row goes through the `else` arm in `submit`.
 Hint: Either a row is missing for what this arm answers, or nothing reaches it — which an
 `unreachable` states.
 ----
 
-A warning, needing the arms measured (<<example-branch-coverage>>). Quoted at the `+if+`, `+match+` or attempted construction the arm belongs to rather than at the arm's own body: the fork is what the author wrote, and a body is what lowering rewrites. A behavior no row names is not warned about, whether or not another behavior's rows run through it. An arm that answers nothing is not an arm and is not warned about (<<an-arm-that-answers-nothing-is-not-an-arm>>); the hint names `+unreachable+` because stating that nothing reaches an arm is what answers this warning where no row can.
+A warning, needing the arms measured (<<example-branch-coverage>>). Quoted at the `+if+`, `+match+` or attempted construction the arm belongs to rather than at the arm's own body: the fork is what the author wrote, and a body is what lowering rewrites.
+
+A behavior no row names is not warned about, whether or not another behavior's rows run through it. An arm that answers nothing is not an arm and is not warned about (<<an-arm-that-answers-nothing-is-not-an-arm>>); the hint names `+unreachable+` because stating that nothing reaches an arm is what answers this warning where no row can.
+
+What the way through is called comes from the construct as well as from the way. An `+if+` has a `+then+` and an `+else+` to quote; a `+guard+` has the `+else+` the author wrote and, on the other side, the rest of the block, which is named as that rather than as a `+then+` nobody wrote; a guard comprehension has neither word, and its two ways are the element it yields and the empty list it yields instead.
 
 [#e1919]
 === A stand-in and a recorded row answer one input differently


### PR DESCRIPTION
An `if`, a `guard` and a guard comprehension are one `Core.If` by the time coverage is numbered (ADR-0020, ADR-0021), and `CoverageSites` read the source's own words off that node — saying so in its own class comment: *"A `guard … else` is an `if` by the time it gets here, so it needs no case of its own."* That is right about Core and wrong about what is being measured.

Measured on `develop` at `38026cc7` with `souther examples`, and again here:

| source | boundary origin | ways through it |
| --- | --- | --- |
| `if temp >= 240 then 1 else 2` | `guard@5:5` → `if@5:5` | `then` / `else` — unchanged |
| `guard temp >= 240 else Low` | `guard@9:5` — unchanged | `then` → `continued`, `else` unchanged |
| `[ temp \| temp >= 240 ]` | `guard@5:5` → `comprehension@5:5` | `then` / `else` → `kept` / `dropped` |

Only the middle row's origin and only the first row's arms were words anyone wrote.

## What was missing

`CoverageOrigin` already crosses lowering and expansion so that copies of one fork stay one obligation, and `lowered(part)` already derives a comprehension's guards from the comprehension. It preserved **which** construct this is. What it did not carry is **what** that construct was, and that is the whole of the gap — the origin word and the arm words are two symptoms of it, which is why they are one change.

## What this does

**One owner for the source kind.** `CoverageOrigin` gains a `CoverageConstruct`. `AstBuilder.construct(kind)` is the only place one is made and its five callers are the five constructs a row can be owed for; the counter increments per call, so no two origins share an ordinal and adding this does not move identity. Every rewrite from Ast through Core already copies `origin()`, so an expansion preserves it with no new rule to keep. No `Core` node learns a surface form.

**Outcomes become data.** `Site` carried a `Kind` that put a source outcome, a lowering mechanism and an instrumentation site in one enum, and a `String label` frozen in one language at analysis time. Both become a `SourceOutcome` — `Held(HeldBy)`, `Failed(FailedBy)`, `Matched`, `Compared`.

It does not carry the construct. `Site` reaches it through its `Obligation`, and a second copy would let one site say `GUARD` in one component and `IF` in the next — in a change whose point is a single truth for provenance. The meaning is the pair, so the pair is what `OutcomeName.of` is total over, and `Site`'s compact constructor refuses a combination no construct of the language has (a comprehension attempting a construction, a `match` settling a condition). `isArm()` moves onto the outcome, which is the special case `Site.Kind.COMPARISON` used to be.

`HeldBy` and `FailedBy` are separate because only the failing side of an attempt names a clause, and because `Held(boolean)` would be a boolean whose meaning the type does not state.

**Words move to where a reader is.** No reader-facing string is decided in `CoverageSites`. A phrase dropped into a sentence is localized at render time through `Localizable`, which is what `tok.*` and `kind.*` already do and what ADR-0101 leaves beside its rule that a value selecting a whole wording makes two records. `E1916`'s guard case becomes `NoRowIsAtTheLineAConstructDrew`, its label becomes `TheConstructThatDrawsTheLine`, and `E1918` takes its arm as a phrase:

```
No row is at price/temp = 240, which is where the `if` draws its line.
No row goes through the empty list the comprehension yields in `pick`.
`pick` の内包表記が空リストを返す側を通る行が、ありません。
```

**The schema grows by addition only.** `then`, `else`, `case`, `constructed` and `departure` all stay and are all still written; `continued`, `kept` and `dropped` are words no earlier document carried, and `construct` is an optional key saying which construct an `else` belongs to. That is the rule the schema's own preamble states, so `schemaVersion` stays 1.

## How the acceptance matrix is held

`AnOutcomeIsNamedByWhatWasWrittenTest` walks the five source shapes, the admissible pairs, and a comprehension with two guards inside a helper called twice — one construct, lowered into two forks, each copied twice.

The last two rows of the matrix are held by machinery rather than by a rule someone has to remember, so they were checked by breaking the machinery and watching the test go red:

| break | red |
| --- | --- |
| `lowered()` drops the kind | 4 |
| `HelperInliner` mints an origin instead of copying one | 2 |
| `Lower` stops deriving a fork per guard | 1 |

`CI=1 mvn -Plint verify` is green.

**One thing the green does not say.** The conformance corpus does not exercise any of this: its only boundary origins are `guard@1:73:5`, which is a real `guard`, and it has no unreached arm at all. The corpus says this broke nothing; what says the routes are fixed is the test above and the five models run by hand.

## Out of scope

Whether the measure should still be called `branch` and its unit an *arm*. ADR-0089 names it "arms of the body", and a `guard`'s successful side and a comprehension's filter are not arms anyone wrote — but that is a decision about what Souther measures rather than a repair of provenance, and it can be taken on its own now that the outcomes are data.

Closes #841

🤖 Generated with [Claude Code](https://claude.com/claude-code)
