### PR TITLE
Take develop off the released version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Highlight Souther sources on GitHub using F#'s grammar (closest ML-family match).
+*.sou linguist-language=FSharp

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.souther-lang</groupId>
     <artifactId>souther-parent</artifactId>
-    <version>0.1.0-rc5</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Souther</name>

--- a/souther-bench/pom.xml
+++ b/souther-bench/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-rc5</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-bench</artifactId>

--- a/souther-build-driver/pom.xml
+++ b/souther-build-driver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-rc5</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-build-driver</artifactId>

--- a/souther-cli/pom.xml
+++ b/souther-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-rc5</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-cli</artifactId>

--- a/souther-compiler/pom.xml
+++ b/souther-compiler/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-rc5</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-compiler</artifactId>

--- a/souther-fmt/pom.xml
+++ b/souther-fmt/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-rc5</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-fmt</artifactId>

--- a/souther-lsp/pom.xml
+++ b/souther-lsp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-rc5</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-lsp</artifactId>

--- a/souther-runtime/pom.xml
+++ b/souther-runtime/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-rc5</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-runtime</artifactId>

--- a/souther-syntax/pom.xml
+++ b/souther-syntax/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-rc5</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-syntax</artifactId>


### PR DESCRIPTION
`0.1.0-rc5` is tagged and published, so develop goes back to `0.1.0-SNAPSHOT`. The examples repository builds against that SNAPSHOT and would otherwise resolve a released artifact instead of what develop is building.

`.gitattributes` comes back with it. It was committed straight to `main` a month ago (`1f42985f`) and has been there alone since, so every release PR reads as develop deleting it, and the `.sou` highlighting it asks for is off on every branch but one. The merge kept it — a file the base has and the head never had is not a deletion — but that is the merge being careful rather than the two branches agreeing about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)