### PR TITLE
Bump the reactor to 0.1.0-rc5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.souther-lang</groupId>
     <artifactId>souther-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.0-rc5</version>
     <packaging>pom</packaging>
 
     <name>Souther</name>

--- a/souther-bench/pom.xml
+++ b/souther-bench/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc5</version>
     </parent>
 
     <artifactId>souther-bench</artifactId>

--- a/souther-build-driver/pom.xml
+++ b/souther-build-driver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc5</version>
     </parent>
 
     <artifactId>souther-build-driver</artifactId>

--- a/souther-cli/pom.xml
+++ b/souther-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc5</version>
     </parent>
 
     <artifactId>souther-cli</artifactId>

--- a/souther-compiler/pom.xml
+++ b/souther-compiler/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc5</version>
     </parent>
 
     <artifactId>souther-compiler</artifactId>

--- a/souther-fmt/pom.xml
+++ b/souther-fmt/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc5</version>
     </parent>
 
     <artifactId>souther-fmt</artifactId>

--- a/souther-lsp/pom.xml
+++ b/souther-lsp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc5</version>
     </parent>
 
     <artifactId>souther-lsp</artifactId>

--- a/souther-runtime/pom.xml
+++ b/souther-runtime/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc5</version>
     </parent>
 
     <artifactId>souther-runtime</artifactId>

--- a/souther-syntax/pom.xml
+++ b/souther-syntax/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc5</version>
     </parent>
 
     <artifactId>souther-syntax</artifactId>


### PR DESCRIPTION
The reactor moves to 0.1.0-rc5. The examples pin the compiler separately, in souther-lang/examples,
and track develop rather than a release, so they stay on the SNAPSHOT they build against.

`souther-build-driver` is published for the first time by this release. A build plugin resolves that
artifact for the version a project names, so this is what lets `souther-maven-plugin` and
`souther-gradle-plugin` be cut against a Souther anyone can resolve — and with them, `souther init`
writes a project that builds with no version overridden.

`mvn -Plint clean verify` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
