### PR TITLE
Say which rule went unread, and let the reading that knows say it

### DIFF
--- a/souther-cli/src/test/java/souther/cli/MainExamplesSubcommandTest.java
+++ b/souther-cli/src/test/java/souther/cli/MainExamplesSubcommandTest.java
@@ -153,7 +153,7 @@ class MainExamplesSubcommandTest {
     void theJsonCarriesTheNumbersABuildReads() throws Exception {
         JsonNode root = JSON.readTree(run("--format", "json"));
 
-        assertEquals(3, root.get("schemaVersion").asInt());
+        assertEquals(4, root.get("schemaVersion").asInt());
         assertEquals("complete", root.get("status").asString());
         assertNotNull(root.get("compilerVersion"));
 
@@ -182,8 +182,8 @@ class MainExamplesSubcommandTest {
     @Test
     void theEmittedJsonHasTheShippedSchemaShape() throws Exception {
         JsonNode schema;
-        try (var in = Main.class.getResourceAsStream("/souther/adequacy-schema-3.json")) {
-            assertNotNull(in, "adequacy-schema-3.json ships beside the compiler");
+        try (var in = Main.class.getResourceAsStream("/souther/adequacy-schema-4.json")) {
+            assertNotNull(in, "adequacy-schema-4.json ships beside the compiler");
             schema = JSON.readTree(new String(in.readAllBytes(), StandardCharsets.UTF_8));
         }
         JsonNode root = JSON.readTree(run("--format", "json"));
@@ -304,7 +304,7 @@ class MainExamplesSubcommandTest {
     void aKeyAddedSinceIsNotDemandedOfADocumentWrittenBeforeIt() throws Exception {
         JsonNode schema;
         try (java.io.InputStream in =
-                     Main.class.getResourceAsStream("/souther/adequacy-schema-3.json")) {
+                     Main.class.getResourceAsStream("/souther/adequacy-schema-4.json")) {
             assertNotNull(in);
             schema = JSON.readTree(new String(in.readAllBytes(), StandardCharsets.UTF_8));
         }

--- a/souther-cli/src/test/java/souther/cli/MainExamplesSubcommandTest.java
+++ b/souther-cli/src/test/java/souther/cli/MainExamplesSubcommandTest.java
@@ -153,7 +153,7 @@ class MainExamplesSubcommandTest {
     void theJsonCarriesTheNumbersABuildReads() throws Exception {
         JsonNode root = JSON.readTree(run("--format", "json"));
 
-        assertEquals(4, root.get("schemaVersion").asInt());
+        assertEquals(3, root.get("schemaVersion").asInt());
         assertEquals("complete", root.get("status").asString());
         assertNotNull(root.get("compilerVersion"));
 
@@ -182,8 +182,8 @@ class MainExamplesSubcommandTest {
     @Test
     void theEmittedJsonHasTheShippedSchemaShape() throws Exception {
         JsonNode schema;
-        try (var in = Main.class.getResourceAsStream("/souther/adequacy-schema-4.json")) {
-            assertNotNull(in, "adequacy-schema-4.json ships beside the compiler");
+        try (var in = Main.class.getResourceAsStream("/souther/adequacy-schema-3.json")) {
+            assertNotNull(in, "adequacy-schema-3.json ships beside the compiler");
             schema = JSON.readTree(new String(in.readAllBytes(), StandardCharsets.UTF_8));
         }
         JsonNode root = JSON.readTree(run("--format", "json"));
@@ -304,7 +304,7 @@ class MainExamplesSubcommandTest {
     void aKeyAddedSinceIsNotDemandedOfADocumentWrittenBeforeIt() throws Exception {
         JsonNode schema;
         try (java.io.InputStream in =
-                     Main.class.getResourceAsStream("/souther/adequacy-schema-4.json")) {
+                     Main.class.getResourceAsStream("/souther/adequacy-schema-3.json")) {
             assertNotNull(in);
             schema = JSON.readTree(new String(in.readAllBytes(), StandardCharsets.UTF_8));
         }

--- a/souther-cli/src/test/java/souther/cli/WhatStrictRefusesIsWhatTheRowsDoNotCoverTest.java
+++ b/souther-cli/src/test/java/souther/cli/WhatStrictRefusesIsWhatTheRowsDoNotCoverTest.java
@@ -318,7 +318,7 @@ class WhatStrictRefusesIsWhatTheRowsDoNotCoverTest {
                                                Partitions.OmittedAxis... omitted) {
         return new PartitionEvidence(PartitionEvidence.Partitioned.of(List.of()),
                 PartitionEvidence.Bounded.of(List.of(boundary)), PartitionEvidence.PairSpace.NONE,
-                List.of(), List.of(), List.of(), List.of(omitted), List.of());
+                List.of(), List.of(), List.of(), List.of(), List.of(omitted), List.of());
     }
 
     /** What one behavior's partition makes of the whole report, with nothing else asked about. */

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -364,7 +364,7 @@ public final class FieldDomains {
      *             own terms
      */
     public record Unread(String path, boolean measured, RuleRef.Invariant from,
-                         Core part, souther.compiler.inputs.BlockReason why) {}
+                         Core part, souther.compiler.inputs.BlockReason.AboutARule why) {}
 
     /**
      * The declaration whose clause could have moved where the coordinate at {@code path} stops, or

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1308,7 +1308,7 @@ public final class InvariantChecker {
         if (!InvariantBound.ordering(comparison.op())) {
             return;
         }
-        BlockReason why = UnreadComparison.why(sideOf(comparison.left(), at, byName),
+        BlockReason.AboutARule why = UnreadComparison.why(sideOf(comparison.left(), at, byName),
                 sideOf(comparison.right(), at, byName), quantityOf(comparison, at, byName));
         for (Coordinate each : coordinatesIn(comparison, at, byName)) {
             FieldDomains.Unread said =

--- a/souther-compiler/src/main/java/souther/compiler/check/Required.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Required.java
@@ -338,7 +338,7 @@ public sealed interface Required {
          * an invariant's own gives — a {@code guard}'s comparison and a newtype's bound are two
          * producers of one kind of evidence (spec §example-partition).
          */
-        record NoLine(souther.compiler.inputs.BlockReason why) implements LineRead {
+        record NoLine(souther.compiler.inputs.BlockReason.AboutARule why) implements LineRead {
 
             public NoLine {
                 if (why == null) {

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
@@ -51,6 +51,14 @@ public final class RuleAccounting {
      */
     static RuleAccounting of(RuleRef rule, Required required,
                              Function<Owed, Outcome> answered) {
+        return new RuleAccounting(rule, citedAsAClause(rule), required,
+                answers(rule, required, answered));
+    }
+
+    /** {@code answered} asked once for each question the rule raises, and nothing else. Apart from
+     *  the citation, which the two ways in do not find the same way. */
+    private static Map<Owed, Outcome> answers(RuleRef rule, Required required,
+                                              Function<Owed, Outcome> answered) {
         Map<Owed, Outcome> answers = new LinkedHashMap<>();
         for (Owed each : required.obligations()) {
             Outcome outcome = answered.apply(each);
@@ -60,7 +68,24 @@ public final class RuleAccounting {
             }
             answers.put(each, outcome);
         }
-        return new RuleAccounting(rule, new RuleCitation.Named(rule.named()), required, answers);
+        return answers;
+    }
+
+    /**
+     * How a reader finds a rule this way in can be about.
+     *
+     * <p>A clause, either kind, and never a comparison. What comes this way is a rule an author
+     * wrote a name beside; {@link #ofComparison} is the way in for one that is written rather than
+     * named, and it is handed the place because nothing here could work it out.
+     */
+    private static RuleCitation citedAsAClause(RuleRef rule) {
+        return switch (rule) {
+            case RuleRef.Invariant it -> RuleCitation.named(it);
+            case RuleRef.Ensures it -> RuleCitation.named(it);
+            case RuleRef.Guard _ -> throw new IllegalArgumentException(
+                    "a comparison is written rather than named, so it is cited by where it is"
+                            + " written and not through this");
+        };
     }
 
     /**
@@ -75,12 +100,12 @@ public final class RuleAccounting {
                                               Required.ComparisonSubject of,
                                               Required.LineRead read, RuleCitation cited) {
         Required required = Required.ofComparison(claim, of);
-        return new RuleAccounting(rule, cited, required, answersOf(rule, required, read).answers);
+        return new RuleAccounting(rule, cited, required, answersOf(rule, required, read));
     }
 
-    private static RuleAccounting answersOf(RuleRef rule, Required required,
-                                            Required.LineRead read) {
-        return of(rule, required, _ -> switch (read) {
+    private static Map<Owed, Outcome> answersOf(RuleRef rule, Required required,
+                                                Required.LineRead read) {
+        return answers(rule, required, _ -> switch (read) {
             // The reading that draws the line answers both of the questions the line raises: the
             // classes either side of it are what it divided the position into, and the values it
             // named are where the rows go.
@@ -204,7 +229,8 @@ public final class RuleAccounting {
         }
 
         /** The reading that turns a clause into an end a line can be drawn at. */
-        record TheEndReadingSays(souther.compiler.inputs.BlockReason why) implements Why {
+        record TheEndReadingSays(souther.compiler.inputs.BlockReason.AboutARule why)
+                implements Why {
 
             public TheEndReadingSays {
                 if (why == null) {

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleCitation.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleCitation.java
@@ -25,6 +25,25 @@ import souther.compiler.types.CoverageConstruct;
  */
 public sealed interface RuleCitation {
 
+    /**
+     * How a reader finds a rule the author wrote a name beside.
+     *
+     * <p>Two overloads and no {@code RuleRef} one, which is the point. {@link RuleRef#named} answers
+     * for a comparison too — with what it is rather than what it is called — and a total factory
+     * over {@code RuleRef} would hand that back as a name, sending an author to look for a clause
+     * called {@code the comparison}. Nothing in {@link Named} would refuse it: the string is not
+     * empty. A comparison is found by {@link WrittenAt}, from the construct it stands in and the
+     * place it is written, which is two coordinates this could not invent.
+     */
+    static Named named(RuleRef.Invariant rule) {
+        return new Named(rule.named());
+    }
+
+    /** The same, of a clause of an {@code ensures}. */
+    static Named named(RuleRef.Ensures rule) {
+        return new Named(rule.named());
+    }
+
     /** The name the author gave it, as a report writes the rule. */
     record Named(String name) implements RuleCitation {
 

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleRef.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleRef.java
@@ -43,15 +43,26 @@ public sealed interface RuleRef {
      *
      * <p>The comparison and not the fork testing it. A condition can be an application of a
      * function parameter, so one predicate handed to two calls is one rule and two predicates
-     * written apart are two — neither of which the fork can say
-     * ({@link souther.compiler.coverage.CoverageSites.Plan#comparisonSiteOf}). Which fork this
-     * comparison was read under is where it was met, and belongs beside this.
+     * written apart are two — neither of which the fork can say. Which fork this comparison was
+     * read under is where it was met, and belongs beside this.
+     *
+     * <p><b>Read off the source and never off a measurement.</b> The two components are what the
+     * author wrote: which behavior, and which construct of which module. A run's numbering of
+     * comparisons is a fact about instrumentation — a condition both of whose arms can record
+     * nothing is not numbered at all — and taking an identity from it says a rule exists because
+     * something could be measured about it. A model states its rules whether or not this compiler
+     * arranged to watch them.
+     *
+     * @param behavior whose body it is written in. Two behaviors calling one helper each read its
+     *                 comparison, and the readings are what a coverage question is raised per
+     * @param origin   which construct of which module the author wrote, which is what tells one
+     *                 comparison from another wherever it is met
      */
-    record Guard(souther.compiler.coverage.CoverageSites.ComparisonRef comparison)
+    record Guard(String behavior, souther.compiler.types.CoverageOrigin origin)
             implements RuleRef {
 
         public Guard {
-            if (comparison == null) {
+            if (behavior == null || origin == null) {
                 throw new IllegalArgumentException("a guard's rule is one of its comparisons");
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
@@ -111,7 +111,7 @@ public final class UnreadComparison {
      * @param quantityIsOver the positions the canonical form's quantity is over, or null where the
      *                       arithmetic read no form at all
      */
-    public static <K> BlockReason why(Side<K> left, Side<K> right,
+    public static <K> BlockReason.AboutARule why(Side<K> left, Side<K> right,
                                       Set<K> quantityIsOver) {
         // What the rule cuts, where the arithmetic could be read at all. A quantity over
         // more than one position divides none of them — which values of one are on which
@@ -127,7 +127,7 @@ public final class UnreadComparison {
 
     /** The same, where the arithmetic named no quantity — which is every carrier whose
      *  values do not count, and every form outside the affine fragment. */
-    private static <K> BlockReason whatTheSidesSay(Side<K> left, Side<K> right) {
+    private static <K> BlockReason.AboutARule whatTheSidesSay(Side<K> left, Side<K> right) {
         Set<K> named = new LinkedHashSet<>(left.positions());
         named.addAll(right.positions());
         if (!left.positions().isEmpty() && !right.positions().isEmpty() && named.size() > 1) {

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -74,20 +74,6 @@ public final class CoverageSites {
      */
     public record Obligation(String behavior, CoverageOrigin origin, int part) {}
 
-    /**
-     * Which comparison of which behavior, as the rule it is.
-     *
-     * <p>An {@link Obligation} with no {@code part}, and its own type rather than that one used
-     * narrowly. A part says which arm of a fork, and a comparison has none — it is one construct,
-     * and what a fork holds several of is arms. Held as an obligation, a value carrying an arm's
-     * part reads as a comparison wherever a comparison is asked for, and nothing would say it is
-     * not one.
-     *
-     * <p>The comparison and not the fork testing it. A condition can be an application of a
-     * function parameter, so one predicate handed to two calls is one of these and two predicates
-     * written apart are two, neither of which the fork can say.
-     */
-    public record ComparisonRef(String behavior, CoverageOrigin origin) {}
 
     /**
      * One outcome of one construct, as it stands in the tree that runs.
@@ -126,24 +112,6 @@ public final class CoverageSites {
             return obligation.origin().kind();
         }
 
-        /**
-         * Which comparison this is a site of.
-         *
-         * <p>Asked here rather than assembled by the caller, so that what a comparison is called
-         * and what this walk numbered are one answer. Built outside, the two would be two
-         * derivations of one identity, and a comparison could be named after the fork testing it.
-         *
-         * @throws IllegalStateException where this site is not a comparison's. Which sites are
-         *                               comparisons is this walk's to say, and a caller working it
-         *                               out from the shape of a node is reading the tree again
-         */
-        public ComparisonRef comparison() {
-            if (!(outcome instanceof SourceOutcome.Compared)) {
-                throw new IllegalStateException(
-                        "site " + index + " is " + name() + " and not a comparison");
-            }
-            return new ComparisonRef(behavior, obligation.origin());
-        }
 
         /** What a reader is told this is, which the two halves settle together. */
         public OutcomeName name() {

--- a/souther-compiler/src/main/java/souther/compiler/inputs/BlockReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/BlockReason.java
@@ -22,21 +22,62 @@ package souther.compiler.inputs;
 public sealed interface BlockReason {
 
     /**
-     * What a value reading's account of what it left unread comes to here.
+     * A rule this read and could not use, which is a reason there is always a rule to name.
+     *
+     * <p>Whose rule it is, is the producer's to carry. What this says is that there is one: a
+     * comparison was written, a reader took it apart as far as it goes, and what stopped it is a
+     * fact about that rule and this compiler. So a finding built on one of these owes an identity
+     * for the rule, and the type is what makes owing it unavoidable.
+     */
+    sealed interface AboutARule extends BlockReason {}
+
+    /**
+     * The reading did not get to the rules of the position, so there is no rule to name.
+     *
+     * <p>Not a rule read and found wanting. A depth, a shape nothing reaches into, a type that
+     * could not be worked out, a gathering that stopped — none of them is about any one thing an
+     * author wrote, and a finding built on one names the position and nothing else. Told apart from
+     * the above by the type, because the two used to be one set and a report could name a rule for
+     * some of them and not the rest with nothing saying which was which.
+     */
+    sealed interface AboutThePosition extends BlockReason {}
+
+    /**
+     * What a value reading's account of a rule it could not use comes to here.
      *
      * <p>The one place the two vocabularies meet, so a reader holding a reading's completeness and
      * one holding a block reason cannot come to different words for one stop. A relation between
      * two positions is what {@link ComparisonBetweenPositions} already says, whichever rule wrote
      * it: a {@code guard} comparing two inputs and an {@code invariant} relating two fields leave a
-     * reader the same thing to know. The other two are their own, because what would lift each is
-     * different work — one wants a reader for a form, and one wants the gathering to reach further.
+     * reader the same thing to know. The other is its own, because what would lift it is different
+     * work — a reader for a form rather than a gathering that reaches further.
+     *
+     * <p>{@link souther.compiler.values.UnreadReason#NOT_REACHED} is refused rather than answered.
+     * A reading that never arrived at the rules of a position is holding no rule for this to be
+     * about, so a caller here would be naming one it does not have — which is the whole of what
+     * {@link AboutThePosition} is beside this for.
      */
-    static BlockReason of(souther.compiler.values.UnreadReason why) {
+    static AboutARule ofARuleTheValueReadingLeft(souther.compiler.values.UnreadReason why) {
         return switch (why) {
             case RELATES_TWO_POSITIONS -> new ComparisonBetweenPositions();
             case FORM_NOT_READ, ALTERNATIVE_NOT_READ -> new UnreadValueRule();
-            case NOT_REACHED -> new ValueRulesNotReached();
+            case NOT_REACHED -> throw new IllegalArgumentException(
+                    "a reading that did not reach the rules of a position holds no rule to say"
+                            + " this of");
         };
+    }
+
+    /**
+     * The same, for a caller that has to answer for every way a value reading can be short.
+     *
+     * <p>What a position is left with, and not a finding: both authorities are legitimate answers
+     * to "why is there nothing here", and which of them it is decides what a report may go on to
+     * say rather than whether the reading stopped. Written in terms of the one above, so the
+     * classification is stated once.
+     */
+    static BlockReason of(souther.compiler.values.UnreadReason why) {
+        return why == souther.compiler.values.UnreadReason.NOT_REACHED
+                ? new ValueRulesNotReached() : ofARuleTheValueReadingLeft(why);
     }
 
     /**
@@ -44,10 +85,10 @@ public sealed interface BlockReason {
      * declaration reachable from itself. Such a model compiles, so this is a position a report is
      * asked about and cannot be answered for.
      */
-    record TypeUnresolved() implements BlockReason {}
+    record TypeUnresolved() implements AboutThePosition {}
 
     /** The walk stopped before reaching what is under the position. */
-    record DepthLimit() implements BlockReason {}
+    record DepthLimit() implements AboutThePosition {}
 
     /**
      * The shape at the position holds values this cannot reach into, and which reaching is missing
@@ -58,7 +99,7 @@ public sealed interface BlockReason {
      * holds one, and deciding what part of a mapping a rule is even about. Reporting them alike
      * would let one of them being implemented read as all three.
      */
-    record UnsupportedTraversal(Traversal traversal) implements BlockReason {}
+    record UnsupportedTraversal(Traversal traversal) implements AboutThePosition {}
 
     /**
      * A comparison naming the position is written in a form no reader here takes apart: the
@@ -69,11 +110,11 @@ public sealed interface BlockReason {
      * producers of one kind of evidence (spec §example-partition), and what stopped each of them is
      * the same fact about this compiler.
      */
-    record UnreadComparisonForm() implements BlockReason {}
+    record UnreadComparisonForm() implements AboutARule {}
 
     /** A comparison naming the position is against values no line is drawn on here — the carrier,
      *  asked of the carrier. */
-    record UnreadComparisonDomain() implements BlockReason {}
+    record UnreadComparisonDomain() implements AboutARule {}
 
     /**
      * A rule naming which values the position may hold is written in a form no reader here takes
@@ -85,7 +126,7 @@ public sealed interface BlockReason {
      * different work — one wants a wider fragment of comparison forms, and one wants a reading of
      * values that follows a rule into a shape it does not enter today.
      */
-    record UnreadValueRule() implements BlockReason {}
+    record UnreadValueRule() implements AboutARule {}
 
     /**
      * The reading of what the position may hold never reached the rules about it.
@@ -96,7 +137,23 @@ public sealed interface BlockReason {
      * the rule, and all of them leave the same hole: what is written about this position is not
      * known to have been read.
      */
-    record ValueRulesNotReached() implements BlockReason {}
+    record ValueRulesNotReached() implements AboutThePosition {}
+
+    /**
+     * Each of two rules is read, and they are about different coordinates of one position, so
+     * neither can be the one it is measured at.
+     *
+     * <p>Nothing is wrong with either rule. A {@code String} is the one thing that can be measured
+     * two ways — its own order, and the length of it — and which of them a position is measured at
+     * is settled by whichever the model wrote about. Where the position's own type chose neither
+     * and the value it sits in states an end on each, choosing either would put a line the author
+     * can read beside one they cannot see, so both go unread and each says so.
+     *
+     * <p>Its own case and not {@link UnreadComparisonForm}. The forms were read: what is missing is
+     * not a reader for an expression but a rule for which coordinate wins, and an author told the
+     * first would go looking for a syntax this compiler handles perfectly well.
+     */
+    record CompetingCoordinates() implements AboutARule {}
 
     /**
      * The comparison relates two positions rather than dividing one.
@@ -106,7 +163,7 @@ public sealed interface BlockReason {
      * partition of one is not — so a line like this is settled beside the partition rather than in
      * it, and the position it names is left with no class of its own from this rule.
      */
-    record ComparisonBetweenPositions() implements BlockReason {}
+    record ComparisonBetweenPositions() implements AboutARule {}
 
     /** What a derivation would have to be able to reach into. */
     enum Traversal {

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Distinctions.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Distinctions.java
@@ -71,7 +71,7 @@ public final class Distinctions {
 
     /** Whether this reading could be made at all, or what stopped it. A type nothing could be read
      *  off is not a position with no distinctions: nothing was read to say so. */
-    static BlockReason unreadableAt(TypeView view) {
+    static BlockReason.AboutThePosition unreadableAt(TypeView view) {
         return view.shape() instanceof Shape.Unresolved ? new BlockReason.TypeUnresolved() : null;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -215,8 +215,14 @@ public final class InputDomain {
                 : DeclaredBounds.of(type, symbols, Carrier.WHOLE, taken);
         DeclaredBounds.Bounds valueOfType = carried == null ? null
                 : DeclaredBounds.of(type, symbols, carried, null);
+        // Rules about both coordinates and nothing here to choose between. Said before they are
+        // dropped and from the list that still holds them, because this is the one place that knows
+        // which rules they were — recovered afterwards from a position with no axis, the finding
+        // could name the position and nothing else, which is what it is for.
+        List<UnreadRule> competing = List.of();
         if (undecidable(ofType, valueOfType, stated, taken, carried)) {
-            stated = List.of();   // rules about both coordinates and nothing here to choose between
+            competing = competingCoordinates(stated, path);
+            stated = List.of();
         }
         boolean bySize = measuredHere(ofType, valueOfType, stated, taken);
         NumericTerm term = bySize ? new NumericTerm.SizeOf(taken, path) : new NumericTerm.ValueOf(path);
@@ -241,7 +247,7 @@ public final class InputDomain {
         // own type draws a line, because a clause relating two fields is not a partition of one.
         NumericDomain.Bounds admissible = nothingExists ? null
                 : TypeBounds.admissible(own, projected, term);
-        List<UnreadRule> unread = unreadRulesAt(placed, path);
+        List<UnreadRule> unread = unreadRulesAt(placed, path, competing);
 
         List<Case> declared = Distinctions.ofType(view, symbols);
         ReadingResult reading = crossed(declared, view, admissible, admitted, symbols, unread,
@@ -330,6 +336,29 @@ public final class InputDomain {
     }
 
     /**
+     * One finding per rule dropped because the position's two coordinates are both spoken for.
+     *
+     * <p>Per rule and not per position. Both of them were read, both place an end, and neither can
+     * be the one the position is measured at — so each is a rule an author would have to rewrite,
+     * and telling them the position was short of something leaves them to work out which two of
+     * their clauses are in the way. A rule placing two ends is one rule and one finding, which is
+     * what the key settles.
+     */
+    private static List<UnreadRule> competingCoordinates(List<FieldDomains.Placed> stated,
+                                                         TermPath path) {
+        List<UnreadRule> out = new ArrayList<>();
+        for (FieldDomains.Placed each : stated) {
+            UnreadRule said = new UnreadRule(each.from(),
+                    souther.compiler.check.RuleCitation.named(each.from()), path,
+                    new BlockReason.CompetingCoordinates());
+            if (out.stream().noneMatch(had -> had.sameAs(said))) {
+                out.add(said);
+            }
+        }
+        return List.copyOf(out);
+    }
+
+    /**
      * Whether the rules reaching this position say where both of its coordinates stop, with its own
      * type having said nothing about either.
      *
@@ -370,11 +399,15 @@ public final class InputDomain {
      * <p>One line per reason, as a {@code guard}'s comparison is. Two clauses stopped by the same
      * limit are one thing for a reader to lift; two stopped by different limits are two.
      */
-    private static List<UnreadRule> unreadRulesAt(PlacedRules placed, TermPath path) {
-        List<UnreadRule> out = new ArrayList<>();
+    private static List<UnreadRule> unreadRulesAt(PlacedRules placed, TermPath path,
+                                                  List<UnreadRule> competing) {
+        List<UnreadRule> out = new ArrayList<>(competing);
         for (FieldDomains.Unread each : placed.unreadAt(path)) {
-            UnreadRule said = new UnreadRule(path, each.why());
-            if (!out.contains(said)) {
+            // The rule the reading of ends was holding when it gave up, carried rather than left
+            // behind. It is a clause of an invariant, so it has a name and the handle is that name.
+            UnreadRule said = new UnreadRule(each.from(),
+                    souther.compiler.check.RuleCitation.named(each.from()), path, each.why());
+            if (out.stream().noneMatch(had -> had.sameAs(said))) {
                 out.add(said);
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -396,8 +396,10 @@ public final class InputDomain {
      * rule about one of its fields was dropped in silence; and where both had something to say
      * about one clause, the report printed two causes for it.
      *
-     * <p>One line per reason, as a {@code guard}'s comparison is. Two clauses stopped by the same
-     * limit are one thing for a reader to lift; two stopped by different limits are two.
+     * <p>One finding per rule, as a {@code guard}'s comparison is. Two clauses stopped by the same
+     * limit at one position are two things for a reader to lift and are two findings: which clause
+     * to rewrite is what an author acts on, and a position is not it. Kept per reason, the second
+     * of them was dropped as a repeat of the first.
      */
     private static List<UnreadRule> unreadRulesAt(PlacedRules placed, TermPath path,
                                                   List<UnreadRule> competing) {

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
@@ -191,4 +191,5 @@ public sealed interface Position permits ReadPosition {
     /** Whether the position is made of positions, and what it is left with if nothing answers for
      *  it. */
     StructuralInspection structure();
+
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PositionReadingBlocked.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PositionReadingBlocked.java
@@ -9,10 +9,17 @@ package souther.compiler.inputs;
  * gathering that stopped â and what there is to say is the position and the limit. Carrying a rule
  * for one of these would be naming a rule nothing observed.
  *
- * <p>Not a verdict about the position. Whether it comes back divided is settled elsewhere and by
- * other evidence: a rule a body writes may divide a position whose own type this could not read
- * into. What is here is what this reading was short of, which is true either way and is what an
- * author is told so that a report does not print an absence it did not establish.
+ * <p>Made after the answer, and not by the reading that stopped. What a producer records is a
+ * candidate — {@link StructuralInspection.Blocked}, or the account the reading of values gave of
+ * itself — and a candidate becomes one of these exactly where neither the position's own
+ * declarations nor a body's rules answered for it. That is settled in one place
+ * ({@code PendingPosition.reportable}), which is why nothing outside constructs one: written where
+ * the producer records it, every position holding an {@code Option} said its values are held
+ * inside something this does not reach into, whether or not the reading of it came to anything.
+ *
+ * <p>Not a verdict either. Whether the position comes back divided is a separate answer from the
+ * same pair of readings, and neither is read off the other: this says what an author is waiting on,
+ * so that a report does not print an absence it did not establish.
  *
  * @param at  the position, spelled the way a report names it
  * @param why what would have to change before the reading could get there, in this compiler's own

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PositionReadingBlocked.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PositionReadingBlocked.java
@@ -1,0 +1,28 @@
+package souther.compiler.inputs;
+
+/**
+ * A position whose reading stopped before it got to what is written about it.
+ *
+ * <p>The other half of {@link UnreadRule}, and told apart from it by which authority answers. There
+ * a rule was read and could not be used, and the finding names it; here nothing about any one rule
+ * is known â a depth, a shape this does not reach into, a type that could not be worked out, a
+ * gathering that stopped â and what there is to say is the position and the limit. Carrying a rule
+ * for one of these would be naming a rule nothing observed.
+ *
+ * <p>Not a verdict about the position. Whether it comes back divided is settled elsewhere and by
+ * other evidence: a rule a body writes may divide a position whose own type this could not read
+ * into. What is here is what this reading was short of, which is true either way and is what an
+ * author is told so that a report does not print an absence it did not establish.
+ *
+ * @param at  the position, spelled the way a report names it
+ * @param why what would have to change before the reading could get there, in this compiler's own
+ *            terms. Which word a report writes for it is {@link ReportedReason}'s
+ */
+public record PositionReadingBlocked(TermPath at, BlockReason.AboutThePosition why) {
+
+    public PositionReadingBlocked {
+        if (at == null || why == null) {
+            throw new IllegalArgumentException("a reading stopped somewhere, and at something");
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/StructuralInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/StructuralInspection.java
@@ -76,7 +76,7 @@ public sealed interface StructuralInspection {
      * reported. What it does not do is let a rule about what is <em>inside</em> stand in for
      * reaching inside.
      */
-    record Blocked(BlockReason why) implements Pending {}
+    record Blocked(BlockReason.AboutThePosition why) implements Pending {}
 
     /**
      * What is under {@code shape}, or why nothing can be.

--- a/souther-compiler/src/main/java/souther/compiler/inputs/UnreadRule.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/UnreadRule.java
@@ -1,22 +1,62 @@
 package souther.compiler.inputs;
 
+import souther.compiler.check.RuleCitation;
+import souther.compiler.check.RuleRef;
+
 /**
- * A position a rule is written about that this did not turn into a line, and what stopped it.
+ * One rule of the model, at one position it is about, that this did not turn into a line.
  *
- * <p>Asked of the rule and not of the position. One position carries more than one statement, and a
- * line read at it says nothing about the rest — a threshold on {@code x} does not answer for the
- * bound beside it that nothing could read.
+ * <p>Asked of the rule, and it names one. One position carries more than one statement, and a line
+ * read at it says nothing about the rest — a threshold on {@code x} does not answer for the bound
+ * beside it that nothing could read. Carrying only the position, the sentence written from this
+ * told an author that a rule about {@code r.cost} went unread and left them to find which rule; and
+ * two rules stopped by one limit at one position came out as one line, which is what a finding
+ * asked of the rule may not do.
  *
- * <p><b>Whichever rule drew it.</b> A {@code guard}'s comparison and a newtype's invariant are two
- * producers of one kind of evidence (spec §example-partition), so a reader of this list is told the
- * same thing about either and does not have to know which wrote it. Named after the guard while only
- * guards produced one, an invariant nothing could read had nowhere to be said and was dropped in
- * silence — the position then came back as one the model divides no way, which is the opposite of
- * what the declaration says.
+ * <p><b>Whichever rule drew it.</b> A {@code guard}'s comparison, a newtype's invariant and a
+ * clause of an {@code ensures} are three producers of one kind of evidence (spec
+ * §example-partition), so a reader of this list is told the same thing about any of them and does
+ * not have to know which wrote it. Named after the guard while only guards produced one, an
+ * invariant nothing could read had nowhere to be said and was dropped in silence — the position
+ * then came back as one the model divides no way, which is the opposite of what the declaration
+ * says.
  *
- * @param at  the position, spelled the way a report names it
- * @param why what would have to change before this rule could be a line, in this compiler's own
- *            terms. Which word a report writes for it is {@link ReportedReason}'s, so a capability
- *            gained here need not move a published vocabulary
+ * <p>Two values and not one, and for two reasons. {@code rule} tells one rule from another and is
+ * what a reader groups by; {@code cited} is the handle an author acts on, and the two are not in
+ * step wherever a rule has no name. Neither stands in for the other, and only the
+ * first is part of what makes two of these one finding.
+ *
+ * @param rule  which rule of the model, as everything that names a rule names it
+ * @param cited how a reader finds it — a name where the author gave one, a place where they did not
+ * @param at    the position, spelled the way a report names it. One of these per position the rule
+ *              is about: {@code a < b} leaves neither of them divided, and a reader looking up
+ *              either is owed the same answer. Filed at the first alone, which position was named
+ *              would turn on which side the author wrote it
+ * @param why   what would have to change before this rule could be a line, in this compiler's own
+ *              terms. Which word a report writes for it is {@link ReportedReason}'s, so a
+ *              capability gained here need not move a published vocabulary
  */
-public record UnreadRule(TermPath at, BlockReason why) {}
+public record UnreadRule(RuleRef rule, RuleCitation cited, TermPath at,
+                         BlockReason.AboutARule why) {
+
+    public UnreadRule {
+        if (rule == null || cited == null) {
+            throw new IllegalArgumentException(
+                    "a rule this could not read is one a reader can be sent to look at");
+        }
+        if (at == null || why == null) {
+            throw new IllegalArgumentException("a rule went unread somewhere, and for something");
+        }
+    }
+
+    /**
+     * Whether this is the same finding as {@code other}.
+     *
+     * <p>The rule, the position and the limit. The citation is left out on purpose: a rule and the
+     * handle for it are two questions, and a key holding the handle would file one rule under
+     * several wherever the two come apart.
+     */
+    public boolean sameAs(UnreadRule other) {
+        return rule.equals(other.rule) && at.equals(other.at) && why.equals(other.why);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/BodyCutInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BodyCutInspection.java
@@ -39,9 +39,15 @@ public sealed interface BodyCutInspection {
     /**
      * A rule was written about the position and nothing here turned it into a line.
      *
-     * <p>Not a verdict on the position. Something else may still answer for it — this is what it
-     * would be left with — and what {@code why} names is a capability, so a report saying it is
-     * telling an author what to wait for rather than what the model says.
+     * <p>Not a verdict on the position. Something else may still answer for it, and what this
+     * settles is only that this phase did not.
+     *
+     * <p>It carries no reason, and the reason is not lost. A rule this phase read and could not use
+     * is an {@link souther.compiler.inputs.UnreadRule} made by the reader that read it, naming
+     * which rule; carried through here as well, one limit at one position stood for however many
+     * rules were stopped by it, and the first of them was the one a report printed.
+     * What this phase owes the verdict is whether it drew anything, which is the whole of what
+     * three cases say.
      */
-    record Blocked(BlockReason why) implements BodyCutInspection {}
+    record Blocked() implements BodyCutInspection {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -165,7 +165,8 @@ public final class EnsuresThresholds {
         // said, because a position left out of every answer is reported as one the model draws no
         // line through — and the model says otherwise in the rule this stopped on.
         if (!(e instanceof Core.Binary comparison) || !GuardThresholds.orders(comparison.op())) {
-            reportUnread(e, rule.value(), reads, symbols, out.unread());
+            reportUnread(new RuleRef.Ensures(rule.id(), clause), e, rule.value(),
+                    reads, symbols, out.unread());
             return;
         }
         // What the comparison cuts is read the same way wherever a comparison is written, which is
@@ -175,7 +176,8 @@ public final class EnsuresThresholds {
         if (cutting == null) {
             // The positions are named as unread, because what the partition could not read here it
             // still could not read.
-            reportUnread(comparison, rule.value(), reads, symbols, out.unread());
+            reportUnread(new RuleRef.Ensures(rule.id(), clause), comparison,
+                    rule.value(), reads, symbols, out.unread());
             // Every position the comparison names, by the walk a body's conditions use. Asked of the
             // narrower reading instead, a comparison this could not read had no position to be filed
             // at — which is exactly the comparison whose questions stand, so the clause that most
@@ -202,7 +204,8 @@ public final class EnsuresThresholds {
             // The positions are named as ones nothing divides, which is what a rule over a quantity
             // that is not one position's own values leaves them — the same note the same shape gets
             // from a body's conditions, said by the same reader.
-            reportUnread(comparison, rule.value(), reads, symbols, out.unread());
+            reportUnread(new RuleRef.Ensures(rule.id(), clause), comparison,
+                    rule.value(), reads, symbols, out.unread());
             // Null where the quantity does not reach the line, which is the line and not one of its
             // points. What a clause raises is answered by what came of reading it and never by which
             // reading was tried: read off the branch, a rule that drew nothing reported a line.
@@ -250,7 +253,7 @@ public final class EnsuresThresholds {
         out.accounting().add(new GuardThresholds.Guards.AtAPosition(at, term,
                 RuleAccounting.ofComparison(named, ComparisonClaim.of(comparison.op()), of, read,
                         // A clause belongs to a behavior, so there is always something to call it.
-                        new souther.compiler.check.RuleCitation.Named(named.named()))));
+                        souther.compiler.check.RuleCitation.named(named))));
     }
 
     /**
@@ -271,17 +274,19 @@ public final class EnsuresThresholds {
      * is not — a rule stated in some other form — what stopped this is the form, which is the one
      * of the three reasons that does not turn on what two sides name.
      */
-    private static void reportUnread(Core statement, BindingId answer, InputReads reads,
-                                     Symbols symbols, List<UnreadRule> unread) {
+    private static void reportUnread(RuleRef.Ensures rule, Core statement, BindingId answer,
+                                     InputReads reads, Symbols symbols, List<UnreadRule> unread) {
         if (readsTheAnswer(statement, answer)) {
             return;
         }
-        BlockReason why = statement instanceof Core.Binary comparison
+        BlockReason.AboutARule why = statement instanceof Core.Binary comparison
                 ? GuardThresholds.why(comparison, reads, symbols)
                 : new BlockReason.UnreadComparisonForm();
+        souther.compiler.check.RuleCitation cited =
+                souther.compiler.check.RuleCitation.named(rule);
         for (TermPath named : GuardThresholds.mentionedIn(statement, reads, symbols)) {
-            UnreadRule here = new UnreadRule(named, why);
-            if (unread.stream().noneMatch(had -> had.equals(here))) {
+            UnreadRule here = new UnreadRule(rule, cited, named, why);
+            if (unread.stream().noneMatch(had -> had.sameAs(here))) {
                 unread.add(here);
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -141,8 +141,8 @@ public final class GuardThresholds {
             // and a line read at it says nothing about the rest: kept per position, a threshold on
             // `x` swallowed the comparison beside it that nothing could read, which is "a result
             // exists, so the reading is complete".
-            for (UnreadRule compared : comparedIn(iff.cond(), read, reads, symbols)) {
-                if (unread.stream().noneMatch(had -> had.equals(compared))) {
+            for (UnreadRule compared : comparedIn(behavior, iff, read, reads, symbols)) {
+                if (unread.stream().noneMatch(had -> had.sameAs(compared))) {
                     unread.add(compared);
                 }
             }
@@ -166,29 +166,40 @@ public final class GuardThresholds {
      * question, and this establishes only that the model draws something at this position — which is
      * exactly what {@code not derivable} would otherwise deny.
      */
-    private static List<UnreadRule> comparedIn(Core e, List<Core> read, InputReads reads,
-                                               Symbols symbols) {
+    private static List<UnreadRule> comparedIn(String behavior, Core.If iff, List<Core> read,
+                                               InputReads reads, Symbols symbols) {
         List<UnreadRule> out = new ArrayList<>();
-        compared(e, read, reads, symbols, out);
+        compared(behavior, iff, iff.cond(), read, reads, symbols, out);
         return out;
     }
 
-    private static void compared(Core e, List<Core> read, InputReads reads, Symbols symbols,
-                                 List<UnreadRule> out) {
+    private static void compared(String behavior, Core.If iff, Core e, List<Core> read,
+                                 InputReads reads, Symbols symbols, List<UnreadRule> out) {
         // By the comparison it is, and not by what it was about: two comparisons at one position are
         // two statements, and this one having been read is no answer about the other.
         if (e instanceof Core.Binary comparison && orders(comparison.op())
                 && read.stream().anyMatch(each -> each == comparison)) {
             return;
         }
-        if (e instanceof Core.Binary binary && orders(binary.op())) {
+        if (e instanceof Core.Binary binary && orders(binary.op()) && writtenHere(binary)) {
             List<TermPath> named = new ArrayList<>();
             mentioned(binary.left(), reads, symbols, named);
             mentioned(binary.right(), reads, symbols, named);
-            BlockReason why = why(binary, reads, symbols);
+            BlockReason.AboutARule why = why(binary, reads, symbols);
+            // The rule the author wrote, read off the source. Which comparison it is is the
+            // behavior and the construct; where a reader is sent is the fork it stands in and the
+            // place it is written. Neither comes from the plan: a condition both of whose arms can
+            // record nothing is numbered nowhere, and a model states its rules regardless.
+            RuleRef.Guard rule = new RuleRef.Guard(behavior, binary.origin());
+            souther.compiler.check.RuleCitation cited = citationOf(iff, binary);
             for (TermPath each : named) {
-                if (out.stream().noneMatch(had -> had.at().equals(each))) {
-                    out.add(new UnreadRule(each, why));
+                // One per position the comparison names, and told from its neighbours by the rule
+                // as well as the place. Kept by position alone, the second comparison of one
+                // condition about one position was dropped as a repeat of the first — which is the
+                // defect this finding is about, one level in.
+                UnreadRule said = new UnreadRule(rule, cited, each, why);
+                if (out.stream().noneMatch(had -> had.sameAs(said))) {
+                    out.add(said);
                 }
             }
         }
@@ -198,7 +209,34 @@ public final class GuardThresholds {
         // expansion as being about nothing.
         InputReads inside = e instanceof Core.LetIn let ? reads.and(let.binder(), let.value())
                 : reads;
-        Core.forEachChild(e, child -> compared(child, read, inside, symbols, out));
+        Core.forEachChild(e, child -> compared(behavior, iff, child, read, inside, symbols, out));
+    }
+
+    /**
+     * Whether the author wrote this comparison in the reach being read.
+     *
+     * <p>A helper is spliced into every body that calls it, so its own comparisons stand in this
+     * tree and are not this behavior's rules to answer for. {@code Int.clamp(0, 100, n) > 70} is
+     * one comparison an author wrote here and two they wrote nowhere near here, and a report
+     * naming the second two tells them to go and edit a function they may not own.
+     *
+     * <p>Asked of the comparison and not of the fork above it. The one the author wrote sits
+     * outside an expansion whose insides they did not, so a subtree is the wrong unit — and the
+     * walk still goes through the expansion, because that is where a call's argument is bound and
+     * a comparison read without it is about nothing.
+     *
+     * <p>{@link Citation} and not the position, which cannot say this: a spliced node carries the
+     * coordinates of the code it was copied from. {@link Citation.Elsewhere} is what already
+     * distinguishes code reached from another declaration from code written where the reader is
+     * standing, and it is the same answer {@link souther.compiler.check.RuleCitation} renders.
+     *
+     * <p>The scope the accounting is already held to. A comparison inside a helper raises no
+     * question there either ({@code AComparisonInsideAHelperRaisesNothingTest}), so widening this
+     * one alone would leave a finding about a rule no accounting has ever heard of. That the two
+     * ought to widen together is a known gap and is not this issue's.
+     */
+    private static boolean writtenHere(Core.Binary comparison) {
+        return !(Citation.of(comparison.pos()) instanceof Citation.Elsewhere);
     }
 
     /**
@@ -234,7 +272,7 @@ public final class GuardThresholds {
      * a body's read of a parameter is what names one here, and a coordinate of a value is what
      * names one over there.
      */
-    static BlockReason why(Core.Binary comparison, InputReads reads,
+    static BlockReason.AboutARule why(Core.Binary comparison, InputReads reads,
                            Symbols symbols) {
         return UnreadComparison.why(sideOf(comparison.left(), reads, symbols),
                 sideOf(comparison.right(), reads, symbols),
@@ -333,11 +371,11 @@ public final class GuardThresholds {
             // rule's.
             Cutting cutting = Cutting.of(behavior, each.comparison(), reads, symbols);
             if (cutting == null) {
-                raisesNoLine(accounting, plan, site, guard, iff, each.comparison(), reads, symbols);
+                raisesNoLine(accounting, behavior, iff, each.comparison(), reads, symbols);
                 continue;
             }
             OriginRef.GuardOrigin origin = new OriginRef.GuardOrigin(
-                    new RuleRef.Guard(plan.site(site).comparison()),
+                    new RuleRef.Guard(behavior, each.comparison().origin()),
                     new OriginRef.GuardOrigin.Read(guard, site, Citation.of(iff.pos())),
                     cutting.valueBelongsBelow(), each.witness(), cutting.holdsAtTheValue(),
                     cutting.singles());
@@ -351,7 +389,7 @@ public final class GuardThresholds {
                 // against a negative draws nothing.
                 Border drawn = Border.at(cutting.target(), origin, cutting.within());
                 if (drawn == null) {
-                    raisesNoLine(accounting, plan, site, guard, iff, each.comparison(), reads,
+                    raisesNoLine(accounting, behavior, iff, each.comparison(), reads,
                             symbols);
                     continue;
                 }
@@ -366,7 +404,7 @@ public final class GuardThresholds {
                 }
                 // Filed at the position the reading names first, which is the one a line between two
                 // would be read `on`. One comparison is one line however many positions it mentions.
-                raises(accounting, plan, site, guard, iff, each.comparison(), named.get(0),
+                raises(accounting, behavior, iff, each.comparison(), named.get(0),
                         comparedTerm(each.comparison(), reads, symbols),
                         subjectsOf(each.comparison(), reads, symbols, null),
                         new Required.LineRead.ALineBetweenTwoPositions());
@@ -379,7 +417,7 @@ public final class GuardThresholds {
             } else {
                 out.add(new Threshold(divided, value, cutting.valueBelongsBelow(), origin));
             }
-            raises(accounting, plan, site, guard, iff, each.comparison(), divided.path(), divided,
+            raises(accounting, behavior, iff, each.comparison(), divided.path(), divided,
                     subjectsOf(each.comparison(), reads, symbols, null),
                     new Required.LineRead.ALineOnThePosition());
         }
@@ -387,16 +425,16 @@ public final class GuardThresholds {
     }
 
     /** What a comparison nothing read raises, filed at the position the reading names first. */
-    private static void raisesNoLine(List<Guards.AtAPosition> accounting, CoverageSites.Plan plan,
-                                     int site, CoverageSites.GuardRef guard, Core.If iff,
-                                     Core.Binary comparison, InputReads reads, Symbols symbols) {
+    private static void raisesNoLine(List<Guards.AtAPosition> accounting, String behavior,
+                                     Core.If iff, Core.Binary comparison, InputReads reads,
+                                     Symbols symbols) {
         List<TermPath> named = new ArrayList<>();
         mentioned(comparison.left(), reads, symbols, named);
         mentioned(comparison.right(), reads, symbols, named);
         if (named.isEmpty()) {
             return;   // a comparison about no position of the input raises nothing about one
         }
-        raises(accounting, plan, site, guard, iff, comparison, named.get(0),
+        raises(accounting, behavior, iff, comparison, named.get(0),
                 comparedTerm(comparison, reads, symbols),
                 subjectsOf(comparison, reads, symbols, null),
                 new Required.LineRead.NoLine(why(comparison, reads, symbols)));
@@ -486,18 +524,36 @@ public final class GuardThresholds {
      * where nothing answers it — walked from the lines, such a rule would be one the model never
      * wrote.
      */
-    private static void raises(List<Guards.AtAPosition> out, CoverageSites.Plan plan, int site,
-                               CoverageSites.GuardRef guard, Core.If iff, Core.Binary comparison,
-                               TermPath at, NumericTerm term,
+    private static void raises(List<Guards.AtAPosition> out, String behavior, Core.If iff,
+                               Core.Binary comparison, TermPath at, NumericTerm term,
                                Required.ComparisonSubject of, Required.LineRead read) {
         out.add(new Guards.AtAPosition(at, term, RuleAccounting.ofComparison(
-                new RuleRef.Guard(plan.site(site).comparison()),
+                new RuleRef.Guard(behavior, comparison.origin()),
                 souther.compiler.check.ComparisonClaim.of(comparison.op()), of, read,
                 // A comparison is written rather than named, so a reader is sent where the author
                 // wrote it — the comparison's own place and not the fork's. Two comparisons of one
                 // condition are two rules, and cited at the `if` they were one handle twice.
-                new souther.compiler.check.RuleCitation.WrittenAt(
-                        guard.origin().kind(), Citation.of(comparison.pos())))));
+                //
+                // The construct is the fork's, which is what a rule with no name is found by: an
+                // `if` and a `guard` are two things an author wrote and a reader looks for two
+                // different words. Asked of the comparison's own origin instead, the answer is
+                // `BINARY`, which is not a construct a rule is written in at all.
+                citationOf(iff, comparison))));
+    }
+
+    /**
+     * How a reader finds a comparison, which is what construct it stands in and where it is
+     * written.
+     *
+     * <p>Two coordinates from two places, and neither stands for the other. The fork says what to
+     * call the thing the author wrote; the comparison says where in the file to look. A condition
+     * holding two comparisons is two rules under one construct, so citing both at the fork would be
+     * one handle twice.
+     */
+    static souther.compiler.check.RuleCitation.WrittenAt citationOf(Core.If iff,
+                                                                   Core.Binary comparison) {
+        return new souther.compiler.check.RuleCitation.WrittenAt(
+                iff.origin().kind(), Citation.of(comparison.pos()));
     }
 
     /** One comparison of a condition, and which arms of the {@code if} prove it was evaluated. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -209,31 +209,39 @@ public final class GuardThresholds {
         // expansion as being about nothing.
         InputReads inside = e instanceof Core.LetIn let ? reads.and(let.binder(), let.value())
                 : reads;
-        Core.forEachChild(e, child -> compared(behavior, iff, child, read, inside, symbols, out));
+        Core.forEachChild(e, child -> {
+            // Not into a fork of its own. A condition can hold one — `guard (if a < b then ...)` —
+            // and its comparisons are written in that fork rather than in this one, so citing them
+            // here would take the word from one construct and the place from another. The walk that
+            // found this fork reaches that one too, and reads it against itself.
+            if (!(child instanceof Core.If)) {
+                compared(behavior, iff, child, read, inside, symbols, out);
+            }
+        });
     }
 
     /**
-     * Whether the author wrote this comparison in the reach being read.
+     * Whether this comparison is written in code this compile can send a reader to.
      *
-     * <p>A helper is spliced into every body that calls it, so its own comparisons stand in this
-     * tree and are not this behavior's rules to answer for. {@code Int.clamp(0, 100, n) > 70} is
-     * one comparison an author wrote here and two they wrote nowhere near here, and a report
-     * naming the second two tells them to go and edit a function they may not own.
+     * <p>A call is spliced into the body that makes it, so a comparison written in something else
+     * stands in this tree. Where that something else is out of sight — a library this compile has
+     * no file for — the comparison is not a rule anybody reading this behavior can act on:
+     * {@code Int.clamp(0, 100, n) > 70} is one comparison an author wrote and two they cannot open,
+     * and naming the second two tells them to edit a function they do not have.
+     *
+     * <p>A helper of their own is not one of these. It has a file, the report cites it where it is
+     * written, and it is theirs to rewrite — so the line is drawn at what a reader can reach and
+     * not at whether an expansion happened.
+     *
+     * <p>{@link Citation} and not the position, which cannot say this: a spliced node carries the
+     * coordinates of the code it was copied from. {@link Citation.Elsewhere} is exactly "written
+     * where this compile has no file", and it is the same answer
+     * {@link souther.compiler.check.RuleCitation} renders.
      *
      * <p>Asked of the comparison and not of the fork above it. The one the author wrote sits
      * outside an expansion whose insides they did not, so a subtree is the wrong unit — and the
      * walk still goes through the expansion, because that is where a call's argument is bound and
      * a comparison read without it is about nothing.
-     *
-     * <p>{@link Citation} and not the position, which cannot say this: a spliced node carries the
-     * coordinates of the code it was copied from. {@link Citation.Elsewhere} is what already
-     * distinguishes code reached from another declaration from code written where the reader is
-     * standing, and it is the same answer {@link souther.compiler.check.RuleCitation} renders.
-     *
-     * <p>The scope the accounting is already held to. A comparison inside a helper raises no
-     * question there either ({@code AComparisonInsideAHelperRaisesNothingTest}), so widening this
-     * one alone would leave a finding about a rule no accounting has ever heard of. That the two
-     * ought to widen together is a known gap and is not this issue's.
      */
     private static boolean writtenHere(Core.Binary comparison) {
         return !(Citation.of(comparison.pos()) instanceof Citation.Elsewhere);

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -78,6 +78,7 @@ public final class Partitions {
                                java.util.Set<NumericTerm> uncertain,
                                List<UndividedPosition> undivided,
                                List<UnreadRule> unread,
+                               List<souther.compiler.inputs.PositionReadingBlocked> blocked,
                                List<Border> between,
                                List<GuardThresholds.Guards.AtAPosition> compared) {
         public Partitioning {
@@ -88,6 +89,7 @@ public final class Partitions {
             uncertain = java.util.Set.copyOf(uncertain);
             undivided = List.copyOf(undivided);
             unread = List.copyOf(unread);
+            blocked = List.copyOf(blocked);
             between = List.copyOf(between);
         }
 
@@ -166,7 +168,7 @@ public final class Partitions {
             keep(new ArrayList<>(), measured, axis, null, unread);
         }
         return new Partitioning(kept, omitted, domains, uncertain, undividedIn(measured),
-                List.copyOf(unread), List.of(), List.of());
+                List.copyOf(unread), blockedIn(measured), List.of(), List.of());
     }
 
     /**
@@ -197,10 +199,12 @@ public final class Partitions {
             measured.add(new Measured(axis, drew));
             return;
         }
-        BlockReason unread = rules.stream().filter(one -> one.at().equals(axis.path()))
-                .map(UnreadRule::why).findFirst().orElse(null);
-        measured.add(new Measured(axis, unread == null ? new BodyCutInspection.Exhausted()
-                : new BodyCutInspection.Blocked(unread)));
+        // Whether this phase left anything at the position unread, and not which limit it was.
+        // A limit belongs to the rule it stopped, and the findings carry it there; taken as the
+        // position's, the first rule of however many were stopped alike was the one a report named.
+        boolean anyUnread = rules.stream().anyMatch(one -> one.at().equals(axis.path()));
+        measured.add(new Measured(axis, anyUnread ? new BodyCutInspection.Blocked()
+                : new BodyCutInspection.Exhausted()));
     }
 
     /**
@@ -221,6 +225,30 @@ public final class Partitions {
             PendingPosition pending = PendingPosition.of(each.axis());
             if (pending != null) {
                 out.add(pending.complete(each.body()));
+            }
+        }
+        return List.copyOf(out);
+    }
+
+    /**
+     * The positions this reading did not get to the rules of, resolved.
+     *
+     * <p>Off the same pairing the verdict is, and neither is read from the other. Both phases have
+     * spoken by the time a {@link Measured} exists — what the position's own declarations answered
+     * and what a body's rules drew — and a candidate that neither of them answered is what an
+     * author is waiting on. Written where the producer records it, every position holding an
+     * `+Option+` said so whether or not the reading of it came to anything, and `not read` would be
+     * a list of what this compiler cannot generally do rather than of what it did not read here.
+     */
+    private static List<souther.compiler.inputs.PositionReadingBlocked> blockedIn(
+            List<Measured> measured) {
+        List<souther.compiler.inputs.PositionReadingBlocked> out = new ArrayList<>();
+        for (Measured each : measured) {
+            PendingPosition pending = PendingPosition.of(each.axis());
+            souther.compiler.inputs.PositionReadingBlocked stopped =
+                    pending == null ? null : pending.reportable();
+            if (stopped != null && !out.contains(stopped)) {
+                out.add(stopped);
             }
         }
         return List.copyOf(out);
@@ -313,7 +341,7 @@ public final class Partitions {
         // them wrote about and neither could turn into a line is named once, whichever wrote it.
         List<UnreadRule> rules = new ArrayList<>(base.unread());
         for (UnreadRule each : unread) {
-            if (rules.stream().noneMatch(had -> had.equals(each))) {
+            if (rules.stream().noneMatch(had -> had.sameAs(each))) {
                 rules.add(each);
             }
         }
@@ -398,7 +426,7 @@ public final class Partitions {
                     reachable.isEmpty() ? null : new BodyCutInspection.Evidence(), rules);
         }
         return new Partitioning(out, base.omitted(), domainsOf(base, out), base.uncertain(),
-                undividedIn(measured), List.copyOf(rules), between, compared);
+                undividedIn(measured), List.copyOf(rules), blockedIn(measured), between, compared);
     }
 
     /**
@@ -627,7 +655,7 @@ public final class Partitions {
                                List<Axis> out, Map<NumericTerm, NumericDomain.Bounds> domains,
                                java.util.Set<NumericTerm> uncertain, List<UnreadRule> unread) {
         for (UnreadRule each : position.unreadRules()) {
-            if (unread.stream().noneMatch(had -> had.equals(each))) {
+            if (unread.stream().noneMatch(had -> had.sameAs(each))) {
                 unread.add(each);
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
@@ -81,20 +81,6 @@ sealed interface PendingPosition {
     }
 
     /**
-     * What the position comes to, once what the rules said about it is known.
-     *
-     * <p>The phase's answer and not one producer's. A {@code guard}'s comparison and a newtype's
-     * invariant are two producers of one kind of evidence, and {@link BodyCutInspection} is what
-     * came of asking them — which is why this takes one of those rather than a list of lines and a
-     * reason beside it. What makes it the phase's answer is where it is produced, not this
-     * signature: a caller inside this package can still build one out of half a reading.
-     *
-     * <p>The structural reason outranks the rules'. Where the walk could not reach into what a
-     * position holds, a rule naming something inside it describes that same stop from the other end
-     * and the first is the cause (issue #626). So a {@link Blocked} completes as itself whatever
-     * the rules came to, and only a {@link Leaf} can reach an absence.
-     */
-    /**
      * The finding this comes to, or null where there is none to make.
      *
      * <p>The resolution, and the only place a structural stop becomes something a report says. What
@@ -120,6 +106,20 @@ sealed interface PendingPosition {
                 ? new souther.compiler.inputs.PositionReadingBlocked(at(), why) : null;
     }
 
+    /**
+     * What the position comes to, once what the rules said about it is known.
+     *
+     * <p>The phase's answer and not one producer's. A {@code guard}'s comparison and a newtype's
+     * invariant are two producers of one kind of evidence, and {@link BodyCutInspection} is what
+     * came of asking them — which is why this takes one of those rather than a list of lines and a
+     * reason beside it. What makes it the phase's answer is where it is produced, not this
+     * signature: a caller inside this package can still build one out of half a reading.
+     *
+     * <p>The structural reason outranks the rules'. Where the walk could not reach into what a
+     * position holds, a rule naming something inside it describes that same stop from the other end
+     * and the first is the cause (issue #626). So a {@link Blocked} completes as itself whatever
+     * the rules came to, and only a {@link Leaf} can reach an absence.
+     */
     default UndividedPosition complete(BodyCutInspection body) {
         if (body instanceof BodyCutInspection.Evidence) {
             // A line was drawn and the axis carrying it says it has none. Nothing a reader of a

--- a/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
@@ -94,6 +94,32 @@ sealed interface PendingPosition {
      * and the first is the cause (issue #626). So a {@link Blocked} completes as itself whatever
      * the rules came to, and only a {@link Leaf} can reach an absence.
      */
+    /**
+     * The finding this comes to, or null where there is none to make.
+     *
+     * <p>The resolution, and the only place a structural stop becomes something a report says. What
+     * a producer records is a candidate: the walk could not reach into what a position holds, and
+     * that is worth telling an author exactly when nothing else answered for the position. Reported
+     * off the producer alone, {@code note: String?} said its values are held inside something this
+     * does not reach into — true of the compiler, and no account of this position, whose two cases
+     * the reading divided perfectly well. Reaching one of these is already the proof that nothing
+     * did: {@link #of} refuses an axis with evidence.
+     *
+     * <p>Null where the surviving reason is about a rule. Such a reason is a rule this read and
+     * could not use, which is an {@link souther.compiler.inputs.UnreadRule} made by the reader that
+     * read it and carrying which rule — said again here, it would be the same fact twice, once
+     * without the rule.
+     *
+     * <p>Null for a {@link Leaf} too: nothing stopped, so there is nothing to be waiting on.
+     */
+    default souther.compiler.inputs.PositionReadingBlocked reportable() {
+        if (!(this instanceof Blocked blocked)) {
+            return null;
+        }
+        return blocked.why() instanceof BlockReason.AboutThePosition why
+                ? new souther.compiler.inputs.PositionReadingBlocked(at(), why) : null;
+    }
+
     default UndividedPosition complete(BodyCutInspection body) {
         if (body instanceof BodyCutInspection.Evidence) {
             // A line was drawn and the axis carrying it says it has none. Nothing a reader of a
@@ -103,11 +129,9 @@ sealed interface PendingPosition {
                     "the rules drew a line at " + at() + " and its axis has no evidence");
         }
         return switch (this) {
-            case Blocked blocked ->
-                    UndividedPosition.cannotDerive(at(), ReportedReason.of(blocked.why()));
+            case Blocked _ -> UndividedPosition.cannotDerive(at());
             case Leaf _ -> switch (body) {
-                case BodyCutInspection.Blocked blocked ->
-                        UndividedPosition.cannotDerive(at(), ReportedReason.of(blocked.why()));
+                case BodyCutInspection.Blocked _ -> UndividedPosition.cannotDerive(at());
                 // The producers of both phases asked, none of them stopped, and none of them found
                 // anything. Which is the only way to an absence, and is what one means: what those
                 // readers read, rather than a claim about what could have been written.

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReportedReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReportedReason.java
@@ -44,6 +44,8 @@ public final class ReportedReason {
                     UndividedPosition.Reason.RULES_NOT_READ_AT_ALL;
             case BlockReason.UnreadComparisonDomain _ ->
                     UndividedPosition.Reason.UNSUPPORTED_DOMAIN;
+            case BlockReason.CompetingCoordinates _ ->
+                    UndividedPosition.Reason.COMPETING_COORDINATES;
             case BlockReason.ComparisonBetweenPositions _ ->
                     UndividedPosition.Reason.UNSUPPORTED_PARTITION_SHAPE;
         };

--- a/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
@@ -64,8 +64,8 @@ public record UndividedPosition(TermPath at, Why why) {
          * <p>What stopped it is not here. A verdict says whether anything divides the position; the
          * findings beside it say what was not read and by whose account, and each of those is made
          * by the reader that has the fact — with the rule where there is one. Carried here too, a
-         * report read the cause back off the verdict, which is where the rule had already been lost
-         *.
+         * report read the cause back off the verdict, which is where the rule had already been
+         * lost.
          */
         record CannotDerive() implements Why {}
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
@@ -58,8 +58,16 @@ public record UndividedPosition(TermPath at, Why why) {
             }
         }
 
-        /** Something is written here that this did not read, so nothing is established either way. */
-        record CannotDerive(Reason reason) implements Why {}
+        /**
+         * Something is written here that this did not read, so nothing is established either way.
+         *
+         * <p>What stopped it is not here. A verdict says whether anything divides the position; the
+         * findings beside it say what was not read and by whose account, and each of those is made
+         * by the reader that has the fact — with the rule where there is one. Carried here too, a
+         * report read the cause back off the verdict, which is where the rule had already been lost
+         *.
+         */
+        record CannotDerive() implements Why {}
     }
 
     /**
@@ -103,6 +111,15 @@ public record UndividedPosition(TermPath at, Why why) {
         /** The values the comparison is against are not ones a line can be drawn on here. */
         UNSUPPORTED_DOMAIN,
         /**
+         * Two rules of the position are about its two coordinates, and neither can be chosen.
+         *
+         * <p>Not {@link #UNSUPPORTED_SYNTAX}, which is where a rule was read and could not be
+         * used: here both were read and used perfectly well, and what is missing is a rule for
+         * which of a position's two coordinates it is measured at. Said as the first, an author was
+         * sent looking for a form this compiler reads.
+         */
+        COMPETING_COORDINATES,
+        /**
          * The comparison relates two positions rather than dividing one.
          *
          * <p>`+x < y+` says where one position stands against another, and a class here is a set of
@@ -141,8 +158,8 @@ public record UndividedPosition(TermPath at, Why why) {
         return new UndividedPosition(proven.at(), Why.Absent.PROVEN);
     }
 
-    static UndividedPosition cannotDerive(TermPath at, Reason reason) {
-        return new UndividedPosition(at, new Why.CannotDerive(reason));
+    static UndividedPosition cannotDerive(TermPath at) {
+        return new UndividedPosition(at, new Why.CannotDerive());
     }
 
     public boolean isAbsent() {

--- a/souther-compiler/src/main/java/souther/compiler/query/About.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/About.java
@@ -77,6 +77,20 @@ public sealed interface About {
         }
     }
 
+    /**
+     * A finding about one rule of the model, which is what carries its identity.
+     *
+     * <p>Which findings these are is answered here and nowhere else. Read off a list of kinds, a
+     * writer had to be told again every time one was added â and a kind added and not told wrote no
+     * identity, which is one rule's findings coming out identical in every field with nothing to
+     * join them by. A shape that is about a rule says so by being one of these.
+     */
+    sealed interface OfARule extends About {
+
+        /** Which rule, as everything that names a rule names it. */
+        souther.compiler.check.RuleRef rule();
+    }
+
     /** A position the model draws no line through. */
     record APositionNoLineDivides(
             souther.compiler.partition.UndividedPosition position) implements About {
@@ -93,9 +107,14 @@ public sealed interface About {
      * unread and left them to work out which rule — which the accounting was made to say and this
      * measure beside it was not.
      */
-    record ARuleThisCouldNotRead(PartitionEvidence.NotRead.ARule finding) implements About {
+    record ARuleThisCouldNotRead(PartitionEvidence.NotRead.ARule finding) implements OfARule {
         public ARuleThisCouldNotRead {
             java.util.Objects.requireNonNull(finding, "a finding is about something");
+        }
+
+        @Override
+        public souther.compiler.check.RuleRef rule() {
+            return finding.rule();
         }
     }
 
@@ -129,7 +148,13 @@ public sealed interface About {
      * taken apart. It was taken apart into six elements one seam later, which is the thing that
      * contract was written against.
      */
-    record AQuestionNothingAnswered(PartitionEvidence.Unanswered asked) implements About {
+    record AQuestionNothingAnswered(PartitionEvidence.Unanswered asked) implements OfARule {
+
+        @Override
+        public souther.compiler.check.RuleRef rule() {
+            return asked.rule();
+        }
+
         public AQuestionNothingAnswered {
             java.util.Objects.requireNonNull(asked, "a finding is about something");
         }

--- a/souther-compiler/src/main/java/souther/compiler/query/About.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/About.java
@@ -85,10 +85,32 @@ public sealed interface About {
         }
     }
 
-    /** A position something is written about that this did not read, with what stopped it. */
-    record APositionThisCouldNotRead(PartitionEvidence.UnreadPosition position) implements About {
+    /**
+     * A rule of the model this read and could not turn into a line, and what stopped it.
+     *
+     * <p>Named by the rule, because a position is not what an author edits. Carrying only the
+     * position, the sentence written from this told an author that a rule about somewhere went
+     * unread and left them to work out which rule — which the accounting was made to say and this
+     * measure beside it was not.
+     */
+    record ARuleThisCouldNotRead(PartitionEvidence.NotRead.ARule finding) implements About {
+        public ARuleThisCouldNotRead {
+            java.util.Objects.requireNonNull(finding, "a finding is about something");
+        }
+    }
+
+    /**
+     * A position whose rules this reading never arrived at, with what stopped it.
+     *
+     * <p>Its own shape beside the rule above, and not that one with the rule left out. There is no
+     * rule to name here and a reader is owed the position and the limit; a consumer told to read an
+     * absent field to know which of the two it holds is reconstructing the authority from the
+     * payload.
+     */
+    record APositionThisCouldNotRead(PartitionEvidence.NotRead.APosition finding)
+            implements About {
         public APositionThisCouldNotRead {
-            java.util.Objects.requireNonNull(position, "a finding is about something");
+            java.util.Objects.requireNonNull(finding, "a finding is about something");
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/About.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/About.java
@@ -91,6 +91,20 @@ public sealed interface About {
         souther.compiler.check.RuleRef rule();
     }
 
+    /**
+     * A finding about something this reading did not read, whichever authority answered.
+     *
+     * <p>Both shapes carry a limit, and a reader acts on it: which one is in the way is the thing
+     * either finding was added to say. Asked here rather than matched against the kinds that have
+     * one, for the reason {@link OfARule} is: a shape added and not listed writes no limit, and one
+     * rule's findings at one position come out identical wherever it stopped for two of them.
+     */
+    sealed interface OfSomethingNotRead extends About {
+
+        /** The finding itself, whose reason is what a document promises its reader. */
+        PartitionEvidence.NotRead finding();
+    }
+
     /** A position the model draws no line through. */
     record APositionNoLineDivides(
             souther.compiler.partition.UndividedPosition position) implements About {
@@ -107,7 +121,8 @@ public sealed interface About {
      * unread and left them to work out which rule — which the accounting was made to say and this
      * measure beside it was not.
      */
-    record ARuleThisCouldNotRead(PartitionEvidence.NotRead.ARule finding) implements OfARule {
+    record ARuleThisCouldNotRead(PartitionEvidence.NotRead.ARule finding)
+            implements OfARule, OfSomethingNotRead {
         public ARuleThisCouldNotRead {
             java.util.Objects.requireNonNull(finding, "a finding is about something");
         }
@@ -127,7 +142,7 @@ public sealed interface About {
      * payload.
      */
     record APositionThisCouldNotRead(PartitionEvidence.NotRead.APosition finding)
-            implements About {
+            implements OfSomethingNotRead {
         public APositionThisCouldNotRead {
             java.util.Objects.requireNonNull(finding, "a finding is about something");
         }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -8,6 +8,7 @@ import souther.compiler.diag.DiagnosticCode;
 import souther.compiler.diag.msg.DeadBranchMessage;
 import souther.compiler.diag.msg.ExampleMessage;
 import souther.compiler.diag.Citation;
+import souther.compiler.inputs.BlockReason;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.examples.FixtureReader;
 import souther.compiler.ast.Hir;
@@ -1375,7 +1376,7 @@ public final class Adequacy {
                     // that the switch stays exhaustive over what a finding can be about rather than
                     // over the ones thought of here.
                     case About.ACaseNothingWasSeenToProduce _, About.AClassNoRowIsIn _,
-                            About.APositionNoLineDivides _, About.APositionThisCouldNotRead _,
+                            About.APositionNoLineDivides _, About.APositionThisCouldNotRead _, About.ARuleThisCouldNotRead _,
                             About.APositionWhoseRulesWereNotReached _,
                             About.AQuestionNothingAnswered _,
                             About.APositionPastTheAxisLimit _ ->
@@ -1791,7 +1792,15 @@ public final class Adequacy {
                 case About.APointOfABorder(var point) -> point.role().againstTheLine()
                         ? Kind.BOUNDARY_UNMET : Kind.DOMAIN_POINT_UNCOVERED;
                 case About.APositionNoLineDivides _ -> Kind.PARTITION_NOT_DERIVABLE;
-                case About.APositionThisCouldNotRead _ -> Kind.PARTITION_NOT_READ;
+                case About.ARuleThisCouldNotRead _ -> Kind.PARTITION_NOT_READ;
+                // Which of the two public words a position's stop is, read off what stopped it.
+                // A reading that never arrived at the rules of a position is the thing
+                // PARTITION_RULES_NOT_REACHED is for, and it is that whether the axes went on to
+                // measure the position or not — said as PARTITION_NOT_READ, a consumer would have
+                // to read the reason back to find the one word that already exists for it.
+                case About.APositionThisCouldNotRead(var it) ->
+                        it.finding().why() instanceof BlockReason.ValueRulesNotReached
+                                ? Kind.PARTITION_RULES_NOT_REACHED : Kind.PARTITION_NOT_READ;
                 case About.APositionWhoseRulesWereNotReached _ ->
                         Kind.PARTITION_RULES_NOT_REACHED;
                 case About.AQuestionNothingAnswered _ -> Kind.RULE_UNACCOUNTED;
@@ -1969,11 +1978,16 @@ public final class Adequacy {
             // And what this could not read, asked of the one reading that answers it. A position
             // with classes can still carry a statement nothing read, so this is not filtered by the
             // list above.
-            for (PartitionEvidence.UnreadPosition each : partition.notRead()) {
+            for (PartitionEvidence.NotRead each : partition.notRead()) {
                 // Not measured, because nothing here established anything either way about it.
                 out.add(new Finding(behavior.name(), MeasurementStatus.NOT_MEASURED,
                         Citation.of(behavior.pos()),
-                        new About.APositionThisCouldNotRead(each)));
+                        switch (each) {
+                            case PartitionEvidence.NotRead.ARule rule ->
+                                    new About.ARuleThisCouldNotRead(rule);
+                            case PartitionEvidence.NotRead.APosition position ->
+                                    new About.APositionThisCouldNotRead(position);
+                        }));
             }
             // A position the axes did measure, whose rules this reading is short of. A different
             // thing to act on from one nothing divided: the classes beside it are what the model
@@ -2119,7 +2133,7 @@ public final class Adequacy {
                         // defaulted, so that one added later has to be answered here rather than
                         // arriving as a warning with no sentence.
                         case About.ACaseNothingWasSeenToProduce _, About.AClassNoRowIsIn _,
-                                About.APositionNoLineDivides _, About.APositionThisCouldNotRead _,
+                                About.APositionNoLineDivides _, About.APositionThisCouldNotRead _, About.ARuleThisCouldNotRead _,
                                 About.APositionWhoseRulesWereNotReached _,
                                 About.AQuestionNothingAnswered _,
                                 About.APositionPastTheAxisLimit _ ->
@@ -2184,7 +2198,7 @@ public final class Adequacy {
                 // reason the switch above gives.
                 case About.ACaseNoRowAppliesItTo _, About.ACaseNothingWasSeenToProduce _,
                         About.AClassNoRowIsIn _, About.APositionNoLineDivides _,
-                        About.APositionThisCouldNotRead _,
+                        About.APositionThisCouldNotRead _, About.ARuleThisCouldNotRead _,
                         About.APositionWhoseRulesWereNotReached _,
                         About.AQuestionNothingAnswered _,
                         About.APositionPastTheAxisLimit _ -> { }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -8,7 +8,6 @@ import souther.compiler.diag.DiagnosticCode;
 import souther.compiler.diag.msg.DeadBranchMessage;
 import souther.compiler.diag.msg.ExampleMessage;
 import souther.compiler.diag.Citation;
-import souther.compiler.inputs.BlockReason;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.examples.FixtureReader;
 import souther.compiler.ast.Hir;
@@ -1793,14 +1792,12 @@ public final class Adequacy {
                         ? Kind.BOUNDARY_UNMET : Kind.DOMAIN_POINT_UNCOVERED;
                 case About.APositionNoLineDivides _ -> Kind.PARTITION_NOT_DERIVABLE;
                 case About.ARuleThisCouldNotRead _ -> Kind.PARTITION_NOT_READ;
-                // Which of the two public words a position's stop is, read off what stopped it.
-                // A reading that never arrived at the rules of a position is the thing
-                // PARTITION_RULES_NOT_REACHED is for, and it is that whether the axes went on to
-                // measure the position or not — said as PARTITION_NOT_READ, a consumer would have
-                // to read the reason back to find the one word that already exists for it.
-                case About.APositionThisCouldNotRead(var it) ->
-                        it.finding().why() instanceof BlockReason.ValueRulesNotReached
-                                ? Kind.PARTITION_RULES_NOT_REACHED : Kind.PARTITION_NOT_READ;
+                // One word, whatever stopped the reading, and the reason beside it says which.
+                // PARTITION_RULES_NOT_REACHED belongs to the finding above — a position the axes
+                // did measure — and the two write nothing but the position, so sharing the word
+                // would put two findings a reader can tell apart in the report under one a
+                // consumer cannot.
+                case About.APositionThisCouldNotRead _ -> Kind.PARTITION_NOT_READ;
                 case About.APositionWhoseRulesWereNotReached _ ->
                         Kind.PARTITION_RULES_NOT_REACHED;
                 case About.AQuestionNothingAnswered _ -> Kind.RULE_UNACCOUNTED;

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -167,7 +167,8 @@ final class Coverages {
         }
         return new PartitionEvidence(PartitionEvidence.Partitioned.of(axes),
                 PartitionEvidence.Bounded.of(boundaries), pairsOf(divided, readings),
-                partitioning.undivided(), partitioning.unread(), List.copyOf(standing),
+                partitioning.undivided(), partitioning.unread(), partitioning.blocked(),
+                List.copyOf(standing),
                 partitioning.omitted(),
                 whyUnclassified(readings.byRow(),
                         partitioning.axes().stream().map(Axis::id).toList()));

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -34,6 +34,7 @@ public record PartitionEvidence(Partitioned partitioned, Bounded bounded,
                                 PairSpace pairs,
                                 List<souther.compiler.partition.UndividedPosition> notDerivable,
                                 List<souther.compiler.inputs.UnreadRule> unread,
+                                List<souther.compiler.inputs.PositionReadingBlocked> blocked,
                                 List<Unanswered> unanswered,
                                 List<Partitions.OmittedAxis> omitted,
                                 List<Incompleteness> whyUnclassified) {
@@ -49,11 +50,12 @@ public record PartitionEvidence(Partitioned partitioned, Bounded bounded,
      */
     public static final PartitionEvidence NONE = new PartitionEvidence(Partitioned.absent(),
             Bounded.absent(), PairSpace.NONE, List.of(), List.of(), List.of(), List.of(),
-            List.of());
+            List.of(), List.of());
 
     public PartitionEvidence {
         notDerivable = List.copyOf(notDerivable);
         unread = List.copyOf(unread);
+        blocked = List.copyOf(blocked);
         unanswered = List.copyOf(unanswered);
         omitted = List.copyOf(omitted);
         whyUnclassified = List.copyOf(whyUnclassified);
@@ -117,19 +119,69 @@ public record PartitionEvidence(Partitioned partitioned, Bounded bounded,
     }
 
     /**
-     * A position something is written about that this reading did not turn into a line, and what
-     * stopped it.
+     * One entry of what this reading could not read, as a document writes it.
+     *
+     * <p>Two shapes because two authorities answer. A rule was read and could not be used, and the
+     * finding names which rule; or the reading never got to the rules of a position, and there is
+     * no rule to name. Written as one shape with the rule left out where there is none, a consumer
+     * would have to read an absent field to know which of the two it was holding â which is the
+     * reconstruction this pair exists to stop.
      *
      * <p>The reason in the vocabulary a document promises its reader, not the one this compiler
      * records for itself: which capability was missing is this compiler's own business, and which
      * kind of thing stopped the derivation is what a reader can act on.
      */
-    public record UnreadPosition(String at,
-                                 souther.compiler.partition.UndividedPosition.Reason reason) {}
+    public sealed interface NotRead {
+
+        /** The position it is about, spelled the way a report names it. */
+        String at();
+
+        /** What stopped it, in the words a document promises. */
+        souther.compiler.partition.UndividedPosition.Reason reason();
+
+        /** A rule of the model this read and could not turn into a line. */
+        record ARule(souther.compiler.inputs.UnreadRule finding) implements NotRead {
+
+            @Override
+            public String at() {
+                return finding.at().toString();
+            }
+
+            @Override
+            public souther.compiler.partition.UndividedPosition.Reason reason() {
+                return souther.compiler.partition.ReportedReason.of(finding.why());
+            }
+
+            /** Which rule, which is what tells this finding from the one beside it. */
+            public souther.compiler.check.RuleRef rule() {
+                return finding.rule();
+            }
+
+            /** And how a reader finds that rule, which is not what tells it from another. */
+            public souther.compiler.check.RuleCitation cited() {
+                return finding.cited();
+            }
+        }
+
+        /** A position whose rules this reading never arrived at. */
+        record APosition(souther.compiler.inputs.PositionReadingBlocked finding)
+                implements NotRead {
+
+            @Override
+            public String at() {
+                return finding.at().toString();
+            }
+
+            @Override
+            public souther.compiler.partition.UndividedPosition.Reason reason() {
+                return souther.compiler.partition.ReportedReason.of(finding.why());
+            }
+        }
+    }
 
     /**
-     * Every position this reading carries an unread finding about: a rule it did not turn into a
-     * line, and a position it divided no way and said why.
+     * Everything this reading could not read: the rules it did not turn into lines, and the
+     * positions it did not reach the rules of.
      *
      * <p>Not every position whose rules this reading is short of. How far the reading of a position
      * ran is what its axis carries ({@link AxisCoverage#read()}), and a position measured on a
@@ -138,35 +190,21 @@ public record PartitionEvidence(Partitioned partitioned, Bounded bounded,
      * be the very thing it was written to stop: one question answered by a list that answers
      * another.
      *
-     * <p>One reading, and the two surfaces write from it. It used to be assembled twice — a person
-     * was shown the rules no line came from together with the positions divided no way, and the
-     * document was written from the second alone — so a rule left unread at a position the axes
-     * went on to measure reached one reader and stopped there. Nothing was wrong with either list;
-     * what was wrong is that one question was answered by reading two of them in one place and one
-     * of them in the other.
+     * <p><b>Both halves are canonical and neither is recovered from a verdict.</b> This used to add
+     * the positions {@link #notDerivable} could not derive, which is an account of whether anything
+     * divides a position and not of what was read — and a rule left unread reached that list only
+     * after being projected onto the position it was about, losing the rule on the way. So a rule
+     * and the position it is at came back as two entries of one list, one of which could name
+     * nothing. What is joined here are the two findings themselves, each from the
+     * reader that made it.
      *
-     * <p>The rules come first and the undivided positions after, deduplicated: a position can be
-     * in both, and it is one thing that was found about it either way.
+     * <p>The rules come first and the positions after, in the order each was read.
      */
-    public List<UnreadPosition> notRead() {
-        List<UnreadPosition> out = new java.util.ArrayList<>();
-        for (souther.compiler.inputs.UnreadRule each : unread) {
-            add(out, new UnreadPosition(each.at().toString(),
-                    souther.compiler.partition.ReportedReason.of(each.why())));
-        }
-        for (souther.compiler.partition.UndividedPosition position : notDerivable) {
-            if (position.why() instanceof souther.compiler.partition.UndividedPosition.Why
-                    .CannotDerive stopped) {
-                add(out, new UnreadPosition(position.at().toString(), stopped.reason()));
-            }
-        }
+    public List<NotRead> notRead() {
+        List<NotRead> out = new java.util.ArrayList<>();
+        unread.forEach(each -> out.add(new NotRead.ARule(each)));
+        blocked.forEach(each -> out.add(new NotRead.APosition(each)));
         return List.copyOf(out);
-    }
-
-    private static void add(List<UnreadPosition> out, UnreadPosition said) {
-        if (!out.contains(said)) {
-            out.add(said);
-        }
     }
 
     /** The positions, for a reader that wants them and not what the measure made of itself. */

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -60,7 +60,7 @@ import java.util.Set;
 public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy.Level askedLevel,
                              MeasurementStatus status, List<ModuleReport> modules) {
 
-    public static final int SCHEMA_VERSION = 4;
+    public static final int SCHEMA_VERSION = 3;
 
     /**
      * Whether the rows meet what the asked measures require of them.
@@ -1667,15 +1667,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // how a reader finds it, and two rules an author named alike have the same words — so a
             // consumer joining findings to the questions they came from wants this.
             //
-            // Both kinds that are about a rule. Written for the question alone, two rules stopped
-            // by one limit at one position came out as two findings identical in every field, and
-            // a consumer had nothing to join them to the entries that do carry the rule.
-            switch (finding.about()) {
-                case About.AQuestionNothingAnswered(var asked) ->
-                        ruleId(f.putObject("ruleId"), asked.rule());
-                case About.ARuleThisCouldNotRead(var unread) ->
-                        ruleId(f.putObject("ruleId"), unread.rule());
-                default -> { }
+            // Asked of the subject rather than matched against the kinds that have one. Listed
+            // here, a kind added and not listed wrote no identity, and one rule's findings came out
+            // identical in every field with nothing to join them by.
+            if (finding.about() instanceof About.OfARule about) {
+                ruleId(f.putObject("ruleId"), about.rule());
             }
             // Present where the kind has one. A finding a build is not told about under any code is
             // not one with an empty code, and a consumer joining these to the diagnostics a build

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1666,8 +1666,16 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // Which rule this is about, where the finding is about one. The words in `subject` are
             // how a reader finds it, and two rules an author named alike have the same words — so a
             // consumer joining findings to the questions they came from wants this.
-            if (finding.about() instanceof About.AQuestionNothingAnswered(var asked)) {
-                ruleId(f.putObject("ruleId"), asked.rule());
+            //
+            // Both kinds that are about a rule. Written for the question alone, two rules stopped
+            // by one limit at one position came out as two findings identical in every field, and
+            // a consumer had nothing to join them to the entries that do carry the rule.
+            switch (finding.about()) {
+                case About.AQuestionNothingAnswered(var asked) ->
+                        ruleId(f.putObject("ruleId"), asked.rule());
+                case About.ARuleThisCouldNotRead(var unread) ->
+                        ruleId(f.putObject("ruleId"), unread.rule());
+                default -> { }
             }
             // Present where the kind has one. A finding a build is not told about under any code is
             // not one with an empty code, and a consumer joining these to the diagnostics a build

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -60,7 +60,7 @@ import java.util.Set;
 public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy.Level askedLevel,
                              MeasurementStatus status, List<ModuleReport> modules) {
 
-    public static final int SCHEMA_VERSION = 3;
+    public static final int SCHEMA_VERSION = 4;
 
     /**
      * Whether the rows meet what the asked measures require of them.
@@ -828,12 +828,25 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             }
         }
         // Said apart from the line above it, which is the whole of what this pair is for: one names
-        // a position the model divides no way, and this one a position nobody has established
-        // anything about.
+        // a position the model divides no way, and this one a rule nobody could turn into a line.
+        //
+        // Named by the rule, as the accounting's line is. A position was all a reader used to be
+        // given, which sent them looking for a rule the sentence never named — and two rules
+        // stopped by one limit at one position came out as one line.
         for (Adequacy.Finding f : behavior.findings()) {
-            if (f.about() instanceof About.APositionThisCouldNotRead(var position)) {
+            if (f.about() instanceof About.ARuleThisCouldNotRead(var it)) {
+                out.append(String.format("      %s not read: %s — %s, about `%s`%n",
+                        mark(f), cited(it.cited(), names, declaredIn),
+                        whyUnread(it.reason()), it.at()));
+            }
+        }
+        // And a position whose rules this reading never arrived at, which names no rule because
+        // nothing observed one. Its own line, so that a reader is not left reading an absent rule
+        // to work out which of the two they are being told.
+        for (Adequacy.Finding f : behavior.findings()) {
+            if (f.about() instanceof About.APositionThisCouldNotRead(var it)) {
                 out.append(String.format("      %s not read: %s (%s)%n",
-                        mark(f), position.at(), whyUnread(position.reason())));
+                        mark(f), it.at(), whyUnread(it.reason())));
             }
         }
         // And a third thing, said apart from both: a rule written about a position the axes did
@@ -868,12 +881,20 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      */
     private static String whyUnread(souther.compiler.partition.UndividedPosition.Reason reason) {
         return switch (reason) {
-            case UNSUPPORTED_SYNTAX -> "a rule about it is one this compiler did not read";
-            case RULES_NOT_READ_AT_ALL -> "the rules written about it were not reached at all";
-            case UNSUPPORTED_DOMAIN ->
-                    "it is compared against values no line can be drawn on here";
+            // The three a rule reaches, written about the rule: the line these appear on names it,
+            // so a sentence saying "a rule about it" would name the rule and then not say so.
+            case UNSUPPORTED_SYNTAX -> "written in a form this compiler does not read";
+            case UNSUPPORTED_DOMAIN -> "compared against values no line can be drawn on here";
+            case COMPETING_COORDINATES ->
+                    "a rule beside it is about the position's other coordinate, so neither can be"
+                            + " chosen";
             case UNSUPPORTED_PARTITION_SHAPE ->
-                    "the comparison relates it to another position rather than dividing it";
+                    "it relates two positions rather than dividing one";
+            // And the four a position reaches, written about the position, because that is all
+            // there is: nothing observed a rule to name. Which reasons reach which of the two is
+            // settled by the authority a reason belongs to
+            // ({@link souther.compiler.inputs.BlockReason}), so no reason is written both ways.
+            case RULES_NOT_READ_AT_ALL -> "the rules written about it were not reached at all";
             case DEPTH_LIMIT -> "the walk stopped before reaching what is under it";
             case TYPE_UNRESOLVED -> "its type could not be worked out here";
             case UNSUPPORTED_TRAVERSAL ->
@@ -1189,10 +1210,10 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // The comparison, by the behavior it is written in and the construct it was numbered
             // as. The numbering starts at zero in each source, so the source is part of it.
             case souther.compiler.check.RuleRef.Guard it -> {
-                into.put("declaredIn", it.comparison().origin().module());
-                into.put("behavior", it.comparison().behavior());
-                into.put("ordinal", it.comparison().origin().ordinal());
-                into.put("lowered", it.comparison().origin().lowered());
+                into.put("declaredIn", it.origin().module());
+                into.put("behavior", it.behavior());
+                into.put("ordinal", it.origin().ordinal());
+                into.put("lowered", it.origin().lowered());
             }
         }
     }
@@ -1572,6 +1593,16 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             ObjectNode said = unread.addObject();
             said.put("position", each.at());
             said.put("reason", word(each.reason()));
+            // And which rule, where one was read and could not be used. Absent where the reading
+            // never arrived at the rules of the position: there is nothing to name, and a field
+            // holding a placeholder would say this compiler had looked at a rule it never saw.
+            // Present, the pair is this: `rule` is the handle an author acts on and `ruleId` is
+            // what tells one rule from another, and the two are not in step wherever a rule has no
+            // name of its own.
+            if (each instanceof PartitionEvidence.NotRead.ARule rule) {
+                said.put("rule", rule.cited().said(sources::written, null));
+                ruleId(said.putObject("ruleId"), rule.rule());
+            }
         });
         ArrayNode omitted = out.putArray("omitted");
         partition.omitted().forEach(o -> omitted.add(o.axis().toString()));
@@ -1672,7 +1703,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             case About.ACaseNoRowExpects _, About.ACaseNothingWasSeenToProduce _,
                     About.ACaseNoRowAppliesItTo _, About.AClassNoRowIsIn _,
                     About.APointOfABorder _, About.APositionNoLineDivides _,
-                    About.APositionThisCouldNotRead _, About.AQuestionNothingAnswered _,
+                    About.APositionThisCouldNotRead _, About.ARuleThisCouldNotRead _,
+                    About.AQuestionNothingAnswered _,
                     About.APositionWhoseRulesWereNotReached _,
                     About.APositionPastTheAxisLimit _ -> null;
         };
@@ -1704,7 +1736,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             case About.AClassNoRowIsIn(var missing) ->
                     missing.name() + " (at " + missing.axis().path() + ")";
             case About.APositionNoLineDivides(var position) -> position.at().toString();
-            case About.APositionThisCouldNotRead(var position) -> position.at();
+            case About.APositionThisCouldNotRead(var it) -> it.at();
+            case About.ARuleThisCouldNotRead(var it) -> it.at();
             case About.APositionWhoseRulesWereNotReached(var axis) -> axis.path();
             case About.APositionPastTheAxisLimit(var dropped) -> dropped.axis().toString();
             // The rule and what it was left saying. Named by the position alone, two rules nothing

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1673,6 +1673,13 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             if (finding.about() instanceof About.OfARule about) {
                 ruleId(f.putObject("ruleId"), about.rule());
             }
+            // And which limit stopped it, where the finding is about one being in the way. Two
+            // conjuncts of one clause about one position can stop for two different limits, so
+            // written without this a rule's findings there are one object twice — and the entry
+            // beside them in `notRead` is keyed on the reason, which leaves nothing to join by.
+            if (finding.about() instanceof About.OfSomethingNotRead about) {
+                f.put("reason", word(about.finding().reason()));
+            }
             // Present where the kind has one. A finding a build is not told about under any code is
             // not one with an empty code, and a consumer joining these to the diagnostics a build
             // printed reads the difference.

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -417,6 +417,7 @@ public final class GeneratedRows {
             // defaulted so that a shape added later has to be given words here.
             case About.ACaseNothingWasSeenToProduce _, About.AClassNoRowIsIn _,
                     About.APositionNoLineDivides _, About.APositionThisCouldNotRead _,
+                    About.ARuleThisCouldNotRead _,
                     About.AQuestionNothingAnswered _,
                     About.APositionWhoseRulesWereNotReached _,
                     About.APositionPastTheAxisLimit _ ->

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-3.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-3.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://souther-lang.org/schema/adequacy-4.json",
+  "$id": "https://souther-lang.org/schema/adequacy-3.json",
   "title": "Souther adequacy report",
   "description": "How well a model's `example`s cover it. Emitted by `souther examples --format json`. A reader keys on `schemaVersion`: a change that removes or renames anything here raises it, and something added since does not — a key added since is optional, and a word added to an enumerated field is one no earlier document carried, so a document written before either existed is still a document of this version. That is one direction: every object here is closed, so an older copy of this schema refuses a document carrying a key added since. A reader that has to accept newer documents wants the newer schema, not a higher number.",
   "type": "object",
@@ -9,7 +9,7 @@
   "properties": {
     "schemaVersion": {
       "type": "integer",
-      "const": 4
+      "const": 3
     },
     "compilerVersion": {
       "type": "string",
@@ -35,7 +35,7 @@
   },
   "$defs": {
     "notReadReason": {
-      "description": "Why a reading is short of the rules. `unsupported_syntax` is a rule that was read and could not be used — an expression the terms do not name; `rules_not_read_at_all` is a rule the reading never arrived at, with which limit stopped the walk neither recorded nor promised; `unsupported_domain` is a comparison against values no line can be drawn on; `unsupported_partition_shape` is a comparison relating two positions rather than dividing one; `competing_coordinates` is two rules of one position, each read and each about a different coordinate of it — its own order and a count taken of it — with the position's own type having chosen neither, so nothing here can say which one it is measured at; `depth_limit` is the walk stopping before it reached the position; `type_unresolved` is a type at the position that could not be worked out; `unsupported_traversal` is values held inside something the walk does not reach into. Every one of them is a fact about the compiler and none is a fact about the model.",
+      "description": "Why a reading is short of the rules. `unsupported_syntax` is a rule that was read and could not be used — an expression the terms do not name; `rules_not_read_at_all` is a position whose rules the reading never arrived at — no rule is named because none was seen — with which limit stopped the walk neither recorded nor promised; `unsupported_domain` is a comparison against values no line can be drawn on; `unsupported_partition_shape` is a comparison relating two positions rather than dividing one; `competing_coordinates` is two rules of one position, each read and each about a different coordinate of it — its own order and a count taken of it — with the position's own type having chosen neither, so nothing here can say which one it is measured at; `depth_limit` is the walk stopping before it reached the position; `type_unresolved` is a type at the position that could not be worked out; `unsupported_traversal` is values held inside something the walk does not reach into. Every one of them is a fact about the compiler and none is a fact about the model.",
       "enum": ["unsupported_syntax", "rules_not_read_at_all", "unsupported_domain", "unsupported_partition_shape", "competing_coordinates", "depth_limit", "type_unresolved", "unsupported_traversal"]
     },
     "ruleId": {

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-3.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-3.json
@@ -120,6 +120,11 @@
         "additionalProperties": false,
         "allOf": [
           {
+            "if": { "properties": { "kind": { "const": "partition_not_read" } }, "required": ["kind"] },
+            "then": { "required": ["reason"] },
+            "else": { "not": { "required": ["reason"] } }
+          },
+          {
             "if": { "properties": { "kind": { "const": "rule_unaccounted" } }, "required": ["kind"] },
             "then": { "required": ["ruleId"] },
             "else": {
@@ -131,7 +136,7 @@
         ],
         "properties": {
           "kind": {
-            "description": "What the measure established. `output_case_unspecified` is a case of the output no row expects and `output_case_unverified` is one some row expects and nothing was seen to produce; `input_case_unspecified` is a case of an input no row applies the behavior to and `axis_class_uncovered` is a class of a derived position no row is in — the two read alike about one class and only one of them is refused over. `boundary_unmet` is a line some rule draws that no row sits on, `arm_unreached` an arm of the body no row goes through. `partition_not_derivable`, `partition_not_read`, `partition_rules_not_reached` and `partition_omitted` are positions the model divides no way, positions some rule about which was not read, positions the axes did measure whose rules the walk never reached, and positions past the axis limit. `rule_unaccounted` is one question a rule raised that nothing answered — said whether or not an axis came back for the position it is about, since a rule this compiler could not read is exactly the one no axis is derived from, and named for the question rather than for a measure because which section a reader meets it under follows from what it asks.",
+            "description": "What the measure established. `output_case_unspecified` is a case of the output no row expects and `output_case_unverified` is one some row expects and nothing was seen to produce; `input_case_unspecified` is a case of an input no row applies the behavior to and `axis_class_uncovered` is a class of a derived position no row is in — the two read alike about one class and only one of them is refused over. `boundary_unmet` is a line some rule draws that no row sits on, `arm_unreached` an arm of the body no row goes through. `partition_not_derivable`, `partition_not_read`, `partition_rules_not_reached` and `partition_omitted` are positions the model divides no way, what a reading did not read, positions the axes did measure whose rules the walk never reached, and positions past the axis limit. A `partition_not_read` is one of two things and `ruleId` says which: with it, a rule this read and could not turn into a line, named because the reader that stopped knows which rule; without it, a position whose rules the reading never arrived at, where no rule is named because none was seen. `reason` is on both, and says which limit is in the way. `rule_unaccounted` is one question a rule raised that nothing answered — said whether or not an axis came back for the position it is about, since a rule this compiler could not read is exactly the one no axis is derived from, and named for the question rather than for a measure because which section a reader meets it under follows from what it asks.",
             "enum": ["output_case_unspecified", "input_case_unspecified", "boundary_unmet", "arm_unreached", "output_case_unverified", "axis_class_uncovered",
               "domain_point_uncovered", "partition_not_derivable", "partition_not_read", "rule_unaccounted", "partition_rules_not_reached", "partition_omitted"]
           },
@@ -140,6 +145,7 @@
             "enum": ["refused", "undecided", "reported"]
           },
           "ruleId": { "$ref": "#/$defs/ruleId", "description": "Which rule the finding is about, where it is about one. `subject` beside it is what a reader is shown, and two rules an author named alike are shown the same words — so this is what says they are two. It names the rule and not the question: one rule raises more than one, and `subject` beside it is what tells those apart. Written for `rule_unaccounted`, and for `partition_not_read` where that entry is about a rule rather than about a position the reading never arrived at — which is why it is required for the first and only allowed for the second. The other kinds are not about a rule and never carry it." },
+          "reason": { "$ref": "#/$defs/notReadReason", "description": "Which limit stopped the reading, present exactly on `partition_not_read`. The same word the `partition.notRead` entry this came from carries, and what a consumer joins the two by. Written because a rule can be stopped at one position by two limits at once — one conjunct of a clause relating two positions and the conjunct beside it in a form nothing reads — and the findings are then two, differing here and nowhere else." },
           "subject": {
             "type": "string",
             "description": "What the finding is about, written to name what is already in this document: a class name is one of an axis's `classes`, an arm's label one in `branch.unreached`, and `axis = value` names a `boundaries` entry. An input's case carries its position — `C (in #1)` — because two parameters of one type give two findings a class name alone cannot tell apart."

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-4.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-4.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://souther-lang.org/schema/adequacy-3.json",
+  "$id": "https://souther-lang.org/schema/adequacy-4.json",
   "title": "Souther adequacy report",
   "description": "How well a model's `example`s cover it. Emitted by `souther examples --format json`. A reader keys on `schemaVersion`: a change that removes or renames anything here raises it, and something added since does not — a key added since is optional, and a word added to an enumerated field is one no earlier document carried, so a document written before either existed is still a document of this version. That is one direction: every object here is closed, so an older copy of this schema refuses a document carrying a key added since. A reader that has to accept newer documents wants the newer schema, not a higher number.",
   "type": "object",
@@ -9,7 +9,7 @@
   "properties": {
     "schemaVersion": {
       "type": "integer",
-      "const": 3
+      "const": 4
     },
     "compilerVersion": {
       "type": "string",
@@ -35,8 +35,8 @@
   },
   "$defs": {
     "notReadReason": {
-      "description": "Why a reading is short of the rules. `unsupported_syntax` is a rule that was read and could not be used — an expression the terms do not name; `rules_not_read_at_all` is a rule the reading never arrived at, with which limit stopped the walk neither recorded nor promised; `unsupported_domain` is a comparison against values no line can be drawn on; `unsupported_partition_shape` is a comparison relating two positions rather than dividing one; `depth_limit` is the walk stopping before it reached the position; `type_unresolved` is a type at the position that could not be worked out; `unsupported_traversal` is values held inside something the walk does not reach into. Every one of them is a fact about the compiler and none is a fact about the model.",
-      "enum": ["unsupported_syntax", "rules_not_read_at_all", "unsupported_domain", "unsupported_partition_shape", "depth_limit", "type_unresolved", "unsupported_traversal"]
+      "description": "Why a reading is short of the rules. `unsupported_syntax` is a rule that was read and could not be used — an expression the terms do not name; `rules_not_read_at_all` is a rule the reading never arrived at, with which limit stopped the walk neither recorded nor promised; `unsupported_domain` is a comparison against values no line can be drawn on; `unsupported_partition_shape` is a comparison relating two positions rather than dividing one; `competing_coordinates` is two rules of one position, each read and each about a different coordinate of it — its own order and a count taken of it — with the position's own type having chosen neither, so nothing here can say which one it is measured at; `depth_limit` is the walk stopping before it reached the position; `type_unresolved` is a type at the position that could not be worked out; `unsupported_traversal` is values held inside something the walk does not reach into. Every one of them is a fact about the compiler and none is a fact about the model.",
+      "enum": ["unsupported_syntax", "rules_not_read_at_all", "unsupported_domain", "unsupported_partition_shape", "competing_coordinates", "depth_limit", "type_unresolved", "unsupported_traversal"]
     },
     "ruleId": {
       "type": "object",
@@ -135,7 +135,7 @@
             "description": "What a build does about this one. `refused` is a gap `--strict` and a warned build refuse over; `reported` is a kind neither refuses over, whatever its measurement managed; `undecided` is a kind they would refuse over, from a measurement that came to no answer — telling an author to write a row they may already have written is worse than saying nothing, so it is named and not refused.",
             "enum": ["refused", "undecided", "reported"]
           },
-          "ruleId": { "$ref": "#/$defs/ruleId", "description": "Which rule the finding is about, where it is about one. `subject` beside it is what a reader is shown, and two rules an author named alike are shown the same words — so this is what says they are two. It names the rule and not the question: one rule raises more than one, and `subject` beside it is what tells those apart. Written for `rule_unaccounted` and for no other kind." },
+          "ruleId": { "$ref": "#/$defs/ruleId", "description": "Which rule the finding is about, where it is about one. `subject` beside it is what a reader is shown, and two rules an author named alike are shown the same words — so this is what says they are two. It names the rule and not the question: one rule raises more than one, and `subject` beside it is what tells those apart. Written for `rule_unaccounted` and for `partition_not_read` where that entry is about a rule; the other kinds are not about one." },
           "subject": {
             "type": "string",
             "description": "What the finding is about, written to name what is already in this document: a class name is one of an axis's `classes`, an arm's label one in `branch.unreached`, and `axis = value` names a `boundaries` entry. An input's case carries its position — `C (in #1)` — because two parameters of one type give two findings a class name alone cannot tell apart."
@@ -439,14 +439,17 @@
         },
         "notRead": {
           "type": "array",
-          "description": "Positions some rule about which this reading did not turn into a line, each with what stopped it. What separates them from `notDerivable` is that the model does state something here — which limit stopped each one is what says whose work it is to lift. Not a statement that the position was not measured: a position with an axis and classes can carry a rule nothing read, and whether the reading of a position ran to the end is what that axis's `read` says. Not in `required`: a document written before this field existed is still a document of this version.",
+          "description": "What this reading could not read, each entry with the position it is at and what stopped it. What separates them from `notDerivable` is that the model does state something here — which limit stopped each one is what says whose work it is to lift. Not a statement that the position was not measured: a position with an axis and classes can carry a rule nothing read, and whether the reading of a position ran to the end is what that axis's `read` says. Two shapes, told apart by whether `rule` is there: an entry with one is a rule this read and could not turn into a line, and an entry without one is a position whose rules the reading never arrived at, where there is no rule to name because none was observed. Not in `required`: a document written before this field existed is still a document of this version.",
           "items": {
             "type": "object",
             "required": ["position", "reason"],
             "additionalProperties": false,
+            "dependentRequired": { "rule": ["ruleId"], "ruleId": ["rule"] },
             "properties": {
               "position": { "type": "string" },
-              "reason": { "$ref": "#/$defs/notReadReason" }
+              "reason": { "$ref": "#/$defs/notReadReason" },
+              "rule": { "type": "string", "description": "How a reader finds the rule this could not turn into a line: the name the author gave it where there is one — `invariant Length (even)` — and where it is written where there is none, as `if@<source>:<line>:<column>`. The same handle an `unanswered` entry and a `boundaries` entry write for the same rule. Present exactly where the entry is about a rule; a position the reading never reached has none, and a placeholder here would say a rule had been looked at that nothing saw. Not what tells one rule from another: `ruleId` beside this is." },
+              "ruleId": { "$ref": "#/$defs/ruleId", "description": "Which rule the entry is about, present exactly with `rule`. A key within this document: a consumer groups by it and shows `rule`. Two rules stopped by one limit at one position are two entries and differ here — keyed on the position and the reason alone, they were one." }
             }
           }
         },

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-4.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-4.json
@@ -122,7 +122,11 @@
           {
             "if": { "properties": { "kind": { "const": "rule_unaccounted" } }, "required": ["kind"] },
             "then": { "required": ["ruleId"] },
-            "else": { "not": { "required": ["ruleId"] } }
+            "else": {
+              "if": { "properties": { "kind": { "const": "partition_not_read" } }, "required": ["kind"] },
+              "then": true,
+              "else": { "not": { "required": ["ruleId"] } }
+            }
           }
         ],
         "properties": {
@@ -135,7 +139,7 @@
             "description": "What a build does about this one. `refused` is a gap `--strict` and a warned build refuse over; `reported` is a kind neither refuses over, whatever its measurement managed; `undecided` is a kind they would refuse over, from a measurement that came to no answer — telling an author to write a row they may already have written is worse than saying nothing, so it is named and not refused.",
             "enum": ["refused", "undecided", "reported"]
           },
-          "ruleId": { "$ref": "#/$defs/ruleId", "description": "Which rule the finding is about, where it is about one. `subject` beside it is what a reader is shown, and two rules an author named alike are shown the same words — so this is what says they are two. It names the rule and not the question: one rule raises more than one, and `subject` beside it is what tells those apart. Written for `rule_unaccounted` and for `partition_not_read` where that entry is about a rule; the other kinds are not about one." },
+          "ruleId": { "$ref": "#/$defs/ruleId", "description": "Which rule the finding is about, where it is about one. `subject` beside it is what a reader is shown, and two rules an author named alike are shown the same words — so this is what says they are two. It names the rule and not the question: one rule raises more than one, and `subject` beside it is what tells those apart. Written for `rule_unaccounted`, and for `partition_not_read` where that entry is about a rule rather than about a position the reading never arrived at — which is why it is required for the first and only allowed for the second. The other kinds are not about a rule and never carry it." },
           "subject": {
             "type": "string",
             "description": "What the finding is about, written to name what is already in this document: a class name is one of an axis's `classes`, an arm's label one in `branch.unreached`, and `axis = value` names a `boundaries` entry. An input's case carries its position — `C (in #1)` — because two parameters of one type give two findings a class name alone cannot tell apart."

--- a/souther-compiler/src/test/java/souther/compiler/AComparisonInsideAConjunctionIsStillTheModelsLineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AComparisonInsideAConjunctionIsStillTheModelsLineTest.java
@@ -83,7 +83,7 @@ class AComparisonInsideAConjunctionIsStillTheModelsLineTest {
     /** And the position is no longer one nothing was established about. */
     @Test
     void thePositionIsNoLongerReportedAsUnread() {
-        assertFalse(blockOf("inAConjunction").contains("not read: r.cost"),
+        assertFalse(notReadAbout(blockOf("inAConjunction"), "r.cost"),
                 blockOf("inAConjunction"));
     }
 
@@ -122,5 +122,19 @@ class AComparisonInsideAConjunctionIsStillTheModelsLineTest {
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("no line at " + axis + " = " + value))
                 .owed().coverage();
+    }
+
+    /**
+     * Whether any {@code not read} line of {@code block} is about {@code position}.
+     *
+     * <p>Asked as a line rather than as a prefix. A finding about a rule names the rule first and
+     * the position after it, and one about a position names the position — so a test matching
+     * `+not read: <position>+` stopped meaning anything for the first kind rather than failing,
+     * which is a negative assertion that passes because the words moved.
+     */
+    private static boolean notReadAbout(String block, String position) {
+        return block.lines().anyMatch(line -> line.contains("not read:")
+                && (line.contains("not read: " + position + " ")
+                        || line.contains("about `" + position + "`")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/ALineDrawnOnADateIsALineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ALineDrawnOnADateIsALineTest.java
@@ -51,7 +51,7 @@ class ALineDrawnOnADateIsALineTest {
         String human = report();
 
         assertTrue(human.contains("partition   axes 1"), human);
-        assertFalse(human.contains("not read: on"), human);
+        assertFalse(notReadAbout(human, "on"), human);
     }
 
     /** Both sides of the line are owed, and the row already written covers the one it is on. */
@@ -70,5 +70,19 @@ class ALineDrawnOnADateIsALineTest {
 
         assertFalse(human.contains("20454"), human);
         assertFalse(human.contains("20453"), human);
+    }
+
+    /**
+     * Whether any {@code not read} line of {@code block} is about {@code position}.
+     *
+     * <p>Asked as a line rather than as a prefix. A finding about a rule names the rule first and
+     * the position after it, and one about a position names the position — so a test matching
+     * `+not read: <position>+` stopped meaning anything for the first kind rather than failing,
+     * which is a negative assertion that passes because the words moved.
+     */
+    private static boolean notReadAbout(String block, String position) {
+        return block.lines().anyMatch(line -> line.contains("not read:")
+                && (line.contains("not read: " + position + " ")
+                        || line.contains("about `" + position + "`")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/AMeasuredPositionSaysHowFarItsRulesWereReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasuredPositionSaysHowFarItsRulesWereReadTest.java
@@ -98,7 +98,7 @@ class AMeasuredPositionSaysHowFarItsRulesWereReadTest {
         assertTrue(human.contains("rules not reached: i.assignee"),
                 "a measured position says its rules were never reached, which a position with no"
                         + " axis does not: " + human);
-        assertFalse(human.contains("not read: i.assignee"),
+        assertFalse(notReadAbout(human, "i.assignee"),
                 "and is not said as one nothing divided: " + human);
     }
 
@@ -111,5 +111,19 @@ class AMeasuredPositionSaysHowFarItsRulesWereReadTest {
         assertEquals("complete", read.get("extent").asText());
         assertFalse(read.has("rulesNotReached"), "nothing was left standing: " + read);
         assertFalse(read.has("unanswered"), "nothing was left standing: " + read);
+    }
+
+    /**
+     * Whether any {@code not read} line of {@code block} is about {@code position}.
+     *
+     * <p>Asked as a line rather than as a prefix. A finding about a rule names the rule first and
+     * the position after it, and one about a position names the position — so a test matching
+     * `+not read: <position>+` stopped meaning anything for the first kind rather than failing,
+     * which is a negative assertion that passes because the words moved.
+     */
+    private static boolean notReadAbout(String block, String position) {
+        return block.lines().anyMatch(line -> line.contains("not read:")
+                && (line.contains("not read: " + position + " ")
+                        || line.contains("about `" + position + "`")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/APositionThisDidNotReadIsNotOneTheModelSaysNothingAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/APositionThisDidNotReadIsNotOneTheModelSaysNothingAboutTest.java
@@ -160,7 +160,7 @@ class APositionThisDidNotReadIsNotOneTheModelSaysNothingAboutTest {
     void anEqualityIsRead() {
         String block = blockOf("byEquality");
 
-        assertFalse(block.contains("not read: r.cost"), block);
+        assertFalse(notReadAbout(block, "r.cost"), block);
         assertFalse(block.contains("not derivable: r.cost"), block);
     }
 
@@ -176,7 +176,7 @@ class APositionThisDidNotReadIsNotOneTheModelSaysNothingAboutTest {
     void aCarrierNoLineIsDrawnOnSaysThat() {
         String block = blockOf("byCase");
 
-        assertTrue(block.contains("not read: s"), block);
+        assertTrue(notReadAbout(block, "s"), block);
         assertTrue(block.contains("no line can be drawn on"), block);
     }
 
@@ -185,7 +185,7 @@ class APositionThisDidNotReadIsNotOneTheModelSaysNothingAboutTest {
     void aDateTimeIsReadAsADateIs() {
         String block = blockOf("byDateTime");
 
-        assertFalse(block.contains("not read: at"), block);
+        assertFalse(notReadAbout(block, "at"), block);
         assertFalse(block.contains("not derivable: at"), block);
     }
 
@@ -202,8 +202,8 @@ class APositionThisDidNotReadIsNotOneTheModelSaysNothingAboutTest {
         String block = blockOf("boundedByAnUnreadableEnd");
 
         assertFalse(block.contains("not derivable: m"), block);
-        assertTrue(block.contains("not read: m"), block);
-        assertTrue(block.contains("did not read"), block);
+        assertTrue(notReadAbout(block, "m"), block);
+        assertTrue(block.contains("this compiler does not read"), block);
     }
 
     /**
@@ -218,7 +218,7 @@ class APositionThisDidNotReadIsNotOneTheModelSaysNothingAboutTest {
         String block = blockOf("boundedByADate");
 
         assertFalse(block.contains("not derivable: c"), block);
-        assertFalse(block.contains("not read: c"), block);
+        assertFalse(notReadAbout(block, "c"), block);
         assertTrue(block.contains("border      borders 1   coverage items 0/0   excluded 2   (2 not measured"), block);
     }
 
@@ -269,7 +269,7 @@ class APositionThisDidNotReadIsNotOneTheModelSaysNothingAboutTest {
         String block = blockOf("boundedByANumber");
 
         assertFalse(block.contains("not derivable: a"), block);
-        assertFalse(block.contains("not read: a"), block);
+        assertFalse(notReadAbout(block, "a"), block);
     }
 
     /** The one that is read is not named either way. */
@@ -278,6 +278,20 @@ class APositionThisDidNotReadIsNotOneTheModelSaysNothingAboutTest {
         String block = blockOf("alone");
 
         assertFalse(block.contains("not derivable: r.cost"), block);
-        assertFalse(block.contains("not read: r.cost"), block);
+        assertFalse(notReadAbout(block, "r.cost"), block);
+    }
+
+    /**
+     * Whether any {@code not read} line of {@code block} is about {@code position}.
+     *
+     * <p>Asked as a line rather than as a prefix. A finding about a rule names the rule first and
+     * the position after it, and one about a position names the position — so a test matching
+     * `+not read: <position>+` stopped meaning anything for the first kind rather than failing,
+     * which is a negative assertion that passes because the words moved.
+     */
+    private static boolean notReadAbout(String block, String position) {
+        return block.lines().anyMatch(line -> line.contains("not read:")
+                && (line.contains("not read: " + position + " ")
+                        || line.contains("about `" + position + "`")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/AQuestionIsPrintedUnderTheMeasureThatAnswersItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AQuestionIsPrintedUnderTheMeasureThatAnswersItTest.java
@@ -80,7 +80,11 @@ class AQuestionIsPrintedUnderTheMeasureThatAnswersItTest {
         assertTrue(section(report, "border").contains(
                         "not accounted for: invariant Length (max) — where the values stop on"),
                 section(report, "border"));
-        assertTrue(!section(report, "partition").contains("invariant Length (max)"),
+        // The question, and not every mention of the rule. The classes measure names the same rule
+        // where it could not turn it into a line, which is a different thing said about it: what
+        // this is about is where the question a rule raised is answered.
+        assertTrue(!section(report, "partition")
+                        .contains("not accounted for: invariant Length (max)"),
                 "and not beside the classes, which is a different measure with a count of its own:\n"
                         + section(report, "partition"));
     }

--- a/souther-compiler/src/test/java/souther/compiler/ARuleNoOtherReadingTakesInIsStillSaidHereTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleNoOtherReadingTakesInIsStillSaidHereTest.java
@@ -32,9 +32,18 @@ class ARuleNoOtherReadingTakesInIsStillSaidHereTest {
         return AdequacyReport.of(compilation).human(SourceNameResolver.identity());
     }
 
-    /** A size bounded past the greatest whole number, which nothing else takes in. */
+    /**
+     * A size bounded past the greatest whole number, which nothing else takes in.
+     *
+     * <p>Said as a question nothing answered, and it names the rule. Which reading was short of it
+     * is this compiler's own business and is not a second thing to tell an author: what they can
+     * act on is that a rule of theirs raised a question about the values here and no reading of the
+     * model answered it. It used to be said twice — once here without naming the rule, because a
+     * value reading files what it could not take in under the position rather than under the clause
+     *.
+     */
     @Test
-    void aSizeBoundPastTheEndOfTheWholeNumbersIsNamedAsUnread() {
+    void aSizeBoundPastTheEndOfTheWholeNumbersIsNamedAsUnaccountedFor() {
         String human = reportOf("""
                 module example.sized
 
@@ -48,7 +57,8 @@ class ARuleNoOtherReadingTakesInIsStillSaidHereTest {
                 let weigh (t) = if String.length(t.value) > 3 then Long else Short
                 """);
 
-        assertTrue(human.contains("not read: t"), human);
+        assertTrue(human.contains("not accounted for: invariant Tag (long)"), human);
+        assertTrue(human.contains("which values may stand at t"), human);
     }
 
     /**
@@ -58,7 +68,7 @@ class ARuleNoOtherReadingTakesInIsStillSaidHereTest {
      * unread, which is the answer this is meant to tell apart.
      */
     @Test
-    void anOrdinarySizeBoundIsNotNamedAsUnread() {
+    void anOrdinarySizeBoundIsNotNamedAsUnaccountedFor() {
         String human = reportOf("""
                 module example.sized
 
@@ -72,6 +82,21 @@ class ARuleNoOtherReadingTakesInIsStillSaidHereTest {
                 let weigh (t) = if String.length(t.value) > 3 then Long else Short
                 """);
 
-        assertFalse(human.contains("not read: t"), human);
+        assertFalse(human.contains("not accounted for: invariant Tag (long)"), human);
+        assertFalse(notReadAbout(human, "t"), human);
+    }
+
+    /**
+     * Whether any {@code not read} line of {@code block} is about {@code position}.
+     *
+     * <p>Asked as a line rather than as a prefix. A finding about a rule names the rule first and
+     * the position after it, and one about a position names the position — so a test matching
+     * `+not read: <position>+` stopped meaning anything for the first kind rather than failing,
+     * which is a negative assertion that passes because the words moved.
+     */
+    private static boolean notReadAbout(String block, String position) {
+        return block.lines().anyMatch(line -> line.contains("not read:")
+                && (line.contains("not read: " + position + " ")
+                        || line.contains("about `" + position + "`")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/ARuleNoOtherReadingTakesInIsStillSaidHereTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleNoOtherReadingTakesInIsStillSaidHereTest.java
@@ -39,8 +39,8 @@ class ARuleNoOtherReadingTakesInIsStillSaidHereTest {
      * is this compiler's own business and is not a second thing to tell an author: what they can
      * act on is that a rule of theirs raised a question about the values here and no reading of the
      * model answered it. It used to be said twice — once here without naming the rule, because a
-     * value reading files what it could not take in under the position rather than under the clause
-     *.
+     * value reading files what it could not take in under the position rather than under the
+     * clause.
      */
     @Test
     void aSizeBoundPastTheEndOfTheWholeNumbersIsNamedAsUnaccountedFor() {

--- a/souther-compiler/src/test/java/souther/compiler/ARuleThisCouldNotReadIsNamedByTheRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleThisCouldNotReadIsNamedByTheRuleTest.java
@@ -1,0 +1,246 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.PartitionEvidence;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A rule this could not turn into a line is reported as the rule it is.
+ *
+ * <p>What the accounting was made to say, asked of the measure beside it. An author told that a
+ * rule about {@code r.cost} went unread, with nothing saying which rule, has to go and find it; and
+ * two rules stopped by one limit at one position came out as one line, because the finding was
+ * keyed on the position and the limit. What a finding of this kind is asked of is the rule, so it
+ * names one — by what tells it from its neighbours and by what a reader looks it up with, which
+ * are two questions and not one.
+ *
+ * <p>Three producers write these, and a reader of the list is told the same thing about any of them
+ * (spec §example-partition). All three are here, because what each of them had in hand was a
+ * different value and each dropped it at its own seam.
+ */
+class ARuleThisCouldNotReadIsNamedByTheRuleTest {
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    /** Two clauses of one declaration, stopped by one limit at one position. */
+    private static final String TWO_INVARIANTS = """
+            module m
+
+            data Ok
+            data R = { a: Int, b: Int }
+                invariant first  = a < b
+                invariant second = b < a
+
+            behavior f : (r: R) -> Ok
+                constructs Ok
+            let f (r) = Ok
+            """;
+
+    /** Two comparisons of one condition, about one position. */
+    private static final String TWO_COMPARISONS = """
+            module m
+
+            data Ok
+            data No
+
+            behavior f : (n: Int) -> Ok | No
+            let f (n) =
+                if Int.multiply(n, n) < 4 || Int.multiply(n, n) > 9 then Ok else No
+            """;
+
+    /** Two clauses of one {@code ensures}, about one position. */
+    private static final String TWO_ENSURES = """
+            module m
+
+            data Ok = { v: Int }
+
+            behavior f : (a: Int, b: Int) -> Ok
+                constructs Ok
+                ensures low  = a < b
+                ensures high = b < a
+            let f (a, b) = Ok { v = a }
+            """;
+
+    /**
+     * Two clauses of a declaration are two findings, and each says which clause.
+     *
+     * <p>The invariant producer had the rule all along: the reading of ends records which clause it
+     * gave up on, and the seam onto the position kept the position and the reason and dropped the
+     * rest. So the two clauses became one line and the line named neither.
+     */
+    @Test
+    void twoInvariantClausesStoppedAlikeAreTwoFindings() {
+        // Two rules about two positions, so four findings: a reader looking up either position is
+        // owed both rules. What was one line is the pair at one position.
+        assertEquals(4, rulesNotRead(TWO_INVARIANTS).size(), () -> unread(TWO_INVARIANTS));
+        assertEquals(2, ruleIdsNotRead(TWO_INVARIANTS).size(), () -> unread(TWO_INVARIANTS));
+        assertTrue(human(TWO_INVARIANTS).contains("not read: invariant R (first)"),
+                human(TWO_INVARIANTS));
+        assertTrue(human(TWO_INVARIANTS).contains("not read: invariant R (second)"),
+                human(TWO_INVARIANTS));
+    }
+
+    /** And two comparisons of one condition, which the guard producer kept one of. */
+    @Test
+    void twoComparisonsStoppedAlikeAreTwoFindings() {
+        assertEquals(2, rulesNotRead(TWO_COMPARISONS).size(), () -> unread(TWO_COMPARISONS));
+        assertEquals(2, ruleIdsNotRead(TWO_COMPARISONS).size(), () -> unread(TWO_COMPARISONS));
+    }
+
+    /** And two clauses of an {@code ensures}. */
+    @Test
+    void twoEnsuresClausesStoppedAlikeAreTwoFindings() {
+        assertEquals(2, ruleIdsNotRead(TWO_ENSURES).size(), () -> unread(TWO_ENSURES));
+        assertTrue(human(TWO_ENSURES).contains("not read: ensures f (low)"), human(TWO_ENSURES));
+        assertTrue(human(TWO_ENSURES).contains("not read: ensures f (high)"), human(TWO_ENSURES));
+    }
+
+    /**
+     * A rule about two positions is a finding at each of them.
+     *
+     * <p>{@code a < b} divides neither, and a reader looking up either is owed the same answer.
+     * Filed at the first position the reading names, which position was told about would turn on
+     * which side the author wrote it — so the same rule written the other way round would answer
+     * about the other one.
+     */
+    @Test
+    void aRuleAboutTwoPositionsIsAFindingAtEach() {
+        assertEquals(List.of("r.a", "r.b"),
+                rulesNotRead(TWO_INVARIANTS).stream()
+                        .map(PartitionEvidence.NotRead::at).distinct().sorted().toList(),
+                () -> unread(TWO_INVARIANTS));
+    }
+
+    /**
+     * A comparison written inside a helper is not one of these.
+     *
+     * <p>A helper is spliced into every body that calls it, so its comparisons stand in this tree
+     * and are not this behavior's rules to answer for. The author wrote {@code > 70} here and the
+     * comparisons inside {@code Int.clamp} nowhere near here, and a report naming the second sends
+     * them to edit a function they may not own.
+     *
+     * <p>Asked of the comparison and not of the fork it sits under: the one the author wrote is the
+     * operand of a call whose insides they did not write, so a subtree is the wrong unit. What
+     * tells the two apart is the citation, which already says whether code was written where the
+     * reader is standing or reached from somewhere else.
+     *
+     * <p>The accounting beside this still raises questions for the helper's own forks. That is
+     * where it stood before this issue and is not changed here; that the two ought to draw the line
+     * in one place is its own question.
+     */
+    @Test
+    void aComparisonInsideAnExpandedHelperIsNotOneOfThese() {
+        String model = """
+                module m
+
+                data Low
+                data Accepted = { at: Int }
+
+                behavior classify : (n: Int) -> Accepted | Low
+                    constructs Accepted
+
+                let classify (n) = {
+                    guard Int.clamp(0, 100, n) > 70 else Low
+                    Accepted { at = n }
+                }
+                """;
+
+        List<PartitionEvidence.NotRead> said = rulesNotRead(model);
+
+        assertEquals(1, said.size(), () -> unread(model));
+        assertTrue(human(model).contains("not read: guard@"), human(model));
+        assertTrue(human(model).lines()
+                        .filter(line -> line.contains("not read:"))
+                        .noneMatch(line -> line.contains("Int.clamp")),
+                human(model));
+    }
+
+    /**
+     * A rule can be both, and the two say different things about it.
+     *
+     * <p>This measure says the reading that draws lines could not adopt the rule; the accounting
+     * says no reading at all took it in. A rule can be either without the other — one the value
+     * reading took in whole is still one no line came of — and where both are true a reader is told
+     * both, under the same {@code ruleId} and in different words. Deduplicated, the two would be
+     * back to one answer for two questions, which is the pair this keeps apart.
+     */
+    @Test
+    void aRuleMayBeBothUnreadHereAndUnansweredBeside() {
+        String model = """
+                module m
+
+                data Ok
+                data No
+                data Tag = String
+                    invariant long = String.length(value) > 9223372036854775807
+
+                behavior f : (t: Tag) -> Ok | No
+                let f (t) = if String.length(t.value) > Int.add(1, 2) then Ok else No
+                """;
+
+        assertTrue(human(model).contains("not read: if@"), human(model));
+        assertTrue(human(model).contains("not accounted for: invariant Tag (long)"), human(model));
+    }
+
+    /** Every rule of the behavior that this could not turn into a line. */
+    private static List<PartitionEvidence.NotRead> rulesNotRead(String model) {
+        List<PartitionEvidence.NotRead> out = new ArrayList<>();
+        for (PartitionEvidence.NotRead each : measured(model).notRead()) {
+            if (each instanceof PartitionEvidence.NotRead.ARule) {
+                out.add(each);
+            }
+        }
+        return out;
+    }
+
+    /** And how many rules those are, which is what a document keys them by. */
+    private static Set<souther.compiler.check.RuleRef> ruleIdsNotRead(String model) {
+        Set<souther.compiler.check.RuleRef> out = new LinkedHashSet<>();
+        for (PartitionEvidence.NotRead each : rulesNotRead(model)) {
+            out.add(((PartitionEvidence.NotRead.ARule) each).rule());
+        }
+        return out;
+    }
+
+    private static PartitionEvidence measured(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).modules().get(0).behaviors().get(0).partition();
+    }
+
+    private static String human(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).human(SourceNameResolver.identity());
+    }
+
+    private static String unread(String model) {
+        JsonNode document = JSON.readTree(json(model));
+        return document.get("modules").get(0).get("behaviors").get(0)
+                .get("partition").get("notRead").toString();
+    }
+
+    private static String json(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).json(SourceNameResolver.identity());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/ARuleThisCouldNotReadIsNamedByTheRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleThisCouldNotReadIsNamedByTheRuleTest.java
@@ -171,30 +171,73 @@ class ARuleThisCouldNotReadIsNamedByTheRuleTest {
     }
 
     /**
-     * A rule can be both, and the two say different things about it.
+     * One rule under both measures, and the same identity under each.
      *
      * <p>This measure says the reading that draws lines could not adopt the rule; the accounting
-     * says no reading at all took it in. A rule can be either without the other — one the value
-     * reading took in whole is still one no line came of — and where both are true a reader is told
-     * both, under the same {@code ruleId} and in different words. Deduplicated, the two would be
-     * back to one answer for two questions, which is the pair this keeps apart.
+     * says no reading at all took it in. A rule can be either without the other, and where both are
+     * true a reader is told both — in different words, about the same rule. So the two entries
+     * carry one identity and a consumer can join them; deduplicated, they would be back to one
+     * answer for two questions.
+     *
+     * <p>Asked of the identities and not of the words. Two entries that happen to mention a rule
+     * apiece say nothing about whether it is the same rule, which is the whole of what a consumer
+     * wants here.
      */
     @Test
-    void aRuleMayBeBothUnreadHereAndUnansweredBeside() {
+    void oneRuleUnderBothMeasuresCarriesOneIdentity() {
+        // A bound this reads, and beside it a clause the reading of ends could not turn into a line
+        // and the reading of values has no word for. The second is the rule under both measures.
         String model = """
                 module m
 
-                data Ok
-                data No
-                data Tag = String
-                    invariant long = String.length(value) > 9223372036854775807
+                data Length = Int
+                    invariant min    = value >= 1
+                    invariant square = value * value >= 4
 
-                behavior f : (t: Tag) -> Ok | No
-                let f (t) = if String.length(t.value) > Int.add(1, 2) then Ok else No
+                behavior price : (length: Length) -> Int
+                let price (length) = if length.value >= 5 then 1 else 2
                 """;
 
-        assertTrue(human(model).contains("not read: if@"), human(model));
-        assertTrue(human(model).contains("not accounted for: invariant Tag (long)"), human(model));
+        JsonNode partition = JSON.readTree(json(model))
+                .get("modules").get(0).get("behaviors").get(0).get("partition");
+        Set<String> unread = ruleIdsOf(partition.get("notRead"));
+        Set<String> standing = ruleIdsOf(partition.get("unanswered"));
+
+        assertEquals(1, standing.size(), () -> partition.toString());
+        assertTrue(unread.containsAll(standing), () -> partition.toString());
+    }
+
+    /** And a finding carries it too, so the two surfaces join. */
+    @Test
+    void aFindingAboutARuleCarriesTheIdentityAsWell() {
+        JsonNode findings = JSON.readTree(json(TWO_INVARIANTS))
+                .get("modules").get(0).get("behaviors").get(0).get("findings");
+
+        Set<String> said = new LinkedHashSet<>();
+        int counted = 0;
+        for (JsonNode each : findings) {
+            if (!"partition_not_read".equals(each.get("kind").asString())) {
+                continue;
+            }
+            counted++;
+            said.add(each.get("ruleId").toString());
+        }
+        assertEquals(4, counted, findings::toString);
+        assertEquals(2, said.size(), findings::toString);
+    }
+
+    /** The rules named by every entry of {@code entries}, as the document identifies them. */
+    private static Set<String> ruleIdsOf(JsonNode entries) {
+        Set<String> out = new LinkedHashSet<>();
+        if (entries == null) {
+            return out;   // absent where the measure found none, which is not an empty array
+        }
+        entries.forEach(each -> {
+            if (each.has("ruleId")) {
+                out.add(each.get("ruleId").toString());
+            }
+        });
+        return out;
     }
 
     /** Every rule of the behavior that this could not turn into a line. */

--- a/souther-compiler/src/test/java/souther/compiler/ARuleThisCouldNotReadIsNamedByTheRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleThisCouldNotReadIsNamedByTheRuleTest.java
@@ -127,24 +127,19 @@ class ARuleThisCouldNotReadIsNamedByTheRuleTest {
     }
 
     /**
-     * A comparison written inside a helper is not one of these.
+     * A comparison written in code the author cannot open is not one of these.
      *
-     * <p>A helper is spliced into every body that calls it, so its comparisons stand in this tree
-     * and are not this behavior's rules to answer for. The author wrote {@code > 70} here and the
-     * comparisons inside {@code Int.clamp} nowhere near here, and a report naming the second sends
-     * them to edit a function they may not own.
+     * <p>The author wrote {@code > 70} here and the comparisons inside {@code Int.clamp} in a
+     * library this compile has no file for. A report naming the second sends them to edit a
+     * function they do not have — while a helper of their own has a file, is cited where it is
+     * written, and is theirs to rewrite.
      *
-     * <p>Asked of the comparison and not of the fork it sits under: the one the author wrote is the
-     * operand of a call whose insides they did not write, so a subtree is the wrong unit. What
-     * tells the two apart is the citation, which already says whether code was written where the
-     * reader is standing or reached from somewhere else.
-     *
-     * <p>The accounting beside this still raises questions for the helper's own forks. That is
-     * where it stood before this issue and is not changed here; that the two ought to draw the line
-     * in one place is its own question.
+     * <p>The accounting beside this still raises questions for the library's own forks. That is
+     * where it stood before this change and is not changed here; that the two ought to draw the
+     * line in one place is its own question.
      */
     @Test
-    void aComparisonInsideAnExpandedHelperIsNotOneOfThese() {
+    void aComparisonWrittenOutOfSightIsNotOneOfThese() {
         String model = """
                 module m
 
@@ -238,6 +233,35 @@ class ARuleThisCouldNotReadIsNamedByTheRuleTest {
             }
         });
         return out;
+    }
+
+    /**
+     * A comparison written inside a fork of its own is cited by that fork.
+     *
+     * <p>A condition can hold a fork — {@code guard Int.add(if a < b then 1 else 2, 0) > 0} — and
+     * the comparison inside it is written in the {@code if}, not in the {@code guard} around it.
+     * Walked from the outer fork, the word came from one construct and the place from the other,
+     * and the entry the inner fork made of itself was dropped as a repeat.
+     */
+    @Test
+    void aComparisonInsideAForkOfItsOwnIsCitedByThatFork() {
+        String model = """
+                module m
+
+                data Ok
+                data No
+
+                behavior f : (a: Int, b: Int) -> Ok | No
+                let f (a, b) = {
+                    guard Int.add(if Int.multiply(a, a) < b then 1 else 2, 0) > 0 else No
+                    Ok
+                }
+                """;
+
+        String human = human(model);
+
+        assertTrue(human.lines().anyMatch(line -> line.contains("not read: guard@")), human);
+        assertTrue(human.lines().anyMatch(line -> line.contains("not read: if@")), human);
     }
 
     /** Every rule of the behavior that this could not turn into a line. */

--- a/souther-compiler/src/test/java/souther/compiler/ARuleThisCouldNotReadIsNamedByTheRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleThisCouldNotReadIsNamedByTheRuleTest.java
@@ -264,6 +264,49 @@ class ARuleThisCouldNotReadIsNamedByTheRuleTest {
         assertTrue(human.lines().anyMatch(line -> line.contains("not read: if@")), human);
     }
 
+    /**
+     * One rule stopped twice at one position is two findings, told apart by the limit.
+     *
+     * <p>A clause is read a conjunct at a time and each conjunct stops for its own reason: here one
+     * relates two positions and the one beside it is written in a form nothing reads. Both are the
+     * same rule about the same position, so the rule and the place say nothing about which is
+     * which — and a finding carrying only those came out as one object twice, with the entry beside
+     * it in `notRead` keyed on the very thing that was missing.
+     */
+    @Test
+    void oneRuleStoppedTwiceAtOnePositionIsTwoFindings() {
+        String model = """
+                module m
+
+                data Ok
+                data R = { a: Int, b: Int }
+                    invariant mixed = a < b && Int.multiply(a, a) < 10
+
+                behavior f : (r: R) -> Ok
+                    constructs Ok
+                let f (r) = Ok
+                """;
+
+        JsonNode findings = JSON.readTree(json(model))
+                .get("modules").get(0).get("behaviors").get(0).get("findings");
+
+        Set<String> whole = new LinkedHashSet<>();
+        Set<String> withoutTheReason = new LinkedHashSet<>();
+        for (JsonNode each : findings) {
+            if (!"partition_not_read".equals(each.get("kind").asString())
+                    || !"r.a".equals(each.get("subject").asString())) {
+                continue;
+            }
+            whole.add(each.toString());
+            withoutTheReason.add(each.get("subject").asString() + each.get("ruleId").toString());
+        }
+
+        assertEquals(2, whole.size(), findings::toString);
+        assertEquals(1, withoutTheReason.size(),
+                () -> "one rule and one position, so the reason is the whole of the difference: "
+                        + findings);
+    }
+
     /** Every rule of the behavior that this could not turn into a line. */
     private static List<PartitionEvidence.NotRead> rulesNotRead(String model) {
         List<PartitionEvidence.NotRead> out = new ArrayList<>();

--- a/souther-compiler/src/test/java/souther/compiler/AnEqualityDividesTheValuesInTwoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEqualityDividesTheValuesInTwoTest.java
@@ -91,7 +91,7 @@ class AnEqualityDividesTheValuesInTwoTest {
         String human = reportOf(MODEL);
 
         assertTrue(human.contains("partition   axes 1"), human);
-        assertFalse(human.contains("not read: retries"), human);
+        assertFalse(notReadAbout(human, "retries"), human);
     }
 
     /** Two rows on either side of the equality cover it, with nothing left owed. */
@@ -153,5 +153,19 @@ class AnEqualityDividesTheValuesInTwoTest {
         // the equality's value is one more distinction on top of them rather than instead of them.
         assertTrue(human.contains("x <= 0"), human);
         assertTrue(human.contains("no row is in"), human);
+    }
+
+    /**
+     * Whether any {@code not read} line of {@code block} is about {@code position}.
+     *
+     * <p>Asked as a line rather than as a prefix. A finding about a rule names the rule first and
+     * the position after it, and one about a position names the position — so a test matching
+     * `+not read: <position>+` stopped meaning anything for the first kind rather than failing,
+     * which is a negative assertion that passes because the words moved.
+     */
+    private static boolean notReadAbout(String block, String position) {
+        return block.lines().anyMatch(line -> line.contains("not read:")
+                && (line.contains("not read: " + position + " ")
+                        || line.contains("about `" + position + "`")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest.java
@@ -90,8 +90,8 @@ class AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest {
     void aGuardNamesBothPositionsItCompares() {
         String block = blockOf("mix");
 
-        assertTrue(block.contains("not read: order.straw"), block);
-        assertTrue(block.contains("not read: order.choco"), block);
+        assertTrue(notReadAbout(block, "order.straw"), block);
+        assertTrue(notReadAbout(block, "order.choco"), block);
     }
 
     /** And the {@code invariant} of the same shape, at both the positions it compares. */
@@ -99,8 +99,8 @@ class AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest {
     void andSoDoesAnInvariantOfTheSameShape() {
         String block = blockOf("quote");
 
-        assertTrue(block.contains("not read: parcel.length"), block);
-        assertTrue(block.contains("not read: parcel.width"), block);
+        assertTrue(notReadAbout(block, "parcel.length"), block);
+        assertTrue(notReadAbout(block, "parcel.width"), block);
     }
 
     /** In the same words, since what stopped each of them is the same fact about this compiler. */
@@ -123,7 +123,7 @@ class AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest {
     void andForAComparisonWithOnePositionOnEachSide() {
         assertEquals(saidAbout(blockOf("byGuard"), "b.x"),
                 saidAbout(blockOf("byRule"), "p.x"));
-        assertTrue(blockOf("byRule").contains("relates it to another position"), blockOf("byRule"));
+        assertTrue(blockOf("byRule").contains("relates two positions"), blockOf("byRule"));
     }
 
     /**
@@ -139,8 +139,8 @@ class AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest {
         String rule = blockOf("byRuleAboutOne");
         String guard = blockOf("byGuardAboutOne");
 
-        assertFalse(rule.contains("another position"), rule);
-        assertFalse(guard.contains("another position"), guard);
+        assertFalse(rule.contains("relates two positions"), rule);
+        assertFalse(guard.contains("relates two positions"), guard);
         assertEquals(saidAbout(guard, "b.x"), saidAbout(rule, "s.x"));
     }
 
@@ -162,7 +162,7 @@ class AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest {
     void andOnceEach() {
         String block = blockOf("quote");
 
-        assertEquals(1, block.lines().filter(line -> line.contains("not read: parcel.length")).count(),
+        assertEquals(1, block.lines().filter(line -> notReadAbout(line, "parcel.length")).count(),
                 block);
     }
 
@@ -196,14 +196,38 @@ class AnInvariantSaysARuleWentUnreadTheWayAGuardDoesTest {
         compilation.answerEverything();
         String human = AdequacyReport.of(compilation).human(SourceNameResolver.identity());
 
-        assertEquals(1, human.lines().filter(line -> line.contains("not read: q ")).count(), human);
+        assertEquals(1, human.lines().filter(line -> notReadAbout(line, "q")).count(), human);
         assertTrue(human.contains("no line can be drawn on"), human);
     }
 
+    /**
+     * What the report says stopped the reading at {@code position}, without the rule that stopped
+     * there.
+     *
+     * <p>The words alone, which is what these rows compare: an invariant and a guard of one shape
+     * are owed the same sentence, and they are two rules with two handles. Taken with the handle,
+     * every row here would differ for the reason the rows exist to say does not matter.
+     */
     private static String saidAbout(String block, String position) {
-        return block.lines().filter(line -> line.contains("not read: " + position + " "))
-                .map(line -> line.substring(line.indexOf('(')))
+        return block.lines().filter(line -> notReadAbout(line, position))
+                .map(line -> line.contains(" — ")
+                        ? line.substring(line.indexOf(" — ") + 3, line.indexOf(", about `"))
+                        : line.substring(line.indexOf('(') + 1, line.lastIndexOf(')')))
                 .findFirst().orElseThrow(() -> new AssertionError(
                         "nothing said about `" + position + "`: " + block));
+    }
+
+    /**
+     * Whether any {@code not read} line of {@code block} is about {@code position}.
+     *
+     * <p>Asked as a line rather than as a prefix. A finding about a rule names the rule first and
+     * the position after it, and one about a position names the position — so a test matching
+     * `+not read: <position>+` stopped meaning anything for the first kind rather than failing,
+     * which is a negative assertion that passes because the words moved.
+     */
+    private static boolean notReadAbout(String block, String position) {
+        return block.lines().anyMatch(line -> line.contains("not read:")
+                && (line.contains("not read: " + position + " ")
+                        || line.contains("about `" + position + "`")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/BothSurfacesSayWhatWasFoundAboutAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/BothSurfacesSayWhatWasFoundAboutAPositionTest.java
@@ -72,16 +72,35 @@ class BothSurfacesSayWhatWasFoundAboutAPositionTest {
     private static List<String> documentSaysNotRead(String source) {
         List<String> said = new ArrayList<>();
         partitionOf(source).get("notRead").forEach(each ->
-                said.add(each.get("position").asText() + ":" + each.get("reason").asText()));
+                said.add(each.get("position").asText() + ":" + each.get("reason").asText()
+                        + ":" + (each.has("rule") ? each.get("rule").asText() : "-")));
         return said;
     }
 
     @Test
     void aPositionOnlyTheHumanLineNamedIsInTheDocumentToo() {
-        assertTrue(humanOf(MEASURED_AND_UNREAD).contains("not read: n"),
+        assertTrue(notReadAbout(humanOf(MEASURED_AND_UNREAD), "n"),
                 humanOf(MEASURED_AND_UNREAD));
 
-        assertEquals(List.of("n:unsupported_syntax"), documentSaysNotRead(MEASURED_AND_UNREAD),
+        // The handle too, because that is the half a person is shown. Keyed on the position and the
+        // reason alone, two rules stopped alike here were one entry and the document could not say
+        // which of them a reader was being told about.
+        assertEquals(List.of("n:unsupported_syntax:guard@0:11:32"),
+                documentSaysNotRead(MEASURED_AND_UNREAD),
                 "the document says what the report said");
+    }
+
+    /**
+     * Whether any {@code not read} line of {@code block} is about {@code position}.
+     *
+     * <p>Asked as a line rather than as a prefix. A finding about a rule names the rule first and
+     * the position after it, and one about a position names the position — so a test matching
+     * `+not read: <position>+` stopped meaning anything for the first kind rather than failing,
+     * which is a negative assertion that passes because the words moved.
+     */
+    private static boolean notReadAbout(String block, String position) {
+        return block.lines().anyMatch(line -> line.contains("not read:")
+                && (line.contains("not read: " + position + " ")
+                        || line.contains("about `" + position + "`")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/EveryKeyThisWritesIsOneTheSchemaDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryKeyThisWritesIsOneTheSchemaDeclaresTest.java
@@ -57,8 +57,8 @@ class EveryKeyThisWritesIsOneTheSchemaDeclaresTest {
 
     private static JsonNode schema() throws Exception {
         try (InputStream in =
-                     AdequacyReport.class.getResourceAsStream("/souther/adequacy-schema-4.json")) {
-            assertNotNull(in, "adequacy-schema-4.json ships beside the compiler");
+                     AdequacyReport.class.getResourceAsStream("/souther/adequacy-schema-3.json")) {
+            assertNotNull(in, "adequacy-schema-3.json ships beside the compiler");
             return JSON.readTree(new String(in.readAllBytes(), StandardCharsets.UTF_8));
         }
     }

--- a/souther-compiler/src/test/java/souther/compiler/EveryKeyThisWritesIsOneTheSchemaDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryKeyThisWritesIsOneTheSchemaDeclaresTest.java
@@ -57,8 +57,8 @@ class EveryKeyThisWritesIsOneTheSchemaDeclaresTest {
 
     private static JsonNode schema() throws Exception {
         try (InputStream in =
-                     AdequacyReport.class.getResourceAsStream("/souther/adequacy-schema-3.json")) {
-            assertNotNull(in, "adequacy-schema-3.json ships beside the compiler");
+                     AdequacyReport.class.getResourceAsStream("/souther/adequacy-schema-4.json")) {
+            assertNotNull(in, "adequacy-schema-4.json ships beside the compiler");
             return JSON.readTree(new String(in.readAllBytes(), StandardCharsets.UTF_8));
         }
     }

--- a/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Every word the shipped schema allows is one somebody accounted for.
  *
- * <p>Every enumerated field of {@code adequacy-schema-4.json} is a second spelling of a Java enum.
+ * <p>Every enumerated field of {@code adequacy-schema-3.json} is a second spelling of a Java enum.
  * The two are edited in different files by different hands, and until this test nothing noticed when
  * one moved: `ROW_TIMED_OUT` became `ROW_UNDECIDED` when a row stopped being held to a clock, the
  * rename was right, and the schema went on promising a word that had not been emitted since.
@@ -59,7 +59,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class EverySchemaWordIsAccountedForTest {
 
-    private static final String SCHEMA = "/souther/adequacy-schema-4.json";
+    private static final String SCHEMA = "/souther/adequacy-schema-3.json";
     private static final JsonMapper JSON = JsonMapper.builder().build();
 
     /**
@@ -531,7 +531,7 @@ class EverySchemaWordIsAccountedForTest {
 
     private static JsonNode schema() {
         try (InputStream in = AdequacyReport.class.getResourceAsStream(SCHEMA)) {
-            assertNotNull(in, "adequacy-schema-4.json ships beside the compiler");
+            assertNotNull(in, "adequacy-schema-3.json ships beside the compiler");
             return JSON.readTree(new String(in.readAllBytes(), StandardCharsets.UTF_8));
         } catch (java.io.IOException e) {
             throw new AssertionError(e);

--- a/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Every word the shipped schema allows is one somebody accounted for.
  *
- * <p>Every enumerated field of {@code adequacy-schema-3.json} is a second spelling of a Java enum.
+ * <p>Every enumerated field of {@code adequacy-schema-4.json} is a second spelling of a Java enum.
  * The two are edited in different files by different hands, and until this test nothing noticed when
  * one moved: `ROW_TIMED_OUT` became `ROW_UNDECIDED` when a row stopped being held to a clock, the
  * rename was right, and the schema went on promising a word that had not been emitted since.
@@ -59,7 +59,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class EverySchemaWordIsAccountedForTest {
 
-    private static final String SCHEMA = "/souther/adequacy-schema-3.json";
+    private static final String SCHEMA = "/souther/adequacy-schema-4.json";
     private static final JsonMapper JSON = JsonMapper.builder().build();
 
     /**
@@ -372,10 +372,9 @@ class EverySchemaWordIsAccountedForTest {
                                 new souther.compiler.check.BehaviorContract.RuleId(
                                         new souther.compiler.types.ValueName.Behavior("m", "f"),
                                         0, 0, on), "Found")),
-                        AdequacyReport.ruleWord(new souther.compiler.check.RuleRef.Guard(
-                                new souther.compiler.coverage.CoverageSites.ComparisonRef("f",
-                                        new souther.compiler.types.CoverageOrigin("m", 0, 0,
-                                                souther.compiler.types.CoverageConstruct.IF))))),
+                        AdequacyReport.ruleWord(new souther.compiler.check.RuleRef.Guard("f",
+                                new souther.compiler.types.CoverageOrigin("m", 0, 0,
+                                        souther.compiler.types.CoverageConstruct.IF)))),
                 allowedAt(schema(), List.of("$defs", "ruleId", "properties", "kind")));
     }
 
@@ -532,7 +531,7 @@ class EverySchemaWordIsAccountedForTest {
 
     private static JsonNode schema() {
         try (InputStream in = AdequacyReport.class.getResourceAsStream(SCHEMA)) {
-            assertNotNull(in, "adequacy-schema-3.json ships beside the compiler");
+            assertNotNull(in, "adequacy-schema-4.json ships beside the compiler");
             return JSON.readTree(new String(in.readAllBytes(), StandardCharsets.UTF_8));
         } catch (java.io.IOException e) {
             throw new AssertionError(e);

--- a/souther-compiler/src/test/java/souther/compiler/WhatAReadingLeavesStandingIsAStateTheSchemaSaysTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatAReadingLeavesStandingIsAStateTheSchemaSaysTest.java
@@ -101,8 +101,8 @@ class WhatAReadingLeavesStandingIsAStateTheSchemaSaysTest {
 
     private static JsonNode schema() throws Exception {
         try (InputStream in =
-                     AdequacyReport.class.getResourceAsStream("/souther/adequacy-schema-3.json")) {
-            assertNotNull(in, "adequacy-schema-3.json ships beside the compiler");
+                     AdequacyReport.class.getResourceAsStream("/souther/adequacy-schema-4.json")) {
+            assertNotNull(in, "adequacy-schema-4.json ships beside the compiler");
             return JSON.readTree(new String(in.readAllBytes(), StandardCharsets.UTF_8));
         }
     }

--- a/souther-compiler/src/test/java/souther/compiler/WhatAReadingLeavesStandingIsAStateTheSchemaSaysTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatAReadingLeavesStandingIsAStateTheSchemaSaysTest.java
@@ -101,8 +101,8 @@ class WhatAReadingLeavesStandingIsAStateTheSchemaSaysTest {
 
     private static JsonNode schema() throws Exception {
         try (InputStream in =
-                     AdequacyReport.class.getResourceAsStream("/souther/adequacy-schema-4.json")) {
-            assertNotNull(in, "adequacy-schema-4.json ships beside the compiler");
+                     AdequacyReport.class.getResourceAsStream("/souther/adequacy-schema-3.json")) {
+            assertNotNull(in, "adequacy-schema-3.json ships beside the compiler");
             return JSON.readTree(new String(in.readAllBytes(), StandardCharsets.UTF_8));
         }
     }

--- a/souther-compiler/src/test/java/souther/compiler/WhatBuildsATemporalIsWhatTheNameDenotesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatBuildsATemporalIsWhatTheNameDenotesTest.java
@@ -149,7 +149,7 @@ class WhatBuildsATemporalIsWhatTheNameDenotesTest {
                 report(CONSTRUCTED));
         assertFalse(report(ANSWERS_ONE).contains("coverage items 0/0"), report(ANSWERS_ONE));
         assertTrue(report(ANSWERS_ONE).contains(
-                        "· not read: on (a rule about it is one this compiler did not read)"),
+                        "written in a form this compiler does not read, about `on`"),
                 report(ANSWERS_ONE));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest.java
@@ -284,7 +284,7 @@ class ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest {
                 "the rule a reader is sent to look at is the one that wrote the clause");
     }
 
-    private static List<BlockReason> reasonsAt(FieldDomains read, String path) {
+    private static List<BlockReason.AboutARule> reasonsAt(FieldDomains read, String path) {
         return read.unreadAt(path).stream().map(FieldDomains.Unread::why).toList();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderIsALineOnWhateverTheRuleCutsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderIsALineOnWhateverTheRuleCutsTest.java
@@ -178,12 +178,10 @@ class ABorderIsALineOnWhateverTheRuleCutsTest {
         // And what it leaves the positions is said in the same words as well. A rule over a quantity
         // that is not one position's own values divides none of them, whoever wrote it.
         assertTrue(report.contains(
-                "not read: a (the comparison relates it to another position rather than"
-                        + " dividing it)"), report);
+                "it relates two positions rather than dividing one, about `a`"), report);
         assertTrue(report(guarded(
                         "Int.add(Int.multiply(3, a.value), Int.multiply(6, b.value)) <= 48"))
-                        .contains("not read: a (the comparison relates it to another position"
-                                + " rather than dividing it)"),
+                        .contains("it relates two positions rather than dividing one, about `a`"),
                 "a body's conditions say it the same way");
     }
 
@@ -623,9 +621,13 @@ class ABorderIsALineOnWhateverTheRuleCutsTest {
                     | "one" : (Bound(1), Bound(1)) -> Yes { v = 1 }
                 """;
 
-        assertEquals(report(written.formatted(
-                        "Int.add(Int.multiply(3, a.value), Int.multiply(6, b.value)) <= 48")),
-                report(written.formatted("a.value * 3 + b.value * 6 <= 48")),
+        // Apart from where the rule is written, which is a place and not the rule. The two
+        // spellings are two lengths of text and the handle a report prints points at each of them,
+        // so a comparison that kept the column would be asserting the two were written alike.
+        assertEquals(exceptWhereRulesAreWritten(report(written.formatted(
+                        "Int.add(Int.multiply(3, a.value), Int.multiply(6, b.value)) <= 48"))),
+                exceptWhereRulesAreWritten(
+                        report(written.formatted("a.value * 3 + b.value * 6 <= 48"))),
                 "one rule, whichever way the arithmetic is spelled");
     }
 
@@ -692,7 +694,7 @@ class ABorderIsALineOnWhateverTheRuleCutsTest {
         // And the question the comparison raises is answered by what came of reading it. Answered by
         // which reading was tried, a rule that drew nothing reported a line as read, and the
         // positions it names went unaccounted for.
-        assertTrue(report.contains("not read: a") && report.contains("not read: b"),
+        assertTrue(notReadAbout(report, "a") && notReadAbout(report, "b"),
                 "the positions are still named, and as positions nothing divided:\n" + report);
     }
 
@@ -752,5 +754,25 @@ class ABorderIsALineOnWhateverTheRuleCutsTest {
         compilation.measure(Adequacy.Asked.reportOnly());
         compilation.answerEverything();
         return GeneratedRows.of(compilation, null, null, true, SourceNameResolver.identity());
+    }
+
+    /**
+     * Whether any {@code not read} line of {@code block} is about {@code position}.
+     *
+     * <p>Asked as a line rather than as a prefix. A finding about a rule names the rule first and
+     * the position after it, and one about a position names the position — so a test matching
+     * `+not read: <position>+` stopped meaning anything for the first kind rather than failing,
+     * which is a negative assertion that passes because the words moved.
+     */
+    private static boolean notReadAbout(String block, String position) {
+        return block.lines().anyMatch(line -> line.contains("not read:")
+                && (line.contains("not read: " + position + " ")
+                        || line.contains("about `" + position + "`")));
+    }
+
+    /** The same report with every citation of a rule with no name blanked, since where a rule is
+     *  written is a place and two spellings of one rule are at two of them. */
+    private static String exceptWhereRulesAreWritten(String report) {
+        return report.replaceAll("(guard|if|comprehension)@\\d+:\\d+", "$1@<written>");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACallIsAValueOnlyWhenItIsTheConstructionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACallIsAValueOnlyWhenItIsTheConstructionTest.java
@@ -17,6 +17,7 @@ import souther.compiler.query.Shapes;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -81,10 +82,12 @@ class ACallIsAValueOnlyWhenItIsTheConstructionTest {
 
             assertEquals(List.of(), guards.thresholds(),
                     each[0] + ": an implementation nothing here has read draws no line");
-            assertEquals(List.of(new UnreadRule(TermPath.of("t"),
-                            new BlockReason.UnreadComparisonForm())),
-                    guards.unread(),
+            assertEquals(1, guards.unread().size(),
                     each[0] + ": and the position says a rule about it went unread");
+            UnreadRule said = guards.unread().getFirst();
+            assertEquals(TermPath.of("t"), said.at(), each[0] + ": at the position");
+            assertInstanceOf(BlockReason.UnreadComparisonForm.class, said.why(),
+                    each[0] + ": for the form it is written in");
         }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClauseReachingOneCoordinatePlacesAnEdgeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClauseReachingOneCoordinatePlacesAnEdgeTest.java
@@ -314,8 +314,8 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
                   onSpan                   implemented   rows 1    pending 0
                     signature   not applicable (this behavior's output is not a sum)
                     partition   not measured (no partition axis was derived at any position)
-                      · not read: v.startsAt (the comparison relates it to another position rather than dividing it)
-                      · not read: v.endsAt (the comparison relates it to another position rather than dividing it)
+                      · not read: invariant Span #1 — it relates two positions rather than dividing one, about `v.startsAt`
+                      · not read: invariant Span #1 — it relates two positions rather than dividing one, about `v.endsAt`
                     border      not measured (no line was derived at any position)
                 """), report);
     }
@@ -330,8 +330,8 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
                   onFloor                  implemented   rows 1    pending 0
                     signature   not applicable (this behavior's output is not a sum)
                     partition   not measured (no partition axis was derived at any position)
-                      · not read: v.n (the comparison relates it to another position rather than dividing it)
-                      · not read: v.min (the comparison relates it to another position rather than dividing it)
+                      · not read: invariant Floor #1 — it relates two positions rather than dividing one, about `v.n`
+                      · not read: invariant Floor #1 — it relates two positions rather than dividing one, about `v.min`
                     border      not measured (no line was derived at any position)
                 """), report);
     }
@@ -455,6 +455,11 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
      * a report says is that they were not read, which sends the author to a limit of this compiler
      * rather than to a distinction their model does not draw. Taking whichever was looked at first
      * would put a line the author can read beside one they cannot see.
+     *
+     * <p>Both clauses are named, since both are rules the author would have to rewrite. One line
+     * said the position was short of something and left them to find which two of their clauses
+     * were in the way — and said it in the words of a form this compiler cannot read, which is a
+     * cause it was never observed to have.
      */
     @Test
     void rulesAboutBothCoordinatesLeaveThePositionUndivided() {
@@ -464,7 +469,8 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
                   onR                      implemented   rows 1    pending 0
                     signature   not applicable (this behavior's output is not a sum)
                     partition   not measured (no partition axis was derived at any position)
-                      · not read: v.s (a rule about it is one this compiler did not read)
+                      · not read: invariant R #1 — a rule beside it is about the position's other coordinate, so neither can be chosen, about `v.s`
+                      · not read: invariant R #2 — a rule beside it is about the position's other coordinate, so neither can be chosen, about `v.s`
                     border      not measured (no line was derived at any position)
                 """), report);
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AComparisonThisDoesNotReadIsStillNoticedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AComparisonThisDoesNotReadIsStillNoticedTest.java
@@ -11,7 +11,10 @@ import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.TermPath;
+import souther.compiler.check.RuleCitation;
+import souther.compiler.check.RuleRef;
 import souther.compiler.inputs.UnreadRule;
+import souther.compiler.types.CoverageConstruct;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -19,6 +22,7 @@ import souther.compiler.query.Shapes;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -164,11 +168,43 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
         assertEquals(1, guards.thresholds().size(), guards.thresholds().toString());
     }
 
-    /** One position said once, however many comparisons in the body name it. */
+    /**
+     * Two comparisons about one position are two findings, however alike they read.
+     *
+     * <p>Asked of the position, the second was dropped as a repeat of the first — and what an
+     * author is owed is one line per rule they would have to rewrite. The two here are stopped by
+     * the same limit at the same position and are two things to do, which is the whole of issue
+     * the same defect seen from inside one condition.
+     */
     @Test
-    void aPositionIsNamedOnceRatherThanPerComparison() {
-        assertEquals(1, read("at: Int",
-                "Int.multiply(at, at) < 4 || Int.multiply(at, at) > 9").unread().size());
+    void twoComparisonsAboutOnePositionAreTwoFindings() {
+        List<UnreadRule> unread = read("at: Int",
+                "Int.multiply(at, at) < 4 || Int.multiply(at, at) > 9").unread();
+
+        assertEquals(List.of(new Said(TermPath.of("at"), new BlockReason.UnreadComparisonForm()),
+                        new Said(TermPath.of("at"), new BlockReason.UnreadComparisonForm())),
+                said(unread));
+        assertEquals(2, unread.stream().map(UnreadRule::rule).distinct().count(),
+                () -> "two comparisons are two rules: " + unread);
+    }
+
+    /**
+     * And the rule is named, by what tells one from another and by what a reader looks for.
+     *
+     * <p>The position was all this used to carry, so a report could say a rule about `+p.x+` went
+     * unread and name no rule. What identifies a comparison is the behavior it is
+     * written in and the construct the author wrote; what finds it is the fork it stands in and the
+     * place. Neither is the plan\u0027s: a condition nothing can be measured about is numbered nowhere,
+     * and the model states the rule regardless.
+     */
+    @Test
+    void aFindingNamesTheComparisonThatWentUnread() {
+        UnreadRule said = read("p: Pair", "Int.multiply(p.x, p.x) < 10").unread().getFirst();
+
+        assertInstanceOf(RuleRef.Guard.class, said.rule());
+        RuleCitation.WrittenAt cited = assertInstanceOf(RuleCitation.WrittenAt.class, said.cited());
+        assertEquals(CoverageConstruct.IF, cited.construct(),
+                "a rule with no name is found by the construct it is written in");
     }
 
     /**
@@ -186,9 +222,9 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
      */
     @Test
     void aPositionNamedInsideAnExpressionIsStillNoticed() {
-        assertEquals(List.of(new UnreadRule(TermPath.of("p").then("x"),
+        assertEquals(List.of(new Said(TermPath.of("p").then("x"),
                         new BlockReason.UnreadComparisonForm())),
-                read("p: Pair", "Int.multiply(p.x, p.x) < 10").unread());
+                said(read("p: Pair", "Int.multiply(p.x, p.x) < 10").unread()));
     }
 
     /**
@@ -201,11 +237,11 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
     @Test
     void twoPositionsComparedWithEachOtherSayWhichLimitThatIs() {
         assertEquals(List.of(
-                        new UnreadRule(TermPath.of("p").then("x"),
+                        new Said(TermPath.of("p").then("x"),
                                 new BlockReason.ComparisonBetweenPositions()),
-                        new UnreadRule(TermPath.of("p").then("y"),
+                        new Said(TermPath.of("p").then("y"),
                                 new BlockReason.ComparisonBetweenPositions())),
-                read("p: Pair", "p.x < p.y").unread());
+                said(read("p: Pair", "p.x < p.y").unread()));
     }
 
     /**
@@ -222,9 +258,9 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
                 read("p: Pair", "p.x <= 5 && Int.multiply(p.x, p.x) < 10");
 
         assertEquals(1, guards.thresholds().size(), guards.thresholds().toString());
-        assertEquals(List.of(new UnreadRule(TermPath.of("p").then("x"),
+        assertEquals(List.of(new Said(TermPath.of("p").then("x"),
                         new BlockReason.UnreadComparisonForm())),
-                guards.unread());
+                said(guards.unread()));
     }
 
     /**
@@ -242,11 +278,11 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
     @Test
     void aRelationWithArithmeticOnOneSideIsStillARelation() {
         assertEquals(List.of(
-                        new UnreadRule(TermPath.of("p").then("x"),
+                        new Said(TermPath.of("p").then("x"),
                                 new BlockReason.ComparisonBetweenPositions()),
-                        new UnreadRule(TermPath.of("p").then("y"),
+                        new Said(TermPath.of("p").then("y"),
                                 new BlockReason.ComparisonBetweenPositions())),
-                read("p: Pair", "p.x < Int.multiply(p.y, p.y)").unread());
+                said(read("p: Pair", "p.x < Int.multiply(p.y, p.y)").unread()));
     }
 
     /**
@@ -259,8 +295,20 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
      */
     @Test
     void aReadableCarrierAgainstAnUnreadableSideIsNotACarrierProblem() {
-        assertEquals(List.of(new UnreadRule(TermPath.of("p").then("x"),
+        assertEquals(List.of(new Said(TermPath.of("p").then("x"),
                         new BlockReason.UnreadComparisonForm())),
-                read("p: Pair", "p.x < Int.min(1, 2)").unread());
+                said(read("p: Pair", "p.x < Int.min(1, 2)").unread()));
+    }
+
+    /**
+     * What a finding says about a position, apart from which rule said it.
+     *
+     * <p>Spelled out where every entry is about one rule and what is being read is the position and
+     * the limit. Which rule it was has its own test, because it is its own question.
+     */
+    private record Said(TermPath at, BlockReason why) {}
+
+    private static List<Said> said(List<UnreadRule> unread) {
+        return unread.stream().map(each -> new Said(each.at(), each.why())).toList();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ALineBetweenTwoPositionsIsStillALineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ALineBetweenTwoPositionsIsStillALineTest.java
@@ -370,7 +370,7 @@ class ALineBetweenTwoPositionsIsStillALineTest {
                 report);
         assertTrue(report.contains("no row is at the ON point benefitOf/charge = ceiling + 1001"),
                 report);
-        assertTrue(report.contains("not read: charge"), report);
+        assertTrue(notReadAbout(report, "charge"), report);
     }
 
     /**
@@ -401,14 +401,13 @@ class ALineBetweenTwoPositionsIsStillALineTest {
         String report = report(TWO_NEWTYPES);
 
         int partition = report.indexOf("    partition ");
-        int note = report.indexOf("· not read: charge");
+        int note = report.indexOf("dividing one, about `charge`");
         int boundary = report.indexOf("    border ");
 
         assertTrue(note > partition && note < boundary,
                 "the note about the classes sits under the classes measure:\n" + report);
         assertTrue(report.contains(
-                "not read: charge (the comparison relates it to another position"
-                        + " rather than dividing it)"), report);
+                "it relates two positions rather than dividing one, about `charge`"), report);
     }
 
     /**
@@ -533,5 +532,19 @@ class ALineBetweenTwoPositionsIsStillALineTest {
 
         assertEquals(1, report.split("    border ", -1).length - 1, report);
         assertEquals(1, report.split("    partition ", -1).length - 1, report);
+    }
+
+    /**
+     * Whether any {@code not read} line of {@code block} is about {@code position}.
+     *
+     * <p>Asked as a line rather than as a prefix. A finding about a rule names the rule first and
+     * the position after it, and one about a position names the position — so a test matching
+     * `+not read: <position>+` stopped meaning anything for the first kind rather than failing,
+     * which is a negative assertion that passes because the words moved.
+     */
+    private static boolean notReadAbout(String block, String position) {
+        return block.lines().anyMatch(line -> line.contains("not read:")
+                && (line.contains("not read: " + position + " ")
+                        || line.contains("about `" + position + "`")));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionMeasuredTwoWaysNamesBothRulesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionMeasuredTwoWaysNamesBothRulesTest.java
@@ -1,0 +1,140 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.RuleRef;
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.PartitionEvidence;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A position whose two coordinates are both spoken for says which rules compete for it.
+ *
+ * <p>A {@code String} is the one thing that can be measured two ways — its own order, and the
+ * length of it — and which of them a position is measured at is settled by whichever the model
+ * wrote about. Where its own type chose neither and the value it sits in states an end on each,
+ * choosing either would put a line the author can read beside one they cannot see, so both rules
+ * are left unread.
+ *
+ * <p>Both of them, and each by name. One line said the position was short of something and left the
+ * author to work out which two of their clauses were in the way — and said it in the words of a
+ * form this compiler cannot read, which is a cause it was never observed to have: the clauses were
+ * read perfectly well.
+ *
+ * <p>Its own reason and not one of the three beside it. What is missing is not a reader for an
+ * expression, nor a carrier, nor a class about two positions: it is a rule for which coordinate
+ * wins, and an author sent after any of the other three would be looking for something that is
+ * already there.
+ */
+class APositionMeasuredTwoWaysNamesBothRulesTest {
+
+    private static final String ORDER_FIRST = """
+            module m
+
+            data Ok
+            data R = { s: String }
+                invariant low  = s >= "m"
+                invariant long = String.length(s) >= 3
+
+            behavior f : (v: R) -> Ok
+                constructs Ok
+            let f (v) = Ok
+            """;
+
+    /** The same two rules, written the other way round. */
+    private static final String LENGTH_FIRST = """
+            module m
+
+            data Ok
+            data R = { s: String }
+                invariant long = String.length(s) >= 3
+                invariant low  = s >= "m"
+
+            behavior f : (v: R) -> Ok
+                constructs Ok
+            let f (v) = Ok
+            """;
+
+    /** Both clauses are named, and both under the reason that says what is missing. */
+    @Test
+    void bothRulesAreNamedAndNeitherIsCalledUnreadableSyntax() {
+        List<PartitionEvidence.NotRead> said = notRead(ORDER_FIRST);
+
+        assertEquals(2, said.size(), said::toString);
+        assertEquals(Set.of(souther.compiler.partition.UndividedPosition.Reason
+                        .COMPETING_COORDINATES),
+                said.stream().map(PartitionEvidence.NotRead::reason)
+                        .collect(java.util.stream.Collectors.toSet()),
+                said::toString);
+        assertEquals(2, rules(ORDER_FIRST).size(), said::toString);
+        assertEquals(List.of("v.s", "v.s"),
+                said.stream().map(PartitionEvidence.NotRead::at).toList());
+    }
+
+    /**
+     * And which two they are does not depend on the order the author wrote them in.
+     *
+     * <p>The reading that gave them up looks at both, so a set built from one of them would be the
+     * walk's answer rather than the model's — which is the shape a report keyed on "the first
+     * limit in the way" already had.
+     */
+    @Test
+    void theSameTwoRulesWhicheverOrderTheyAreWrittenIn() {
+        assertEquals(named(rules(ORDER_FIRST)), named(rules(LENGTH_FIRST)));
+        assertEquals(Set.of("invariant R (low)", "invariant R (long)"), named(rules(ORDER_FIRST)));
+    }
+
+    /**
+     * And neither of them raises a question nothing answered.
+     *
+     * <p>The two measures are not one. This one says the reading that draws lines could not adopt
+     * the rule; the accounting says no reading at all took it in, and here the readings that turn a
+     * clause into where the values stop did take both of them in. A model where they agreed would
+     * hide that they are asked of different things.
+     */
+    @Test
+    void andNeitherIsAQuestionNothingAnswered() {
+        assertTrue(human(ORDER_FIRST).contains("not read: invariant R (low)"), human(ORDER_FIRST));
+        assertFalse(human(ORDER_FIRST).contains("not accounted for: invariant R (low)"),
+                human(ORDER_FIRST));
+    }
+
+    private static Set<String> named(Set<RuleRef> rules) {
+        Set<String> out = new LinkedHashSet<>();
+        rules.forEach(each -> out.add(each.named()));
+        return out;
+    }
+
+    private static Set<RuleRef> rules(String model) {
+        Set<RuleRef> out = new LinkedHashSet<>();
+        for (PartitionEvidence.NotRead each : notRead(model)) {
+            out.add(((PartitionEvidence.NotRead.ARule) each).rule());
+        }
+        return out;
+    }
+
+    private static List<PartitionEvidence.NotRead> notRead(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).modules().get(0).behaviors().get(0)
+                .partition().notRead();
+    }
+
+    private static String human(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).human(SourceNameResolver.identity());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -81,30 +81,30 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
                 .complete(new BodyCutInspection.Exhausted());
 
         assertFalse(said.isAbsent(), said.toString());
-        assertEquals(UndividedPosition.Reason.UNSUPPORTED_SYNTAX,
-                ((UndividedPosition.Why.CannotDerive) said.why()).reason());
+        // And the verdict says only that: what stopped it is the rule's, said by the reader that
+        // read the rule and naming which rule it was.
+        assertNull(PendingPosition.of(pending(new StructuralInspection.Leaf(), unread))
+                        .reportable(),
+                "a rule this read and could not use is not a position nothing was reached at");
     }
 
     /**
-     * And it is what is said where a body's comparison also came to nothing.
+     * Neither of two rules becomes the position's account, where a body's comparison came to
+     * nothing as well.
      *
-     * <p>Both are true of the position and one line is written. The rule on the declaration is the
-     * one whose being read would give the position an axis; a comparison relating it to another
-     * position divides it no way however well it is read, so the reason that names a limit is the
-     * one a reader is sent to. Written the other way round, an author reading "the comparison
-     * relates it to another position" would take that for the whole account and never learn that a
-     * rule on their own type went unread.
+     * <p>Both are rules this read and could not use, and each is said by the reader that read it,
+     * naming which rule. There used to be one line here and a precedence deciding which of the two
+     * reasons it carried — which is the shape of it: an author was told one limit and never
+     * learnt that the other rule existed. What the position itself has to say is that nothing was
+     * established, and no more.
      */
     @Test
-    void aRuleOnTheDeclarationIsSaidAheadOfWhatABodyCameTo() {
-        UndividedPosition said =
-                PendingPosition.of(pending(new StructuralInspection.Leaf(),
-                                new BlockReason.UnreadValueRule()))
-                        .complete(new BodyCutInspection.Blocked(
-                                new BlockReason.ComparisonBetweenPositions()));
+    void twoRulesLeaveThePositionWithNoAccountOfItsOwn() {
+        PendingPosition pending = PendingPosition.of(pending(new StructuralInspection.Leaf(),
+                new BlockReason.UnreadValueRule()));
 
-        assertEquals(UndividedPosition.Reason.UNSUPPORTED_SYNTAX,
-                ((UndividedPosition.Why.CannotDerive) said.why()).reason());
+        assertFalse(pending.complete(new BodyCutInspection.Blocked()).isAbsent());
+        assertNull(pending.reportable(), "each rule is said with its rule, not as this position");
     }
 
     // --- what can be pending at all -------------------------------------------------------------
@@ -150,11 +150,10 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
     @Test
     void aLeafWhoseRuleWentUnreadSaysThat() {
         UndividedPosition done = new PendingPosition.Leaf(AT)
-                .complete(new BodyCutInspection.Blocked(new BlockReason.UnreadComparisonForm()));
+                .complete(new BodyCutInspection.Blocked());
 
         assertFalse(done.isAbsent());
-        assertEquals(new UndividedPosition.Why.CannotDerive(
-                UndividedPosition.Reason.UNSUPPORTED_SYNTAX), done.why());
+        assertEquals(new UndividedPosition.Why.CannotDerive(), done.why());
     }
 
     /**
@@ -169,12 +168,16 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
     void aReadingThatStoppedOutranksWhatTheRulesCameTo() {
         PendingPosition blocked = new PendingPosition.Blocked(AT,
                 new BlockReason.UnsupportedTraversal(BlockReason.Traversal.SEQUENCE_ELEMENT));
-        UndividedPosition.Why expected = new UndividedPosition.Why.CannotDerive(
-                UndividedPosition.Reason.UNSUPPORTED_TRAVERSAL);
+        UndividedPosition.Why expected = new UndividedPosition.Why.CannotDerive();
 
         assertEquals(expected, blocked.complete(new BodyCutInspection.Exhausted()).why());
-        assertEquals(expected, blocked.complete(
-                new BodyCutInspection.Blocked(new BlockReason.UnreadComparisonForm())).why());
+        assertEquals(expected, blocked.complete(new BodyCutInspection.Blocked()).why());
+        // And the finding is the stop, whatever the rules came to: a rule naming something inside a
+        // position the walk could not enter describes that same stop from the other end.
+        assertEquals(new souther.compiler.inputs.PositionReadingBlocked(AT,
+                        new BlockReason.UnsupportedTraversal(
+                                BlockReason.Traversal.SEQUENCE_ELEMENT)),
+                blocked.reportable());
     }
 
     /** A line drawn at a position whose axis says it has none is two readings disagreeing, and

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatStoppedADerivationIsWhatIsReportedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatStoppedADerivationIsWhatIsReportedTest.java
@@ -35,11 +35,27 @@ class WhatStoppedADerivationIsWhatIsReportedTest {
         return evidence;
     }
 
-    private static UndividedPosition.Why whyAt(PartitionEvidence evidence, String position) {
+    /**
+     * What a report is told stopped the reading at {@code position}.
+     *
+     * <p>Off the findings and not off the verdict. The verdict says whether anything divides the
+     * position; what stopped the reading is a finding, made by whichever reader stopped, and a test
+     * that read it back off the verdict would be asserting the reconstruction this arrangement
+     * removes.
+     */
+    private static List<UndividedPosition.Reason> whyAt(PartitionEvidence evidence,
+                                                       String position) {
+        return evidence.notRead().stream()
+                .filter(each -> each.at().equals(position))
+                .map(PartitionEvidence.NotRead::reason)
+                .toList();
+    }
+
+    /** And that the verdict says nothing was established, without saying what stopped it. */
+    private static boolean couldNotDerive(PartitionEvidence evidence, String position) {
         return evidence.notDerivable().stream()
-                .filter(each -> each.at().toString().equals(position))
-                .map(UndividedPosition::why)
-                .findFirst().orElse(null);
+                .anyMatch(each -> each.at().toString().equals(position)
+                        && each.why() instanceof UndividedPosition.Why.CannotDerive);
     }
 
     /**
@@ -49,16 +65,16 @@ class WhatStoppedADerivationIsWhatIsReportedTest {
      */
     @Test
     void aTypeThisCouldNotInterpretIsSaidToBeThatRatherThanAnAbsence() {
-        UndividedPosition.Why why = whyAt(measured("""
+        PartitionEvidence measured = measured("""
                 module demo
                 data Ok
                 data Cyclic = Cyclic
                 behavior run : (x: Cyclic) -> Ok
                 let run (x) = Ok
-                """, "run"), "x");
+                """, "run");
 
-        assertEquals(new UndividedPosition.Why.CannotDerive(
-                UndividedPosition.Reason.TYPE_UNRESOLVED), why);
+        assertEquals(List.of(UndividedPosition.Reason.TYPE_UNRESOLVED), whyAt(measured, "x"));
+        assertTrue(couldNotDerive(measured, "x"), "and nothing is established either way");
     }
 
     /**
@@ -68,7 +84,7 @@ class WhatStoppedADerivationIsWhatIsReportedTest {
      */
     @Test
     void aThresholdOnAnElementSaysTheElementsCouldNotBeReached() {
-        UndividedPosition.Why why = whyAt(measured("""
+        PartitionEvidence measured = measured("""
                 module demo
                 data Ok
                 data Item = { charge: Int }
@@ -76,10 +92,12 @@ class WhatStoppedADerivationIsWhatIsReportedTest {
                 let run (items) =
                     { guard List.length(List.filter((i) -> i.charge >= 21000, items)) < 1 else Ok
                       Ok }
-                """, "run"), "items");
+                """, "run");
 
-        assertEquals(new UndividedPosition.Why.CannotDerive(
-                UndividedPosition.Reason.UNSUPPORTED_TRAVERSAL), why);
+        assertTrue(whyAt(measured, "items")
+                        .contains(UndividedPosition.Reason.UNSUPPORTED_TRAVERSAL),
+                () -> "said " + whyAt(measured, "items"));
+        assertTrue(couldNotDerive(measured, "items"), "and nothing is established either way");
     }
 
     /**
@@ -97,17 +115,19 @@ class WhatStoppedADerivationIsWhatIsReportedTest {
      */
     @Test
     void aRuleThatDividedNothingLeavesThePositionWithWhatItHad() {
-        UndividedPosition.Why why = whyAt(measured("""
+        PartitionEvidence measured = measured("""
                 module demo
                 data Ok
                 data Item = { charge: Int }
                 behavior run : (items: List<Item>) -> Ok
                 let run (items) = { guard List.length(items) < -1 else Ok
                     Ok }
-                """, "run"), "items");
+                """, "run");
 
-        assertEquals(new UndividedPosition.Why.CannotDerive(
-                UndividedPosition.Reason.UNSUPPORTED_TRAVERSAL), why);
+        assertTrue(whyAt(measured, "items")
+                        .contains(UndividedPosition.Reason.UNSUPPORTED_TRAVERSAL),
+                () -> "said " + whyAt(measured, "items"));
+        assertTrue(couldNotDerive(measured, "items"), "and nothing is established either way");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatWasNotReadIsSaidByWhoeverKnowsWhichRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatWasNotReadIsSaidByWhoeverKnowsWhichRuleTest.java
@@ -1,0 +1,129 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.PartitionEvidence;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Two authorities answer "this was not read", and which of them it is decides what can be said.
+ *
+ * <p>A rule was read and could not be used, and the reader that read it knows which rule; or the
+ * reading never arrived at the rules of a position, and there is no rule to name because none was
+ * observed. Written as one shape with the rule left out where there is none, a consumer would have
+ * to read an absent field to know which of the two it was holding — and a report would name a rule
+ * for some entries and not the rest with nothing saying why.
+ *
+ * <p>Which public word each is told under is read off the same answer. A reading that never reached
+ * the rules is what {@code PARTITION_RULES_NOT_REACHED} exists for and is that whether or not the
+ * axes went on to measure the position; the rest are {@code PARTITION_NOT_READ}.
+ */
+class WhatWasNotReadIsSaidByWhoeverKnowsWhichRuleTest {
+
+    /** A rule read and given up on: the position is inside an expression the terms do not name. */
+    private static final String A_RULE = """
+            module m
+
+            data Ok
+            data No
+
+            behavior f : (n: Int) -> Ok | No
+            let f (n) = if Int.multiply(n, n) < 10 then Ok else No
+            """;
+
+    /** A position whose values are held inside something the walk does not reach into. */
+    private static final String A_POSITION = """
+            module m
+
+            data Ok
+            data Item = { charge: Int }
+
+            behavior f : (items: List<Item>) -> Ok
+                constructs Ok
+            let f (items) =
+                { guard List.length(List.filter((i) -> i.charge >= 21000, items)) < 1 else Ok
+                  Ok }
+            """;
+
+    /** A rule finding names the rule, and is told under the word for a rule. */
+    @Test
+    void aRuleThisReadAndCouldNotUseNamesIt() {
+        PartitionEvidence.NotRead said = notRead(A_RULE).getFirst();
+
+        PartitionEvidence.NotRead.ARule rule =
+                assertInstanceOf(PartitionEvidence.NotRead.ARule.class, said);
+        assertInstanceOf(souther.compiler.check.RuleRef.Guard.class, rule.rule());
+        assertEquals(List.of(Adequacy.Kind.PARTITION_NOT_READ), kinds(A_RULE));
+    }
+
+    /**
+     * And a position finding names no rule, because nothing observed one.
+     *
+     * <p>The threshold is on an element of the list, and the elements cannot be reached
+     * reached. What stopped this is the reach and not any one clause, so what is said is the position
+     * and the limit — and the shape has nowhere to put a rule, which is what stops one being
+     * invented.
+     */
+    @Test
+    void aPositionTheReadingDidNotReachNamesNoRule() {
+        List<PartitionEvidence.NotRead> said = notRead(A_POSITION);
+
+        assertTrue(said.stream().anyMatch(each ->
+                        each instanceof PartitionEvidence.NotRead.APosition
+                                && each.reason() == UndividedPosition.Reason.UNSUPPORTED_TRAVERSAL),
+                said::toString);
+        assertFalse(said.stream().anyMatch(each -> each instanceof PartitionEvidence.NotRead.ARule),
+                said::toString);
+    }
+
+    /**
+     * A report names the rule where there is one and the position where there is not, and the two
+     * sentences are written apart.
+     *
+     * <p>One sentence over both would have to say "a rule about it" of an entry with no rule, which
+     * is the sentence this is against — an author told that a rule went unread with nothing saying
+     * which.
+     */
+    @Test
+    void theTwoAreWrittenApart() {
+        assertTrue(human(A_RULE).contains("not read: if@"), human(A_RULE));
+        assertFalse(human(A_RULE).contains("not read: n "), human(A_RULE));
+        assertTrue(human(A_POSITION).contains("not read: items ("), human(A_POSITION));
+    }
+
+    private static List<Adequacy.Kind> kinds(String model) {
+        return findings(model).stream()
+                .filter(each -> each.kind() == Adequacy.Kind.PARTITION_NOT_READ
+                        || each.kind() == Adequacy.Kind.PARTITION_RULES_NOT_REACHED)
+                .map(Adequacy.Finding::kind).toList();
+    }
+
+    private static List<Adequacy.Finding> findings(String model) {
+        return report(model).modules().get(0).behaviors().get(0).findings();
+    }
+
+    private static List<PartitionEvidence.NotRead> notRead(String model) {
+        return report(model).modules().get(0).behaviors().get(0).partition().notRead();
+    }
+
+    private static String human(String model) {
+        return report(model).human(SourceNameResolver.identity());
+    }
+
+    private static AdequacyReport report(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatWasNotReadIsSaidByWhoeverKnowsWhichRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatWasNotReadIsSaidByWhoeverKnowsWhichRuleTest.java
@@ -24,9 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * to read an absent field to know which of the two it was holding — and a report would name a rule
  * for some entries and not the rest with nothing saying why.
  *
- * <p>Which public word each is told under is read off the same answer. A reading that never reached
- * the rules is what {@code PARTITION_RULES_NOT_REACHED} exists for and is that whether or not the
- * axes went on to measure the position; the rest are {@code PARTITION_NOT_READ}.
+ * <p>Both are told under {@code PARTITION_NOT_READ}, and the reason beside each says which limit
+ * it is waiting on. {@code PARTITION_RULES_NOT_REACHED} belongs to the finding about a position the
+ * axes did measure, which is a different thing to act on and writes the same one field.
  */
 class WhatWasNotReadIsSaidByWhoeverKnowsWhichRuleTest {
 

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion" : 4,
+  "schemaVersion" : 3,
   "compilerVersion" : "<version>",
   "status" : "complete",
   "adequacy" : "satisfied",
@@ -460,9 +460,20 @@
         },
         "notDerivable" : [ "指示.記録時刻" ],
         "notRead" : [ {
+          "position" : "指示.集荷時刻",
+          "reason" : "unsupported_syntax",
+          "rule" : "guard@1:54:50",
+          "ruleId" : {
+            "kind" : "guard",
+            "declaredIn" : "conformance.shipping",
+            "behavior" : "出荷する",
+            "ordinal" : 5,
+            "lowered" : 0
+          }
+        }, {
           "position" : "指示.受付日",
           "reason" : "unsupported_syntax",
-          "rule" : "guard@1:52:57",
+          "rule" : "if@1:52:57",
           "ruleId" : {
             "kind" : "guard",
             "declaredIn" : "conformance.shipping",
@@ -473,23 +484,12 @@
         }, {
           "position" : "指示.締切",
           "reason" : "unsupported_syntax",
-          "rule" : "guard@1:52:57",
+          "rule" : "if@1:52:57",
           "ruleId" : {
             "kind" : "guard",
             "declaredIn" : "conformance.shipping",
             "behavior" : "出荷する",
             "ordinal" : 4,
-            "lowered" : 0
-          }
-        }, {
-          "position" : "指示.集荷時刻",
-          "reason" : "unsupported_syntax",
-          "rule" : "guard@1:54:50",
-          "ruleId" : {
-            "kind" : "guard",
-            "declaredIn" : "conformance.shipping",
-            "behavior" : "出荷する",
-            "ordinal" : 5,
             "lowered" : 0
           }
         }, {
@@ -515,6 +515,17 @@
       }, {
         "kind" : "partition_not_read",
         "disposition" : "reported",
+        "subject" : "指示.集荷時刻",
+        "ruleId" : {
+          "kind" : "guard",
+          "declaredIn" : "conformance.shipping",
+          "behavior" : "出荷する",
+          "ordinal" : 5,
+          "lowered" : 0
+        }
+      }, {
+        "kind" : "partition_not_read",
+        "disposition" : "reported",
         "subject" : "指示.受付日",
         "ruleId" : {
           "kind" : "guard",
@@ -532,17 +543,6 @@
           "declaredIn" : "conformance.shipping",
           "behavior" : "出荷する",
           "ordinal" : 4,
-          "lowered" : 0
-        }
-      }, {
-        "kind" : "partition_not_read",
-        "disposition" : "reported",
-        "subject" : "指示.集荷時刻",
-        "ruleId" : {
-          "kind" : "guard",
-          "declaredIn" : "conformance.shipping",
-          "behavior" : "出荷する",
-          "ordinal" : 5,
           "lowered" : 0
         }
       }, {

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion" : 3,
+  "schemaVersion" : 4,
   "compilerVersion" : "<version>",
   "status" : "complete",
   "adequacy" : "satisfied",
@@ -461,13 +461,37 @@
         "notDerivable" : [ "指示.記録時刻" ],
         "notRead" : [ {
           "position" : "指示.受付日",
-          "reason" : "unsupported_syntax"
+          "reason" : "unsupported_syntax",
+          "rule" : "guard@1:52:57",
+          "ruleId" : {
+            "kind" : "guard",
+            "declaredIn" : "conformance.shipping",
+            "behavior" : "出荷する",
+            "ordinal" : 4,
+            "lowered" : 0
+          }
         }, {
           "position" : "指示.締切",
-          "reason" : "unsupported_syntax"
+          "reason" : "unsupported_syntax",
+          "rule" : "guard@1:52:57",
+          "ruleId" : {
+            "kind" : "guard",
+            "declaredIn" : "conformance.shipping",
+            "behavior" : "出荷する",
+            "ordinal" : 4,
+            "lowered" : 0
+          }
         }, {
           "position" : "指示.集荷時刻",
-          "reason" : "unsupported_syntax"
+          "reason" : "unsupported_syntax",
+          "rule" : "guard@1:54:50",
+          "ruleId" : {
+            "kind" : "guard",
+            "declaredIn" : "conformance.shipping",
+            "behavior" : "出荷する",
+            "ordinal" : 5,
+            "lowered" : 0
+          }
         }, {
           "position" : "指示.品目",
           "reason" : "unsupported_traversal"

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
@@ -515,15 +515,36 @@
       }, {
         "kind" : "partition_not_read",
         "disposition" : "reported",
-        "subject" : "指示.受付日"
+        "subject" : "指示.受付日",
+        "ruleId" : {
+          "kind" : "guard",
+          "declaredIn" : "conformance.shipping",
+          "behavior" : "出荷する",
+          "ordinal" : 4,
+          "lowered" : 0
+        }
       }, {
         "kind" : "partition_not_read",
         "disposition" : "reported",
-        "subject" : "指示.締切"
+        "subject" : "指示.締切",
+        "ruleId" : {
+          "kind" : "guard",
+          "declaredIn" : "conformance.shipping",
+          "behavior" : "出荷する",
+          "ordinal" : 4,
+          "lowered" : 0
+        }
       }, {
         "kind" : "partition_not_read",
         "disposition" : "reported",
-        "subject" : "指示.集荷時刻"
+        "subject" : "指示.集荷時刻",
+        "ruleId" : {
+          "kind" : "guard",
+          "declaredIn" : "conformance.shipping",
+          "behavior" : "出荷する",
+          "ordinal" : 5,
+          "lowered" : 0
+        }
       }, {
         "kind" : "partition_not_read",
         "disposition" : "reported",

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
@@ -303,7 +303,8 @@
       }, {
         "kind" : "partition_not_read",
         "disposition" : "reported",
-        "subject" : "指示.品目"
+        "subject" : "指示.品目",
+        "reason" : "unsupported_traversal"
       } ]
     }, {
       "name" : "出荷する",
@@ -522,7 +523,8 @@
           "behavior" : "出荷する",
           "ordinal" : 5,
           "lowered" : 0
-        }
+        },
+        "reason" : "unsupported_syntax"
       }, {
         "kind" : "partition_not_read",
         "disposition" : "reported",
@@ -533,7 +535,8 @@
           "behavior" : "出荷する",
           "ordinal" : 4,
           "lowered" : 0
-        }
+        },
+        "reason" : "unsupported_syntax"
       }, {
         "kind" : "partition_not_read",
         "disposition" : "reported",
@@ -544,11 +547,13 @@
           "behavior" : "出荷する",
           "ordinal" : 4,
           "lowered" : 0
-        }
+        },
+        "reason" : "unsupported_syntax"
       }, {
         "kind" : "partition_not_read",
         "disposition" : "reported",
-        "subject" : "指示.品目"
+        "subject" : "指示.品目",
+        "reason" : "unsupported_traversal"
       } ]
     } ]
   } ],


### PR DESCRIPTION
Puts #886 on `develop`, where it should have gone.

#893 was opened against `develop` and merged against `main` — its base had been
retargeted and I did not check it again before merging. So the work is on the
release branch and not on the branch features go to. `v0.1.0-rc5` points at
`32ccc81c` and is unaffected; `main` simply carries this ahead of a release.

These are the same four commits, cherry-picked onto `develop`. The tree is
identical to what landed on `main` apart from the version and the release notes
`develop` has since gained.

The change itself is described in #893. In short: a position's unread rule was
reported without naming the rule, and two rules stopped by one limit at one
position came out as one line. `UnreadRule` now carries the identity and the
handle #883 settled; `BlockReason` splits into the authority that has a rule to
name and the one that does not; a structural stop is a candidate that becomes a
finding only where nothing else answered; the verdict stops carrying a cause;
and `competing_coordinates` names a limit the old word was standing in for.

Schema stays at 3 — the version is raised when a field is removed or renamed and
not when one is added.

Full reactor green, 5727 tests. The conformance corpus keeps its five `notRead`
entries and gains provenance on the three that are about a rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
