### PR TITLE
Write a temporal out as a value rather than as a call to be recognised

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -138,6 +138,16 @@ public final class CallElaborator {
             return preservedCall(call, callee, kept, env, ctx, expected);
         }
         CallArgs ca = new CallArgs(call.args(), env, ctx);
+        // A temporal written out is a value, not an application: which it is was settled when the
+        // callee was resolved, and it becomes a value of its own here so that nothing downstream is
+        // left asking a call whether it is one. Three readers were asking, each off a different
+        // thing in reach — the spelling, the answered type, the shape of the argument — and each was
+        // right only about programs that name none of the four temporals themselves. Asked of what
+        // the name denotes, which is what the library says about itself.
+        if (callee != null && callee.denotes() instanceof ValueName.Stdlib library
+                && library.constructs() instanceof Type.Prim kind) {
+            return temporalLiteral(call, kind, ca);
+        }
         Type result = typeOfCall(ca, call, env, ctx, expected);
         // applying something this body binds is a different operation from calling something
         // declared elsewhere, and it is the only one that carries a binding into the emitted tree
@@ -554,78 +564,69 @@ public final class CallElaborator {
             }
             return applied.result();
         }
-        return switch (library ? callee.reaches() : "") {
-            case "Date", "Time", "DateTime", "Instant" -> {
-                arity(call, 1);
-                ca.type(0);   // the literal text, which temporalLiteral parses
-                yield temporalLiteral(call, callee);
+        // a function-typed value in scope (a helper's function parameter) applied to
+        // arguments — f(x) (spec §fn-declaration). A newtype construction 金額(500) never
+        // reaches here — NewtypeDesugar has lowered it to a NewData literal.
+        // a function value in force, or a recursive helper's signature: which of the two
+        // is the denotation's to say, and only one of them is bound here
+        if (env.of(callee.denotes(), call.written()) instanceof Type.FnOf fn) {
+            if (args.size() != fn.params().size()) {
+                throw CompileException.of(Diagnostic
+                                .at(call.appliedAt())
+                                .say(new DeclarationMessage.AppliedToAnotherNumberOfArguments(call.written(), String.valueOf(fn.params().size()), String.valueOf(args.size()))).build());
             }
-            default -> {
-                // a function-typed value in scope (a helper's function parameter) applied to
-                // arguments — f(x) (spec §fn-declaration). A newtype construction 金額(500) never
-                // reaches here — NewtypeDesugar has lowered it to a NewData literal.
-                // a function value in force, or a recursive helper's signature: which of the two
-                // is the denotation's to say, and only one of them is bound here
-                if (env.of(callee.denotes(), call.written()) instanceof Type.FnOf fn) {
-                    if (args.size() != fn.params().size()) {
-                        throw CompileException.of(Diagnostic
-                                        .at(call.appliedAt())
-                                        .say(new DeclarationMessage.AppliedToAnotherNumberOfArguments(call.written(), String.valueOf(fn.params().size()), String.valueOf(args.size()))).build());
-                    }
-                    yield applySignature(call, fn, ca, expected, env, ctx).result();
-                }
-                // A library name that matched no builtin or intrinsic above is a wrong stdlib call
-                // (spec §stdlib) — reported as that, not as a missing behavior. Asked of which kind
-                // of name this reaches and not of whether the spelling holds a dot: a field read
-                // applied (`deps.count(x)`) is quoted with a dot in it and reaches a binding, and
-                // what is wrong with it is that it is not a function, which the report below says.
-                if (callee.reachedAs() instanceof ReachName.OfLibrary) {
-                    throw CompileException.of(Diagnostic
-                                    .at(call.appliedAt()).say(new NameMessage.NotAStandardLibraryFunction(call.written())).build());
-                }
-                // A helper another module declares is expanded where it is called, or — where it
-                // recurses — bound as a signature and answered above. Reaching here it is neither,
-                // which is this compiler having failed to do one of them rather than anything the
-                // author wrote. Said outright: reported as a wrong library call, it named a library
-                // the author never wrote.
-                if (callee.denotes() instanceof ValueName.Helper helper) {
-                    throw new IllegalStateException("`" + helper + "` was neither expanded nor"
-                            + " bound before the call to it at " + call.pos() + " was typed");
-                }
-                // a required behavior called inline (spec §unmarked-output, §fn), or one that requires nothing and
-                // is called by name (spec [#calling-a-behavior]). Both are typed against the callee's
-                // declaration; where the behavior comes from at run time is the backend's to know.
-                // Asked of the declaration the call reaches. Two modules may declare a behavior
-                // of one name, and a table asked with the name this module writes answers for
-                // whichever of them the entry happens to be.
-                // A behavior named outright, or the trailing parameter an implementation takes it
-                // as — which is a binding, and which behavior it stands for was settled where the
-                // `depends on` clause was resolved.
-                ValueName.Behavior reached = switch (callee.denotes()) {
-                    case ValueName.Behavior behavior -> behavior;
-                    case ValueName.Local local -> ctx.dependencyOf(local.id());
-                    default -> null;
-                };
-                ReqSig required = reached == null ? null : ctx.reqs().get(reached);
-                if (required == null && reached != null) {
-                    required = ctx.callees().get(reached);
-                }
-                if (required == null) {
-                    Elaborator.optionCaseWritten(call.written(), call.pos());
-                    CompileException bareLibraryName = StdlibNames.writtenBare(
-                            call.written(), call.written(), call.name().region());
-                    if (bareLibraryName != null) {
-                        throw bareLibraryName;
-                    }
-                    throw noCallee(call);
-                }
-                arity(call, required.params().size());
-                for (int i = 0; i < required.params().size(); i++) {
-                    ca.require(i, required.params().get(i), "argument " + (i + 1) + " of " + call.written());
-                }
-                yield required.success();
-            }
+            return applySignature(call, fn, ca, expected, env, ctx).result();
+        }
+        // A library name that matched no builtin or intrinsic above is a wrong stdlib call
+        // (spec §stdlib) — reported as that, not as a missing behavior. Asked of which kind
+        // of name this reaches and not of whether the spelling holds a dot: a field read
+        // applied (`deps.count(x)`) is quoted with a dot in it and reaches a binding, and
+        // what is wrong with it is that it is not a function, which the report below says.
+        if (callee.reachedAs() instanceof ReachName.OfLibrary) {
+            throw CompileException.of(Diagnostic
+                            .at(call.appliedAt()).say(new NameMessage.NotAStandardLibraryFunction(call.written())).build());
+        }
+        // A helper another module declares is expanded where it is called, or — where it
+        // recurses — bound as a signature and answered above. Reaching here it is neither,
+        // which is this compiler having failed to do one of them rather than anything the
+        // author wrote. Said outright: reported as a wrong library call, it named a library
+        // the author never wrote.
+        if (callee.denotes() instanceof ValueName.Helper helper) {
+            throw new IllegalStateException("`" + helper + "` was neither expanded nor"
+                    + " bound before the call to it at " + call.pos() + " was typed");
+        }
+        // a required behavior called inline (spec §unmarked-output, §fn), or one that requires nothing and
+        // is called by name (spec [#calling-a-behavior]). Both are typed against the callee's
+        // declaration; where the behavior comes from at run time is the backend's to know.
+        // Asked of the declaration the call reaches. Two modules may declare a behavior
+        // of one name, and a table asked with the name this module writes answers for
+        // whichever of them the entry happens to be.
+        // A behavior named outright, or the trailing parameter an implementation takes it
+        // as — which is a binding, and which behavior it stands for was settled where the
+        // `depends on` clause was resolved.
+        ValueName.Behavior reached = switch (callee.denotes()) {
+            case ValueName.Behavior behavior -> behavior;
+            case ValueName.Local local -> ctx.dependencyOf(local.id());
+            default -> null;
         };
+        ReqSig required = reached == null ? null : ctx.reqs().get(reached);
+        if (required == null && reached != null) {
+            required = ctx.callees().get(reached);
+        }
+        if (required == null) {
+            Elaborator.optionCaseWritten(call.written(), call.pos());
+            CompileException bareLibraryName = StdlibNames.writtenBare(
+                    call.written(), call.written(), call.name().region());
+            if (bareLibraryName != null) {
+                throw bareLibraryName;
+            }
+            throw noCallee(call);
+        }
+        arity(call, required.params().size());
+        for (int i = 0; i < required.params().size(); i++) {
+            ca.require(i, required.params().get(i), "argument " + (i + 1) + " of " + call.written());
+        }
+        return required.success();
     }
 
     /**
@@ -736,23 +737,32 @@ public final class CallElaborator {
      * rather than a run (and an {@code example} fixture, which may only hold literals, can carry a
      * temporal at all). This form spells one out; a temporal computed from values comes from the
      * boundary, from the arithmetic, or from {@code Date.fromParts} / {@code Time.fromParts}, which
-     * answer a case where the parts name no such moment. */
-    static Type temporalLiteral(Hir.Apply call, Hir.Var.Denoting callee) {
-        Type.Prim kind = Type.Prim.named(callee.reaches());
+     * answer a case where the parts name no such moment.
+     *
+     * <p>{@code kind} is handed in rather than read off the spelling: which temporal this builds is
+     * what the callee's denotation said ({@link ValueName.Stdlib#constructs()}), and the spelling is
+     * only what a report quotes. The node this answers with is the value itself, so the text is read
+     * here once and nothing downstream reconstructs it from a call. */
+    static Core.Temporal temporalLiteral(Hir.Apply call, Type.Prim kind, CallArgs ca) {
+        arity(call, 1);
+        ca.type(0);   // the text, typed where it stands
         if (!(call.args().get(0) instanceof Hir.StringLit lit)) {
             throw CompileException.of(Diagnostic
                             .at(call.appliedAt()).say(new TypeMessage.ATemporalTakesAWrittenString(call.written())).build());
         }
-        parseTemporal(call.written(), lit.value(), lit.reportedAt());
-        return kind;
+        parseTemporal(kind, call.written(), lit.value(), lit.reportedAt());
+        return new Core.Temporal(kind, lit.value(), call.pos());
     }
 
     /** Parses a written temporal, reporting a malformed one against {@code at} — the text the
      * message quotes, which is the part of the form a reader cannot work out from the message.
      * Returns the parsed value so the backend and the example verifier share this one reading of
-     * the text. */
-    public static Object parseTemporal(String fn, String text, Region at) {
-        Type.Prim kind = Type.Prim.named(fn);
+     * the text.
+     *
+     * <p>{@code kind} decides which parse runs and {@code fn} is only what a report quotes. They
+     * were one value, and the caller that had a name for a temporal it had not resolved got the
+     * parse the name spelled. */
+    public static Object parseTemporal(Type.Prim kind, String fn, String text, Region at) {
         Object parsed;
         try {
             parsed = switch (kind) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
@@ -368,8 +368,8 @@ public sealed interface Carrier {
                 case null, default -> null;
             };
             case Days _, Seconds _, SecondsOfDay _, Nanos _ ->
-                    constructedFrom(bare) instanceof Core.Str iso
-                            ? placeOf(new ObservedValue.Temporal(iso.value())) : null;
+                    bare instanceof Core.Temporal written
+                            ? placeOf(new ObservedValue.Temporal(written.text())) : null;
             // A case, which is named rather than written. Where the position counts in some other
             // enumeration's declaration this is a value of neither, and that is said by `at`.
             case Ordinal ordinal ->
@@ -403,36 +403,20 @@ public sealed interface Carrier {
                 ? bare(nd.values().get(0).value(), symbols) : e;
     }
 
-    /**
-     * The text a temporal construction was written with, or null where {@code e} is not one.
-     *
-     * <p>What makes it one is the callee, and never the type of what comes back. A call answering
-     * with a {@code Time} is not a {@code Time} anyone here wrote down: an injected behavior
-     * {@code openingAt("16:00:00")} answers whatever its implementation makes of that text, and read
-     * off the answer's type the argument became a line — a boundary this compiler made up, at a
-     * value no rule in the model states, reported as one the model drew.
-     *
-     * <p>A construction is a library namespace applied ({@link ValueName.Stdlib}), which is the one
-     * shape that builds a value rather than computing one, and {@code isNamespace} is how that is
-     * asked. Not by the name: an operation a library gave its own module's name renders the same
-     * either way, which is the reading-a-name-back-out that type exists to stop.
-     */
-    private static Core constructedFrom(Core e) {
-        return e instanceof Core.Call call
-                && call.fn() instanceof Core.Reached reached
-                && reached.denotes() instanceof ValueName.Stdlib lib && lib.isNamespace()
-                && call.args().size() == 1
-                ? call.args().get(0) : null;
-    }
-
     /** The count a written temporal is, or null where the expression is not one of that kind. A
      *  temporal is written as a literal with its text spelled out (spec
      *  §a-temporal-value-is-written-as-a-literal), so it is read here rather than run. Which
-     *  construction it is comes from the callee, for the reason {@link #written} gives. */
+     *  construction it is comes from the callee, for the reason {@link #written} gives.
+     *
+     *  <p>Whether the callee builds anything is {@link ValueName.Stdlib#constructs}, which is where
+     *  that is settled. Being the namespace rather than an operation of it is the wider question: a
+     *  namespace that builds nothing is one of these too, and the text handed to {@code countOf}
+     *  would then be parsed as a moment because of where it stands. */
     private static Count temporal(Hir.Expr e,
                                   java.util.function.Function<String, Count> countOf) {
         return e instanceof Hir.Apply call && call.answered() != null
-                && call.answered().denotes() instanceof ValueName.Stdlib lib && lib.isNamespace()
+                && call.answered().denotes() instanceof ValueName.Stdlib lib
+                && lib.constructs() != null
                 && call.args().size() == 1 && call.args().get(0) instanceof Hir.StringLit iso
                 ? countOf.apply(iso.value()) : null;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -899,6 +899,12 @@ final class Terms {
             case Core.Decimal d -> new Naming.Named(interned.written(d.value()));
             case Core.Str str -> new Naming.Named(interned.written(str.value()));
             case Core.Bool b -> new Naming.Named(interned.written(b.value()));
+            // Named as the construction it is written as, which is the term two writings of one
+            // date already shared when this arrived here as a call. The text alone would be the term
+            // the string of it has, and a `Date` is not the text of one.
+            case Core.Temporal t -> new Naming.Named(interned.called(
+                    ValueName.Stdlib.namespace(t.kind().shown()),
+                    List.of(interned.written(t.text()))));
             case Core.UnitValue u -> new Naming.Named(interned.unit(u.data()));
             case Core.Neg n -> over(List.of(n.operand()), at, bound, depth, leaf,
                     ps -> interned.negated(ps.get(0)));
@@ -1312,7 +1318,13 @@ final class Terms {
      * expands to binds each argument and reads it back, which is the source's own text moved. */
     static boolean isWritten(Core e, Set<BindingId> written) {
         return switch (e) {
-            case Core.Int _, Core.Decimal _, Core.Str _, Core.Bool _, Core.UnitValue _ -> true;
+            // A temporal is one of the literals the language has (spec
+            // §a-temporal-value-is-written-as-a-literal), so it is written wherever it stands. It
+            // was carried here as a call and answered `false` in this switch's default while
+            // `asWrittenValue` was writing it back out — one value, two answers about whether the
+            // source holds it.
+            case Core.Int _, Core.Decimal _, Core.Str _, Core.Bool _, Core.Temporal _,
+                 Core.UnitValue _ -> true;
             case Core.Neg n -> isWritten(n.operand(), written);
             case Core.Read r -> written.contains(r.binding());
             case Core.ListLit list -> list.elements().stream().allMatch(x -> isWritten(x, written));
@@ -1428,23 +1440,20 @@ final class Terms {
                                 call.pos(), null);
             }
             // A temporal is written as a literal with its text spelled out (spec
-            // §a-temporal-value-is-written-as-a-literal), and what the analysis representation keeps
-            // of one is a call to the operation that builds it. Rendered here for the same reason
-            // every other written form is: it is a value the author wrote, and a reader handed
-            // nothing for it reads the rule around it as a rule about something unknown.
+            // §a-temporal-value-is-written-as-a-literal). Rendered here for the same reason every
+            // other written form is: it is a value the author wrote, and a reader handed nothing for
+            // it reads the rule around it as a rule about something unknown. Written back as the
+            // construction it was written as, which is the form a report and `ConstEval` read.
             //
-            // Held to the calls that answer a temporal, which is what a temporal literal is. Every
-            // call to a resolved name would be a wider claim than the one this makes: the contract
-            // above is that what is computed answers with nothing, and the fold beneath it
-            // (`ConstEval`) is written against that. Which calls those are is read off the type
-            // rather than a list of names, so a temporal added to the language is one of these
-            // without anybody remembering to say so.
-            case Core.Call call when call.fn() instanceof Core.Reached reached
-                    && temporal(call.type()) -> {
-                List<Hir.Expr> args = written(call.args());
-                yield args == null ? null
-                        : new Hir.Apply(reached.denotes().name(), reached.denotes(), reached.name(),
-                                args, ConstructionOrigin.own(), call.pos(), null);
+            // This used to be held to the calls answering a temporal — which took any behavior
+            // answering a `Date` over written arguments for a date the source spells out, and let a
+            // line be drawn where the compiler knows no value. What is written is the node now, and
+            // nothing here decides it.
+            case Core.Temporal t -> {
+                ValueName.Stdlib namespace = ValueName.Stdlib.namespace(t.kind().shown());
+                yield new Hir.Apply(namespace.qualified(), namespace, reachOf(namespace),
+                        List.of(new Hir.StringLit(t.text(), t.pos(), null)),
+                        ConstructionOrigin.own(), t.pos(), null);
             }
             // A case of an enumeration is written by naming it, so the value is the name.
             case Core.UnitValue unit -> Hir.Var.respelled(unit.data().name(),
@@ -1453,12 +1462,6 @@ final class Terms {
                     new ReachName.Bare(unit.data().name()), unit.pos(), null);
             case null, default -> null;
         };
-    }
-
-    /** Whether {@code type} is one a temporal literal answers. */
-    private static boolean temporal(Type type) {
-        return type == Type.DATE || type == Type.TIME || type == Type.DATETIME
-                || type == Type.INSTANT;
     }
 
     /** Every argument as it was written, or null where any of them was computed. */

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -692,6 +692,7 @@ final class BodyGen {
                 case Core.Bool x -> {
                     if (x.value()) code.iconst_1(); else code.iconst_0();
                 }
+                case Core.Temporal t -> temporal(t);
                 case Core.Read v -> {
                     Var var = locals.get(v.binding());
                     if (var == null) {
@@ -1206,37 +1207,39 @@ final class BodyGen {
                 putIntoMap(call);
                 return;
             }
-            switch (call.name()) {
-                case "Date", "Time", "DateTime", "Instant" -> {
-                    // a written temporal: the checker has already parsed the literal, so the text is
-                    // known good and this is a plain parse of a constant string.
-                    ClassDesc cd = JvmTypes.boxedPrim(Type.Prim.named(call.name()));
-                    code.loadConstant(((Core.Str) call.args().get(0)).value());
-                    code.invokestatic(cd, "parse", MethodTypeDesc.of(cd, CD_CharSequence));
+            // an injected behavior a lambda captured arrives in a slot rather than in a field of the
+            // enclosing behavior, and is applied as the value it is. This asks where the value is,
+            // not what the name means: what it means was settled when the call was elaborated, and
+            // an injected behavior is not a binding.
+            Var behavior = captured.get(call.name());
+            if (behavior != null && behavior.type() instanceof Type.FnOf fnType) {
+                applyCaptured(call, fnType);
+            } else if (ctx.emittedHelpers.containsKey(call.name())) {
+                // The one loop the language has is emitted where it stands, not called.
+                if (!call.name().equals(FOLD) || !folded(call)) {
+                    recursiveHelperCall(call);
                 }
-                default -> {
-                    // an injected behavior a lambda captured arrives in a slot rather than in a
-                    // field of the enclosing behavior, and is applied as the value it is. This asks
-                    // where the value is, not what the name means: what it means was settled when
-                    // the call was elaborated, and an injected behavior is not a binding.
-                    Var behavior = captured.get(call.name());
-                    if (behavior != null && behavior.type() instanceof Type.FnOf fnType) {
-                        applyCaptured(call, fnType);
-                    } else if (ctx.emittedHelpers.containsKey(call.name())) {
-                        // The one loop the language has is emitted where it stands, not called.
-                        if (!call.name().equals(FOLD) || !folded(call)) {
-                            recursiveHelperCall(call);
-                        }
-                    } else if (behaviorOf(call) != null && reqNames.contains(behaviorOf(call))) {
-                        requiredCall(call);
-                    } else if (behaviorOf(call) != null
-                            && ctx.calleeSig(behaviorOf(call)) != null) {
-                        behaviorCall(call);
-                    } else {
-                        throw new IllegalStateException("unknown function `" + call.name() + "`");
-                    }
-                }
+            } else if (behaviorOf(call) != null && reqNames.contains(behaviorOf(call))) {
+                requiredCall(call);
+            } else if (behaviorOf(call) != null
+                    && ctx.calleeSig(behaviorOf(call)) != null) {
+                behaviorCall(call);
+            } else {
+                throw new IllegalStateException("unknown function `" + call.name() + "`");
             }
+        }
+
+        /** A temporal the source spelled out. The checker read the text when it typed the form, so
+         * this is a parse of a constant that is known to parse, and which parse to run is the kind
+         * on the node.
+         *
+         * <p>It used to be a call whose spelling this compared against the four temporals, so a
+         * model declaring a behavior of its own named {@code Date} had its own behavior emitted as
+         * this. A written temporal is a value here, and a call is a call. */
+        private void temporal(Core.Temporal t) {
+            ClassDesc cd = JvmTypes.boxedPrim(t.kind());
+            code.loadConstant(t.text());
+            code.invokestatic(cd, "parse", MethodTypeDesc.of(cd, CD_CharSequence));
         }
 
         /** Calls a recursive helper as a static method on {@code $Fns} (spec §fn-declaration): each argument is
@@ -2070,6 +2073,7 @@ final class BodyGen {
                 case Core.Decimal _ -> { }
                 case Core.Str _ -> { }
                 case Core.Bool _ -> { }
+                case Core.Temporal _ -> { }
                 case Core.Unreachable _ -> { }
                 // reads nothing the enclosing body binds
                 case Core.UnitValue _ -> { }

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -51,6 +51,41 @@ public sealed interface Core {
 
     record Bool(boolean value, Type type, SourcePos pos) implements Core {}
 
+    /**
+     * A temporal written out: {@code Date("2026-07-01")}, {@code Time("09:00")},
+     * {@code DateTime("2026-07-01T09:00")}, {@code Instant("2026-07-01T09:00:00Z")}.
+     *
+     * <p>A literal, and here beside the other four for the reason the language calls it one
+     * (spec §a-temporal-value-is-written-as-a-literal): the text is written where the value goes,
+     * and the checker has already read it. It was carried this far as a {@link Call} instead, which
+     * is the shape an application has — so every reader that needed to know a written temporal from
+     * a call had to work it out, and each took a different thing to work it out from: the spelling
+     * in front of the argument, the type the call answered, the shape of the argument. A model
+     * declaring a behavior of its own named {@code Date} was compiled as this construction, its
+     * injected implementation never called. None of them is a question this node can be asked.
+     *
+     * <p>{@code kind} is the temporal, and the node's type is it: one value, so the two cannot
+     * disagree. {@code text} is the ISO text as it was written, which is what a reader of this wants
+     * — the backend parses it, a boundary reads its place — and the parse the checker already did is
+     * what says the text is good.
+     */
+    record Temporal(Type.Prim kind, String text, SourcePos pos) implements Core {
+
+        public Temporal {
+            if (kind == null || !kind.temporal()) {
+                throw new IllegalArgumentException("`" + kind + "` is no temporal");
+            }
+            if (text == null) {
+                throw new IllegalArgumentException("a written temporal is written out");
+            }
+        }
+
+        @Override
+        public Type type() {
+            return kind;
+        }
+    }
+
     /** A read of something the body binds: a parameter, a {@code let}, a lambda's parameter, a
      * {@code match} arm's binding. {@code binding} is which one; {@code name} is what to call the
      * local it is emitted as, and what a diagnostic quotes. */
@@ -446,6 +481,7 @@ public sealed interface Core {
             case Decimal x -> x;
             case Str x -> x;
             case Bool x -> x;
+            case Temporal x -> x;
             case Read x -> x;
             case UnitValue x -> x;
             case OptionNone x -> x;
@@ -565,6 +601,7 @@ public sealed interface Core {
             case Decimal x -> new Decimal(x.value(), x.type(), null);
             case Str x -> new Str(x.value(), x.type(), null);
             case Bool x -> new Bool(x.value(), x.type(), null);
+            case Temporal x -> new Temporal(x.kind(), x.text(), null);
             case Read x -> readWithoutItsPlace(x);
             case UnitValue x -> new UnitValue(x.data(), x.type(), null);
             case OptionNone x -> new OptionNone(x.type(), null);

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -414,8 +414,8 @@ public final class CoverageSites {
             // nothing inside it can do either.
             boolean inside = reachable && answers(e);
             switch (e) {
-                case Core.Int _, Core.Decimal _, Core.Str _, Core.Bool _, Core.Read _,
-                     Core.UnitValue _, Core.OptionNone _ -> { }
+                case Core.Int _, Core.Decimal _, Core.Str _, Core.Bool _, Core.Temporal _,
+                     Core.Read _, Core.UnitValue _, Core.OptionNone _ -> { }
                 // A leaf, and one holding no fork. Whether the arm it stands in is an arm to cover is
                 // decided where that arm is made, not here.
                 case Core.Unreachable _ -> { }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/NormalReturn.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/NormalReturn.java
@@ -36,7 +36,7 @@ public final class NormalReturn {
     public static boolean of(Core e) {
         return switch (e) {
             case Core.Unreachable _ -> false;
-            case Core.Int _, Core.Decimal _, Core.Str _, Core.Bool _, Core.Read _,
+            case Core.Int _, Core.Decimal _, Core.Str _, Core.Bool _, Core.Temporal _, Core.Read _,
                  Core.UnitValue _, Core.OptionNone _ -> true;
             case Core.Neg n -> of(n.operand());
             case Core.FieldAccess fa -> of(fa.target());

--- a/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
@@ -1332,8 +1332,13 @@ public final class FixtureReader {
             case Hir.Var v -> statedByName(v);
             case Hir.Apply c when constructsANewtype(c) -> caseNamed(constructs(c));
             // `Date("…")` is a temporal, and `Set.fromList([…])` a collection: values under no name.
+            // Whether the first of those builds anything is {@link ValueName.Stdlib#constructs},
+            // which is the one place that says so — and it is what this asks, so a module's own
+            // behavior spelled like a namespace is not read as one, and a namespace that builds
+            // nothing (`List`, `Option`) is the call it is and is refused where it is read.
             case Hir.Apply c when c.answered() != null
-                    && (Type.Prim.named(c.answered().reaches()) != null
+                    && ((c.answered().denotes() instanceof ValueName.Stdlib library
+                                    && library.constructs() != null)
                             || "Set.fromList".equals(c.answered().reaches())
                             || "Map.fromList".equals(c.answered().reaches())) ->
                     STATES_NO_NAME;
@@ -1638,15 +1643,21 @@ public final class FixtureReader {
     }
 
     private Object newtypeInner(Hir.Apply c, Position at, Admission admission) {
-        Type.Prim written = c.answered() == null
-                ? null : Type.Prim.named(c.answered().reaches());
-        if (written != null && written.temporal()) {
+        // Which temporal this builds, or none — asked of what the callee denotes
+        // ({@link ValueName.Stdlib#constructs()}), as every other question about which operation a
+        // call applies is. Read off the spelling, a model's own behavior named `Date` was a written
+        // date here; a fixture expression is never elaborated, so this reader answers for itself and
+        // has to ask the same place the elaborator asks.
+        Type.Prim temporal = c.answered() != null
+                && c.answered().denotes() instanceof ValueName.Stdlib library
+                ? library.constructs() : null;
+        if (temporal != null) {
             // a written date: the decoders take the parsed temporal, not its text (a Date field's
             // neutral form is a LocalDate), so the fixture hands over the same value the checker read
             if (c.args().size() != 1 || !(c.args().get(0) instanceof Hir.StringLit lit)) {
                 throw new FixtureException("`" + c.written() + "` takes one written string");
             }
-            return CallElaborator.parseTemporal(c.written(), lit.value(), lit.reportedAt());
+            return CallElaborator.parseTemporal(temporal, c.written(), lit.value(), lit.reportedAt());
         }
         if (!constructsANewtype(c)) {
             throw new FixtureException("`" + c.written() + "` is not a newtype; a fixture cannot call it");

--- a/souther-compiler/src/main/java/souther/compiler/types/ValueName.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/ValueName.java
@@ -87,6 +87,34 @@ public sealed interface ValueName {
             return name == null;
         }
 
+        /**
+         * The primitive this builds when it is applied, or null where applying it builds nothing.
+         *
+         * <p>The one place that says what a library name applied to an argument <em>constructs</em>,
+         * as against computing something. Only the namespace itself builds a value —
+         * {@code Date("2026-09-30")} — and only where the namespace is one of the temporals;
+         * {@code Date.fromParts} is an operation and answers a case, and {@code List} builds nothing
+         * by being applied.
+         *
+         * <p>Asked here rather than at each reader, because a reader that had to answer it took the
+         * only thing in reach, which was the spelling in front of the argument. Three of them did,
+         * each with a different reading of it, and a model declaring a behavior of its own called
+         * {@code Date} was compiled as this construction.
+         *
+         * <p>What is read is the alias, through {@link Type.Prim#named} — the backwards reading of
+         * the one table that writes a primitive out, not a second list of the four spellings. That
+         * a namespace constructs the primitive its alias is written as holds because the library
+         * publishes it under that alias; a library that published a temporal under some other name
+         * would be deciding this here, and this is where it would be decided.
+         */
+        public Type.Prim constructs() {
+            if (!isNamespace()) {
+                return null;
+            }
+            Type.Prim prim = Type.Prim.named(alias);
+            return prim != null && prim.temporal() ? prim : null;
+        }
+
         /** The operation this reaches, or null where it is the namespace itself. */
         public String operation() {
             return name;

--- a/souther-compiler/src/test/java/souther/compiler/WhatBuildsATemporalIsWhatTheNameDenotesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatBuildsATemporalIsWhatTheNameDenotesTest.java
@@ -1,0 +1,164 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+import souther.runtime.Behavior;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Which applications build a temporal, and which only answer one.
+ *
+ * <p>{@code Date("2026-01-01")} builds a date, and the checker settles that where it resolves the
+ * name: the callee denotes the library namespace, which constructs. Nothing else does — a behavior a
+ * model declares of its own named {@code Date} is a behavior, and a behavior answering a {@code Date}
+ * over a written string is a behavior too, whatever it is spelled and whatever it answers.
+ *
+ * <p>Readers downstream of that used to decide it for themselves, and each took what was in reach:
+ * the emitter compared the callee's spelling against the four temporals, and the readings that draw
+ * lines read the type the call answered. So a model's own {@code Date} was compiled as
+ * {@code LocalDate.parse} with its injected implementation never called, and a line was drawn at a
+ * date wherever a behavior answering one was applied to a literal. What the source wrote is a value
+ * of its own now, so none of them has anything left to decide.
+ */
+class WhatBuildsATemporalIsWhatTheNameDenotesTest {
+
+    /** The library's namespace applied: this one builds. */
+    private static final String CONSTRUCTED = """
+            module demo
+
+            data Stale
+            data Fresh
+
+            behavior freshness : (on: Date) -> Stale | Fresh
+                constructs Stale, Fresh
+            let freshness (on) = if on < Date("2026-01-01") then Stale else Fresh
+            """;
+
+    /** A behavior of the model's own, spelled like the namespace. */
+    private static final String SPELLED_THE_SAME = """
+            module demo
+
+            behavior Date : (s: String) -> String
+
+            behavior g : (n: Int) -> String
+                depends on Date
+
+            let g (n, Date) = Date("2026-08-01")
+            """;
+
+    /** A behavior answering a temporal, applied to a written string. */
+    private static final String ANSWERS_ONE = """
+            module demo
+
+            data Stale
+            data Fresh
+
+            behavior asOf : (s: String) -> Date
+
+            behavior freshness : (on: Date) -> Stale | Fresh
+                constructs Stale, Fresh
+                depends on asOf
+            let freshness (on, asOf) = if on < asOf("2026-01-01") then Stale else Fresh
+            """;
+
+    private static List<Core> nodes(String source, String behavior) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        assertEquals(List.of(),
+                compilation.db().allReports().stream().map(Object::toString).toList(),
+                "the model compiles");
+        List<Core> out = new ArrayList<>();
+        collect(compilation.db().ask(new Bodies.CheckedBehavior("demo", behavior)).value(), out);
+        return out;
+    }
+
+    private static void collect(Core e, List<Core> out) {
+        if (e == null) {
+            return;
+        }
+        out.add(e);
+        Core.forEachChild(e, child -> collect(child, out));
+    }
+
+    private static <T> T only(List<Core> nodes, Class<T> kind) {
+        List<Core> found = nodes.stream().filter(kind::isInstance).toList();
+        assertEquals(1, found.size(), () -> "one " + kind.getSimpleName() + " in " + nodes);
+        return kind.cast(found.get(0));
+    }
+
+    /** The namespace applied is the value it builds, with the text the source wrote on it. */
+    @Test
+    void theLibraryNamespaceAppliedIsAWrittenTemporal() {
+        Core.Temporal written = only(nodes(CONSTRUCTED, "freshness"), Core.Temporal.class);
+
+        assertEquals(souther.compiler.types.Type.Prim.DATE, written.kind());
+        assertEquals("2026-01-01", written.text());
+    }
+
+    /** A behavior of the model's own is a call, however it is spelled. */
+    @Test
+    void aBehaviorSpelledLikeTheNamespaceIsACall() {
+        List<Core> nodes = nodes(SPELLED_THE_SAME, "g");
+
+        assertTrue(nodes.stream().noneMatch(Core.Temporal.class::isInstance), nodes.toString());
+        Core.Call call = only(nodes, Core.Call.class);
+        assertInstanceOf(souther.compiler.types.ValueName.Behavior.class,
+                assertInstanceOf(Core.Reached.class, call.fn()).denotes());
+    }
+
+    /** And it is what runs: the implementation the model was handed, not a parse of the text. */
+    @Test
+    void thatBehaviorsOwnImplementationIsWhatRuns() throws Exception {
+        BytesClassLoader loader =
+                new BytesClassLoader(Compiler.compile(SPELLED_THE_SAME), getClass().getClassLoader());
+        Behavior<Object, Object> supplied = s -> "supplied " + s;
+
+        Object g = Emitted.behavior(loader, "demo", "g")
+                .getConstructors()[0].newInstance(supplied);
+
+        assertEquals("supplied 2026-08-01", Codecs.apply(g, 1L));
+    }
+
+    /** A behavior answering a temporal is a call too, and answers no place a line could be at. */
+    @Test
+    void aBehaviorAnsweringATemporalIsACall() {
+        List<Core> nodes = nodes(ANSWERS_ONE, "freshness");
+
+        assertTrue(nodes.stream().noneMatch(Core.Temporal.class::isInstance), nodes.toString());
+        Core.Call call = only(nodes, Core.Call.class);
+        assertInstanceOf(souther.compiler.types.ValueName.Behavior.class,
+                assertInstanceOf(Core.Reached.class, call.fn()).denotes());
+    }
+
+    /** The measurement says the same: a line stands where the source wrote a date, and nowhere
+     *  a behavior was asked for one. */
+    @Test
+    void aLineIsDrawnOnlyWhereADateIsWritten() {
+        assertTrue(report(CONSTRUCTED).contains("boundary    0/0   (2 not measured"),
+                report(CONSTRUCTED));
+        assertFalse(report(ANSWERS_ONE).contains("boundary    0/0"), report(ANSWERS_ONE));
+        assertTrue(report(ANSWERS_ONE).contains(
+                        "· not read: on (a rule about it is one this compiler did not read)"),
+                report(ANSWERS_ONE));
+    }
+
+    private static String report(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).human(SourceNameResolver.identity());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/core/EveryTermCanBeReadWithoutItsPlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/core/EveryTermCanBeReadWithoutItsPlaceTest.java
@@ -50,7 +50,7 @@ class EveryTermCanBeReadWithoutItsPlaceTest {
             data Small = Int
                 invariant value > 0
 
-            data In  = { xs: List<Int>, s: String, k: Int, note: String? }
+            data In  = { xs: List<Int>, s: String, k: Int, note: String?, on: Date }
             data Out = { n: Int, label: String, pair: Int, kept: String? }
             data Bag = { items: List<Int> }
 
@@ -89,9 +89,10 @@ class EveryTermCanBeReadWithoutItsPlaceTest {
                 let picked = if Small(negated) as ok then ok.value else noted
                 let fs: List<(Int) -> Int> = [(x) -> x + 1, (x) -> x + 2]
                 let applied = all((f) -> f(i.k) > 0, fs)
+                let dated = if i.on < Date("2026-01-01") then 1 else 0
                 Out {
                     n = left + right + picked + length([1, 2, 3])
-                            + (if every then 1 else 0) + (if applied then 1 else 0),
+                            + (if every then 1 else 0) + (if applied then 1 else 0) + dated,
                     label = "fixed",
                     kept = "here",
                     pair = negated


### PR DESCRIPTION
Closes #855.

## What was wrong

`Date("2026-07-01")` reached the backend as a `Core.Call` — the shape an application has. Nothing on it said it was a value the source spelled out, so every reader that needed to tell one from a call worked it out, and each took whatever was in reach:

| reader | what it read | wrong for |
|---|---|---|
| `BodyGen` | the callee's rendered spelling, against the four temporals | any callee spelled `Date`/`Time`/`DateTime`/`Instant` |
| `Terms.asWrittenValue` | the type the call answered | any call answering a temporal over written arguments |
| the carrier reading | the answered type plus the shape of the argument | the same |

A model declaring `behavior Date : (s: String) -> String` and applying it compiled to `LocalDate.parse`, with the injected implementation stored in `$dep0` and never called. Where the shapes on the stack did not line up, what the author saw was an internal compiler error about their own model.

The checker was never in doubt: it gates on what the callee denotes and reads a spelling only behind that gate. What was missing is that its answer stopped there.

## What this does

A written temporal is a node. `Core.Temporal` holds the temporal and the ISO text, and its type is the temporal — one value, so the two cannot disagree. `CallElaborator` builds it where the call used to be built, chosen by `ValueName.Stdlib.constructs()`, now the one place that says what a library name applied constructs as against computes.

The four spellings are gone from `BodyGen` and `CallElaborator`, and `Terms.temporal(Type)` — the copy written as a type — with them. `parseTemporal` takes the temporal it parses rather than the spelling; the spelling was only ever what a report quotes.

`Carrier` reads the node instead of recognising the construction, so `constructedFrom` is gone. `FixtureReader` asks the same two questions of the same place: a fixture expression is never elaborated, so no node reaches it and it was answering for itself off `Type.Prim.named(reaches())` — the same wrong question one representation up.

## The sweep

The exhaustive switches caught the walking: `Core.atSlots`, `Core.withoutItsPlace`, `NormalReturn.of`, `CoverageSites.walk`, `BodyGen.genExpr` and `collectFree`, `Terms.naming`. They do not catch a reader that interprets, because each of those carries a default — and three of them were already answering about a temporal, wrongly:

- `Terms.isWritten` said a written date was not written, while `asWrittenValue` beside it wrote the same value back out
- `Terms.namedByRule` said a clause reading one reads nothing
- `Terms.shapeOf` called it an answer rather than a value

Each now says what it says of every other literal. The remaining `Core.Call` readers — `GrowingFold`, `Intrinsics`, `PathEngine`, `NumericMeasures` — were checked one by one; none had an arm a temporal ever entered.

## Since the first push

Rebased onto develop, which took #847 in the meantime. That change moved the carrier reading into `Carrier` and had already made it ask the denotation, so this branch replaces that recognition with the node and drops `constructedFrom`. `ALineDrawnOnADateIsALineTest` went red on the plain rebase — the reading no longer saw a written temporal at all — which is what found it.

Two review points taken, both about asking the wider question where the narrow one exists:

- `FixtureReader.states()` asks `constructs() != null` rather than `isNamespace()`, so `List(…)`/`Option(…)` are the calls they are. On measurement the two answers are indistinguishable, because the checker refuses a non-constructing namespace application before any fixture is read; the change is for the single answer, not for a symptom.
- `Carrier.temporal(Hir.Expr)` — the `Hir` counterpart, from #847 — asks `constructs()` for the same reason.

## Tests

`WhatBuildsATemporalIsWhatTheNameDenotesTest` fixes the three cases: the library namespace applied is a `Temporal`; a behavior spelled like it is a call and its own implementation is what runs; a behavior answering a temporal is a call that draws no line.

`EveryTermCanBeReadWithoutItsPlaceTest` reaches the new kind by writing one, rather than listing it beside `OptionNone` — a temporal is a kind sources write.

`CI=1 mvn -o -Plint verify` is green across all nine modules (5408 tests in the compiler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)