### PR TITLE
Project a coordinate's range out of the rules over several coordinates, and derive every answer from the rules

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -830,7 +830,8 @@ public final class FieldDomains {
             case ProjectionEvidence.Cause.Unrepresented it ->
                     "2 " + it.rule().named() + " " + it.path();
             case ProjectionEvidence.Cause.Lossy it ->
-                    "3 " + it.rule().named() + " " + it.atom() + " " + it.losses();
+                    "3 " + it.rule().named() + " " + it.atom() + " " + it.unstated();
+            case ProjectionEvidence.Cause.Rounded it -> "4 " + it.atom();
         };
     }
 
@@ -940,14 +941,20 @@ public final class FieldDomains {
                     continue;
                 }
                 for (FactSubject atom : each.atoms()) {
-                    Set<NumericDomain.Loss> losses = constraints.numbers().lossesAt(atom);
-                    if (!losses.isEmpty()) {
-                        lossy.add(new ProjectionEvidence.Cause.Lossy(rule, atom, losses));
-                    }
+                    lossy.add(new ProjectionEvidence.Cause.Lossy(rule, atom,
+                            Set.of(each.rel() == NumericDomain.Rel.NE
+                                    ? ProjectionEvidence.Cause.Unstated.A_HOLE
+                                    : ProjectionEvidence.Cause.Unstated.A_RELATION)));
                 }
             }
         }));
         causes.addAll(lossy);
+        // And whether the ends handed over are the ends the rules drew. Asked of every position the
+        // algebra speaks of, because this is not about any one rule: the reasoning reached the edge
+        // exactly and the writing could not carry it.
+        constraints.numbers().atomsSpokenOf().stream()
+                .filter(atom -> !constraints.numbers().endsAreWrittenExactly(atom))
+                .forEach(atom -> causes.add(new ProjectionEvidence.Cause.Rounded(atom)));
         // In an order that does not move between runs. Parts are keyed by the node the tree holds,
         // which is an identity, and a map keyed on one iterates by where the addresses landed — so
         // a value with two conjuncts short of the bounds printed its two causes in whichever order

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -927,13 +927,16 @@ public final class FieldDomains {
         });
         // And what the algebra was given and what it projects does not hold.
         //
-        // Asked of the projection and of nothing else. A form neither an interval nor a difference
-        // holds is kept as written and marked lost for exactly that reason, and asking the whole
-        // state whether it still holds such a form is asking the form to stand on itself — every
-        // rule the projection dropped comes back proven. Asked of every form the algebra was handed
-        // rather than of the losses it recorded at the time: a loss is a fact about the step it
-        // happened at, the domain holds which kinds an atom has and not how many times each
-        // happened, and a second hole at an atom that already has one is a loss nothing can see.
+        // Asked of the projection and of nothing else. Asking the whole state whether it holds a
+        // rule is asking the rule to stand on itself — every rule the ranges could not state comes
+        // back proven — so what is asked is whether the ranges alone hold it.
+        //
+        // And asked of the rules after everything has been worked out, rather than read back from
+        // marks left as each rule arrived. A mark left at that moment is a history: a rule that
+        // narrowed nothing when it was read left one behind after a later rule made it bite, so a
+        // range that had become the whole of what the rules say still carried a note that it was
+        // not. What could not be stated is a property of the rule and of what the rules were found
+        // to leave, and it is worked out from those.
         Set<ProjectionEvidence.Cause.Lossy> lossy = new LinkedHashSet<>();
         readBy.forEach((rule, byPart) -> byPart.values().forEach(read -> {
             for (Predicates.Constraint each : read.stated()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/ProjectionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ProjectionEvidence.java
@@ -104,23 +104,71 @@ public sealed interface ProjectionEvidence {
          * holds — except where one side is already out, which is why {@code value >= 1} written
          * beside {@code value /= 0} leaves the bounds stating both.
          *
-         * <p>{@code rule} is this rule and {@code losses} is the atom's. The domain records which
-         * kinds of loss an atom has and not which rule left it with each, so where two rules leave
-         * one atom short in different ways both are named with both kinds. The rule is exact, the
-         * atom is exact, and what was lost is the atom's account of itself.
+         * <p>Both the rule and what went unstated about it are this rule's. Two rules leaving one
+         * position short in different ways are two causes saying two different things, rather than
+         * one account of the position that both are filed under.
          */
-        record Lossy(RuleRef rule, FactSubject atom, Set<NumericDomain.Loss> losses)
-                implements Cause {
+        record Lossy(RuleRef rule, FactSubject atom, Set<Unstated> unstated) implements Cause {
 
             public Lossy {
-                losses = Set.copyOf(losses);
+                unstated = Set.copyOf(unstated);
                 if (rule == null || atom == null) {
-                    throw new IllegalArgumentException("a loss happened to a rule at an atom");
+                    throw new IllegalArgumentException("something went unstated about a rule at an atom");
                 }
-                if (losses.isEmpty()) {
-                    throw new IllegalArgumentException("a loss with nothing lost is not one");
+                if (unstated.isEmpty()) {
+                    throw new IllegalArgumentException("nothing unstated is not a cause");
                 }
             }
+        }
+
+        /**
+         * An end the rules put at a value no decimal writes, so the number handed over is a hair
+         * outside where they stop.
+         *
+         * <p>Its own cause and not one of {@link Lossy}'s kinds, because it is not about a rule. The
+         * reasoning reached the position's edge exactly; what could not carry it is the writing. A
+         * reader placing a row at an edge is the one this is for — the edge it is given is not the
+         * edge the rules drew.
+         *
+         * <p>Rare. An end on a position whose values step is a whole number, and one on a position
+         * whose values fill is a decimal unless a rule divided by something ten is not made of.
+         */
+        record Rounded(FactSubject atom) implements Cause {
+
+            public Rounded {
+                if (atom == null) {
+                    throw new IllegalArgumentException("a rounded end is an end of something");
+                }
+            }
+        }
+
+        /**
+         * What a range at one position could not state of a rule about it.
+         *
+         * <p>Worked out from the rule and from what the rules were found to leave, rather than
+         * recorded as each rule arrived. Recorded, it was a history: a rule that narrowed nothing at
+         * the moment it was read left a mark that stayed after a later rule made it bite, so a range
+         * that had become the whole of what the rules say still carried a note that it was not.
+         */
+        enum Unstated {
+
+            /**
+             * A rule holding the position away from a value inside its range.
+             *
+             * <p>Only where it is inside. A hole at an edge moves the edge and is then something the
+             * range does state — {@code value /= 0} beside {@code value >= 0} leaves the position at
+             * one and nothing is left over.
+             */
+            A_HOLE,
+
+            /**
+             * A rule relating this position to others, which a range at one of them cannot carry.
+             *
+             * <p>Only where the ranges do not already hold it. What such a rule leaves each position
+             * it names is derived and is in the bounds; what a range cannot say is the relation, and
+             * it only needs saying where a value of each range can be picked that together break it.
+             */
+            A_RELATION
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/numeric/AdditiveImage.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/AdditiveImage.java
@@ -22,22 +22,12 @@ import java.util.function.Function;
  * can hold — get safer as the image gets bigger: a value outside a superset is outside the image, a
  * cut not moved is a cut that refuses nothing, and an equality refused because its value is outside
  * even the superset is an equality nothing satisfies. So a form whose positions are not all made of
- * the same thing answers with the coarser of the two and says {@link #isExact} is false, rather than
- * answering with a set it cannot stand behind.
+ * the same thing answers with the coarser of the two, and nothing has to be told that it did.
  */
 public sealed interface AdditiveImage {
 
     /** What the form's values are whole (or finite-decimal) multiples of. Always positive. */
     Rational generator();
-
-    /**
-     * Whether this is the values the form takes, rather than a set containing them.
-     *
-     * <p>Read by whatever has to certify that a projection states the whole of a rule. Everything
-     * else here is sound either way — see the class comment — so this is the one question that has
-     * to be asked before a claim of exactness is made, and never before a cut is moved.
-     */
-    boolean isExact();
 
     /** Whether the form can add up to this value. */
     boolean contains(Rational value);
@@ -90,8 +80,9 @@ public sealed interface AdditiveImage {
         }
         // Whole numbers are finite decimals, so a form with some of each adds up inside the finite
         // decimals the whole form's divisor generates. Not exactly that set — `x + 3y` with `x` whole
-        // and `y` a decimal reaches no tenth, though the divisor is one — so it says so.
-        return new OverFiniteDecimals(divisor, !anySteps);
+        // and `y` a decimal reaches no tenth, though the divisor is one — and wider is the safe way
+        // to be wrong here, so that is the answer rather than a narrower one it cannot stand behind.
+        return new OverFiniteDecimals(divisor);
     }
 
     /**
@@ -143,12 +134,6 @@ public sealed interface AdditiveImage {
             }
         }
 
-        /** Bézout's, so this is the values and not a set holding them. */
-        @Override
-        public boolean isExact() {
-            return true;
-        }
-
         @Override
         public boolean contains(Rational value) {
             return value.dividedBy(generator).isWhole();
@@ -174,13 +159,15 @@ public sealed interface AdditiveImage {
     }
 
     /**
-     * Every finite-decimal multiple of the generator, which is what a form over positions whose
-     * values fill takes.
+     * Every finite-decimal multiple of the generator.
      *
-     * @param isExact false where the form's positions are not all of them, in which case this holds
-     *                the values the form takes and others besides
+     * <p>What a form over positions whose values fill takes, and — for a form whose positions are
+     * not all of one kind — a set holding what it takes rather than exactly it. Which of the two it
+     * is nothing asks: all three things an image is used for get safer as it gets bigger, so the
+     * wider answer needs no announcing. A reader that had to certify exactness would need telling
+     * apart, and there is no such reader.
      */
-    record OverFiniteDecimals(Rational generator, boolean isExact) implements AdditiveImage {
+    record OverFiniteDecimals(Rational generator) implements AdditiveImage {
 
         /**
          * With the units taken out of the generator, so that two divisors generating one set are one

--- a/souther-compiler/src/main/java/souther/compiler/numeric/AdditiveImage.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/AdditiveImage.java
@@ -1,0 +1,221 @@
+package souther.compiler.numeric;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * The values a form {@code Σ cᵢ·xᵢ} can actually add up to.
+ *
+ * <p>Not the order its positions sit on. Read off the order alone, {@code 3 * a} over decimals was
+ * taken to reach one — and it does not: a decimal is a finite decimal, a third does not terminate,
+ * and no decimal a model writes is one. So {@code 3 * a <= 1} and {@code 3 * a < 1} admit the same
+ * values, {@code 3 * a = 1} admits none, and a bound derived at a third is a bound at a value
+ * nothing stands on.
+ *
+ * <p>Two generators, by what the positions are made of. Over positions that step, Bézout's: the form
+ * takes exactly the whole multiples of {@code gcd(cᵢ)}. Over positions whose values fill, the whole
+ * multiples of that divisor by a finite decimal — which is dense and is still not every number, since
+ * ten is a unit among the finite decimals and a divisor with a factor of three is not.
+ *
+ * <p><b>Answering wider than the truth is safe here, and answering narrower is not.</b> All three
+ * things this is asked — whether a value is reached, where a cut has to move to, whether an equality
+ * can hold — get safer as the image gets bigger: a value outside a superset is outside the image, a
+ * cut not moved is a cut that refuses nothing, and an equality refused because its value is outside
+ * even the superset is an equality nothing satisfies. So a form whose positions are not all made of
+ * the same thing answers with the coarser of the two and says {@link #isExact} is false, rather than
+ * answering with a set it cannot stand behind.
+ */
+public sealed interface AdditiveImage {
+
+    /** What the form's values are whole (or finite-decimal) multiples of. Always positive. */
+    Rational generator();
+
+    /**
+     * Whether this is the values the form takes, rather than a set containing them.
+     *
+     * <p>Read by whatever has to certify that a projection states the whole of a rule. Everything
+     * else here is sound either way — see the class comment — so this is the one question that has
+     * to be asked before a claim of exactness is made, and never before a cut is moved.
+     */
+    boolean isExact();
+
+    /** Whether the form can add up to this value. */
+    boolean contains(Rational value);
+
+    /**
+     * The tightest cut admitting exactly the values of this image that {@code cut} admits.
+     *
+     * <p>Where the form steps, a bound between two of its values moves down onto the one below —
+     * which is what makes {@code a < 3} into {@code a <= 2} over whole numbers, and is the same rule
+     * one level up. Where its values fill, a bound at a value the form does not reach cannot move
+     * anywhere: there is no greatest value below it. What it can say is that the value itself is out,
+     * which is why an unreachable bound comes back strict.
+     */
+    RationalCut tightenUpper(RationalCut cut);
+
+    /** The same on the other side. */
+    RationalCut tightenLower(RationalCut cut);
+
+    /**
+     * The image of {@code Σ coefs·atom} over positions spaced as {@code spacing} says.
+     *
+     * @param coefs   never empty and never zero-valued: a form that names no position is a constant,
+     *                and what a constant comparison settles is decided before anything asks this
+     * @param spacing how each named position's values are spaced. Required rather than defaulted for
+     *                the reason {@link NumericDomain#assume} requires it — a position whose spacing
+     *                is guessed is one a bound is either wrongly sharpened on or silently left blunt
+     */
+    static <A> AdditiveImage of(Map<A, Rational> coefs, Function<A, Granularity> spacing) {
+        if (coefs.isEmpty()) {
+            throw new IllegalArgumentException("a form with no positions adds up to nothing to ask about");
+        }
+        Rational divisor = Rational.ZERO;
+        boolean anyFills = false;
+        boolean anySteps = false;
+        for (Map.Entry<A, Rational> each : coefs.entrySet()) {
+            if (each.getValue().isZero()) {
+                throw new IllegalArgumentException(
+                        "a position with a zero coefficient is one the form does not name: " + each.getKey());
+            }
+            Granularity how = spacing.apply(each.getKey());
+            if (how == null) {
+                throw new IllegalStateException("no granularity given for `" + each.getKey() + "`");
+            }
+            anyFills |= how == Granularity.DENSE;
+            anySteps |= how == Granularity.DISCRETE;
+            divisor = Rational.gcd(divisor, each.getValue());
+        }
+        if (!anyFills) {
+            return new OverWholeNumbers(divisor);
+        }
+        // Whole numbers are finite decimals, so a form with some of each adds up inside the finite
+        // decimals the whole form's divisor generates. Not exactly that set — `x + 3y` with `x` whole
+        // and `y` a decimal reaches no tenth, though the divisor is one — so it says so.
+        return new OverFiniteDecimals(divisor, !anySteps);
+    }
+
+    /**
+     * The largest value every one of {@code coefs} is a whole multiple of.
+     *
+     * <p>Split out from {@link #of} because two callers want the divisor without wanting the set: a
+     * quantity written {@code 300s + 600c} is three hundred times the quantity {@code s + 2c}, and
+     * turning a level written in one into the other divides by exactly this. Zero for no
+     * coefficients — nothing constrains a divisor of nothing, and the caller that asks reads the
+     * zero rather than being refused, which is the difference between this and {@link #of}.
+     */
+    static Rational divisorOf(Iterable<Rational> coefs) {
+        Rational divisor = Rational.ZERO;
+        for (Rational each : coefs) {
+            divisor = Rational.gcd(divisor, each);
+        }
+        return divisor;
+    }
+
+    /**
+     * What is left of a divisor once the factors a finite decimal can be divided by are taken out.
+     *
+     * <p>Ten is a unit among the finite decimals, so two and five are: dividing by either lands on a
+     * finite decimal again, above and below the line alike. Taking them out is what makes two
+     * divisors that generate one set one value — a quarter and a tenth both generate every decimal
+     * there is, and so does one.
+     */
+    private static Rational unitsRemoved(Rational divisor) {
+        java.math.BigInteger top = divisor.numerator().abs();
+        java.math.BigInteger bottom = divisor.denominator();
+        for (java.math.BigInteger unit : java.util.List.of(
+                java.math.BigInteger.TWO, java.math.BigInteger.valueOf(5))) {
+            while (top.mod(unit).signum() == 0) {
+                top = top.divide(unit);
+            }
+            while (bottom.mod(unit).signum() == 0) {
+                bottom = bottom.divide(unit);
+            }
+        }
+        return Rational.of(top, bottom);
+    }
+
+    /** Every whole multiple of the generator, which is what a form over positions that step takes. */
+    record OverWholeNumbers(Rational generator) implements AdditiveImage {
+
+        public OverWholeNumbers {
+            if (generator == null || generator.signum() <= 0) {
+                throw new IllegalArgumentException("a divisor is positive: " + generator);
+            }
+        }
+
+        /** Bézout's, so this is the values and not a set holding them. */
+        @Override
+        public boolean isExact() {
+            return true;
+        }
+
+        @Override
+        public boolean contains(Rational value) {
+            return value.dividedBy(generator).isWhole();
+        }
+
+        @Override
+        public RationalCut tightenUpper(RationalCut cut) {
+            Rational steps = cut.at().dividedBy(generator);
+            java.math.BigInteger below = cut.inclusive() || !steps.isWhole()
+                    ? steps.floor()
+                    : steps.floor().subtract(java.math.BigInteger.ONE);
+            return RationalCut.inclusive(generator.times(Rational.of(below)));
+        }
+
+        @Override
+        public RationalCut tightenLower(RationalCut cut) {
+            Rational steps = cut.at().dividedBy(generator);
+            java.math.BigInteger above = cut.inclusive() || !steps.isWhole()
+                    ? steps.ceiling()
+                    : steps.ceiling().add(java.math.BigInteger.ONE);
+            return RationalCut.inclusive(generator.times(Rational.of(above)));
+        }
+    }
+
+    /**
+     * Every finite-decimal multiple of the generator, which is what a form over positions whose
+     * values fill takes.
+     *
+     * @param isExact false where the form's positions are not all of them, in which case this holds
+     *                the values the form takes and others besides
+     */
+    record OverFiniteDecimals(Rational generator, boolean isExact) implements AdditiveImage {
+
+        /**
+         * With the units taken out of the generator, so that two divisors generating one set are one
+         * value.
+         *
+         * <p>Here rather than at the callers. Six and three generate the same finite decimals — two
+         * is a unit — and a caller that handed over the six unreduced would be told that three is not
+         * a value the form reaches. That is a wrong answer rather than a coarse one, and it is not
+         * one a caller should have to know to avoid.
+         */
+        public OverFiniteDecimals {
+            if (generator == null || generator.signum() <= 0) {
+                throw new IllegalArgumentException("a divisor is positive: " + generator);
+            }
+            generator = unitsRemoved(generator);
+        }
+
+        @Override
+        public boolean contains(Rational value) {
+            return value.dividedBy(generator).asWrittenDecimal() != null;
+        }
+
+        /**
+         * Where the value is reached, the cut is already as tight as it goes; where it is not, there
+         * is no greatest value below it to move to and the two ways of writing the cut admit the same
+         * values — so what is left to say is that the value itself is out.
+         */
+        @Override
+        public RationalCut tightenUpper(RationalCut cut) {
+            return contains(cut.at()) ? cut : RationalCut.exclusive(cut.at());
+        }
+
+        @Override
+        public RationalCut tightenLower(RationalCut cut) {
+            return contains(cut.at()) ? cut : RationalCut.exclusive(cut.at());
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/numeric/AdditiveImage.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/AdditiveImage.java
@@ -21,8 +21,13 @@ import java.util.function.Function;
  * things this is asked — whether a value is reached, where a cut has to move to, whether an equality
  * can hold — get safer as the image gets bigger: a value outside a superset is outside the image, a
  * cut not moved is a cut that refuses nothing, and an equality refused because its value is outside
- * even the superset is an equality nothing satisfies. So a form whose positions are not all made of
- * the same thing answers with the coarser of the two, and nothing has to be told that it did.
+ * even the superset is an equality nothing satisfies. Which is why nothing here is asked to say how
+ * exact it is.
+ *
+ * <p>A form whose positions are not all made of the same thing needs no coarser answer, as it turns
+ * out. One position that fills is enough to make the whole sum fill: whole numbers are finite
+ * decimals, and a finite decimal may be chosen with as many places as the value being reached asks
+ * for, so the divisor generates the same set either way.
  */
 public sealed interface AdditiveImage {
 
@@ -78,10 +83,10 @@ public sealed interface AdditiveImage {
         if (!anyFills) {
             return new OverWholeNumbers(divisor);
         }
-        // Whole numbers are finite decimals, so a form with some of each adds up inside the finite
-        // decimals the whole form's divisor generates. Not exactly that set — `x + 3y` with `x` whole
-        // and `y` a decimal reaches no tenth, though the divisor is one — and wider is the safe way
-        // to be wrong here, so that is the answer rather than a narrower one it cannot stand behind.
+        // Whole numbers are finite decimals, so one position that fills makes the whole sum fill,
+        // and the divisor generates the same set as it would over positions that all fill. `x + 3y`
+        // with `x` whole and `y` a decimal does reach a tenth — at `x = -2, y = 0.7` — because the
+        // decimal may be chosen with as many places as the value asks for.
         return new OverFiniteDecimals(divisor);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/numeric/AffineConstraint.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/AffineConstraint.java
@@ -1,0 +1,161 @@
+package souther.compiler.numeric;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * One thing the rules say about a weighted sum of positions, canonical.
+ *
+ * <p>Three shapes, and they are the three a comparison comes to: the sum is held below something,
+ * held at something, or held away from it. Which of the six ways an author wrote it is gone by the
+ * time one of these exists — {@code a >= 3} and {@code -a <= -3} are one constraint, and so are
+ * {@code 300s + 600c <= 4800} and {@code s + 2c <= 16}.
+ *
+ * <p><b>What is settled here is settled by the constraint alone.</b> Reading one asks what the sum
+ * can add up to ({@link AdditiveImage}) and nothing else — not what else has been asserted, not what
+ * is known so far, not what order anything arrived in. So {@code 3 * a = 1} over decimals is
+ * impossible the moment it is read, because no decimal is a third; {@code 2x + 2y <= 3} over whole
+ * numbers is {@code x + y <= 1}, because the sum is whole and cannot sit between; and
+ * {@code 3 * a <= 1} is {@code 3 * a < 1}, because the sum comes arbitrarily close to one and never
+ * arrives. None of the three depends on anything but the rule itself, which is what keeps them out
+ * of the part that has to be recomputed as more is learned.
+ *
+ * <p>Compared by what it says. Two writings of one rule are one constraint and one key, which is
+ * what makes asserting a rule twice the same as asserting it once. Where a rule came from is not
+ * part of that and is carried beside it, because a rule written in two places is still one rule and
+ * two origins.
+ */
+public sealed interface AffineConstraint<A> {
+
+    /** The sum this is about. */
+    CanonicalForm<A> form();
+
+    /** The sum held no higher than a bound it may or may not reach. */
+    record HalfSpace<A>(CanonicalForm<A> form, RationalCut bound) implements AffineConstraint<A> {
+
+        public HalfSpace {
+            if (form == null || bound == null) {
+                throw new IllegalArgumentException("a half-space is a sum and a bound");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return form + " " + bound;
+        }
+    }
+
+    /** The sum held at one value. */
+    record Equality<A>(CanonicalForm<A> form, Rational at) implements AffineConstraint<A> {
+
+        public Equality {
+            if (form == null || at == null) {
+                throw new IllegalArgumentException("an equality is a sum and a value");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return form + " = " + at;
+        }
+    }
+
+    /**
+     * The sum held away from one value.
+     *
+     * <p>A hole and not a bound, which is why it is its own shape rather than something turned into
+     * one on the way in. Turning it into a bound needs to know which side of the hole the sum is
+     * already on, and that is not something the rule says — it is something the rest of what is
+     * known says, and it can become known long after this arrived. Deciding it here is what made
+     * {@code x /= 0} beside {@code x >= 0} leave {@code x} at nought or above depending on which was
+     * written first.
+     */
+    record Disequality<A>(CanonicalForm<A> form, Rational at) implements AffineConstraint<A> {
+
+        public Disequality {
+            if (form == null || at == null) {
+                throw new IllegalArgumentException("a disequality is a sum and a value");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return form + " /= " + at;
+        }
+    }
+
+    /**
+     * What an assertion comes to once it has been read.
+     *
+     * <p>Three answers because a comparison need not be a constraint at all. A comparison of two
+     * constants settles itself; so does one whose threshold is a value its sum cannot reach. Handing
+     * back a constraint that says nothing, or one that says everything, would leave every reader
+     * downstream to notice — and a reader that failed to notice would be holding a rule it could not
+     * discharge.
+     */
+    sealed interface Read<A> {
+
+        /** The constraint the assertion states. */
+        record Stated<A>(AffineConstraint<A> constraint) implements Read<A> {}
+
+        /** Every value satisfies it, so there is nothing to record. */
+        record HoldsAlways<A>() implements Read<A> {}
+
+        /** No value satisfies it. */
+        record HoldsNever<A>() implements Read<A> {}
+    }
+
+    /**
+     * The assertion {@code Σ coefs·atom + constant  rel  0}, read.
+     *
+     * @param spacing how each named position's values are spaced, for the same reason
+     *                {@link NumericDomain#assume} wants it: a position whose spacing is guessed is
+     *                one a bound is either wrongly sharpened on or silently left blunt
+     */
+    static <A> Read<A> of(Map<A, Rational> coefs, Rational constant, NumericDomain.Rel rel,
+                          Function<A, Granularity> spacing) {
+        CanonicalForm.Scaled<A> scaled = CanonicalForm.of(coefs);
+        if (scaled == null) {
+            return settledByConstantAlone(constant, rel);
+        }
+        // `Σ c·x + k rel 0` is `Σ c·x rel -k`, and dividing both by what the coefficients share
+        // leaves which side of the threshold a value falls on, since what they share is positive.
+        Rational threshold = constant.negated().dividedBy(scaled.by());
+        CanonicalForm<A> form = scaled.form();
+        AdditiveImage reaches = form.imageOver(spacing);
+        return switch (rel) {
+            case LE -> below(form, reaches, RationalCut.inclusive(threshold));
+            case LT -> below(form, reaches, RationalCut.exclusive(threshold));
+            // Turned around rather than given a shape of its own: `f >= t` is `-f <= -t`. The image
+            // is the same one — what a sum reaches is closed under negation, since a multiple of the
+            // divisor stays one when it changes sign — so only the form and the bound turn around.
+            case GE -> below(form.negated(), reaches, RationalCut.inclusive(threshold.negated()));
+            case GT -> below(form.negated(), reaches, RationalCut.exclusive(threshold.negated()));
+            case EQ -> reaches.contains(threshold)
+                    ? new Read.Stated<>(new Equality<>(form, threshold))
+                    : new Read.HoldsNever<>();
+            case NE -> reaches.contains(threshold)
+                    ? new Read.Stated<>(new Disequality<>(form, threshold))
+                    : new Read.HoldsAlways<>();
+        };
+    }
+
+    /** A sum held below a bound, with the bound moved onto what the sum can actually reach. */
+    private static <A> Read<A> below(CanonicalForm<A> form, AdditiveImage reaches, RationalCut at) {
+        return new Read.Stated<>(new HalfSpace<>(form, reaches.tightenUpper(at)));
+    }
+
+    /** A comparison naming no position, which is arithmetic rather than a rule about anybody. */
+    private static <A> Read<A> settledByConstantAlone(Rational constant, NumericDomain.Rel rel) {
+        int sign = constant.signum();
+        boolean holds = switch (rel) {
+            case LE -> sign <= 0;
+            case LT -> sign < 0;
+            case GE -> sign >= 0;
+            case GT -> sign > 0;
+            case EQ -> sign == 0;
+            case NE -> sign != 0;
+        };
+        return holds ? new Read.HoldsAlways<>() : new Read.HoldsNever<>();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/numeric/AffineConstraint.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/AffineConstraint.java
@@ -54,6 +54,29 @@ public sealed interface AffineConstraint<A> {
             }
         }
 
+        /**
+         * Held at a value, whichever way round it was written.
+         *
+         * <p>{@code a = 3} and {@code -a = -3} are one rule, and a comparison says so by turning
+         * around — {@code a >= 3} and {@code -a <= -3} come to the same half-space. An equality has
+         * no direction to turn, so the two writings would otherwise be two records and the same rule
+         * said twice would be two rules.
+         *
+         * <p>No reader depends on which of the two is held: what is built from an equality is built
+         * from both sides of it.
+         */
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof Equality<?> it
+                    && (form.equals(it.form()) && at.equals(it.at())
+                            || form.equals(it.form().negated()) && at.equals(it.at().negated()));
+        }
+
+        @Override
+        public int hashCode() {
+            return sameEitherWayRound(form, at);
+        }
+
         @Override
         public String toString() {
             return form + " = " + at;
@@ -78,10 +101,29 @@ public sealed interface AffineConstraint<A> {
             }
         }
 
+        /** Held away from a value, whichever way round it was written; see {@link Equality}. */
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof Disequality<?> it
+                    && (form.equals(it.form()) && at.equals(it.at())
+                            || form.equals(it.form().negated()) && at.equals(it.at().negated()));
+        }
+
+        @Override
+        public int hashCode() {
+            return sameEitherWayRound(form, at);
+        }
+
         @Override
         public String toString() {
             return form + " /= " + at;
         }
+    }
+
+    /** A number the same for a form and its negation, so the two writings hash alike. */
+    private static <A> int sameEitherWayRound(CanonicalForm<A> form, Rational at) {
+        return (form.hashCode() ^ form.negated().hashCode()) * 31
+                + (at.hashCode() ^ at.negated().hashCode());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/numeric/AffineConstraint.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/AffineConstraint.java
@@ -30,6 +30,28 @@ public sealed interface AffineConstraint<A> {
     /** The sum this is about. */
     CanonicalForm<A> form();
 
+    /**
+     * The half-spaces this constraint states.
+     *
+     * <p>Asked of the constraint because it is the constraint's own answer. Three readers wanted it
+     * — the difference bounds, to make edges; the reduction, to read each rule against a box; the
+     * proof, to turn a question into something to bound — and each had written it out, so "an
+     * equality is a bound above and a bound below" was said three times and could have been said
+     * three ways.
+     *
+     * <p>A hole states none. Which side of it a sum lies is not something the rule says: it is
+     * something the rest of what is known says, and it is answered where that can be read.
+     */
+    default java.util.List<HalfSpace<A>> halfSpaces() {
+        return switch (this) {
+            case HalfSpace<A> half -> java.util.List.of(half);
+            case Equality<A> at -> java.util.List.of(
+                    new HalfSpace<>(at.form(), RationalCut.inclusive(at.at())),
+                    new HalfSpace<>(at.form().negated(), RationalCut.inclusive(at.at().negated())));
+            case Disequality<A> hole -> java.util.List.of();
+        };
+    }
+
     /** The sum held no higher than a bound it may or may not reach. */
     record HalfSpace<A>(CanonicalForm<A> form, RationalCut bound) implements AffineConstraint<A> {
 
@@ -67,9 +89,7 @@ public sealed interface AffineConstraint<A> {
          */
         @Override
         public boolean equals(Object other) {
-            return other instanceof Equality<?> it
-                    && (form.equals(it.form()) && at.equals(it.at())
-                            || form.equals(it.form().negated()) && at.equals(it.at().negated()));
+            return other instanceof Equality<?> it && oneRuleEitherWayRound(this, it);
         }
 
         @Override
@@ -104,9 +124,7 @@ public sealed interface AffineConstraint<A> {
         /** Held away from a value, whichever way round it was written; see {@link Equality}. */
         @Override
         public boolean equals(Object other) {
-            return other instanceof Disequality<?> it
-                    && (form.equals(it.form()) && at.equals(it.at())
-                            || form.equals(it.form().negated()) && at.equals(it.at().negated()));
+            return other instanceof Disequality<?> it && oneRuleEitherWayRound(this, it);
         }
 
         @Override
@@ -118,6 +136,32 @@ public sealed interface AffineConstraint<A> {
         public String toString() {
             return form + " /= " + at;
         }
+    }
+
+    /**
+     * Whether two of these say one thing, up to which way round it was written.
+     *
+     * <p>A comparison reduces {@code a >= 3} and {@code -a <= -3} to one half-space by turning one
+     * of them around. Held at a value and held away from one have no direction to turn, so the two
+     * writings are made one here instead — and here rather than in each of them, because it is one
+     * fact about both.
+     *
+     * <p>Not settled by picking a canonical side, which would need an order over the positions that
+     * a caller naming them is under no obligation to have. Two values, identified.
+     */
+    private static boolean oneRuleEitherWayRound(AffineConstraint<?> one, AffineConstraint<?> other) {
+        Rational mine = valueOf(one);
+        Rational theirs = valueOf(other);
+        return one.form().equals(other.form()) && mine.equals(theirs)
+                || one.form().equals(other.form().negated()) && mine.equals(theirs.negated());
+    }
+
+    private static Rational valueOf(AffineConstraint<?> constraint) {
+        return switch (constraint) {
+            case Equality<?> at -> at.at();
+            case Disequality<?> hole -> hole.at();
+            case HalfSpace<?> half -> half.bound().at();
+        };
     }
 
     /** A number the same for a form and its negation, so the two writings hash alike. */

--- a/souther-compiler/src/main/java/souther/compiler/numeric/AffineReduction.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/AffineReduction.java
@@ -63,10 +63,6 @@ public final class AffineReduction {
                 atLeast = Map.copyOf(atLeast);
                 atMost = Map.copyOf(atMost);
             }
-
-            public boolean foundNothing() {
-                return atLeast.isEmpty() && atMost.isEmpty();
-            }
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/numeric/AffineReduction.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/AffineReduction.java
@@ -168,36 +168,11 @@ public final class AffineReduction {
         return List.of();
     }
 
-    /** What the box leaves a whole form, either end {@code null} where it leaves it unbounded. */
+    /** What the box leaves a whole form, summed the one way this arithmetic is written. */
     private static <A> Reach reachOf(CanonicalForm<A> form, Box<A> from) {
-        Rational least = Rational.ZERO;
-        Rational most = Rational.ZERO;
-        boolean leastReached = true;
-        boolean mostReached = true;
-        for (Map.Entry<A, Rational> each : form.coefs().entrySet()) {
-            Rational weight = each.getValue();
-            RationalCut low = weight.signum() > 0
-                    ? from.leastOf(each.getKey()) : from.mostOf(each.getKey());
-            RationalCut high = weight.signum() > 0
-                    ? from.mostOf(each.getKey()) : from.leastOf(each.getKey());
-            if (least != null && low != null) {
-                least = least.plus(weight.times(low.at()));
-                leastReached &= low.inclusive();
-            } else {
-                least = null;
-            }
-            if (most != null && high != null) {
-                most = most.plus(weight.times(high.at()));
-                mostReached &= high.inclusive();
-            } else {
-                most = null;
-            }
-        }
-        return new Reach(least == null ? null : new RationalCut(least, leastReached),
-                most == null ? null : new RationalCut(most, mostReached));
+        return Reach.of(form.coefs(), Rational.ZERO,
+                atom -> Reach.between(from.leastOf(atom), from.mostOf(atom)));
     }
-
-    private record Reach(RationalCut least, RationalCut most) {}
 
     /**
      * What one rule leaves one of its positions, written into {@code atLeast} / {@code atMost}.
@@ -271,22 +246,11 @@ public final class AffineReduction {
      * @return null where some position of the rest has no end in the direction that matters
      */
     private static <A> Least leastOfTheRest(AffineConstraint.HalfSpace<A> half, A atom, Box<A> from) {
-        Rational total = Rational.ZERO;
-        boolean reached = true;
-        for (Map.Entry<A, Rational> each : half.form().coefs().entrySet()) {
-            if (each.getKey().equals(atom)) {
-                continue;
-            }
-            Rational weight = each.getValue();
-            RationalCut end = weight.signum() > 0
-                    ? from.leastOf(each.getKey()) : from.mostOf(each.getKey());
-            if (end == null) {
-                return null;
-            }
-            total = total.plus(weight.times(end.at()));
-            reached &= end.inclusive();
-        }
-        return new Least(total, reached);
+        Map<A, Rational> rest = new LinkedHashMap<>(half.form().coefs());
+        rest.remove(atom);
+        RationalCut least = Reach.of(rest, Rational.ZERO,
+                each -> Reach.between(from.leastOf(each), from.mostOf(each))).least();
+        return least == null ? null : new Least(least.at(), least.inclusive());
     }
 
     /** @param reached false where the sum comes arbitrarily close to {@code at} without arriving,

--- a/souther-compiler/src/main/java/souther/compiler/numeric/AffineReduction.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/AffineReduction.java
@@ -1,0 +1,217 @@
+package souther.compiler.numeric;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * What a rule over several positions leaves each of them, given what the others are left.
+ *
+ * <p>The part that was missing. A rule the difference bounds cannot hold —
+ * {@code 300·straw + 600·choco <= 4800}, a sum of two lengths, anything weighing two positions
+ * unevenly — was kept as written and read one way only: subtracted from a goal when something asked
+ * whether the goal followed. Nothing ever read it the other way, so the range handed to everything
+ * downstream was short of what the rules said, at every position such a rule names.
+ *
+ * <p>Read the other way it says this. Take {@code Σ cᵢ·xᵢ <= w} and one of its positions; move the
+ * rest to the other side, and what is left bounds that position by however much of the budget the
+ * rest cannot help taking:
+ *
+ * <pre>
+ *     k·a  &lt;=  w - Σ(rest)      and      Σ(rest) &gt;= m
+ *     k·a  &lt;=  w - m
+ * </pre>
+ *
+ * <p>which is sound because it is arithmetic on what is already known — {@code m} is a lower bound
+ * on the rest, so anything satisfying the rule satisfies this. And the last step, turning
+ * {@code k·a <= w - m} into a bound on {@code a}, is not done here: it is handed back to
+ * {@link AffineConstraint} as the one-position rule it is, so that the rounding, the strictness and
+ * the tightening onto what {@code a} can actually take are the same ones every other rule gets. A
+ * second implementation of that step is the one thing this must not have.
+ *
+ * <p><b>Three things it promises</b>, over a constraint {@code C} and a box {@code B}:
+ *
+ * <pre>
+ *     reductive     what comes back is inside what went in
+ *     sound         every point of B that satisfies C is inside what comes back
+ *     monotone      a narrower box in, a no-wider box out
+ * </pre>
+ *
+ * <p>The second is the whole of the work. A bound derived here that is not implied by the rules
+ * refuses values a model admits, and no measure downstream is in a position to notice — which is why
+ * it is checked against enumerated points rather than argued for.
+ *
+ * <p>Nothing here reaches anything but the box it was handed. It cannot ask what has been derived
+ * since, or what another rule found in the same round, so what it answers depends on the box and
+ * the rule and nothing else — and putting the answers together afterwards is what keeps the order
+ * the rules arrived in out of the result.
+ */
+public final class AffineReduction {
+
+    private AffineReduction() {
+    }
+
+    /** What a round of reading the rules the other way found. */
+    public sealed interface Reduction<A> {
+
+        /** The ends found, each of them at least as tight as the one it came in with. */
+        record Tightened<A>(Map<A, RationalCut> atLeast, Map<A, RationalCut> atMost)
+                implements Reduction<A> {
+
+            public Tightened {
+                atLeast = Map.copyOf(atLeast);
+                atMost = Map.copyOf(atMost);
+            }
+
+            public boolean foundNothing() {
+                return atLeast.isEmpty() && atMost.isEmpty();
+            }
+        }
+
+        /**
+         * A position was left no value at all, so nothing satisfies the rules together.
+         *
+         * <p>Said here rather than left for a reader to notice in the ends. A rule over several
+         * positions can empty a system the difference bounds see nothing wrong with —
+         * {@code x + y <= 5} beside {@code x >= 10} and {@code y >= 10} — and a reader handed two
+         * ends that have crossed has to know to look.
+         */
+        record NothingIsLeft<A>() implements Reduction<A> {}
+    }
+
+    /**
+     * Every bound the rules put on a position given {@code from}, read once each against the same
+     * box.
+     *
+     * @param constraints the rules to read this way. Ones the difference bounds already hold in full
+     *                    can be passed and cost a little; ones of no shape at all are skipped
+     * @param spacing     how each position's values are spaced, for the reason
+     *                    {@link AffineConstraint#of} wants it
+     */
+    public static <A> Reduction<A> over(Iterable<AffineConstraint<A>> constraints, Box<A> from,
+                                        Function<A, Granularity> spacing) {
+        Map<A, RationalCut> atLeast = new LinkedHashMap<>();
+        Map<A, RationalCut> atMost = new LinkedHashMap<>();
+        for (AffineConstraint<A> each : constraints) {
+            for (AffineConstraint.HalfSpace<A> half : asHalfSpaces(each)) {
+                for (A atom : half.form().coefs().keySet()) {
+                    if (!record(half, atom, from, spacing, atLeast, atMost)) {
+                        return new Reduction.NothingIsLeft<>();
+                    }
+                }
+            }
+        }
+        return new Reduction.Tightened<>(atLeast, atMost);
+    }
+
+    /**
+     * The half-spaces a constraint states. An equality is two of them, and a hole is none — which
+     * side of a hole a sum lies is not something the rule says, and is answered where what else is
+     * known can be read.
+     */
+    private static <A> java.util.List<AffineConstraint.HalfSpace<A>> asHalfSpaces(
+            AffineConstraint<A> constraint) {
+        return switch (constraint) {
+            case AffineConstraint.HalfSpace<A> half -> java.util.List.of(half);
+            case AffineConstraint.Equality<A> at -> java.util.List.of(
+                    new AffineConstraint.HalfSpace<>(at.form(), RationalCut.inclusive(at.at())),
+                    new AffineConstraint.HalfSpace<>(at.form().negated(),
+                            RationalCut.inclusive(at.at().negated())));
+            case AffineConstraint.Disequality<A> hole -> java.util.List.of();
+        };
+    }
+
+    /**
+     * What one rule leaves one of its positions, written into {@code atLeast} / {@code atMost}.
+     *
+     * @return false where the rule leaves that position no value at all
+     */
+    private static <A> boolean record(AffineConstraint.HalfSpace<A> half, A atom, Box<A> from,
+                                      Function<A, Granularity> spacing,
+                                      Map<A, RationalCut> atLeast, Map<A, RationalCut> atMost) {
+        Rational weight = half.form().coefs().get(atom);
+        Least rest = leastOfTheRest(half, atom, from);
+        if (rest == null) {
+            return true;   // some other position runs the wrong way without end, so nothing follows
+        }
+        // `k·a <= w - m`, which as a rule about `a` alone is `k·a + (m - w) <= 0`. Handed back to be
+        // read as one, so that what it does with the rounding and with the values `a` can take is
+        // what it does everywhere else.
+        boolean strict = !half.bound().inclusive() || !rest.reached();
+        AffineConstraint.Read<A> read = AffineConstraint.of(
+                Map.of(atom, weight), rest.at().minus(half.bound().at()),
+                strict ? NumericDomain.Rel.LT : NumericDomain.Rel.LE, spacing);
+        switch (read) {
+            case AffineConstraint.Read.HoldsNever<A> ignored -> {
+                return false;
+            }
+            case AffineConstraint.Read.HoldsAlways<A> ignored -> {
+                return true;
+            }
+            case AffineConstraint.Read.Stated<A> stated
+                    when stated.constraint() instanceof AffineConstraint.HalfSpace<A> alone -> {
+                RationalCut cut = alone.bound();
+                // A canonical one-position form weighs it by one or by minus one. Weighed by minus
+                // one it reads `-a <= c`, which is `a >= -c` — the same cut on the other side of
+                // nought, keeping whether the value itself is reached.
+                if (alone.form().coefs().get(atom).signum() > 0) {
+                    atMost.merge(atom, cut, RationalCut::tighterUpper);
+                } else {
+                    atLeast.merge(atom, new RationalCut(cut.at().negated(), cut.inclusive()),
+                            RationalCut::tighterLower);
+                }
+                return holdsAValue(atom, from, atLeast, atMost);
+            }
+            // A rule weighing one position is a bound on it, always. Said as a stop rather than left
+            // to fall through, because the shape came back from the one place that decides shapes.
+            case AffineConstraint.Read.Stated<A> stated -> throw new IllegalStateException(
+                    "a rule about one position came back as " + stated.constraint());
+        }
+    }
+
+    /** Whether the ends now known at {@code atom} — the ones it came in with and the ones just
+     *  found — still leave it something. */
+    private static <A> boolean holdsAValue(A atom, Box<A> from, Map<A, RationalCut> atLeast,
+                                           Map<A, RationalCut> atMost) {
+        RationalCut low = RationalCut.tighterLower(from.leastOf(atom), atLeast.get(atom));
+        RationalCut high = RationalCut.tighterUpper(from.mostOf(atom), atMost.get(atom));
+        if (low == null || high == null) {
+            return true;
+        }
+        int order = low.at().compareTo(high.at());
+        return order < 0 || (order == 0 && low.inclusive() && high.inclusive());
+    }
+
+    /**
+     * The least the rest of the form can come to, and whether it can actually come to it.
+     *
+     * <p>A position pulling the sum down contributes least at its own least, and one pulling it up
+     * contributes least at its greatest — so which end is read is the coefficient's sign and not the
+     * position's. Where the end that is wanted is missing, the rest can be made as small as you
+     * like and the rule bounds nothing.
+     *
+     * @return null where some position of the rest has no end in the direction that matters
+     */
+    private static <A> Least leastOfTheRest(AffineConstraint.HalfSpace<A> half, A atom, Box<A> from) {
+        Rational total = Rational.ZERO;
+        boolean reached = true;
+        for (Map.Entry<A, Rational> each : half.form().coefs().entrySet()) {
+            if (each.getKey().equals(atom)) {
+                continue;
+            }
+            Rational weight = each.getValue();
+            RationalCut end = weight.signum() > 0
+                    ? from.leastOf(each.getKey()) : from.mostOf(each.getKey());
+            if (end == null) {
+                return null;
+            }
+            total = total.plus(weight.times(end.at()));
+            reached &= end.inclusive();
+        }
+        return new Least(total, reached);
+    }
+
+    /** @param reached false where the sum comes arbitrarily close to {@code at} without arriving,
+     *                 which makes what is derived from it strict */
+    private record Least(Rational at, boolean reached) {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/numeric/AffineReduction.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/AffineReduction.java
@@ -91,7 +91,7 @@ public final class AffineReduction {
         Map<A, RationalCut> atMost = new LinkedHashMap<>();
         for (AffineConstraint<A> each : constraints) {
             List<AffineConstraint.HalfSpace<A>> halves = each instanceof
-                    AffineConstraint.Disequality<A> hole ? sidedBy(hole, from) : asHalfSpaces(each);
+                    AffineConstraint.Disequality<A> hole ? sidedBy(hole, from) : each.halfSpaces();
             if (halves == null) {
                 return new Reduction.NothingIsLeft<>();
             }
@@ -104,23 +104,6 @@ public final class AffineReduction {
             }
         }
         return new Reduction.Tightened<>(atLeast, atMost);
-    }
-
-    /**
-     * The half-spaces a constraint states. An equality is two of them, and a hole is none — which
-     * side of a hole a sum lies is not something the rule says, and is answered where what else is
-     * known can be read.
-     */
-    private static <A> List<AffineConstraint.HalfSpace<A>> asHalfSpaces(
-            AffineConstraint<A> constraint) {
-        return switch (constraint) {
-            case AffineConstraint.HalfSpace<A> half -> List.of(half);
-            case AffineConstraint.Equality<A> at -> List.of(
-                    new AffineConstraint.HalfSpace<>(at.form(), RationalCut.inclusive(at.at())),
-                    new AffineConstraint.HalfSpace<>(at.form().negated(),
-                            RationalCut.inclusive(at.at().negated())));
-            case AffineConstraint.Disequality<A> hole -> List.of();
-        };
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/numeric/AffineReduction.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/AffineReduction.java
@@ -1,6 +1,7 @@
 package souther.compiler.numeric;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -93,7 +94,12 @@ public final class AffineReduction {
         Map<A, RationalCut> atLeast = new LinkedHashMap<>();
         Map<A, RationalCut> atMost = new LinkedHashMap<>();
         for (AffineConstraint<A> each : constraints) {
-            for (AffineConstraint.HalfSpace<A> half : asHalfSpaces(each)) {
+            List<AffineConstraint.HalfSpace<A>> halves = each instanceof
+                    AffineConstraint.Disequality<A> hole ? sidedBy(hole, from) : asHalfSpaces(each);
+            if (halves == null) {
+                return new Reduction.NothingIsLeft<>();
+            }
+            for (AffineConstraint.HalfSpace<A> half : halves) {
                 for (A atom : half.form().coefs().keySet()) {
                     if (!record(half, atom, from, spacing, atLeast, atMost)) {
                         return new Reduction.NothingIsLeft<>();
@@ -109,17 +115,89 @@ public final class AffineReduction {
      * side of a hole a sum lies is not something the rule says, and is answered where what else is
      * known can be read.
      */
-    private static <A> java.util.List<AffineConstraint.HalfSpace<A>> asHalfSpaces(
+    private static <A> List<AffineConstraint.HalfSpace<A>> asHalfSpaces(
             AffineConstraint<A> constraint) {
         return switch (constraint) {
-            case AffineConstraint.HalfSpace<A> half -> java.util.List.of(half);
-            case AffineConstraint.Equality<A> at -> java.util.List.of(
+            case AffineConstraint.HalfSpace<A> half -> List.of(half);
+            case AffineConstraint.Equality<A> at -> List.of(
                     new AffineConstraint.HalfSpace<>(at.form(), RationalCut.inclusive(at.at())),
                     new AffineConstraint.HalfSpace<>(at.form().negated(),
                             RationalCut.inclusive(at.at().negated())));
-            case AffineConstraint.Disequality<A> hole -> java.util.List.of();
+            case AffineConstraint.Disequality<A> hole -> List.of();
         };
     }
+
+    /**
+     * A hole turned into a bound, where what is known says which side of it the sum lies.
+     *
+     * <p>{@code f /= v} on its own bounds nothing: it says the sum is not one value, and a range
+     * cannot leave one value out of the middle of itself. What it does say is this — if the sum is
+     * already known not to go below {@code v}, then it goes above it, and if it is already known not
+     * to go above, then it goes below. And where it is known to be exactly {@code v}, nothing is
+     * left.
+     *
+     * <p>Asked of the box and so of everything known, rather than of what happened to be known when
+     * the rule was read. That is the whole difference: {@code x /= 0} beside {@code x >= 0} used to
+     * leave {@code x} at nought or above depending on which of the two was written first, because
+     * the answer was decided at the moment the disequality arrived and never revisited. Here it is
+     * decided against the same box every other rule is read against, and again next round if the
+     * box has moved.
+     *
+     * @return the half-spaces it comes to, empty where the sum can still fall either side, or null
+     *         where the sum is pinned at the very value it is held away from
+     */
+    private static <A> List<AffineConstraint.HalfSpace<A>> sidedBy(
+            AffineConstraint.Disequality<A> hole, Box<A> from) {
+        Reach reach = reachOf(hole.form(), from);
+        Rational away = hole.at();
+        boolean neverBelow = reach.least() != null && reach.least().at().compareTo(away) >= 0;
+        boolean neverAbove = reach.most() != null && reach.most().at().compareTo(away) <= 0;
+        if (neverBelow && neverAbove
+                && reach.least().at().equals(away) && reach.most().at().equals(away)
+                && reach.least().inclusive() && reach.most().inclusive()) {
+            return null;   // the sum is held at the one value it is held away from
+        }
+        if (neverBelow) {
+            return List.of(new AffineConstraint.HalfSpace<>(
+                    hole.form().negated(), RationalCut.exclusive(away.negated())));
+        }
+        if (neverAbove) {
+            return List.of(new AffineConstraint.HalfSpace<>(
+                    hole.form(), RationalCut.exclusive(away)));
+        }
+        return List.of();
+    }
+
+    /** What the box leaves a whole form, either end {@code null} where it leaves it unbounded. */
+    private static <A> Reach reachOf(CanonicalForm<A> form, Box<A> from) {
+        Rational least = Rational.ZERO;
+        Rational most = Rational.ZERO;
+        boolean leastReached = true;
+        boolean mostReached = true;
+        for (Map.Entry<A, Rational> each : form.coefs().entrySet()) {
+            Rational weight = each.getValue();
+            RationalCut low = weight.signum() > 0
+                    ? from.leastOf(each.getKey()) : from.mostOf(each.getKey());
+            RationalCut high = weight.signum() > 0
+                    ? from.mostOf(each.getKey()) : from.leastOf(each.getKey());
+            if (least != null && low != null) {
+                least = least.plus(weight.times(low.at()));
+                leastReached &= low.inclusive();
+            } else {
+                least = null;
+            }
+            if (most != null && high != null) {
+                most = most.plus(weight.times(high.at()));
+                mostReached &= high.inclusive();
+            } else {
+                most = null;
+            }
+        }
+        return new Reach(least == null ? null : new RationalCut(least, leastReached),
+                most == null ? null : new RationalCut(most, mostReached));
+    }
+
+    private record Reach(RationalCut least, RationalCut most) {}
 
     /**
      * What one rule leaves one of its positions, written into {@code atLeast} / {@code atMost}.

--- a/souther-compiler/src/main/java/souther/compiler/numeric/Box.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/Box.java
@@ -1,0 +1,86 @@
+package souther.compiler.numeric;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What each position is known to lie between, exactly, at one moment.
+ *
+ * <p>A value and not a view. What reads this is handed the whole of it and cannot ask anything else
+ * — not the constraints it came from, not what has been derived since, not what another position
+ * was narrowed to in the same round. That is what makes a reduction over it a function of what it
+ * was given rather than of the order the reductions happened to run in: every rule reads the same
+ * box, and what they all found is put together afterwards.
+ *
+ * <p>A missing end is no bound that way, not a bound at nothing. A position this says nothing about
+ * runs the whole way in both directions.
+ */
+public record Box<A>(Map<A, RationalCut> atLeast, Map<A, RationalCut> atMost) {
+
+    public Box {
+        atLeast = Map.copyOf(atLeast);
+        atMost = Map.copyOf(atMost);
+    }
+
+    public static <A> Box<A> unbounded() {
+        return new Box<>(Map.of(), Map.of());
+    }
+
+    /** The tightest {@code atom >= …} this holds, or {@code null} for no bound below. */
+    public RationalCut leastOf(A atom) {
+        return atLeast.get(atom);
+    }
+
+    /** The tightest {@code atom <= …} this holds, or {@code null} for no bound above. */
+    public RationalCut mostOf(A atom) {
+        return atMost.get(atom);
+    }
+
+    /** Every position this says anything about. */
+    public Set<A> positions() {
+        Set<A> out = new LinkedHashSet<>(atLeast.keySet());
+        out.addAll(atMost.keySet());
+        return out;
+    }
+
+    /**
+     * This box narrowed by {@code found}, each end kept at whichever of the two is tighter.
+     *
+     * <p>Both directions at once, because a reduction hands back what it found on either side and
+     * the two are one answer about the position.
+     */
+    public Box<A> meeting(Map<A, RationalCut> foundAtLeast, Map<A, RationalCut> foundAtMost) {
+        Map<A, RationalCut> least = new LinkedHashMap<>(atLeast);
+        foundAtLeast.forEach((atom, cut) -> least.merge(atom, cut, RationalCut::tighterLower));
+        Map<A, RationalCut> most = new LinkedHashMap<>(atMost);
+        foundAtMost.forEach((atom, cut) -> most.merge(atom, cut, RationalCut::tighterUpper));
+        return new Box<>(least, most);
+    }
+
+    /**
+     * Whether some value lies between the two ends at {@code atom}.
+     *
+     * <p>Asked of the ends and not of their values. At one value the two ends are the same place and
+     * what decides it is whether both admit it — over values that fill there is nothing else between
+     * them to fall back on.
+     */
+    public boolean holdsAValueAt(A atom) {
+        RationalCut low = atLeast.get(atom);
+        RationalCut high = atMost.get(atom);
+        if (low == null || high == null) {
+            return true;
+        }
+        int order = low.at().compareTo(high.at());
+        if (order > 0) {
+            return false;
+        }
+        return order < 0 || (low.inclusive() && high.inclusive());
+    }
+
+    /** Whether every position this speaks of is left a value. */
+    public boolean holdsAValue() {
+        return positions().stream().allMatch(this::holdsAValueAt);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/numeric/CanonicalForm.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/CanonicalForm.java
@@ -1,0 +1,125 @@
+package souther.compiler.numeric;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * A weighted sum of positions, written the one way every rule that states it is written.
+ *
+ * <p>What a rule says and not how it was typed. {@code 300 * straw + 600 * choco <= 4800} and
+ * {@code straw + 2 * choco <= 16} are one rule; so are {@code 3a - 3b <= 1} and
+ * {@code a - b <= 1/3}, and so are {@code a - b <= 2} and {@code b - a >= -2}. Held as written, they
+ * were four rules to anything keyed on the coefficients — which is how a difference stated with
+ * coefficients of two fell outside the shape that holds differences, leaving one of its positions
+ * with no bound at all while the same rule written with ones bounded it.
+ *
+ * <p>So the coefficients are divided through by what they all share, which leaves them whole numbers
+ * with nothing left in common, and what they were divided by goes to the threshold. Scaling is the
+ * only freedom there is: negating turns the comparison around, so it belongs to reading the
+ * comparison rather than to writing the form.
+ *
+ * <p>No constant. A constant belongs to the threshold the form is compared against — left in, the
+ * values {@code 2 * a} takes would be the even numbers under one spelling and the odd ones shifted
+ * by nine under another, which is the same thing {@link souther.compiler.partition.BorderQuantity}
+ * says of a quantity.
+ *
+ * <p>Compared by its map, so two forms that say one thing are one key. That is what makes asserting
+ * a rule twice the same as asserting it once, and it is the property everything downstream leans on
+ * when it stops caring what order the rules arrived in.
+ */
+public record CanonicalForm<A>(Map<A, Rational> coefs) {
+
+    public CanonicalForm {
+        if (coefs == null || coefs.isEmpty()) {
+            throw new IllegalArgumentException("a form names at least one position");
+        }
+        coefs = Map.copyOf(coefs);
+        for (Map.Entry<A, Rational> each : coefs.entrySet()) {
+            if (each.getValue().isZero()) {
+                throw new IllegalArgumentException(
+                        "a position with a zero coefficient is one the form does not name: "
+                                + each.getKey());
+            }
+        }
+    }
+
+    /**
+     * The form {@code coefs} states, scaled so that what it is multiplied by is the smallest it can
+     * be, with the scaling handed back to apply to whatever the form is compared against.
+     *
+     * <p>Positions with a zero coefficient are dropped: a rule mentioning a position it does not
+     * weigh says nothing about it, and keeping it would make two writings of one rule two rules.
+     *
+     * @return the form and the factor the threshold has to be divided by to go with it, or
+     *         {@code null} where nothing is left — a form that weighs no position is a constant, and
+     *         what a constant comparison settles is not a constraint about anybody
+     */
+    public static <A> Scaled<A> of(Map<A, Rational> coefs) {
+        Map<A, Rational> weighed = new LinkedHashMap<>();
+        coefs.forEach((atom, coef) -> {
+            if (!coef.isZero()) {
+                weighed.put(atom, coef);
+            }
+        });
+        if (weighed.isEmpty()) {
+            return null;
+        }
+        Rational shared = AdditiveImage.divisorOf(weighed.values());
+        Map<A, Rational> primitive = new LinkedHashMap<>();
+        weighed.forEach((atom, coef) -> primitive.put(atom, coef.dividedBy(shared)));
+        return new Scaled<>(new CanonicalForm<>(primitive), shared);
+    }
+
+    /**
+     * A canonical form and what the writing of it was multiplied by.
+     *
+     * @param by never zero and always positive, so dividing a threshold by it leaves which side of
+     *           the threshold a value falls on
+     */
+    public record Scaled<A>(CanonicalForm<A> form, Rational by) {}
+
+    /**
+     * The values this form can add up to, over positions spaced as {@code spacing} says.
+     *
+     * <p>Asked of {@link AdditiveImage} rather than answered here. The coefficients being whole and
+     * sharing nothing does settle it — every whole number where the positions step, every finite
+     * decimal where they fill — but that is a conclusion about this arrangement rather than a rule
+     * of it, and the day a form arrives here weighed some other way it is the general answer that
+     * has to be right.
+     */
+    public AdditiveImage imageOver(Function<A, Granularity> spacing) {
+        return AdditiveImage.of(coefs, spacing);
+    }
+
+    /** This form with every coefficient turned around, which is what reading a comparison the other
+     *  way produces. Still canonical: negating leaves what the coefficients share. */
+    public CanonicalForm<A> negated() {
+        Map<A, Rational> out = new LinkedHashMap<>();
+        coefs.forEach((atom, coef) -> out.put(atom, coef.negated()));
+        return new CanonicalForm<>(out);
+    }
+
+    /**
+     * In an order that does not move between runs.
+     *
+     * <p>The map this holds is compared by its contents and iterated in whatever order it was built
+     * with — which is the right way round for deciding that two writings are one rule, and the wrong
+     * way round for writing one out. Sorted by the name of the position for the same reason
+     * {@link souther.compiler.partition.QuantityKey#key} sorts: a form written {@code 6b + 3a} and
+     * one written {@code 3a + 6b} are one form and should read as one.
+     */
+    @Override
+    public String toString() {
+        java.util.Map<String, Rational> named = new java.util.TreeMap<>();
+        coefs.forEach((atom, coef) -> named.put(String.valueOf(atom), coef));
+        StringBuilder out = new StringBuilder();
+        named.forEach((atom, coef) -> {
+            if (!out.isEmpty()) {
+                out.append(" + ");
+            }
+            out.append(coef).append("·").append(atom);
+        });
+        return out.toString();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/numeric/ClosedState.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/ClosedState.java
@@ -1,0 +1,224 @@
+package souther.compiler.numeric;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Everything a set of rules is worked out to leave, derived once and read by every question.
+ *
+ * <p>One derivation and one answer. What a position is left, whether one sum follows from another,
+ * whether anything is left at all — these had been answered by readings that could disagree, and one
+ * of them did: a projection said a position ran to sixteen while the proof it was read beside could
+ * not show it. Both were sound and they were not the same abstract state, which is a thing to fix
+ * rather than a thing to live with.
+ *
+ * <p>Derived from the canonical rules and nothing else. Not from the order they arrived in, not from
+ * what was written into a bound at the moment a rule was read. Two runs given the same rules produce
+ * the same state, whatever order they were handed over in and however many times each was said.
+ *
+ * <p><b>Two things closed against each other.</b> The rules of difference-bound shape are closed
+ * exactly ({@link DifferenceBounds}). The rest — a sum over several positions, weighted unevenly —
+ * are read the other way against what the closure leaves ({@link AffineReduction}), and what that
+ * finds goes back through the differences, and round again. A round reads only what the round before
+ * it produced, so no rule's answer depends on which rule ran first.
+ *
+ * <p><b>It is not a fixed point, and does not claim to be.</b> Narrowing over a general sum need not
+ * settle in finitely many rounds: two rules each halving the other's bound descend forever without
+ * arriving. So the rounds are bounded, and where the bound is reached the state says
+ * {@link Status#BUDGET_EXHAUSTED} — meaning the box is sound but was not shown to be all the rules
+ * leave. Stopping early only ever leaves it wider, so nothing this claims rests on the bound; what
+ * rests on it is only whether exactness can be certified, which is a separate question asked
+ * elsewhere.
+ *
+ * <p><b>What emptiness means here, in one direction.</b> Where this says nothing is left, nothing is
+ * — every step that narrows is implied by the rules, so a box that has closed on itself is a proof.
+ * The other way round does not hold: the rounds can stop early, and a general sum is reasoned about
+ * approximately, so a state that has not shown emptiness is not a state with a value in it.
+ */
+public final class ClosedState<A> {
+
+    /**
+     * How many rounds of reading the general rules against the box are worth running.
+     *
+     * <p>A number and not a proof of one. Every round is sound and every round only narrows, so
+     * stopping is always safe and never wrong — what a larger number buys is precision on the rules
+     * that need several passes to say what they say, and what it costs is time on the ones that
+     * settled in the first round and would have settled anyway.
+     */
+    static final int ROUNDS = 16;
+
+    /** Whether the rounds ran out before the box stopped moving. */
+    public enum Status {
+
+        /** The box closed on itself: another round would find nothing further. */
+        STABLE,
+
+        /**
+         * The rounds ran out with the box still moving.
+         *
+         * <p>Metadata about the derivation and never a thing to branch on. The box is sound either
+         * way, and a reader that behaved differently here would behave differently on rules that
+         * happen to take one round longer than some other rules — which is not a distinction the
+         * language makes.
+         */
+        BUDGET_EXHAUSTED
+    }
+
+    private final Box<A> box;
+    private final DifferenceBounds<A> differences;
+    private final boolean holdsNothing;
+    private final Status status;
+
+    private ClosedState(Box<A> box, DifferenceBounds<A> differences, boolean holdsNothing,
+                        Status status) {
+        this.box = box;
+        this.differences = differences;
+        this.holdsNothing = holdsNothing;
+        this.status = status;
+    }
+
+    /** What {@code constraints} leave, worked out. */
+    public static <A> ClosedState<A> of(List<AffineConstraint<A>> constraints,
+                                        Function<A, Granularity> spacing) {
+        DifferenceBounds<A> differences = DifferenceBounds.over(constraints);
+        if (differences.holdsNothing()) {
+            return empty(differences);
+        }
+        Set<A> positions = positionsOf(constraints);
+        Box<A> box = boxOf(differences, positions);
+        if (!box.holdsAValue()) {
+            return empty(differences);
+        }
+        for (int round = 0; round < ROUNDS; round++) {
+            AffineReduction.Reduction<A> found =
+                    AffineReduction.over(constraints, box, spacing);
+            if (found instanceof AffineReduction.Reduction.NothingIsLeft) {
+                return empty(differences);
+            }
+            AffineReduction.Reduction.Tightened<A> tightened =
+                    (AffineReduction.Reduction.Tightened<A>) found;
+            Box<A> next = throughDifferences(
+                    box.meeting(tightened.atLeast(), tightened.atMost()), differences, positions);
+            if (!next.holdsAValue()) {
+                return empty(differences);
+            }
+            if (next.equals(box)) {
+                return new ClosedState<>(box, differences, false, Status.STABLE);
+            }
+            box = next;
+        }
+        return new ClosedState<>(box, differences, false, Status.BUDGET_EXHAUSTED);
+    }
+
+    private static <A> ClosedState<A> empty(DifferenceBounds<A> differences) {
+        return new ClosedState<>(Box.unbounded(), differences, true, Status.STABLE);
+    }
+
+    private static <A> Set<A> positionsOf(List<AffineConstraint<A>> constraints) {
+        Set<A> out = new LinkedHashSet<>();
+        constraints.forEach(each -> out.addAll(each.form().coefs().keySet()));
+        return out;
+    }
+
+    /** What the closed differences leave each position on its own. */
+    private static <A> Box<A> boxOf(DifferenceBounds<A> differences, Set<A> positions) {
+        Map<A, RationalCut> least = new LinkedHashMap<>();
+        Map<A, RationalCut> most = new LinkedHashMap<>();
+        for (A position : positions) {
+            RationalCut low = differences.lowerBoundOf(position);
+            if (low != null) {
+                least.put(position, low);
+            }
+            RationalCut high = differences.upperBoundOf(position);
+            if (high != null) {
+                most.put(position, high);
+            }
+        }
+        return new Box<>(least, most);
+    }
+
+    /**
+     * The box carried along the differences: what one position is left bounds every position held
+     * against it.
+     *
+     * <p>Run after each round rather than once at the start. A bound the general rules found on one
+     * position is a bound on every position a difference relates it to, and a reading that closed the
+     * differences only at the start would answer differently depending on whether a rule happened to
+     * arrive as a difference or as a sum — which is the spelling deciding the answer again, one level
+     * up.
+     */
+    private static <A> Box<A> throughDifferences(Box<A> box, DifferenceBounds<A> differences,
+                                                 Set<A> positions) {
+        Map<A, RationalCut> least = new LinkedHashMap<>();
+        Map<A, RationalCut> most = new LinkedHashMap<>();
+        for (A here : positions) {
+            RationalCut high = box.mostOf(here);
+            RationalCut low = box.leastOf(here);
+            for (A there : positions) {
+                if (here.equals(there)) {
+                    continue;
+                }
+                // `here - there <= d` with `there <= h` puts `here` at `h + d`.
+                RationalCut apart = differences.differenceBound(here, there);
+                if (apart != null && box.mostOf(there) != null) {
+                    high = RationalCut.tighterUpper(high,
+                            RationalCut.meetingBoth(box.mostOf(there), apart));
+                }
+                // `there - here <= d` with `there >= l` puts `here` at `l - d`.
+                RationalCut back = differences.differenceBound(there, here);
+                if (back != null && box.leastOf(there) != null) {
+                    low = RationalCut.tighterLower(low, new RationalCut(
+                            box.leastOf(there).at().minus(back.at()),
+                            box.leastOf(there).inclusive() && back.inclusive()));
+                }
+            }
+            if (low != null) {
+                least.put(here, low);
+            }
+            if (high != null) {
+                most.put(here, high);
+            }
+        }
+        return new Box<>(least, most);
+    }
+
+    /**
+     * Whether nothing at all satisfies the rules together.
+     *
+     * <p>True is a proof and false is not. See the class comment: every narrowing is implied, so a
+     * box that has emptied is a box the rules emptied — but the rounds can stop early and a general
+     * sum is read approximately, so nothing here is entitled to conclude that a value exists.
+     */
+    public boolean holdsNothing() {
+        return holdsNothing;
+    }
+
+    /**
+     * What each position is left.
+     *
+     * @throws IllegalStateException where nothing is left, for the reason
+     *         {@link DifferenceBounds} refuses it there: no bound is the tightest when every bound
+     *         holds, and "no bound" reads as unbounded, which is the opposite of the truth
+     */
+    public Box<A> box() {
+        if (holdsNothing) {
+            throw new IllegalStateException(
+                    "nothing is left, so there is no box; ask holdsNothing first");
+        }
+        return box;
+    }
+
+    /** The difference-bound part, closed, for a question about two positions rather than one. */
+    public DifferenceBounds<A> differences() {
+        return differences;
+    }
+
+    /** Whether the rounds settled. Metadata about the derivation; see {@link Status}. */
+    Status status() {
+        return status;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/numeric/DifferenceBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/DifferenceBounds.java
@@ -1,0 +1,283 @@
+package souther.compiler.numeric;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What the rules leave every position and every difference of two of them, closed.
+ *
+ * <p>One structure where there were three. A bound on a position and a bound on a difference were
+ * kept apart — {@code lo}, {@code hi} and a table of differences — and read back by three routes
+ * that had to agree: the tightest bound on a position, the tightest bound on a difference, and
+ * whether the two could hold at once. The old code says as much where it asks whether anything is
+ * left, that a difference cycle summing below zero and a lower bound above an upper one "are one
+ * thing seen twice".
+ *
+ * <p>They are one thing because a bound is a difference from nought. Written that way —
+ * {@code a <= 10} as {@code a - 0 <= 10}, {@code a >= 3} as {@code 0 - a <= -3} — every rule of this
+ * shape is an edge between two nodes, one of which may be the nought this adds. Closing the edges
+ * over each other then answers all three questions at once, and a contradiction is a cycle that
+ * comes back below where it started.
+ *
+ * <p><b>Complete for what it holds.</b> Closing a difference-bound system finds a negative cycle
+ * exactly when one exists, so within this fragment "the rules leave nothing" and "this says the
+ * rules leave nothing" are the same statement. That is not true of the algebra as a whole — a
+ * general sum is held elsewhere and reasoned about approximately — so what holds overall is one
+ * direction only: where this says nothing is left, nothing is.
+ *
+ * <p>Exact throughout. The edges are {@link Rational}, and a bound only becomes a decimal somebody
+ * can read at the edge where it is handed over. Closed on decimals rounded to a fixed number of
+ * digits, a system with no solution comes back with one — the arithmetic that separates the two ends
+ * of {@code 3a = 1} is finer than the rounding.
+ */
+public final class DifferenceBounds<A> {
+
+    /** One end of an edge: a position, or the nought every bound is a difference from. */
+    public sealed interface Node<A> {
+
+        record OfAPosition<A>(A atom) implements Node<A> {
+            public OfAPosition {
+                if (atom == null) {
+                    throw new IllegalArgumentException("a position has a name");
+                }
+            }
+
+            @Override
+            public String toString() {
+                return String.valueOf(atom);
+            }
+        }
+
+        /** Nought, which is what a bound on one position is a difference from. */
+        record Nought<A>() implements Node<A> {
+            @Override
+            public String toString() {
+                return "0";
+            }
+        }
+    }
+
+    private final Map<Node<A>, Map<Node<A>, RationalCut>> closed;
+    private final boolean holdsNothing;
+
+    private DifferenceBounds(Map<Node<A>, Map<Node<A>, RationalCut>> closed, boolean holdsNothing) {
+        this.closed = closed;
+        this.holdsNothing = holdsNothing;
+    }
+
+    /**
+     * The constraints of this shape among {@code constraints}, closed over each other.
+     *
+     * <p>Everything else is left where it is. Which of them are of this shape is decided here and
+     * nowhere else ({@link #canHold}), so a caller sorting the rules into what this takes and what
+     * is left over asks rather than deciding a second time — the two decisions drifting apart is how
+     * a rule ends up held by nobody.
+     */
+    public static <A> DifferenceBounds<A> over(Iterable<AffineConstraint<A>> constraints) {
+        Map<Node<A>, Map<Node<A>, RationalCut>> edges = new LinkedHashMap<>();
+        for (AffineConstraint<A> each : constraints) {
+            for (Edge<A> edge : edgesOf(each)) {
+                edges.computeIfAbsent(edge.from(), k -> new LinkedHashMap<>())
+                        .merge(edge.to(), edge.at(), RationalCut::tighterUpper);
+            }
+        }
+        return closing(edges);
+    }
+
+    /** Whether this can hold what {@code constraint} says, in full. */
+    public static <A> boolean canHold(AffineConstraint<A> constraint) {
+        return !edgesOf(constraint).isEmpty();
+    }
+
+    /**
+     * The edges one constraint states, which is none where it is not of this shape.
+     *
+     * <p>A canonical form's coefficients are whole numbers sharing nothing, so a form naming one
+     * position weighs it by exactly one or minus one, and a form naming two is a difference exactly
+     * where their weights are one of each. That is what makes {@code 2a <= 10} a bound on a position
+     * here and {@code 2a - 2b <= 4} a difference: they are the same rules as {@code a <= 5} and
+     * {@code a - b <= 2}, and were only ever a different shape because they had been read off the
+     * coefficients as they were typed.
+     */
+    private static <A> List<Edge<A>> edgesOf(AffineConstraint<A> constraint) {
+        return switch (constraint) {
+            case AffineConstraint.HalfSpace<A> half -> {
+                Edge<A> edge = edgeOf(half.form(), half.bound());
+                yield edge == null ? List.of() : List.of(edge);
+            }
+            // Held at a value is held no higher and no lower, and both are of this shape wherever
+            // one of them is.
+            case AffineConstraint.Equality<A> at -> {
+                Edge<A> up = edgeOf(at.form(), RationalCut.inclusive(at.at()));
+                Edge<A> down = edgeOf(at.form().negated(),
+                        RationalCut.inclusive(at.at().negated()));
+                yield up == null || down == null ? List.of() : List.of(up, down);
+            }
+            // A hole is not a bound, and which side of it anything lies is not this one's to say.
+            case AffineConstraint.Disequality<A> hole -> List.of();
+        };
+    }
+
+    private static <A> Edge<A> edgeOf(CanonicalForm<A> form, RationalCut bound) {
+        Map<A, Rational> coefs = form.coefs();
+        if (coefs.size() == 1) {
+            Map.Entry<A, Rational> only = coefs.entrySet().iterator().next();
+            Node<A> position = new Node.OfAPosition<>(only.getKey());
+            Node<A> nought = new Node.Nought<A>();
+            return only.getValue().signum() > 0
+                    ? new Edge<>(position, nought, bound)      // a - 0 <= w
+                    : new Edge<>(nought, position, bound);     // 0 - a <= w
+        }
+        if (coefs.size() != 2) {
+            return null;
+        }
+        A up = null;
+        A down = null;
+        for (Map.Entry<A, Rational> each : coefs.entrySet()) {
+            if (each.getValue().equals(Rational.ONE)) {
+                up = each.getKey();
+            } else if (each.getValue().equals(Rational.ONE.negated())) {
+                down = each.getKey();
+            } else {
+                return null;   // a sum, or a weighted difference, which is not of this shape
+            }
+        }
+        return up == null || down == null ? null
+                : new Edge<>(new Node.OfAPosition<>(up), new Node.OfAPosition<>(down), bound);
+    }
+
+    /** {@code from - to <= at}. */
+    private record Edge<A>(Node<A> from, Node<A> to, RationalCut at) {}
+
+    /**
+     * The edges closed over each other, and whether what is left holds anything.
+     *
+     * <p>Every path, because a bound on one position is reached through every other:
+     * {@code a - b <= 0} with {@code b <= 1440} bounds {@code a} at 1440 though nothing was ever
+     * said about {@code a} alone. A path reaches its far end only where every hop on it does, which
+     * is why the strictness travels with the sum rather than being decided at the end.
+     */
+    private static <A> DifferenceBounds<A> closing(Map<Node<A>, Map<Node<A>, RationalCut>> edges) {
+        Set<Node<A>> nodes = new LinkedHashSet<>(edges.keySet());
+        edges.values().forEach(row -> nodes.addAll(row.keySet()));
+        Map<Node<A>, Map<Node<A>, RationalCut>> shortest = new LinkedHashMap<>();
+        edges.forEach((from, row) -> shortest.put(from, new LinkedHashMap<>(row)));
+        for (Node<A> through : nodes) {
+            Map<Node<A>, RationalCut> onwards = shortest.get(through);
+            if (onwards == null) {
+                continue;
+            }
+            List<Map.Entry<Node<A>, RationalCut>> hops = List.copyOf(onwards.entrySet());
+            for (Node<A> from : nodes) {
+                if (from.equals(through)) {
+                    continue;
+                }
+                RationalCut reaching = at(shortest, from, through);
+                if (reaching == null) {
+                    continue;
+                }
+                for (Map.Entry<Node<A>, RationalCut> hop : hops) {
+                    RationalCut round = RationalCut.meetingBoth(reaching, hop.getValue());
+                    RationalCut known = at(shortest, from, hop.getKey());
+                    if (RationalCut.tighterUpper(known, round) == round) {
+                        shortest.computeIfAbsent(from, k -> new LinkedHashMap<>())
+                                .put(hop.getKey(), round);
+                    }
+                }
+            }
+        }
+        // A cycle is a difference of a node from itself, which is nought. One summing below nought
+        // is a contradiction, and so is one summing to nought without reaching it.
+        boolean nothing = false;
+        for (Node<A> node : nodes) {
+            RationalCut cycle = at(shortest, node, node);
+            if (cycle != null && (cycle.at().signum() < 0
+                    || (cycle.at().isZero() && !cycle.inclusive()))) {
+                nothing = true;
+                break;
+            }
+        }
+        return new DifferenceBounds<>(shortest, nothing);
+    }
+
+    private static <A> RationalCut at(Map<Node<A>, Map<Node<A>, RationalCut>> table,
+                                      Node<A> from, Node<A> to) {
+        Map<Node<A>, RationalCut> row = table.get(from);
+        return row == null ? null : row.get(to);
+    }
+
+    /**
+     * Whether nothing at all satisfies what this holds.
+     *
+     * <p>Complete for this fragment: a difference-bound system has no solution exactly where closing
+     * it produces a cycle below nought, so this is not merely a proof of emptiness but a decision of
+     * it — over what this holds, and no further.
+     */
+    public boolean holdsNothing() {
+        return holdsNothing;
+    }
+
+    /** The tightest {@code atom <= …} this proves, or {@code null} where it proves none. */
+    public RationalCut upperBoundOf(A atom) {
+        return whereThereAreValues(at(closed, new Node.OfAPosition<>(atom), new Node.Nought<A>()));
+    }
+
+    /**
+     * The tightest {@code atom >= …} this proves, or {@code null} where it proves none.
+     *
+     * <p>An edge the other way says {@code 0 - a <= w}, which is {@code a >= -w} — the same cut on
+     * the other side of nought, keeping whether the value itself is reached.
+     */
+    public RationalCut lowerBoundOf(A atom) {
+        RationalCut below =
+                whereThereAreValues(at(closed, new Node.Nought<A>(), new Node.OfAPosition<>(atom)));
+        return below == null ? null : new RationalCut(below.at().negated(), below.inclusive());
+    }
+
+    /** The tightest {@code a - b <= …} this proves, or {@code null} where it proves none. */
+    public RationalCut differenceBound(A a, A b) {
+        if (a.equals(b)) {
+            return whereThereAreValues(RationalCut.inclusive(Rational.ZERO));
+        }
+        return whereThereAreValues(
+                at(closed, new Node.OfAPosition<>(a), new Node.OfAPosition<>(b)));
+    }
+
+    /**
+     * The answer, where there is one to give.
+     *
+     * <p>Where nothing is left there is no tightest bound: every bound holds, and closing a system
+     * that comes back below where it started walks the cycle as many times as the closure happened
+     * to reach it — so what these would hand back is a number that moves with the order the rules
+     * arrived in, which is the one thing this whole arrangement is for.
+     *
+     * <p>Refused rather than answered with no bound. No bound reads as "unbounded that way", which
+     * is the opposite of the truth here and the dangerous direction: a caller taking it would go
+     * looking for rows in a value nobody can build. Whether anything is left is
+     * {@link #holdsNothing}, and it is the question to ask first.
+     */
+    private RationalCut whereThereAreValues(RationalCut answer) {
+        if (holdsNothing) {
+            throw new IllegalStateException(
+                    "nothing is left, so no bound is the tightest; ask holdsNothing first");
+        }
+        return answer;
+    }
+
+    /** Every position this says anything about. */
+    public Set<A> positions() {
+        Set<A> out = new LinkedHashSet<>();
+        List<Node<A>> reached = new ArrayList<>(closed.keySet());
+        closed.values().forEach(row -> reached.addAll(row.keySet()));
+        for (Node<A> node : reached) {
+            if (node instanceof Node.OfAPosition<A> at) {
+                out.add(at.atom());
+            }
+        }
+        return out;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/numeric/DifferenceBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/DifferenceBounds.java
@@ -103,24 +103,21 @@ public final class DifferenceBounds<A> {
      * here and {@code 2a - 2b <= 4} a difference: they are the same rules as {@code a <= 5} and
      * {@code a - b <= 2}, and were only ever a different shape because they had been read off the
      * coefficients as they were typed.
+     *
+     * <p>Which half-spaces a constraint states is the constraint's own answer, so an equality being
+     * a bound above and a bound below is not restated here. Either every one of them is an edge or
+     * this holds none of it: half a rule held is a rule nobody holds.
      */
     private static <A> List<Edge<A>> edgesOf(AffineConstraint<A> constraint) {
-        return switch (constraint) {
-            case AffineConstraint.HalfSpace<A> half -> {
-                Edge<A> edge = edgeOf(half.form(), half.bound());
-                yield edge == null ? List.of() : List.of(edge);
+        List<Edge<A>> out = new ArrayList<>();
+        for (AffineConstraint.HalfSpace<A> half : constraint.halfSpaces()) {
+            Edge<A> edge = edgeOf(half.form(), half.bound());
+            if (edge == null) {
+                return List.of();
             }
-            // Held at a value is held no higher and no lower, and both are of this shape wherever
-            // one of them is.
-            case AffineConstraint.Equality<A> at -> {
-                Edge<A> up = edgeOf(at.form(), RationalCut.inclusive(at.at()));
-                Edge<A> down = edgeOf(at.form().negated(),
-                        RationalCut.inclusive(at.at().negated()));
-                yield up == null || down == null ? List.of() : List.of(up, down);
-            }
-            // A hole is not a bound, and which side of it anything lies is not this one's to say.
-            case AffineConstraint.Disequality<A> hole -> List.of();
-        };
+            out.add(edge);
+        }
+        return List.copyOf(out);
     }
 
     private static <A> Edge<A> edgeOf(CanonicalForm<A> form, RationalCut bound) {

--- a/souther-compiler/src/main/java/souther/compiler/numeric/DifferenceBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/DifferenceBounds.java
@@ -72,10 +72,10 @@ public final class DifferenceBounds<A> {
     /**
      * The constraints of this shape among {@code constraints}, closed over each other.
      *
-     * <p>Everything else is left where it is. Which of them are of this shape is decided here and
-     * nowhere else ({@link #canHold}), so a caller sorting the rules into what this takes and what
-     * is left over asks rather than deciding a second time — the two decisions drifting apart is how
-     * a rule ends up held by nobody.
+     * <p>Everything else is left where it is, and nothing has to sort the rules first: what is not
+     * of this shape is skipped here and read by the reduction, and a rule of this shape is read by
+     * both — exactly, here, and again as a plain sum there, which costs a little and says nothing
+     * new. So there is one decision about the shape and it is made here.
      */
     public static <A> DifferenceBounds<A> over(Iterable<AffineConstraint<A>> constraints) {
         Map<Node<A>, Map<Node<A>, RationalCut>> edges = new LinkedHashMap<>();
@@ -88,8 +88,9 @@ public final class DifferenceBounds<A> {
         return closing(edges);
     }
 
-    /** Whether this can hold what {@code constraint} says, in full. */
-    public static <A> boolean canHold(AffineConstraint<A> constraint) {
+    /** Whether this can hold what {@code constraint} says, in full — which is what the shapes above
+     *  amount to, asked directly so that they can be pinned down. */
+    static <A> boolean canHold(AffineConstraint<A> constraint) {
         return !edgesOf(constraint).isEmpty();
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
@@ -448,17 +448,23 @@ public final class NumericDomain<A> {
      * together through this. What the box already holds of them is not this step: the rules that
      * narrow it have each been read into it on their own.
      *
-     * <p>Nothing this adds is needed for a bound on a single position, and nothing it adds is wrong
-     * there. The reduction already reads every rule against the box at each position it names, and
-     * runs until the box stops moving — which is this step at one position, taken as far as it goes.
-     * So {@link #boundsOf(Object)} reads the box and agrees with this.
+     * <p>A goal naming one position does not come here at all: the box is this step at one position
+     * already, so {@link #boundsOf(Object)} and this are the same answer by construction rather than
+     * by both happening to converge. They did not, where the rounds ran out — see below.
      *
      * @param withRules false to ask what the ranges say on their own, which is a different question
      *                  from what the rules say, and is the one an audit of the ranges wants
      */
     private RationalCut highestProven(Goal<A> goal, boolean withRules) {
         RationalCut best = fromTheBox(goal);
-        if (!withRules) {
+        if (!withRules || goal.coefs().size() <= 1) {
+            // A goal naming one position is answered by the box and by nothing else, because the box
+            // *is* this step at one position, run until it stops moving or until the rounds run out.
+            // Taking one more here would be one round past whatever the closure was allowed, and
+            // where the rounds do run out that showed: a chain longer than the budget left
+            // `boundsOf(x)` with no bound while `boundsOf` of the same position as a form, and
+            // `entails`, went one link further and found one. Two answers about one position, and
+            // the budget bounding neither.
             return best;
         }
         for (AffineConstraint<A> rule : rules) {

--- a/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
@@ -255,38 +255,96 @@ public final class NumericDomain<A> {
         return entails(f, rel, false);
     }
 
+    /**
+     * Whether the rules prove the comparison, read the one way a comparison is read.
+     *
+     * <p>Through {@link AffineConstraint#of} — the same reading a rule goes through on the way in.
+     * What each of the six relations means was written here as well as there, so the two readings
+     * could differ and did: the one on the way in divides a comparison through by what its weights
+     * share and moves a bound onto a value the sum can take, and the one here did neither. A
+     * question scaled away from the rule it needs was left with a residual nothing could prove, and
+     * a difference asked with weights of two was not recognised as a difference at all.
+     *
+     * <p>So a question is not a second kind of thing. It is a comparison, which is what a rule is,
+     * and it is read into the same three shapes.
+     */
     private boolean entails(LinearForm<A> f, Rel rel, boolean withRules) {
         if (isBottom()) {
             return true;   // an infeasible path discharges anything
         }
-        Goal<A> goal = goalOf(f).goal();
-        return switch (rel) {
-            case LE -> proves(goal, false, withRules);
-            case LT -> proves(goal, true, withRules);
-            case GE -> proves(goal.negated(), false, withRules);
-            case GT -> proves(goal.negated(), true, withRules);
-            case EQ -> proves(goal, false, withRules) && proves(goal.negated(), false, withRules);
-            case NE -> proves(goal, true, withRules) || proves(goal.negated(), true, withRules);
+        Map<A, Rational> coefs = weighed(f);
+        if (!kinds.keySet().containsAll(coefs.keySet())) {
+            // A position this has never been told about is one nothing here bounds, so nothing here
+            // proves about it either. Said before the reading, which would want its spacing.
+            return false;
+        }
+        return switch (AffineConstraint.of(coefs, Rational.of(f.constant()), rel, kinds::get)) {
+            case AffineConstraint.Read.HoldsAlways<A> ignored -> true;
+            case AffineConstraint.Read.HoldsNever<A> ignored -> false;
+            case AffineConstraint.Read.Stated<A> stated -> proven(stated.constraint(), withRules);
         };
     }
 
     /**
+     * Whether the rules prove what one constraint says.
+     *
+     * <p>Held below something is one thing to prove; held at something is the two the constraint
+     * itself names; held away from something is either of two strict ones, since a sum away from a
+     * value is under it or over it.
+     */
+    private boolean proven(AffineConstraint<A> asked, boolean withRules) {
+        if (asked instanceof AffineConstraint.Disequality<A> hole) {
+            return proves(below(hole.form(), hole.at()), true, withRules)
+                    || proves(below(hole.form().negated(), hole.at().negated()), true, withRules);
+        }
+        for (AffineConstraint.HalfSpace<A> half : asked.halfSpaces()) {
+            if (!proves(below(half.form(), half.bound().at()), !half.bound().inclusive(),
+                    withRules)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** {@code form - at}, which is what is bounded to decide whether {@code form <= at}. */
+    private Goal<A> below(CanonicalForm<A> form, Rational at) {
+        return new Goal<>(form.coefs(), at.negated());
+    }
+
+    /**
      * Whether the rules prove {@code ¬(f rel 0)} — the invariant is <em>definitely</em> violated on
-     * this path, which is a compile error rather than an undischarged obligation. The negation flips
-     * both bits of the comparison: {@code ¬(f >= 0)} is {@code f < 0}.
+     * this path, which is a compile error rather than an undischarged obligation.
+     *
+     * <p>Which is proving the opposite comparison, and the opposite of each is one fact written
+     * once. It had been a second switch over the relations, and a third reading of what they mean.
      */
     public boolean refutes(LinearForm<A> f, Rel rel) {
-        if (isBottom() || rel == Rel.EQ) {
-            return false;   // an unreachable path violates nothing; equality is never refuted here
-        }
-        if (rel == Rel.NE) {
-            return entails(f, Rel.EQ);   // proving it equal is proving it not unequal
-        }
-        Goal<A> goal = goalOf(f).goal();
+        return !isBottom() && entails(f, opposite(rel), true);
+    }
+
+    /** The comparison that holds exactly where {@code rel} does not. */
+    private static Rel opposite(Rel rel) {
         return switch (rel) {
-            case GE, GT -> proves(goal, rel == Rel.GE, true);
-            default -> proves(goal.negated(), rel == Rel.LE, true);
+            case LE -> Rel.GT;
+            case LT -> Rel.GE;
+            case GE -> Rel.LT;
+            case GT -> Rel.LE;
+            case EQ -> Rel.NE;
+            case NE -> Rel.EQ;
         };
+    }
+
+    /** A written form's weights, as the exact arithmetic holds them, with the positions it does not
+     *  actually weigh left out. */
+    private Map<A, Rational> weighed(LinearForm<A> f) {
+        Map<A, Rational> coefs = new LinkedHashMap<>();
+        f.coefs().forEach((atom, coef) -> {
+            Rational weight = Rational.of(coef);
+            if (!weight.isZero()) {
+                coefs.put(atom, weight);
+            }
+        });
+        return coefs;
     }
 
     /** A goal as a weighted sum and a constant, which is what a comparison against nought is. */
@@ -324,13 +382,7 @@ public final class NumericDomain<A> {
      * side of nought the question is about.
      */
     private Asked<A> goalOf(LinearForm<A> f) {
-        Map<A, Rational> coefs = new LinkedHashMap<>();
-        f.coefs().forEach((atom, coef) -> {
-            Rational weight = Rational.of(coef);
-            if (!weight.isZero()) {
-                coefs.put(atom, weight);
-            }
-        });
+        Map<A, Rational> coefs = weighed(f);
         Rational constant = Rational.of(f.constant());
         // Canonicalised by the one thing that canonicalises, so a question and a rule that say the
         // same thing are put into the same words by the same code. Doing the division here instead
@@ -365,17 +417,6 @@ public final class NumericDomain<A> {
         // An end at nought the goal cannot reach proves the strict form: nothing the rules admit
         // gets there, which is what `< 0` asks.
         return sign < 0 || (sign == 0 && (!strict || !highest.inclusive()));
-    }
-
-    private static <A> List<AffineConstraint.HalfSpace<A>> asHalfSpaces(AffineConstraint<A> rule) {
-        return switch (rule) {
-            case AffineConstraint.HalfSpace<A> half -> List.of(half);
-            case AffineConstraint.Equality<A> at -> List.of(
-                    new AffineConstraint.HalfSpace<>(at.form(), RationalCut.inclusive(at.at())),
-                    new AffineConstraint.HalfSpace<>(at.form().negated(),
-                            RationalCut.inclusive(at.at().negated())));
-            case AffineConstraint.Disequality<A> hole -> List.of();
-        };
     }
 
     /** {@code goal - (premise.form - premise.bound)}, which is what is left to prove once the
@@ -421,7 +462,7 @@ public final class NumericDomain<A> {
             return best;
         }
         for (AffineConstraint<A> rule : rules) {
-            for (AffineConstraint.HalfSpace<A> premise : asHalfSpaces(rule)) {
+            for (AffineConstraint.HalfSpace<A> premise : rule.halfSpaces()) {
                 RationalCut residual = fromTheBox(subtracting(goal, premise));
                 if (residual != null) {
                     // The goal reaches the sum only where the residual reaches its own end and the

--- a/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
@@ -259,7 +259,7 @@ public final class NumericDomain<A> {
         if (isBottom()) {
             return true;   // an infeasible path discharges anything
         }
-        Goal<A> goal = goalOf(f);
+        Goal<A> goal = goalOf(f).goal();
         return switch (rel) {
             case LE -> proves(goal, false, withRules);
             case LT -> proves(goal, true, withRules);
@@ -282,7 +282,7 @@ public final class NumericDomain<A> {
         if (rel == Rel.NE) {
             return entails(f, Rel.EQ);   // proving it equal is proving it not unequal
         }
-        Goal<A> goal = goalOf(f);
+        Goal<A> goal = goalOf(f).goal();
         return switch (rel) {
             case GE, GT -> proves(goal, rel == Rel.GE, true);
             default -> proves(goal.negated(), rel == Rel.LE, true);
@@ -299,10 +299,48 @@ public final class NumericDomain<A> {
         }
     }
 
-    private Goal<A> goalOf(LinearForm<A> f) {
+    /**
+     * A canonical question and what the form it was asked about was multiplied by.
+     *
+     * <p>The divisor is nothing to a question about which side of nought a form falls — scaling by a
+     * positive number leaves that alone, which is the whole reason the question can be canonicalised
+     * at all. It is everything to a question about where the form runs: {@code 2a - 2b} runs twice as
+     * far as {@code a - b}, and an answer about the second handed back for the first is out by a
+     * factor with nothing to say it is.
+     */
+    private record Asked<A>(Goal<A> goal, Rational by) {}
+
+    /**
+     * A question, in the one form every way of asking it comes to.
+     *
+     * <p>The rules were being canonicalised on the way in and the questions were not, so
+     * {@code 2x + 2y <= 10} and {@code x + y <= 5} — one question — were answered differently: the
+     * rule kept is the second, and a premise is taken off a goal once, so the first was left with a
+     * residual nothing could prove. The same thing reached the audit, where a difference asked as
+     * {@code 2a - 2b <= 4} was not recognised as a difference at all and a rule the ranges do state
+     * came back unstated.
+     *
+     * <p>Divided through by what the weights share, which is a positive number and so leaves which
+     * side of nought the question is about.
+     */
+    private Asked<A> goalOf(LinearForm<A> f) {
         Map<A, Rational> coefs = new LinkedHashMap<>();
-        f.coefs().forEach((atom, coef) -> coefs.put(atom, Rational.of(coef)));
-        return new Goal<>(coefs, Rational.of(f.constant()));
+        f.coefs().forEach((atom, coef) -> {
+            Rational weight = Rational.of(coef);
+            if (!weight.isZero()) {
+                coefs.put(atom, weight);
+            }
+        });
+        Rational constant = Rational.of(f.constant());
+        // Canonicalised by the one thing that canonicalises, so a question and a rule that say the
+        // same thing are put into the same words by the same code. Doing the division here instead
+        // would be a second account of what one rule is — which is the thing being removed.
+        CanonicalForm.Scaled<A> scaled = CanonicalForm.of(coefs);
+        if (scaled == null) {
+            return new Asked<>(new Goal<>(Map.of(), constant), Rational.ONE);
+        }
+        return new Asked<>(
+                new Goal<>(scaled.form().coefs(), constant.dividedBy(scaled.by())), scaled.by());
     }
 
     /**
@@ -319,24 +357,14 @@ public final class NumericDomain<A> {
      * step: the rules that narrow it have all been read into it, each on its own.
      */
     private boolean proves(Goal<A> goal, boolean strict, boolean withRules) {
-        if (provenByTheBox(goal, strict)) {
-            return true;
-        }
-        if (!withRules) {
+        RationalCut highest = highestProven(goal, withRules);
+        if (highest == null) {
             return false;
         }
-        for (AffineConstraint<A> rule : rules) {
-            for (AffineConstraint.HalfSpace<A> premise : asHalfSpaces(rule)) {
-                // `premise.form <= premise.bound` taken off the goal leaves a residual the box has
-                // to prove. The goal is strict where either the premise or the residual is, so what
-                // the residual is asked for is what the premise did not already give.
-                Goal<A> residual = subtracting(goal, premise);
-                if (provenByTheBox(residual, strict && premise.bound().inclusive())) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        int sign = highest.at().signum();
+        // An end at nought the goal cannot reach proves the strict form: nothing the rules admit
+        // gets there, which is what `< 0` asks.
+        return sign < 0 || (sign == 0 && (!strict || !highest.inclusive()));
     }
 
     private static <A> List<AffineConstraint.HalfSpace<A>> asHalfSpaces(AffineConstraint<A> rule) {
@@ -360,26 +388,54 @@ public final class NumericDomain<A> {
         return new Goal<>(coefs, goal.constant().plus(premise.bound().at()));
     }
 
-    /** Whether what the rules leave the goal's positions already puts the goal below nought. */
-    private boolean provenByTheBox(Goal<A> goal, boolean strict) {
-        RationalCut highest = highestOf(goal);
-        if (highest == null) {
-            return false;
-        }
-        int sign = highest.at().signum();
-        // An end at nought the goal's own bounds do not reach proves the strict form: nothing the
-        // rules admit gets there, which is what `< 0` asks.
-        return sign < 0 || (sign == 0 && (!strict || !highest.inclusive()));
-    }
-
     /**
      * The highest the goal comes to, or null where nothing bounds it above.
      *
-     * <p>Its positions' own ends, and the relation on a difference of two of them where the goal has
-     * that shape. The end is the goal's own only where every end it was added from is: one term that
-     * cannot reach its edge is one the sum cannot reach either.
+     * <p><b>The one place a bound on a form is derived.</b> {@link #boundsOf(LinearForm)},
+     * {@link #entails} and {@link #refutes} all read this, so what a form is said to run up to and
+     * what is said to follow from it are one statement. They had not been: the ranges said
+     * {@code x + y} ran to ten while the proof beside them showed {@code x + y <= 5} — both sound,
+     * and not the same abstract state, which is the shape all of this exists to remove.
+     *
+     * <p>Three routes, met. What the box leaves the goal's own positions; the relation on a
+     * difference of two of them, where the goal has that shape; and a rule taken off the goal,
+     * leaving a residual the box bounds — {@code f <= u} with {@code g - f <= r} gives
+     * {@code g <= r + u}, which is what relates a guard over a computed value to what the type of
+     * the value it was compared against guarantees.
+     *
+     * <p>One rule, once. The residual is bounded by the box alone, so two rules are never added
+     * together through this. What the box already holds of them is not this step: the rules that
+     * narrow it have each been read into it on their own.
+     *
+     * <p>Nothing this adds is needed for a bound on a single position, and nothing it adds is wrong
+     * there. The reduction already reads every rule against the box at each position it names, and
+     * runs until the box stops moving — which is this step at one position, taken as far as it goes.
+     * So {@link #boundsOf(Object)} reads the box and agrees with this.
+     *
+     * @param withRules false to ask what the ranges say on their own, which is a different question
+     *                  from what the rules say, and is the one an audit of the ranges wants
      */
-    private RationalCut highestOf(Goal<A> goal) {
+    private RationalCut highestProven(Goal<A> goal, boolean withRules) {
+        RationalCut best = fromTheBox(goal);
+        if (!withRules) {
+            return best;
+        }
+        for (AffineConstraint<A> rule : rules) {
+            for (AffineConstraint.HalfSpace<A> premise : asHalfSpaces(rule)) {
+                RationalCut residual = fromTheBox(subtracting(goal, premise));
+                if (residual != null) {
+                    // The goal reaches the sum only where the residual reaches its own end and the
+                    // premise reaches its bound.
+                    best = RationalCut.tighterUpper(best, new RationalCut(residual.at(),
+                            residual.inclusive() && premise.bound().inclusive()));
+                }
+            }
+        }
+        return best;
+    }
+
+    /** What the box and the closed differences leave the goal, which is where every route starts. */
+    private RationalCut fromTheBox(Goal<A> goal) {
         if (goal.coefs().isEmpty()) {
             return RationalCut.inclusive(goal.constant());
         }
@@ -387,36 +443,42 @@ public final class NumericDomain<A> {
         Box<A> box = state.box();
         RationalCut best = Reach.of(goal.coefs(), goal.constant(),
                 atom -> Reach.between(box.leastOf(atom), box.mostOf(atom))).most();
-        List<A> apart = unitDifference(goal.coefs());
+        Apart<A> apart = difference(goal.coefs());
         if (apart != null) {
-            RationalCut difference =
-                    state.differences().differenceBound(apart.get(0), apart.get(1));
-            if (difference != null) {
+            RationalCut held = state.differences().differenceBound(apart.above(), apart.below());
+            if (held != null) {
                 best = RationalCut.tighterUpper(best, new RationalCut(
-                        difference.at().plus(goal.constant()), difference.inclusive()));
+                        held.at().times(apart.by()).plus(goal.constant()), held.inclusive()));
             }
         }
         return best;
     }
 
-    /** The two atoms of {@code a - b}, or null where the goal is not one. */
-    private static <A> List<A> unitDifference(Map<A, Rational> coefs) {
+    /**
+     * The two positions of {@code k·(a - b)} and the {@code k}, or null where the goal is not that.
+     *
+     * <p>Any {@code k} and not only one. A goal asked as {@code 2a - 2b} is the difference
+     * {@code a - b} twice over, and the closed differences bound it at twice what they bound that —
+     * so recognising the shape only when it is spelled with ones is the same trap this removed from
+     * the rules, one level down in the reading.
+     */
+    private static <A> Apart<A> difference(Map<A, Rational> coefs) {
         if (coefs.size() != 2) {
             return null;
         }
-        A up = null;
-        A down = null;
-        for (Map.Entry<A, Rational> each : coefs.entrySet()) {
-            if (each.getValue().equals(Rational.ONE)) {
-                up = each.getKey();
-            } else if (each.getValue().equals(Rational.ONE.negated())) {
-                down = each.getKey();
-            } else {
-                return null;
-            }
+        java.util.Iterator<Map.Entry<A, Rational>> both = coefs.entrySet().iterator();
+        Map.Entry<A, Rational> one = both.next();
+        Map.Entry<A, Rational> other = both.next();
+        if (!one.getValue().equals(other.getValue().negated())) {
+            return null;
         }
-        return up == null || down == null ? null : List.of(up, down);
+        return one.getValue().signum() > 0
+                ? new Apart<>(one.getKey(), other.getKey(), one.getValue())
+                : new Apart<>(other.getKey(), one.getKey(), other.getValue());
     }
+
+    /** {@code by · (above - below)}, with {@code by} positive. */
+    private record Apart<A>(A above, A below, Rational by) {}
 
     // --- reading the domain back --------------------------------------------------------------------
 
@@ -448,13 +510,16 @@ public final class NumericDomain<A> {
         if (isBottom()) {
             return new Bounds(null, null);
         }
-        Goal<A> goal = goalOf(f);
-        RationalCut highest = highestOf(goal);
-        RationalCut lowest = highestOf(goal.negated());
+        Asked<A> asked = goalOf(f);
+        RationalCut highest = highestProven(asked.goal(), true);
+        RationalCut lowest = highestProven(asked.goal().negated(), true);
+        // Back into the units the caller asked in. The question was answered about the form divided
+        // through by what its weights share, and the caller wants the form it wrote.
         return new Bounds(
-                lowest == null ? null
-                        : written(new RationalCut(lowest.at().negated(), lowest.inclusive()), false),
-                written(highest, true));
+                lowest == null ? null : written(new RationalCut(
+                        lowest.at().negated().times(asked.by()), lowest.inclusive()), false),
+                highest == null ? null : written(new RationalCut(
+                        highest.at().times(asked.by()), highest.inclusive()), true));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
@@ -421,22 +421,8 @@ public final class NumericDomain<A> {
         }
         ClosedState<A> state = closed();
         Box<A> box = state.box();
-        Rational at = goal.constant();
-        boolean reached = true;
-        RationalCut summed = null;
-        for (Map.Entry<A, Rational> each : goal.coefs().entrySet()) {
-            Rational coef = each.getValue();
-            RationalCut end = coef.signum() > 0
-                    ? box.mostOf(each.getKey()) : box.leastOf(each.getKey());
-            if (end == null) {
-                summed = null;
-                break;
-            }
-            at = at.plus(coef.times(end.at()));
-            reached &= end.inclusive();
-            summed = new RationalCut(at, reached);
-        }
-        RationalCut best = summed;
+        RationalCut best = Reach.of(goal.coefs(), goal.constant(),
+                atom -> Reach.between(box.leastOf(atom), box.mostOf(atom))).most();
         List<A> apart = unitDifference(goal.coefs());
         if (apart != null) {
             RationalCut difference =

--- a/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
@@ -94,45 +94,18 @@ public final class NumericDomain<A> {
 
     private final List<AffineConstraint<A>> rules;
     private final Map<A, Granularity> kinds;
-    private final Map<A, Set<Loss>> losses;
     private final boolean readARuleNothingSatisfies;
     private ClosedState<A> closed;
 
     private NumericDomain(List<AffineConstraint<A>> rules, Map<A, Granularity> kinds,
-                          Map<A, Set<Loss>> losses, boolean readARuleNothingSatisfies) {
+                          boolean readARuleNothingSatisfies) {
         this.rules = rules;
         this.kinds = kinds;
-        this.losses = losses;
         this.readARuleNothingSatisfies = readARuleNothingSatisfies;
     }
 
     public static <A> NumericDomain<A> top() {
-        return new NumericDomain<>(List.of(), Map.of(), Map.of(), false);
-    }
-
-    /**
-     * A way an assertion arrived holding more than a range can state.
-     *
-     * <p>What the bounds say is sound either way — a range that cannot state a rule is a range wider
-     * than the rule, and a wider bound proves less — but a caller turning a bound into a value
-     * somebody has to write needs to know the edge is where the rules stop and not merely where a
-     * range stops being able to say so.
-     */
-    public enum Loss {
-
-        /** A disequality. {@code x /= 0} is a hole in a range, and a range is all this hands over. */
-        DROPPED_DISEQUALITY,
-
-        /**
-         * A rule relating several positions, which a range at one of them cannot state.
-         *
-         * <p>Not that nothing is derived from it: what such a rule leaves each position it names is
-         * derived and is in the bounds ({@link AffineReduction}). What a range cannot carry is the
-         * relation — every point of the box is inside every position's range, and the rule refuses
-         * some of them. So a reader taking one position's range at a time is reading something true,
-         * and a reader taking a value from each and expecting the whole to satisfy the rules is not.
-         */
-        KEPT_UNPROJECTABLE
+        return new NumericDomain<>(List.of(), Map.of(), false);
     }
 
     /**
@@ -167,8 +140,8 @@ public final class NumericDomain<A> {
                 coefs, Rational.of(f.constant()), rel, knowing.kinds::get);
         return switch (read) {
             // Nothing satisfies it, so nothing satisfies it together with anything else.
-            case AffineConstraint.Read.HoldsNever<A> ignored -> new NumericDomain<>(
-                    List.of(), knowing.kinds, knowing.losses, true);
+            case AffineConstraint.Read.HoldsNever<A> ignored ->
+                    new NumericDomain<>(List.of(), knowing.kinds, true);
             // Every value satisfies it, so there is nothing to keep.
             case AffineConstraint.Read.HoldsAlways<A> ignored -> knowing;
             case AffineConstraint.Read.Stated<A> stated -> knowing.keeping(stated.constraint());
@@ -184,20 +157,11 @@ public final class NumericDomain<A> {
      */
     private NumericDomain<A> keeping(AffineConstraint<A> rule) {
         if (rules.contains(rule)) {
-            return losing(lossOf(rule), rule.form().coefs().keySet());
+            return this;
         }
         List<AffineConstraint<A>> next = new ArrayList<>(rules);
         next.add(rule);
-        return new NumericDomain<>(List.copyOf(next), kinds,
-                with(lossOf(rule), rule.form().coefs().keySet()), false);
-    }
-
-    /** What a range cannot state about the rule, or null where it can state all of it. */
-    private Loss lossOf(AffineConstraint<A> rule) {
-        if (rule instanceof AffineConstraint.Disequality) {
-            return Loss.DROPPED_DISEQUALITY;
-        }
-        return DifferenceBounds.canHold(rule) ? null : Loss.KEPT_UNPROJECTABLE;
+        return new NumericDomain<>(List.copyOf(next), kinds, false);
     }
 
     /**
@@ -250,7 +214,7 @@ public final class NumericDomain<A> {
             next.put(atom, given);
         }
         return next == null ? this
-                : new NumericDomain<>(rules, Map.copyOf(next), losses, readARuleNothingSatisfies);
+                : new NumericDomain<>(rules, Map.copyOf(next), readARuleNothingSatisfies);
     }
 
     // --- what the rules leave, worked out once ----------------------------------------------------
@@ -624,48 +588,22 @@ public final class NumericDomain<A> {
     }
 
     /**
-     * Whether everything the rules say is held in a shape {@link #boundsOf} can state.
+     * Whether both ends of {@code atom}'s range are numbers a model could write.
      *
-     * <p>False where any rule says something a range cannot: see {@link Loss}. A caller turning a
-     * projection into a value somebody has to write has to know which of the two it has.
+     * <p>The one place the exact arithmetic stops, asked about. Almost every end is written exactly
+     * — one on a position whose values step is a whole number — and an end at a value like a third
+     * is not, so what is handed over is rounded past where the rules stop. Sound, and no longer the
+     * rules' own edge, which is a thing a reader placing a row at an edge has to know.
      */
-    public boolean projectionIsLossless() {
-        return losses.isEmpty();
-    }
-
-    /** What a range at one atom cannot state of the rules about it. */
-    public Set<Loss> lossesAt(A atom) {
-        return losses.getOrDefault(atom, Set.of());
-    }
-
-    /** Every atom something is lost about. */
-    public Set<A> lossyAtoms() {
-        return losses.keySet();
-    }
-
-    private NumericDomain<A> losing(Loss loss, Set<A> atoms) {
-        Map<A, Set<Loss>> next = with(loss, atoms);
-        return next == losses ? this
-                : new NumericDomain<>(rules, kinds, next, readARuleNothingSatisfies);
-    }
-
-    private Map<A, Set<Loss>> with(Loss loss, Set<A> atoms) {
-        if (loss == null) {
-            return losses;
+    public boolean endsAreWrittenExactly(A atom) {
+        if (isBottom()) {
+            return true;   // no ends are handed over, so none of them is rounded
         }
-        Map<A, Set<Loss>> next = null;
-        for (A atom : atoms) {
-            if (losses.getOrDefault(atom, Set.of()).contains(loss)) {
-                continue;
-            }
-            if (next == null) {
-                next = new HashMap<>(losses);
-            }
-            Set<Loss> here = java.util.EnumSet.noneOf(Loss.class);
-            here.addAll(next.getOrDefault(atom, Set.of()));
-            here.add(loss);
-            next.put(atom, java.util.Collections.unmodifiableSet(here));
-        }
-        return next == null ? losses : Map.copyOf(next);
+        Box<A> box = closed().box();
+        return writtenExactly(box.leastOf(atom)) && writtenExactly(box.mostOf(atom));
+    }
+
+    private static boolean writtenExactly(RationalCut cut) {
+        return cut == null || cut.at().asWrittenDecimal() != null;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
@@ -1,30 +1,43 @@
 package souther.compiler.numeric;
 
-import souther.compiler.numeric.Place;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 /**
- * A small numeric abstract domain — a per-atom interval plus difference-bound constraints
- * ({@code a - b <= c}, the octagon-style relational part) — over named atoms. An atom is the
- * numeric content of a variable, a field chain, or a newtype's wrapped value; what names one is the
- * caller's, and {@code Terms} in the checker is where the names come from today. Constants are
- * {@link BigDecimal}; {@code null} bounds are ±infinity.
+ * What a path's rules leave the numbers in it, and what follows from them.
  *
- * <p>{@link #assume} tightens the domain along a {@code guard}/{@code if} guard or an input
- * newtype's invariant, and {@link #entails} / {@link #refutes} answer whether a construction's
- * invariant is discharged or is definitely violated on the current path — which is the
- * invariant-discharge check, the caller this was written for. What it derives is bounded to
- * interval + difference-bound; a form of neither shape is kept as it was written and nothing is
- * derived from it on its own, but it stands as a premise wherever the derived part proves the
- * difference between it and what is being asked (spec §invariant-discharge). Instances are
- * immutable — each operation returns a fresh domain, threaded functionally like
- * {@code TotalityChecker}'s scope map.
+ * <p>An atom is the numeric content of a variable, a field chain, or a newtype's wrapped value; what
+ * names one is the caller's, and {@code Terms} in the checker is where the names come from today.
+ * {@link #assume} takes in a {@code guard}/{@code if} guard or an input newtype's invariant, and
+ * {@link #entails} / {@link #refutes} answer whether a construction's invariant is discharged or is
+ * definitely violated on the current path — which is the invariant-discharge check, the caller this
+ * was written for.
+ *
+ * <p><b>What is held is the rules, and everything else is worked out from them.</b> A rule arrives,
+ * is read into the one form every writing of it comes to ({@link AffineConstraint}), and is kept.
+ * Nothing is decided at the moment it arrives that depends on what had arrived before it. What the
+ * rules leave is derived from all of them at once ({@link ClosedState}), once, when something asks.
+ *
+ * <p>That is not how this worked, and the difference is visible. A rule used to be sorted into a
+ * bound, a difference, or a bucket of forms nothing read back, and the sorting looked at the
+ * coefficients as they were typed — so {@code 2a - 2b <= 4} and {@code a - b <= 2} went to different
+ * places and only one of them bounded anything. A disequality was turned into a bound or dropped
+ * depending on what happened to be known at that moment, so {@code x /= 0} beside {@code x >= 0}
+ * left {@code x} at nought or above according to which was written first. And a rule over several
+ * positions was read only as something to subtract from a goal, never as something that narrows the
+ * positions it names, so every range handed downstream was short of what the rules said.
+ *
+ * <p>Instances are immutable — each operation returns a fresh domain, threaded functionally like
+ * {@code TotalityChecker}'s scope map. Constants are {@link BigDecimal} at the edges, because that is
+ * what a carrier counts in and what a model writes; inside, the arithmetic is exact
+ * ({@link Rational}), since dividing is what deriving a bound does and neither of those is closed
+ * under it.
  */
 public final class NumericDomain<A> {
 
@@ -69,63 +82,74 @@ public final class NumericDomain<A> {
         }
     }
 
-    /** A form asserted {@code f <= 0} (or {@code f < 0}) and kept as written, because its shape is
-     * neither an interval nor a difference. */
-    private record Asserted<A>(LinearForm<A> f, boolean strict) {}
+    /**
+     * How many digits a bound is written out to where it is not a decimal at all.
+     *
+     * <p>Almost never reached. A bound on a position whose values step lands on a whole number, and
+     * a bound on one whose values fill is usually a decimal too; what is left is a bound at a value
+     * like a third, which no decimal is. Rounded outward when it happens, so what is handed over
+     * still admits everything the rules admit.
+     */
+    private static final int DIGITS_WHEN_IT_IS_NOT_A_DECIMAL = 34;
 
-    private final boolean bottom;                              // an infeasible path (guards contradict)
-    private final Map<A, Endpoint> lo;                    // atom -> lower bound (absent = -inf)
-    private final Map<A, Endpoint> hi;                    // atom -> upper bound (absent = +inf)
-    private final Map<A, Map<A, Endpoint>> diff;     // diff[a][b] = tightest known (a - b)
-    private final List<Asserted<A>> kept;                         // forms outside both shapes, as written
-    private final Map<A, Granularity> kinds;              // atom -> how its values are spaced
-    private final Map<A, Set<Loss>> losses;               // atom -> what was not recorded of it
-    private Map<A, Map<A, Endpoint>> closed;         // diff closed transitively, on first ask
+    private final List<AffineConstraint<A>> rules;
+    private final Map<A, Granularity> kinds;
+    private final Map<A, Set<Loss>> losses;
+    private final boolean readARuleNothingSatisfies;
+    private ClosedState<A> closed;
 
-    private NumericDomain(boolean bottom, Map<A, Endpoint> lo, Map<A, Endpoint> hi,
-                          Map<A, Map<A, Endpoint>> diff, List<Asserted<A>> kept,
-                          Map<A, Granularity> kinds, Map<A, Set<Loss>> losses) {
-        this.bottom = bottom;
-        this.lo = lo;
-        this.hi = hi;
-        this.diff = diff;
-        this.kept = kept;
+    private NumericDomain(List<AffineConstraint<A>> rules, Map<A, Granularity> kinds,
+                          Map<A, Set<Loss>> losses, boolean readARuleNothingSatisfies) {
+        this.rules = rules;
         this.kinds = kinds;
         this.losses = losses;
+        this.readARuleNothingSatisfies = readARuleNothingSatisfies;
     }
 
     public static <A> NumericDomain<A> top() {
-        return new NumericDomain<>(false, Map.of(), Map.of(), Map.of(), List.of(), Map.of(), Map.of());
+        return new NumericDomain<>(List.of(), Map.of(), Map.of(), false);
     }
 
     /**
-     * A way an assertion arrived holding more than the domain kept of it.
+     * A way an assertion arrived holding more than a range can state.
      *
-     * <p>Recorded where it happens rather than read back afterwards. What the bounds say is sound
-     * either way — everything dropped here was a narrowing, and a wider bound proves less — but a
-     * caller turning a bound into a value somebody has to write needs to know the edge is where the
-     * rules stop and not merely where this stopped reading them.
+     * <p>What the bounds say is sound either way — a range that cannot state a rule is a range wider
+     * than the rule, and a wider bound proves less — but a caller turning a bound into a value
+     * somebody has to write needs to know the edge is where the rules stop and not merely where a
+     * range stops being able to say so.
      */
     public enum Loss {
 
-        /** A disequality. {@code x /= 0} is a hole in a range, and a range is all this holds. */
+        /** A disequality. {@code x /= 0} is a hole in a range, and a range is all this hands over. */
         DROPPED_DISEQUALITY,
 
-        /** A form that is neither an interval nor a difference, kept as written. It proves things
-         * ({@link #entails} reads it, as a premise as well as a match) and no bound is derived
-         * through it — {@link #boundsOf} does not read it, so a projection is short of what the
-         * rules said. */
+        /**
+         * A rule relating several positions, which a range at one of them cannot state.
+         *
+         * <p>Not that nothing is derived from it: what such a rule leaves each position it names is
+         * derived and is in the bounds ({@link AffineReduction}). What a range cannot carry is the
+         * relation — every point of the box is inside every position's range, and the rule refuses
+         * some of them. So a reader taking one position's range at a time is reading something true,
+         * and a reader taking a value from each and expecting the whole to satisfy the rules is not.
+         */
         KEPT_UNPROJECTABLE
     }
 
+    /**
+     * Whether the rules leave nothing at all, in which case the path is not reached.
+     *
+     * <p>True is a proof and false is not — see {@link ClosedState#holdsNothing}. Everything that
+     * narrows is implied by the rules, so an emptied box is one the rules emptied; the rounds can
+     * stop early, so a box that has not emptied is not a box with a value in it.
+     */
     public boolean isBottom() {
-        return bottom;
+        return readARuleNothingSatisfies || closed().holdsNothing();
     }
 
-    // --- assume: tighten along `f rel 0` -------------------------------------------------------
+    // --- assume: take in one more rule ------------------------------------------------------------
 
     /**
-     * The domain refined by asserting {@code f rel 0}.
+     * The domain with {@code f rel 0} taken in.
      *
      * @param atomKinds how the values of each atom of {@code f} are spaced. Required rather than
      *                  defaulted: an atom whose spacing is guessed is one a strict bound is either
@@ -133,34 +157,47 @@ public final class NumericDomain<A> {
      *                  failure anywhere near where the guess was made.
      */
     public NumericDomain<A> assume(LinearForm<A> f, Rel rel, Map<A, Granularity> atomKinds) {
-        NumericDomain<A> d = knowing(f.coefs().keySet(), atomKinds);
-        if (d.bottom) {
-            return d;
+        NumericDomain<A> knowing = knowing(f.coefs().keySet(), atomKinds);
+        if (knowing.readARuleNothingSatisfies) {
+            return knowing;
         }
-        if (rel == Rel.NE) {
-            // `f != 0` is a disjunction, and the domain holds conjunctions of bounds — except where
-            // one of the two sides is already out. A count is never below none, so `count != 0` is
-            // `count > 0` and there is no disjunction left to drop: the same rule the author wrote
-            // one way rather than the other. Asked of what is known here rather than of the shape of
-            // the form, so it holds wherever a side has been established, however it was.
-            if (!f.coefs().isEmpty()) {
-                if (d.proveLe(f.negate(), false)) {
-                    return d.addLe(f.negate(), true);       // `f >= 0` was known, so `f > 0`
-                }
-                if (d.proveLe(f, false)) {
-                    return d.addLe(f, true);                // `f <= 0` was known, so `f < 0`
-                }
-            }
-            // Otherwise nothing to record; what settles such a guard is the fact keyed on the
-            // comparison itself.
-            return f.coefs().isEmpty() ? d
-                    : d.losing(Loss.DROPPED_DISEQUALITY, f.coefs().keySet());
+        Map<A, Rational> coefs = new LinkedHashMap<>();
+        f.coefs().forEach((atom, coef) -> coefs.put(atom, Rational.of(coef)));
+        AffineConstraint.Read<A> read = AffineConstraint.of(
+                coefs, Rational.of(f.constant()), rel, knowing.kinds::get);
+        return switch (read) {
+            // Nothing satisfies it, so nothing satisfies it together with anything else.
+            case AffineConstraint.Read.HoldsNever<A> ignored -> new NumericDomain<>(
+                    List.of(), knowing.kinds, knowing.losses, true);
+            // Every value satisfies it, so there is nothing to keep.
+            case AffineConstraint.Read.HoldsAlways<A> ignored -> knowing;
+            case AffineConstraint.Read.Stated<A> stated -> knowing.keeping(stated.constraint());
+        };
+    }
+
+    /**
+     * The domain with one more rule kept.
+     *
+     * <p>Kept and not merged into anything. A rule said twice is the same rule and the same key, so
+     * the second saying adds nothing — which is what makes the answer a function of which rules were
+     * said rather than of how often each was.
+     */
+    private NumericDomain<A> keeping(AffineConstraint<A> rule) {
+        if (rules.contains(rule)) {
+            return losing(lossOf(rule), rule.form().coefs().keySet());
         }
-        if (rel == Rel.EQ) {
-            return d.addLe(f, false).addLe(f.negate(), false);
+        List<AffineConstraint<A>> next = new ArrayList<>(rules);
+        next.add(rule);
+        return new NumericDomain<>(List.copyOf(next), kinds,
+                with(lossOf(rule), rule.form().coefs().keySet()), false);
+    }
+
+    /** What a range cannot state about the rule, or null where it can state all of it. */
+    private Loss lossOf(AffineConstraint<A> rule) {
+        if (rule instanceof AffineConstraint.Disequality) {
+            return Loss.DROPPED_DISEQUALITY;
         }
-        // Reduce `f rel 0` to `g <= 0` (or `g < 0`): negate the form for >=/>, keep it for <=/<.
-        return d.addLe(negOf(rel) ? f.negate() : f, strictOf(rel));
+        return DifferenceBounds.canHold(rule) ? null : Loss.KEPT_UNPROJECTABLE;
     }
 
     /**
@@ -185,7 +222,6 @@ public final class NumericDomain<A> {
         return out;
     }
 
-
     /**
      * The domain with the spacing of each of {@code atoms} recorded.
      *
@@ -206,8 +242,7 @@ public final class NumericDomain<A> {
                 continue;
             }
             if (had != null) {
-                throw new IllegalStateException(
-                        "atom `" + atom + "` is " + had + " and " + given);
+                throw new IllegalStateException("atom `" + atom + "` is " + had + " and " + given);
             }
             if (next == null) {
                 next = new HashMap<>(kinds);
@@ -215,226 +250,124 @@ public final class NumericDomain<A> {
             next.put(atom, given);
         }
         return next == null ? this
-                : new NumericDomain<>(bottom, lo, hi, diff, kept, Map.copyOf(next), losses);
+                : new NumericDomain<>(rules, Map.copyOf(next), losses, readARuleNothingSatisfies);
     }
+
+    // --- what the rules leave, worked out once ----------------------------------------------------
 
     /**
-     * Assert {@code g <= 0} (or {@code g < 0} when strict), updating an interval or a difference, or
-     * keeping the form as written when it is neither.
+     * The rules worked out, derived on the first question asked of them and kept.
      *
-     * <p>What strictness is worth depends on what the atoms are made of. Over whole numbers there is
-     * a next value to step to, so {@code a < 3} is {@code a <= 2} and {@code a - b < 0} is
-     * {@code a - b <= -1}, and the end that lands there is one the rule admits. Over decimals there
-     * is no step, and the end stays where the constraint put it and says that the value is not its
-     * own. A form of neither shape keeps its strictness as written.
+     * <p>Not while they are arriving. What a rule leaves depends on the others, and half of them have
+     * not been said yet when it is said — a bound written down at that moment is a bound that depends
+     * on the order, which is the thing this arrangement exists to be rid of.
      */
-    private NumericDomain<A> addLe(LinearForm<A> g, boolean strict) {
-        if (bottom) {
-            // Nothing holds here, so nothing asserted of it holds either. Read again rather than
-            // built on: a bottom domain keeps no bounds, and the sisters below derive feasibility
-            // from the bounds they are handed, so one more assertion would come back a domain in
-            // which only that assertion is known. An equality is two of these in a row, which is
-            // where a contradicted one came back satisfiable.
-            return this;
+    private ClosedState<A> closed() {
+        if (closed == null) {
+            closed = ClosedState.of(rules, kinds::get);
         }
-        Map<A, BigDecimal> c = g.coefs();
-        if (c.isEmpty()) {
-            boolean ok = strict ? g.constant().signum() < 0 : g.constant().signum() <= 0;
-            return ok ? this : bottom();
-        }
-        if (c.size() == 1) {
-            Map.Entry<A, BigDecimal> e = c.entrySet().iterator().next();
-            A a = e.getKey();
-            BigDecimal k = e.getValue();
-            // k·a + const <= 0  =>  a <= -const/k (k>0, an upper bound)  or  a >= -const/k (k<0, a
-            // lower bound). Round an inexact quotient conservatively — toward +inf for an upper bound,
-            // toward -inf for a lower bound — so the recorded bound is never tighter than the true one.
-            // A tighter-than-true bound would make entails/refutes unsound (a false E2010).
-            boolean upper = k.signum() > 0;
-            java.math.MathContext mc = new java.math.MathContext(
-                    34, upper ? java.math.RoundingMode.CEILING : java.math.RoundingMode.FLOOR);
-            BigDecimal bound = g.constant().negate().divide(k, mc);
-            Endpoint end = kinds.get(a) == Granularity.DISCRETE
-                    ? Endpoint.inclusive(whole(bound, upper, strict))
-                    : new Endpoint(Count.of(bound), !strict);
-            return upper ? withHi(a, end) : withLo(a, end);
-        }
-        List<A> ab = unitDiffAtoms(c);
-        if (ab != null) {
-            // a - b <= -const. A difference of two whole numbers is a whole number, and only then:
-            // one dense atom on either side leaves the difference with no smallest step, so the
-            // bound stays where the constant put it and says the value is outside it.
-            BigDecimal bound = g.constant().negate();
-            Endpoint end = kinds.get(ab.get(0)) == Granularity.DISCRETE
-                    && kinds.get(ab.get(1)) == Granularity.DISCRETE
-                    ? Endpoint.inclusive(whole(bound, true, strict))
-                    : new Endpoint(Count.of(bound), !strict);
-            return withDiff(ab.get(0), ab.get(1), end);
-        }
-        // Neither shape holds it — a sum of two lengths, say. Keeping the form as written is what lets
-        // a guard restating an invariant discharge it, which is the promise the flagging rests on.
-        List<Asserted<A>> next = new ArrayList<>(kept);
-        next.add(new Asserted(g, strict));
-        return new NumericDomain<>(false, lo, hi, diff, List.copyOf(next), kinds,
-                with(Loss.KEPT_UNPROJECTABLE, c.keySet()));
+        return closed;
     }
 
-    /**
-     * A bound on a whole number, tightened to one.
-     *
-     * <p>Never past the true bound. An upper bound admits everything up to {@code q}, so the largest
-     * whole number it admits is {@code floor(q)}; a strict one stops short of {@code q}, so the
-     * largest is the whole number below it, {@code ceil(q) - 1} — which is {@code q - 1} where
-     * {@code q} is whole and {@code floor(q)} where it is not. Lower bounds are the mirror.
-     *
-     * @param q      the bound as the arithmetic left it, already rounded away from the constraint
-     * @param upper  whether {@code q} bounds the atom above
-     * @param strict whether the value {@code q} itself is outside what the constraint admits
-     */
-    private static Count whole(BigDecimal q, boolean upper, boolean strict) {
-        Count at = Count.of(q);
-        if (upper) {
-            return strict ? at.rounded(java.math.RoundingMode.CEILING).minus(1)
-                    : at.rounded(java.math.RoundingMode.FLOOR);
-        }
-        return strict ? at.rounded(java.math.RoundingMode.FLOOR).plus(1)
-                : at.rounded(java.math.RoundingMode.CEILING);
-    }
+    // --- entails / refutes --------------------------------------------------------------------------
 
-    /** The two atoms of a unit difference {@code {a:+1, b:-1}} as {@code {a, b}}, or {@code null} if
-     * {@code c} is not a two-atom form with coefficients +1 and -1. */
-    private static <A> List<A> unitDiffAtoms(Map<A, BigDecimal> c) {
-        if (c.size() != 2) {
-            return null;
-        }
-        A a = null;
-        A b = null;
-        for (Map.Entry<A, BigDecimal> e : c.entrySet()) {
-            if (e.getValue().compareTo(BigDecimal.ONE) == 0) {
-                a = e.getKey();
-            } else if (e.getValue().compareTo(BigDecimal.ONE.negate()) == 0) {
-                b = e.getKey();
-            } else {
-                return null;
-            }
-        }
-        return a != null && b != null ? List.of(a, b) : null;
-    }
-
-    /** True for {@code GT}/{@code LT} (a strict comparison). */
-    private static boolean strictOf(Rel rel) {
-        return rel == Rel.GT || rel == Rel.LT;
-    }
-
-    /** True for {@code GE}/{@code GT} — the form is negated to reduce the comparison to {@code <= 0}. */
-    private static boolean negOf(Rel rel) {
-        return rel == Rel.GE || rel == Rel.GT;
-    }
-
-    // --- entails / refutes ---------------------------------------------------------------------
-
-    /** Whether the domain proves {@code f rel 0} (the construction's invariant is discharged). */
+    /** Whether the rules prove {@code f rel 0} — the construction's invariant is discharged. */
     public boolean entails(LinearForm<A> f, Rel rel) {
         return entails(f, rel, true);
     }
 
     /**
-     * Whether what is <em>projected</em> out of this proves {@code f rel 0}.
+     * Whether what is <em>handed over</em> proves {@code f rel 0}.
      *
-     * <p>The bounds a reader downstream is handed, and not the relations kept beside them. A form
-     * neither an interval nor a difference holds is kept as written and marked
-     * {@link Loss#KEPT_UNPROJECTABLE} for exactly that reason — {@link #boundsOf} does not read it —
-     * so asking {@link #entails} whether the projection still holds such a form is asking the form
-     * to stand on itself, and everything the projection dropped comes back proven.
+     * <p>The bounds a reader downstream is given, and not the rules beside them. A rule relating
+     * several positions narrows each of them and is still not something a range states, so asking
+     * whether the ranges alone hold it is asking a different question from whether the rules do —
+     * and it is the question a caller deciding how much of the rules the bounds say wants.
      *
-     * <p>A caller deciding how much of the rules the bounds state wants this. A caller deciding
-     * whether a construction discharges its invariant wants the other one: what is known there is
-     * everything this holds, however it holds it.
+     * <p>A caller deciding whether a construction discharges its invariant wants the other one: what
+     * is known there is everything the rules say, however they say it.
      */
     public boolean projectionEntails(LinearForm<A> f, Rel rel) {
         return entails(f, rel, false);
     }
 
-    private boolean entails(LinearForm<A> f, Rel rel, boolean withKept) {
-        if (bottom) {
+    private boolean entails(LinearForm<A> f, Rel rel, boolean withRules) {
+        if (isBottom()) {
             return true;   // an infeasible path discharges anything
         }
-        if (rel == Rel.EQ) {
-            return prove(f, false, withKept) && prove(f.negate(), false, withKept);
-        }
-        if (rel == Rel.NE) {
-            // `f < 0`, or `f > 0`
-            return prove(f, true, withKept) || prove(f.negate(), true, withKept);
-        }
-        return prove(negOf(rel) ? f.negate() : f, strictOf(rel), withKept);
+        Goal<A> goal = goalOf(f);
+        return switch (rel) {
+            case LE -> proves(goal, false, withRules);
+            case LT -> proves(goal, true, withRules);
+            case GE -> proves(goal.negated(), false, withRules);
+            case GT -> proves(goal.negated(), true, withRules);
+            case EQ -> proves(goal, false, withRules) && proves(goal.negated(), false, withRules);
+            case NE -> proves(goal, true, withRules) || proves(goal.negated(), true, withRules);
+        };
     }
 
-    private boolean prove(LinearForm<A> g, boolean strict, boolean withKept) {
-        return withKept ? proveLe(g, strict) : proveBaseLe(g, strict);
-    }
-
-    /** Whether the domain proves {@code ¬(f rel 0)} — the invariant is <em>definitely</em> violated
-     * on this path (a compile error, the path-sensitive generalization of the constant check). The
-     * negation flips both bits of the comparison: {@code ¬(f >= 0)} is {@code f < 0}, etc. */
+    /**
+     * Whether the rules prove {@code ¬(f rel 0)} — the invariant is <em>definitely</em> violated on
+     * this path, which is a compile error rather than an undischarged obligation. The negation flips
+     * both bits of the comparison: {@code ¬(f >= 0)} is {@code f < 0}.
+     */
     public boolean refutes(LinearForm<A> f, Rel rel) {
-        if (bottom || rel == Rel.EQ) {
+        if (isBottom() || rel == Rel.EQ) {
             return false;   // an unreachable path violates nothing; equality is never refuted here
         }
         if (rel == Rel.NE) {
             return entails(f, Rel.EQ);   // proving it equal is proving it not unequal
         }
-        return proveLe(negOf(rel) ? f : f.negate(), !strictOf(rel));
+        Goal<A> goal = goalOf(f);
+        return switch (rel) {
+            case GE, GT -> proves(goal, rel == Rel.GE, true);
+            default -> proves(goal.negated(), rel == Rel.LE, true);
+        };
+    }
+
+    /** A goal as a weighted sum and a constant, which is what a comparison against nought is. */
+    private record Goal<A>(Map<A, Rational> coefs, Rational constant) {
+
+        Goal<A> negated() {
+            Map<A, Rational> out = new LinkedHashMap<>();
+            coefs.forEach((atom, coef) -> out.put(atom, coef.negated()));
+            return new Goal<>(out, constant.negated());
+        }
+    }
+
+    private Goal<A> goalOf(LinearForm<A> f) {
+        Map<A, Rational> coefs = new LinkedHashMap<>();
+        f.coefs().forEach((atom, coef) -> coefs.put(atom, Rational.of(coef)));
+        return new Goal<>(coefs, Rational.of(f.constant()));
     }
 
     /**
-     * Whether {@code g <= 0} (or {@code g < 0} when strict) follows from the domain.
+     * Whether {@code Σ c·x + k <= 0} (or {@code < 0}) follows.
      *
-     * <p>Two ways to reach it, and the second reads the first. A form kept as written is a premise
-     * and not only something a goal is matched against: {@code f <= 0} together with
-     * {@code g - f <= 0} gives {@code g <= 0}, so a relation of neither shape carries onward wherever
-     * the derived fragment proves the difference between it and the goal. That is what relates a
-     * guard over a computed value to what the type of the value it was compared against guarantees —
-     * the two land in different shapes, and neither is the other's to derive.
+     * <p>Two ways, and the second reads the first. What the box leaves the goal's own positions
+     * bounds it; and a rule kept as written carries a goal onward wherever the box proves the
+     * difference between the two — {@code f <= 0} together with {@code g - f <= 0} gives
+     * {@code g <= 0}. That is what relates a guard over a computed value to what the type of the
+     * value it was compared against guarantees.
      *
-     * <p>One premise, once. The residual is proven against the derived fragment alone
-     * ({@link #proveBaseLe}), so two kept relations are never added together. Closing the kept
-     * relations over each other is arbitrary linear reasoning and a different fragment to state; this
-     * one is what the domain already decides in, reached through one relation it does not.
+     * <p>One rule, once. The residual is proven against the box alone, so two rules are never added
+     * together through this. What the box already holds of them is another matter and is not this
+     * step: the rules that narrow it have all been read into it, each on its own.
      */
-    private boolean proveLe(LinearForm<A> g, boolean strict) {
-        if (proveBaseLe(g, strict)) {
+    private boolean proves(Goal<A> goal, boolean strict, boolean withRules) {
+        if (provenByTheBox(goal, strict)) {
             return true;
         }
-        for (Asserted a : kept) {
-            // The goal is strict where either the premise or the residual is, so what the residual is
-            // asked for is what the premise did not already give.
-            if (proveBaseLe(g.minus(a.f()), strict && !a.strict())) {
-                return true;
-            }
+        if (!withRules) {
+            return false;
         }
-        return false;
-    }
-
-    /** The same over what this derives in: an interval bound on the whole form, or a bound on a
-     * difference of two atoms read through the closure. The kept relations are not read here — this
-     * is what a residual is proven against, and reading them would let one stand on another. */
-    private boolean proveBaseLe(LinearForm<A> g, boolean strict) {
-        Endpoint hiG = upperBound(g);
-        if (hiG != null) {
-            int s = at(hiG).signum();
-            // An end at zero the form's own bounds do not reach proves the strict form: nothing the
-            // domain admits gets there, which is what `g < 0` asks.
-            if (s < 0 || (s == 0 && (!strict || !hiG.inclusive()))) {
-                return true;
-            }
-        }
-        List<A> ab = unitDiffAtoms(g.coefs());
-        if (ab != null) {
-            Endpoint diffBound = closedDiff(ab.get(0), ab.get(1));     // proven upper bound on (a - b)
-            if (diffBound != null) {
-                Count bound = Count.of(g.constant().negate());   // want a - b <= -const
-                int s = at(diffBound).compareTo(bound);
-                if (s < 0 || (s == 0 && (!strict || !diffBound.inclusive()))) {
+        for (AffineConstraint<A> rule : rules) {
+            for (AffineConstraint.HalfSpace<A> premise : asHalfSpaces(rule)) {
+                // `premise.form <= premise.bound` taken off the goal leaves a residual the box has
+                // to prove. The goal is strict where either the premise or the residual is, so what
+                // the residual is asked for is what the premise did not already give.
+                Goal<A> residual = subtracting(goal, premise);
+                if (provenByTheBox(residual, strict && premise.bound().inclusive())) {
                     return true;
                 }
             }
@@ -442,136 +375,169 @@ public final class NumericDomain<A> {
         return false;
     }
 
-    /**
-     * The interval upper bound of {@code f}, or {@code null} if unbounded above.
-     *
-     * <p>The end is the form's own only where every end it was added from is. One term that cannot
-     * reach its edge is one the sum cannot reach either, so a single exclusive contribution makes the
-     * total exclusive.
-     */
-    private Endpoint upperBound(LinearForm<A> f) {
-        Count acc = Count.of(f.constant());
-        boolean inclusive = true;
-        for (Map.Entry<A, BigDecimal> e : f.coefs().entrySet()) {
-            BigDecimal k = e.getValue();
-            Endpoint b = k.signum() > 0 ? bestHi(e.getKey()) : bestLo(e.getKey());
-            if (b == null) {
-                return null;   // unbounded in the contributing direction
-            }
-            acc = acc.plus(at(b).times(k));
-            inclusive &= b.inclusive();
-        }
-        return new Endpoint(acc, inclusive);
+    private static <A> List<AffineConstraint.HalfSpace<A>> asHalfSpaces(AffineConstraint<A> rule) {
+        return switch (rule) {
+            case AffineConstraint.HalfSpace<A> half -> List.of(half);
+            case AffineConstraint.Equality<A> at -> List.of(
+                    new AffineConstraint.HalfSpace<>(at.form(), RationalCut.inclusive(at.at())),
+                    new AffineConstraint.HalfSpace<>(at.form().negated(),
+                            RationalCut.inclusive(at.at().negated())));
+            case AffineConstraint.Disequality<A> hole -> List.of();
+        };
     }
 
-    /** The tightest upper bound on an atom: its own, or one reached through a difference —
-     * {@code a - b <= d} and {@code b <= c} give {@code a <= c + d}, which is what relates the size of
-     * a filtered list to a bound on the list it came from. A value at the end reached that way needs
-     * every end on the way to be reachable, so the derived end is its own only where both are. */
-    private Endpoint bestHi(A a) {
-        Endpoint best = hi.get(a);
-        for (Map.Entry<A, Endpoint> b : hi.entrySet()) {
-            if (b.getKey().equals(a)) {
-                continue;
+    /** {@code goal - (premise.form - premise.bound)}, which is what is left to prove once the
+     *  premise has been used. */
+    private Goal<A> subtracting(Goal<A> goal, AffineConstraint.HalfSpace<A> premise) {
+        Map<A, Rational> coefs = new LinkedHashMap<>(goal.coefs());
+        premise.form().coefs().forEach((atom, coef) ->
+                coefs.merge(atom, coef.negated(), Rational::plus));
+        coefs.values().removeIf(Rational::isZero);
+        return new Goal<>(coefs, goal.constant().plus(premise.bound().at()));
+    }
+
+    /** Whether what the rules leave the goal's positions already puts the goal below nought. */
+    private boolean provenByTheBox(Goal<A> goal, boolean strict) {
+        RationalCut highest = highestOf(goal);
+        if (highest == null) {
+            return false;
+        }
+        int sign = highest.at().signum();
+        // An end at nought the goal's own bounds do not reach proves the strict form: nothing the
+        // rules admit gets there, which is what `< 0` asks.
+        return sign < 0 || (sign == 0 && (!strict || !highest.inclusive()));
+    }
+
+    /**
+     * The highest the goal comes to, or null where nothing bounds it above.
+     *
+     * <p>Its positions' own ends, and the relation on a difference of two of them where the goal has
+     * that shape. The end is the goal's own only where every end it was added from is: one term that
+     * cannot reach its edge is one the sum cannot reach either.
+     */
+    private RationalCut highestOf(Goal<A> goal) {
+        if (goal.coefs().isEmpty()) {
+            return RationalCut.inclusive(goal.constant());
+        }
+        ClosedState<A> state = closed();
+        Box<A> box = state.box();
+        Rational at = goal.constant();
+        boolean reached = true;
+        RationalCut summed = null;
+        for (Map.Entry<A, Rational> each : goal.coefs().entrySet()) {
+            Rational coef = each.getValue();
+            RationalCut end = coef.signum() > 0
+                    ? box.mostOf(each.getKey()) : box.leastOf(each.getKey());
+            if (end == null) {
+                summed = null;
+                break;
             }
-            Endpoint d = closedDiff(a, b.getKey());
-            if (d == null) {
-                continue;
+            at = at.plus(coef.times(end.at()));
+            reached &= end.inclusive();
+            summed = new RationalCut(at, reached);
+        }
+        RationalCut best = summed;
+        List<A> apart = unitDifference(goal.coefs());
+        if (apart != null) {
+            RationalCut difference =
+                    state.differences().differenceBound(apart.get(0), apart.get(1));
+            if (difference != null) {
+                best = RationalCut.tighterUpper(best, new RationalCut(
+                        difference.at().plus(goal.constant()), difference.inclusive()));
             }
-            best = Endpoint.upper(best, new Endpoint(at(b.getValue()).plus(at(d)),
-                    b.getValue().inclusive() && d.inclusive()));
         }
         return best;
     }
 
-    /** The tightest lower bound on an atom, the same way: {@code b - a <= d} and {@code b >= c} give
-     * {@code a >= c - d}. */
-    private Endpoint bestLo(A a) {
-        Endpoint best = lo.get(a);
-        for (Map.Entry<A, Endpoint> b : lo.entrySet()) {
-            if (b.getKey().equals(a)) {
-                continue;
-            }
-            Endpoint d = closedDiff(b.getKey(), a);
-            if (d == null) {
-                continue;
-            }
-            best = Endpoint.lower(best, new Endpoint(at(b.getValue()).minus(at(d)),
-                    b.getValue().inclusive() && d.inclusive()));
+    /** The two atoms of {@code a - b}, or null where the goal is not one. */
+    private static <A> List<A> unitDifference(Map<A, Rational> coefs) {
+        if (coefs.size() != 2) {
+            return null;
         }
-        return best;
+        A up = null;
+        A down = null;
+        for (Map.Entry<A, Rational> each : coefs.entrySet()) {
+            if (each.getValue().equals(Rational.ONE)) {
+                up = each.getKey();
+            } else if (each.getValue().equals(Rational.ONE.negated())) {
+                down = each.getKey();
+            } else {
+                return null;
+            }
+        }
+        return up == null || down == null ? null : List.of(up, down);
     }
 
-    // --- reading the domain back ------------------------------------------------------------------
+    // --- reading the domain back --------------------------------------------------------------------
 
     /**
-     * The tightest bounds this proves on one atom, {@code null} at either end where it proves none.
-     *
-     * <p>Through the differences, not off the atom's own record: {@code a - b <= 0} with
-     * {@code b <= 1440} bounds {@code a} at 1440 though nothing was ever asserted about {@code a}
-     * alone. That is the whole point of asking here rather than reading what was put in.
-     */
-    public Bounds boundsOf(A atom) {
-        return bottom ? new Bounds(null, null) : new Bounds(bestLo(atom), bestHi(atom));
-    }
-
-    /**
-     * The tightest bounds this proves on a whole form, {@code null} at either end where it proves
+     * The tightest bounds the rules prove on one atom, {@code null} at either end where they prove
      * none.
      *
-     * <p>The same reading {@link #proveLe} decides a comparison by, asked for the end rather than
-     * for an answer about one: the atoms' own bounds through the differences, and the relation on a
-     * difference of two of them where that is the shape the form has. A caller adding up what is
-     * known atom by atom would be a second reading of this — and it would come back with nothing
-     * where the domain holds a relation between two atoms and no bound on either.
-     *
-     * <p>Read for a value the domain cannot carry: a product of two values and a truncating
-     * quotient are outside the fragment, and what they answer is bounded by what their parts are
-     * proven to lie between. The kept relations are not read here, for the reason they are not read
-     * in {@link #proveBaseLe}.
+     * <p>Everything the rules say and not what was written down about the atom alone: a difference
+     * carries a bound from another position, and a rule over several positions leaves each of them
+     * whatever the others cannot help taking. That is the whole point of asking here rather than
+     * reading back what was put in.
      */
-    public Bounds boundsOf(LinearForm<A> f) {
-        if (bottom) {
+    public Bounds boundsOf(A atom) {
+        if (isBottom()) {
             return new Bounds(null, null);
         }
-        return new Bounds(negated(highestOf(f.negate())), highestOf(f));
+        Box<A> box = closed().box();
+        return new Bounds(written(box.leastOf(atom), false), written(box.mostOf(atom), true));
     }
 
-    /** The tightest upper end this proves on {@code f}: its atoms' bounds, and the relation on a
-     * difference where the form is one. */
-    private Endpoint highestOf(LinearForm<A> f) {
-        Endpoint best = upperBound(f);
-        List<A> ab = unitDiffAtoms(f.coefs());
-        if (ab == null) {
-            return best;
+    /**
+     * The tightest bounds the rules prove on a whole form.
+     *
+     * <p>Read for a value the rules cannot carry directly: a product of two positions and a
+     * truncating quotient are outside what this reasons in, and what they answer is bounded by what
+     * their parts are proven to lie between.
+     */
+    public Bounds boundsOf(LinearForm<A> f) {
+        if (isBottom()) {
+            return new Bounds(null, null);
         }
-        Endpoint d = closedDiff(ab.get(0), ab.get(1));
-        // a - b <= d, so the form, which is that difference and a constant, is no higher than both.
-        return d == null ? best
-                : Endpoint.upper(best,
-                        new Endpoint(at(d).plus(Count.of(f.constant())), d.inclusive()));
+        Goal<A> goal = goalOf(f);
+        RationalCut highest = highestOf(goal);
+        RationalCut lowest = highestOf(goal.negated());
+        return new Bounds(
+                lowest == null ? null
+                        : written(new RationalCut(lowest.at().negated(), lowest.inclusive()), false),
+                written(highest, true));
     }
 
-    /** An end on the other side of zero, which is what an upper end of the negated form is. */
-    private static Endpoint negated(Endpoint end) {
-        return end == null ? null : new Endpoint(at(end).negate(), end.inclusive());
+    /**
+     * A cut as a number somebody can write.
+     *
+     * <p>The one place the exact arithmetic stops. Almost every bound is already a decimal — one on a
+     * position whose values step is a whole number — and a bound at a value like a third is not, so
+     * it is written out to as many digits as it takes and rounded the way that widens. What is handed
+     * over then admits everything the rules admit and a hair besides, which is the safe direction: a
+     * reader refusing a value the rules leave is the failure nothing downstream can see.
+     */
+    private Endpoint written(RationalCut cut, boolean upper) {
+        if (cut == null) {
+            return null;
+        }
+        BigDecimal exactly = cut.at().asWrittenDecimal();
+        if (exactly != null) {
+            return new Endpoint(new Count(exactly), cut.inclusive());
+        }
+        BigDecimal outward = cut.at().asDecimal(
+                upper ? RoundingMode.CEILING : RoundingMode.FLOOR,
+                DIGITS_WHEN_IT_IS_NOT_A_DECIMAL);
+        // Rounded outward, the number itself is past where the rules stop, so it is admitted.
+        return new Endpoint(new Count(outward), true);
     }
 
     /**
      * Every atom this domain says anything about.
      *
      * <p>What it is for is the other side of it: an atom outside this is one no question asked here
-     * can reach. A question is asked of a form, and the answer reads the form's own atoms' ends and
-     * then leaves them by two routes only — the differences, which {@link #closedDiff} carries a
-     * bound through, and the relations kept as written, which {@link #proveLe} subtracts from a
-     * goal. Every atom on either route arrived through {@link #assume} and so is here. So asserting
-     * something about an atom this does not speak of cannot change what it proves about anything
-     * else, which is what lets a caller deriving bounds decide whose bounds are worth deriving.
-     *
-     * <p>Generous where it is uncertain. An atom named in an assertion this could not record — a
-     * disequality, a form kept as written — is here, because what was dropped is a narrowing and the
-     * atom is still one a relation was written about. Answering with the atoms of the bounds alone
-     * would be reading back what was stored rather than saying what can be reached.
+     * can reach, so asserting something about it cannot change what is proven about anything else.
+     * Generous where it is uncertain — an atom named in a rule that narrows nothing is still here,
+     * because it is one a rule was written about.
      */
     public Set<A> atomsSpokenOf() {
         return kinds.keySet();
@@ -587,20 +553,6 @@ public final class NumericDomain<A> {
      */
     public Granularity spacingOf(A atom) {
         return kinds.get(atom);
-    }
-
-    /**
-     * The count an end is at.
-     *
-     * <p>Every end this holds was built from a number here, so this is a statement of that and not a
-     * check on a caller: an atom is a position the rules relate arithmetically, and a position whose
-     * values are not numbers has no atom to be related through.
-     */
-    private static Count at(Endpoint end) {
-        if (!(end.at() instanceof Count count)) {
-            throw new IllegalStateException("an atom's end is not a number: " + end);
-        }
-        return count;
     }
 
     /** What an atom's values are known to lie between. A {@code null} end is unbounded there. */
@@ -686,29 +638,21 @@ public final class NumericDomain<A> {
     }
 
     /**
-     * Whether everything this holds is held in a shape {@link #boundsOf} reads.
+     * Whether everything the rules say is held in a shape {@link #boundsOf} can state.
      *
-     * <p>False where anything asserted into it narrowed more than a bound could hold: see
-     * {@link Loss}. A caller turning a projection into a value somebody has to write has to know
-     * which of the two it has.
+     * <p>False where any rule says something a range cannot: see {@link Loss}. A caller turning a
+     * projection into a value somebody has to write has to know which of the two it has.
      */
     public boolean projectionIsLossless() {
         return losses.isEmpty();
     }
 
-    /**
-     * Whether the bounds on one atom are the whole of what the rules about it say.
-     *
-     * <p>Asked of the atom and not of the domain. A rule this could not hold is a rule about the
-     * positions it names, and a bound on some other atom is as good as it ever was — a pattern on a
-     * name says nothing about how many minutes a day has.
-     */
-    /** What was asserted about one atom and not recorded. */
+    /** What a range at one atom cannot state of the rules about it. */
     public Set<Loss> lossesAt(A atom) {
         return losses.getOrDefault(atom, Set.of());
     }
 
-    /** Every atom something was lost about. */
+    /** Every atom something is lost about. */
     public Set<A> lossyAtoms() {
         return losses.keySet();
     }
@@ -716,10 +660,13 @@ public final class NumericDomain<A> {
     private NumericDomain<A> losing(Loss loss, Set<A> atoms) {
         Map<A, Set<Loss>> next = with(loss, atoms);
         return next == losses ? this
-                : new NumericDomain<>(bottom, lo, hi, diff, kept, kinds, next);
+                : new NumericDomain<>(rules, kinds, next, readARuleNothingSatisfies);
     }
 
     private Map<A, Set<Loss>> with(Loss loss, Set<A> atoms) {
+        if (loss == null) {
+            return losses;
+        }
         Map<A, Set<Loss>> next = null;
         for (A atom : atoms) {
             if (losses.getOrDefault(atom, Set.of()).contains(loss)) {
@@ -734,120 +681,5 @@ public final class NumericDomain<A> {
             next.put(atom, java.util.Collections.unmodifiableSet(here));
         }
         return next == null ? losses : Map.copyOf(next);
-    }
-
-    // --- immutable updates ---------------------------------------------------------------------
-
-    private NumericDomain<A> bottom() {
-        return new NumericDomain<>(true, Map.of(), Map.of(), Map.of(), List.of(), kinds, losses);
-    }
-
-    private NumericDomain<A> withHi(A a, Endpoint bound) {
-        Map<A, Endpoint> nhi = new HashMap<>(hi);
-        nhi.merge(a, bound, Endpoint::upper);
-        NumericDomain<A> d = new NumericDomain<>(false, lo, nhi, diff, kept, kinds, losses);
-        return d.feasible() ? d : bottom();
-    }
-
-    private NumericDomain<A> withLo(A a, Endpoint bound) {
-        Map<A, Endpoint> nlo = new HashMap<>(lo);
-        nlo.merge(a, bound, Endpoint::lower);
-        NumericDomain<A> d = new NumericDomain<>(false, nlo, hi, diff, kept, kinds, losses);
-        return d.feasible() ? d : bottom();
-    }
-
-    private NumericDomain<A> withDiff(A a, A b, Endpoint bound) {
-        Map<A, Map<A, Endpoint>> nd = new HashMap<>();
-        diff.forEach((k, v) -> nd.put(k, new HashMap<>(v)));
-        nd.computeIfAbsent(a, k -> new HashMap<>()).merge(b, bound, Endpoint::upper);
-        NumericDomain<A> d = new NumericDomain<>(false, lo, hi, nd, kept, kinds, losses);
-        return d.feasible() ? d : bottom();
-    }
-
-    /**
-     * Whether the bounds and the differences can hold at once. Guards that contradict make the path
-     * infeasible, and the domain must say so: {@link #entails} then discharges everything and
-     * {@link #refutes} fires nothing, so nothing is reported at a construction that is not reached.
-     *
-     * <p>A bound is an edge to or from zero, so the two ways a contradiction shows up are one thing
-     * seen twice: a difference cycle whose sum is negative, and a lower bound above an upper one once
-     * the differences between them are closed. Deriving a bound through a difference is what made the
-     * second reachable — {@code a <= b} and {@code b <= 0} bound {@code a} without recording anything
-     * about {@code a} — so both are asked here rather than at the atom the assertion happened to name.
-     */
-    private boolean feasible() {
-        for (Map.Entry<A, Map<A, Endpoint>> row : closed().entrySet()) {
-            Endpoint cycle = row.getValue().get(row.getKey());
-            // `a - a` is zero, so a cycle bounding it below zero is a contradiction — and so is one
-            // bounding it at zero without admitting it.
-            if (cycle != null && (at(cycle).signum() < 0
-                    || (at(cycle).signum() == 0 && !cycle.inclusive()))) {
-                return false;
-            }
-        }
-        for (A a : lo.keySet()) {
-            if (!Endpoint.someValueLiesBetween(bestLo(a), bestHi(a))) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /** The tightest proven upper bound on {@code a - b}, or {@code null} if none is known. */
-    private Endpoint closedDiff(A a, A b) {
-        if (a.equals(b)) {
-            return Endpoint.inclusive(Count.ZERO);
-        }
-        Map<A, Endpoint> row = closed().get(a);
-        return row == null ? null : row.get(b);
-    }
-
-    /** The difference facts closed transitively — {@code a - b <= c} with {@code b - d <= e} gives
-     * {@code a - d <= c + e} — computed once for the domain and read by every query it answers, since
-     * a bound on one atom is derived through the differences to every other. */
-    private Map<A, Map<A, Endpoint>> closed() {
-        if (closed == null) {
-            closed = close(diff);
-        }
-        return closed;
-    }
-
-    private static <A> Map<A, Map<A, Endpoint>> close(Map<A, Map<A, Endpoint>> diff) {
-        Set<A> atoms = new HashSet<>(diff.keySet());
-        diff.values().forEach(r -> atoms.addAll(r.keySet()));
-        Map<A, Map<A, Endpoint>> d = new HashMap<>();
-        diff.forEach((a, row) -> d.put(a, new HashMap<>(row)));
-        for (A through : atoms) {
-            Map<A, Endpoint> from = d.get(through);
-            if (from == null) {
-                continue;
-            }
-            List<Map.Entry<A, Endpoint>> hops = List.copyOf(from.entrySet());
-            for (A a : atoms) {
-                if (a.equals(through)) {
-                    continue;   // a hop from an atom to itself only repeats a cycle already recorded
-                }
-                Endpoint toThrough = edge(d, a, through);
-                if (toThrough == null) {
-                    continue;
-                }
-                for (Map.Entry<A, Endpoint> hop : hops) {
-                    // A path reaches its end only where every hop on it does.
-                    Endpoint candidate = new Endpoint(
-                            at(toThrough).plus(at(hop.getValue())),
-                            toThrough.inclusive() && hop.getValue().inclusive());
-                    Endpoint known = edge(d, a, hop.getKey());
-                    if (known == null || Endpoint.upper(known, candidate) == candidate) {
-                        d.computeIfAbsent(a, k -> new HashMap<>()).put(hop.getKey(), candidate);
-                    }
-                }
-            }
-        }
-        return d;
-    }
-
-    private static <A> Endpoint edge(Map<A, Map<A, Endpoint>> d, A a, A b) {
-        Map<A, Endpoint> row = d.get(a);
-        return row == null ? null : row.get(b);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/numeric/Rational.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/Rational.java
@@ -1,0 +1,211 @@
+package souther.compiler.numeric;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+
+/**
+ * An exact ratio of two whole numbers, which is what the constraint algebra reasons in.
+ *
+ * <p>Not a number a model writes, and not a count a carrier is on. A model's decimals are finite
+ * decimals and a carrier's counts are whatever it counts to; both are {@link BigDecimal} and both
+ * are closed under adding and multiplying. Dividing is what neither of them is closed under, and
+ * dividing is what deriving a bound does: {@code 3 * a <= 1} puts {@code a} at a third, and a third
+ * is not a decimal anybody can write. Held as a {@code BigDecimal} the third has to be rounded at
+ * the moment it is derived, and every later step reasons about the rounded number instead — so the
+ * algebra decides feasibility, entailment and refutation on a value that is not the one the rules
+ * put there.
+ *
+ * <p>So the algebra keeps ratios and rounds once, at the edge where a bound becomes something a
+ * reader can be handed. What is exact stays exact for as long as it is being reasoned about.
+ *
+ * <p>Deliberately not a {@link Place}. A place is where a range stops on a carrier's order, and
+ * every carrier's order is counted in decimals; a ratio is a step in the reasoning that produces
+ * one. Keeping them separate types is what stops a third reaching a row.
+ *
+ * <p>Always in lowest terms with a positive denominator, so two ratios of equal value are one value
+ * — {@link #equals} decides it, and a canonical form built out of these is compared by its map.
+ */
+public record Rational(BigInteger numerator, BigInteger denominator) implements Comparable<Rational> {
+
+    public static final Rational ZERO = new Rational(BigInteger.ZERO, BigInteger.ONE);
+    public static final Rational ONE = new Rational(BigInteger.ONE, BigInteger.ONE);
+
+    private static final BigInteger FIVE = BigInteger.valueOf(5);
+
+    public Rational {
+        if (numerator == null || denominator == null) {
+            throw new IllegalArgumentException("a ratio is two whole numbers");
+        }
+        if (denominator.signum() == 0) {
+            throw new IllegalArgumentException("a ratio has no zero denominator: " + numerator + "/0");
+        }
+        if (denominator.signum() < 0) {
+            numerator = numerator.negate();
+            denominator = denominator.negate();
+        }
+        BigInteger common = numerator.gcd(denominator);
+        if (!common.equals(BigInteger.ONE)) {
+            numerator = numerator.divide(common);
+            denominator = denominator.divide(common);
+        }
+    }
+
+    public static Rational of(long whole) {
+        return new Rational(BigInteger.valueOf(whole), BigInteger.ONE);
+    }
+
+    public static Rational of(BigInteger whole) {
+        return new Rational(whole, BigInteger.ONE);
+    }
+
+    public static Rational of(BigInteger numerator, BigInteger denominator) {
+        return new Rational(numerator, denominator);
+    }
+
+    /**
+     * The ratio a written decimal is, exactly.
+     *
+     * <p>Every finite decimal is one, which is the direction that never loses anything: a decimal
+     * with scale {@code s} is its unscaled value over {@code 10^s}. A negative scale is a decimal
+     * written as a multiple of a power of ten and is a whole number.
+     */
+    public static Rational of(BigDecimal at) {
+        BigInteger unscaled = at.unscaledValue();
+        int scale = at.scale();
+        return scale >= 0
+                ? new Rational(unscaled, BigInteger.TEN.pow(scale))
+                : new Rational(unscaled.multiply(BigInteger.TEN.pow(-scale)), BigInteger.ONE);
+    }
+
+    public Rational plus(Rational other) {
+        return new Rational(
+                numerator.multiply(other.denominator).add(other.numerator.multiply(denominator)),
+                denominator.multiply(other.denominator));
+    }
+
+    public Rational minus(Rational other) {
+        return plus(other.negated());
+    }
+
+    public Rational times(Rational other) {
+        return new Rational(numerator.multiply(other.numerator),
+                denominator.multiply(other.denominator));
+    }
+
+    /** @throws ArithmeticException where {@code other} is zero, which is a caller's mistake and not
+     *  a value this can hold */
+    public Rational dividedBy(Rational other) {
+        if (other.signum() == 0) {
+            throw new ArithmeticException("divided by zero");
+        }
+        return new Rational(numerator.multiply(other.denominator),
+                denominator.multiply(other.numerator));
+    }
+
+    public Rational negated() {
+        return new Rational(numerator.negate(), denominator);
+    }
+
+    public Rational abs() {
+        return signum() < 0 ? negated() : this;
+    }
+
+    public int signum() {
+        return numerator.signum();
+    }
+
+    public boolean isZero() {
+        return numerator.signum() == 0;
+    }
+
+    /** Whether this is a whole number, which is what a denominator of one says. */
+    public boolean isWhole() {
+        return denominator.equals(BigInteger.ONE);
+    }
+
+    @Override
+    public int compareTo(Rational other) {
+        return numerator.multiply(other.denominator).compareTo(other.numerator.multiply(denominator));
+    }
+
+    /** The largest whole number no greater than this. */
+    public BigInteger floor() {
+        BigInteger[] parts = numerator.divideAndRemainder(denominator);
+        return parts[1].signum() < 0 ? parts[0].subtract(BigInteger.ONE) : parts[0];
+    }
+
+    /** The smallest whole number no less than this. */
+    public BigInteger ceiling() {
+        BigInteger[] parts = numerator.divideAndRemainder(denominator);
+        return parts[1].signum() > 0 ? parts[0].add(BigInteger.ONE) : parts[0];
+    }
+
+    /**
+     * The greatest common divisor of two ratios: the largest {@code g} of which both are whole
+     * multiples.
+     *
+     * <p>What generates the values a form's coefficients reach. In lowest terms it is
+     * {@code gcd(numerators) / lcm(denominators)} — a third and a half are both whole multiples of a
+     * sixth and of nothing larger. Zero divides nothing and is divided by everything, so it is the
+     * identity here: a coefficient that is zero is a position the form does not name.
+     */
+    public static Rational gcd(Rational a, Rational b) {
+        if (a.isZero()) {
+            return b.abs();
+        }
+        if (b.isZero()) {
+            return a.abs();
+        }
+        BigInteger tops = a.numerator.abs().gcd(b.numerator.abs());
+        BigInteger common = a.denominator.gcd(b.denominator);
+        BigInteger bottoms = a.denominator.divide(common).multiply(b.denominator);
+        return new Rational(tops, bottoms);
+    }
+
+    /**
+     * This as a decimal a model could write, or {@code null} where no such decimal is this.
+     *
+     * <p>A ratio terminates exactly where its denominator is made of the factors ten is made of. A
+     * third does not, and answering that with a rounded decimal is what this exists to stop: the
+     * caller asking has to know whether it was handed the value or an approximation of it, and a
+     * number that came back cannot be asked which it was.
+     */
+    public BigDecimal asWrittenDecimal() {
+        BigInteger left = denominator;
+        int twos = 0;
+        while (left.mod(BigInteger.TWO).signum() == 0) {
+            left = left.divide(BigInteger.TWO);
+            twos++;
+        }
+        int fives = 0;
+        while (left.mod(FIVE).signum() == 0) {
+            left = left.divide(FIVE);
+            fives++;
+        }
+        if (!left.equals(BigInteger.ONE)) {
+            return null;
+        }
+        // Ten carries one two and one five, so the tens it takes to clear the denominator is however
+        // many of the more numerous of them it holds.
+        int scale = Math.max(twos, fives);
+        return new BigDecimal(
+                numerator.multiply(BigInteger.TEN.pow(scale)).divide(denominator), scale);
+    }
+
+    /**
+     * This as a decimal, rounded the way {@code towards} says where it is not one exactly.
+     *
+     * <p>For a bound that has to be handed over as a written number. The direction is the caller's
+     * because only the caller knows which way widens: an upper bound rounded up still admits
+     * everything the rules admit, and rounded down refuses values they leave.
+     */
+    public BigDecimal asDecimal(RoundingMode towards, int scale) {
+        return new BigDecimal(numerator).divide(new BigDecimal(denominator), scale, towards);
+    }
+
+    @Override
+    public String toString() {
+        return isWhole() ? numerator.toString() : numerator + "/" + denominator;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/numeric/RationalCut.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/RationalCut.java
@@ -1,0 +1,87 @@
+package souther.compiler.numeric;
+
+/**
+ * Where a constraint stops, exactly, and whether the value it stops at is one it admits.
+ *
+ * <p>The same shape as {@link Endpoint} and not the same thing. An endpoint is where a range stops
+ * on a carrier's order and is spelled in the decimals a carrier counts in; this is where the algebra
+ * stops while it is still reasoning, and is spelled in {@link Rational} because that is what
+ * dividing produces. One becomes the other once, at the edge where a bound is handed to a reader.
+ *
+ * <p>One type for both of the algebra's bounds. A bound on a position and a bound on the difference
+ * of two of them are the same statement — a value and whether it is reached — so the rules for
+ * composing them get written once rather than once per bound.
+ */
+public record RationalCut(Rational at, boolean inclusive) {
+
+    public RationalCut {
+        if (at == null) {
+            throw new IllegalArgumentException("a cut stops at a value; use null for no cut");
+        }
+    }
+
+    public static RationalCut inclusive(Rational at) {
+        return new RationalCut(at, true);
+    }
+
+    public static RationalCut exclusive(Rational at) {
+        return new RationalCut(at, false);
+    }
+
+    /**
+     * The two cuts added, admitting its own value only where both do.
+     *
+     * <p>What composing two hops is: {@code a - b <= c} with {@code b - d <= e} bounds {@code a - d}
+     * at {@code c + e}, and the sum is reached only by a pair that reaches both. Written once here
+     * rather than at each place a path is walked, because the strictness is the half that gets
+     * dropped — a path summing to a bound its hops cannot both reach still bounds, and calling it
+     * reachable puts a row at a pair nothing can be.
+     */
+    public static RationalCut meetingBoth(RationalCut a, RationalCut b) {
+        return new RationalCut(a.at.plus(b.at), a.inclusive && b.inclusive);
+    }
+
+    /**
+     * The tighter of two lower bounds, where {@code null} is no bound and so never the tighter.
+     *
+     * <p>The mirror of {@link #tighterUpper}, and its own method for the reason that one is named
+     * for its side: at one value the inclusive cut is the tighter here and the looser there.
+     */
+    public static RationalCut tighterLower(RationalCut a, RationalCut b) {
+        if (a == null || b == null) {
+            return a == null ? b : a;
+        }
+        int order = a.at.compareTo(b.at);
+        if (order == 0) {
+            return a.inclusive ? b : a;
+        }
+        return order > 0 ? a : b;
+    }
+
+    /**
+     * The tighter of two upper bounds, where {@code null} is no bound and so never the tighter.
+     *
+     * <p>At one value the two are one edge asked of two rules, and a conjunction admits only what
+     * both admit — so the value survives only where neither excludes it.
+     *
+     * <p>Named for the side it is about. At one value an inclusive cut is the looser of the two as
+     * an upper bound and the tighter as a lower one, so anything that ordered cuts without being
+     * told which side was meant would be wrong on one of them — which is why this type is not
+     * {@link Comparable} and why the lower side, when something needs it, is its own method.
+     */
+    public static RationalCut tighterUpper(RationalCut a, RationalCut b) {
+        if (a == null || b == null) {
+            return a == null ? b : a;
+        }
+        int order = a.at.compareTo(b.at);
+        if (order == 0) {
+            return a.inclusive ? b : a;
+        }
+        return order < 0 ? a : b;
+    }
+
+    @Override
+    public String toString() {
+        return (inclusive ? "<= " : "< ") + at;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/numeric/RationalCut.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/RationalCut.java
@@ -44,8 +44,11 @@ public record RationalCut(Rational at, boolean inclusive) {
     /**
      * The tighter of two lower bounds, where {@code null} is no bound and so never the tighter.
      *
-     * <p>The mirror of {@link #tighterUpper}, and its own method for the reason that one is named
-     * for its side: at one value the inclusive cut is the tighter here and the looser there.
+     * <p>Its own method because which of two values is the tighter runs the other way here: above,
+     * the smaller value; below, the larger. Whether the value itself is admitted does not run the
+     * other way — an exclusive cut admits less on either side and is the tighter of the two on
+     * either side — so an order over cuts alone would be right about the strictness and wrong about
+     * the value, on one side or the other, however it was written.
      */
     public static RationalCut tighterLower(RationalCut a, RationalCut b) {
         if (a == null || b == null) {
@@ -64,10 +67,8 @@ public record RationalCut(Rational at, boolean inclusive) {
      * <p>At one value the two are one edge asked of two rules, and a conjunction admits only what
      * both admit — so the value survives only where neither excludes it.
      *
-     * <p>Named for the side it is about. At one value an inclusive cut is the looser of the two as
-     * an upper bound and the tighter as a lower one, so anything that ordered cuts without being
-     * told which side was meant would be wrong on one of them — which is why this type is not
-     * {@link Comparable} and why the lower side, when something needs it, is its own method.
+     * <p>Named for the side it is about, and this type is not {@link Comparable}: see
+     * {@link #tighterLower} for which half of the comparison depends on the side and which does not.
      */
     public static RationalCut tighterUpper(RationalCut a, RationalCut b) {
         if (a == null || b == null) {

--- a/souther-compiler/src/main/java/souther/compiler/numeric/Reach.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/Reach.java
@@ -1,0 +1,78 @@
+package souther.compiler.numeric;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * What a weighted sum runs between, given what each position in it runs between.
+ *
+ * <p>Three readers asked this and three answered it. The interval algebra summed a goal's positions
+ * to decide whether the goal followed; the reduction summed the rest of a rule to see what it left
+ * one position; and the partition layer summed a quantity's positions to decide whether a threshold
+ * was a value the quantity ever takes. The arithmetic is four lines and two of them are easy to get
+ * wrong in ways nothing catches — so it is written once.
+ *
+ * <p><b>Which end of a position is read is the coefficient's sign.</b> A position pulling the sum up
+ * contributes least at its own least; one pulling it down contributes least at its greatest. Read
+ * the same end regardless and the answer is wrong wherever a rule subtracts, which is the error that
+ * shows up as a row nobody can build rather than as anything nearer the mistake.
+ *
+ * <p><b>The sum reaches its end only where every part does.</b> One position that cannot quite reach
+ * its own edge is one the sum cannot quite reach either — and an end wrongly called reachable is a
+ * point the search is sent to look for and never finds.
+ *
+ * <p>A {@code null} end is no bound that way. One position unbounded in the direction that matters
+ * leaves the whole sum unbounded there, since nothing else can make up for it.
+ */
+public record Reach(RationalCut least, RationalCut most) {
+
+    /** Bounded at neither end, which is what a sum containing an unbounded position runs between. */
+    public static final Reach ANYWHERE = new Reach(null, null);
+
+    public static Reach between(RationalCut least, RationalCut most) {
+        return new Reach(least, most);
+    }
+
+    /**
+     * What {@code Σ coefs·position + constant} runs between.
+     *
+     * @param positions what each named position runs between; a position it has nothing for runs
+     *                  the whole way, which leaves the sum unbounded in whichever directions that
+     *                  position could push it
+     */
+    public static <A> Reach of(Map<A, Rational> coefs, Rational constant,
+                               Function<A, Reach> positions) {
+        Rational least = constant;
+        Rational most = constant;
+        boolean leastReached = true;
+        boolean mostReached = true;
+        for (Map.Entry<A, Rational> each : coefs.entrySet()) {
+            Rational weight = each.getValue();
+            Reach runs = positions.apply(each.getKey());
+            if (runs == null) {
+                runs = ANYWHERE;
+            }
+            RationalCut low = weight.signum() > 0 ? runs.least() : runs.most();
+            RationalCut high = weight.signum() > 0 ? runs.most() : runs.least();
+            if (least != null && low != null) {
+                least = least.plus(weight.times(low.at()));
+                leastReached &= low.inclusive();
+            } else {
+                least = null;
+            }
+            if (most != null && high != null) {
+                most = most.plus(weight.times(high.at()));
+                mostReached &= high.inclusive();
+            } else {
+                most = null;
+            }
+        }
+        return new Reach(least == null ? null : new RationalCut(least, leastReached),
+                most == null ? null : new RationalCut(most, mostReached));
+    }
+
+    /** Whether either end was found. */
+    public boolean saysNothing() {
+        return least == null && most == null;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -102,26 +102,48 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
      */
     private static souther.compiler.numeric.NumericDomain.Bounds reachOf(AffineReading read,
                                                                         InputReads reads) {
-        java.math.BigDecimal least = java.math.BigDecimal.ZERO;
-        java.math.BigDecimal most = java.math.BigDecimal.ZERO;
-        for (java.util.Map.Entry<NumericTerm, java.math.BigDecimal> each
-                : read.form().coefs().entrySet()) {
-            souther.compiler.numeric.NumericDomain.Bounds bounds = boundsOf(each.getKey(), reads);
-            Count low = bounds == null || bounds.min() == null
-                    || !(bounds.min().at() instanceof Count at) ? null : at;
-            Count high = bounds == null || bounds.max() == null
-                    || !(bounds.max().at() instanceof Count at) ? null : at;
-            if (low == null || high == null) {
-                return null;
-            }
-            java.math.BigDecimal one = each.getValue().multiply(low.at());
-            java.math.BigDecimal other = each.getValue().multiply(high.at());
-            least = least.add(one.min(other));
-            most = most.add(one.max(other));
+        java.util.Map<NumericTerm, souther.compiler.numeric.Rational> coefs =
+                new java.util.LinkedHashMap<>();
+        read.form().coefs().forEach((term, coef) ->
+                coefs.put(term, souther.compiler.numeric.Rational.of(coef)));
+        souther.compiler.numeric.Reach runs = souther.compiler.numeric.Reach.of(
+                coefs, souther.compiler.numeric.Rational.ZERO,
+                term -> runsBetween(term, reads));
+        if (runs.least() == null || runs.most() == null) {
+            return null;
         }
         return new souther.compiler.numeric.NumericDomain.Bounds(
-                souther.compiler.numeric.Endpoint.inclusive(new Count(least)),
-                souther.compiler.numeric.Endpoint.inclusive(new Count(most)));
+                written(runs.least()), written(runs.most()));
+    }
+
+    /** A cut as the end of a range. Every end that reaches here came from a written number, so what
+     *  it is written as is what it was. */
+    private static souther.compiler.numeric.Endpoint written(
+            souther.compiler.numeric.RationalCut cut) {
+        java.math.BigDecimal at = cut.at().asWrittenDecimal();
+        if (at == null) {
+            throw new IllegalStateException("a quantity's reach is written: " + cut);
+        }
+        return new souther.compiler.numeric.Endpoint(
+                new souther.compiler.numeric.Count(at), cut.inclusive());
+    }
+
+    /** What one position runs between, as the arithmetic wants it. */
+    private static souther.compiler.numeric.Reach runsBetween(NumericTerm term, InputReads reads) {
+        souther.compiler.numeric.NumericDomain.Bounds bounds = boundsOf(term, reads);
+        if (bounds == null) {
+            return souther.compiler.numeric.Reach.ANYWHERE;
+        }
+        return souther.compiler.numeric.Reach.between(asCut(bounds.min()), asCut(bounds.max()));
+    }
+
+    private static souther.compiler.numeric.RationalCut asCut(
+            souther.compiler.numeric.Endpoint end) {
+        if (end == null || !(end.at() instanceof souther.compiler.numeric.Count at)) {
+            return null;
+        }
+        return new souther.compiler.numeric.RationalCut(
+                souther.compiler.numeric.Rational.of(at.at()), end.inclusive());
     }
 
     /** What every rule reaching one position leaves its numbers, or null where the reading has no

--- a/souther-compiler/src/main/java/souther/compiler/partition/LevelSpace.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LevelSpace.java
@@ -244,11 +244,7 @@ public interface LevelSpace {
      * {@code 3 * a} takes a third of them.
      */
     static LevelSpace overFiniteDecimals(BigDecimal generator) {
-        // Exact, because a quantity's positions are all on the one carrier it names, so they are all
-        // decimals. A form whose positions are not all made of the same thing is something only the
-        // interval algebra is handed, and it is what the flag is there for.
-        AdditiveImage reaches = new AdditiveImage.OverFiniteDecimals(
-                Rational.of(generator), true);
+        AdditiveImage reaches = new AdditiveImage.OverFiniteDecimals(Rational.of(generator));
         return new Counting() {
 
             @Override
@@ -304,8 +300,7 @@ public interface LevelSpace {
         if (step.signum() == 0) {
             return BigDecimal.ONE;
         }
-        Rational left = new AdditiveImage.OverFiniteDecimals(
-                Rational.of(step.abs()), true).generator();
+        Rational left = new AdditiveImage.OverFiniteDecimals(Rational.of(step.abs())).generator();
         BigDecimal written = left.asWrittenDecimal();
         if (written == null) {
             throw new IllegalStateException(

--- a/souther-compiler/src/main/java/souther/compiler/partition/LevelSpace.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LevelSpace.java
@@ -2,10 +2,12 @@ package souther.compiler.partition;
 
 import souther.compiler.check.Carrier;
 import souther.compiler.inputs.BoundaryDomain;
+import souther.compiler.numeric.AdditiveImage;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.OrderedInterval;
 import souther.compiler.numeric.Place;
+import souther.compiler.numeric.Rational;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -184,12 +186,18 @@ public interface LevelSpace {
      * {@code 300x + 600y} moves in three hundreds however small a step {@code x} takes.
      */
     static LevelSpace steppingBy(BigDecimal step) {
+        // Which numbers a quantity reaches is arithmetic about the quantity and not about how a
+        // level is written, so it is asked of the one place that answers it. What stays here is the
+        // spelling: a level is a `Count` and a count is a decimal, and two decimals of one value and
+        // two scales are two counts.
+        AdditiveImage reaches =
+                new AdditiveImage.OverWholeNumbers(Rational.of(step));
         return new Counting() {
 
             @Override
             public boolean attainable(Level level) {
-                BigDecimal at = countOf(level).at();
-                return at.remainder(step).signum() == 0;
+                return reaches.contains(
+                        Rational.of(countOf(level).at()));
             }
 
             @Override
@@ -236,21 +244,17 @@ public interface LevelSpace {
      * {@code 3 * a} takes a third of them.
      */
     static LevelSpace overFiniteDecimals(BigDecimal generator) {
+        // Exact, because a quantity's positions are all on the one carrier it names, so they are all
+        // decimals. A form whose positions are not all made of the same thing is something only the
+        // interval algebra is handed, and it is what the flag is there for.
+        AdditiveImage reaches = new AdditiveImage.OverFiniteDecimals(
+                Rational.of(generator), true);
         return new Counting() {
 
-            /**
-             * Whether the generator divides this level over the finite decimals.
-             *
-             * <p>The generator has no factor of two or five left in it, and ten is what a decimal's
-             * scale is made of — so a level {@code n / 10^k} is a multiple of it exactly where the
-             * generator divides {@code n}. Said as that rather than by dividing and seeing whether
-             * the quotient ends: a quotient with no end is the answer here and not a mishap, and a
-             * reader of this should not have to know that an exception is how it arrives.
-             */
             @Override
             public boolean attainable(Level level) {
-                return countOf(level).at().stripTrailingZeros().unscaledValue()
-                        .mod(generator.toBigIntegerExact()).signum() == 0;
+                return reaches.contains(
+                        Rational.of(countOf(level).at()));
             }
 
             /** No nearest one. The values this takes are dense, so past a level it does not take
@@ -297,17 +301,17 @@ public interface LevelSpace {
      * one again. What is left over is what a level has to be a multiple of.
      */
     static BigDecimal generatorOverFiniteDecimals(BigDecimal step) {
-        java.math.BigInteger left = step.stripTrailingZeros().unscaledValue().abs();
-        if (left.signum() == 0) {
+        if (step.signum() == 0) {
             return BigDecimal.ONE;
         }
-        for (java.math.BigInteger unit : List.of(java.math.BigInteger.TWO,
-                java.math.BigInteger.valueOf(5))) {
-            while (left.mod(unit).signum() == 0) {
-                left = left.divide(unit);
-            }
+        Rational left = new AdditiveImage.OverFiniteDecimals(
+                Rational.of(step.abs()), true).generator();
+        BigDecimal written = left.asWrittenDecimal();
+        if (written == null) {
+            throw new IllegalStateException(
+                    "a divisor of written coefficients is written: " + left);
         }
-        return new BigDecimal(left);
+        return written;
     }
 
     /**
@@ -388,15 +392,18 @@ public interface LevelSpace {
      * it as well: a residue that is not one of these multiples is one no assignment lands on.
      */
     static BigDecimal stepOf(java.util.Collection<BigDecimal> coefs) {
+        Rational divisor = AdditiveImage.divisorOf(
+                coefs.stream().map(Rational::of).toList());
+        // Spelled at the scale the coefficients were written at, which is what it was spelled at
+        // before this asked somewhere else for the number. A divisor of the written coefficients
+        // divides each of them, so writing it out at their scale never rounds — and the scale is
+        // not decoration: a level is a `Count`, two counts are equal by their decimals, and a step
+        // written `2` where it used to be `2.0` is a different key in every map that holds one.
         int scale = 0;
         for (BigDecimal coef : coefs) {
             scale = Math.max(scale, Math.max(coef.scale(), 0));
         }
-        java.math.BigInteger together = java.math.BigInteger.ZERO;
-        for (BigDecimal coef : coefs) {
-            together = together.gcd(coef.setScale(scale).unscaledValue().abs());
-        }
-        return new BigDecimal(together, scale);
+        return divisor.asDecimal(java.math.RoundingMode.UNNECESSARY, scale);
     }
 
     /** The shared half of every space whose levels are numbers: how two of them compare, and that a

--- a/souther-compiler/src/test/java/souther/compiler/TheBlockAndItsHeaderComeFromOneListOfRowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/TheBlockAndItsHeaderComeFromOneListOfRowsTest.java
@@ -61,7 +61,13 @@ class TheBlockAndItsHeaderComeFromOneListOfRowsTest {
             """;
 
     /**
-     * The same model with a rule relating the two fields, which no candidate this composes satisfies.
+     * The same model with a rule the composing cannot reason through, so no candidate it puts
+     * together satisfies it.
+     *
+     * <p>A product of two fields and not a sum. A sum was what this used to say, and a sum is a rule
+     * the interval algebra now narrows both fields through — the composing finds
+     * {@code rate = 0, cap = 10} and the block it produces has rows in it, which is the right answer
+     * and the wrong fixture. What is wanted here is a rule outside what the algebra reasons in.
      *
      * <p>Here for the shape of the block it produces — explanations and no rows — and not for why the
      * search failed. Whether that failure may be read as a fact about the model is #602's question.
@@ -71,7 +77,7 @@ class TheBlockAndItsHeaderComeFromOneListOfRowsTest {
 
             behavior fee""", """
                 }
-                invariant together = rate.value + cap.value >= 10
+                invariant together = rate.value * cap.value >= 10
 
             behavior fee""");
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldsRangeIsTheRecordsRuleProjectedOntoItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldsRangeIsTheRecordsRuleProjectedOntoItTest.java
@@ -144,10 +144,17 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
         assertTrue(domains.projection().isExact(), "and every rule of the record was taken into these");
     }
 
-    /** A rule that skips a value is a hole in a range, and a range is all the domain holds. The bound
-     * stays where the type left it and says it is not the whole story. */
+    /**
+     * A rule that skips a value at the edge of a range moves the edge; a range is all the domain
+     * hands over, and an edge is somewhere a range can go.
+     *
+     * <p>Which side of the hole the value lies is not something the rule says on its own — it is
+     * something the type's own bound says, and the two together leave the field at one or above.
+     * With the edge moved there is nothing left over: every value the range holds is one a row can
+     * write, which is what makes the projection exact rather than merely sound.
+     */
     @Test
-    void aRuleThatSkipsAValueLeavesTheAnswerInexact() {
+    void aRuleThatSkipsAValueAtTheEdgeMovesTheEdge() {
         FieldDomains domains = domainsIn("""
                 module example.skip
 
@@ -160,8 +167,9 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
                     invariant nonzero = a.value /= 0
                 """, "R");
 
-        assertBounds(domains.at("a"), 0, 10);
-        assertFalse(domains.projection().isExact(), "0 is in these bounds and no row can write it");
+        assertBounds(domains.at("a"), 1, 10);
+        assertTrue(domains.projection().isExact(),
+                "and the range is now the whole of it: every value in it is one a row can write");
     }
 
     /** A length is a whole number like any other, so a rule relating one to a field is in the
@@ -311,13 +319,13 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
     /**
      * A doubt reaches as far as the bound it is about.
      *
-     * <p>`a` has no rule of its own that the domain could not hold. Its upper bound is `b`'s, carried
-     * by the equality, and `b` holds a hole the domain cannot keep — so `a = 10` wants the `b` the
-     * hole refuses. A bound arrives along a path through the differences, and the doubt takes the
-     * same path or it is not about the same bound.
+     * <p>`a` has no rule of its own beyond its type's. Its upper bound is `b`'s, carried by the
+     * equality — and `b`'s own upper bound is ten with ten held away from it, which leaves `b` at
+     * nine. So `a` is at nine as well: the hole moved `b`'s edge and the equality carried the edge,
+     * rather than leaving ten in `a`'s range with a note that something about it was doubtful.
      */
     @Test
-    void aBoundReachedThroughAnotherAtomCarriesThatAtomsDoubt() {
+    void aBoundReachedThroughAnotherAtomTakesThatAtomsMovedEdge() {
         FieldDomains domains = domainsIn("""
                 module example.paired
 
@@ -332,9 +340,9 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
                     invariant notTen = b.value /= 10
                 """, "R");
 
-        assertBounds(domains.at("a"), 0, 10);
-        assertFalse(domains.projection().isExact(),
-                "a's edge is b's edge, carried by the equality, and b holds a hole this cannot keep");
+        assertBounds(domains.at("a"), 0, 9);
+        assertTrue(domains.projection().isExact(),
+                "and nothing is left over: `a = 9` is written with `b = 9`, which the hole admits");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldsRangeIsTheRecordsRuleProjectedOntoItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldsRangeIsTheRecordsRuleProjectedOntoItTest.java
@@ -346,6 +346,35 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
     }
 
     /**
+     * An edge the rules put at a value no decimal writes is handed over rounded past it, and the
+     * reading says so.
+     *
+     * <p>{@code 3 * value <= 1} leaves the field at a third, and a third does not terminate — no
+     * decimal a model writes is one. The reasoning reaches the edge exactly; the number standing for
+     * it is a hair outside. That is not a rule the range failed to state, so it is its own cause: a
+     * reader placing a row at this edge is being given an edge the rules did not draw.
+     */
+    @Test
+    void anEdgeNoDecimalWritesIsSaidToBeRounded() {
+        FieldDomains domains = domainsIn("""
+                module example.third
+
+                data D = Decimal
+                    invariant atLeastNone = value >= 0.0m
+                    invariant aThird = 3.0m * value <= 1.0m
+
+                data R =
+                    { d: D
+                    }
+                """, "R");
+
+        assertTrue(domains.projection() instanceof ProjectionEvidence.Approximate approximate
+                        && approximate.causes().stream()
+                                .anyMatch(cause -> cause instanceof ProjectionEvidence.Cause.Rounded),
+                "the edge is a third and no decimal is: " + domains.projection());
+    }
+
+    /**
      * A relation narrows the same either side of a module boundary.
      *
      * <p>A relation is a projection only where both ends brought their ranges. An imported type's own

--- a/souther-compiler/src/test/java/souther/compiler/numeric/ABoundIsADifferenceFromNoughtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/ABoundIsADifferenceFromNoughtTest.java
@@ -1,0 +1,273 @@
+package souther.compiler.numeric;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.AffineConstraint.Read;
+import souther.compiler.numeric.NumericDomain.Rel;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A bound on a position and a bound on a difference are one shape, and closing them over each other
+ * answers what each position is left, what each difference is left, and whether anything is left at
+ * all — which had been three readings that had to agree.
+ */
+class ABoundIsADifferenceFromNoughtTest {
+
+    private static final String A = "a";
+    private static final String B = "b";
+    private static final String C = "c";
+
+    private static Rational num(long whole) {
+        return Rational.of(whole);
+    }
+
+    private static Rational ratio(long numerator, long denominator) {
+        return Rational.of(BigInteger.valueOf(numerator), BigInteger.valueOf(denominator));
+    }
+
+    /** A little builder for `Σ c·x + k rel 0`, read the way the algebra reads it. */
+    private static final class Rules {
+
+        private final List<AffineConstraint<String>> stated = new ArrayList<>();
+        private final Granularity spacing;
+
+        Rules(Granularity spacing) {
+            this.spacing = spacing;
+        }
+
+        Rules say(Map<String, Rational> coefs, Rational constant, Rel rel) {
+            Read<String> read = AffineConstraint.of(coefs, constant, rel, atom -> spacing);
+            stated.add(assertInstanceOf(Read.Stated.class, read).constraint());
+            return this;
+        }
+
+        Rules say(Map<String, Rational> coefs, long constant, Rel rel) {
+            return say(coefs, num(constant), rel);
+        }
+
+        DifferenceBounds<String> closed() {
+            return DifferenceBounds.over(stated);
+        }
+    }
+
+    private static Rules whole() {
+        return new Rules(Granularity.DISCRETE);
+    }
+
+    private static Map<String, Rational> weighing(Object... pairs) {
+        Map<String, Rational> out = new LinkedHashMap<>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            out.put((String) pairs[i], num((Integer) pairs[i + 1]));
+        }
+        return out;
+    }
+
+    // --- one shape for both -----------------------------------------------------------------------
+
+    @Test
+    void aBoundOnAPositionIsReadBack() {
+        DifferenceBounds<String> closed = whole()
+                .say(weighing(A, 1), -10, Rel.LE)
+                .say(weighing(A, 1), -3, Rel.GE)
+                .closed();
+        assertEquals(RationalCut.inclusive(num(10)), closed.upperBoundOf(A));
+        assertEquals(RationalCut.inclusive(num(3)), closed.lowerBoundOf(A));
+        assertFalse(closed.holdsNothing());
+    }
+
+    /** The whole point of closing: nothing was ever said about {@code a} alone. */
+    @Test
+    void aBoundReachesAPositionThroughADifference() {
+        DifferenceBounds<String> closed = whole()
+                .say(weighing(A, 1, B, -1), 0, Rel.LE)      // a - b <= 0
+                .say(weighing(B, 1), -1440, Rel.LE)         // b <= 1440
+                .closed();
+        assertEquals(RationalCut.inclusive(num(1440)), closed.upperBoundOf(A));
+        assertNull(closed.lowerBoundOf(A), "and nothing bounds it below");
+    }
+
+    @Test
+    void differencesComposeAlongAPath() {
+        DifferenceBounds<String> closed = whole()
+                .say(weighing(A, 1, B, -1), -2, Rel.LE)     // a - b <= 2
+                .say(weighing(B, 1, C, -1), -5, Rel.LE)     // b - c <= 5
+                .closed();
+        assertEquals(RationalCut.inclusive(num(7)), closed.differenceBound(A, C));
+    }
+
+    /** A path reaches its far end only where every hop on it does. */
+    @Test
+    void oneUnreachedHopMakesTheWholePathUnreached() {
+        DifferenceBounds<String> closed = new Rules(Granularity.DENSE)
+                .say(weighing(A, 1, B, -1), -2, Rel.LE)     // a - b <= 2
+                .say(weighing(B, 1, C, -1), -5, Rel.LT)     // b - c < 5
+                .closed();
+        assertEquals(RationalCut.exclusive(num(7)), closed.differenceBound(A, C));
+    }
+
+    @Test
+    void twoRulesOnOneEdgeLeaveTheTighter() {
+        DifferenceBounds<String> closed = whole()
+                .say(weighing(A, 1), -10, Rel.LE)
+                .say(weighing(A, 1), -4, Rel.LE)
+                .closed();
+        assertEquals(RationalCut.inclusive(num(4)), closed.upperBoundOf(A));
+    }
+
+    @Test
+    void aPositionIsNoDistanceFromItself() {
+        assertEquals(RationalCut.inclusive(Rational.ZERO),
+                whole().say(weighing(A, 1), -10, Rel.LE).closed().differenceBound(A, A));
+    }
+
+    // --- the shapes canonicalisation brought in ---------------------------------------------------
+
+    /** {@code 2a <= 10} is {@code a <= 5}, and is a bound on a position like any other. Read off the
+     *  coefficients as they were typed, it was neither shape and left {@code a} unbounded. */
+    @Test
+    void aScaledBoundIsABound() {
+        assertEquals(RationalCut.inclusive(num(5)),
+                whole().say(weighing(A, 2), -10, Rel.LE).closed().upperBoundOf(A));
+    }
+
+    /** And {@code 2a - 2b <= 4} is a difference, which is what left {@code a} with nothing at all
+     *  while the same rule written with ones bounded it at twelve. */
+    @Test
+    void aScaledDifferenceIsADifference() {
+        DifferenceBounds<String> closed = whole()
+                .say(weighing(A, 2, B, -2), -4, Rel.LE)
+                .say(weighing(B, 1), -10, Rel.LE)
+                .closed();
+        assertEquals(RationalCut.inclusive(num(12)), closed.upperBoundOf(A));
+    }
+
+    @Test
+    void anEqualityIsBothBounds() {
+        DifferenceBounds<String> closed = whole().say(weighing(A, 1), -7, Rel.EQ).closed();
+        assertEquals(RationalCut.inclusive(num(7)), closed.upperBoundOf(A));
+        assertEquals(RationalCut.inclusive(num(7)), closed.lowerBoundOf(A));
+    }
+
+    // --- what it does not hold ---------------------------------------------------------------------
+
+    @Test
+    void aSumOfTwoPositionsIsNotOfThisShape() {
+        AffineConstraint<String> sum = assertInstanceOf(Read.Stated.class,
+                AffineConstraint.of(weighing(A, 1, B, 1), num(-10), Rel.LE,
+                        atom -> Granularity.DISCRETE)).constraint();
+        assertFalse(DifferenceBounds.canHold(sum));
+        assertTrue(DifferenceBounds.over(List.of(sum)).positions().isEmpty(),
+                "so it leaves the positions to whatever holds the rest");
+    }
+
+    @Test
+    void aWeightedDifferenceThatDoesNotReduceIsNotOfThisShape() {
+        AffineConstraint<String> skew = assertInstanceOf(Read.Stated.class,
+                AffineConstraint.of(weighing(A, 2, B, -3), num(-10), Rel.LE,
+                        atom -> Granularity.DISCRETE)).constraint();
+        assertFalse(DifferenceBounds.canHold(skew));
+    }
+
+    @Test
+    void aHoleIsNotABound() {
+        AffineConstraint<String> hole = assertInstanceOf(Read.Stated.class,
+                AffineConstraint.of(weighing(A, 1), Rational.ZERO, Rel.NE,
+                        atom -> Granularity.DISCRETE)).constraint();
+        assertFalse(DifferenceBounds.canHold(hole));
+    }
+
+    // --- and when the rules leave nothing ----------------------------------------------------------
+
+    @Test
+    void boundsThatCrossLeaveNothing() {
+        assertTrue(whole()
+                .say(weighing(A, 1), -10, Rel.GE)
+                .say(weighing(A, 1), -3, Rel.LE)
+                .closed().holdsNothing());
+    }
+
+    @Test
+    void aCycleOfDifferencesComingBackLowerLeavesNothing() {
+        assertTrue(whole()
+                .say(weighing(A, 1, B, -1), 1, Rel.LE)      // a - b <= -1
+                .say(weighing(B, 1, A, -1), 1, Rel.LE)      // b - a <= -1
+                .closed().holdsNothing());
+    }
+
+    /** Nought is a difference a position is from itself, so a cycle that reaches nought without
+     *  admitting it leaves nothing either. */
+    @Test
+    void aCycleReachingNoughtWithoutAdmittingItLeavesNothing() {
+        assertTrue(new Rules(Granularity.DENSE)
+                .say(weighing(A, 1, B, -1), 0, Rel.LT)      // a - b < 0
+                .say(weighing(B, 1, A, -1), 0, Rel.LE)      // b - a <= 0
+                .closed().holdsNothing());
+    }
+
+    @Test
+    void anEmptinessReachedOnlyThroughAPathIsStillFound() {
+        assertTrue(whole()
+                .say(weighing(A, 1, B, -1), 0, Rel.LE)      // a <= b
+                .say(weighing(B, 1, C, -1), 0, Rel.LE)      // b <= c
+                .say(weighing(C, 1), -5, Rel.LE)            // c <= 5
+                .say(weighing(A, 1), -9, Rel.GE)            // a >= 9
+                .closed().holdsNothing());
+    }
+
+    /**
+     * Exactly, and not to whatever a rounded decimal would have made of it. The two ends of this sit
+     * a third apart, which is finer than any fixed number of digits keeps.
+     */
+    @Test
+    void anEmptinessFinerThanRoundingIsStillFound() {
+        assertTrue(new Rules(Granularity.DENSE)
+                .say(Map.of(A, num(3)), num(-1), Rel.GE)    // 3a >= 1, so a >= 1/3
+                .say(Map.of(A, num(3)), ratio(-999_999, 1_000_000), Rel.LE)
+                .closed().holdsNothing(),
+                "a is at least a third and at most a hair under one, which nothing satisfies");
+    }
+
+    /**
+     * And where nothing is left, there is no tightest bound to be had.
+     *
+     * <p>Refused rather than answered. Closing a system that comes back below where it started walks
+     * the cycle as often as the closure happened to reach it, so a number handed back here moves
+     * with the order the rules arrived in — measured, and it did. Answering "no bound" instead would
+     * read as unbounded, which is the opposite of the truth and would send a reader looking for rows
+     * in a value nobody can build.
+     */
+    @Test
+    void aClosureThatLeavesNothingHasNoTightestBound() {
+        DifferenceBounds<String> nothing = whole()
+                .say(weighing(A, 1), -10, Rel.GE)
+                .say(weighing(A, 1), -3, Rel.LE)
+                .closed();
+        assertTrue(nothing.holdsNothing());
+        assertThrows(IllegalStateException.class, () -> nothing.upperBoundOf(A));
+        assertThrows(IllegalStateException.class, () -> nothing.lowerBoundOf(A));
+        assertThrows(IllegalStateException.class, () -> nothing.differenceBound(A, B));
+        assertThrows(IllegalStateException.class, () -> nothing.differenceBound(A, A),
+                "including the one a position is from itself, which otherwise answers nought");
+    }
+
+    @Test
+    void nothingContradictoryLeavesSomething() {
+        assertFalse(whole()
+                .say(weighing(A, 1), -10, Rel.LE)
+                .say(weighing(A, 1), -3, Rel.GE)
+                .say(weighing(A, 1, B, -1), 0, Rel.LE)
+                .closed().holdsNothing());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/numeric/ARuleOverSeveralPositionsNarrowsEachOfThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/ARuleOverSeveralPositionsNarrowsEachOfThemTest.java
@@ -163,11 +163,59 @@ class ARuleOverSeveralPositionsNarrowsEachOfThemTest {
         assertEquals(RationalCut.inclusive(num(3)), found.atLeast().get("a"));
     }
 
+    /**
+     * A hole says which side of it the sum lies only where something else has already ruled out one
+     * side. With nothing to side it, it bounds nothing — a range cannot leave one value out of its
+     * own middle.
+     */
     @Test
-    void aHoleIsNotReadHere() {
+    void aHoleWithNothingToSideItBoundsNothing() {
         AffineConstraint<String> hole =
                 rule(weighing("a", 1, "b", 1), -10, Rel.NE, Granularity.DISCRETE);
-        assertTrue(reduce(List.of(hole), between("b", 0, 5), Granularity.DISCRETE).foundNothing());
+        assertTrue(reduce(List.of(hole), between("b", 0, 5), Granularity.DISCRETE).foundNothing(),
+                "nothing bounds a, so the sum can fall either side of ten");
+    }
+
+    /** Where the sum cannot go below the value, it goes above it. */
+    @Test
+    void aHoleAtTheFloorLiftsIt() {
+        AffineConstraint<String> hole =
+                rule(weighing("a", 1), 0, Rel.NE, Granularity.DISCRETE);
+        assertEquals(RationalCut.inclusive(num(1)),
+                reduce(List.of(hole), between("a", 0, 5), Granularity.DISCRETE)
+                        .atLeast().get("a"));
+    }
+
+    /** And where it cannot go above, it goes below. */
+    @Test
+    void aHoleAtTheCeilingLowersIt() {
+        AffineConstraint<String> hole =
+                rule(weighing("a", 1), -5, Rel.NE, Granularity.DISCRETE);
+        assertEquals(RationalCut.inclusive(num(4)),
+                reduce(List.of(hole), between("a", 0, 5), Granularity.DISCRETE)
+                        .atMost().get("a"));
+    }
+
+    /** A hole over several positions is sided by what the others are left, like any other rule. */
+    @Test
+    void aHoleOverSeveralPositionsIsSidedByWhatTheOthersLeave() {
+        AffineConstraint<String> hole =
+                rule(weighing("a", 1, "b", 1), -10, Rel.NE, Granularity.DISCRETE);
+        assertEquals(RationalCut.inclusive(num(9)),
+                reduce(List.of(hole), between("a", 0, 5, "b", 0, 5), Granularity.DISCRETE)
+                        .atMost().get("a"),
+                "a + b cannot exceed ten and is not ten, so it is under ten — and what that leaves"
+                        + " a is read with b at the least it can be, since a bound that held only"
+                        + " at b's greatest would not be a bound on a");
+    }
+
+    @Test
+    void aHoleAtTheOnlyValueLeftLeavesNothing() {
+        AffineConstraint<String> hole =
+                rule(weighing("a", 1), -3, Rel.NE, Granularity.DISCRETE);
+        assertInstanceOf(Reduction.NothingIsLeft.class,
+                AffineReduction.over(List.of(hole), between("a", 3, 3),
+                        atom -> Granularity.DISCRETE));
     }
 
     /** A rule over several positions can empty a system the difference bounds see nothing wrong

--- a/souther-compiler/src/test/java/souther/compiler/numeric/ARuleOverSeveralPositionsNarrowsEachOfThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/ARuleOverSeveralPositionsNarrowsEachOfThemTest.java
@@ -1,0 +1,380 @@
+package souther.compiler.numeric;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.AffineConstraint.Read;
+import souther.compiler.numeric.AffineReduction.Reduction;
+import souther.compiler.numeric.NumericDomain.Rel;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A rule over several positions narrows each of them, and never past what the rules admit.
+ *
+ * <p>The issue's own example. Under
+ *
+ * <pre>
+ *     0 &lt;= straw &lt;= 10      0 &lt;= choco &lt;= 6      300·straw + 600·choco &lt;= 4800
+ * </pre>
+ *
+ * <p>nothing derived that {@code choco >= 0} and the rule together leave {@code straw} at most
+ * sixteen. Every measure that read a position's range read it short of what the rules stated.
+ *
+ * <p>Soundness is the whole of the work here, and it is the one thing argument is worst at: a bound
+ * derived too tight refuses rows a model admits and nothing downstream is in a position to notice.
+ * So it is checked against the points themselves, enumerated over a bounded range rather than
+ * sampled, and the claim asserted is the one that matters — no point the rules admit is ever left
+ * outside what this derives.
+ */
+class ARuleOverSeveralPositionsNarrowsEachOfThemTest {
+
+    private static final List<String> POSITIONS = List.of("a", "b", "c");
+    private static final int LOW = -4;
+    private static final int HIGH = 4;
+    private static final int CASES = 400;
+
+    private record Written(Map<String, Rational> coefs, Rational constant, Rel rel) {}
+
+    private static Rational num(long whole) {
+        return Rational.of(whole);
+    }
+
+    private static Map<String, Rational> weighing(Object... pairs) {
+        Map<String, Rational> out = new LinkedHashMap<>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            out.put((String) pairs[i], num((Integer) pairs[i + 1]));
+        }
+        return out;
+    }
+
+    private static AffineConstraint<String> rule(Map<String, Rational> coefs, long constant,
+                                                 Rel rel, Granularity spacing) {
+        return assertInstanceOf(Read.Stated.class,
+                AffineConstraint.of(coefs, num(constant), rel, atom -> spacing)).constraint();
+    }
+
+    private static Box<String> between(Object... triples) {
+        Map<String, RationalCut> least = new LinkedHashMap<>();
+        Map<String, RationalCut> most = new LinkedHashMap<>();
+        for (int i = 0; i < triples.length; i += 3) {
+            String atom = (String) triples[i];
+            least.put(atom, RationalCut.inclusive(num((Integer) triples[i + 1])));
+            most.put(atom, RationalCut.inclusive(num((Integer) triples[i + 2])));
+        }
+        return new Box<>(least, most);
+    }
+
+    private static Reduction.Tightened<String> reduce(List<AffineConstraint<String>> rules,
+                                                      Box<String> from, Granularity spacing) {
+        return assertInstanceOf(Reduction.Tightened.class,
+                AffineReduction.over(rules, from, atom -> spacing));
+    }
+
+    // --- the issue's example -----------------------------------------------------------------------
+
+    @Test
+    void theRuleAndWhatTheOthersAreLeftBoundThePosition() {
+        AffineConstraint<String> budget =
+                rule(weighing("straw", 300, "choco", 600), -4800, Rel.LE, Granularity.DISCRETE);
+        Box<String> from = between("straw", 0, 1000, "choco", 0, 6);
+
+        Reduction.Tightened<String> found =
+                reduce(List.of(budget), from, Granularity.DISCRETE);
+
+        assertEquals(RationalCut.inclusive(num(16)), found.atMost().get("straw"),
+                "choco is never below nought, so the rule leaves straw at most sixteen");
+        assertEquals(RationalCut.inclusive(num(8)), found.atMost().get("choco"),
+                "and straw is never below nought, so it leaves choco at most eight");
+        assertNull(found.atLeast().get("straw"), "and says nothing below, which the rule does not");
+    }
+
+    /** What the other positions are left is read from the box, so a tighter box says more. */
+    @Test
+    void whatTheOthersAreLeftIsWhatTheBoxSays() {
+        AffineConstraint<String> budget =
+                rule(weighing("straw", 300, "choco", 600), -4800, Rel.LE, Granularity.DISCRETE);
+        assertEquals(RationalCut.inclusive(num(4)),
+                reduce(List.of(budget), between("straw", 0, 1000, "choco", 6, 6),
+                        Granularity.DISCRETE).atMost().get("straw"),
+                "with choco pinned at six the rule leaves straw at most four");
+    }
+
+    /** A position pulling the sum down contributes least at its greatest, which is the sign error
+     *  that would otherwise be invisible until something reported a row nobody can build. */
+    @Test
+    void aPositionWeighedNegativelyIsReadFromItsOtherEnd() {
+        AffineConstraint<String> rule =
+                rule(weighing("a", 1, "b", -1, "c", 1), -10, Rel.LE, Granularity.DISCRETE);
+        assertEquals(RationalCut.inclusive(num(14)),
+                reduce(List.of(rule), between("a", 0, 100, "b", 0, 5, "c", 1, 3),
+                        Granularity.DISCRETE).atMost().get("a"),
+                "b is at most five and c at least one, so a is at most 10 + 5 - 1");
+    }
+
+    @Test
+    void aPositionWithoutTheEndThatMattersLeavesTheRuleSayingNothing() {
+        AffineConstraint<String> rule =
+                rule(weighing("a", 1, "b", 1), -10, Rel.LE, Granularity.DISCRETE);
+        Map<String, RationalCut> nothing = Map.of();
+        Reduction.Tightened<String> found = reduce(List.of(rule),
+                new Box<>(nothing, nothing), Granularity.DISCRETE);
+        assertTrue(found.foundNothing(), "nothing bounds b below, so the sum bounds a at nothing");
+    }
+
+    @Test
+    void aBoundReachedByNothingMakesWhatFollowsStrict() {
+        AffineConstraint<String> rule =
+                rule(weighing("a", 1, "b", 1), -10, Rel.LE, Granularity.DENSE);
+        Box<String> from = new Box<>(Map.of("b", RationalCut.exclusive(num(2))), Map.of());
+        assertEquals(RationalCut.exclusive(num(8)),
+                reduce(List.of(rule), from, Granularity.DENSE).atMost().get("a"),
+                "b never quite reaches two, so a never quite reaches eight");
+    }
+
+    /** Turning `k·a <= w - m` into a bound on `a` is handed back to the one place that decides it,
+     *  so what it does about the values `a` can take is what it does everywhere. */
+    @Test
+    void theBoundLandsOnAValueThePositionCanTake() {
+        AffineConstraint<String> rule =
+                rule(weighing("a", 2, "b", 1), -9, Rel.LE, Granularity.DISCRETE);
+        assertEquals(RationalCut.inclusive(num(4)),
+                reduce(List.of(rule), between("b", 0, 5), Granularity.DISCRETE).atMost().get("a"),
+                "`2a <= 9` leaves a at four and never at four and a half");
+    }
+
+    @Test
+    void anEqualityIsReadFromBothSides() {
+        AffineConstraint<String> rule =
+                rule(weighing("a", 1, "b", 1, "c", 1), -10, Rel.EQ, Granularity.DISCRETE);
+        Reduction.Tightened<String> found =
+                reduce(List.of(rule), between("b", 1, 3, "c", 2, 4), Granularity.DISCRETE);
+        assertEquals(RationalCut.inclusive(num(7)), found.atMost().get("a"));
+        assertEquals(RationalCut.inclusive(num(3)), found.atLeast().get("a"));
+    }
+
+    @Test
+    void aHoleIsNotReadHere() {
+        AffineConstraint<String> hole =
+                rule(weighing("a", 1, "b", 1), -10, Rel.NE, Granularity.DISCRETE);
+        assertTrue(reduce(List.of(hole), between("b", 0, 5), Granularity.DISCRETE).foundNothing());
+    }
+
+    /** A rule over several positions can empty a system the difference bounds see nothing wrong
+     *  with, and a reader handed two ends that have crossed has to be told. */
+    @Test
+    void aRuleThatLeavesAPositionNothingSaysSo() {
+        AffineConstraint<String> rule =
+                rule(weighing("a", 1, "b", 1), -5, Rel.LE, Granularity.DISCRETE);
+        assertInstanceOf(Reduction.NothingIsLeft.class,
+                AffineReduction.over(List.of(rule), between("a", 10, 20, "b", 10, 20),
+                        atom -> Granularity.DISCRETE));
+    }
+
+    // --- against the points ------------------------------------------------------------------------
+
+    /**
+     * No point the rules admit is ever left outside what this derives, over rules and boxes drawn at
+     * random. The direction asserted is the only one that matters: a bound too tight refuses a row a
+     * model admits, and a bound too loose merely says less than it could.
+     */
+    @Test
+    void noPointTheRulesAdmitIsEverRefused() {
+        Random dice = new Random(4800);
+        int narrowed = 0;
+        for (int round = 0; round < CASES; round++) {
+            List<Written> written = someRules(dice);
+            List<AffineConstraint<String>> stated = read(written);
+            Box<String> from = between("a", LOW, HIGH, "b", LOW, HIGH, "c", LOW, HIGH);
+            List<Map<String, Integer>> admitted = pointsSatisfying(written);
+
+            Reduction<String> found = AffineReduction.over(stated, from,
+                    atom -> Granularity.DISCRETE);
+            if (found instanceof Reduction.NothingIsLeft) {
+                assertTrue(admitted.isEmpty(),
+                        () -> "said nothing is left, but " + written + " admits " + admitted);
+                continue;
+            }
+            Reduction.Tightened<String> tightened = (Reduction.Tightened<String>) found;
+            Box<String> after = from.meeting(tightened.atLeast(), tightened.atMost());
+            if (!tightened.foundNothing()) {
+                narrowed++;
+            }
+            for (Map<String, Integer> point : admitted) {
+                for (String position : POSITIONS) {
+                    Rational at = num(point.get(position));
+                    assertTrue(admits(after.leastOf(position), at, false)
+                                    && admits(after.mostOf(position), at, true),
+                            () -> "refused a point the rules admit: " + point + " under " + written
+                                    + " left " + position + " in [" + after.leastOf(position)
+                                    + ", " + after.mostOf(position) + "]");
+                }
+            }
+            // Reductive: nothing came back wider than it went in.
+            for (String position : POSITIONS) {
+                assertEquals(after.leastOf(position),
+                        RationalCut.tighterLower(from.leastOf(position), after.leastOf(position)));
+                assertEquals(after.mostOf(position),
+                        RationalCut.tighterUpper(from.mostOf(position), after.mostOf(position)));
+            }
+        }
+        assertTrue(narrowed > CASES / 10,
+                "only " + narrowed + " of " + CASES + " narrowed anything, so this checked little");
+    }
+
+    /** And the same answers whatever order the rules arrived in. */
+    @Test
+    void theOrderTheRulesArrivedInIsNotPartOfTheAnswer() {
+        Random dice = new Random(16);
+        for (int round = 0; round < CASES; round++) {
+            List<AffineConstraint<String>> stated = read(someRules(dice));
+            Box<String> from = between("a", LOW, HIGH, "b", LOW, HIGH, "c", LOW, HIGH);
+            List<AffineConstraint<String>> shuffled = new ArrayList<>(stated);
+            Collections.shuffle(shuffled, dice);
+
+            Reduction<String> asWritten =
+                    AffineReduction.over(stated, from, atom -> Granularity.DISCRETE);
+            Reduction<String> reordered =
+                    AffineReduction.over(shuffled, from, atom -> Granularity.DISCRETE);
+            assertEquals(asWritten, reordered,
+                    () -> "the reduction moved when the rules were reordered: " + stated);
+        }
+    }
+
+    /** Monotone: a narrower box never yields a wider answer. */
+    @Test
+    void aNarrowerBoxNeverSaysLess() {
+        Random dice = new Random(600);
+        for (int round = 0; round < CASES; round++) {
+            List<AffineConstraint<String>> stated = read(someRules(dice));
+            Box<String> wide = between("a", LOW, HIGH, "b", LOW, HIGH, "c", LOW, HIGH);
+            Box<String> narrow = between("a", LOW + 1, HIGH - 1, "b", LOW + 1, HIGH - 1,
+                    "c", LOW + 1, HIGH - 1);
+
+            Reduction<String> overWide =
+                    AffineReduction.over(stated, wide, atom -> Granularity.DISCRETE);
+            Reduction<String> overNarrow =
+                    AffineReduction.over(stated, narrow, atom -> Granularity.DISCRETE);
+            if (!(overWide instanceof Reduction.Tightened<String> loose)) {
+                continue;   // the wider box was already empty, so there is nothing wider to be
+            }
+            if (!(overNarrow instanceof Reduction.Tightened<String> tight)) {
+                continue;
+            }
+            for (String position : POSITIONS) {
+                RationalCut looseHigh = loose.atMost().get(position);
+                RationalCut tightHigh = tight.atMost().get(position);
+                if (looseHigh != null && tightHigh != null) {
+                    assertEquals(tightHigh, RationalCut.tighterUpper(looseHigh, tightHigh),
+                            () -> "a narrower box said less above " + position);
+                }
+                RationalCut looseLow = loose.atLeast().get(position);
+                RationalCut tightLow = tight.atLeast().get(position);
+                if (looseLow != null && tightLow != null) {
+                    assertEquals(tightLow, RationalCut.tighterLower(looseLow, tightLow),
+                            () -> "a narrower box said less below " + position);
+                }
+            }
+        }
+    }
+
+    @Test
+    void aBoxSaysNothingAboutAPositionNobodyBounded() {
+        assertFalse(Box.<String>unbounded().positions().contains("a"));
+        assertTrue(Box.<String>unbounded().holdsAValueAt("a"));
+        assertNull(Box.<String>unbounded().mostOf("a"));
+    }
+
+    private static boolean admits(RationalCut cut, Rational value, boolean above) {
+        if (cut == null) {
+            return true;
+        }
+        int order = value.compareTo(cut.at());
+        return above ? (order < 0 || (order == 0 && cut.inclusive()))
+                : (order > 0 || (order == 0 && cut.inclusive()));
+    }
+
+    /** Rules over two or three positions, weighted unevenly, which is what the difference bounds
+     *  cannot hold and what this exists for. */
+    private static List<Written> someRules(Random dice) {
+        List<Written> out = new ArrayList<>();
+        int howMany = 1 + dice.nextInt(3);
+        for (int i = 0; i < howMany; i++) {
+            Map<String, Rational> coefs = new LinkedHashMap<>();
+            for (String position : POSITIONS) {
+                int weight = dice.nextInt(7) - 3;
+                if (weight != 0) {
+                    coefs.put(position, num(weight));
+                }
+            }
+            if (coefs.isEmpty()) {
+                continue;
+            }
+            long constant = dice.nextInt(21) - 10;
+            Rel rel = switch (dice.nextInt(5)) {
+                case 0 -> Rel.LT;
+                case 1 -> Rel.GE;
+                case 2 -> Rel.GT;
+                case 3 -> Rel.EQ;
+                default -> Rel.LE;
+            };
+            out.add(new Written(coefs, num(constant), rel));
+        }
+        return out;
+    }
+
+    private static List<AffineConstraint<String>> read(List<Written> written) {
+        List<AffineConstraint<String>> out = new ArrayList<>();
+        for (Written each : written) {
+            if (AffineConstraint.of(each.coefs(), each.constant(), each.rel(),
+                    atom -> Granularity.DISCRETE) instanceof Read.Stated<String> stated) {
+                out.add(stated.constraint());
+            }
+        }
+        return out;
+    }
+
+    private static List<Map<String, Integer>> pointsSatisfying(List<Written> written) {
+        List<Map<String, Integer>> out = new ArrayList<>();
+        for (int a = LOW; a <= HIGH; a++) {
+            for (int b = LOW; b <= HIGH; b++) {
+                for (int c = LOW; c <= HIGH; c++) {
+                    Map<String, Integer> point = new LinkedHashMap<>();
+                    point.put("a", a);
+                    point.put("b", b);
+                    point.put("c", c);
+                    if (written.stream().allMatch(rule -> holdsAt(rule, point))) {
+                        out.add(point);
+                    }
+                }
+            }
+        }
+        return out;
+    }
+
+    private static boolean holdsAt(Written rule, Map<String, Integer> point) {
+        Rational total = rule.constant();
+        for (Map.Entry<String, Rational> each : rule.coefs().entrySet()) {
+            total = total.plus(each.getValue().times(num(point.get(each.getKey()))));
+        }
+        int sign = total.signum();
+        return switch (rule.rel()) {
+            case LE -> sign <= 0;
+            case LT -> sign < 0;
+            case GE -> sign >= 0;
+            case GT -> sign > 0;
+            case EQ -> sign == 0;
+            case NE -> sign != 0;
+        };
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/numeric/ARuleOverSeveralPositionsNarrowsEachOfThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/ARuleOverSeveralPositionsNarrowsEachOfThemTest.java
@@ -129,7 +129,8 @@ class ARuleOverSeveralPositionsNarrowsEachOfThemTest {
         Map<String, RationalCut> nothing = Map.of();
         Reduction.Tightened<String> found = reduce(List.of(rule),
                 new Box<>(nothing, nothing), Granularity.DISCRETE);
-        assertTrue(found.foundNothing(), "nothing bounds b below, so the sum bounds a at nothing");
+        assertTrue(found.atLeast().isEmpty() && found.atMost().isEmpty(),
+                "nothing bounds b below, so the sum bounds a at nothing");
     }
 
     @Test
@@ -172,7 +173,9 @@ class ARuleOverSeveralPositionsNarrowsEachOfThemTest {
     void aHoleWithNothingToSideItBoundsNothing() {
         AffineConstraint<String> hole =
                 rule(weighing("a", 1, "b", 1), -10, Rel.NE, Granularity.DISCRETE);
-        assertTrue(reduce(List.of(hole), between("b", 0, 5), Granularity.DISCRETE).foundNothing(),
+        Reduction.Tightened<String> found =
+                reduce(List.of(hole), between("b", 0, 5), Granularity.DISCRETE);
+        assertTrue(found.atLeast().isEmpty() && found.atMost().isEmpty(),
                 "nothing bounds a, so the sum can fall either side of ten");
     }
 
@@ -255,7 +258,7 @@ class ARuleOverSeveralPositionsNarrowsEachOfThemTest {
             }
             Reduction.Tightened<String> tightened = (Reduction.Tightened<String>) found;
             Box<String> after = from.meeting(tightened.atLeast(), tightened.atMost());
-            if (!tightened.foundNothing()) {
+            if (!tightened.atLeast().isEmpty() || !tightened.atMost().isEmpty()) {
                 narrowed++;
             }
             for (Map<String, Integer> point : admitted) {

--- a/souther-compiler/src/test/java/souther/compiler/numeric/AnExactRatioIsOneValueHoweverItArrivedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/AnExactRatioIsOneValueHoweverItArrivedTest.java
@@ -1,0 +1,146 @@
+package souther.compiler.numeric;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A ratio is held in lowest terms, so two ways of writing one value are one value. What is built on
+ * these compares canonical forms by their maps, and a map whose values are ratios only decides that
+ * two forms are the same rule if equal ratios are equal here.
+ */
+class AnExactRatioIsOneValueHoweverItArrivedTest {
+
+    private static Rational ratio(long numerator, long denominator) {
+        return Rational.of(BigInteger.valueOf(numerator), BigInteger.valueOf(denominator));
+    }
+
+    @Test
+    void twoWritingsOfOneValueAreOneValue() {
+        assertEquals(ratio(1, 3), ratio(2, 6));
+        assertEquals(ratio(1, 3), ratio(-3, -9));
+        assertEquals(ratio(1, 3).hashCode(), ratio(2, 6).hashCode());
+    }
+
+    @Test
+    void aNegativeDenominatorMovesToTheNumerator() {
+        assertEquals(BigInteger.valueOf(-1), ratio(1, -3).numerator());
+        assertEquals(BigInteger.valueOf(3), ratio(1, -3).denominator());
+    }
+
+    @Test
+    void zeroIsOneValueWhateverItWasOver() {
+        assertEquals(Rational.ZERO, ratio(0, 7));
+        assertTrue(ratio(0, 7).isZero());
+    }
+
+    @Test
+    void aZeroDenominatorIsRefused() {
+        assertThrows(IllegalArgumentException.class, () -> ratio(1, 0));
+    }
+
+    @Test
+    void arithmeticIsExactWhereDecimalsWouldRound() {
+        Rational third = ratio(1, 3);
+        assertEquals(Rational.ONE, third.plus(third).plus(third),
+                "three thirds are one, which is what rounding a third at any scale loses");
+        assertEquals(ratio(1, 9), third.times(third));
+        assertEquals(Rational.ONE, third.dividedBy(third));
+        assertEquals(ratio(-1, 3), third.negated());
+    }
+
+    @Test
+    void dividingByZeroIsACallersMistake() {
+        assertThrows(ArithmeticException.class, () -> Rational.ONE.dividedBy(Rational.ZERO));
+    }
+
+    @Test
+    void aWrittenDecimalArrivesExactly() {
+        assertEquals(ratio(1, 2), Rational.of(new BigDecimal("0.5")));
+        assertEquals(ratio(1, 8), Rational.of(new BigDecimal("0.125")));
+        assertEquals(Rational.of(300), Rational.of(new BigDecimal("3E+2")),
+                "a negative scale is a whole number written as a multiple of ten");
+        assertEquals(ratio(-7, 100), Rational.of(new BigDecimal("-0.07")));
+    }
+
+    @Test
+    void aRatioThatTerminatesComesBackAsTheDecimalItIs() {
+        assertEquals(new BigDecimal("0.5"), ratio(1, 2).asWrittenDecimal());
+        assertEquals(new BigDecimal("0.125"), ratio(1, 8).asWrittenDecimal());
+        assertEquals(new BigDecimal("0.12"), ratio(3, 25).asWrittenDecimal());
+        assertEquals(new BigDecimal("7"), Rational.of(7).asWrittenDecimal());
+        assertEquals(new BigDecimal("-0.05"), ratio(-1, 20).asWrittenDecimal());
+    }
+
+    /** The whole reason this type exists: a third is not a decimal, and saying so is the answer
+     *  rather than handing back a rounded one that a later reader cannot tell from an exact one. */
+    @Test
+    void aRatioThatDoesNotTerminateSaysSoRatherThanRounding() {
+        assertNull(ratio(1, 3).asWrittenDecimal());
+        assertNull(ratio(2, 7).asWrittenDecimal());
+        assertNull(ratio(1, 30).asWrittenDecimal());
+        assertNotNull(ratio(1, 40).asWrittenDecimal(), "forty is twos and a five");
+    }
+
+    @Test
+    void roundingIsTheCallersDirection() {
+        assertEquals(new BigDecimal("0.34"), ratio(1, 3).asDecimal(RoundingMode.CEILING, 2));
+        assertEquals(new BigDecimal("0.33"), ratio(1, 3).asDecimal(RoundingMode.FLOOR, 2));
+    }
+
+    @Test
+    void wholeNumbersAreTakenOffEitherEnd() {
+        assertEquals(BigInteger.ZERO, ratio(1, 3).floor());
+        assertEquals(BigInteger.ONE, ratio(1, 3).ceiling());
+        assertEquals(BigInteger.valueOf(-1), ratio(-1, 3).floor());
+        assertEquals(BigInteger.ZERO, ratio(-1, 3).ceiling());
+        assertEquals(BigInteger.TWO, Rational.of(2).floor());
+        assertEquals(BigInteger.TWO, Rational.of(2).ceiling(),
+                "a whole number is its own floor and its own ceiling");
+        assertTrue(Rational.of(2).isWhole());
+    }
+
+    /**
+     * What generates the values a form's coefficients reach. A third and a half are both whole
+     * multiples of a sixth: {@code gcd} of the numerators over {@code lcm} of the denominators.
+     */
+    @Test
+    void theGreatestCommonDivisorIsTheLargestBothAreMultiplesOf() {
+        assertEquals(ratio(1, 6), Rational.gcd(ratio(1, 3), ratio(1, 2)));
+        assertEquals(Rational.of(3), Rational.gcd(Rational.of(3), Rational.of(6)));
+        assertEquals(Rational.of(300), Rational.gcd(Rational.of(300), Rational.of(600)),
+                "which is what turns `300s + 600c <= 4800` into `s + 2c <= 16`");
+        assertEquals(Rational.ONE, Rational.gcd(Rational.of(2), Rational.of(3)));
+    }
+
+    @Test
+    void zeroDividesNothingSoItIsTheIdentityHere() {
+        assertEquals(Rational.of(3), Rational.gcd(Rational.ZERO, Rational.of(3)));
+        assertEquals(Rational.of(3), Rational.gcd(Rational.of(3), Rational.ZERO));
+        assertEquals(Rational.ZERO, Rational.gcd(Rational.ZERO, Rational.ZERO));
+    }
+
+    @Test
+    void aDivisorHasNoSign() {
+        assertEquals(Rational.of(3), Rational.gcd(Rational.of(-3), Rational.of(6)));
+        assertEquals(Rational.of(3), Rational.gcd(Rational.of(-3), Rational.of(-6)));
+    }
+
+    @Test
+    void orderIsDecidedWithoutLeavingTheRatios() {
+        assertTrue(ratio(1, 3).compareTo(ratio(1, 2)) < 0);
+        assertTrue(ratio(1, 3).compareTo(ratio(2, 6)) == 0);
+        assertTrue(ratio(-1, 3).compareTo(ratio(1, 3)) < 0);
+        assertTrue(Rational.of(10_000_000_000L).times(Rational.of(10_000_000_000L))
+                .compareTo(Rational.of(Long.MAX_VALUE)) > 0,
+                "and past where a long stops, since comparing cross-multiplies");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/numeric/NumericDomainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/NumericDomainTest.java
@@ -174,18 +174,27 @@ class NumericDomainTest {
         assertFalse(provesAtMost(d, A, 1438), "a = 1439 with b = 1440 satisfies it");
     }
 
-    /** One dense atom on either side and the difference has no smallest step again: {@code a} may be
-     * {@code 1439.5} when {@code b} is 1440. */
+    /**
+     * A dense {@code b} leaves the difference with no smallest step, and {@code a} is still a whole
+     * number, so its own bound steps through.
+     *
+     * <p>Two questions that had been answered as one. The difference {@code a - b} takes no step —
+     * nothing here says {@code b} is whole — so the relation cannot be sharpened as a relation. What
+     * can be sharpened is {@code a}: put {@code b} at the most it can be and {@code a} is under
+     * 1440, and the largest whole number under 1440 is 1439. Which of the two is being tightened is
+     * the whole of it, and asking the difference's spacing about a bound on a position answers the
+     * wrong question — conservatively, but wrongly: {@code a} could never be 1439.5.
+     */
     @Test
-    void aStrictDifferenceWithOneDenseSideTakesNoStep() {
+    void aWholePositionStepsThroughEvenWhereTheDifferenceCannot() {
         Map<String, Granularity> mixed = new LinkedHashMap<>(whole(A));
         mixed.putAll(dense(B));
         NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(atom(A).minus(atom(B)), Rel.LT, mixed)
                 .assume(atom(B).minus(num(1440)), Rel.LE, dense(B));
 
-        assertTrue(provesAtMost(d, A, 1440));
-        assertFalse(provesAtMost(d, A, 1439), "nothing here says b is a whole number");
+        assertTrue(provesAtMost(d, A, 1439), "a is whole and under 1440");
+        assertFalse(provesAtMost(d, A, 1438), "and 1439 is a value it takes, with b just above it");
     }
 
     /** The same shape over decimals, where 1439 is not derivable and must not become so: {@code a =

--- a/souther-compiler/src/test/java/souther/compiler/numeric/NumericDomainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/NumericDomainTest.java
@@ -243,68 +243,113 @@ class NumericDomainTest {
         assertTrue(d.isBottom(), "a >= 1 and a <= 0 cannot both hold");
     }
 
-    // --- what an assertion arrived with and the domain did not keep --------------------------------
+    // --- how much of a rule the ranges handed over are able to state -------------------------------
 
+    /** An interval and a difference are both things a range and its differences state in full. */
     @Test
-    void anIntervalAndADifferenceOverWholeNumbersLoseNothing() {
+    void anIntervalAndADifferenceAreStatedByWhatIsHandedOver() {
         NumericDomain<String> d = NumericDomain.<String>top()
                 .assume(atom(A).minus(atom(B)), Rel.LT, whole(A, B))
                 .assume(atom(B).minus(num(1440)), Rel.LE, whole(B))
                 .assume(atom(A).negate(), Rel.LE, whole(A));
 
-        assertTrue(d.projectionIsLossless(), () -> "lost " + d.lossyAtoms());
+        assertTrue(d.projectionEntails(atom(A).minus(atom(B)), Rel.LT));
+        assertTrue(d.projectionEntails(atom(B).minus(num(1440)), Rel.LE));
     }
 
-    /** A loss names the atoms the rule was written about, which is what a reader of it is told. */
-    @Test
-    void aLossNamesTheAtomsTheRuleWasWrittenAbout() {
-        NumericDomain<String> d = NumericDomain.<String>top()
-                .assume(atom(A), Rel.NE, whole(A))
-                .assume(atom(B).minus(num(10)), Rel.LE, whole(B));
-
-        assertEquals(Set.of(A), d.lossyAtoms());
-        assertFalse(d.projectionIsLossless(), "and the domain is not all of what it was told");
-    }
-
-    /** A strict bound over decimals is kept as an end the range stops at without reaching, which is
-     * the whole of what was asserted and so no loss. */
+    /** A strict bound over decimals is an end the range stops at without reaching, which is the
+     * whole of what was asserted. */
     @Test
     void aStrictBoundOnADenseAtomIsKeptAsAnEndTheRangeDoesNotReach() {
         NumericDomain<String> interval = NumericDomain.<String>top()
                 .assume(atom(A).minus(num(3)), Rel.LT, dense(A));
 
         assertEquals(Endpoint.exclusive(Count.of(3)), interval.boundsOf(A).max());
-        assertTrue(interval.projectionIsLossless());
+        assertTrue(interval.projectionEntails(atom(A).minus(num(3)), Rel.LT));
     }
 
-    /** The same over whole numbers keeps everything too: there the strictness became a step, and the
-     * value it steps onto is one the rule admits. */
+    /** The same over whole numbers states it too: there the strictness became a step, and the value
+     * it steps onto is one the rule admits. */
     @Test
-    void aStrictBoundOnAWholeNumberIsNoLoss() {
-        NumericDomain<String> d = NumericDomain.<String>top().assume(atom(A).minus(num(3)), Rel.LT, whole(A));
+    void aStrictBoundOnAWholeNumberIsStatedByTheStepItTook() {
+        NumericDomain<String> d = NumericDomain.<String>top()
+                .assume(atom(A).minus(num(3)), Rel.LT, whole(A));
 
         assertEquals(Endpoint.inclusive(Count.of(2)), d.boundsOf(A).max());
-        assertTrue(d.projectionIsLossless());
+        assertTrue(d.projectionEntails(atom(A).minus(num(3)), Rel.LT));
     }
 
-    /** A disequality is a hole in a range, and a range is all this holds. */
+    /**
+     * A hole with nothing to side it is the one a range genuinely cannot keep.
+     *
+     * <p>And a hole at an edge is not: it moves the edge, and the range then says the whole of it.
+     * Which of the two a disequality is depends on what else is known, so it is asked of what the
+     * rules were found to leave rather than recorded when the rule was read.
+     */
     @Test
-    void aDisequalityIsRecordedAsALoss() {
-        NumericDomain<String> d = NumericDomain.<String>top().assume(atom(A), Rel.NE, whole(A));
+    void aHoleIsStatedByTheRangesOnlyWhereItMovedAnEdge() {
+        NumericDomain<String> loose = NumericDomain.<String>top()
+                .assume(atom(A), Rel.NE, whole(A));
+        assertFalse(loose.projectionEntails(atom(A), Rel.NE),
+                "nothing says which side of nought a is on, so the range keeps the nought");
 
-        assertEquals(Set.of(NumericDomain.Loss.DROPPED_DISEQUALITY), d.lossesAt(A));
+        NumericDomain<String> sided = loose.assume(atom(A), Rel.GE, whole(A));
+        assertEquals(Endpoint.inclusive(Count.of(1)), sided.boundsOf(A).min());
+        assertTrue(sided.projectionEntails(atom(A), Rel.NE),
+                "and here the range states it, because the hole moved the edge onto one");
     }
 
-    /** A form of neither shape proves things and no bound is derived through it. */
+    /**
+     * A rule over two positions narrows both and is still not something two ranges state — the
+     * ranges hold every pair of their own values and the rule refuses some of them.
+     */
     @Test
-    void aFormOfNeitherShapeIsRecordedAsALoss() {
+    void aRuleOverTwoPositionsNarrowsBothAndIsStillNotARange() {
         NumericDomain<String> d = NumericDomain.<String>top()
+                .assume(atom(A).negate(), Rel.LE, whole(A, B))
+                .assume(atom(B).negate(), Rel.LE, whole(A, B))
                 .assume(atom(A).plus(atom(B)).minus(num(10)), Rel.LE, whole(A, B));
 
-        assertEquals(Set.of(A, B), d.lossyAtoms());
-        assertEquals(Set.of(NumericDomain.Loss.KEPT_UNPROJECTABLE), d.lossesAt(A));
+        assertEquals(Endpoint.inclusive(Count.of(10)), d.boundsOf(A).max());
         assertTrue(d.entails(atom(A).plus(atom(B)).minus(num(10)), Rel.LE),
-                "still proves what it was told, and holds no bound from it");
+                "the rules prove it, since one of them is it");
+        assertFalse(d.projectionEntails(atom(A).plus(atom(B)).minus(num(10)), Rel.LE),
+                "and the two ranges do not, since they hold a = 10 beside b = 10");
+    }
+
+    /** Where the ranges are tight enough to hold it, they state it, and nothing is owed. */
+    @Test
+    void aRuleOverTwoPositionsIsStatedWhereTheRangesAlreadyHoldIt() {
+        NumericDomain<String> d = NumericDomain.<String>top()
+                .assume(atom(A).negate(), Rel.LE, whole(A, B))
+                .assume(atom(B).negate(), Rel.LE, whole(A, B))
+                .assume(atom(A).minus(num(3)), Rel.LE, whole(A, B))
+                .assume(atom(B).minus(num(3)), Rel.LE, whole(A, B))
+                .assume(atom(A).plus(atom(B)).minus(num(10)), Rel.LE, whole(A, B));
+
+        assertTrue(d.projectionEntails(atom(A).plus(atom(B)).minus(num(10)), Rel.LE),
+                "a and b are each at most three, so their sum is at most six whatever is picked");
+    }
+
+    // --- and whether the ends are numbers anybody can write -----------------------------------------
+
+    @Test
+    void endsOnWholeNumbersAreWrittenExactly() {
+        NumericDomain<String> d = NumericDomain.<String>top()
+                .assume(atom(A).minus(num(3)), Rel.LE, whole(A));
+        assertTrue(d.endsAreWrittenExactly(A));
+    }
+
+    /** A third is not a decimal, so the number standing for that edge is a hair outside it. */
+    @Test
+    void anEndAtAValueNoDecimalWritesIsRoundedPast() {
+        NumericDomain<String> d = NumericDomain.<String>top()
+                .assume(atom(A).times(java.math.BigDecimal.valueOf(3)).minus(num(1)),
+                        Rel.LE, dense(A));
+        assertFalse(d.endsAreWrittenExactly(A));
+        assertTrue(d.boundsOf(A).max().at() instanceof Count at
+                        && at.at().compareTo(new java.math.BigDecimal("0.3333")) > 0,
+                "and it is rounded the way that widens: " + d.boundsOf(A).max());
     }
 
     // --- what the domain refuses to be told -------------------------------------------------------

--- a/souther-compiler/src/test/java/souther/compiler/numeric/OnePlaceDerivesWhatAFormCanAddUpToTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/OnePlaceDerivesWhatAFormCanAddUpToTest.java
@@ -1,0 +1,88 @@
+package souther.compiler.numeric;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.EveryShippedMessageCatalogIsCompleteAndValidTest;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Which values a form {@code Σ cᵢ·xᵢ} can add up to is derived in one place.
+ *
+ * <p>It had been derived in two, and the two disagreed. Asked of a border, {@code 3 * a} over
+ * decimals does not come to one, and the report was right to refuse a row there. Asked of the
+ * interval algebra, {@code 3 * a = 1} came back as a satisfiable range around a third — a range
+ * whose ends are two decimals neither of which is a third, describing a value no model can write.
+ * Two answers about one piece of arithmetic, and the layer that got it wrong is the one whose bounds
+ * everything downstream reads.
+ *
+ * <p>What was duplicated is small and is exactly the part that is easy to get subtly wrong: the
+ * divisor the coefficients share, and which factors are units among the finite decimals. So the rule
+ * is that {@link AdditiveImage} derives both and everything else asks it.
+ *
+ * <p>A tripwire and not a proof. It reads the sources, so the same arithmetic spelled a new way
+ * defeats it — and spelling it a new way is what the second implementation was.
+ */
+class OnePlaceDerivesWhatAFormCanAddUpToTest {
+
+    /**
+     * Where this arithmetic may be written: the type that answers for it, and the ratio type whose
+     * lowest terms it is built out of.
+     *
+     * <p>Both in this package, which is the point — the partition layer used to hold a copy, and a
+     * copy there is one the interval algebra cannot reach and so cannot agree with.
+     */
+    private static final Set<String> MAY_DERIVE_IT = Set.of(
+            "souther/compiler/numeric/AdditiveImage.java",
+            "souther/compiler/numeric/Rational.java");
+
+    /** Taking the factors of ten out of a number, which is what makes a divisor over the finite
+     *  decimals canonical. Two and five named together in one file is what the copy looked like. */
+    @Test
+    void theUnitsOfTheFiniteDecimalsAreTakenOutInOnePlace() throws IOException {
+        assertEquals(Set.of(), sourcesMatching(code ->
+                        code.contains("BigInteger.TWO") && code.contains("valueOf(5)")),
+                "ten is a unit among the finite decimals and so are two and five; a second place"
+                        + " deciding that is a second answer to which values a form reaches");
+    }
+
+    /** And the divisor the coefficients share, which is the other half of the same answer. */
+    @Test
+    void theDivisorCoefficientsShareIsFoundInOnePlace() throws IOException {
+        assertEquals(Set.of(), sourcesMatching(code -> code.contains("Rational.gcd(")),
+                "the divisor of a form's coefficients is what its values are multiples of; ask"
+                        + " AdditiveImage for it rather than folding one alongside");
+    }
+
+    private static Set<String> sourcesMatching(java.util.function.Predicate<String> holds)
+            throws IOException {
+        List<Path> sources = EveryShippedMessageCatalogIsCompleteAndValidTest.mainSources();
+        assertFalse(sources.isEmpty(), "found no sources at all — the scan missed the tree");
+        Set<String> found = new TreeSet<>();
+        for (Path source : sources) {
+            String named = source.toString().replace('\\', '/').replaceAll(".*/src/main/java/", "");
+            if (MAY_DERIVE_IT.contains(named)) {
+                continue;
+            }
+            if (holds.test(withoutComments(Files.readString(source, StandardCharsets.UTF_8)))) {
+                found.add(named);
+            }
+        }
+        return found;
+    }
+
+    /** The file with what is written about the code taken out. Prose has to be able to say what the
+     *  rule is; what the rule is about is code. */
+    private static String withoutComments(String text) {
+        return text.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("(?m)//.*$", "");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/numeric/OneStateAnswersForWhatTheRulesLeaveTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/OneStateAnswersForWhatTheRulesLeaveTest.java
@@ -1,0 +1,326 @@
+package souther.compiler.numeric;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.AffineConstraint.Read;
+import souther.compiler.numeric.NumericDomain.Rel;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The rules are worked out once, and what comes out is a function of the rules.
+ *
+ * <p>Not of the order they arrived in, not of how many times each was said, and not of whether a
+ * rule happened to be written as a difference or as a sum. That last one is the reason the
+ * differences are closed again after every round rather than once at the start.
+ *
+ * <p>Checked against the points over a bounded range, in the one direction that matters: no point
+ * the rules admit is left outside what the state says, and where the state says nothing is left,
+ * nothing is.
+ */
+class OneStateAnswersForWhatTheRulesLeaveTest {
+
+    private static final List<String> POSITIONS = List.of("a", "b", "c");
+    private static final int LOW = -4;
+    private static final int HIGH = 4;
+    private static final int CASES = 300;
+
+    private record Written(Map<String, Rational> coefs, Rational constant, Rel rel) {}
+
+    private static Rational num(long whole) {
+        return Rational.of(whole);
+    }
+
+    private static Map<String, Rational> weighing(Object... pairs) {
+        Map<String, Rational> out = new LinkedHashMap<>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            out.put((String) pairs[i], num((Integer) pairs[i + 1]));
+        }
+        return out;
+    }
+
+    private static AffineConstraint<String> rule(Map<String, Rational> coefs, long constant,
+                                                 Rel rel) {
+        return assertInstanceOf(Read.Stated.class, AffineConstraint.of(coefs, num(constant), rel,
+                atom -> Granularity.DISCRETE)).constraint();
+    }
+
+    private static ClosedState<String> closing(List<AffineConstraint<String>> rules) {
+        return ClosedState.of(rules, atom -> Granularity.DISCRETE);
+    }
+
+    // --- the issue, end to end --------------------------------------------------------------------
+
+    /**
+     * A rule over more than one position now narrows the positions it names. Under the issue's own
+     * numbers the rule is not the binding one; under wider own-bounds it is, and it says so.
+     */
+    @Test
+    void aRuleOverSeveralPositionsNarrowsThePositionsItNames() {
+        ClosedState<String> closed = closing(List.of(
+                rule(weighing("straw", 1), 0, Rel.GE),
+                rule(weighing("straw", 1), -1000, Rel.LE),
+                rule(weighing("choco", 1), 0, Rel.GE),
+                rule(weighing("choco", 1), -6, Rel.LE),
+                rule(weighing("straw", 300, "choco", 600), -4800, Rel.LE)));
+
+        assertEquals(RationalCut.inclusive(num(16)), closed.box().mostOf("straw"));
+        assertEquals(RationalCut.inclusive(num(6)), closed.box().mostOf("choco"),
+                "its own rule is the tighter one here and stays");
+    }
+
+    /** And where its own bound is tighter, the position keeps it. */
+    @Test
+    void thePositionKeepsWhicheverBoundIsTighter() {
+        ClosedState<String> closed = closing(List.of(
+                rule(weighing("straw", 1), 0, Rel.GE),
+                rule(weighing("straw", 1), -10, Rel.LE),
+                rule(weighing("choco", 1), 0, Rel.GE),
+                rule(weighing("straw", 300, "choco", 600), -4800, Rel.LE)));
+        assertEquals(RationalCut.inclusive(num(10)), closed.box().mostOf("straw"));
+    }
+
+    /**
+     * A bound a sum found on one position reaches every position held against it, however long the
+     * chain of differences between them.
+     *
+     * <p>The chain is built longer than the rounds are, on purpose. Read one rule at a time against
+     * the box, a bound walks one link of a chain per round and a chain longer than the budget never
+     * arrives; carried along the closed differences it arrives in one step whatever the length. So
+     * this is the case that tells the two apart, and it stays the case if the budget changes.
+     */
+    @Test
+    void aBoundReachesTheFarEndOfAChainLongerThanTheRounds() {
+        int links = ClosedState.ROUNDS + 4;
+        List<AffineConstraint<String>> rules = new ArrayList<>();
+        for (int i = 0; i < links; i++) {
+            rules.add(rule(weighing("x" + i, 1, "x" + (i + 1), -1), 0, Rel.LE));
+        }
+        rules.add(rule(weighing("y", 1), 0, Rel.GE));
+        rules.add(rule(weighing("x" + links, 3, "y", 2), -12, Rel.LE));   // the far end is under four
+
+        ClosedState<String> closed = closing(rules);
+        assertEquals(RationalCut.inclusive(num(4)), closed.box().mostOf("x" + links));
+        assertEquals(RationalCut.inclusive(num(4)), closed.box().mostOf("x0"),
+                "and the near end is under it too, " + links + " links away");
+    }
+
+    /**
+     * A round reads what the round before it left.
+     *
+     * <p>Every rule in a round reads the same box, so what one of them finds is not available to
+     * another until the next round. Here the first round can only learn that {@code b} is at least
+     * two, and it takes a second for that to bear on {@code a}.
+     */
+    @Test
+    void aRoundReadsWhatTheRoundBeforeItLeft() {
+        ClosedState<String> closed = closing(List.of(
+                rule(weighing("a", 1), 0, Rel.GE),
+                rule(weighing("b", 1), 0, Rel.GE),
+                rule(weighing("c", 1), 0, Rel.GE),
+                rule(weighing("c", 1), -5, Rel.LE),
+                rule(weighing("b", 2, "c", -1), -4, Rel.GE),      // first round: b >= 2
+                rule(weighing("a", 1, "b", 3), -20, Rel.LE)));    // second round: a <= 14
+
+        assertEquals(RationalCut.inclusive(num(2)), closed.box().leastOf("b"));
+        assertEquals(RationalCut.inclusive(num(14)), closed.box().mostOf("a"),
+                "which one round cannot say, since it reads b at nought or above");
+    }
+
+    // --- emptiness ---------------------------------------------------------------------------------
+
+    @Test
+    void aSumThatLeavesNothingIsFoundThoughNoDifferenceIsWrong() {
+        ClosedState<String> closed = closing(List.of(
+                rule(weighing("a", 1), -10, Rel.GE),
+                rule(weighing("b", 1), -10, Rel.GE),
+                rule(weighing("a", 1, "b", 1), -5, Rel.LE)));
+        assertTrue(closed.holdsNothing());
+        assertThrows(IllegalStateException.class, closed::box);
+    }
+
+    /** Over decimals `3a` never comes to one, so this is a rule nothing satisfies — and it is
+     *  settled when the rule is read rather than by anything the state does. */
+    @Test
+    void aRuleAtAValueItsSumCannotReachLeavesNothing() {
+        Read<String> read = AffineConstraint.of(Map.of("a", num(3)), num(-1), Rel.EQ,
+                atom -> Granularity.DENSE);
+        assertInstanceOf(Read.HoldsNever.class, read);
+    }
+
+    // --- the same rules, the same answer ------------------------------------------------------------
+
+    @Test
+    void theOrderTheRulesArrivedInIsNotPartOfTheAnswer() {
+        Random dice = new Random(891);
+        for (int round = 0; round < CASES; round++) {
+            List<AffineConstraint<String>> stated = read(someRules(dice));
+            List<AffineConstraint<String>> shuffled = new ArrayList<>(stated);
+            Collections.shuffle(shuffled, dice);
+
+            ClosedState<String> asWritten = closing(stated);
+            ClosedState<String> reordered = closing(shuffled);
+            assertEquals(asWritten.holdsNothing(), reordered.holdsNothing(),
+                    () -> "emptiness moved when the rules were reordered: " + stated);
+            if (asWritten.holdsNothing()) {
+                continue;
+            }
+            assertEquals(asWritten.box(), reordered.box(),
+                    () -> "the box moved when the rules were reordered: " + stated);
+        }
+    }
+
+    @Test
+    void sayingARuleTwiceSaysWhatSayingItOnceSays() {
+        Random dice = new Random(1016);
+        for (int round = 0; round < CASES; round++) {
+            List<AffineConstraint<String>> stated = read(someRules(dice));
+            List<AffineConstraint<String>> doubled = new ArrayList<>(stated);
+            doubled.addAll(stated);
+            ClosedState<String> once = closing(stated);
+            ClosedState<String> twice = closing(doubled);
+            assertEquals(once.holdsNothing(), twice.holdsNothing());
+            if (!once.holdsNothing()) {
+                assertEquals(once.box(), twice.box());
+            }
+        }
+    }
+
+    // --- against the points -------------------------------------------------------------------------
+
+    @Test
+    void noPointTheRulesAdmitIsEverRefused() {
+        Random dice = new Random(4800);
+        int narrowed = 0;
+        int empties = 0;
+        for (int round = 0; round < CASES; round++) {
+            List<Written> written = someRules(dice);
+            List<AffineConstraint<String>> stated = read(written);
+            // Every position bounded to the range, so the points enumerated are all the points.
+            for (String position : POSITIONS) {
+                stated.add(rule(weighing(position, 1), -LOW, Rel.GE));
+                stated.add(rule(weighing(position, 1), -HIGH, Rel.LE));
+            }
+            List<Map<String, Integer>> admitted = pointsSatisfying(written);
+            ClosedState<String> closed = closing(stated);
+
+            if (admitted.isEmpty()) {
+                empties++;
+                continue;   // emptiness is proven one way only, so nothing is owed here
+            }
+            assertFalse(closed.holdsNothing(),
+                    () -> "said nothing is left, but " + written + " admits " + admitted.size());
+            for (Map<String, Integer> point : admitted) {
+                for (String position : POSITIONS) {
+                    Rational at = num(point.get(position));
+                    assertTrue(admits(closed.box().leastOf(position), at, false)
+                                    && admits(closed.box().mostOf(position), at, true),
+                            () -> "refused a point the rules admit: " + point + " under " + written
+                                    + " left " + position + " in ["
+                                    + closed.box().leastOf(position) + ", "
+                                    + closed.box().mostOf(position) + "]");
+                }
+            }
+            for (String position : POSITIONS) {
+                int most = admitted.stream().mapToInt(p -> p.get(position)).max().orElseThrow();
+                if (closed.box().mostOf(position) != null
+                        && closed.box().mostOf(position).at().compareTo(num(HIGH)) < 0) {
+                    narrowed++;
+                }
+                assertTrue(most <= HIGH);
+            }
+        }
+        assertTrue(narrowed > 0 && empties > 0,
+                "narrowed " + narrowed + " and " + empties + " were empty, so this checked little");
+    }
+
+    private static boolean admits(RationalCut cut, Rational value, boolean above) {
+        if (cut == null) {
+            return true;
+        }
+        int order = value.compareTo(cut.at());
+        return above ? (order < 0 || (order == 0 && cut.inclusive()))
+                : (order > 0 || (order == 0 && cut.inclusive()));
+    }
+
+    private static List<Written> someRules(Random dice) {
+        List<Written> out = new ArrayList<>();
+        int howMany = 1 + dice.nextInt(3);
+        for (int i = 0; i < howMany; i++) {
+            Map<String, Rational> coefs = new LinkedHashMap<>();
+            for (String position : POSITIONS) {
+                int weight = dice.nextInt(5) - 2;
+                if (weight != 0) {
+                    coefs.put(position, num(weight));
+                }
+            }
+            if (coefs.isEmpty()) {
+                continue;
+            }
+            Rel rel = switch (dice.nextInt(4)) {
+                case 0 -> Rel.LT;
+                case 1 -> Rel.GE;
+                case 2 -> Rel.EQ;
+                default -> Rel.LE;
+            };
+            out.add(new Written(coefs, num(dice.nextInt(15) - 7), rel));
+        }
+        return out;
+    }
+
+    private static List<AffineConstraint<String>> read(List<Written> written) {
+        List<AffineConstraint<String>> out = new ArrayList<>();
+        for (Written each : written) {
+            if (AffineConstraint.of(each.coefs(), each.constant(), each.rel(),
+                    atom -> Granularity.DISCRETE) instanceof Read.Stated<String> stated) {
+                out.add(stated.constraint());
+            }
+        }
+        return out;
+    }
+
+    private static List<Map<String, Integer>> pointsSatisfying(List<Written> written) {
+        List<Map<String, Integer>> out = new ArrayList<>();
+        for (int a = LOW; a <= HIGH; a++) {
+            for (int b = LOW; b <= HIGH; b++) {
+                for (int c = LOW; c <= HIGH; c++) {
+                    Map<String, Integer> point = new LinkedHashMap<>();
+                    point.put("a", a);
+                    point.put("b", b);
+                    point.put("c", c);
+                    if (written.stream().allMatch(rule -> holdsAt(rule, point))) {
+                        out.add(point);
+                    }
+                }
+            }
+        }
+        return out;
+    }
+
+    private static boolean holdsAt(Written rule, Map<String, Integer> point) {
+        Rational total = rule.constant();
+        for (Map.Entry<String, Rational> each : rule.coefs().entrySet()) {
+            total = total.plus(each.getValue().times(num(point.get(each.getKey()))));
+        }
+        int sign = total.signum();
+        return switch (rule.rel()) {
+            case LE -> sign <= 0;
+            case LT -> sign < 0;
+            case GE -> sign >= 0;
+            case GT -> sign > 0;
+            case EQ -> sign == 0;
+            case NE -> sign != 0;
+        };
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/numeric/TheSameRulesLeaveTheSameThingHoweverTheyArrivedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/TheSameRulesLeaveTheSameThingHoweverTheyArrivedTest.java
@@ -1,0 +1,226 @@
+package souther.compiler.numeric;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.NumericDomain.Bounds;
+import souther.compiler.numeric.NumericDomain.LinearForm;
+import souther.compiler.numeric.NumericDomain.Rel;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a domain says is a function of the rules it was given, and of nothing else.
+ *
+ * <p>Not of the order they arrived in. That had not been true, and it was not the diagnostics that
+ * moved but the answer itself — measured on this domain before any of this was written:
+ *
+ * <pre>
+ *     x /= 0 ; x &gt;= 0  left x in [0, ∞)
+ *     x &gt;= 0 ; x /= 0  left x in [1, ∞)
+ * </pre>
+ *
+ * <p>Two rules, two orders, two ranges, and the first of them admits a value the rules refuse. The
+ * cause was that a disequality was turned into a bound using whatever happened to be known at the
+ * moment it was read, and never looked at again.
+ *
+ * <p>Nor of how many times each rule was said. A rule written twice is one rule.
+ */
+class TheSameRulesLeaveTheSameThingHoweverTheyArrivedTest {
+
+    private record Written(LinearForm<String> form, Rel rel) {}
+
+    private static LinearForm<String> atom(String a) {
+        return LinearForm.atom(a);
+    }
+
+    private static LinearForm<String> num(long n) {
+        return LinearForm.constant(BigDecimal.valueOf(n));
+    }
+
+    private static LinearForm<String> scaled(String a, long k) {
+        return LinearForm.<String>atom(a).times(BigDecimal.valueOf(k));
+    }
+
+    private static Map<String, Granularity> whole(String... atoms) {
+        Map<String, Granularity> out = new LinkedHashMap<>();
+        for (String each : atoms) {
+            out.put(each, Granularity.DISCRETE);
+        }
+        return out;
+    }
+
+    private static NumericDomain<String> given(List<Written> rules, Map<String, Granularity> kinds) {
+        NumericDomain<String> out = NumericDomain.top();
+        for (Written each : rules) {
+            out = out.assume(each.form(), each.rel(), kinds);
+        }
+        return out;
+    }
+
+    // --- the case that was measured -----------------------------------------------------------------
+
+    @Test
+    void aHoleAndABoundLeaveTheSameThingWhicheverWasWrittenFirst() {
+        Map<String, Granularity> kinds = whole("x");
+        Written hole = new Written(atom("x"), Rel.NE);
+        Written floor = new Written(atom("x"), Rel.GE);
+
+        Bounds holeFirst = given(List.of(hole, floor), kinds).boundsOf("x");
+        Bounds floorFirst = given(List.of(floor, hole), kinds).boundsOf("x");
+
+        assertEquals(floorFirst, holeFirst, "the same two rules, the other way round");
+        assertEquals(Endpoint.inclusive(new Count(BigDecimal.ONE)), holeFirst.min(),
+                "and both leave x at one or above, which is what the two rules say together");
+    }
+
+    /** The hole is read against everything known and not against what was known at the time, so it
+     *  bites when a later rule is what makes it bite. */
+    @Test
+    void aHoleBitesOnWhatALaterRuleEstablishes() {
+        Map<String, Granularity> kinds = whole("x");
+        NumericDomain<String> d = NumericDomain.<String>top()
+                .assume(atom("x"), Rel.NE, kinds)
+                .assume(atom("x").minus(num(5)), Rel.LE, kinds)
+                .assume(atom("x"), Rel.GE, kinds);
+        assertEquals(Endpoint.inclusive(new Count(BigDecimal.ONE)), d.boundsOf("x").min());
+    }
+
+    @Test
+    void aHoleWithNothingToSideItStaysAHole() {
+        Map<String, Granularity> kinds = whole("x");
+        NumericDomain<String> d = NumericDomain.<String>top().assume(atom("x"), Rel.NE, kinds);
+        assertTrue(d.boundsOf("x").saysNothing(), "nothing says which side of nought x is on");
+        assertFalse(d.isBottom());
+    }
+
+    @Test
+    void aHoleAtTheOnlyValueLeftLeavesNothing() {
+        Map<String, Granularity> kinds = whole("x");
+        NumericDomain<String> d = NumericDomain.<String>top()
+                .assume(atom("x"), Rel.GE, kinds)
+                .assume(atom("x"), Rel.LE, kinds)
+                .assume(atom("x"), Rel.NE, kinds);
+        assertTrue(d.isBottom(), "x is nought and x is not nought");
+    }
+
+    // --- the issue -----------------------------------------------------------------------------------
+
+    /** A rule over more than one position now narrows the positions it names, and the proof knows
+     *  what the range knows. */
+    @Test
+    void aRuleOverTwoPositionsNarrowsThemAndIsProvenFromWhatItLeft() {
+        Map<String, Granularity> kinds = whole("straw", "choco");
+        NumericDomain<String> d = NumericDomain.<String>top()
+                .assume(atom("straw"), Rel.GE, kinds)
+                .assume(atom("straw").minus(num(1000)), Rel.LE, kinds)
+                .assume(atom("choco"), Rel.GE, kinds)
+                .assume(atom("choco").minus(num(6)), Rel.LE, kinds)
+                .assume(scaled("straw", 300).plus(scaled("choco", 600)).minus(num(4800)),
+                        Rel.LE, kinds);
+
+        assertEquals(Endpoint.inclusive(new Count(BigDecimal.valueOf(16))),
+                d.boundsOf("straw").max(), "choco is never below nought");
+        assertTrue(d.entails(atom("straw").minus(num(16)), Rel.LE),
+                "and the proof says what the range says");
+        assertTrue(d.projectionEntails(atom("straw").minus(num(16)), Rel.LE),
+                "including what is handed over on its own");
+    }
+
+    /** A rule that contradicts the bounds makes the path unreachable, rather than leaving a range
+     *  describing a value nobody can build while the proof discharges everything. */
+    @Test
+    void aRuleThatCannotHoldWithTheBoundsLeavesNothing() {
+        Map<String, Granularity> kinds = whole("a", "b");
+        NumericDomain<String> d = NumericDomain.<String>top()
+                .assume(atom("a").minus(num(20)), Rel.GE, kinds)
+                .assume(atom("b").minus(num(20)), Rel.GE, kinds)
+                .assume(scaled("a", 300).plus(scaled("b", 600)).minus(num(4800)), Rel.LE, kinds);
+        assertTrue(d.isBottom());
+        assertTrue(d.boundsOf("a").saysNothing(), "and hands over no range at all");
+    }
+
+    /** Over decimals `3a` never comes to one, so this is a path nothing reaches — where it used to
+     *  come back with a range around a third whose two ends are decimals and a third is not. */
+    @Test
+    void aRuleAtAValueItsSumCannotReachLeavesNothing() {
+        Map<String, Granularity> dense = Map.of("a", Granularity.DENSE);
+        NumericDomain<String> d = NumericDomain.<String>top()
+                .assume(scaled("a", 3).minus(num(1)), Rel.EQ, dense);
+        assertTrue(d.isBottom());
+    }
+
+    // --- and over rules drawn at random ---------------------------------------------------------------
+
+    @Test
+    void theOrderAndTheRepetitionAreNotPartOfAnyAnswer() {
+        Map<String, Granularity> kinds = whole("a", "b", "c");
+        Random dice = new Random(891);
+        for (int round = 0; round < 300; round++) {
+            List<Written> rules = someRules(dice);
+            NumericDomain<String> asWritten = given(rules, kinds);
+
+            List<Written> shuffled = new ArrayList<>(rules);
+            Collections.shuffle(shuffled, dice);
+            NumericDomain<String> reordered = given(shuffled, kinds);
+
+            List<Written> doubled = new ArrayList<>(rules);
+            doubled.addAll(rules);
+            NumericDomain<String> twice = given(doubled, kinds);
+
+            for (NumericDomain<String> other : List.of(reordered, twice)) {
+                assertEquals(asWritten.isBottom(), other.isBottom(),
+                        () -> "whether anything is left moved: " + rules);
+                for (String position : List.of("a", "b", "c")) {
+                    assertEquals(asWritten.boundsOf(position), other.boundsOf(position),
+                            () -> "the range at " + position + " moved: " + rules);
+                }
+                for (Written each : rules) {
+                    assertEquals(asWritten.entails(each.form(), each.rel()),
+                            other.entails(each.form(), each.rel()),
+                            () -> "what is proven moved: " + rules);
+                    assertEquals(asWritten.refutes(each.form(), each.rel()),
+                            other.refutes(each.form(), each.rel()),
+                            () -> "what is refuted moved: " + rules);
+                }
+            }
+        }
+    }
+
+    private static List<Written> someRules(Random dice) {
+        List<String> positions = List.of("a", "b", "c");
+        List<Written> out = new ArrayList<>();
+        int howMany = 2 + dice.nextInt(4);
+        for (int i = 0; i < howMany; i++) {
+            LinearForm<String> form = num(dice.nextInt(15) - 7);
+            for (String position : positions) {
+                int weight = dice.nextInt(5) - 2;
+                if (weight != 0) {
+                    form = form.plus(scaled(position, weight));
+                }
+            }
+            if (form.coefs().isEmpty()) {
+                continue;
+            }
+            Rel rel = switch (dice.nextInt(6)) {
+                case 0 -> Rel.LT;
+                case 1 -> Rel.GE;
+                case 2 -> Rel.GT;
+                case 3 -> Rel.EQ;
+                case 4 -> Rel.NE;
+                default -> Rel.LE;
+            };
+            out.add(new Written(form, rel));
+        }
+        return out;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/numeric/TheSameRulesLeaveTheSameThingHoweverTheyArrivedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/TheSameRulesLeaveTheSameThingHoweverTheyArrivedTest.java
@@ -222,6 +222,41 @@ class TheSameRulesLeaveTheSameThingHoweverTheyArrivedTest {
                 d.boundsOf(scaled("a", 2).minus(scaled("b", 2))).max());
     }
 
+    /**
+     * An equality is definitely violated where the rules leave the value out of reach.
+     *
+     * <p>Refuting was a switch of its own over the relations, and it declined to refute an equality
+     * at all. Reading a question the way a rule is read leaves refuting as proving the opposite
+     * comparison, and the opposite of held-at is held-away — so this follows rather than being
+     * decided again.
+     *
+     * <p>It cannot refuse a program that was being accepted: where this is true the equality was not
+     * being discharged either, so what changes is which of the two is said.
+     */
+    @Test
+    void anEqualityIsRefutedWhereTheRulesPutItsValueOutOfReach() {
+        Map<String, Granularity> kinds = whole("x");
+        NumericDomain<String> d = NumericDomain.<String>top()
+                .assume(atom("x").minus(num(3)), Rel.LE, kinds);
+
+        assertTrue(d.refutes(atom("x").minus(num(5)), Rel.EQ), "x is at most three");
+        assertFalse(d.entails(atom("x").minus(num(5)), Rel.EQ), "and was never discharged either");
+        assertFalse(d.refutes(atom("x").minus(num(2)), Rel.EQ), "where two is a value it can take");
+    }
+
+    /** A question about a position this was never told of is one it proves nothing about, rather
+     *  than one it refuses to be asked. */
+    @Test
+    void aQuestionAboutAPositionThisNeverHeardOfIsNotProven() {
+        Map<String, Granularity> kinds = whole("x");
+        NumericDomain<String> d = NumericDomain.<String>top()
+                .assume(atom("x").minus(num(3)), Rel.LE, kinds);
+
+        assertFalse(d.entails(atom("elsewhere").minus(num(5)), Rel.LE));
+        assertFalse(d.refutes(atom("elsewhere").minus(num(5)), Rel.LE));
+        assertTrue(d.boundsOf(atom("elsewhere")).saysNothing());
+    }
+
     // --- and over rules drawn at random ---------------------------------------------------------------
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/numeric/TheSameRulesLeaveTheSameThingHoweverTheyArrivedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/TheSameRulesLeaveTheSameThingHoweverTheyArrivedTest.java
@@ -159,6 +159,69 @@ class TheSameRulesLeaveTheSameThingHoweverTheyArrivedTest {
         assertTrue(d.isBottom());
     }
 
+    // --- and the same question, however it is asked ---------------------------------------------------
+
+    /**
+     * What a form is said to run up to and what is said to follow from it are one statement.
+     *
+     * <p>They had not been. Under {@code x, y in [0, 5]} with {@code x + y <= 5}, the proof showed
+     * the sum at five and the ranges said it ran to ten — the ranges reading the box alone while the
+     * proof read the box and the rules. Both sound, and not the same abstract state, which is the
+     * whole of what this is for: a reader placing a row where a quantity reaches ten is placing it
+     * where nothing can be built.
+     */
+    @Test
+    void whatAFormRunsUpToIsWhatFollowsFromIt() {
+        Map<String, Granularity> kinds = whole("x", "y");
+        NumericDomain<String> d = NumericDomain.<String>top()
+                .assume(atom("x"), Rel.GE, kinds)
+                .assume(atom("x").minus(num(5)), Rel.LE, kinds)
+                .assume(atom("y"), Rel.GE, kinds)
+                .assume(atom("y").minus(num(5)), Rel.LE, kinds)
+                .assume(atom("x").plus(atom("y")).minus(num(5)), Rel.LE, kinds);
+
+        assertTrue(d.entails(atom("x").plus(atom("y")).minus(num(5)), Rel.LE));
+        assertEquals(Endpoint.inclusive(new Count(BigDecimal.valueOf(5))),
+                d.boundsOf(atom("x").plus(atom("y"))).max(),
+                "and the range says the same five the proof does");
+    }
+
+    /**
+     * A question scaled by a positive number is the same question.
+     *
+     * <p>The rules were canonicalised on the way in and the questions were not, so a rule kept as
+     * {@code x + y <= 5} did not answer {@code 2x + 2y <= 10}: a rule is taken off a goal once, and
+     * the goal was left with a residual nothing could prove. The audit had it worse — a difference
+     * asked as {@code 2a - 2b <= 4} was not recognised as a difference at all, so a rule the ranges
+     * do state came back unstated, and the spelling decided the answer again.
+     */
+    @Test
+    void aQuestionScaledUpIsTheSameQuestion() {
+        Map<String, Granularity> kinds = whole("a", "b");
+        NumericDomain<String> d = NumericDomain.<String>top()
+                .assume(atom("a").minus(atom("b")).minus(num(2)), Rel.LE, kinds);
+
+        assertEquals(d.entails(atom("a").minus(atom("b")).minus(num(2)), Rel.LE),
+                d.entails(scaled("a", 2).minus(scaled("b", 2)).minus(num(4)), Rel.LE));
+        assertEquals(d.projectionEntails(atom("a").minus(atom("b")).minus(num(2)), Rel.LE),
+                d.projectionEntails(scaled("a", 2).minus(scaled("b", 2)).minus(num(4)), Rel.LE));
+        assertTrue(d.entails(scaled("a", 2).minus(scaled("b", 2)).minus(num(4)), Rel.LE));
+    }
+
+    /** And a bound asked about a form scaled up comes back scaled up: {@code 2a - 2b} runs twice as
+     *  far as {@code a - b}, so an answer about one handed back for the other is out by a factor. */
+    @Test
+    void aBoundOnAScaledFormIsScaledToMatch() {
+        Map<String, Granularity> kinds = whole("a", "b");
+        NumericDomain<String> d = NumericDomain.<String>top()
+                .assume(atom("a").minus(atom("b")).plus(num(2)), Rel.LE, kinds);
+
+        assertEquals(Endpoint.inclusive(new Count(BigDecimal.valueOf(-2))),
+                d.boundsOf(atom("a").minus(atom("b"))).max());
+        assertEquals(Endpoint.inclusive(new Count(BigDecimal.valueOf(-4))),
+                d.boundsOf(scaled("a", 2).minus(scaled("b", 2))).max());
+    }
+
     // --- and over rules drawn at random ---------------------------------------------------------------
 
     @Test
@@ -177,6 +240,19 @@ class TheSameRulesLeaveTheSameThingHoweverTheyArrivedTest {
             doubled.addAll(rules);
             NumericDomain<String> twice = given(doubled, kinds);
 
+            // The same questions, scaled up, are the same questions.
+            for (Written each : rules) {
+                LinearForm<String> doubledForm = each.form().times(BigDecimal.valueOf(3));
+                assertEquals(asWritten.entails(each.form(), each.rel()),
+                        asWritten.entails(doubledForm, each.rel()),
+                        () -> "scaling the question moved what is proven: " + rules);
+                assertEquals(asWritten.refutes(each.form(), each.rel()),
+                        asWritten.refutes(doubledForm, each.rel()),
+                        () -> "scaling the question moved what is refuted: " + rules);
+                assertEquals(asWritten.projectionEntails(each.form(), each.rel()),
+                        asWritten.projectionEntails(doubledForm, each.rel()),
+                        () -> "scaling the question moved what the ranges state: " + rules);
+            }
             for (NumericDomain<String> other : List.of(reordered, twice)) {
                 assertEquals(asWritten.isBottom(), other.isBottom(),
                         () -> "whether anything is left moved: " + rules);

--- a/souther-compiler/src/test/java/souther/compiler/numeric/TheSameRulesLeaveTheSameThingHoweverTheyArrivedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/TheSameRulesLeaveTheSameThingHoweverTheyArrivedTest.java
@@ -257,6 +257,36 @@ class TheSameRulesLeaveTheSameThingHoweverTheyArrivedTest {
         assertTrue(d.boundsOf(atom("elsewhere")).saysNothing());
     }
 
+    /**
+     * A position's bound is one answer, including where the rounds run out.
+     *
+     * <p>The box is the reduction run until it stops moving or until the budget stops it. A reader
+     * that took one more rule off a goal about a single position would be going one round past
+     * whatever the closure was allowed — and where the budget bites, it did: a chain longer than the
+     * rounds left `boundsOf(x)` with no bound while the same position asked as a form found one.
+     * Two answers about one position, and the budget bounding neither.
+     *
+     * <p>Built one link longer than the budget on purpose, from the budget, so it stays the case
+     * that tells them apart if the budget changes.
+     */
+    @Test
+    void aPositionsBoundIsOneAnswerEvenWhereTheRoundsRunOut() {
+        int chain = ClosedState.ROUNDS + 1;
+        Map<String, Granularity> kinds = new LinkedHashMap<>();
+        for (int i = 0; i <= chain; i++) {
+            kinds.put("x" + i, Granularity.DISCRETE);
+        }
+        NumericDomain<String> d = NumericDomain.<String>top()
+                .assume(atom("x" + chain).minus(num(1)), Rel.LE, kinds);
+        for (int i = 0; i < chain; i++) {
+            // Not a difference, so it carries one link per round rather than through the closure.
+            d = d.assume(atom("x" + i).minus(scaled("x" + (i + 1), 2)), Rel.LE, kinds);
+        }
+
+        assertEquals(d.boundsOf("x0"), d.boundsOf(atom("x0")),
+                "the same position, asked as a position and as a form");
+    }
+
     // --- and over rules drawn at random ---------------------------------------------------------------
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/numeric/TwoWritingsOfOneRuleAreOneConstraintTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/TwoWritingsOfOneRuleAreOneConstraintTest.java
@@ -100,6 +100,36 @@ class TwoWritingsOfOneRuleAreOneConstraintTest {
         assertNotEquals(whole(weighing(A, 1), -3, Rel.LE), whole(weighing(A, 1), -4, Rel.LE));
     }
 
+    /**
+     * An equality has no direction to turn, so the two ways of writing it have to be made one rule
+     * rather than turning into one.
+     *
+     * <p>A comparison says {@code a >= 3} and {@code -a <= -3} are one thing by reducing both to the
+     * same half-space. {@code a = 3} and {@code -a = -3} have no such reduction, and were two
+     * records — so the same rule said both ways was two rules in the set.
+     */
+    @Test
+    void anEqualityIsOneRuleWhicheverWayRoundItWasWritten() {
+        assertEquals(whole(weighing(A, 1), -3, Rel.EQ), whole(weighing(A, -1), 3, Rel.EQ));
+        assertEquals(whole(weighing(A, 1), -3, Rel.EQ).hashCode(),
+                whole(weighing(A, -1), 3, Rel.EQ).hashCode());
+        assertEquals(whole(weighing(A, 1, B, -1), 0, Rel.EQ),
+                whole(weighing(B, 1, A, -1), 0, Rel.EQ));
+    }
+
+    @Test
+    void aDisequalityIsOneRuleWhicheverWayRoundItWasWritten() {
+        assertEquals(whole(weighing(A, 1), -3, Rel.NE), whole(weighing(A, -1), 3, Rel.NE));
+        assertEquals(whole(weighing(A, 1), -3, Rel.NE).hashCode(),
+                whole(weighing(A, -1), 3, Rel.NE).hashCode());
+    }
+
+    @Test
+    void anEqualityAtOneValueIsNotAnEqualityAtAnother() {
+        assertNotEquals(whole(weighing(A, 1), -3, Rel.EQ), whole(weighing(A, 1), -4, Rel.EQ));
+        assertNotEquals(whole(weighing(A, 1), -3, Rel.EQ), whole(weighing(A, 1), -3, Rel.NE));
+    }
+
     // --- what the rule settles on its own ---------------------------------------------------------
 
     /** Over whole numbers the sum cannot sit between two of its values, so the bound comes down

--- a/souther-compiler/src/test/java/souther/compiler/numeric/TwoWritingsOfOneRuleAreOneConstraintTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/TwoWritingsOfOneRuleAreOneConstraintTest.java
@@ -1,0 +1,196 @@
+package souther.compiler.numeric;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.AffineConstraint.Read;
+import souther.compiler.numeric.NumericDomain.Rel;
+
+import java.math.BigInteger;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * A rule is one constraint however it was typed, and what a constraint settles on its own it settles
+ * when it is read rather than later.
+ *
+ * <p>The first half is what a reading keyed on the coefficients could not do: a difference written
+ * with coefficients of two fell outside the shape that holds differences, and one of its positions
+ * came away with no bound at all while the same rule written with ones bounded it.
+ *
+ * <p>The second half is what nothing did at all. Over decimals {@code 3 * a} never comes to one, so
+ * {@code 3 * a = 1} is a rule no value satisfies — and the interval algebra used to answer it with a
+ * range around a third whose two ends are decimals, neither of which is a third.
+ */
+class TwoWritingsOfOneRuleAreOneConstraintTest {
+
+    private static final String A = "a";
+    private static final String B = "b";
+
+    private static Rational num(long whole) {
+        return Rational.of(whole);
+    }
+
+    private static Rational ratio(long numerator, long denominator) {
+        return Rational.of(BigInteger.valueOf(numerator), BigInteger.valueOf(denominator));
+    }
+
+    private static Map<String, Rational> weighing(Object... pairs) {
+        Map<String, Rational> out = new LinkedHashMap<>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            out.put((String) pairs[i], num((Integer) pairs[i + 1]));
+        }
+        return out;
+    }
+
+    private static AffineConstraint<String> whole(Map<String, Rational> coefs, long constant,
+                                                  Rel rel) {
+        Read<String> read = AffineConstraint.of(coefs, num(constant), rel,
+                atom -> Granularity.DISCRETE);
+        return assertInstanceOf(Read.Stated.class, read).constraint();
+    }
+
+    private static Read<String> decimals(Map<String, Rational> coefs, Rational constant, Rel rel) {
+        return AffineConstraint.of(coefs, constant, rel, atom -> Granularity.DENSE);
+    }
+
+    // --- one rule, however it was written ---------------------------------------------------------
+
+    /** The rule from the issue: three hundred and six hundred share three hundred, and what they
+     *  share goes to the threshold. */
+    @Test
+    void aScaledRuleIsTheRuleItScales() {
+        assertEquals(whole(weighing(A, 1, B, 2), -16, Rel.LE),
+                whole(weighing(A, 300, B, 600), -4800, Rel.LE));
+    }
+
+    /** The shape that had fallen out: a difference stated with coefficients of two is a difference. */
+    @Test
+    void aScaledDifferenceIsADifference() {
+        assertEquals(whole(weighing(A, 1, B, -1), -2, Rel.LE),
+                whole(weighing(A, 2, B, -2), -4, Rel.LE));
+    }
+
+    @Test
+    void aComparisonWrittenTheOtherWayIsTheSameComparison() {
+        assertEquals(whole(weighing(A, 1, B, -1), -2, Rel.LE),
+                whole(weighing(B, 1, A, -1), 2, Rel.GE));
+        assertEquals(whole(weighing(A, 1), -3, Rel.GE), whole(weighing(A, -1), 3, Rel.LE));
+    }
+
+    @Test
+    void thePositionsAreNamedInWhateverOrderAndTheRuleIsOne() {
+        assertEquals(whole(weighing(A, 1, B, 2), -16, Rel.LE),
+                whole(weighing(B, 2, A, 1), -16, Rel.LE));
+    }
+
+    @Test
+    void aPositionTheRuleDoesNotWeighIsNotOneItNames() {
+        Map<String, Rational> withNought = weighing(A, 1, B, 2);
+        withNought.put("c", Rational.ZERO);
+        assertEquals(whole(weighing(A, 1, B, 2), -16, Rel.LE), whole(withNought, -16, Rel.LE));
+    }
+
+    @Test
+    void twoRulesThatSayDifferentThingsStayTwo() {
+        assertNotEquals(whole(weighing(A, 1), -3, Rel.LE), whole(weighing(A, 1), -3, Rel.LT));
+        assertNotEquals(whole(weighing(A, 1), -3, Rel.LE), whole(weighing(A, 1), -4, Rel.LE));
+    }
+
+    // --- what the rule settles on its own ---------------------------------------------------------
+
+    /** Over whole numbers the sum cannot sit between two of its values, so the bound comes down
+     *  onto one. Real arithmetic gives one and a half and stops there. */
+    @Test
+    void aBoundBetweenTwoOfTheSumsValuesComesDownOntoOne() {
+        AffineConstraint<String> read = whole(weighing(A, 2, B, 2), -3, Rel.LE);
+        assertEquals(new AffineConstraint.HalfSpace<>(
+                        new CanonicalForm<>(Map.of(A, Rational.ONE, B, Rational.ONE)),
+                        RationalCut.inclusive(num(1))),
+                read, "`2x + 2y <= 3` over whole numbers states `x + y <= 1`");
+    }
+
+    @Test
+    void aStrictBoundOverWholeNumbersLandsOnTheValueBelow() {
+        assertEquals(whole(weighing(A, 1), -2, Rel.LE), whole(weighing(A, 1), -3, Rel.LT));
+    }
+
+    @Test
+    void aBoundBelowZeroComesDownRatherThanTowardsIt() {
+        assertEquals(whole(weighing(A, 1), 2, Rel.GE), whole(weighing(A, 2), 5, Rel.GE),
+                "`2a >= -5` is `a >= -2` and never `a >= -3`");
+        assertNotEquals(whole(weighing(A, 1), 3, Rel.GE), whole(weighing(A, 2), 5, Rel.GE),
+                "which is the direction rounding toward zero would get wrong");
+    }
+
+    /** The measurement that started this. Two layers of the compiler disagreed about whether
+     *  {@code 3 * a} comes to one; it does not, and an equality at one holds of nothing. */
+    @Test
+    void anEqualityAtAValueTheSumCannotReachHoldsOfNothing() {
+        assertInstanceOf(Read.HoldsNever.class,
+                decimals(weighing(A, 3), num(-1), Rel.EQ));
+        assertInstanceOf(Read.Stated.class, decimals(weighing(A, 3), num(-3), Rel.EQ),
+                "and three is a value it does reach");
+    }
+
+    /** The same fact on the other side: held away from a value it never takes, it is held away from
+     *  nothing. */
+    @Test
+    void aDisequalityAtSuchAValueHoldsOfEverything() {
+        assertInstanceOf(Read.HoldsAlways.class, decimals(weighing(A, 3), num(-1), Rel.NE));
+        assertInstanceOf(Read.Stated.class, decimals(weighing(A, 3), num(-3), Rel.NE));
+    }
+
+    /** And a bound at such a value is a bound the sum comes arbitrarily close to and never reaches,
+     *  which is the strict comparison — the same rule written either way. */
+    @Test
+    void aBoundAtSuchAValueIsStrict() {
+        assertEquals(decimals(weighing(A, 3), num(-1), Rel.LT),
+                decimals(weighing(A, 3), num(-1), Rel.LE),
+                "`3a <= 1` and `3a < 1` admit the same decimals");
+        AffineConstraint<String> read =
+                assertInstanceOf(Read.Stated.class, decimals(weighing(A, 3), num(-1), Rel.LE))
+                        .constraint();
+        assertEquals(new AffineConstraint.HalfSpace<>(
+                        new CanonicalForm<>(Map.of(A, Rational.ONE)),
+                        RationalCut.exclusive(ratio(1, 3))),
+                read);
+    }
+
+    @Test
+    void aBoundAtAValueTheSumDoesReachKeepsWhateverTheRuleSaid() {
+        assertNotEquals(decimals(weighing(A, 3), num(-3), Rel.LT),
+                decimals(weighing(A, 3), num(-3), Rel.LE));
+    }
+
+    // --- a comparison that names nobody -----------------------------------------------------------
+
+    @Test
+    void aComparisonOfConstantsSettlesItself() {
+        assertInstanceOf(Read.HoldsAlways.class,
+                AffineConstraint.of(Map.of(), num(-1), Rel.LE, atom -> Granularity.DISCRETE));
+        assertInstanceOf(Read.HoldsNever.class,
+                AffineConstraint.of(Map.of(), num(1), Rel.LE, atom -> Granularity.DISCRETE));
+        assertInstanceOf(Read.HoldsAlways.class,
+                AffineConstraint.of(Map.of(), Rational.ZERO, Rel.EQ, atom -> Granularity.DISCRETE));
+        assertInstanceOf(Read.HoldsNever.class,
+                AffineConstraint.of(Map.of(), Rational.ZERO, Rel.NE, atom -> Granularity.DISCRETE));
+    }
+
+    // --- a disequality stays a hole ----------------------------------------------------------------
+
+    /**
+     * Never turned into a bound here. Which side of the hole the sum lies is not something the rule
+     * says — it is something the rest of what is known says, and it can become known long after this
+     * arrived. Deciding it on the way in is what made the answer depend on which rule was written
+     * first.
+     */
+    @Test
+    void aDisequalityIsHeldAsAHoleAndNotAsABound() {
+        assertInstanceOf(AffineConstraint.Disequality.class,
+                whole(weighing(A, 1), 0, Rel.NE));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/numeric/WhatAFormAddsUpToIsNotWhatItsOrderHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/WhatAFormAddsUpToIsNotWhatItsOrderHoldsTest.java
@@ -145,19 +145,22 @@ class WhatAFormAddsUpToIsNotWhatItsOrderHoldsTest {
     // --- positions that are not all of one kind --------------------------------------------------
 
     /**
-     * The case the partition layer never faces, because a border's quantity is over one carrier.
-     * Nothing stops a guard relating an {@code Int} to a {@code Decimal}, and the true image is
-     * neither of the two shapes — so it answers with a set holding it and says so.
+     * A form over positions of both kinds fills, and its divisor generates the same set as it would
+     * over positions that all fill.
+     *
+     * <p>One that fills is enough. A finite decimal may be chosen with as many places as the value
+     * being reached asks for, so {@code x + 3y} with {@code x} whole reaches a tenth — at
+     * {@code x = -2, y = 0.7} — even though {@code x} alone never leaves the whole numbers.
      */
     @Test
-    void aFormOverBothAnswersWiderAndSaysSo() {
+    void oneFillingPositionMakesTheWholeSumFill() {
         Map<String, Granularity> kinds = new LinkedHashMap<>();
         kinds.put("x", Granularity.DISCRETE);
         kinds.put("y", Granularity.DENSE);
         AdditiveImage image = AdditiveImage.of(form("x", 1, "y", 3), kinds::get);
-        assertTrue(image.contains(ratio(1, 10)),
-                "`x + 3y` reaches no tenth, and this says it might — the wider answer, which is the"
-                        + " safe one, since everything an image is asked gets safer as it grows");
+        assertTrue(image.contains(ratio(1, 10)), "at x = -2, y = 0.7");
+        assertEquals(Rational.of(-2).plus(Rational.of(3).times(ratio(7, 10))), ratio(1, 10),
+                "which is not a claim about the image but arithmetic anyone can do");
         assertFalse(over(form("x", 1, "y", 3), Granularity.DISCRETE).contains(ratio(1, 10)),
                 "where the exact answer over whole numbers refuses it");
     }

--- a/souther-compiler/src/test/java/souther/compiler/numeric/WhatAFormAddsUpToIsNotWhatItsOrderHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/WhatAFormAddsUpToIsNotWhatItsOrderHoldsTest.java
@@ -41,7 +41,6 @@ class WhatAFormAddsUpToIsNotWhatItsOrderHoldsTest {
     void aFormOverWholeNumbersTakesTheMultiplesOfItsDivisor() {
         AdditiveImage image = over(form("s", 300, "c", 600), Granularity.DISCRETE);
         assertEquals(Rational.of(300), image.generator());
-        assertTrue(image.isExact());
         assertTrue(image.contains(Rational.of(4800)));
         assertTrue(image.contains(Rational.of(-900)));
         assertFalse(image.contains(Rational.of(4900)));
@@ -111,7 +110,6 @@ class WhatAFormAddsUpToIsNotWhatItsOrderHoldsTest {
     void aFormOverDecimalsDoesNotReachWhatItsDivisorDoesNotDivide() {
         AdditiveImage image = over(form("a", 3), Granularity.DENSE);
         assertEquals(Rational.of(3), image.generator());
-        assertTrue(image.isExact());
         assertFalse(image.contains(Rational.of(1)), "a third is not a decimal anybody writes");
         assertTrue(image.contains(Rational.of(3)));
         assertTrue(image.contains(ratio(3, 10)), "and it is still dense: a tenth of three is one");
@@ -157,8 +155,9 @@ class WhatAFormAddsUpToIsNotWhatItsOrderHoldsTest {
         kinds.put("x", Granularity.DISCRETE);
         kinds.put("y", Granularity.DENSE);
         AdditiveImage image = AdditiveImage.of(form("x", 1, "y", 3), kinds::get);
-        assertFalse(image.isExact(), "`x + 3y` reaches no tenth, though its divisor is one");
-        assertTrue(image.contains(ratio(1, 10)), "so this is the wider answer, which is the safe one");
+        assertTrue(image.contains(ratio(1, 10)),
+                "`x + 3y` reaches no tenth, and this says it might — the wider answer, which is the"
+                        + " safe one, since everything an image is asked gets safer as it grows");
         assertFalse(over(form("x", 1, "y", 3), Granularity.DISCRETE).contains(ratio(1, 10)),
                 "where the exact answer over whole numbers refuses it");
     }

--- a/souther-compiler/src/test/java/souther/compiler/numeric/WhatAFormAddsUpToIsNotWhatItsOrderHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/WhatAFormAddsUpToIsNotWhatItsOrderHoldsTest.java
@@ -1,0 +1,187 @@
+package souther.compiler.numeric;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A form's values are what its coefficients generate over what its positions hold, and not every
+ * number on the order those positions sit on. Over decimals {@code 3 * a} never comes to one, so a
+ * bound written at one is a bound at a value nothing stands on — which decides three separate
+ * questions: whether an equality can hold, whether a cut can move, and whether a cut is strict.
+ */
+class WhatAFormAddsUpToIsNotWhatItsOrderHoldsTest {
+
+    private static Rational ratio(long numerator, long denominator) {
+        return Rational.of(BigInteger.valueOf(numerator), BigInteger.valueOf(denominator));
+    }
+
+    private static Map<String, Rational> form(Object... pairs) {
+        Map<String, Rational> out = new LinkedHashMap<>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            out.put((String) pairs[i], Rational.of((long) (int) (Integer) pairs[i + 1]));
+        }
+        return out;
+    }
+
+    private static AdditiveImage over(Map<String, Rational> coefs, Granularity everywhere) {
+        return AdditiveImage.of(coefs, atom -> everywhere);
+    }
+
+    // --- over positions that step ---------------------------------------------------------------
+
+    @Test
+    void aFormOverWholeNumbersTakesTheMultiplesOfItsDivisor() {
+        AdditiveImage image = over(form("s", 300, "c", 600), Granularity.DISCRETE);
+        assertEquals(Rational.of(300), image.generator());
+        assertTrue(image.isExact());
+        assertTrue(image.contains(Rational.of(4800)));
+        assertTrue(image.contains(Rational.of(-900)));
+        assertFalse(image.contains(Rational.of(4900)));
+    }
+
+    @Test
+    void coprimeCoefficientsReachEveryWholeNumber() {
+        AdditiveImage image = over(form("a", 2, "b", 3), Granularity.DISCRETE);
+        assertEquals(Rational.ONE, image.generator());
+        assertTrue(image.contains(Rational.of(1)), "two and three make one, which is Bezout's");
+    }
+
+    /** The rule {@code NumericDomain} already applies to one position, one level up: a bound
+     *  between two values the form takes moves down onto the one below. */
+    @Test
+    void anUpperCutMovesOntoTheValueBelowIt() {
+        AdditiveImage image = over(form("a", 1), Granularity.DISCRETE);
+        assertEquals(RationalCut.inclusive(Rational.of(3)),
+                image.tightenUpper(RationalCut.inclusive(ratio(7, 2))));
+        assertEquals(RationalCut.inclusive(Rational.of(2)),
+                image.tightenUpper(RationalCut.exclusive(Rational.of(3))),
+                "`a < 3` over whole numbers is `a <= 2`");
+        assertEquals(RationalCut.inclusive(Rational.of(3)),
+                image.tightenUpper(RationalCut.inclusive(Rational.of(3))),
+                "and a bound already on a value it takes does not move");
+    }
+
+    @Test
+    void aLowerCutMovesOntoTheValueAboveIt() {
+        AdditiveImage image = over(form("a", 1), Granularity.DISCRETE);
+        assertEquals(RationalCut.inclusive(Rational.of(4)),
+                image.tightenLower(RationalCut.inclusive(ratio(7, 2))));
+        assertEquals(RationalCut.inclusive(Rational.of(4)),
+                image.tightenLower(RationalCut.exclusive(Rational.of(3))));
+        assertEquals(RationalCut.inclusive(Rational.of(-3)),
+                image.tightenLower(RationalCut.inclusive(ratio(-7, 2))),
+                "and the same below zero, where rounding toward zero would go the wrong way");
+    }
+
+    /** What the user's example turns on: over whole numbers {@code 2x + 2y <= 3} states
+     *  {@code x + y <= 1}, which is not something real arithmetic gives. */
+    @Test
+    void aCutBetweenTheFormsValuesIsTightenedOntoOne() {
+        AdditiveImage image = over(form("x", 2, "y", 2), Granularity.DISCRETE);
+        assertEquals(Rational.of(2), image.generator());
+        assertEquals(RationalCut.inclusive(Rational.of(2)),
+                image.tightenUpper(RationalCut.inclusive(Rational.of(3))),
+                "`2x + 2y <= 3` is `2x + 2y <= 2`, which is `x + y <= 1`");
+    }
+
+    @Test
+    void aDivisorTheCoefficientsShareCanBeADecimal() {
+        Map<String, Rational> halves = new LinkedHashMap<>();
+        halves.put("a", ratio(1, 2));
+        halves.put("b", ratio(1, 4));
+        AdditiveImage image = AdditiveImage.of(halves, atom -> Granularity.DISCRETE);
+        assertEquals(ratio(1, 4), image.generator());
+        assertTrue(image.contains(ratio(3, 4)));
+        assertFalse(image.contains(ratio(1, 8)));
+    }
+
+    // --- over positions whose values fill --------------------------------------------------------
+
+    /** The measurement that started this: two layers of the compiler disagreed about whether
+     *  {@code 3 * a} comes to one. It does not. */
+    @Test
+    void aFormOverDecimalsDoesNotReachWhatItsDivisorDoesNotDivide() {
+        AdditiveImage image = over(form("a", 3), Granularity.DENSE);
+        assertEquals(Rational.of(3), image.generator());
+        assertTrue(image.isExact());
+        assertFalse(image.contains(Rational.of(1)), "a third is not a decimal anybody writes");
+        assertTrue(image.contains(Rational.of(3)));
+        assertTrue(image.contains(ratio(3, 10)), "and it is still dense: a tenth of three is one");
+    }
+
+    @Test
+    void tenIsAUnitSoTwoAndFiveAre() {
+        assertEquals(Rational.ONE, over(form("a", 2), Granularity.DENSE).generator());
+        assertEquals(Rational.ONE, over(form("a", 5), Granularity.DENSE).generator());
+        assertEquals(Rational.ONE, over(form("a", 10), Granularity.DENSE).generator());
+        assertEquals(Rational.of(3), over(form("a", 6), Granularity.DENSE).generator(),
+                "six is a two and a three, and only the three is left");
+        assertTrue(over(form("a", 2), Granularity.DENSE).contains(ratio(1, 100)));
+    }
+
+    /** No greatest value below an unreached one, so the cut cannot move — what it can say is that
+     *  the value is out, which is why {@code 3a <= 1} and {@code 3a < 1} are one rule. */
+    @Test
+    void anUnreachedUpperCutBecomesStrictWhereItStands() {
+        AdditiveImage image = over(form("a", 3), Granularity.DENSE);
+        assertEquals(RationalCut.exclusive(Rational.of(1)),
+                image.tightenUpper(RationalCut.inclusive(Rational.of(1))));
+        assertEquals(RationalCut.exclusive(Rational.of(1)),
+                image.tightenUpper(RationalCut.exclusive(Rational.of(1))));
+        assertEquals(RationalCut.inclusive(Rational.of(3)),
+                image.tightenUpper(RationalCut.inclusive(Rational.of(3))),
+                "and a cut at a value it does reach keeps the value");
+        assertEquals(RationalCut.exclusive(Rational.of(3)),
+                image.tightenUpper(RationalCut.exclusive(Rational.of(3))),
+                "including when the rule was written to exclude it");
+    }
+
+    // --- positions that are not all of one kind --------------------------------------------------
+
+    /**
+     * The case the partition layer never faces, because a border's quantity is over one carrier.
+     * Nothing stops a guard relating an {@code Int} to a {@code Decimal}, and the true image is
+     * neither of the two shapes — so it answers with a set holding it and says so.
+     */
+    @Test
+    void aFormOverBothAnswersWiderAndSaysSo() {
+        Map<String, Granularity> kinds = new LinkedHashMap<>();
+        kinds.put("x", Granularity.DISCRETE);
+        kinds.put("y", Granularity.DENSE);
+        AdditiveImage image = AdditiveImage.of(form("x", 1, "y", 3), kinds::get);
+        assertFalse(image.isExact(), "`x + 3y` reaches no tenth, though its divisor is one");
+        assertTrue(image.contains(ratio(1, 10)), "so this is the wider answer, which is the safe one");
+        assertFalse(over(form("x", 1, "y", 3), Granularity.DISCRETE).contains(ratio(1, 10)),
+                "where the exact answer over whole numbers refuses it");
+    }
+
+    // --- what it refuses to be asked --------------------------------------------------------------
+
+    @Test
+    void aFormNamingNoPositionIsNotAskedAboutHere() {
+        assertThrows(IllegalArgumentException.class,
+                () -> AdditiveImage.of(Map.<String, Rational>of(), atom -> Granularity.DISCRETE));
+    }
+
+    @Test
+    void aSpacingIsNeverGuessed() {
+        assertThrows(IllegalStateException.class,
+                () -> AdditiveImage.of(form("a", 1), atom -> null));
+    }
+
+    @Test
+    void aZeroCoefficientIsAPositionTheFormDoesNotName() {
+        Map<String, Rational> withZero = new LinkedHashMap<>();
+        withZero.put("a", Rational.ZERO);
+        assertThrows(IllegalArgumentException.class,
+                () -> AdditiveImage.of(withZero, atom -> Granularity.DISCRETE));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/numeric/WhatAWeightedSumRunsBetweenIsAskedInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/WhatAWeightedSumRunsBetweenIsAskedInOnePlaceTest.java
@@ -1,0 +1,110 @@
+package souther.compiler.numeric;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Three readers asked what a weighted sum runs between and three answered it: the algebra summing a
+ * goal, the reduction summing the rest of a rule, and the partition layer summing a quantity to see
+ * whether a threshold is a value it ever takes.
+ *
+ * <p>Four lines of arithmetic, two of which are easy to get wrong in ways nothing catches — which
+ * end of a position to read, and whether the sum reaches its own end. So they are checked here, on
+ * the one place that now does it.
+ */
+class WhatAWeightedSumRunsBetweenIsAskedInOnePlaceTest {
+
+    private static Rational num(long whole) {
+        return Rational.of(whole);
+    }
+
+    private static Map<String, Rational> weighing(Object... pairs) {
+        Map<String, Rational> out = new LinkedHashMap<>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            out.put((String) pairs[i], num((Integer) pairs[i + 1]));
+        }
+        return out;
+    }
+
+    private static Reach shut(long least, long most) {
+        return Reach.between(RationalCut.inclusive(num(least)), RationalCut.inclusive(num(most)));
+    }
+
+    private static Reach reachOf(Map<String, Rational> coefs, Map<String, Reach> positions) {
+        return Reach.of(coefs, Rational.ZERO, positions::get);
+    }
+
+    @Test
+    void aSumRunsBetweenWhatItsPartsRunBetween() {
+        assertEquals(shut(0, 30), reachOf(weighing("a", 3), Map.of("a", shut(0, 10))));
+        assertEquals(shut(3, 17),
+                reachOf(weighing("a", 1, "b", 2), Map.of("a", shut(1, 5), "b", shut(1, 6))));
+    }
+
+    /**
+     * A position pulling the sum down contributes least at its greatest.
+     *
+     * <p>Read from the same end regardless, this is wrong wherever a rule subtracts — and it comes
+     * out as a threshold declared outside a quantity's reach when it is inside, which is a border
+     * not drawn rather than anything nearer the mistake.
+     */
+    @Test
+    void whichEndOfAPositionIsReadIsTheSignOfItsWeight() {
+        assertEquals(shut(-6, -1), reachOf(weighing("a", -1), Map.of("a", shut(1, 6))));
+        assertEquals(shut(-5, 4),
+                reachOf(weighing("a", 1, "b", -1), Map.of("a", shut(0, 5), "b", shut(1, 5))),
+                "least is a at nought with b at five; most is a at five with b at one");
+    }
+
+    /** The sum reaches its end only where every part does. An end wrongly called reachable is a
+     *  point a search is sent to look for and never finds. */
+    @Test
+    void oneUnreachedEndMakesTheWholeSumUnreached() {
+        Map<String, Reach> positions = new LinkedHashMap<>();
+        positions.put("a", shut(0, 5));
+        positions.put("b", Reach.between(RationalCut.inclusive(num(0)),
+                RationalCut.exclusive(num(4))));
+        Reach runs = reachOf(weighing("a", 1, "b", 1), positions);
+        assertEquals(RationalCut.inclusive(num(0)), runs.least(), "both reach their least");
+        assertEquals(RationalCut.exclusive(num(9)), runs.most(), "b never quite reaches four");
+    }
+
+    /** And an unreached end on the far side of a negative weight is the one that goes unreached. */
+    @Test
+    void anUnreachedEndTravelsWithTheSignToo() {
+        Map<String, Reach> positions = Map.of("a", Reach.between(
+                RationalCut.exclusive(num(1)), RationalCut.inclusive(num(6))));
+        Reach runs = reachOf(weighing("a", -1), positions);
+        assertEquals(RationalCut.inclusive(num(-6)), runs.least());
+        assertEquals(RationalCut.exclusive(num(-1)), runs.most(),
+                "a never quite reaches one, so minus a never quite reaches minus one");
+    }
+
+    @Test
+    void aPositionUnboundedTheWayItMattersLeavesTheSumUnbounded() {
+        Map<String, Reach> positions = new LinkedHashMap<>();
+        positions.put("a", shut(0, 5));
+        positions.put("b", Reach.between(RationalCut.inclusive(num(0)), null));
+        Reach runs = reachOf(weighing("a", 1, "b", 1), positions);
+        assertEquals(RationalCut.inclusive(num(0)), runs.least());
+        assertNull(runs.most(), "nothing bounds b above, so nothing bounds the sum above");
+    }
+
+    @Test
+    void aPositionNothingIsKnownAboutRunsTheWholeWay() {
+        assertTrue(reachOf(weighing("a", 1), Map.of()).saysNothing());
+        assertTrue(Reach.ANYWHERE.saysNothing());
+    }
+
+    @Test
+    void theConstantMovesBothEnds() {
+        assertEquals(shut(10, 15),
+                Reach.of(weighing("a", 1), num(10), atom -> shut(0, 5)));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/numeric/WhatIsDerivedOverDecimalsIsNeverTighterThanTheRationalsAllowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/WhatIsDerivedOverDecimalsIsNeverTighterThanTheRationalsAllowTest.java
@@ -237,13 +237,17 @@ class WhatIsDerivedOverDecimalsIsNeverTighterThanTheRationalsAllowTest {
                 checked++;
                 assertFalse(most.inclusive(),
                         () -> "ours admits a value the rationals refuse at " + position);
-                assertFalse(new AdditiveImage.OverFiniteDecimals(Rational.ONE, true)
+                assertFalse(new AdditiveImage.OverFiniteDecimals(Rational.ONE)
                                 .contains(most.at()),
                         () -> "ours refuses " + most.at() + " at " + position + ", which is a"
                                 + " decimal the position can take: " + written);
             }
         }
-        assertTrue(checked >= 0, "and where they never disagree there is nothing to say");
+        // No floor on `checked`: the two may simply never disagree, and a run in which they do not
+        // is a run with nothing to check rather than a run that checked too little. Counted and
+        // reported instead of asserted, since a counter is never below nought and an assertion that
+        // it is not would say nothing at all.
+        System.out.println("strictness differed at " + checked + " bounds of " + CASES + " systems");
     }
 
     /** The case the whole distinction is about, spelled out. */

--- a/souther-compiler/src/test/java/souther/compiler/numeric/WhatIsDerivedOverDecimalsIsNeverTighterThanTheRationalsAllowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/WhatIsDerivedOverDecimalsIsNeverTighterThanTheRationalsAllowTest.java
@@ -1,0 +1,327 @@
+package souther.compiler.numeric;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.AffineConstraint.Read;
+import souther.compiler.numeric.NumericDomain.Rel;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What is derived over positions whose values fill, checked against arithmetic that shares nothing
+ * with it.
+ *
+ * <p>The whole-number checks enumerate: every position is bounded to a small range, so the points in
+ * it are all the points there are, and "nothing is left" is decided rather than merely not
+ * contradicted. Over decimals there is no enumerating — between any two values lie infinitely many —
+ * so the check here is a second piece of arithmetic instead: Fourier–Motzkin elimination over exact
+ * ratios, which decides linear arithmetic over the rationals and is written out below, sharing with
+ * the implementation only {@link Rational}.
+ *
+ * <p><b>What it can and cannot say.</b> Souther's decimals are finite decimals and not the rationals:
+ * {@code 3 * a} comes arbitrarily close to one and never arrives, so this compiler answers
+ * {@code 3a <= 1} with {@code 3a < 1} — which is right, and is not something arithmetic over the
+ * rationals can confirm, since over those a third is a perfectly good value. Elimination is therefore
+ * no oracle for the strictness.
+ *
+ * <p>It is an oracle for the value, and that is where an unsound narrowing would show. The one thing
+ * being a finite decimal ever does to a bound is refuse the value it already stopped at — the cut
+ * never moves. So the value this compiler derives must be one the rationals allow, and a bound
+ * derived tighter than the rationals allow is wrong however the decimals are counted.
+ *
+ * <pre>
+ *     derived value is never below what elimination allows     (an upper bound)
+ *     derived value is never above what elimination allows     (a lower bound)
+ *     where the two values agree, ours may be the stricter     (and only off the image)
+ * </pre>
+ *
+ * <p>Looser is expected and is not a failure: narrowing a box one rule at a time is weaker than
+ * eliminating variables, so this compiler answers with less than elimination wherever a bound needs
+ * two rules combined.
+ */
+class WhatIsDerivedOverDecimalsIsNeverTighterThanTheRationalsAllowTest {
+
+    private static final List<String> POSITIONS = List.of("a", "b", "c");
+    private static final int CASES = 400;
+
+    private record Written(Map<String, Rational> coefs, Rational constant, Rel rel) {}
+
+    private static Rational num(long whole) {
+        return Rational.of(whole);
+    }
+
+    private static Rational ratio(long numerator, long denominator) {
+        return Rational.of(java.math.BigInteger.valueOf(numerator),
+                java.math.BigInteger.valueOf(denominator));
+    }
+
+    // --- the arithmetic this is checked against ------------------------------------------------------
+
+    /** {@code Σ c·x <= k}, or {@code < k} when strict. */
+    private record Row(Map<String, Rational> coefs, Rational at, boolean strict) {
+
+        Rational weightOf(String position) {
+            return coefs.getOrDefault(position, Rational.ZERO);
+        }
+    }
+
+    /**
+     * The rows with {@code position} eliminated: every pair of a row bounding it above and one
+     * bounding it below is combined, and rows that do not name it are kept.
+     *
+     * <p>Fourier–Motzkin. Scaling each side so the weights cancel is exact here because the
+     * arithmetic is ratios; done in decimals it would round, and a bound that rounds is not an oracle
+     * for one that does not.
+     */
+    private static List<Row> eliminating(String position, List<Row> rows) {
+        List<Row> above = new ArrayList<>();
+        List<Row> below = new ArrayList<>();
+        List<Row> without = new ArrayList<>();
+        for (Row row : rows) {
+            int sign = row.weightOf(position).signum();
+            if (sign > 0) {
+                above.add(row);
+            } else if (sign < 0) {
+                below.add(row);
+            } else {
+                without.add(row);
+            }
+        }
+        for (Row upper : above) {
+            for (Row lower : below) {
+                Rational up = upper.weightOf(position);
+                Rational down = lower.weightOf(position).negated();
+                Map<String, Rational> coefs = new LinkedHashMap<>();
+                for (String each : namedIn(List.of(upper, lower))) {
+                    Rational combined = upper.weightOf(each).dividedBy(up)
+                            .plus(lower.weightOf(each).dividedBy(down));
+                    if (!combined.isZero()) {
+                        coefs.put(each, combined);
+                    }
+                }
+                without.add(new Row(coefs,
+                        upper.at().dividedBy(up).plus(lower.at().dividedBy(down)),
+                        upper.strict() || lower.strict()));
+            }
+        }
+        return without;
+    }
+
+    private static Set<String> namedIn(List<Row> rows) {
+        Set<String> out = new LinkedHashSet<>();
+        rows.forEach(row -> out.addAll(row.coefs().keySet()));
+        return out;
+    }
+
+    /** What the rows leave {@code position} over the rationals, either end null for no bound. */
+    private static Reach eliminatingDownTo(String position, List<Row> rows) {
+        List<Row> left = rows;
+        for (String other : POSITIONS) {
+            if (!other.equals(position)) {
+                left = eliminating(other, left);
+            }
+        }
+        RationalCut most = null;
+        RationalCut least = null;
+        for (Row row : left) {
+            Rational weight = row.weightOf(position);
+            if (weight.isZero()) {
+                continue;   // a row with nothing left in it says whether the system holds, not where
+            }
+            RationalCut cut = new RationalCut(row.at().dividedBy(weight.abs()), !row.strict());
+            if (weight.signum() > 0) {
+                most = RationalCut.tighterUpper(most, cut);
+            } else {
+                least = RationalCut.tighterLower(least,
+                        new RationalCut(cut.at().negated(), cut.inclusive()));
+            }
+        }
+        return Reach.between(least, most);
+    }
+
+    /** Whether the rows hold at all over the rationals. */
+    private static boolean anyRationalPointSatisfies(List<Row> rows) {
+        List<Row> left = rows;
+        for (String each : POSITIONS) {
+            left = eliminating(each, left);
+        }
+        for (Row row : left) {
+            if (!row.coefs().isEmpty()) {
+                continue;
+            }
+            int sign = row.at().signum();
+            if (row.strict() ? sign <= 0 : sign < 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // --- and the check --------------------------------------------------------------------------------
+
+    @Test
+    void noBoundIsTighterThanTheRationalsAllow() {
+        Random dice = new Random(1439);
+        int narrowed = 0;
+        for (int round = 0; round < CASES; round++) {
+            List<Written> written = someRules(dice);
+            List<Row> rows = asRows(written);
+            if (!anyRationalPointSatisfies(rows)) {
+                continue;   // nothing to be tight about
+            }
+            ClosedState<String> closed = ClosedState.of(read(written), atom -> Granularity.DENSE);
+            if (closed.holdsNothing()) {
+                continue;   // said over decimals and not over the rationals; see the class comment
+            }
+            for (String position : POSITIONS) {
+                Reach allowed = eliminatingDownTo(position, rows);
+                RationalCut most = closed.box().mostOf(position);
+                RationalCut least = closed.box().leastOf(position);
+                if (most != null) {
+                    narrowed++;
+                    assertFalse(allowed.most() == null,
+                            () -> "bounded " + position + " above where the rationals leave it"
+                                    + " unbounded: " + written);
+                    assertTrue(most.at().compareTo(allowed.most().at()) >= 0,
+                            () -> "derived " + position + " <= " + most.at() + " where the rationals"
+                                    + " allow only " + allowed.most().at() + ": " + written);
+                }
+                if (least != null) {
+                    assertFalse(allowed.least() == null,
+                            () -> "bounded " + position + " below where the rationals leave it"
+                                    + " unbounded: " + written);
+                    assertTrue(least.at().compareTo(allowed.least().at()) <= 0,
+                            () -> "derived " + position + " >= " + least.at() + " where the rationals"
+                                    + " allow only " + allowed.least().at() + ": " + written);
+                }
+            }
+        }
+        assertTrue(narrowed > CASES / 4,
+                "only " + narrowed + " bounds were derived at all, so this checked little");
+    }
+
+    /** And where the two agree on the value, ours is the stricter only where the value is one the
+     *  sum cannot take. */
+    @Test
+    void whereTheValuesAgreeOursIsStricterOnlyOffTheImage() {
+        Random dice = new Random(600);
+        int checked = 0;
+        for (int round = 0; round < CASES; round++) {
+            List<Written> written = someRules(dice);
+            List<Row> rows = asRows(written);
+            if (!anyRationalPointSatisfies(rows)) {
+                continue;
+            }
+            ClosedState<String> closed = ClosedState.of(read(written), atom -> Granularity.DENSE);
+            if (closed.holdsNothing()) {
+                continue;
+            }
+            for (String position : POSITIONS) {
+                RationalCut most = closed.box().mostOf(position);
+                RationalCut allowed = eliminatingDownTo(position, rows).most();
+                if (most == null || allowed == null
+                        || most.at().compareTo(allowed.at()) != 0
+                        || most.inclusive() == allowed.inclusive()) {
+                    continue;
+                }
+                checked++;
+                assertFalse(most.inclusive(),
+                        () -> "ours admits a value the rationals refuse at " + position);
+                assertFalse(new AdditiveImage.OverFiniteDecimals(Rational.ONE, true)
+                                .contains(most.at()),
+                        () -> "ours refuses " + most.at() + " at " + position + ", which is a"
+                                + " decimal the position can take: " + written);
+            }
+        }
+        assertTrue(checked >= 0, "and where they never disagree there is nothing to say");
+    }
+
+    /** The case the whole distinction is about, spelled out. */
+    @Test
+    void aThirdIsNotADecimalSoTheBoundStopsShortOfIt() {
+        List<Written> written = List.of(new Written(Map.of("a", num(3)), num(-1), Rel.LE));
+        ClosedState<String> closed = ClosedState.of(read(written), atom -> Granularity.DENSE);
+
+        assertEquals(RationalCut.exclusive(ratio(1, 3)), closed.box().mostOf("a"),
+                "3a <= 1 leaves a under a third and never at it");
+        assertEquals(RationalCut.inclusive(ratio(1, 3)),
+                eliminatingDownTo("a", asRows(written)).most(),
+                "where over the rationals a third is a value like any other");
+    }
+
+    // --- the rules ------------------------------------------------------------------------------------
+
+    private static List<Written> someRules(Random dice) {
+        List<Written> out = new ArrayList<>();
+        // A bound or two on the positions themselves, because narrowing a box needs somewhere to
+        // start: a rule over three positions none of which is bounded says nothing about any of
+        // them, and a run of those would be four hundred cases checking nothing.
+        for (String position : POSITIONS) {
+            if (dice.nextBoolean()) {
+                out.add(new Written(Map.of(position, Rational.ONE),
+                        num(dice.nextInt(9) - 8), Rel.GE));
+            }
+            if (dice.nextBoolean()) {
+                out.add(new Written(Map.of(position, Rational.ONE),
+                        num(-dice.nextInt(9)), Rel.LE));
+            }
+        }
+        int howMany = 2 + dice.nextInt(3);
+        for (int i = 0; i < howMany; i++) {
+            Map<String, Rational> coefs = new LinkedHashMap<>();
+            for (String position : POSITIONS) {
+                int weight = dice.nextInt(7) - 3;
+                if (weight != 0) {
+                    coefs.put(position, num(weight));
+                }
+            }
+            if (coefs.isEmpty()) {
+                continue;
+            }
+            Rel rel = switch (dice.nextInt(4)) {
+                case 0 -> Rel.LT;
+                case 1 -> Rel.GE;
+                case 2 -> Rel.GT;
+                default -> Rel.LE;
+            };
+            out.add(new Written(coefs, num(dice.nextInt(17) - 8), rel));
+        }
+        return out;
+    }
+
+    private static List<AffineConstraint<String>> read(List<Written> written) {
+        List<AffineConstraint<String>> out = new ArrayList<>();
+        for (Written each : written) {
+            if (AffineConstraint.of(each.coefs(), each.constant(), each.rel(),
+                    atom -> Granularity.DENSE) instanceof Read.Stated<String> stated) {
+                out.add(stated.constraint());
+            }
+        }
+        return out;
+    }
+
+    /** The rules as {@code Σ c·x <= k}, which is the one shape elimination works in. */
+    private static List<Row> asRows(List<Written> written) {
+        List<Row> out = new ArrayList<>();
+        for (Written each : written) {
+            boolean flip = each.rel() == Rel.GE || each.rel() == Rel.GT;
+            boolean strict = each.rel() == Rel.LT || each.rel() == Rel.GT;
+            Map<String, Rational> coefs = new LinkedHashMap<>();
+            each.coefs().forEach((position, weight) ->
+                    coefs.put(position, flip ? weight.negated() : weight));
+            Rational at = flip ? each.constant() : each.constant().negated();
+            out.add(new Row(coefs, at, strict));
+        }
+        return out;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/numeric/WhatTheDifferenceBoundsSayIsWhatThePointsSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/WhatTheDifferenceBoundsSayIsWhatThePointsSayTest.java
@@ -1,0 +1,257 @@
+package souther.compiler.numeric;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.AffineConstraint.Read;
+import souther.compiler.numeric.NumericDomain.Rel;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Everything the closure says is checked against the points themselves.
+ *
+ * <p>Enumerated and not sampled. Every position is bounded to a small range as part of the system,
+ * so the points inside that range are all the points there are — which makes "nothing satisfies
+ * this" a thing the enumeration decides rather than a thing it fails to find a counterexample to.
+ * A check that only looked for counterexamples could not tell an empty system from one whose
+ * solutions it did not happen to try.
+ *
+ * <p>Three claims, and the second is the one the whole arrangement turns on.
+ *
+ * <pre>
+ *     sound        every point the rules admit lies inside every bound derived
+ *     decided      it says nothing is left exactly where nothing is left
+ *     tight        each bound is reached by some point the rules admit
+ * </pre>
+ *
+ * <p>Soundness alone would be satisfied by deriving nothing. Being decided is what says the closure
+ * finds a contradiction whenever the rules hold one — for this fragment, where that is a theorem —
+ * so a path that reaches no value cannot come back looking satisfiable. Tightness is what says the
+ * bounds are the rules' own and not merely implied by them.
+ *
+ * <p>And the same answers whatever order the rules arrived in, which is the property this whole
+ * arrangement exists to restore.
+ */
+class WhatTheDifferenceBoundsSayIsWhatThePointsSayTest {
+
+    private static final List<String> POSITIONS = List.of("a", "b", "c");
+    private static final int LOW = -4;
+    private static final int HIGH = 4;
+    private static final int CASES = 300;
+
+    private record Written(Map<String, Rational> coefs, Rational constant, Rel rel) {}
+
+    @Test
+    void everyClosureAgreesWithTheePointsItIsAbout() {
+        Random dice = new Random(891);
+        int empties = 0;
+        for (int round = 0; round < CASES; round++) {
+            List<Written> written = aSystem(dice);
+            List<AffineConstraint<String>> stated = read(written);
+            DifferenceBounds<String> closed = DifferenceBounds.over(stated);
+            List<Map<String, Integer>> admitted = pointsSatisfying(written);
+
+            if (admitted.isEmpty()) {
+                empties++;
+            }
+            assertEquals(admitted.isEmpty(), closed.holdsNothing(),
+                    () -> "decided: " + written + " admits " + admitted.size() + " points");
+            if (admitted.isEmpty()) {
+                continue;   // nothing is left, so there is no bound to be sound or tight about
+            }
+            assertSoundAndTight(written, closed, admitted);
+        }
+        assertTrue(empties > 20 && empties < CASES - 20,
+                "the systems have to come out both ways to check both, and " + empties
+                        + " of " + CASES + " were empty");
+    }
+
+    /** The same rules in any order are the same answers. */
+    @Test
+    void theOrderTheRulesArrivedInIsNotPartOfTheAnswer() {
+        Random dice = new Random(1016);
+        for (int round = 0; round < CASES; round++) {
+            List<AffineConstraint<String>> stated = read(aSystem(dice));
+            DifferenceBounds<String> asWritten = DifferenceBounds.over(stated);
+            List<AffineConstraint<String>> shuffled = new ArrayList<>(stated);
+            Collections.shuffle(shuffled, dice);
+            DifferenceBounds<String> reordered = DifferenceBounds.over(shuffled);
+
+            assertEquals(asWritten.holdsNothing(), reordered.holdsNothing());
+            if (asWritten.holdsNothing()) {
+                continue;   // where nothing is left there is no tightest bound to compare
+            }
+            for (String position : POSITIONS) {
+                assertEquals(asWritten.upperBoundOf(position), reordered.upperBoundOf(position),
+                        () -> "upper bound of " + position + " moved when the rules were reordered");
+                assertEquals(asWritten.lowerBoundOf(position), reordered.lowerBoundOf(position),
+                        () -> "lower bound of " + position + " moved when the rules were reordered");
+                for (String other : POSITIONS) {
+                    assertEquals(asWritten.differenceBound(position, other),
+                            reordered.differenceBound(position, other));
+                }
+            }
+        }
+    }
+
+    /** And asserting a rule twice says what asserting it once says. */
+    @Test
+    void sayingARuleTwiceSaysWhatSayingItOnceSays() {
+        Random dice = new Random(4800);
+        for (int round = 0; round < CASES; round++) {
+            List<AffineConstraint<String>> stated = read(aSystem(dice));
+            List<AffineConstraint<String>> doubled = new ArrayList<>(stated);
+            doubled.addAll(stated);
+            DifferenceBounds<String> once = DifferenceBounds.over(stated);
+            DifferenceBounds<String> twice = DifferenceBounds.over(doubled);
+            assertEquals(once.holdsNothing(), twice.holdsNothing());
+            if (once.holdsNothing()) {
+                continue;
+            }
+            for (String position : POSITIONS) {
+                assertEquals(once.upperBoundOf(position), twice.upperBoundOf(position));
+                assertEquals(once.lowerBoundOf(position), twice.lowerBoundOf(position));
+            }
+        }
+    }
+
+    private static void assertSoundAndTight(List<Written> written, DifferenceBounds<String> closed,
+                                            List<Map<String, Integer>> admitted) {
+        for (String position : POSITIONS) {
+            RationalCut high = closed.upperBoundOf(position);
+            RationalCut low = closed.lowerBoundOf(position);
+            int most = admitted.stream().mapToInt(point -> point.get(position)).max().orElseThrow();
+            int least = admitted.stream().mapToInt(point -> point.get(position)).min().orElseThrow();
+
+            assertTrue(admits(high, Rational.of(most), true),
+                    () -> "unsound: " + written + " admits " + position + " = " + most
+                            + " and the closure says " + high);
+            assertTrue(admits(low, Rational.of(least), false),
+                    () -> "unsound: " + written + " admits " + position + " = " + least
+                            + " and the closure says >= " + low);
+            assertEquals(RationalCut.inclusive(Rational.of(most)), high,
+                    () -> "not tight above at " + position + " for " + written);
+            assertEquals(RationalCut.inclusive(Rational.of(least)), low,
+                    () -> "not tight below at " + position + " for " + written);
+
+            for (String other : POSITIONS) {
+                if (position.equals(other)) {
+                    continue;
+                }
+                RationalCut apart = closed.differenceBound(position, other);
+                int widest = admitted.stream()
+                        .mapToInt(point -> point.get(position) - point.get(other))
+                        .max().orElseThrow();
+                assertTrue(admits(apart, Rational.of(widest), true),
+                        () -> "unsound: " + written + " admits " + position + " - " + other
+                                + " = " + widest + " and the closure says " + apart);
+                assertEquals(RationalCut.inclusive(Rational.of(widest)), apart,
+                        () -> "not tight on " + position + " - " + other + " for " + written);
+            }
+        }
+    }
+
+    private static boolean admits(RationalCut cut, Rational value, boolean above) {
+        if (cut == null) {
+            return true;
+        }
+        int order = value.compareTo(cut.at());
+        int outside = above ? 1 : -1;
+        return order != outside * 1 && (order != 0 || cut.inclusive());
+    }
+
+    /**
+     * A handful of rules of this fragment's shapes, over positions every one of which is bounded to
+     * the range the points are enumerated over — so the points are all the points there are.
+     */
+    private static List<Written> aSystem(Random dice) {
+        List<Written> out = new ArrayList<>();
+        for (String position : POSITIONS) {
+            out.add(new Written(Map.of(position, Rational.of(-LOW == 0 ? 1 : 1)),
+                    Rational.of(-LOW), Rel.GE));
+            out.add(new Written(Map.of(position, Rational.ONE), Rational.of(-HIGH), Rel.LE));
+        }
+        int howMany = 2 + dice.nextInt(4);
+        for (int i = 0; i < howMany; i++) {
+            String one = POSITIONS.get(dice.nextInt(POSITIONS.size()));
+            long threshold = LOW + dice.nextInt(HIGH - LOW + 1);
+            boolean strict = dice.nextBoolean();
+            if (dice.nextBoolean()) {
+                Rel rel = dice.nextBoolean()
+                        ? (strict ? Rel.LT : Rel.LE) : (strict ? Rel.GT : Rel.GE);
+                // A weight of two as often as one, so the shape canonicalisation brought in is
+                // exercised rather than assumed.
+                long weight = dice.nextBoolean() ? 1 : 2;
+                out.add(new Written(Map.of(one, Rational.of(weight)),
+                        Rational.of(-threshold * weight), rel));
+            } else {
+                String other = POSITIONS.get(dice.nextInt(POSITIONS.size()));
+                if (one.equals(other)) {
+                    continue;
+                }
+                long weight = dice.nextBoolean() ? 1 : 2;
+                Map<String, Rational> coefs = new LinkedHashMap<>();
+                coefs.put(one, Rational.of(weight));
+                coefs.put(other, Rational.of(-weight));
+                out.add(new Written(coefs, Rational.of(-threshold * weight),
+                        strict ? Rel.LT : Rel.LE));
+            }
+        }
+        return out;
+    }
+
+    private static List<AffineConstraint<String>> read(List<Written> written) {
+        List<AffineConstraint<String>> out = new ArrayList<>();
+        for (Written each : written) {
+            Read<String> read = AffineConstraint.of(each.coefs(), each.constant(), each.rel(),
+                    atom -> Granularity.DISCRETE);
+            if (read instanceof Read.Stated<String> stated) {
+                out.add(stated.constraint());
+            }
+        }
+        return out;
+    }
+
+    /** Every whole-numbered point in the range that satisfies every rule as it was written. */
+    private static List<Map<String, Integer>> pointsSatisfying(List<Written> written) {
+        List<Map<String, Integer>> out = new ArrayList<>();
+        for (int a = LOW; a <= HIGH; a++) {
+            for (int b = LOW; b <= HIGH; b++) {
+                for (int c = LOW; c <= HIGH; c++) {
+                    Map<String, Integer> point = new LinkedHashMap<>();
+                    point.put("a", a);
+                    point.put("b", b);
+                    point.put("c", c);
+                    if (written.stream().allMatch(rule -> holdsAt(rule, point))) {
+                        out.add(point);
+                    }
+                }
+            }
+        }
+        return out;
+    }
+
+    private static boolean holdsAt(Written rule, Map<String, Integer> point) {
+        Rational total = rule.constant();
+        for (Map.Entry<String, Rational> each : rule.coefs().entrySet()) {
+            total = total.plus(each.getValue().times(Rational.of(point.get(each.getKey()))));
+        }
+        int sign = total.signum();
+        return switch (rule.rel()) {
+            case LE -> sign <= 0;
+            case LT -> sign < 0;
+            case GE -> sign >= 0;
+            case GT -> sign > 0;
+            case EQ -> sign == 0;
+            case NE -> sign != 0;
+        };
+    }
+}


### PR DESCRIPTION
A rule over more than one coordinate was read and drawn as a border (#871), and it
did not narrow the coordinates it named. `NumericDomain` kept such a rule as
written and said so: `boundsOf` did not read it, so every measure that read a
coordinate's range read it short of what the rules stated.

Measured on the domain before any of this, by probing the built classes:

```
300s + 600c <= 4800, s <= 1000    s <= 1000        ->  s <= 16
  entails s <= 16                  false            ->  true
2a - 2b <= 4, b <= 10              a unbounded      ->  a <= 12
  the same rule as a - b <= 2      lossy at a, b    ->  nothing lost
a >= 20, b >= 20, 300a+600b<=4800  not bottom,      ->  bottom
                                   a in [20, inf),
                                   proves a <= -1000
a + b = c, a,b >= 0, c <= 7        a in [0, inf)    ->  a in [0, 7]
x /= 0 ; x >= 0                    x in [0, inf)    ->  x in [1, inf)
3a = 1 over Decimal                looks satisfiable ->  bottom
```

The issue named the first. The rest came out of looking, and three of them are the
kind that is wrong rather than merely absent.

## What the cause turned out to be

Not "the kept forms are not projected". Each rule was sorted, as it arrived, into a
bound, a difference, or a bucket nothing read back — and the sorting looked at the
coefficients as they were typed, so `2a - 2b <= 4` and `a - b <= 2` went to
different places and only one of them bounded anything. A disequality was turned
into a bound or dropped according to what happened to be known at that moment, so
`x /= 0` beside `x >= 0` left `x` at nought or above depending on which was written
first — the abstract state was a function of the assertion history, which is a
contract that was already broken rather than a new one to aim at.

So what is held is the rules, canonical, and what they leave is worked out from all
of them at once when something asks.

```
canonical constraints
        |
   ClosedState          exact DBM over rationals, bottom proof
        |               sound affine reduction, round budget
   +----+----+
   |    |    |
boundsOf entails refutes

ClosedState + rules + what was written out
        |
   projection audit
```

## What is deliberately not in it

Combining two general half-spaces with different positive multipliers (Farkas / LP),
and the integer frontier — congruence, parity, integer hull. The conditions under
which each deferral expires are written down where the decision is, rather than left
to be rediscovered.

The round budget is not a fixed point and does not claim to be: narrowing over a
general sum need not settle in finitely many rounds. Stopping early only leaves the
box wider, so nothing claimed rests on the budget.

Emptiness holds one way. Where this says nothing is left, nothing is.

## How it is checked

Soundness is the whole of the work here, and it is what argument is worst at: a
bound derived too tight refuses rows a model admits and no measure downstream is in
a position to notice. So it is checked against something other than argument.

- **Whole numbers, enumerated.** Every position bounded to a small range, so the
  points in it are all the points there are — which decides "nothing is left"
  rather than failing to contradict it. The difference bounds are held to sound,
  decided and tight; the reduction and the closed state to sound.
- **Decimals, eliminated.** Fourier-Motzkin over exact ratios, sharing only
  `Rational`. It is no oracle for the strictness, since over the rationals a third
  is a value like any other; it is an oracle for the value, and a value tighter than
  the rationals allow is wrong however the decimals are counted.
- **The same rules, the same answer** — over order, repetition, and at four layers.
- Each claim mutation-checked. Reading the rest of a sum from the wrong end, a
  bound one tighter, a thousandth tighter over decimals, a cycle check missing its
  strict case, a path composition dropping strictness, differences not carried, one
  round only, the exactness check always true: each turns red the test named for it,
  with the counterexample.

Four fixtures moved, all of them asserting a limit rather than a rule. The
conformance corpus did not move.

Refs #891.