### PR TITLE
Say a rule went unread where the reading of ends gave up

### DIFF
--- a/docs/adr/0090-a-types-partition-is-the-equivalence-class-and-a-threshold-gives-the-boundary.md
+++ b/docs/adr/0090-a-types-partition-is-the-equivalence-class-and-a-threshold-gives-the-boundary.md
@@ -7,7 +7,8 @@ line is drawn on is a numeric *term*, not a position — the content of a locati
 one. Revised again for #622: which values a term's line can be drawn on is one table, and a rule
 written over values it does not hold is reported as unread rather than dropped. Revised again for
 #649: what decides whether a clause draws a line is which terms the clause reaches, not which
-declaration it is written on.
+declaration it is written on. Revised again for #868: a rule left unread is a rule about where the
+values stop, and is answered per rule rather than per position.
 
 ## Context
 
@@ -244,6 +245,26 @@ an invariant's bound did not, and a bound it dropped left the position looking l
 bounds — which at a position whose only rule was that bound made the report state the opposite of
 the declaration. The two producers now say it in the same words, because they answer the same
 question: this position was written about and this could not draw the line.
+
+That question is what the sentence covers, and it is narrower than every rule about the position. An
+ordering compared against something no end came out of is one of these. An equality names a value
+rather than an end, a denial takes one away, and a format, a membership or a quantifier says which
+values exist: none of them is a line, so none of them is a line that went unread. A report has
+nowhere to put one, and naming it would send an author after a boundary nobody wrote. What such a
+rule leaves open is which values stand at the position, which is another reading's question and is
+answered where that reading gives up.
+
+Which limit stopped a comparison is one answer for both producers and not a classification each of
+them makes. A relation asks for a class about two positions, a carrier nothing orders asks for that
+order, and what is left is a form this does not take apart — and whether a comparison is a relation
+is asked of what its sides *name*, however deeply. `x < y + 1` relates two positions as surely as
+`x < y` does. Read off whether a side *is* a position, the two producers gave one shape two
+different answers the moment they classified it apart.
+
+And it is asked per rule. A position carries more than one statement, so a line read at it says
+nothing about the rule beside it. Held as what a position is left with when nothing divides it, a
+bound on a field's own type answered for the record's clause about that same field, and two
+declarations differing by one bound said opposite things about the clause above them.
 
 An invariant's bound gives a boundary and not a partition: everything outside it is refused at
 construction, so there is no class on the far side to cover. A `guard`'s line has values on both

--- a/docs/adr/0090-a-types-partition-is-the-equivalence-class-and-a-threshold-gives-the-boundary.md
+++ b/docs/adr/0090-a-types-partition-is-the-equivalence-class-and-a-threshold-gives-the-boundary.md
@@ -261,6 +261,13 @@ is asked of what its sides *name*, however deeply. `x < y + 1` relates two posit
 `x < y` does. Read off whether a side *is* a position, the two producers gave one shape two
 different answers the moment they classified it apart.
 
+Two positions and not a position on each side. `x < x + 1` puts one on either side of the
+comparison and names one position, so there is no second one for a class to be about: what a reader
+would have to be given is a reading of the form. Asked as "does each side name something", both
+producers sent an author looking for a position the model never wrote — which is the distinction
+`Relates` already draws for the readings that turn a clause into values, held here too because it
+is the same question about the same shape.
+
 And it is asked per rule. A position carries more than one statement, so a line read at it says
 nothing about the rule beside it. Held as what a position is left with when nothing divides it, a
 bound on a field's own type answered for the record's clause about that same field, and two

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -61,7 +61,7 @@ public final class FieldDomains {
      * those is a reading that found no rules.
      */
     public static final FieldDomains NONE =
-            new FieldDomains(Map.of(), Map.of(), Map.of(), Map.of(), List.of(), Map.of(),
+            new FieldDomains(Map.of(), Map.of(), Map.of(), Map.of(), List.of(), List.of(), Map.of(),
                     new ReadingEvidence(), Map.of(), true, Set.of(THE_VALUE), NO_POSITIONS,
                     ConstraintState.top(), null, null, null, Map.of(), () -> true);
 
@@ -69,6 +69,9 @@ public final class FieldDomains {
     /** The ends the record's own clauses place, which is a different question from the range they
      * leave — see {@link #placedAt}. */
     private final List<InvariantChecker.Direct> directs;
+    /** The rules saying where a coordinate's values stop that no end came out of — see
+     * {@link #unreadAt}. */
+    private final List<Unread> unread;
     /** What each clause reaching this value raises, keyed on the rule it is. */
     private final Map<RuleRef, Required> raised;
     /** Which readings took each clause in, as each of them said so. */
@@ -113,7 +116,7 @@ public final class FieldDomains {
                          Map<String, NumericDomain.Bounds> heldByField,
                          Map<String, ValueSet> admittedByField,
                          Map<String, UnreadReason> unreadByField,
-                         List<InvariantChecker.Direct> directs,
+                         List<InvariantChecker.Direct> directs, List<Unread> unread,
                          Map<RuleRef, Required> raised, ReadingEvidence took,
                          Map<String, List<TypeSymbol>> narrowers,
                          boolean seeded, Set<String> notGathered,
@@ -126,6 +129,7 @@ public final class FieldDomains {
         this.admittedByField = admittedByField;
         this.unreadByField = unreadByField;
         this.directs = directs;
+        this.unread = unread;
         this.raised = raised;
         this.took = took;
         this.narrowers = narrowers;
@@ -287,7 +291,7 @@ public final class FieldDomains {
         positions.forEach(field ->
                 named(seeded, field).forEach(term -> placeOf.putIfAbsent(term, field)));
         return new FieldDomains(Map.copyOf(out), Map.copyOf(holds), Map.copyOf(admitted),
-                Map.copyOf(unread), seeded.reading().directs(),
+                Map.copyOf(unread), seeded.reading().directs(), seeded.reading().unread(),
                 seeded.reading().raised(), seeded.took(), seeded.reading().narrowers(),
                 seeded.everyClauseRead(), seeded.notGathered(), placeOf,
                 seeded.constraints(), named, data, symbols, settled,
@@ -316,6 +320,28 @@ public final class FieldDomains {
      */
     public record Placed(String path, boolean measured, RuleRef.Invariant from,
                          boolean lower, Endpoint end) {}
+
+    /**
+     * A rule about where one coordinate's values stop that this reading placed no end from, and
+     * what stopped it.
+     *
+     * <p>The other half of {@link Placed} and produced by the same reading of the same clause, which
+     * is what keeps the two from disagreeing about what a rule is. Read by a walk of its own, a
+     * second reader answered for the clauses on a position's own type and knew nothing of the ones
+     * written on the value it sits in — so a clause of a record was dropped without a word while a
+     * {@code guard} of the same shape named both the positions it compared (ADR-0090).
+     *
+     * <p>One per position the rule names, since a rule relating two coordinates is filed under
+     * neither of them alone.
+     *
+     * @param path where the coordinate sits, read from the value these are of
+     * @param from the rule that says where the values stop, which is what a reader is sent to look
+     *             at
+     * @param why  what would have to change before this rule could be a line, in this compiler's
+     *             own terms
+     */
+    public record Unread(String path, RuleRef.Invariant from,
+                         souther.compiler.inputs.BlockReason why) {}
 
     /**
      * The declaration whose clause could have moved where the coordinate at {@code path} stops, or
@@ -492,6 +518,19 @@ public final class FieldDomains {
     /** The ends the rules place on the coordinates at {@code path}, in the order they were read. */
     public List<Placed> placedAt(String path) {
         return placed().stream().filter(each -> each.path().equals(path)).toList();
+    }
+
+    /**
+     * The rules about where the coordinates at {@code path} stop that no end came out of, in the
+     * order they were read.
+     *
+     * <p>Beside {@link #placedAt} and not instead of it. A position carries more than one
+     * statement, so a rule here says nothing about whether an end was placed at the same position
+     * and an end there says nothing about this — read as one answer, a bound on a field's own type
+     * silenced the record's clause about the same field.
+     */
+    public List<Unread> unreadAt(String path) {
+        return unread.stream().filter(each -> each.path().equals(path)).toList();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantBound.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantBound.java
@@ -193,32 +193,6 @@ public record InvariantBound(boolean lower, Endpoint end) {
         return orders(op);
     }
 
-    /**
-     * Whether {@code clause} says where the value stops, however this reading turned out.
-     *
-     * <p>Two questions, and only the second was being asked. Whether a bound was read is
-     * {@link #of}'s; whether the model states one at all is this, and a caller with only the first
-     * answer reports "the model bounds this position no way" about a declaration two lines above it.
-     * A rule of another shape — a format, a quantifier over what the value holds — is not one of
-     * these: it says which values exist and not where they stop, and naming it as a line nothing read
-     * would send an author after a boundary nobody wrote.
-     *
-     * <p>An equality is not one either. It names a value rather than an end, is not read by
-     * {@link #of}, and a report has nowhere to put one — so saying it went unread would state an
-     * obligation that does not exist yet.
-     *
-     * @param measure the operation the number is taken by, or null where the number is the value
-     *                itself
-     */
-    public static boolean statesAnEnd(Hir.Expr clause, ValueName measure) {
-        if (!(clause instanceof Hir.Binary bin) || !orders(bin.op())) {
-            return false;
-        }
-        return measure == null
-                ? isValue(bin.left()) || isValue(bin.right())
-                : takesSizeOfValue(bin.left(), measure) || takesSizeOfValue(bin.right(), measure);
-    }
-
     /** Whether an operator says where values stop rather than which one a value is. */
     private static boolean orders(Hir.BinOp op) {
         return switch (op) {
@@ -246,18 +220,13 @@ public record InvariantBound(boolean lower, Endpoint end) {
     }
 
     /**
-     * Whether the expression is {@code measure} applied to the newtype's value.
+     * Whether {@code e} is {@code measure} applied to the named subject: {@code value} inside a
+     * newtype's rule, a field's name inside the rule of the record that has it.
      *
      * <p>Asked of the name the application resolved to, not of how it was spelled: an import lets a
      * library operation be written without its qualifier, and a reader comparing text would miss
      * every clause written that way while looking as though it had read them.
      */
-    private static boolean takesSizeOfValue(Hir.Expr e, ValueName measure) {
-        return takesSizeOf(e, measure, VALUE);
-    }
-
-    /** The same of a named subject: {@code value} inside a newtype's rule, a field's name inside the
-     * rule of the record that has it. */
     private static boolean takesSizeOf(Hir.Expr e, ValueName measure, String subject) {
         return e instanceof Hir.Apply call && call.args().size() == 1
                 && call.args().get(0) instanceof Hir.Var arg && arg.name().equals(subject)

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1056,30 +1056,43 @@ public final class InvariantChecker {
      * single position to be filed under, and both sides of it are positions this drew no line
      * through.
      *
-     * <p>Which limit stopped it is read the way a {@code guard}'s is. A comparison of two positions
-     * asks for a class that is about both, which a partition of one position is not. A position
-     * whose values carry no order to draw a line on asks for that order. What is left is a form
-     * this does not take apart — the position inside an expression the terms do not name, or a
-     * bound written as something other than a value written out.
+     * <p>Which limit stopped it is {@link UnreadComparison}'s, so a {@code guard} of this shape
+     * cannot come to a different answer. What is read here is only what each side of the comparison
+     * came to, which is this reader's own way of looking a coordinate up.
      */
     private void unreadEnds(Core.Binary comparison, RuleRef.Invariant from, Denotations at,
                             Map<FactSubject, Coordinate> byName, List<FieldDomains.Unread> out) {
         if (!InvariantBound.ordering(comparison.op())) {
             return;
         }
-        boolean between = Relates.twoPositions(comparison, e -> {
-            FactSubject named = nameOf(e, at);
-            return named != null && byName.containsKey(named) ? named : null;
-        });
+        BlockReason why = UnreadComparison.why(sideOf(comparison.left(), at, byName),
+                sideOf(comparison.right(), at, byName));
         for (Coordinate each : coordinatesIn(comparison, at, byName)) {
-            BlockReason why = between ? new BlockReason.ComparisonBetweenPositions()
-                    : each.carrier() == null ? new BlockReason.UnreadComparisonDomain()
-                            : new BlockReason.UnreadComparisonForm();
             FieldDomains.Unread said = new FieldDomains.Unread(each.path(), from, why);
             if (!out.contains(said)) {
                 out.add(said);
             }
         }
+    }
+
+    /**
+     * What one side of a comparison came to here.
+     *
+     * <p>Which coordinates it names is the recursive question and whether it <em>is</em> one is the
+     * narrower one, and the two are what tell a coordinate inside an expression from a coordinate.
+     * Asked the narrow question alone, {@code y + 1} named nothing and a clause relating two
+     * coordinates came back as a form nobody could read — which is the answer a {@code guard}
+     * writing the same comparison does not get.
+     */
+    private UnreadComparison.Side sideOf(Core e, Denotations at,
+                                         Map<FactSubject, Coordinate> byName) {
+        if (coordinatesIn(e, at, byName).isEmpty()) {
+            return new UnreadComparison.Side.NamesNothing();
+        }
+        FactSubject itself = nameOf(e, at);
+        Coordinate here = itself == null ? null : byName.get(itself);
+        return here == null ? new UnreadComparison.Side.HoldsOne()
+                : new UnreadComparison.Side.IsOne(here.carrier() != null);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1083,16 +1083,23 @@ public final class InvariantChecker {
      * Asked the narrow question alone, {@code y + 1} named nothing and a clause relating two
      * coordinates came back as a form nobody could read — which is the answer a {@code guard}
      * writing the same comparison does not get.
+     *
+     * <p>By the place and not by the name. A place answers to more than one name — a number is
+     * called one thing by the interval algebra and another by everything else — so two sides
+     * naming one place through two of its names would be a comparison against another position.
      */
-    private UnreadComparison.Side sideOf(Core e, Denotations at,
-                                         Map<FactSubject, Coordinate> byName) {
-        if (coordinatesIn(e, at, byName).isEmpty()) {
-            return new UnreadComparison.Side.NamesNothing();
+    private UnreadComparison.Side<String> sideOf(Core e, Denotations at,
+                                                 Map<FactSubject, Coordinate> byName) {
+        List<Coordinate> named = coordinatesIn(e, at, byName);
+        if (named.isEmpty()) {
+            return new UnreadComparison.Side.NamesNothing<>();
         }
         FactSubject itself = nameOf(e, at);
         Coordinate here = itself == null ? null : byName.get(itself);
-        return here == null ? new UnreadComparison.Side.HoldsOne()
-                : new UnreadComparison.Side.IsOne(here.carrier() != null);
+        return here == null
+                ? new UnreadComparison.Side.NamesInside<>(new LinkedHashSet<>(
+                        named.stream().map(Coordinate::path).toList()))
+                : new UnreadComparison.Side.IsOne<>(here.path(), here.carrier() != null);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -12,6 +12,7 @@ import souther.compiler.diag.msg.InvariantMessage;
 import souther.compiler.diag.msg.Message;
 import souther.compiler.diag.msg.Supporting;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.inputs.BlockReason;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
@@ -405,7 +406,8 @@ public final class InvariantChecker {
          *  every position, since nothing here knows which of them the rules were about. */
         static Seeded nothingRead() {
             return new Seeded(ConstraintState.top(), Map.of(), Map.of(), Map.of(),
-                    new Reading(List.of(), Map.of(), Map.of()), new ReadingEvidence(), false,
+                    new Reading(List.of(), List.of(), Map.of(), Map.of()), new ReadingEvidence(),
+                    false,
                     Set.of(FieldDomains.THE_VALUE));
         }
 
@@ -769,7 +771,15 @@ public final class InvariantChecker {
         void missed(String path);
     }
 
-    /** A coordinate a clause reaching this value could be about. */
+    /**
+     * A coordinate a clause reaching this value could be about.
+     *
+     * @param carrier what its values are ordered on, or null where nothing here draws a line on
+     *                them. Here rather than left out, because a coordinate is a coordinate whether
+     *                or not an end can be read on it: gated on having one, a rule written about a
+     *                position no line is drawn on named nothing, and the reading that could say so
+     *                had never heard of the position
+     */
     private record Coordinate(String path, boolean measured, Carrier carrier) {}
 
     /**
@@ -788,7 +798,8 @@ public final class InvariantChecker {
      *                  may have raised a question all the same, and a clause that placed one raised
      *                  more than the line. Nothing here says whether anything answered
      */
-    record Reading(List<Direct> directs, Map<String, List<TypeSymbol>> narrowers,
+    record Reading(List<Direct> directs, List<FieldDomains.Unread> unread,
+                   Map<String, List<TypeSymbol>> narrowers,
                    Map<RuleRef, Required> raised) {}
 
     private Reading directsIn(List<Written> stated, Denotations at,
@@ -798,26 +809,25 @@ public final class InvariantChecker {
         Map<FactSubject, Coordinate> byName = new LinkedHashMap<>();
         keys.forEach((path, key) -> {
             Carrier carrier = Carrier.ofValue(typeAt.get(path), symbols);
-            if (carrier != null) {
-                byName.put(key, new Coordinate(path, false, carrier));
-                FactSubject atom = atoms.get(path);
-                if (atom != null) {
-                    byName.put(atom, new Coordinate(path, false, carrier));
-                }
+            byName.put(key, new Coordinate(path, false, carrier));
+            FactSubject atom = atoms.get(path);
+            if (atom != null) {
+                byName.put(atom, new Coordinate(path, false, carrier));
             }
         });
         // A count is a whole number whatever it counts, so nothing about the container decides how
         // its sizes are spaced.
         held.forEach((path, atom) -> byName.put(atom, new Coordinate(path, true, Carrier.WHOLE)));
         List<Direct> out = new ArrayList<>();
+        List<FieldDomains.Unread> unread = new ArrayList<>();
         Map<String, List<TypeSymbol>> narrowers = new LinkedHashMap<>();
         Map<RuleRef, Required> raised = new LinkedHashMap<>();
         stated.forEach(each ->
-                direct(each.clause(), each.from(), at, byName, out, narrowers, raised, took,
+                direct(each.clause(), each.from(), at, byName, out, unread, narrowers, raised, took,
                         typeAt));
         // Insertion order, kept: `Map.copyOf` iterates in an order salted once per JVM run, and
         // what a report prints for a position is these in the order the declaration writes them.
-        return new Reading(List.copyOf(out), Map.copyOf(narrowers),
+        return new Reading(List.copyOf(out), List.copyOf(unread), Map.copyOf(narrowers),
                 java.util.Collections.unmodifiableMap(new LinkedHashMap<>(raised)));
     }
 
@@ -887,6 +897,7 @@ public final class InvariantChecker {
      */
     private void direct(Core clause, RuleRef.Invariant from, Denotations at,
                         Map<FactSubject, Coordinate> byName, List<Direct> out,
+                        List<FieldDomains.Unread> unread,
                         Map<String, List<TypeSymbol>> narrowers,
                         Map<RuleRef, Required> raised, ReadingEvidence took,
                         Map<String, Type> typeAt) {
@@ -896,8 +907,8 @@ public final class InvariantChecker {
         }
         if (bin.op() == Hir.BinOp.AND) {
             // One rule the author wrote, so what it raises is what its conjuncts raise together.
-            direct(bin.left(), from, at, byName, out, narrowers, raised, took, typeAt);
-            direct(bin.right(), from, at, byName, out, narrowers, raised, took, typeAt);
+            direct(bin.left(), from, at, byName, out, unread, narrowers, raised, took, typeAt);
+            direct(bin.right(), from, at, byName, out, unread, narrowers, raised, took, typeAt);
             return;
         }
         if (!InvariantBound.ordering(bin.op()) && bin.op() != Hir.BinOp.EQ) {
@@ -939,6 +950,18 @@ public final class InvariantChecker {
             case InvariantBound.Read.NoEnd _ -> states(bin, at, byName);
         }, at, byName, raised, took, typeAt);
         if (end instanceof InvariantBound.Read.NoEnd) {
+            // A rule saying where the values stop that no end came out of, said as that. Here,
+            // where the reading gave up, because this is the reading a report's line would have
+            // come from: the reading that turns clauses into sets of values has no word for a range
+            // and calls every bound unread, and the accounting beside it answers whether anything
+            // took the rule in — which a construction's discharge check does for a clause no line
+            // was drawn from. Neither of them is the question, and both were being asked it.
+            //
+            // Per rule and not per position, as a `guard`'s comparison already is (spec
+            // §example-partition). A position carries more than one statement, and an end read at
+            // it says nothing about the rule beside it: kept as what the position was left with,
+            // a bound on a field's own type swallowed the record's clause about the same field.
+            unreadEnds(bin, from, at, byName, unread);
             // The declaration and not the clause. Which declaration took an edge in is what ADR-0090
             // names beside a line, and what a reader is sent to look at is the declaration holding
             // the relation.
@@ -982,16 +1005,81 @@ public final class InvariantChecker {
      */
     private void namedIn(Core e, Denotations at, Map<FactSubject, Coordinate> byName,
                          List<Owed.Subject> out) {
-        FactSubject named = nameOf(e, at);
-        Coordinate here = named == null ? null : byName.get(named);
-        if (here != null) {
-            Owed.Subject where = Owed.Subject.at(here.path());
+        for (Coordinate each : coordinatesIn(e, at, byName)) {
+            Owed.Subject where = Owed.Subject.at(each.path());
             if (!out.contains(where)) {
                 out.add(where);
             }
+        }
+    }
+
+    /**
+     * The coordinates {@code e} names, one per place, in the order the walk meets them.
+     *
+     * <p>Where a place answers to more than one name — a number is called one thing by the interval
+     * algebra and another by everything else — the first is kept, which is the value's own
+     * coordinate rather than a count taken of it. What is asked of one of these afterwards is what
+     * its values are ordered on, and a count is ordered as a whole number whatever it counts.
+     */
+    private List<Coordinate> coordinatesIn(Core e, Denotations at,
+                                           Map<FactSubject, Coordinate> byName) {
+        List<Coordinate> out = new ArrayList<>();
+        coordinates(e, at, byName, out);
+        return out;
+    }
+
+    private void coordinates(Core e, Denotations at, Map<FactSubject, Coordinate> byName,
+                             List<Coordinate> out) {
+        FactSubject named = nameOf(e, at);
+        Coordinate here = named == null ? null : byName.get(named);
+        if (here != null) {
+            if (out.stream().noneMatch(had -> had.path().equals(here.path()))) {
+                out.add(here);
+            }
+            return;   // a coordinate names itself, and nothing under it is a coordinate of its own
+        }
+        Core.forEachChild(e, child -> coordinates(child, at, byName, out));
+    }
+
+    /**
+     * What one ordering comparison that placed no end leaves for a report to say, at each position
+     * it names.
+     *
+     * <p>Only an ordering. A rule of another shape — a format, a membership, an equality — says
+     * which values exist and not where they stop, so naming it as a line nothing read would send an
+     * author after a boundary nobody wrote; and an equality names a value rather than an end, which
+     * a report has nowhere to put — saying it went unread would state an obligation that does not
+     * exist yet.
+     *
+     * <p>One finding per position and not one per clause, because that is what a reader acts on and
+     * what a {@code guard}'s comparison already produces: a clause relating two coordinates has no
+     * single position to be filed under, and both sides of it are positions this drew no line
+     * through.
+     *
+     * <p>Which limit stopped it is read the way a {@code guard}'s is. A comparison of two positions
+     * asks for a class that is about both, which a partition of one position is not. A position
+     * whose values carry no order to draw a line on asks for that order. What is left is a form
+     * this does not take apart — the position inside an expression the terms do not name, or a
+     * bound written as something other than a value written out.
+     */
+    private void unreadEnds(Core.Binary comparison, RuleRef.Invariant from, Denotations at,
+                            Map<FactSubject, Coordinate> byName, List<FieldDomains.Unread> out) {
+        if (!InvariantBound.ordering(comparison.op())) {
             return;
         }
-        Core.forEachChild(e, child -> namedIn(child, at, byName, out));
+        boolean between = Relates.twoPositions(comparison, e -> {
+            FactSubject named = nameOf(e, at);
+            return named != null && byName.containsKey(named) ? named : null;
+        });
+        for (Coordinate each : coordinatesIn(comparison, at, byName)) {
+            BlockReason why = between ? new BlockReason.ComparisonBetweenPositions()
+                    : each.carrier() == null ? new BlockReason.UnreadComparisonDomain()
+                            : new BlockReason.UnreadComparisonForm();
+            FieldDomains.Unread said = new FieldDomains.Unread(each.path(), from, why);
+            if (!out.contains(said)) {
+                out.add(said);
+            }
+        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
@@ -1,0 +1,85 @@
+package souther.compiler.check;
+
+import souther.compiler.inputs.BlockReason;
+
+/**
+ * Why a comparison naming a position did not become a line.
+ *
+ * <p>One rule, asked by every reader that has to say so. A {@code guard}'s comparison and an
+ * invariant's clause are two producers of one kind of evidence (spec §example-partition), and what
+ * stopped each of them is the same fact about this compiler — so a reader of either is told the
+ * same thing (ADR-0090). Written twice, the two came apart at once: {@code x < y + 1} was a
+ * comparison between two positions where a body wrote it and a form nobody could read where a
+ * declaration did, which sends an author after two different pieces of work for one shape.
+ *
+ * <p>How a position is looked up stays with each reader, exactly as it does in {@link Relates}. One
+ * asks what a body's read of a parameter names, the other asks what a clause's coordinate is
+ * called; neither is the other's business. What is here is what the answers come to, which is the
+ * part that has to agree.
+ */
+public final class UnreadComparison {
+
+    /**
+     * What one side of a comparison came to, as the reader that looked it up found it.
+     *
+     * <p>Three cases and not a pair of flags. Whether the position this side names carries an order
+     * is a question only about a side that is a position, and a reader handing over an answer for a
+     * side that names none would be filling in a field that stands for nothing.
+     */
+    public sealed interface Side {
+
+        /** Nothing here is one of the positions being read for. */
+        record NamesNothing() implements Side {}
+
+        /**
+         * A position is named from inside an expression this reader does not take apart:
+         * {@code Int.add(length, width)}, {@code p.x + 1}.
+         *
+         * <p>What is missing is a reading of the form. Nothing is known about the order under the
+         * position from here — the expression is what was not read — so nothing about it is said.
+         */
+        record HoldsOne() implements Side {}
+
+        /**
+         * This side is the position itself, or a number taken of it.
+         *
+         * @param ordered whether a line can be drawn on what that position carries, asked of the
+         *                carrier
+         */
+        record IsOne(boolean ordered) implements Side {}
+    }
+
+    /**
+     * What would have to change before this comparison could be a line.
+     *
+     * <p>Three different things, and a reader told one sentence for all of them cannot tell which
+     * limit is theirs to wait on. A comparison between two positions asks for a class that is about
+     * both, which a partition of one position is not. One on a carrier nothing draws a line on asks
+     * for that carrier. What is left is a form this does not read — the position inside an
+     * expression the terms do not name, or a threshold written as something other than a constant.
+     *
+     * <p>Two positions is asked of what the sides <em>name</em>, however deeply, and not of what
+     * they are. That is as true of {@code x < y + 1} as of {@code x < y}: reading it off whether a
+     * side is a position loses the second position entirely and answers with the form.
+     */
+    public static BlockReason why(Side left, Side right) {
+        if (!(left instanceof Side.NamesNothing) && !(right instanceof Side.NamesNothing)) {
+            return new BlockReason.ComparisonBetweenPositions();
+        }
+        return switch (left instanceof Side.NamesNothing ? right : left) {
+            // The position itself against something no end came out of. The carrier, asked of the
+            // carrier: `at < DateTime(...)` stops because nothing draws a line on a date-time,
+            // while `p.x < 1 + 2` stops because the other side is not a form a threshold is read
+            // out of and `p.x` is an `Int` — a carrier lines are drawn on all through the file.
+            case Side.IsOne one -> one.ordered() ? new BlockReason.UnreadComparisonForm()
+                    : new BlockReason.UnreadComparisonDomain();
+            case Side.HoldsOne _ -> new BlockReason.UnreadComparisonForm();
+            // Neither side names a position. Nothing is filed under this — a reason is said at the
+            // positions the comparison names, and it names none — so what is answered is only that
+            // no capability is owed on its account.
+            case Side.NamesNothing _ -> new BlockReason.UnreadComparisonForm();
+        };
+    }
+
+    private UnreadComparison() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
@@ -2,6 +2,9 @@ package souther.compiler.check;
 
 import souther.compiler.inputs.BlockReason;
 
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 /**
  * Why a comparison naming a position did not become a line.
  *
@@ -16,6 +19,10 @@ import souther.compiler.inputs.BlockReason;
  * asks what a body's read of a parameter names, the other asks what a clause's coordinate is
  * called; neither is the other's business. What is here is what the answers come to, which is the
  * part that has to agree.
+ *
+ * <p>What a position is called travels with the answers and is never read here, only compared with
+ * another of its own. So the readers may hold a position under whatever name each of them uses and
+ * still be held to one rule.
  */
 public final class UnreadComparison {
 
@@ -25,20 +32,39 @@ public final class UnreadComparison {
      * <p>Three cases and not a pair of flags. Whether the position this side names carries an order
      * is a question only about a side that is a position, and a reader handing over an answer for a
      * side that names none would be filling in a field that stands for nothing.
+     *
+     * <p>Each carries which positions it named and not only that it named some. Which two positions
+     * a comparison is between is the question the rule below asks, and a side that answered only
+     * "one of them is in here" made {@code x < x + 1} a rule about {@code x} and something else.
      */
-    public sealed interface Side {
+    public sealed interface Side<K> {
+
+        /** The positions this side names, in the order the reader met them. */
+        Set<K> positions();
 
         /** Nothing here is one of the positions being read for. */
-        record NamesNothing() implements Side {}
+        record NamesNothing<K>() implements Side<K> {
+
+            @Override
+            public Set<K> positions() {
+                return Set.of();
+            }
+        }
 
         /**
-         * A position is named from inside an expression this reader does not take apart:
+         * Positions are named from inside an expression this reader does not take apart:
          * {@code Int.add(length, width)}, {@code p.x + 1}.
          *
-         * <p>What is missing is a reading of the form. Nothing is known about the order under the
-         * position from here — the expression is what was not read — so nothing about it is said.
+         * <p>However many of them. What is missing is a reading of the form, and nothing is known
+         * about the order under any position from here — the expression is what was not read — so
+         * nothing about that is said.
          */
-        record HoldsOne() implements Side {}
+        record NamesInside<K>(Set<K> positions) implements Side<K> {
+
+            public NamesInside {
+                positions = java.util.Collections.unmodifiableSet(new LinkedHashSet<>(positions));
+            }
+        }
 
         /**
          * This side is the position itself, or a number taken of it.
@@ -46,7 +72,13 @@ public final class UnreadComparison {
          * @param ordered whether a line can be drawn on what that position carries, asked of the
          *                carrier
          */
-        record IsOne(boolean ordered) implements Side {}
+        record IsOne<K>(K position, boolean ordered) implements Side<K> {
+
+            @Override
+            public Set<K> positions() {
+                return Set.of(position);
+            }
+        }
     }
 
     /**
@@ -61,23 +93,32 @@ public final class UnreadComparison {
      * <p>Two positions is asked of what the sides <em>name</em>, however deeply, and not of what
      * they are. That is as true of {@code x < y + 1} as of {@code x < y}: reading it off whether a
      * side is a position loses the second position entirely and answers with the form.
+     *
+     * <p>And of <em>another</em> position, not of a position on each side ({@link Relates}).
+     * {@code x < x + 1} has a position on both sides and one position, so there is no second one
+     * for a class to be about — what a reader would have to be given is a reading of the form, and
+     * being sent after a relation sends them looking for a position the model never wrote.
      */
-    public static BlockReason why(Side left, Side right) {
-        if (!(left instanceof Side.NamesNothing) && !(right instanceof Side.NamesNothing)) {
+    public static <K> BlockReason why(Side<K> left, Side<K> right) {
+        Set<K> named = new LinkedHashSet<>(left.positions());
+        named.addAll(right.positions());
+        if (!left.positions().isEmpty() && !right.positions().isEmpty() && named.size() > 1) {
             return new BlockReason.ComparisonBetweenPositions();
         }
-        return switch (left instanceof Side.NamesNothing ? right : left) {
+        // The side that names one, and the left where both do — which is the side a threshold would
+        // be read off. What is left over there is then what the coordinate was compared against.
+        return switch (left.positions().isEmpty() ? right : left) {
             // The position itself against something no end came out of. The carrier, asked of the
             // carrier: `at < DateTime(...)` stops because nothing draws a line on a date-time,
             // while `p.x < 1 + 2` stops because the other side is not a form a threshold is read
             // out of and `p.x` is an `Int` — a carrier lines are drawn on all through the file.
-            case Side.IsOne one -> one.ordered() ? new BlockReason.UnreadComparisonForm()
+            case Side.IsOne<K> one -> one.ordered() ? new BlockReason.UnreadComparisonForm()
                     : new BlockReason.UnreadComparisonDomain();
-            case Side.HoldsOne _ -> new BlockReason.UnreadComparisonForm();
+            case Side.NamesInside<K> _ -> new BlockReason.UnreadComparisonForm();
             // Neither side names a position. Nothing is filed under this — a reason is said at the
             // positions the comparison names, and it names none — so what is answered is only that
             // no capability is owed on its account.
-            case Side.NamesNothing _ -> new BlockReason.UnreadComparisonForm();
+            case Side.NamesNothing<K> _ -> new BlockReason.UnreadComparisonForm();
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -4,12 +4,9 @@ import souther.compiler.ast.Hir;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.DeclaredBounds;
 import souther.compiler.check.FieldDomains;
-import souther.compiler.check.ClauseHelpers;
-import souther.compiler.check.InvariantBound;
 import souther.compiler.check.NumericMeasures;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
-import souther.compiler.check.TypeOps;
 import souther.compiler.check.TypeView;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.types.BindingId;
@@ -244,7 +241,7 @@ public final class InputDomain {
         // own type draws a line, because a clause relating two fields is not a partition of one.
         NumericDomain.Bounds admissible = nothingExists ? null
                 : TypeBounds.admissible(own, projected, term);
-        List<UnreadRule> unread = unreadBoundsAt(path, type, symbols, carried, taken);
+        List<UnreadRule> unread = unreadRulesAt(placed, path);
 
         List<Case> declared = Distinctions.ofType(view, symbols);
         ReadingResult reading = crossed(declared, view, admissible, admitted, symbols, unread,
@@ -353,77 +350,30 @@ public final class InputDomain {
     }
 
     /**
-     * The rules on this position's own type that say where its value stops and that nothing here
-     * turned into an end.
+     * The rules saying where this position's values stop that nothing turned into an end.
      *
      * <p>The invariant's half of what a {@code guard}'s comparison is asked. Both draw lines
      * (ADR-0090) and both can be written in a form this does not read, and only one of them was
      * saying so — a bound it dropped left the position looking like one no rule bounds, which is
      * what the declaration above it denies.
      *
-     * @param carried what the value is read on, or null where nothing here draws a line on it
-     * @param measure the operation a number is taken by, or null where none is
+     * <p>Read off the one reading that draws lines from clauses ({@link FieldDomains#unreadAt}) and
+     * not walked again here. A second walk over the position's own type answered for the clauses
+     * written on it and knew nothing of the clauses written on the value it sits in, so a record's
+     * rule about one of its fields was dropped in silence; and where both had something to say
+     * about one clause, the report printed two causes for it.
+     *
+     * <p>One line per reason, as a {@code guard}'s comparison is. Two clauses stopped by the same
+     * limit are one thing for a reader to lift; two stopped by different limits are two.
      */
-    private static List<UnreadRule> unreadBoundsAt(TermPath path, Type type, Symbols symbols,
-                                                   Carrier carried, ValueName measure) {
+    private static List<UnreadRule> unreadRulesAt(PlacedRules placed, TermPath path) {
         List<UnreadRule> out = new ArrayList<>();
-        for (TypeOps.Layer layer : TypeOps.newtypeChain(type, symbols)) {
-            for (Hir.InvariantClause clause : TypeOps.effectiveInvariants(layer.data(), symbols)) {
-                for (Hir.Expr each : ClauseHelpers.conjunctsOf(clause.expr())) {
-                    BlockReason why = whyUnread(each, carried, measure);
-                    // Once per position, as a comparison is: what a reader has to lift is the first
-                    // limit in the way, and a second clause behind it says nothing further.
-                    if (why != null && out.isEmpty()) {
-                        out.add(new UnreadRule(path, why));
-                    }
-                }
+        for (FieldDomains.Unread each : placed.unreadAt(path)) {
+            UnreadRule said = new UnreadRule(path, each.why());
+            if (!out.contains(said)) {
+                out.add(said);
             }
         }
         return List.copyOf(out);
-    }
-
-    /** What stopped one clause from being an end, or null where nothing did — either because it was
-     * read, or because it is not a rule about where the value stops. */
-    private static BlockReason whyUnread(Hir.Expr clause, Carrier carried, ValueName measure) {
-        if (InvariantBound.statesAnEnd(clause, null)) {
-            if (carried == null) {
-                // The value is ordered — it is compared in the clause — and this reads no line on
-                // what carries it. The carrier, asked of the carrier, as a guard's is.
-                return new BlockReason.UnreadComparisonDomain();
-            }
-            return unreadFormOf(InvariantBound.of(clause, carried), true);
-        }
-        if (measure != null && InvariantBound.statesAnEnd(clause, measure)) {
-            // A size is a whole number whatever it is a size of, so nothing here is about a carrier.
-            // And nothing takes a size's ends into the reading that refuses a declaration for
-            // holding no value: that reading is over the positions a value has, and a size is a
-            // number taken of one. So a size bound past the end of the whole numbers is a rule this
-            // report is the only reader of, and going quiet about it would leave it unsaid
-            // everywhere.
-            return unreadFormOf(InvariantBound.ofSize(clause, measure), false);
-        }
-        return null;
-    }
-
-    /**
-     * What a reading of an ordered rule leaves for the report to say about it.
-     *
-     * <p>Nothing where an end was read. A rule stating an end past the last value of the order is
-     * the case the two callers differ on, and what settles it is whether anything else says
-     * something about such a rule: where the declaration is refused for holding no value, this
-     * report is never produced and naming the rule as one nothing could read would send an author
-     * after a bound the compiler understood perfectly; where nothing refuses it, this is its only
-     * reader and silence is the rule going unsaid.
-     *
-     * @param refusedElsewhere whether a rule stating an end past the end of the order is taken into
-     *                         the reading that refuses a declaration for holding no value
-     */
-    private static BlockReason unreadFormOf(InvariantBound.Read read, boolean refusedElsewhere) {
-        return switch (read) {
-            case InvariantBound.Read.AnEnd _ -> null;
-            case InvariantBound.Read.PastWhereTheOrderStops _ ->
-                    refusedElsewhere ? null : new BlockReason.UnreadComparisonForm();
-            case InvariantBound.Read.NoEnd _ -> new BlockReason.UnreadComparisonForm();
-        };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
@@ -105,6 +105,17 @@ record PlacedRules(TypeSymbol value, Rules rules) {
                 : bounds().placedAt(String.join(".", path.fields()));
     }
 
+    /**
+     * The rules saying where the coordinate at {@code path} stops that no end came out of.
+     *
+     * <p>At every path the value has, its own included — unlike {@link #placedAt}, whose empty
+     * answer at the root is what the type's own reading already gives. A rule nothing could read is
+     * not given twice by anybody, and a newtype's own clause is where the question started.
+     */
+    List<FieldDomains.Unread> unreadAt(TermPath path) {
+        return bounds().unreadAt(String.join(".", path.fields()));
+    }
+
     /** Which declarations' clauses are holding the end at {@code path}, on the side asked for. */
     List<TypeSymbol> narrowedBy(TermPath path, boolean lower) {
         return path.fields().isEmpty() ? List.of()

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
@@ -161,7 +161,19 @@ public sealed interface Position permits ReadPosition {
      */
     BlockReason valuesUnread();
 
-    /** The rules written about this position that the reading could not turn into an end. */
+    /**
+     * The rules written about this position that the reading of ends could not turn into one.
+     *
+     * <p>Whichever value they are written on: a clause of this position's own type and a clause of
+     * the value it sits in are two ways of saying where its values stop, and both come from the one
+     * reading that draws lines from clauses.
+     *
+     * <p>Beside whatever the position is otherwise left with and not folded into it. A position
+     * carries more than one statement, so an end read at it says nothing about the rule beside it —
+     * kept as what the position was left with if nothing divided it, a bound on a field's own type
+     * answered for the record's clause about the same field, and the clause was dropped in silence
+     * (issue #868).
+     */
     List<UnreadRule> unreadRules();
 
     /** Whether the position is made of positions, and what it is left with if nothing answers for

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -223,13 +223,21 @@ public final class GuardThresholds {
      * position inside an expression from a position. Asked the narrow question alone,
      * {@code y + 1} named nothing and a comparison of two positions came back as a form nobody
      * could read.
+     *
+     * <p>The positions come from the one walk either way. Read again off the term where there is
+     * one, a side would be carrying two answers to "which position is this about" and the
+     * comparison between them would be settled by whichever the caller looked at.
      */
-    private static UnreadComparison.Side sideOf(Core e, InputReads reads, Symbols symbols) {
-        if (mentionedIn(e, reads, symbols).isEmpty()) {
-            return new UnreadComparison.Side.NamesNothing();
+    private static UnreadComparison.Side<TermPath> sideOf(Core e, InputReads reads,
+                                                          Symbols symbols) {
+        List<TermPath> named = mentionedIn(e, reads, symbols);
+        if (named.isEmpty()) {
+            return new UnreadComparison.Side.NamesNothing<>();
         }
-        return termOf(e, reads, symbols) == null ? new UnreadComparison.Side.HoldsOne()
-                : new UnreadComparison.Side.IsOne(orderable(e.type(), symbols));
+        return termOf(e, reads, symbols) == null
+                ? new UnreadComparison.Side.NamesInside<>(new java.util.LinkedHashSet<>(named))
+                : new UnreadComparison.Side.IsOne<>(named.getFirst(),
+                        orderable(e.type(), symbols));
     }
 
     static List<TermPath> mentionedIn(Core e, InputReads reads, Symbols symbols) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -5,6 +5,7 @@ import souther.compiler.check.Location;
 import souther.compiler.check.NumericMeasures;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.RuleRef;
+import souther.compiler.check.UnreadComparison;
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.InputReads;
@@ -203,36 +204,32 @@ public final class GuardThresholds {
     /**
      * What would have to change before this comparison could be a line.
      *
-     * <p>Three different things, and a reader told one sentence for all of them cannot tell which
-     * limit is theirs to wait on. A comparison between two positions asks for a class that is about
-     * both, which a partition of one position is not. One on a carrier nothing draws a line on asks
-     * for that carrier. What is left is a form this does not read — the position inside an
-     * expression the terms do not name, or a threshold written as something other than a constant —
-     * and each of the three is a different piece of work.
+     * <p>{@link UnreadComparison}'s, which is where the answer is so that an invariant's clause of
+     * the same shape gets the same one. What is this reader's own is how a position is looked up:
+     * a body's read of a parameter is what names one here, and a coordinate of a value is what
+     * names one over there.
      */
     static BlockReason why(Core.Binary comparison, InputReads reads,
                            Symbols symbols) {
-        boolean leftNames = !mentionedIn(comparison.left(), reads, symbols).isEmpty();
-        boolean rightNames = !mentionedIn(comparison.right(), reads, symbols).isEmpty();
-        // Which limit stopped this is asked of what the sides name, not of how far the derivation
-        // got. Two positions against each other is a rule about both of them and a class here is a
-        // set of values of one — and that is as true of `x < y + 1` as of `x < y`, where reading it
-        // off the derivation loses the second position entirely and answers with the carrier.
-        if (leftNames && rightNames) {
-            return new BlockReason.ComparisonBetweenPositions();
+        return UnreadComparison.why(sideOf(comparison.left(), reads, symbols),
+                sideOf(comparison.right(), reads, symbols));
+    }
+
+    /**
+     * What one side of a comparison came to here.
+     *
+     * <p>Which positions it names is {@link #mentioned}'s recursive question and which number a
+     * line could be drawn on is {@link #termOf}'s narrower one, and the two are what tell a
+     * position inside an expression from a position. Asked the narrow question alone,
+     * {@code y + 1} named nothing and a comparison of two positions came back as a form nobody
+     * could read.
+     */
+    private static UnreadComparison.Side sideOf(Core e, InputReads reads, Symbols symbols) {
+        if (mentionedIn(e, reads, symbols).isEmpty()) {
+            return new UnreadComparison.Side.NamesNothing();
         }
-        Core named = leftNames ? comparison.left() : comparison.right();
-        if (termOf(named, reads, symbols) == null) {
-            return new BlockReason.UnreadComparisonForm();   // the position is inside something
-        }
-        // The carrier, asked of the carrier. `at < DateTime(...)` stops because nothing draws a line
-        // on a date-time; `p.x < 1 + 2` stops because the other side is not a form a threshold is
-        // read out of, and `p.x` is an `Int` — a carrier lines are drawn on all through the file.
-        // Reading this off the side that did name a position calls the second one a carrier problem
-        // and sends an author after a domain that is already there.
-        return orderable(named.type(), symbols)
-                ? new BlockReason.UnreadComparisonForm()
-                : new BlockReason.UnreadComparisonDomain();
+        return termOf(e, reads, symbols) == null ? new UnreadComparison.Side.HoldsOne()
+                : new UnreadComparison.Side.IsOne(orderable(e.type(), symbols));
     }
 
     static List<TermPath> mentionedIn(Core e, InputReads reads, Symbols symbols) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -716,7 +716,7 @@ public final class Partitions {
                     case StructuralInspection.Pending pending ->
                             out.add(Axis.pendingAt(id, term, position.type(),
                                     position.unansweredQuestions(), position.rulesNotReached(), pending,
-                                    position.valuesUnread()));
+                                    leftUnread(position)));
                 }
             }
         }
@@ -724,6 +724,22 @@ public final class Partitions {
 
 
 
+
+    /**
+     * What a position with no evidence is left with, where an absence may not be concluded from it.
+     *
+     * <p>The end reading's answer ahead of the value reading's, where both have one. A rule this
+     * read for a line and could not use is the nearer of the two: lifting that limit is what would
+     * give the position an axis, and the reading that turns clauses into sets of values has no word
+     * for a range at all — so it names one limit while the report's own line names another, and one
+     * position came back with two causes for one clause.
+     *
+     * <p>The first, as a comparison's is. What a reader has to lift is the first limit in the way.
+     */
+    private static BlockReason leftUnread(Position position) {
+        return position.unreadRules().isEmpty() ? position.valuesUnread()
+                : position.unreadRules().getFirst().why();
+    }
 
     // --- small helpers ----------------------------------------------------------------------------
 

--- a/souther-compiler/src/test/java/souther/compiler/AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest.java
@@ -1,0 +1,157 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The same rule, written as an {@code invariant} and as a {@code guard}, reported the same way.
+ *
+ * <p>ADR-0090's promise: a rule this could not read is named, whichever rule it was. The two
+ * behaviors below compare the same arithmetic form over two positions — one in a declaration, one
+ * in a body — and a reader is owed the same sentence about both.
+ *
+ * <p>Issue #868. The {@code invariant}'s half was silent, and what silenced it was that its fields
+ * carry a bound of their own: the account was kept as what a position was left with if nothing
+ * divided it, so a line read from one rule answered for the rule beside it. A reader was left with
+ * a model whose only stated rule about {@code length} looked like the one on {@code Cm}.
+ */
+class AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest {
+
+    private static final String MODEL = """
+            module example.parcels
+
+            data Cm = Int
+                invariant value >= 0
+
+            data Parcel = { length: Cm, width: Cm }
+                invariant Int.add(length.value, width.value) <= 150
+
+            data Order = { straw: Cm, choco: Cm }
+
+            data Ok
+            data No
+
+            behavior quote : (parcel: Parcel) -> Ok | No
+                constructs Ok
+            let quote (parcel) = Ok
+
+            behavior mix : (order: Order) -> Ok | No
+                constructs Ok, No
+            let mix (order) =
+                if Int.add(order.straw.value, order.choco.value) <= 150 then Ok else No
+            """;
+
+    private static String blockOf(String behavior) {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        String human = AdequacyReport.of(compilation).human(SourceNameResolver.identity());
+        StringBuilder block = new StringBuilder();
+        boolean inside = false;
+        for (String line : human.split("\n", -1)) {
+            if (line.startsWith("  ") && !line.startsWith("   ")) {
+                inside = line.startsWith("  " + behavior + " ");
+            }
+            if (inside) {
+                block.append(line).append('\n');
+            }
+        }
+        return block.toString();
+    }
+
+    /** The {@code guard}, which always said it, at both the positions it compares. */
+    @Test
+    void aGuardNamesBothPositionsItCompares() {
+        String block = blockOf("mix");
+
+        assertTrue(block.contains("not read: order.straw"), block);
+        assertTrue(block.contains("not read: order.choco"), block);
+    }
+
+    /** And the {@code invariant} of the same shape, at both the positions it compares. */
+    @Test
+    void andSoDoesAnInvariantOfTheSameShape() {
+        String block = blockOf("quote");
+
+        assertTrue(block.contains("not read: parcel.length"), block);
+        assertTrue(block.contains("not read: parcel.width"), block);
+    }
+
+    /** In the same words, since what stopped each of them is the same fact about this compiler. */
+    @Test
+    void andInTheSameWords() {
+        assertEquals(saidAbout(blockOf("mix"), "order.straw"),
+                saidAbout(blockOf("quote"), "parcel.length"));
+    }
+
+    /**
+     * And the line the fields' own type draws is still drawn.
+     *
+     * <p>The rule beside it went unread; this one did not. A reading that answered the pair with
+     * one verdict would have taken the boundary with it.
+     */
+    @Test
+    void andTheBoundTheFieldsOwnTypeStatesIsStillALine() {
+        String block = blockOf("quote");
+
+        assertTrue(block.contains("boundary    0/0   (2 not measured"), block);
+    }
+
+    /** One clause and one sentence: what a reader has to lift is one thing. */
+    @Test
+    void andOnceEach() {
+        String block = blockOf("quote");
+
+        assertEquals(1, block.lines().filter(line -> line.contains("not read: parcel.length")).count(),
+                block);
+    }
+
+    /**
+     * And one clause is one sentence, whichever reading of it gave up first.
+     *
+     * <p>A rule about a position no line can be drawn on is a rule the end reading refuses for one
+     * cause and the value reading for another. Read off both, the report printed two lines about
+     * one clause naming two different limits — a reader cannot act on that, and only one of them is
+     * what would give the position an axis.
+     */
+    @Test
+    void andOnceWhereTwoReadingsBothGaveUpOnTheSameClause() {
+        Compilation compilation = Compilation.ofSource("""
+                module example.stages
+
+                data Prospecting
+                data Qualified
+                data Won
+                data Stage = Prospecting | Qualified | Won
+
+                data AtLeastQualified = Qualified
+                    invariant value >= Prospecting
+
+                data Ok
+
+                behavior stage : (q: AtLeastQualified) -> Ok
+                    constructs Ok
+                let stage (q) = Ok
+                """, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        String human = AdequacyReport.of(compilation).human(SourceNameResolver.identity());
+
+        assertEquals(1, human.lines().filter(line -> line.contains("not read: q ")).count(), human);
+        assertTrue(human.contains("no line can be drawn on"), human);
+    }
+
+    private static String saidAbout(String block, String position) {
+        return block.lines().filter(line -> line.contains("not read: " + position + " "))
+                .map(line -> line.substring(line.indexOf('(')))
+                .findFirst().orElseThrow(() -> new AssertionError(
+                        "nothing said about `" + position + "`: " + block));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest.java
@@ -8,6 +8,7 @@ import souther.compiler.query.Compilation;
 import souther.compiler.report.AdequacyReport;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -59,6 +60,17 @@ class AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest {
             behavior byGuard : (b: Bare) -> Ok | No
                 constructs Ok, No
             let byGuard (b) = if b.x < b.y + 1 then Ok else No
+
+            data Sole = { x: Int }
+                invariant x < x + 1
+
+            behavior byRuleAboutOne : (s: Sole) -> Ok | No
+                constructs Ok
+            let byRuleAboutOne (s) = Ok
+
+            behavior byGuardAboutOne : (b: Bare) -> Ok | No
+                constructs Ok, No
+            let byGuardAboutOne (b) = if b.x < b.x + 1 then Ok else No
             """;
 
     private static String blockOf(String behavior) {
@@ -118,6 +130,24 @@ class AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest {
         assertEquals(saidAbout(blockOf("byGuard"), "b.x"),
                 saidAbout(blockOf("byRule"), "p.x"));
         assertTrue(blockOf("byRule").contains("relates it to another position"), blockOf("byRule"));
+    }
+
+    /**
+     * And neither of them says "another position" where there is only one.
+     *
+     * <p>{@code x < x + 1} puts a position either side of the comparison and names one position.
+     * Both readers had been answering it off whether each side names any position at all, so both
+     * sent a reader looking for a second one the model never wrote — the {@code guard} for as long
+     * as it has been reading comparisons.
+     */
+    @Test
+    void andNeitherNamesASecondPositionWhereThereIsOnlyOne() {
+        String rule = blockOf("byRuleAboutOne");
+        String guard = blockOf("byGuardAboutOne");
+
+        assertFalse(rule.contains("another position"), rule);
+        assertFalse(guard.contains("another position"), guard);
+        assertEquals(saidAbout(guard, "b.x"), saidAbout(rule, "s.x"));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest.java
@@ -46,6 +46,19 @@ class AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest {
                 constructs Ok, No
             let mix (order) =
                 if Int.add(order.straw.value, order.choco.value) <= 150 then Ok else No
+
+            data Pair = { x: Int, y: Int }
+                invariant x < y + 1
+
+            data Bare = { x: Int, y: Int }
+
+            behavior byRule : (p: Pair) -> Ok | No
+                constructs Ok
+            let byRule (p) = Ok
+
+            behavior byGuard : (b: Bare) -> Ok | No
+                constructs Ok, No
+            let byGuard (b) = if b.x < b.y + 1 then Ok else No
             """;
 
     private static String blockOf(String behavior) {
@@ -89,6 +102,22 @@ class AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest {
     void andInTheSameWords() {
         assertEquals(saidAbout(blockOf("mix"), "order.straw"),
                 saidAbout(blockOf("quote"), "parcel.length"));
+    }
+
+    /**
+     * And in the same words for a comparison with one position on each side.
+     *
+     * <p>{@code x < y + 1}, which is the form between the two the pair above holds. The arithmetic
+     * is on the far side of a relation rather than in place of it, so the answer is that the rule
+     * relates two positions — and it has to be that answer on both sides of the language, since the
+     * work a reader is being sent to do is a class about two positions in one case and a reader for
+     * a form in the other.
+     */
+    @Test
+    void andForAComparisonWithOnePositionOnEachSide() {
+        assertEquals(saidAbout(blockOf("byGuard"), "b.x"),
+                saidAbout(blockOf("byRule"), "p.x"));
+        assertTrue(blockOf("byRule").contains("relates it to another position"), blockOf("byRule"));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest.java
@@ -191,9 +191,14 @@ class ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest {
      * order and typechecks — and the sum's places are not its own, so no line divides it. The
      * carrier, asked of the carrier, exactly as a {@code guard} comparing the same field is
      * answered.
+     *
+     * <p>The clause reaches the reading of ends all the same, which is what lets it be answered
+     * for: a coordinate is a coordinate whether or not a line can be drawn on it. So the second
+     * assertion is the one that matters — reading an end here would put a line through a position
+     * that has no order to draw one on.
      */
     @Test
-    void aPositionNoLineCanBeDrawnOnSaysThat() {
+    void aPositionNoLineCanBeDrawnOnSaysThatAndIsGivenNoEnd() {
         FieldDomains read = readingOf("""
                 module example.stages
 
@@ -207,6 +212,7 @@ class ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest {
                 """, "Holder");
 
         assertEquals(List.of(new BlockReason.UnreadComparisonDomain()), reasonsAt(read, "stage"));
+        assertEquals(List.of(), read.placedAt("stage"), "no line is drawn where no order is");
     }
 
     /** And a newtype's own clause reaches the same account, at the position a name wraps. */

--- a/souther-compiler/src/test/java/souther/compiler/check/ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest.java
@@ -185,6 +185,29 @@ class ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest {
     }
 
     /**
+     * And a clause naming one coordinate on each side is one of those, however the sides are
+     * written.
+     *
+     * <p>The form between the two above: {@code x} against {@code y + 1} is a rule about the pair
+     * exactly as {@code x < y} is, and the arithmetic is on the far side of the relation rather
+     * than in place of it. Read off whether a side <em>is</em> a coordinate, {@code y + 1} named
+     * nothing and this came back as a form nobody could read — which is not what a {@code guard}
+     * writing the same comparison is told.
+     */
+    @Test
+    void andSoDoesOneWhereTheSecondPositionIsInsideAnExpression() {
+        FieldDomains read = readingOf("""
+                module example.spans
+
+                data Pair = { x: Int, y: Int }
+                    invariant x < y + 1
+                """, "Pair");
+
+        assertEquals(List.of(new BlockReason.ComparisonBetweenPositions()), reasonsAt(read, "x"));
+        assertEquals(List.of(new BlockReason.ComparisonBetweenPositions()), reasonsAt(read, "y"));
+    }
+
+    /**
      * A position whose values carry no order to draw a line on says that, and says it once.
      *
      * <p>A field declared as one case of an enumeration is ordered — the comparison is on the sum's

--- a/souther-compiler/src/test/java/souther/compiler/check/ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest.java
@@ -1,0 +1,232 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.inputs.BlockReason;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A rule saying where a position's values stop that no end came out of, named at every position it
+ * is about.
+ *
+ * <p>The invariant's half of what a {@code guard}'s comparison already answers (ADR-0090). Both
+ * draw lines, both can be written in a form this compiler does not read, and a reader is told the
+ * same thing about either — so an invariant's clause that placed no end has to be said, and said
+ * once.
+ *
+ * <p>What made it silent was that a position carries more than one statement. The account was kept
+ * as what the position was left with if nothing divided it, so a bound on a field's own type
+ * answered for the record's clause about that same field and the clause was dropped without a word:
+ * two declarations differing by one {@code invariant value >= 0} said opposite things about the
+ * clause above them. That is what the pair below is for — the same relation, once where the fields'
+ * types draw a line and once where they do not — and it is the pair, not either half, that holds
+ * the fix.
+ */
+class ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest {
+
+    private static FieldDomains readingOf(String source, String type) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        assertNotNull(symbols, "the model under test compiles");
+        TypeSymbol named = TypeSymbols.declared(new TypeKey(module, type));
+        Hir.Data data = (Hir.Data) symbols.declarations().declaration(named.key());
+        assertNotNull(data, "no `" + type + "` declared");
+        return FieldDomains.of(named, data, symbols);
+    }
+
+    private static final String MEASURED = """
+            module example.parcels
+
+            data Cm = Int
+                invariant value >= 0
+
+            data Parcel = { length: Cm, width: Cm }
+                invariant Int.add(length.value, width.value) <= 150
+            """;
+
+    private static final String BARE = """
+            module example.parcels
+
+            data Parcel = { length: Int, width: Int }
+                invariant Int.add(length, width) <= 150
+            """;
+
+    /**
+     * A clause comparing an arithmetic form over two fields, where nothing else divides them.
+     *
+     * <p>The half that always worked, here so that the half below cannot pass by accident: what
+     * separates the two is one {@code invariant value >= 0} on the fields' own type, which is not a
+     * fact about this clause.
+     */
+    @Test
+    void aClauseNoEndCameOutOfIsNamedAtEveryFieldItCompares() {
+        FieldDomains read = readingOf(BARE, "Parcel");
+
+        assertEquals(List.of(new BlockReason.UnreadComparisonForm()), reasonsAt(read, "length"));
+        assertEquals(List.of(new BlockReason.UnreadComparisonForm()), reasonsAt(read, "width"));
+    }
+
+    /**
+     * And says so where the fields' own type has already drawn a line through them.
+     *
+     * <p>Issue #868. {@code Cm}'s own bound places an end at each field, and the record's clause
+     * about the pair is a second statement about the same positions — so the report owed both, and
+     * said only the first while the {@code guard} of the same shape two declarations away named
+     * both of the positions it compared.
+     */
+    @Test
+    void andSaysSoWhereTheFieldsOwnTypeAlreadyDrewALine() {
+        FieldDomains read = readingOf(MEASURED, "Parcel");
+
+        assertFalse(read.placedAt("length").isEmpty(), "`Cm` places an end here");
+        assertEquals(List.of(new BlockReason.UnreadComparisonForm()), reasonsAt(read, "length"));
+        assertEquals(List.of(new BlockReason.UnreadComparisonForm()), reasonsAt(read, "width"));
+    }
+
+    /**
+     * A rule an end did come out of is named no way.
+     *
+     * <p>The reading that draws lines is what answers, and it read this one: a report naming it
+     * would send an author after a boundary it is about to print two lines below.
+     */
+    @Test
+    void anEndThisReadIsNotNamed() {
+        FieldDomains read = readingOf("""
+                module example.parcels
+
+                data Cm = Int
+                    invariant value >= 0
+
+                data Parcel = { length: Cm, width: Cm }
+                    invariant length.value <= 150
+                """, "Parcel");
+
+        assertFalse(read.placedAt("length").isEmpty());
+        assertEquals(List.of(), read.unreadAt("length"));
+        assertEquals(List.of(), read.unreadAt("width"));
+    }
+
+    /**
+     * A rule of another shape is not one of these either.
+     *
+     * <p>A format, a membership, a denial: each says which values exist rather than where they
+     * stop, and a report has nowhere to put one as a line. Named here, an author would be sent
+     * after a boundary nobody wrote.
+     */
+    @Test
+    void aRuleThatIsNotAboutWhereTheValuesStopIsNotNamedAsALine() {
+        FieldDomains read = readingOf("""
+                module example.parcels
+
+                data Parcel = { label: String, length: Int }
+                    invariant String.matches(label, "[A-Z]+")
+                    invariant length /= 5
+                """, "Parcel");
+
+        assertEquals(List.of(), read.unreadAt("label"));
+        assertEquals(List.of(), read.unreadAt("length"));
+    }
+
+    /**
+     * An equality least of all, though it reaches this reading as a comparison that placed no end.
+     *
+     * <p>It names a value rather than an end, and the reading of values holds it. Read off "no end
+     * came out of it", every {@code == 5} in every model would be a line somebody was told to go
+     * looking for — which is the failure this whole account is the other side of.
+     */
+    @Test
+    void anEqualityIsNotNamedThoughNoEndCameOutOfIt() {
+        FieldDomains read = readingOf("""
+                module example.parcels
+
+                data Parcel = { length: Int }
+                    invariant length == 5
+                """, "Parcel");
+
+        assertEquals(List.of(), read.unreadAt("length"));
+    }
+
+    /**
+     * A clause relating two fields says that it relates them, at both.
+     *
+     * <p>Which is a different thing for a reader to do about it: nothing is missing from the
+     * carrier — a line drawn on either field against a number would be read — and what a partition
+     * of one position is not is a class about two.
+     */
+    @Test
+    void aClauseRelatingTwoFieldsSaysThatItRelatesThem() {
+        FieldDomains read = readingOf("""
+                module example.spans
+
+                data Bound = Int
+                    invariant value >= 0
+
+                data Span = { low: Bound, high: Bound }
+                    invariant low < high
+                """, "Span");
+
+        assertEquals(List.of(new BlockReason.ComparisonBetweenPositions()), reasonsAt(read, "low"));
+        assertEquals(List.of(new BlockReason.ComparisonBetweenPositions()), reasonsAt(read, "high"));
+    }
+
+    /**
+     * A position whose values carry no order to draw a line on says that, and says it once.
+     *
+     * <p>A field declared as one case of an enumeration is ordered — the comparison is on the sum's
+     * order and typechecks — and the sum's places are not its own, so no line divides it. The
+     * carrier, asked of the carrier, exactly as a {@code guard} comparing the same field is
+     * answered.
+     */
+    @Test
+    void aPositionNoLineCanBeDrawnOnSaysThat() {
+        FieldDomains read = readingOf("""
+                module example.stages
+
+                data Prospecting
+                data Qualified
+                data Won
+                data Stage = Prospecting | Qualified | Won
+
+                data Holder = { stage: Qualified }
+                    invariant stage >= Prospecting
+                """, "Holder");
+
+        assertEquals(List.of(new BlockReason.UnreadComparisonDomain()), reasonsAt(read, "stage"));
+    }
+
+    /** And a newtype's own clause reaches the same account, at the position a name wraps. */
+    @Test
+    void aNewtypesOwnClauseIsNamedAtTheValueItWraps() {
+        FieldDomains read = readingOf("""
+                module example.stepped
+
+                data Stepped = Int
+                    invariant value >= 1 + 1
+                """, "Stepped");
+
+        List<FieldDomains.Unread> said = read.unreadAt(FieldDomains.THE_VALUE);
+        assertEquals(1, said.size(), () -> "said " + said);
+        assertInstanceOf(BlockReason.UnreadComparisonForm.class, said.getFirst().why());
+        assertTrue(said.getFirst().from().clause().id().declaredOn().name().endsWith("Stepped"),
+                "the rule a reader is sent to look at is the one that wrote the clause");
+    }
+
+    private static List<BlockReason> reasonsAt(FieldDomains read, String path) {
+        return read.unreadAt(path).stream().map(FieldDomains.Unread::why).toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest.java
@@ -208,6 +208,26 @@ class ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest {
     }
 
     /**
+     * But one position on both sides of a comparison is not two positions.
+     *
+     * <p>{@code x < x + 1} names {@code x} either side of it and there is no other position for a
+     * class to be about. Told that the rule relates it to another position, a reader goes looking
+     * for one the model never wrote; what would let this be read is a reading of the form, which
+     * is what the position on the right is inside of.
+     */
+    @Test
+    void butOnePositionOnBothSidesIsNotTwoPositions() {
+        FieldDomains read = readingOf("""
+                module example.spans
+
+                data Sole = { x: Int }
+                    invariant x < x + 1
+                """, "Sole");
+
+        assertEquals(List.of(new BlockReason.UnreadComparisonForm()), reasonsAt(read, "x"));
+    }
+
+    /**
      * A position whose values carry no order to draw a line on says that, and says it once.
      *
      * <p>A field declared as one case of an enumeration is ordered — the comparison is on the sum's


### PR DESCRIPTION
Closes #868.

## What was wrong

The issue reports that an `invariant` clause comparing an arithmetic form is dropped without a word, while a `guard` of the same shape names both the positions it compares. The mechanism it names — `InvariantBound.Read.NoEnd` carrying nothing, an arithmetic comparison being a fourth case — is half of it. The reading already names both positions:

```
data Plain = { length: Int, width: Int }
    invariant Int.add(length, width) <= 150
```

reports `not read: p.length` and `not read: p.width`. Adding one clause to the fields' own type silences both:

```
data Cm = Int
    invariant value >= 0
data Parcel = { length: Cm, width: Cm }
    invariant Int.add(length.value, width.value) <= 150
```

The difference is not the clause. The invariant side kept "this could not be read" as what a position is left with if nothing divided it (`Position.valuesUnread` → `PendingPosition`), and `Cm`'s bound gives each field a cut — so the position is no longer pending and the account travels no further. A line read from one rule answered for the rule beside it. The `guard` side already fixed this shape; `GuardThresholds.walk` says so in its own comment.

The vehicle for a per-rule account exists (`Position.unreadRules()`), but its only producer walked the position's own newtype chain and so could never see a clause written on the value the position sits in.

## What this changes

The reading that draws lines keeps its negative answer. `InvariantChecker.direct` is the one place an invariant clause is read for an end — the record's own clauses and the field types' alike, rebased onto positions — and it discarded `NoEnd`. It now emits a `FieldDomains.Unread` at every position an ordering comparison names, with the three reasons a `guard`'s comparison is read with, and `Partitions` collects them whether or not the position was divided.

- `InputDomain.unreadBoundsAt` is deleted, and `InvariantBound.statesAnEnd` with it — it was that walk's only reader.
- A coordinate with no carrier is now a coordinate. Dropped from `byName`, a rule about a position no line can be drawn on named nothing; `data Holder = { stage: Qualified } invariant stage >= Prospecting` now answers in the words a `guard` at the same field already used.
- The end reading outranks the value reading for what a pending position is left with, so one clause gets one sentence.

## Two things found on the way

- The deleted walk was **unobserved**. Disabling it left all 5502 compiler tests green — everything it could find was already said by the value reading's fallback.
- Where it did fire, one clause got **two lines naming different limits**: `(it is compared against values no line can be drawn on here)` beside `(a rule about it is one this compiler did not read)`. That is fixed by the ranking above.

## Left out

A size rule stepping past the last whole number (`List.length(value) > 9223372036854775807`) was named by the deleted walk as a form this compiler could not read, which it reads perfectly. It is silent now rather than wrong. What such a rule states is that no size stands there, and no reading says that yet.

## Verification

`CI=1 mvn -o -Plint verify` green — 5515 compiler tests, all modules, checked-in conformance answers unchanged.

14 new tests, each checked against a broken build: disabling the emitter fails five of the eight readings and three of the six report assertions; removing the ordering guard fails on an equality becoming a line nobody wrote; restoring the old ranking fails on one clause coming back with two causes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)