### PR TITLE
Certify that a row composed for a combination reached it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathReachability.java
@@ -74,15 +74,15 @@ public final class PathReachability {
         }
 
         /**
-         * What arrives at the comparison recorded at {@code probe}, coming out {@code result}.
+         * What arrives at {@code way} — one comparison, coming out one way.
          *
-         * <p>Asked by probe because that is what a line read off a comparison carries. The place is
-         * still the control point — this only finds it.
+         * <p>Asked by the way out because that is what a line read off a comparison carries, and
+         * because it is what a run records. The place is still the control point; this only finds it.
          */
-        public Reachability atComparison(int probe, boolean result) {
+        public Reachability atComparison(souther.compiler.coverage.ComparisonOutcome way) {
             for (Map.Entry<ControlPointId, Reachability> each : found.entrySet()) {
-                if (each.getKey() instanceof ControlPointId.ComparisonOutcome outcome
-                        && outcome.comparisonProbe() == probe && outcome.result() == result) {
+                if (each.getKey() instanceof ControlPointId.ComparisonPoint point
+                        && point.way().equals(way)) {
                     return each.getValue();
                 }
             }
@@ -149,11 +149,14 @@ public final class PathReachability {
             return false;
         }
 
-        /** Whether the comparison at {@code probe} divides nothing that gets to it — one of its two
-         *  outcomes being one nothing takes. */
-        public boolean dividesNothing(int probe) {
-            return atComparison(probe, true) instanceof Reachability.Unreachable
-                    || atComparison(probe, false) instanceof Reachability.Unreachable;
+        /** Whether {@code comparison} divides nothing that gets to it — one of its two outcomes
+         *  being one nothing takes. */
+        public boolean dividesNothing(souther.compiler.coverage.ComparisonOccurrence comparison) {
+            return atComparison(new souther.compiler.coverage.ComparisonOutcome(comparison, true))
+                            instanceof Reachability.Unreachable
+                    || atComparison(
+                            new souther.compiler.coverage.ComparisonOutcome(comparison, false))
+                            instanceof Reachability.Unreachable;
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -607,13 +607,20 @@ final class BodyGen {
          * there, and a measuring build and a shipping build differ by these calls and by nothing else.
          */
         /**
-         * Records that this comparison produced a value, where it is one a guard's condition is made
-         * of.
+         * Records that this comparison produced a value and which value it was, where it is one a
+         * guard's condition is made of.
          *
          * <p>After the value and not before it. What a boundary is met by is the comparison having
          * answered, and an operand can abort on the way — {@code x /= 0 && 100 / x > 1} is why the
          * operators stop when the answer is settled in the first place. A probe in front of the
          * emission would record a comparison that never produced anything as one that did.
+         *
+         * <p>The value itself is handed over, copied off the stack rather than recomputed. Which way
+         * a comparison came out is not something the arm below it can say — a condition stops as soon
+         * as it is settled — so anything that worked it out afterwards would be reasoning where the
+         * value is right there. {@code comparisonMaterialize} has already brought it to an
+         * {@code iconst_0} or {@code iconst_1}, so the copy is of a plain boolean and the original is
+         * left exactly as the emission that follows expects it.
          *
          * <p>Absent is ordinary here, unlike an arm's: what has a site is every comparison of a
          * condition this plan instruments, and the emitter walks comparisons everywhere else too.
@@ -624,8 +631,9 @@ final class BodyGen {
             }
             ctx.comparisonSiteOf(comparison).ifPresent(site -> {
                 ctx.emitted(site);
+                code.dup();
                 code.loadConstant(site);
-                code.invokestatic(CD_Probe, "hit", MTD_Probe_hit);
+                code.invokestatic(CD_Probe, "compared", MTD_Probe_compared);
             });
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Descriptors.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Descriptors.java
@@ -121,6 +121,10 @@ final class Descriptors {
     /** {@code Probe.hit(int)}: records one arm and leaves the stack as it was. */
     static final MethodTypeDesc MTD_Probe_hit =
             MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_int);
+    /** {@code Probe.compared(boolean, int)}: records one comparison and the value it answered,
+     * taking a copy of that value off the stack and leaving the original where it was. */
+    static final MethodTypeDesc MTD_Probe_compared = MethodTypeDesc.of(ConstantDescs.CD_void,
+            ConstantDescs.CD_boolean, ConstantDescs.CD_int);
     /**
      * What an evaluation is allowed, called by classes generated for evaluating and by nothing that
      * ships. Reached the way {@link #CD_Probe} is, and for the same reason.

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ComparisonOccurrence.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ComparisonOccurrence.java
@@ -1,0 +1,29 @@
+package souther.compiler.coverage;
+
+/**
+ * One comparison of one body, as the thing a rule is read off and a run is recorded at.
+ *
+ * <p>What a reading of the model joins on. A line drawn on a comparison, a decision said of it and a
+ * hit recorded at it are three readers of one place, and until now each of them held the emission
+ * site — a number this compiler's instrumentation hands out — and matched on it. That made a
+ * numbering the join key: two readers agreeing meant they had been given the same int, and nothing
+ * said what the int was of.
+ *
+ * <p>So the number stays and stops being the identity. {@link #emissionSite} is read where the
+ * bytecode is written and where a recording is read back, and nowhere that is deciding what a
+ * comparison means.
+ *
+ * <p>Occurrence and not comparison: a non-recursive helper is spliced into each body that calls it,
+ * so one comparison the author wrote is several here, each reached under its caller's own
+ * conditions.
+ *
+ * @param emissionSite where a run through this is recorded, which is the instrumentation's number
+ *                     for it and not this
+ */
+public record ComparisonOccurrence(int emissionSite) {
+
+    @Override
+    public String toString() {
+        return "comparison@" + emissionSite;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ComparisonOutcome.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ComparisonOutcome.java
@@ -1,0 +1,32 @@
+package souther.compiler.coverage;
+
+/**
+ * One comparison coming out one way, as a run records it.
+ *
+ * <p>Recorded from the comparison's own value and never worked out from the arm that follows it. A
+ * condition stops as soon as it is settled, so under {@code A && B} the arm taken when the condition
+ * fails is reached both by a value that made {@code B} false and by one that never evaluated
+ * {@code B} — the arm cannot say which, and a reading that recovered the way out of it would be
+ * guessing at exactly the point a claim about the comparison is made.
+ *
+ * <p>Three states and not two, which is what having these at all buys. A comparison can have come
+ * out one way, come out the other, or not have been reached: the first two are one of these being
+ * recorded and the third is neither of them being, and nothing else in a run's record can tell the
+ * third from the other two.
+ *
+ * @param at   which comparison
+ * @param held the way it came out
+ */
+public record ComparisonOutcome(ComparisonOccurrence at, boolean held) {
+
+    public ComparisonOutcome {
+        if (at == null) {
+            throw new IllegalArgumentException("a way a comparison came out is a way of one");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return at + (held ? " held" : " failed");
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ControlClaim.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ControlClaim.java
@@ -1,0 +1,67 @@
+package souther.compiler.coverage;
+
+import java.util.Optional;
+
+/**
+ * Something a run can be held to: that it passed one place, coming out one way.
+ *
+ * <p>The one thing a reading of the model may assert about a run, and the only shape a certification
+ * has to know. A claim is a place and nothing about why anyone is interested in it — which is what
+ * keeps whatever is doing the reading and whatever records the running from growing into each other.
+ * The reading's own vocabulary changes as the reading gets better; that a comparison came out false
+ * does not.
+ *
+ * <p>Not every place is one of these. An arm no row that stands can be in carries no probe, so a run
+ * through it is not something any recording could hold — and a claim on it would be one nothing could
+ * ever satisfy, which is worse than no claim at all: it reads as a combination that was tried and
+ * missed. {@link #of} is where that is decided, so a claim that exists is one an observation can
+ * answer.
+ */
+public record ControlClaim(ControlPointId at) {
+
+    public ControlClaim {
+        if (at == null) {
+            throw new IllegalArgumentException("a claim is a claim about somewhere");
+        }
+    }
+
+    /**
+     * The claim that a run passed {@code at}, or empty where no run could be recorded there.
+     *
+     * <p>Empty is an ordinary answer and the safe direction: what cannot be witnessed cannot be
+     * claimed, so whatever was going to be built on it is left unbuilt rather than built and never
+     * satisfiable.
+     */
+    public static Optional<ControlClaim> of(ControlPointId at) {
+        return switch (at) {
+            case ControlPointId.ArmOccurrence arm ->
+                    arm.isMeasured() ? Optional.of(new ControlClaim(arm)) : Optional.empty();
+            // A comparison is numbered only where the fork it belongs to has an arm a run can be
+            // recorded in, so one that exists is one a run can be recorded at.
+            case ControlPointId.ComparisonPoint point -> Optional.of(new ControlClaim(point));
+        };
+    }
+
+    /**
+     * Whether {@code seen} did this.
+     *
+     * <p>Existential, the way every measure over a run here is: a row that passed the place passed
+     * it. What this does not say is how many times, which is why a claim is only ever made where a
+     * run passes the place once ({@link CoverageSites.Plan#mayRepeat}).
+     */
+    public boolean satisfiedBy(Observation seen) {
+        return switch (at) {
+            case ControlPointId.ArmOccurrence arm ->
+                    arm.probe().isPresent() && seen.lit(arm.probe().getAsInt());
+            case ControlPointId.ComparisonPoint point -> seen.saw(point.way());
+        };
+    }
+
+    @Override
+    public String toString() {
+        return switch (at) {
+            case ControlPointId.ArmOccurrence arm -> "arm " + arm.controlId();
+            case ControlPointId.ComparisonPoint point -> point.way().toString();
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ControlPointId.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ControlPointId.java
@@ -78,16 +78,37 @@ public sealed interface ControlPointId {
     }
 
     /**
-     * One comparison coming out one way.
+     * The place a comparison comes out one way.
      *
      * <p>Which arm that leads to is not this, and the two are not each other's. A condition stops as
      * soon as it is settled, so under {@code A && B} the arm taken when the condition fails is
      * reached both by a value that made {@code B} false and by one that never reached {@code B} —
      * the arm cannot say which comparison came out which way, and a line is drawn on the comparison.
      *
-     * @param comparisonProbe where the comparison's own value is recorded
-     * @param result          the way it came out
+     * <p>The place and what a run records at it are the same value here ({@link #way}), rather than
+     * this holding a copy of its parts. A reading that carried the comparison and the way separately
+     * would be two halves a caller could pair with another place's, which is what asking a run
+     * whether it did this then takes on trust.
+     *
+     * @param way which comparison, coming out which way — as a run would record it
      */
-    record ComparisonOutcome(int controlId, int comparisonProbe, boolean result)
-            implements ControlPointId {}
+    record ComparisonPoint(int controlId, ComparisonOutcome way) implements ControlPointId {
+
+        public ComparisonPoint {
+            if (way == null) {
+                throw new IllegalArgumentException(
+                        "a place a comparison comes out one way is a place of one way");
+            }
+        }
+
+        /** Which comparison this is a way out of. */
+        public ComparisonOccurrence at() {
+            return way.at();
+        }
+
+        /** The way it came out. */
+        public boolean held() {
+            return way.held();
+        }
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -164,16 +164,33 @@ public final class CoverageSites {
     public record Plan(List<Site> sites, List<GuardRef> guards, IdentityHashMap<Core, int[]> byNode,
                        IdentityHashMap<Core, Integer> byComparison,
                        IdentityHashMap<Core, ControlPointId.ArmOccurrence[]> armsByNode,
-                       IdentityHashMap<Core, Integer> controlByComparison) {
+                       IdentityHashMap<Core, Integer> controlByComparison,
+                       java.util.Set<Core> mayRepeat) {
 
         public static final Plan NONE = new Plan(List.of(), List.of(), new IdentityHashMap<>(),
-                new IdentityHashMap<>(), new IdentityHashMap<>(), new IdentityHashMap<>());
+                new IdentityHashMap<>(), new IdentityHashMap<>(), new IdentityHashMap<>(),
+                java.util.Set.of());
 
         /** The same plan built without the control layer, for a caller assembling one by hand. */
         public Plan(List<Site> sites, List<GuardRef> guards, IdentityHashMap<Core, int[]> byNode,
                     IdentityHashMap<Core, Integer> byComparison) {
             this(sites, guards, byNode, byComparison, new IdentityHashMap<>(),
-                    new IdentityHashMap<>());
+                    new IdentityHashMap<>(), java.util.Set.of());
+        }
+
+        /**
+         * Whether one run of the behavior can pass {@code node} more than once.
+         *
+         * <p>What decides whether a set is enough to say what a run did. A recording holds that a
+         * place was passed and not how many times it was, so two facts recorded about a place a run
+         * passes twice cannot be told from two facts about one passing — and a statement about
+         * several places meeting is about their meeting once, which such a recording cannot answer.
+         *
+         * <p>Inherited downwards, so a node this is false of stands under nothing this is true of.
+         * That is what lets one question asked at a meeting answer for everything the meeting names.
+         */
+        public boolean mayRepeat(Core node) {
+            return mayRepeat.contains(node);
         }
 
         /**
@@ -295,7 +312,7 @@ public final class CoverageSites {
             walk.behavior(body.getKey(), body.getValue());
         }
         return new Plan(List.copyOf(walk.sites), List.copyOf(walk.guards), walk.byNode,
-                walk.byComparison, walk.armsByNode, walk.controlByComparison);
+                walk.byComparison, walk.armsByNode, walk.controlByComparison, walk.mayRepeat);
     }
 
     private static final class Walk {
@@ -308,6 +325,14 @@ public final class CoverageSites {
                 new IdentityHashMap<>();
         private final IdentityHashMap<Core, Integer> controlByComparison = new IdentityHashMap<>();
         private final IdentityHashMap<Core, Boolean> answering = new IdentityHashMap<>();
+        /** The nodes one run can pass more than once. Kept by identity, like everything else here:
+         *  two arms that look the same are equal records and this is about this one. */
+        private final java.util.Set<Core> mayRepeat =
+                java.util.Collections.newSetFromMap(new IdentityHashMap<>());
+        /** Whether the walk is somewhere a run may come back to. Held rather than passed down
+         *  because every node below such a place is one, which is what makes it a state of the walk
+         *  and not a property of the call. */
+        private boolean repeating;
         /** The outcomes that carry nothing of their own. What each of them means is settled with
          *  the construct beside it, so one instance stands for every occurrence. */
         private static final SourceOutcome HELD =
@@ -437,6 +462,9 @@ public final class CoverageSites {
             // Everything below this node is reached by way of the node, so what the node cannot do
             // nothing inside it can do either.
             boolean inside = reachable && answers(e);
+            if (repeating) {
+                mayRepeat.add(e);
+            }
             switch (e) {
                 case Core.Int _, Core.Decimal _, Core.Str _, Core.Bool _, Core.Temporal _,
                      Core.Read _, Core.UnitValue _, Core.OptionNone _ -> { }
@@ -461,7 +489,17 @@ public final class CoverageSites {
                 }
                 // A function value, and its arms are arms: what is written here runs when whatever
                 // this is handed to applies it, and the rows that make that happen go through them.
-                case Core.Block b -> walk(b.body(), inside);
+                //
+                // How many times it applies it is that caller's business and nothing here can say —
+                // a comprehension applies one of these per element — so everything inside is a place
+                // one run may come back to. Recorded rather than assumed anywhere else: what a set
+                // of places can be asked turns on it.
+                case Core.Block b -> {
+                    boolean outside = repeating;
+                    repeating = true;
+                    walk(b.body(), inside);
+                    repeating = outside;
+                }
                 case Core.ListLit lit -> lit.elements().forEach(el -> walk(el, inside));
                 case Core.OptionSome s -> walk(s.value(), inside);
                 case Core.Tuple t -> t.elements().forEach(el -> walk(el, inside));

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -165,17 +165,18 @@ public final class CoverageSites {
                        IdentityHashMap<Core, Integer> byComparison,
                        IdentityHashMap<Core, ControlPointId.ArmOccurrence[]> armsByNode,
                        IdentityHashMap<Core, Integer> controlByComparison,
-                       java.util.Set<Core> mayRepeat) {
+                       java.util.Set<Core> mayRepeat,
+                       IdentityHashMap<Core, ForkOccurrence> forkByNode) {
 
         public static final Plan NONE = new Plan(List.of(), List.of(), new IdentityHashMap<>(),
                 new IdentityHashMap<>(), new IdentityHashMap<>(), new IdentityHashMap<>(),
-                java.util.Set.of());
+                java.util.Set.of(), new IdentityHashMap<>());
 
         /** The same plan built without the control layer, for a caller assembling one by hand. */
         public Plan(List<Site> sites, List<GuardRef> guards, IdentityHashMap<Core, int[]> byNode,
                     IdentityHashMap<Core, Integer> byComparison) {
             this(sites, guards, byNode, byComparison, new IdentityHashMap<>(),
-                    new IdentityHashMap<>(), java.util.Set.of());
+                    new IdentityHashMap<>(), java.util.Set.of(), new IdentityHashMap<>());
         }
 
         /**
@@ -204,6 +205,11 @@ public final class CoverageSites {
          */
         public ControlPointId.ArmOccurrence[] armsOf(Core node) {
             return armsByNode.get(node);
+        }
+
+        /** Which fork {@code node} is, or null where this plan made no arms for it. */
+        public ForkOccurrence forkAt(Core node) {
+            return forkByNode.get(node);
         }
 
         /** Which way {@code comparison} coming out {@code result} is, or empty where this plan
@@ -312,7 +318,8 @@ public final class CoverageSites {
             walk.behavior(body.getKey(), body.getValue());
         }
         return new Plan(List.copyOf(walk.sites), List.copyOf(walk.guards), walk.byNode,
-                walk.byComparison, walk.armsByNode, walk.controlByComparison, walk.mayRepeat);
+                walk.byComparison, walk.armsByNode, walk.controlByComparison, walk.mayRepeat,
+                walk.forkByNode);
     }
 
     private static final class Walk {
@@ -323,6 +330,7 @@ public final class CoverageSites {
         private final IdentityHashMap<Core, Integer> byComparison = new IdentityHashMap<>();
         private final IdentityHashMap<Core, ControlPointId.ArmOccurrence[]> armsByNode =
                 new IdentityHashMap<>();
+        private final IdentityHashMap<Core, ForkOccurrence> forkByNode = new IdentityHashMap<>();
         private final IdentityHashMap<Core, Integer> controlByComparison = new IdentityHashMap<>();
         private final IdentityHashMap<Core, Boolean> answering = new IdentityHashMap<>();
         /** The nodes one run can pass more than once. Kept by identity, like everything else here:
@@ -379,6 +387,20 @@ public final class CoverageSites {
                     // rewrites and carries whatever position it was built from, so quoting it sends
                     // an author somewhere else in the file.
                     Citation.of(owner.pos()), origin);
+        }
+
+        /**
+         * The arms of one fork, and the fork they are arms of.
+         *
+         * <p>Both written here, in one act. What names the fork is the first of its arms, and it is
+         * a name rather than a lookup for exactly that reason: made apart, the fork's identity would
+         * be something each reader worked out again from whatever component it had to hand.
+         */
+        private void arms(Core fork, ControlPointId.ArmOccurrence[] arms) {
+            armsByNode.put(fork, arms);
+            if (arms.length > 0) {
+                forkByNode.put(fork, new ForkOccurrence(arms[0].controlId()));
+            }
         }
 
         /** The probe numbers of {@code arms}, in their order, {@link #NO_SITE} where an arm has
@@ -514,7 +536,7 @@ public final class CoverageSites {
                             armOf(FAILED, iff, iff.origin(), 1, iff.els(), inside);
                     walk(iff.els(), inside);
                     byNode.put(iff, probesOf(then, els));
-                    armsByNode.put(iff, new ControlPointId.ArmOccurrence[] {then, els});
+                    arms(iff, new ControlPointId.ArmOccurrence[] {then, els});
                     if (then.isMeasured() || els.isMeasured()) {
                         guards.add(new GuardRef(behavior, iff.origin(),
                                 then.probe().orElse(NO_SITE), els.probe().orElse(NO_SITE),
@@ -532,7 +554,7 @@ public final class CoverageSites {
                         walk(arm.body(), inside);
                     }
                     byNode.put(m, probesOf(arms));
-                    armsByNode.put(m, arms);
+                    arms(m, arms);
                 }
                 case Core.IfConstructed ic -> {
                     ic.construct().values().forEach(given -> walk(given.value(), inside));
@@ -548,7 +570,7 @@ public final class CoverageSites {
                         walk(arm.body(), inside);
                     }
                     byNode.put(ic, probesOf(arms));
-                    armsByNode.put(ic, arms);
+                    arms(ic, arms);
                 }
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -191,13 +191,35 @@ public final class CoverageSites {
 
         /** Which way {@code comparison} coming out {@code result} is, or empty where this plan
          *  numbered no comparison there. */
-        public java.util.Optional<ControlPointId.ComparisonOutcome> outcomeOf(Core comparison,
-                                                                             boolean result) {
+        public java.util.Optional<ControlPointId.ComparisonPoint> outcomeOf(Core comparison,
+                                                                           boolean result) {
             Integer control = controlByComparison.get(comparison);
-            Integer probe = byComparison.get(comparison);
-            return control == null || probe == null ? java.util.Optional.empty()
-                    : java.util.Optional.of(
-                            new ControlPointId.ComparisonOutcome(control, probe, result));
+            return control == null ? java.util.Optional.empty()
+                    : comparisonAt(comparison).map(at -> new ControlPointId.ComparisonPoint(
+                            control, new ComparisonOutcome(at, result)));
+        }
+
+        /**
+         * Which comparison of this plan {@code comparison} is, or empty where it numbered none there.
+         *
+         * <p>What a reading of the model joins on, and what it is given instead of the number. Empty
+         * is an ordinary answer for the same reason {@link #comparisonSiteOf} has one.
+         */
+        public java.util.Optional<ComparisonOccurrence> comparisonAt(Core comparison) {
+            Integer site = byComparison.get(comparison);
+            return site == null ? java.util.Optional.empty()
+                    : java.util.Optional.of(new ComparisonOccurrence(site));
+        }
+
+        /**
+         * The same, where the caller's own construction says there is one.
+         *
+         * <p>Absent here is not a comparison that cannot be measured — it is this plan and the reader
+         * that found the comparison disagreeing about what a condition is made of, which no
+         * measurement should paper over.
+         */
+        public ComparisonOccurrence requireComparisonAt(Core comparison) {
+            return new ComparisonOccurrence(requireComparisonSiteOf(comparison));
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/coverage/ForkOccurrence.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/ForkOccurrence.java
@@ -1,0 +1,24 @@
+package souther.compiler.coverage;
+
+/**
+ * One fork of a body, as the thing its arms are arms of.
+ *
+ * <p>What tells two decisions apart where all a reading can say is which fork they are of. A reading
+ * that cannot name the position a fork is about still knows that going one way and going the other
+ * are the same decision settled twice, and that is what this is for.
+ *
+ * <p>Named by the first of its arms, and minted where the arms are. The two are made in one act, so
+ * nothing looks a fork up afterwards from a number it was handed: an identity found again from a
+ * component is an identity two readers can derive differently, which is what a number standing in
+ * for a place already did once here.
+ *
+ * <p>Occurrence and not fork: a non-recursive helper is spliced into each body that calls it, so one
+ * {@code if} the author wrote is several of these, each reached under its caller's own conditions.
+ */
+public record ForkOccurrence(int controlId) {
+
+    @Override
+    public String toString() {
+        return "fork " + controlId;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/Observation.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/Observation.java
@@ -1,0 +1,48 @@
+package souther.compiler.coverage;
+
+import java.util.Set;
+
+/**
+ * What one run of one row was seen to do, as a value nothing goes on changing.
+ *
+ * <p>One snapshot and not two channels. What is recorded has two shapes — the places a run passed
+ * through, and the ways the comparisons it evaluated came out — and they are taken together, of one
+ * thread, between one {@code begin} and one {@code end}. Handed over as two values they would be two
+ * things a reader could get from different runs, and a reader that asked for one of them would be
+ * reasoning about a run it had only half of.
+ *
+ * <p>{@link #comparisons} implies {@link #taken}: a way a comparison came out is recorded by the
+ * same call that records the comparison having been reached, so a run holding the first without the
+ * second is one nothing produces. That holds by how the recording is written rather than by a rule
+ * the emitter is asked to keep, which is the difference between an invariant and a convention.
+ *
+ * @param taken       the sites the run was recorded at, which is what a branch measure counts and
+ *                    what a boundary drawn on a guard is met by
+ * @param comparisons the ways the comparisons it evaluated came out
+ */
+public record Observation(Set<Integer> taken, Set<ComparisonOutcome> comparisons) {
+
+    /** A run nothing was recorded of, which is what a caller with no measuring build has. */
+    public static final Observation NONE = new Observation(Set.of(), Set.of());
+
+    public Observation {
+        taken = taken == null ? Set.of() : Set.copyOf(taken);
+        comparisons = comparisons == null ? Set.of() : Set.copyOf(comparisons);
+    }
+
+    /** Whether the run was recorded at {@code site}. */
+    public boolean lit(int site) {
+        return taken.contains(site);
+    }
+
+    /** Whether the run had {@code way} happen. Not the same as its comparison having been reached:
+     *  a comparison that came out the other way was reached and is not this. */
+    public boolean saw(ComparisonOutcome way) {
+        return comparisons.contains(way);
+    }
+
+    /** Whether the run reached {@code comparison} at all, whichever way it came out. */
+    public boolean reached(ComparisonOccurrence comparison) {
+        return lit(comparison.emissionSite());
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/Observation.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/Observation.java
@@ -28,6 +28,20 @@ public record Observation(Set<Integer> taken, Set<ComparisonOutcome> comparisons
     public Observation {
         taken = taken == null ? Set.of() : Set.copyOf(taken);
         comparisons = comparisons == null ? Set.of() : Set.copyOf(comparisons);
+        // Held here and not left to whoever records one. What a recording is written like is a
+        // producer's business and can change; that a way out of a comparison means the comparison
+        // was reached is what every reader of this is entitled to, and a value that broke it would
+        // certify a claim about a place the same value says was never got to.
+        //
+        // Both ways out of one comparison together are not a breach and must not be refused: a
+        // place a run comes back to is evaluated more than once, and a recording that held only
+        // which way it went the first time would be saying less than it saw.
+        for (ComparisonOutcome way : comparisons) {
+            if (!taken.contains(way.at().emissionSite())) {
+                throw new IllegalArgumentException(
+                        "a run that saw " + way + " is one that reached " + way.at());
+            }
+        }
     }
 
     /** Whether the run was recorded at {@code site}. */

--- a/souther-compiler/src/main/java/souther/compiler/coverage/Observation.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/Observation.java
@@ -22,7 +22,9 @@ import java.util.Set;
  */
 public record Observation(Set<Integer> taken, Set<ComparisonOutcome> comparisons) {
 
-    /** A run nothing was recorded of, which is what a caller with no measuring build has. */
+    /** An empty snapshot: a run recorded as having passed nowhere. Not the same as having no
+     *  account of a run at all, which is not something this can say and is said where a run is
+     *  handed over. */
     public static final Observation NONE = new Observation(Set.of(), Set.of());
 
     public Observation {

--- a/souther-compiler/src/main/java/souther/compiler/coverage/Probe.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/Probe.java
@@ -14,46 +14,61 @@ import java.util.Set;
  * classes are generated without the calls, so a jar never refers to this and a project that depends on
  * the runtime never sees it.
  *
- * <p>The set is per thread because a row is per thread. Rows are evaluated on their own workers, and a
- * thread-shared set would attribute every row's arms to every row.
+ * <p>The recording is per thread because a row is per thread. Rows are evaluated on their own workers,
+ * and a thread-shared recording would attribute every row's arms to every row.
+ *
+ * <p>One recording and not one per shape of thing recorded. What a run leaves behind is the places it
+ * passed through and the ways its comparisons came out, and the two are one run's — begun together,
+ * read together and let go together. Kept as two thread locals they would be two lifecycles that
+ * happen to be driven from the same three calls, and a shape added later would be a third: nothing
+ * would stop one of them being begun and another read.
  */
 public final class Probe {
 
-    /** What the thread running a row has been through. Null between rows: a hit with nothing collecting
-     * is a call from code nobody is measuring, and dropping it is right. */
-    private static final ThreadLocal<BitSet> TAKEN = new ThreadLocal<>();
+    /** What the thread running a row has been through. Null between rows: a hit with nothing
+     * collecting is a call from code nobody is measuring, and dropping it is right. */
+    private static final ThreadLocal<Recording> RECORDING = new ThreadLocal<>();
 
-    /** Called by probed code. Public and static because that is what an {@code invokestatic} from a
-     * generated class needs. */
+    /** What one thread is building up while a row runs. Mutable, unshared, and never handed out —
+     * what a caller gets is {@link Observation}, which is a value. */
+    private static final class Recording {
+
+        private final BitSet taken = new BitSet();
+        private final Set<ComparisonOutcome> comparisons = new LinkedHashSet<>();
+    }
+
+    /** Called by probed code where an arm ran. Public and static because that is what an
+     * {@code invokestatic} from a generated class needs. */
     public static void hit(int site) {
-        BitSet taken = TAKEN.get();
-        if (taken != null) {
-            taken.set(site);
+        Recording recording = RECORDING.get();
+        if (recording != null) {
+            recording.taken.set(site);
         }
     }
 
     /** Starts collecting on this thread. */
     public static void begin() {
-        TAKEN.set(new BitSet());
+        RECORDING.set(new Recording());
     }
 
-    /** What this thread has been through so far, as a set nothing can go on changing. */
-    public static Set<Integer> taken() {
-        BitSet taken = TAKEN.get();
-        if (taken == null) {
-            return Set.of();
+    /** What this thread has been through so far, as one value nothing can go on changing. */
+    public static Observation snapshot() {
+        Recording recording = RECORDING.get();
+        if (recording == null) {
+            return Observation.NONE;
         }
         Set<Integer> sites = new LinkedHashSet<>();
-        for (int at = taken.nextSetBit(0); at >= 0; at = taken.nextSetBit(at + 1)) {
+        for (int at = recording.taken.nextSetBit(0); at >= 0;
+                at = recording.taken.nextSetBit(at + 1)) {
             sites.add(at);
         }
-        return Set.copyOf(sites);
+        return new Observation(sites, recording.comparisons);
     }
 
-    /** Stops collecting, and lets go of the set. A worker thread outlives the row it ran, so a set
-     * left behind would be the next row's starting point. */
+    /** Stops collecting, and lets go of the recording. A worker thread outlives the row it ran, so a
+     * recording left behind would be the next row's starting point. */
     public static void end() {
-        TAKEN.remove();
+        RECORDING.remove();
     }
 
     private Probe() {}

--- a/souther-compiler/src/main/java/souther/compiler/coverage/Probe.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/Probe.java
@@ -46,6 +46,27 @@ public final class Probe {
         }
     }
 
+    /**
+     * Called by probed code where a comparison of an instrumented condition answered, with the value
+     * it answered.
+     *
+     * <p>Records both facts, because they are one event. That the comparison was reached and the way
+     * it came out are read by different measures, and emitting a call each would make "a way recorded
+     * implies its comparison reached" a rule the emitter has to keep rather than something no run can
+     * be found breaking.
+     *
+     * <p>Takes the value rather than a second site chosen from it, so that the numbering the emitter
+     * was given is the numbering it uses and a way out is never a number a reading picked.
+     */
+    public static void compared(boolean held, int site) {
+        Recording recording = RECORDING.get();
+        if (recording != null) {
+            recording.taken.set(site);
+            recording.comparisons.add(
+                    new ComparisonOutcome(new ComparisonOccurrence(site), held));
+        }
+    }
+
     /** Starts collecting on this thread. */
     public static void begin() {
         RECORDING.set(new Recording());

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -1060,7 +1060,7 @@ public final class ExampleVerifier {
                     verifier.policy.recursionDepthLimit());
             try {
                 verifier.checkRowNow(fixtures, target, sig, outCases, row, mine, state);
-                state.hits = Probe.taken();
+                state.seen = Probe.snapshot();
             } finally {
                 // Read on every way out, not only the one where the row came back. A row stopped by
                 // its budget is the row whose cost is most worth knowing, and reading it after the
@@ -1105,10 +1105,11 @@ public final class ExampleVerifier {
         private TypeSymbol resultArm;
         private final List<TypeSymbol> inputCases = new ArrayList<>();
         private final List<ObservedValue> inputs = new ArrayList<>();
-        /** The arms this row went through, where the classes it ran were generated to say. Empty
-         * otherwise, and empty for a row that did not finish — a set read from a row still running
-         * would be some of the arms rather than the arms. */
-        private Set<Integer> hits = Set.of();
+        /** What this row was seen to do, where the classes it ran were generated to say. Empty
+         * otherwise, and empty for a row that did not finish — a snapshot read from a row still
+         * running would be some of what it did rather than what it did. */
+        private souther.compiler.coverage.Observation seen =
+                souther.compiler.coverage.Observation.NONE;
         /** What the row cost, in the unit it is held to. Written by the worker when it finishes, so
          * read only for a row that did. */
         private long stepsSpent;
@@ -1166,7 +1167,7 @@ public final class ExampleVerifier {
         return new RowOutcome(row.pos(), target.name(), row.identity(),
                 reached.stage(), state.disposition, state.failurePhase, state.expectedArm,
                 state.resultArm, state.inputCases, state.inputs,
-                ran(reached, new Counting.Read(state.stepsSpent, state.hits)));
+                ran(reached, new Counting.Read(state.stepsSpent, state.seen)));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/examples/RowTrial.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/RowTrial.java
@@ -25,8 +25,10 @@ import java.util.Optional;
  * <p>The same classes an evaluation runs against, reached the same way a written row reaches them —
  * the values are built through this module's own decoders and handed to the answerer this compile
  * emitted. What differs is that there is no row: no expectation to hold the answer to, no fakes, no
- * stand-ins. So a behavior that depends on another cannot be run this way, which is answered rather
- * than raised, and comes back as nothing having run.
+ * stand-ins. So a behavior that depends on another cannot be applied this way, and neither can one
+ * whose implementation is out of reach. Both are said outright by the layer that would have applied
+ * it, and both come back as nothing having run — which is asked of that layer rather than worked out
+ * here from what a behavior declares, there being one question and no reason for two answers to it.
  *
  * <p>A run that aborts still went where it went. An invariant refusing the answer, a budget running
  * out, an {@code unreachable} being reached — each of them happens after the row has passed whatever
@@ -128,17 +130,27 @@ public final class RowTrial {
             return Optional.empty();
         }
         Probe.begin();
-        EvaluationContext.begin(steps.stepLimit(), steps.recursionDepthLimit());
         try {
-            applying.to(over);
-        } catch (RuntimeException | LinkageError | StackOverflowError e) {
-            // It ran and stopped. Where it had got to is what is being asked for.
+            EvaluationContext.begin(steps.stepLimit(), steps.recursionDepthLimit());
+            try {
+                applying.to(over);
+            } catch (ImplementationNotReached | StandinNotBuilt e) {
+                // Not a run at all: nothing was applied. Saying the row did nothing would be saying
+                // it went nowhere, and those are different facts about it — which is the whole of
+                // what this catch is for, and why it names these two and not what they extend.
+                return Optional.empty();
+            } catch (RuntimeException | Error e) {
+                // It ran and stopped. Where it had got to is what is being asked for, and what
+                // stopped it is not: nothing here is judging the row.
+            } finally {
+                EvaluationContext.end();
+            }
+            return Optional.of(Probe.snapshot());
         } finally {
-            EvaluationContext.end();
+            // On every way out, including one nothing here catches. A recording left installed is
+            // where the next reader on this thread would start.
+            Probe.end();
         }
-        Observation seen = Probe.snapshot();
-        Probe.end();
-        return Optional.of(seen);
     }
 
     private RowTrial() {}

--- a/souther-compiler/src/main/java/souther/compiler/examples/RowTrial.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/RowTrial.java
@@ -1,0 +1,145 @@
+package souther.compiler.examples;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.BoundaryInput;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.coverage.Observation;
+import souther.compiler.coverage.Probe;
+import souther.compiler.evaluate.EvaluationContext;
+import souther.compiler.generated.GeneratedImplementations;
+import souther.compiler.generated.MemoryClassLoader;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Running a row nobody has written yet, to see where it goes.
+ *
+ * <p>What a generator cannot do for itself and cannot be told. Which combination of a body's
+ * decisions a composed row sits in is settled by running it: everything up to that point is a
+ * reading of the body, and a reading is what may be wrong.
+ *
+ * <p>The same classes an evaluation runs against, reached the same way a written row reaches them —
+ * the values are built through this module's own decoders and handed to the answerer this compile
+ * emitted. What differs is that there is no row: no expectation to hold the answer to, no fakes, no
+ * stand-ins. So a behavior that depends on another cannot be run this way, which is answered rather
+ * than raised, and comes back as nothing having run.
+ *
+ * <p>A run that aborts still went where it went. An invariant refusing the answer, a budget running
+ * out, an {@code unreachable} being reached — each of them happens after the row has passed whatever
+ * it passed, and what was recorded up to that point is what the row did. So the recording is read on
+ * every way out and the failure itself is dropped: nothing here is judging the row, and a generator
+ * has no expectation for it to have failed against.
+ */
+public final class RowTrial {
+
+    /**
+     * A way to run one row's inputs and see what it did.
+     *
+     * <p>Empty is an ordinary answer and not a failure. Nothing having run a row leaves every
+     * combination as untried as it was; a row that ran and reached nothing is a row that missed, and
+     * the two must not come back as one value.
+     */
+    @FunctionalInterface
+    public interface Application {
+
+        /** What running {@code inputs} was seen doing, or empty where nothing could run them. */
+        Optional<Observation> run(List<Hir.Expr> inputs);
+    }
+
+    /** A way to run rows of any behavior of one module. */
+    @FunctionalInterface
+    public interface Trials {
+
+        /** A way to run rows of {@code behavior}. */
+        Application forBehavior(String behavior, Sig sig);
+    }
+
+    /**
+     * A way to run rows against one module's generated classes.
+     *
+     * <p>One loader for the module, defined once here. The values a row hands over have to be
+     * instances of the classes the answerer applies, so building them and applying them are two ends
+     * of one loader rather than two loaders that agree — and the classes are defined once however
+     * many behaviors are searched.
+     *
+     * <p>The classes have to be the measuring ones. A run of classes emitted without the calls that
+     * record where it went is a run nothing was recorded of, which reads exactly like a run that
+     * went nowhere — so a caller with unmeasured classes must not build one of these, and every
+     * combination would otherwise come back missed.
+     *
+     * @param steps how many counted points a row may pass, and how deep a recursive helper may go.
+     *              A composed row is not a row anyone wrote, so a model that loops on it is this
+     *              search's problem to stop rather than an author's to be told about
+     */
+    public static Trials over(souther.compiler.check.Prepared.ExampleExecution module,
+                              Symbols symbols, Map<String, byte[]> classes, ClassLoader parent,
+                              Map<String, Hir.FnDef> values, GeneratedImplementations generated,
+                              EvaluationPolicy steps) {
+        MemoryClassLoader loader = new MemoryClassLoader(classes, parent);
+        Answerer answerer = Answering.generatedHere().over(generated, loader);
+        return (behavior, sig) -> inputs -> {
+            if (!(answerer.of(behavior) instanceof Answerer.Answer.Something applies)) {
+                return Optional.empty();   // nothing applies this behavior, so nothing ran
+            }
+            // One reader per row, the way a written row has one: what a reading builds up while it
+            // expands a value is that row's, and a reader kept between them would be a session
+            // spanning every candidate of every combination.
+            return went(new FixtureReader(module, symbols, values, loader), applies, behavior, sig,
+                    inputs, steps);
+        };
+    }
+
+    /**
+     * One row, built and applied, and what the probe saw while it was.
+     *
+     * <p>The recording is begun and read on this thread because the run is on this thread. Both it
+     * and the budget are let go on every way out, a worker being something the next row would
+     * otherwise start inside of.
+     */
+    private static Optional<Observation> went(FixtureReader fixtures,
+                                              Answerer.Answer.Something applies, String behavior,
+                                              Sig sig, List<Hir.Expr> inputs,
+                                              EvaluationPolicy steps) {
+        List<BoundaryInput> ins = sig.ins();
+        if (inputs.size() != ins.size()) {
+            return Optional.empty();   // not a row of this behavior, so this is not the thing to run
+        }
+        Answerer.Applying applying;
+        List<Handed> over;
+        try {
+            // Built and gathered before anything is recorded. A value that could not be made is a
+            // row that never ran, and recording the building would put whatever a fixture's own
+            // helpers passed through into what the row is said to have done.
+            over = new ArrayList<>(ins.size());
+            for (int i = 0; i < ins.size(); i++) {
+                Object built = fixtures.built(inputs.get(i), ins.get(i));
+                BoundaryInput at = ins.get(i);
+                String what = "input " + (i + 1) + " of `" + behavior + "`";
+                over.add(new Handed(built, () -> fixtures.neutral(built, at, what)));
+            }
+            applying = applies.applying(List.of());
+        } catch (RuntimeException | LinkageError | StackOverflowError e) {
+            // Nothing was applied. Which of the things that can go wrong before an application it
+            // was is not this search's business: none of them is a fact about where a row goes.
+            return Optional.empty();
+        }
+        Probe.begin();
+        EvaluationContext.begin(steps.stepLimit(), steps.recursionDepthLimit());
+        try {
+            applying.to(over);
+        } catch (RuntimeException | LinkageError | StackOverflowError e) {
+            // It ran and stopped. Where it had got to is what is being asked for.
+        } finally {
+            EvaluationContext.end();
+        }
+        Observation seen = Probe.snapshot();
+        Probe.end();
+        return Optional.of(seen);
+    }
+
+    private RowTrial() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/examples/RowTrial.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/RowTrial.java
@@ -124,9 +124,12 @@ public final class RowTrial {
                 over.add(new Handed(built, () -> fixtures.neutral(built, at, what)));
             }
             applying = applies.applying(List.of());
-        } catch (RuntimeException | LinkageError | StackOverflowError e) {
-            // Nothing was applied. Which of the things that can go wrong before an application it
-            // was is not this search's business: none of them is a fact about where a row goes.
+        } catch (StandinNotBuilt | LinkageError e) {
+            // Nothing was applied, and these are the two ways that happens before an application:
+            // a stand-in that could not be made, and this compiler's own output not linking. Named
+            // rather than taken by category — anything else out of here is this compiler failing at
+            // something it does not have a word for, and turning that into a fact about where a row
+            // went is how a defect in the runner comes back as a defect in the model.
             return Optional.empty();
         }
         Probe.begin();
@@ -134,14 +137,19 @@ public final class RowTrial {
             EvaluationContext.begin(steps.stepLimit(), steps.recursionDepthLimit());
             try {
                 applying.to(over);
-            } catch (ImplementationNotReached | StandinNotBuilt e) {
-                // Not a run at all: nothing was applied. Saying the row did nothing would be saying
-                // it went nowhere, and those are different facts about it — which is the whole of
-                // what this catch is for, and why it names these two and not what they extend.
+            } catch (ImplementationNotReached e) {
+                // Not a run at all: the implementation could not be reached to apply. Saying the
+                // row did nothing would be saying it went nowhere, and those are different facts.
                 return Optional.empty();
-            } catch (RuntimeException | Error e) {
+            } catch (InvocationFailure e) {
                 // It ran and stopped. Where it had got to is what is being asked for, and what
                 // stopped it is not: nothing here is judging the row.
+                //
+                // This one and no wider. What the applied code ends with arrives as this, so a
+                // throwable that is not one is this compiler failing to reach or drive its own
+                // output — and swallowed here it would come back as a candidate that ran and
+                // missed, which is a statement about the model. The seam says which failures it
+                // has ({@link Answerer.Applying#to}) and those are the ones read.
             } finally {
                 EvaluationContext.end();
             }

--- a/souther-compiler/src/main/java/souther/compiler/interaction/Condition.java
+++ b/souther-compiler/src/main/java/souther/compiler/interaction/Condition.java
@@ -1,6 +1,7 @@
 package souther.compiler.interaction;
 
 import souther.compiler.coverage.ComparisonOccurrence;
+import souther.compiler.coverage.ForkOccurrence;
 import souther.compiler.inputs.TermPath;
 
 /**
@@ -50,14 +51,19 @@ public sealed interface Condition {
      * into this outcome; whether the outcomes are two is decided by the fork having two arms, and
      * running them together would report a factor the body has as one it does not.
      *
-     * @param control which fork, among the places of this plan
-     * @param part    which arm of it
+     * <p>Nothing can place one of these at a class of a position, so a group made of one is not a
+     * group anything offers. That it is here at all is what says so: the walk found a decision it
+     * could not name, and a reading that left it out instead would offer the group with one of the
+     * ways it can be settled quietly missing.
+     *
+     * @param fork which fork, as the plan named it
+     * @param part which arm of it
      */
-    record Arm(int control, int part) implements Condition {
+    record Arm(ForkOccurrence fork, int part) implements Condition {
 
         @Override
         public String toString() {
-            return "arm " + control + "/" + part;
+            return fork + "/" + part;
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/interaction/Condition.java
+++ b/souther-compiler/src/main/java/souther/compiler/interaction/Condition.java
@@ -1,5 +1,6 @@
 package souther.compiler.interaction;
 
+import souther.compiler.coverage.ComparisonOccurrence;
 import souther.compiler.inputs.TermPath;
 
 /**
@@ -28,16 +29,17 @@ public sealed interface Condition {
     /**
      * A comparison in the body coming out one way.
      *
-     * @param site  where the comparison's own value is recorded, which is what tells one reading of
-     *              one rule from another: a comparison inside a non-recursive helper is read once
-     *              per call of that helper
-     * @param held  the way it came out
+     * @param comparison which comparison, which is what tells one reading of one rule from another:
+     *                   a comparison inside a non-recursive helper is read once per call of that
+     *                   helper. The occurrence and not the number it is instrumented under — the
+     *                   number is how a run is recorded and is no part of what this decision is
+     * @param held       the way it came out
      */
-    record Side(TermPath at, int site, boolean held) implements Condition {
+    record Side(TermPath at, ComparisonOccurrence comparison, boolean held) implements Condition {
 
         @Override
         public String toString() {
-            return at + (held ? " holds" : " fails") + "@" + site;
+            return at + (held ? " holds" : " fails") + "@" + comparison.emissionSite();
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/interaction/Decision.java
+++ b/souther-compiler/src/main/java/souther/compiler/interaction/Decision.java
@@ -1,0 +1,38 @@
+package souther.compiler.interaction;
+
+import souther.compiler.coverage.ControlClaim;
+
+/**
+ * One decision of a body coming out one way, said twice: as what it takes of the inputs, and as what
+ * a run that did it would be seen to have done.
+ *
+ * <p>Two values and not one with two readings. {@link #constrains} is the reading's own — which
+ * position, which classes of it — and it is what a search for a value works from. {@link #claims} is
+ * a place in the tree that runs, and it is what an observation is held against. Folded together they
+ * would be one vocabulary doing both jobs, which is how a number that says where a run is recorded
+ * came to be what two readings of a rule matched on.
+ *
+ * <p>Made together, here and nowhere else. What keeps them about the same decision is that neither
+ * is looked up from the other afterwards: the walk that reads the body has the node in front of it
+ * and takes both off it at once. A later pass given only the constraint would have to find the place
+ * again by what it is spelled like, which is the reading being done twice and disagreeing once.
+ *
+ * <p>Both halves are required. A decision whose place carries no probe is one no run could ever be
+ * shown to have made, so it is not one of these at all — the walk answers that it cannot name this
+ * way in, and whatever was being built on it goes. Offering it instead would put a combination in
+ * front of an author that every row misses however it is written.
+ */
+public record Decision(Condition constrains, ControlClaim claims) {
+
+    public Decision {
+        if (constrains == null || claims == null) {
+            throw new IllegalArgumentException(
+                    "a decision is what it takes of the inputs and what a run that made it did");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return constrains.toString();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/interaction/Interaction.java
+++ b/souther-compiler/src/main/java/souther/compiler/interaction/Interaction.java
@@ -19,11 +19,16 @@ import java.util.List;
  * @param reach   what holds on the way to the meeting, which every one of its combinations is under
  * @param factors what varies at it, one per value consumed there
  */
-public record Interaction(List<Condition> reach, List<Factor> factors) {
+public record Interaction(List<Decision> reach, List<Factor> factors) {
 
     public Interaction {
         reach = List.copyOf(reach);
         factors = List.copyOf(factors);
+    }
+
+    /** What a run that took the way to the meeting would be seen to have done. */
+    public List<souther.compiler.coverage.ControlClaim> reachClaims() {
+        return reach.stream().map(Decision::claims).toList();
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/interaction/Interactions.java
+++ b/souther-compiler/src/main/java/souther/compiler/interaction/Interactions.java
@@ -88,7 +88,7 @@ public final class Interactions {
     }
 
     private void walk(Core node, InputReads reads, Map<BindingId, List<Outcome>> bound,
-                      Set<Core> absorbed, List<Condition> reach, List<Interaction> found) {
+                      Set<Core> absorbed, List<Decision> reach, List<Interaction> found) {
         if (!answers(node)) {
             // The same invariant the outcomes are read under, and the walk is where it is decided
             // whether there is a group here at all. A subtree that arrives at no value is one no
@@ -152,14 +152,20 @@ public final class Interactions {
      * two.
      */
     private void descend(Core node, InputReads reads, Map<BindingId, List<Outcome>> bound,
-                         Set<Core> absorbed, List<Condition> reach, List<Interaction> found) {
+                         Set<Core> absorbed, List<Decision> reach, List<Interaction> found) {
         switch (node) {
+            // A way in nobody can name stops the walk into that arm, whether what could not be named
+            // is the position the decision is about or the place a run that took it would be seen at.
+            // A group found in there would be under a condition nothing can steer a row into or hold
+            // a run to, and offering it asks for a row that may never arrive.
             case Core.If iff -> {
                 walk(iff.cond(), reads, bound, absorbed, reach, found);
                 Core[] arms = {iff.then(), iff.els()};
                 for (int part = 0; part < arms.length; part++) {
-                    walk(arms[part], reads, bound, absorbed,
-                            and(reach, armCondition(iff, part, reads)), found);
+                    Decision went = armCondition(iff, part, reads);
+                    if (went != null) {
+                        walk(arms[part], reads, bound, absorbed, and(reach, went), found);
+                    }
                 }
             }
             case Core.Match match -> {
@@ -167,8 +173,10 @@ public final class Interactions {
                 walk(match.scrutinee(), reads, bound, absorbed, reach, found);
                 for (int part = 0; part < match.cases().size(); part++) {
                     Core.Case each = match.cases().get(part);
-                    walk(each.body(), reads, bound, absorbed,
-                            and(reach, caseCondition(at, each, match, part)), found);
+                    Decision went = caseCondition(at, each, match, part);
+                    if (went != null) {
+                        walk(each.body(), reads, bound, absorbed, and(reach, went), found);
+                    }
                 }
             }
             case Core.Binary binary when shortCircuits(binary.op()) -> {
@@ -176,9 +184,8 @@ public final class Interactions {
                 // The right runs only where the left did not settle the answer, and which of the
                 // left's outcomes that is takes reading a value rather than a condition. Where the
                 // left is one this can say a side of, that side is what getting here takes; where
-                // it is not, there is nothing to say and the walk does not go in — a group under a
-                // way in nobody can name is one whose rows may not arrive.
-                Condition went = settledBy(binary.left(), binary.op() == Hir.BinOp.AND, reads);
+                // it is not, there is nothing to say and the walk does not go in.
+                Decision went = settledBy(binary.left(), binary.op() == Hir.BinOp.AND, reads);
                 if (went != null) {
                     walk(binary.right(), reads, bound, absorbed, and(reach, went), found);
                 }
@@ -233,15 +240,15 @@ public final class Interactions {
     }
 
     private void walkAll(List<Core> parts, InputReads reads, Map<BindingId, List<Outcome>> bound,
-                         Set<Core> absorbed, List<Condition> reach, List<Interaction> found) {
+                         Set<Core> absorbed, List<Decision> reach, List<Interaction> found) {
         for (Core each : parts) {
             walk(each, reads, bound, absorbed, reach, found);
         }
     }
 
     /** The way in, and one more thing that holds along it. */
-    private static List<Condition> and(List<Condition> reach, Condition went) {
-        List<Condition> both = new ArrayList<>(reach);
+    private static List<Decision> and(List<Decision> reach, Decision went) {
+        List<Decision> both = new ArrayList<>(reach);
         both.add(went);
         return both;
     }
@@ -390,7 +397,10 @@ public final class Interactions {
                 if (!answers(each.body())) {
                     continue;
                 }
-                Condition when = caseCondition(at, each, match, part);
+                Decision when = caseCondition(at, each, match, part);
+                if (when == null) {
+                    continue;
+                }
                 for (Outcome inner : outcomesOf(each.body(), reads, bound)) {
                     out.add(prepend(when, inner));
                 }
@@ -410,7 +420,10 @@ public final class Interactions {
                 if (!answers(arms[part])) {
                     continue;
                 }
-                Condition when = armCondition(iff, part, reads);
+                Decision when = armCondition(iff, part, reads);
+                if (when == null) {
+                    continue;
+                }
                 for (Outcome inner : outcomesOf(arms[part], reads, bound)) {
                     out.add(prepend(when, inner));
                 }
@@ -433,7 +446,10 @@ public final class Interactions {
                 if (!answers(arms.get(part))) {
                     continue;
                 }
-                Condition when = arm(constructed, part);
+                Decision when = forkDecision(constructed, part);
+                if (when == null) {
+                    continue;
+                }
                 for (Outcome inner : outcomesOf(arms.get(part), reads, bound)) {
                     out.add(prepend(when, inner));
                 }
@@ -462,14 +478,19 @@ public final class Interactions {
         return out;
     }
 
-    /** Which case of the union this arm is, said of the position matched on where there is one. */
-    private Condition caseCondition(TermPath at, Core.Case arm, Core.Match match, int part) {
+    /** Which case of the union this arm is, said of the position matched on where there is one, or
+     *  null where no run through the arm could be recorded. */
+    private Decision caseCondition(TermPath at, Core.Case arm, Core.Match match, int part) {
+        souther.compiler.coverage.ControlClaim claim = armClaim(match, part);
+        if (claim == null) {
+            return null;
+        }
         if (at == null) {
-            return arm(match, part);
+            return new Decision(forkArm(match, part), claim);
         }
         List<String> names = arm.pattern().selectors().stream()
                 .map(selector -> selector.name().name()).toList();
-        return new Condition.Case(at, String.join("|", names));
+        return new Decision(new Condition.Case(at, String.join("|", names)), claim);
     }
 
     /**
@@ -480,9 +501,20 @@ public final class Interactions {
      * value that made {@code B} false and by one that never evaluated {@code B}: a row is steered
      * by getting the comparison to answer, which no arm records.
      */
-    private Condition armCondition(Core.If iff, int part, InputReads reads) {
-        Condition said = settledBy(iff.cond(), part == 0, reads);
-        return said != null ? said : arm(iff, part);
+    private Decision armCondition(Core.If iff, int part, InputReads reads) {
+        Decision said = settledBy(iff.cond(), part == 0, reads);
+        if (said != null) {
+            return said;
+        }
+        // The condition is a value rather than a comparison, so nothing recorded the way it came
+        // out — what a run that went this way is seen to have done is that it took this arm.
+        souther.compiler.coverage.ControlClaim claim = armClaim(iff, part);
+        if (claim == null) {
+            return null;
+        }
+        TermPath read = reads.pathOf(iff.cond(), symbols);
+        return new Decision(read == null ? forkArm(iff, part)
+                : new Condition.Case(read, part == 0 ? "true" : "false"), claim);
     }
 
     /**
@@ -492,32 +524,55 @@ public final class Interactions {
      * <p>Asked of a fork's condition and of the left of an operator that stops early, which are the
      * same question: both are a value whose coming out one way is what a row has to arrange.
      */
-    private Condition settledBy(Core test, boolean held, InputReads reads) {
+    private Decision settledBy(Core test, boolean held, InputReads reads) {
         if (!(test instanceof Core.Binary comparison)) {
-            // The condition is the value. A Bool the body branches on is a position of its own and
-            // the two ways it comes out are its two classes, so this is said of it.
-            TermPath read = reads.pathOf(test, symbols);
-            return read == null ? null : new Condition.Case(read, held ? "true" : "false");
+            // The condition is a value rather than a comparison, and nothing records a value coming
+            // out one way. Whether the arm below says it is the caller's question: under a fork
+            // there is an arm to be held to, and on the left of an operator that stops early there
+            // is not.
+            return null;
         }
         souther.compiler.coverage.ComparisonOccurrence site =
                 plan.comparisonAt(comparison).orElse(null);
         TermPath at = firstOf(reads.pathOf(comparison.left(), symbols),
                 reads.pathOf(comparison.right(), symbols));
-        return site == null || at == null ? null : new Condition.Side(at, site, held);
+        if (site == null || at == null) {
+            return null;
+        }
+        return plan.outcomeOf(comparison, held)
+                .flatMap(souther.compiler.coverage.ControlClaim::of)
+                .map(claim -> new Decision(new Condition.Side(at, site, held), claim))
+                .orElse(null);
+    }
+
+    /** One arm of a fork, where a run through it can be recorded, and null where it cannot. */
+    private souther.compiler.coverage.ControlClaim armClaim(Core fork, int part) {
+        ControlPointId.ArmOccurrence[] arms = plan.armsOf(fork);
+        if (arms == null || part >= arms.length) {
+            return null;
+        }
+        return souther.compiler.coverage.ControlClaim.of(arms[part]).orElse(null);
     }
 
     /** The fork itself, for a decision this reading cannot name a position for. */
-    private Condition arm(Core fork, int part) {
+    private Condition forkArm(Core fork, int part) {
         ControlPointId.ArmOccurrence[] arms = plan.armsOf(fork);
         return new Condition.Arm(arms == null || arms.length == 0 ? -1 : arms[0].controlId(), part);
+    }
+
+    /** A fork coming out one way and nothing said about which position, or null where no run
+     *  through the arm could be recorded. */
+    private Decision forkDecision(Core fork, int part) {
+        souther.compiler.coverage.ControlClaim claim = armClaim(fork, part);
+        return claim == null ? null : new Decision(forkArm(fork, part), claim);
     }
 
     private static TermPath firstOf(TermPath left, TermPath right) {
         return left != null ? left : right;
     }
 
-    private static Outcome prepend(Condition when, Outcome outcome) {
-        List<Condition> holds = new ArrayList<>();
+    private static Outcome prepend(Decision when, Outcome outcome) {
+        List<Decision> holds = new ArrayList<>();
         holds.add(when);
         holds.addAll(outcome.holds());
         return new Outcome(holds);
@@ -533,9 +588,9 @@ public final class Interactions {
         List<Outcome> out = new ArrayList<>();
         for (Outcome one : left) {
             for (Outcome other : right) {
-                List<Condition> holds = new ArrayList<>(one.holds());
+                List<Decision> holds = new ArrayList<>(one.holds());
                 boolean agree = true;
-                for (Condition each : other.holds()) {
+                for (Decision each : other.holds()) {
                     if (holds.contains(each)) {
                         continue;
                     }
@@ -557,9 +612,10 @@ public final class Interactions {
     }
 
     /** Whether {@code added} settles a decision the outcome already settles the other way. */
-    private static boolean disagrees(List<Condition> holds, Condition added) {
-        for (Condition each : holds) {
-            boolean same = switch (added) {
+    private static boolean disagrees(List<Decision> holds, Decision added) {
+        for (Decision already : holds) {
+            Condition each = already.constrains();
+            boolean same = switch (added.constrains()) {
                 case Condition.Case one ->
                         each instanceof Condition.Case other && other.at().equals(one.at());
                 case Condition.Side one -> each instanceof Condition.Side other

--- a/souther-compiler/src/main/java/souther/compiler/interaction/Interactions.java
+++ b/souther-compiler/src/main/java/souther/compiler/interaction/Interactions.java
@@ -119,7 +119,18 @@ public final class Interactions {
                     factors.add(new Factor(outcomes));
                 }
             }
-            if (factors.size() > 1) {
+            // A group says that these decisions were settled these ways and met here, which is a
+            // statement about one passing. What can be established about a run is what its recording
+            // holds, and that is which places it passed rather than how many times it passed each —
+            // so where a run may come back to this meeting, the two factors coming out the named
+            // ways is not something any reading of such a recording can tell from their coming out
+            // those ways on different times round. The group would be one nothing could ever show a
+            // row to sit in, so it is not offered.
+            //
+            // Asked at the meeting and nowhere else, which is enough because a place a run may come
+            // back to has everything inside it in the same position: a meeting this is false of
+            // names a way in and factors that are all false of it too.
+            if (factors.size() > 1 && !plan.mayRepeat(node)) {
                 found.add(new Interaction(reach, factors));
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/interaction/Interactions.java
+++ b/souther-compiler/src/main/java/souther/compiler/interaction/Interactions.java
@@ -486,7 +486,8 @@ public final class Interactions {
             return null;
         }
         if (at == null) {
-            return new Decision(forkArm(match, part), claim);
+            Condition fork = forkArm(match, part);
+            return fork == null ? null : new Decision(fork, claim);
         }
         List<String> names = arm.pattern().selectors().stream()
                 .map(selector -> selector.name().name()).toList();
@@ -513,8 +514,9 @@ public final class Interactions {
             return null;
         }
         TermPath read = reads.pathOf(iff.cond(), symbols);
-        return new Decision(read == null ? forkArm(iff, part)
-                : new Condition.Case(read, part == 0 ? "true" : "false"), claim);
+        Condition what = read == null ? forkArm(iff, part)
+                : new Condition.Case(read, part == 0 ? "true" : "false");
+        return what == null ? null : new Decision(what, claim);
     }
 
     /**
@@ -554,17 +556,19 @@ public final class Interactions {
         return souther.compiler.coverage.ControlClaim.of(arms[part]).orElse(null);
     }
 
-    /** The fork itself, for a decision this reading cannot name a position for. */
+    /** The fork itself, for a decision this reading cannot name a position for, or null where the
+     *  plan named no fork here. */
     private Condition forkArm(Core fork, int part) {
-        ControlPointId.ArmOccurrence[] arms = plan.armsOf(fork);
-        return new Condition.Arm(arms == null || arms.length == 0 ? -1 : arms[0].controlId(), part);
+        souther.compiler.coverage.ForkOccurrence named = plan.forkAt(fork);
+        return named == null ? null : new Condition.Arm(named, part);
     }
 
     /** A fork coming out one way and nothing said about which position, or null where no run
      *  through the arm could be recorded. */
     private Decision forkDecision(Core fork, int part) {
         souther.compiler.coverage.ControlClaim claim = armClaim(fork, part);
-        return claim == null ? null : new Decision(forkArm(fork, part), claim);
+        Condition what = forkArm(fork, part);
+        return claim == null || what == null ? null : new Decision(what, claim);
     }
 
     private static TermPath firstOf(TermPath left, TermPath right) {
@@ -620,8 +624,8 @@ public final class Interactions {
                         each instanceof Condition.Case other && other.at().equals(one.at());
                 case Condition.Side one -> each instanceof Condition.Side other
                         && other.comparison().equals(one.comparison());
-                case Condition.Arm one ->
-                        each instanceof Condition.Arm other && other.control() == one.control();
+                case Condition.Arm one -> each instanceof Condition.Arm other
+                        && other.fork().equals(one.fork());
             };
             if (same) {
                 return true;

--- a/souther-compiler/src/main/java/souther/compiler/interaction/Interactions.java
+++ b/souther-compiler/src/main/java/souther/compiler/interaction/Interactions.java
@@ -488,7 +488,8 @@ public final class Interactions {
             TermPath read = reads.pathOf(test, symbols);
             return read == null ? null : new Condition.Case(read, held ? "true" : "false");
         }
-        Integer site = plan.byComparison().get(comparison);
+        souther.compiler.coverage.ComparisonOccurrence site =
+                plan.comparisonAt(comparison).orElse(null);
         TermPath at = firstOf(reads.pathOf(comparison.left(), symbols),
                 reads.pathOf(comparison.right(), symbols));
         return site == null || at == null ? null : new Condition.Side(at, site, held);
@@ -550,8 +551,8 @@ public final class Interactions {
             boolean same = switch (added) {
                 case Condition.Case one ->
                         each instanceof Condition.Case other && other.at().equals(one.at());
-                case Condition.Side one ->
-                        each instanceof Condition.Side other && other.site() == one.site();
+                case Condition.Side one -> each instanceof Condition.Side other
+                        && other.comparison().equals(one.comparison());
                 case Condition.Arm one ->
                         each instanceof Condition.Arm other && other.control() == one.control();
             };

--- a/souther-compiler/src/main/java/souther/compiler/interaction/Outcome.java
+++ b/souther-compiler/src/main/java/souther/compiler/interaction/Outcome.java
@@ -9,10 +9,15 @@ import java.util.List;
  * by both: the comparison on the total is a decision only where the member is Standard, and an
  * outcome naming the comparison alone would name a combination the body has no path to.
  */
-public record Outcome(List<Condition> holds) {
+public record Outcome(List<Decision> holds) {
 
     public Outcome {
         holds = List.copyOf(holds);
+    }
+
+    /** What a run that settled the decision this way would be seen to have done. */
+    public List<souther.compiler.coverage.ControlClaim> claims() {
+        return holds.stream().map(Decision::claims).toList();
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/observe/Counting.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/Counting.java
@@ -1,6 +1,6 @@
 package souther.compiler.observe;
 
-import java.util.Set;
+import souther.compiler.coverage.Observation;
 
 /**
  * What this compile's own counting read of one row's evaluation.
@@ -27,13 +27,18 @@ public sealed interface Counting {
      * of the budget its rows use before one of them reaches it — the only way to set the budget from
      * evidence rather than by guessing. Zero says no counted point was passed, and says only that.
      *
-     * <p>{@link #hits} is the branch sites the row went through. Empty until branches are measured,
-     * which is a property of the compile rather than of the row.
+     * <p>{@link #observation} is what the row was seen to do — the sites it went through and the ways
+     * its comparisons came out. Empty until branches are measured, which is a property of the compile
+     * rather than of the row.
+     *
+     * <p>One value rather than a field per shape of thing recorded. What a run leaves behind is taken
+     * of one thread between one start and one stop, and a record with a field each would let the
+     * halves of one run be filled from different ones.
      */
-    record Read(long steps, Set<Integer> hits) implements Counting {
+    record Read(long steps, Observation observation) implements Counting {
 
         public Read {
-            hits = hits == null ? Set.of() : Set.copyOf(hits);
+            observation = observation == null ? Observation.NONE : observation;
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/observe/Run.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/Run.java
@@ -30,6 +30,7 @@ public record Run(Applied applied, Counting counting) {
 
     /** A row that applied nothing and was read to have spent nothing. */
     public static Run nothing() {
-        return new Run(new Applied.Nothing(), new Counting.Read(0L, java.util.Set.of()));
+        return new Run(new Applied.Nothing(),
+                new Counting.Read(0L, souther.compiler.coverage.Observation.NONE));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/CellSelection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/CellSelection.java
@@ -29,6 +29,14 @@ public record CellSelection(InteractionCells.Cell cell, List<ControlClaim> claim
 
     public CellSelection {
         claims = List.copyOf(claims);
+        if (claims.isEmpty()) {
+            // A combination of a body's decisions is decisions being settled, so a run that filled
+            // one did something. Allowed to be empty, this would be a combination every run
+            // certifies — including one that did nothing — and a claim dropped upstream would come
+            // back not as a combination nothing can witness but as one everything does.
+            throw new IllegalArgumentException(
+                    "a combination of decisions is something a run can be held to");
+        }
     }
 
     /**
@@ -52,14 +60,15 @@ public record CellSelection(InteractionCells.Cell cell, List<ControlClaim> claim
      * The row at {@code where} as a witness that this combination is filled, where {@code seen} says
      * it filled it.
      *
-     * <p>The only way there is to make one. That a row fills a combination is the one thing here a
-     * reader may act on, and it is a conclusion about a run — so it is a value nothing but this can
-     * produce, out of the run itself. A caller holding the classes a row sits in cannot reach for it,
-     * which is what stops the reading that composed a row from being read back as evidence for
-     * itself.
+     * <p>The only way there is to make one, and it asks both halves. A row fills a combination by
+     * sitting where the combination leaves room and by having been seen doing what it names, and a
+     * value that took the second on trust would say a row filled a combination it is not even in.
+     * A caller holding one half cannot reach for it, which is what stops the reading that composed
+     * a row from being read back as evidence for itself.
      */
     public java.util.Optional<CertifiedWitness> certifying(int[] where, Observation seen) {
-        return certifiedBy(seen) ? java.util.Optional.of(new CertifiedWitness(this, where))
+        return cell.holds(where) && certifiedBy(seen)
+                ? java.util.Optional.of(new CertifiedWitness(this, where, seen))
                 : java.util.Optional.empty();
     }
 
@@ -75,10 +84,12 @@ public record CellSelection(InteractionCells.Cell cell, List<ControlClaim> claim
 
         private final CellSelection of;
         private final int[] where;
+        private final Observation seen;
 
-        private CertifiedWitness(CellSelection of, int[] where) {
+        private CertifiedWitness(CellSelection of, int[] where, Observation seen) {
             this.of = of;
             this.where = where.clone();
+            this.seen = seen;
         }
 
         /** Which combination this fills. */
@@ -89,6 +100,11 @@ public record CellSelection(InteractionCells.Cell cell, List<ControlClaim> claim
         /** Which class of each position the row sits at. */
         public int[] where() {
             return where.clone();
+        }
+
+        /** What the run was seen doing, which is what other combinations are asked of in turn. */
+        public Observation seen() {
+            return seen;
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/CellSelection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/CellSelection.java
@@ -1,0 +1,50 @@
+package souther.compiler.partition;
+
+import souther.compiler.coverage.ControlClaim;
+import souther.compiler.coverage.Observation;
+
+import java.util.List;
+
+/**
+ * One combination of a group, as the classes a row filling it may sit in and as what a row that
+ * fills it would be seen to do.
+ *
+ * <p>Two things and the difference between them is the point. The {@link #cell} is a classification
+ * of the search space: it says which classes of each position are still open, which is what a search
+ * for values works from and what a written row's values can be read against. The {@link #claims} are
+ * a statement about a run — that it took the path to the meeting and settled each factor at the
+ * outcome this combination names.
+ *
+ * <p>The first does not establish the second. Putting a value in the classes the cell allows is what
+ * the reading believed would steer a row here, and that belief is a chain of readings: which
+ * position a decision is about, which comparison a line was drawn off, which classes a condition
+ * leaves open. A row whose values sit in the cell and whose run went somewhere else is exactly what
+ * a wrong step anywhere in that chain produces, and it looks like a right one until something asks
+ * the run.
+ *
+ * <p>So nothing here says a row covers this. What sits in the cell is admitted; what did what the
+ * claims name is certified; and only the second is evidence about the combination.
+ */
+public record CellSelection(InteractionCells.Cell cell, List<ControlClaim> claims) {
+
+    public CellSelection {
+        claims = List.copyOf(claims);
+    }
+
+    /**
+     * What {@code seen} did not do of what this names.
+     *
+     * <p>Empty is the certification. Which of them were missed is kept rather than reduced to
+     * whether any were, because that is what says where the reading and the run parted — a row that
+     * never reached the meeting misses the way in, and one that reached it and went the other way
+     * misses an outcome, and those are different things to be told.
+     */
+    public List<ControlClaim> missedBy(Observation seen) {
+        return claims.stream().filter(claim -> !claim.satisfiedBy(seen)).toList();
+    }
+
+    /** Whether {@code seen} did everything this names. */
+    public boolean certifiedBy(Observation seen) {
+        return claims.stream().allMatch(claim -> claim.satisfiedBy(seen));
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/CellSelection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/CellSelection.java
@@ -47,4 +47,48 @@ public record CellSelection(InteractionCells.Cell cell, List<ControlClaim> claim
     public boolean certifiedBy(Observation seen) {
         return claims.stream().allMatch(claim -> claim.satisfiedBy(seen));
     }
+
+    /**
+     * The row at {@code where} as a witness that this combination is filled, where {@code seen} says
+     * it filled it.
+     *
+     * <p>The only way there is to make one. That a row fills a combination is the one thing here a
+     * reader may act on, and it is a conclusion about a run — so it is a value nothing but this can
+     * produce, out of the run itself. A caller holding the classes a row sits in cannot reach for it,
+     * which is what stops the reading that composed a row from being read back as evidence for
+     * itself.
+     */
+    public java.util.Optional<CertifiedWitness> certifying(int[] where, Observation seen) {
+        return certifiedBy(seen) ? java.util.Optional.of(new CertifiedWitness(this, where))
+                : java.util.Optional.empty();
+    }
+
+    /**
+     * A row seen doing what one combination names.
+     *
+     * <p>Its own type because what it says is not what its parts say. The classes and the run are
+     * both readable elsewhere; that the two together fill a combination is the conclusion, and
+     * having it be a value means a reader either has it or does not, rather than deciding it again
+     * from whatever it has to hand.
+     */
+    public static final class CertifiedWitness {
+
+        private final CellSelection of;
+        private final int[] where;
+
+        private CertifiedWitness(CellSelection of, int[] where) {
+            this.of = of;
+            this.where = where.clone();
+        }
+
+        /** Which combination this fills. */
+        public CellSelection of() {
+            return of;
+        }
+
+        /** Which class of each position the row sits at. */
+        public int[] where() {
+            return where.clone();
+        }
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/GenerationReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GenerationReason.java
@@ -57,6 +57,19 @@ public sealed interface GenerationReason {
     record NothingToBuildAgainst(String behavior) implements GenerationReason {}
 
     /**
+     * Rows were offered for combinations of the body's decisions that nothing ran to confirm.
+     *
+     * <p>Which is not that they are wrong. A row is composed by narrowing each position to the
+     * classes the combination leaves it, and whether such a row reaches the meeting is settled by
+     * running it; where nothing could, what the row is offered for is what the reading says.
+     *
+     * <p>Said because silence about it reads as confirmation. The rows are worth offering either
+     * way — this is the account a generation could always give of them — but an author acting on
+     * one is acting on a reading, and that is theirs to know.
+     */
+    record RowsNotConfirmed(String behavior) implements GenerationReason {}
+
+    /**
      * The generated classes would not link, so the decoders could not be reached.
      *
      * <p>What the JVM raised is a {@code LinkageError}, and which of its causes it was is not

--- a/souther-compiler/src/main/java/souther/compiler/partition/GenerationReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GenerationReason.java
@@ -70,6 +70,20 @@ public sealed interface GenerationReason {
     record RowsNotConfirmed(String behavior) implements GenerationReason {}
 
     /**
+     * Combinations no row was offered for, because a row already written may already fill them.
+     *
+     * <p>Which is not that it does. The row sits where one filling the combination would sit, and
+     * whether it takes the path the combination names is settled by running it — so where nothing
+     * could say, the row is given the benefit of it and no work is handed to an author who may have
+     * done it.
+     *
+     * <p>Said because the alternative is silence, and silence here reads as a combination covered.
+     * What an author has is a combination nothing established anything about, and the way to
+     * establish it is to measure.
+     */
+    record CombinationsWithheld(String behavior, int combinations) implements GenerationReason {}
+
+    /**
      * The generated classes would not link, so the decoders could not be reached.
      *
      * <p>What the JVM raised is a {@code LinkageError}, and which of its causes it was is not

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -108,6 +108,34 @@ public final class Generator {
     }
 
     /**
+     * A row that is already written, as the two things this reads it for.
+     *
+     * <p>Where its values sit is what says which classes and which pairs it fills; what its run did
+     * is what says which combinations of the body's decisions it fills. The second is not derivable
+     * from the first, which is the whole of what this issue is about — a row whose values sit in a
+     * combination's classes and whose run went elsewhere fills nothing, and looks from the values
+     * alone exactly like one that fills it.
+     *
+     * @param at   which class of each divided position the row's values fall in
+     * @param seen what the row's run was recorded doing, or {@link Observation#NONE} where nothing
+     *             read it. Nothing read is not nothing done: it certifies no combination, which
+     *             leaves them owed rather than filled
+     */
+    public record ObservedRow(Map<AxisId, Classification> at,
+                              souther.compiler.coverage.Observation seen) {
+
+        public ObservedRow {
+            at = Map.copyOf(at);
+            seen = seen == null ? souther.compiler.coverage.Observation.NONE : seen;
+        }
+
+        /** A row nothing ran, for a caller with no run to read. */
+        public static ObservedRow unseen(Map<AxisId, Classification> at) {
+            return new ObservedRow(at, souther.compiler.coverage.Observation.NONE);
+        }
+    }
+
+    /**
      * A combination no row could be written for, and why.
      *
      * <p>{@code ALL_CANDIDATES_REJECTED} is not a proof that the combination is impossible. It says
@@ -243,8 +271,7 @@ public final class Generator {
      * it brings in. Ties go to the lower index, the axes are ordered before anything starts, and nothing
      * consults a clock or a hash order — the same model and the same rows produce the same rows twice.
      */
-    public static GenerationResult fill(Subject subject,
-                                        List<Map<AxisId, Classification>> existing,
+    public static GenerationResult fill(Subject subject, List<ObservedRow> existing,
                                         CandidateCheck check) {
         return fill(subject, existing, check, List.of());
     }
@@ -259,8 +286,7 @@ public final class Generator {
      * they leave free is what the pairs are spent on — so the rows a cell needs are rows the pair
      * space was going to want anyway, rather than rows added beside them.
      */
-    public static GenerationResult fill(Subject subject,
-                                        List<Map<AxisId, Classification>> existing,
+    public static GenerationResult fill(Subject subject, List<ObservedRow> existing,
                                         CandidateCheck check,
                                         List<souther.compiler.interaction.Interaction> groups) {
         List<Axis> ordered = ordered(subject);
@@ -285,16 +311,16 @@ public final class Generator {
         // covers every pair can still miss a class of a position the pairs happened to fix elsewhere.
         Set<Pair> pairs = pairsOf(axes);
         Set<Pair> singles = singlesOf(axes);
-        for (Map<AxisId, Classification> row : existing) {
-            cover(pairs, singles, axes, whereIn(row, axes));
+        for (ObservedRow row : existing) {
+            cover(pairs, singles, axes, whereIn(row.at(), axes));
         }
 
         List<GeneratedRow> rows = new ArrayList<>();
         List<UnresolvedCombination> unresolved = new ArrayList<>();
         List<GenerationReason> reasons = new ArrayList<>(undecided);
-        List<int[]> written = new ArrayList<>();
-        for (Map<AxisId, Classification> row : existing) {
-            written.add(whereIn(row, axes));
+        List<Placement> written = new ArrayList<>();
+        for (ObservedRow row : existing) {
+            written.add(new Placement(whereIn(row.at(), axes), row.seen()));
         }
         // Built here and not handed in: a cell is one class per position of the axes this
         // generation kept, and the caller's list is neither ordered the same nor filtered the same.
@@ -322,8 +348,9 @@ public final class Generator {
                     continue;
                 }
                 InteractionCells.Cell cell = selection.cell();
-                if (sits(written, cell)) {
-                    // A cell a row already sits in is a cell nothing is owed for.
+                if (fills(written, selection)) {
+                    // A combination a row was seen filling is one nothing is owed for. Sitting in
+                    // its classes is not that, and is not enough.
                     continue;
                 }
                 int[] where = assign(axes, pairs, cell);
@@ -338,7 +365,9 @@ public final class Generator {
                 // out to settle beside that, and a name carrying it would move when nothing about
                 // the row had.
                 rows.add(new GeneratedRow(labels(axes, cell, where), built.row().inputs()));
-                written.add(where);
+                // Counted against the pairs, which are about where a row's values sit, and against
+                // no combination: nothing ran this, so it was seen filling none of them.
+                written.add(new Placement(where, souther.compiler.coverage.Observation.NONE));
                 cover(pairs, singles, axes, where);
             }
         }
@@ -603,9 +632,9 @@ public final class Generator {
     /** Whether every existing row said where it sat at this position. One that did not leaves the
      * position undecided: what the rows cover there is unknown, so what they do not cover is unknown
      * too. */
-    private static boolean readEverywhere(Axis axis, List<Map<AxisId, Classification>> existing) {
-        for (Map<AxisId, Classification> row : existing) {
-            Classification where = row.get(axis.id());
+    private static boolean readEverywhere(Axis axis, List<ObservedRow> existing) {
+        for (ObservedRow row : existing) {
+            Classification where = row.at().get(axis.id());
             if (where != null && !(where instanceof Classification.Classified)) {
                 return false;
             }
@@ -644,15 +673,44 @@ public final class Generator {
         }
     }
 
-    /** Whether a row already written sits inside what {@code cell} leaves each position. */
-    private static boolean sits(List<int[]> written, InteractionCells.Cell cell) {
+    /** A row this generation is counting against the combinations: where it sits, and what its
+     *  run did. */
+    private record Placement(int[] where, souther.compiler.coverage.Observation seen) {}
+
+    /**
+     * Whether {@code cell} leaves room for a row sitting at {@code where}.
+     *
+     * <p>A statement about the search space and about nothing else. Being admitted is what makes a
+     * row a candidate for a combination; it is not what makes it one that fills it.
+     */
+    private static boolean admits(InteractionCells.Cell cell, int[] where) {
         int positions = cell.allowed().length;
-        for (int[] row : written) {
-            boolean all = true;
-            for (int i = 0; i < positions && all; i++) {
-                all = !cell.narrows(i) || (i < row.length && cell.admits(i, row[i]));
+        for (int i = 0; i < positions; i++) {
+            if (cell.narrows(i) && !(i < where.length && cell.admits(i, where[i]))) {
+                return false;
             }
-            if (all) {
+        }
+        return true;
+    }
+
+    /**
+     * Whether a row already counted fills {@code selection} — sits in its classes, and was seen
+     * doing what it names.
+     *
+     * <p>Both, and the second is what settles it. A combination is a path through the body and an
+     * outcome at each of the decisions that meet on it, so what fills one is a run that took that
+     * path and settled them those ways. A row whose values sit in the classes is a row the reading
+     * expected to do that, and every step from the decisions to the classes is a reading that can
+     * be wrong — so taking the values for the answer is taking the reading for its own witness.
+     *
+     * <p>Which is why a row this generation composed and nothing ran fills nothing. It is admitted
+     * and it is not certified, so the combination stays owed. Counting it would be the same mistake
+     * one step earlier: a row offered on the strength of a reading, then read back as evidence for
+     * the reading that offered it.
+     */
+    private static boolean fills(List<Placement> written, CellSelection selection) {
+        for (Placement row : written) {
+            if (admits(selection.cell(), row.where()) && selection.certifiedBy(row.seen())) {
                 return true;
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -137,12 +137,12 @@ public final class Generator {
 
         public ObservedRow {
             at = Map.copyOf(at);
-            watched = watched == null ? new Watched.NotRun() : watched;
+            watched = watched == null ? new Watched.NoAccount() : watched;
         }
 
         /** A row nothing here can say anything about the run of, for a caller with none to read. */
         public static ObservedRow unseen(Map<AxisId, Classification> at) {
-            return new ObservedRow(at, new Watched.NotRun());
+            return new ObservedRow(at, new Watched.NoAccount());
         }
     }
 
@@ -304,16 +304,16 @@ public final class Generator {
         Watched run(List<FixtureTemplate> inputs);
 
         /** Nothing runs here — what a caller with no runtime to run against uses. */
-        Trial NOTHING_RUNS = _ -> new Watched.NotRun();
+        Trial NOTHING_RUNS = _ -> new Watched.NoAccount();
     }
 
     /**
      * What came of running one composed row.
      *
-     * <p>A sum, so that a caller has to say which of the two it has. Not having run a row and having
-     * run one that reached nothing are the same value read from a set of places and are not the same
-     * fact: the first leaves every combination as untried as it was, and the second is a row that
-     * missed.
+     * <p>A sum, so that a caller has to say which of them it has. Having no account of a row and
+     * having one that shows it reached nothing are the same emptiness read off a set of places and
+     * are not the same fact: the first leaves every combination as untried as it was, and the second
+     * is a row that missed.
      */
     public sealed interface Watched {
 
@@ -323,17 +323,15 @@ public final class Generator {
         record Ran(souther.compiler.coverage.Observation seen) implements Watched {}
 
         /**
-         * It ran and nothing was recording, so where it went is not a thing anything here knows.
+         * Nothing here can say what it did.
          *
-         * <p>What a build that does not measure the arms leaves of every row it evaluates. Told
-         * apart from {@link NotRun} because it is a different fact about the row and from
-         * {@link Ran} of an empty recording because that one is a row that reached nothing: three
-         * states that read alike off an empty account and are not one another.
+         * <p>Three things come to this and they are one arm because nothing tells them apart by
+         * acting differently: nothing ran the row, something ran it and nothing was recording, and
+         * something ran it and the recording was never read. What none of them is, is a run that
+         * reached nothing — that is {@link Ran} of an empty account, and it is the one difference
+         * anything here turns on.
          */
-        record Unrecorded() implements Watched {}
-
-        /** Nothing ran it. Never a statement about the row. */
-        record NotRun() implements Watched {}
+        record NoAccount() implements Watched {}
     }
 
     // --- filling the pairs ----------------------------------------------------------------------
@@ -428,6 +426,7 @@ public final class Generator {
         // already sits in costs no row and does not stand in for one that would have.
         boolean anyLeft = true;
         boolean unconfirmed = false;
+        int withheld = 0;
         while (anyLeft && rows.size() < MAX_ROWS) {
             anyLeft = false;
             for (int g = 0; g < byGroup.size() && rows.size() < MAX_ROWS; g++) {
@@ -442,9 +441,15 @@ public final class Generator {
                     // combination the body has a path to and there is nothing to ask for.
                     continue;
                 }
-                if (fills(written, selection)) {
-                    // A combination a row was seen filling is one nothing is owed for. Sitting in
-                    // its classes is not that, and is not enough.
+                Standing standing = standingOf(written, selection);
+                if (standing instanceof Standing.Filled) {
+                    continue;   // a row was seen filling it, so nothing is owed
+                }
+                if (standing instanceof Standing.MayBeWritten) {
+                    // Not filled and not offered: a row in the file sits where one filling this
+                    // would, and nothing could say whether it does. Counted so that it is said —
+                    // an author told nothing here would read it as a combination covered.
+                    withheld++;
                     continue;
                 }
                 switch (witnessFor(subject, axes, pairs, selection, check, trial)) {
@@ -458,7 +463,7 @@ public final class Generator {
                     }
                     case Witness.Unconfirmed offer -> {
                         rows.add(offer.row());
-                        written.add(new Placement.Composed(offer.where(), new Watched.NotRun()));
+                        written.add(new Placement.Composed(offer.where(), new Watched.NoAccount()));
                         cover(pairs, singles, axes, offer.where());
                         // Nothing watched it, so what it is offered for is what the reading says
                         // and not what anything saw. Said once for the behavior: it is one fact
@@ -510,6 +515,10 @@ public final class Generator {
         }
         if (unconfirmed) {
             reasons.add(new GenerationReason.RowsNotConfirmed(axes.get(0).id().behavior()));
+        }
+        if (withheld > 0) {
+            reasons.add(new GenerationReason.CombinationsWithheld(axes.get(0).id().behavior(),
+                    withheld));
         }
         return new GenerationResult(rows, unresolved, reasons);
     }
@@ -798,34 +807,54 @@ public final class Generator {
     }
 
     /**
-     * Whether a row already counted fills {@code selection} — sits in its classes, and was seen
-     * doing what it names.
+     * Where one combination stands before anything is composed for it.
      *
-     * <p>Both, and the second is what settles it. A combination is a path through the body and an
-     * outcome at each of the decisions that meet on it, so what fills one is a run that took that
-     * path and settled them those ways. A row whose values sit in the classes is a row the reading
-     * expected to do that, and every step from the decisions to the classes is a reading that can
-     * be wrong — so taking the values for the answer is taking the reading for its own witness.
+     * <p>Three answers because two questions are being asked of the rows, and folding them into one
+     * is what this issue is about. Whether a combination is filled is a question about evidence, and
+     * only a run answers it. Whether a row for it is worth putting in front of an author is a
+     * question about what is already in their file, and a row they have written answers that
+     * whatever anything can establish about it — re-offering a combination over such a row hands
+     * back work already done.
      *
-     * <p>Where nothing could say what a row did, the two kinds of row part. An author's row is
-     * given the benefit of it: it is in the file, and a combination re-offered because this could
-     * not read the file's own row is a specific piece of work handed to someone who has done it.
-     * A row this search composed is given none: it exists because a reading said so, and counting
-     * one nothing watched is that reading standing as its own witness.
+     * <p>Kept apart because the second is not the first. A combination withheld is not one anything
+     * showed to be filled, so it is not counted as such and it is not passed over in silence: it is
+     * said, and what it says is that a row in the file may fill it and nothing here could tell.
      */
-    private static boolean fills(List<Placement> written, CellSelection selection) {
+    private sealed interface Standing {
+
+        /** A row was seen filling it. The witness is what says so and the only thing that can. */
+        record Filled(CellSelection.CertifiedWitness by) implements Standing {}
+
+        /** A row already in the author's file sits where one filling this would, and nothing could
+         *  say whether it does. Not evidence, and not silence either. */
+        record MayBeWritten() implements Standing {}
+
+        /** Nothing here says anything about it. */
+        record Owed() implements Standing {}
+    }
+
+    /**
+     * Where {@code selection} stands against the rows counted so far.
+     *
+     * <p>Evidence first and on its own terms: a row of either kind, seen doing what the combination
+     * names and sitting where it leaves room, fills it — one question put to one thing that can
+     * answer it. Only where nothing was established does whose row it is come into it, and then it
+     * decides what to offer rather than what is true.
+     */
+    private static Standing standingOf(List<Placement> written, CellSelection selection) {
+        boolean maybe = false;
         for (Placement row : written) {
             if (row.watched() instanceof Watched.Ran ran) {
-                // The one thing that says a row filled a combination, asked of a row already in the
-                // file exactly as it is asked of one this search composed.
-                if (selection.certifying(row.where(), ran.seen()).isPresent()) {
-                    return true;
+                Optional<CellSelection.CertifiedWitness> found =
+                        selection.certifying(row.where(), ran.seen());
+                if (found.isPresent()) {
+                    return new Standing.Filled(found.get());
                 }
             } else if (row instanceof Placement.Written && selection.cell().holds(row.where())) {
-                return true;
+                maybe = true;
             }
         }
-        return false;
+        return maybe ? new Standing.MayBeWritten() : new Standing.Owed();
     }
 
     /** Every position fixed: the seed's two as the seed says, and each of the rest at whichever class
@@ -1010,7 +1039,7 @@ public final class Generator {
                 // Offered as it was before anything ran, and said to be. Both of the ways that
                 // happens come here: nothing applied the row, or nothing was recording while it
                 // was applied.
-                case Watched.NotRun _, Watched.Unrecorded _ -> {
+                case Watched.NoAccount _ -> {
                     return new Witness.Unconfirmed(named, at);
                 }
                 case Watched.Ran ran -> {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -792,7 +792,8 @@ public final class Generator {
      */
     private static boolean fills(List<Placement> written, CellSelection selection) {
         for (Placement row : written) {
-            if (admits(selection.cell(), row.where()) && selection.certifiedBy(row.seen())) {
+            if (admits(selection.cell(), row.where())
+                    && selection.certifying(row.where(), row.seen()).isPresent()) {
                 return true;
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -127,22 +127,22 @@ public final class Generator {
      * combination's classes and whose run went elsewhere fills nothing, and looks from the values
      * alone exactly like one that fills it.
      *
-     * @param at   which class of each divided position the row's values fall in
-     * @param seen what the row's run was recorded doing, or {@link Observation#NONE} where nothing
-     *             read it. Nothing read is not nothing done: it certifies no combination, which
-     *             leaves them owed rather than filled
+     * @param at      which class of each divided position the row's values fall in
+     * @param watched what came of running it. A sum and not an account that may be empty: a run
+     *                that recorded nothing and a row nothing recorded are the same empty account
+     *                and are not the same fact, and which of them this is decides what may be
+     *                concluded from the row
      */
-    public record ObservedRow(Map<AxisId, Classification> at,
-                              souther.compiler.coverage.Observation seen) {
+    public record ObservedRow(Map<AxisId, Classification> at, Watched watched) {
 
         public ObservedRow {
             at = Map.copyOf(at);
-            seen = seen == null ? souther.compiler.coverage.Observation.NONE : seen;
+            watched = watched == null ? new Watched.NotRun() : watched;
         }
 
-        /** A row nothing ran, for a caller with no run to read. */
+        /** A row nothing here can say anything about the run of, for a caller with none to read. */
         public static ObservedRow unseen(Map<AxisId, Classification> at) {
-            return new ObservedRow(at, souther.compiler.coverage.Observation.NONE);
+            return new ObservedRow(at, new Watched.NotRun());
         }
     }
 
@@ -195,12 +195,16 @@ public final class Generator {
              * apart from the one above it because they were there, which is not what that says. */
             LINKAGE_FAILED,
             /**
-             * Every row this composed for the combination ran and went somewhere else.
+             * No row composed for the combination was seen reaching it.
+             *
+             * <p>Said that way round because it is what the search establishes. Some of the
+             * assignments tried may have composed nothing at all, so a word about what every row
+             * did would be a word about rows there were none of; what holds of all of them is that
+             * none was a witness.
              *
              * <p>Not a proof that the combination is unreachable, and nothing reads it as one. It
-             * says this many candidates were tried and none of them was a witness, which is a fact
-             * about the candidates — and, where the reading that named the combination is wrong,
-             * about that reading. Either way the combination stays untried rather than being
+             * is a fact about the candidates — and, where the reading that named the combination is
+             * wrong, about that reading. Either way the combination stays untried rather than being
              * counted as offered (ADR-0091).
              */
             NO_CERTIFIED_WITNESS,
@@ -313,9 +317,20 @@ public final class Generator {
      */
     public sealed interface Watched {
 
-        /** It ran, and this is what it was seen doing. Also what a row that aborted part way comes
-         *  back as: it went where it went before it stopped, and that is recorded. */
+        /** It ran, something was recording, and this is what it was seen doing. Also what a row
+         *  that aborted part way comes back as: it went where it went before it stopped, and that
+         *  is recorded. */
         record Ran(souther.compiler.coverage.Observation seen) implements Watched {}
+
+        /**
+         * It ran and nothing was recording, so where it went is not a thing anything here knows.
+         *
+         * <p>What a build that does not measure the arms leaves of every row it evaluates. Told
+         * apart from {@link NotRun} because it is a different fact about the row and from
+         * {@link Ran} of an empty recording because that one is a row that reached nothing: three
+         * states that read alike off an empty account and are not one another.
+         */
+        record Unrecorded() implements Watched {}
 
         /** Nothing ran it. Never a statement about the row. */
         record NotRun() implements Watched {}
@@ -399,7 +414,7 @@ public final class Generator {
         List<GenerationReason> reasons = new ArrayList<>(undecided);
         List<Placement> written = new ArrayList<>();
         for (ObservedRow row : existing) {
-            written.add(new Placement(whereIn(row.at(), axes), row.seen()));
+            written.add(new Placement.Written(whereIn(row.at(), axes), row.watched()));
         }
         // Built here and not handed in: a cell is one class per position of the axes this
         // generation kept, and the caller's list is neither ordered the same nor filtered the same.
@@ -435,17 +450,20 @@ public final class Generator {
                 switch (witnessFor(subject, axes, pairs, selection, check, trial)) {
                     case Witness.None none -> unresolved.add(new UnresolvedCombination(
                             none.classes(), none.reason(), none.detail(), none.said()));
-                    case Witness.Offer offer -> {
+                    case Witness.Certified found -> {
+                        rows.add(found.row());
+                        written.add(new Placement.Composed(found.by().where(),
+                                new Watched.Ran(found.by().seen())));
+                        cover(pairs, singles, axes, found.by().where());
+                    }
+                    case Witness.Unconfirmed offer -> {
                         rows.add(offer.row());
-                        written.add(new Placement(offer.where(), offer.seen()));
+                        written.add(new Placement.Composed(offer.where(), new Watched.NotRun()));
                         cover(pairs, singles, axes, offer.where());
-                        if (offer.seen().taken().isEmpty()
-                                && offer.seen().comparisons().isEmpty()) {
-                            // Nothing watched it, so what it is offered for is what the reading
-                            // says and not what anything saw. Said once for the behavior rather
-                            // than once a row: it is one fact about this generation.
-                            unconfirmed = true;
-                        }
+                        // Nothing watched it, so what it is offered for is what the reading says
+                        // and not what anything saw. Said once for the behavior: it is one fact
+                        // about this generation.
+                        unconfirmed = true;
                     }
                 }
             }
@@ -755,24 +773,28 @@ public final class Generator {
         }
     }
 
-    /** A row this generation is counting against the combinations: where it sits, and what its
-     *  run did. */
-    private record Placement(int[] where, souther.compiler.coverage.Observation seen) {}
-
     /**
-     * Whether {@code cell} leaves room for a row sitting at {@code where}.
+     * A row this generation counts the combinations against: where it sits, what came of running
+     * it, and whose row it is.
      *
-     * <p>A statement about the search space and about nothing else. Being admitted is what makes a
-     * row a candidate for a combination; it is not what makes it one that fills it.
+     * <p>Whose it is, because being unable to say where a row went costs different things for the
+     * two. A row the author wrote is in the file whatever this can establish about it, so passing
+     * over a combination it may fill risks nothing worse than a combination left owed — while
+     * offering one risks handing them work they have already done. A row this search composed is in
+     * nobody's file, so counting one it cannot judge is reading a reading back as evidence for
+     * itself.
      */
-    private static boolean admits(InteractionCells.Cell cell, int[] where) {
-        int positions = cell.allowed().length;
-        for (int i = 0; i < positions; i++) {
-            if (cell.narrows(i) && !(i < where.length && cell.admits(i, where[i]))) {
-                return false;
-            }
-        }
-        return true;
+    private sealed interface Placement {
+
+        int[] where();
+
+        Watched watched();
+
+        /** A row that is in the author's file. */
+        record Written(int[] where, Watched watched) implements Placement {}
+
+        /** A row this search composed on this pass. */
+        record Composed(int[] where, Watched watched) implements Placement {}
     }
 
     /**
@@ -785,15 +807,21 @@ public final class Generator {
      * expected to do that, and every step from the decisions to the classes is a reading that can
      * be wrong — so taking the values for the answer is taking the reading for its own witness.
      *
-     * <p>Which is why a row this generation composed and nothing ran fills nothing. It is admitted
-     * and it is not certified, so the combination stays owed. Counting it would be the same mistake
-     * one step earlier: a row offered on the strength of a reading, then read back as evidence for
-     * the reading that offered it.
+     * <p>Where nothing could say what a row did, the two kinds of row part. An author's row is
+     * given the benefit of it: it is in the file, and a combination re-offered because this could
+     * not read the file's own row is a specific piece of work handed to someone who has done it.
+     * A row this search composed is given none: it exists because a reading said so, and counting
+     * one nothing watched is that reading standing as its own witness.
      */
     private static boolean fills(List<Placement> written, CellSelection selection) {
         for (Placement row : written) {
-            if (admits(selection.cell(), row.where())
-                    && selection.certifying(row.where(), row.seen()).isPresent()) {
+            if (row.watched() instanceof Watched.Ran ran) {
+                // The one thing that says a row filled a combination, asked of a row already in the
+                // file exactly as it is asked of one this search composed.
+                if (selection.certifying(row.where(), ran.seen()).isPresent()) {
+                    return true;
+                }
+            } else if (row instanceof Placement.Written && selection.cell().holds(row.where())) {
                 return true;
             }
         }
@@ -917,18 +945,23 @@ public final class Generator {
 
     // --- looking for a row that fills a combination ----------------------------------------------
 
-    /** What the search for a row filling one combination came to. */
+    /**
+     * What the search for a row filling one combination came to.
+     *
+     * <p>Three answers and not two, because a row seen filling the combination and a row offered
+     * because nothing could watch it are not the same thing to have found. They differ in what may
+     * afterwards be concluded from the row and in whether this generation may say its rows were
+     * confirmed, so which of them it is, is the answer — rather than something read back off an
+     * empty account of the run.
+     */
     private sealed interface Witness {
 
-        /**
-         * A row to offer, where it sits, and what it was seen doing.
-         *
-         * <p>What it was seen doing is empty where nothing ran it, and that travels with the row
-         * rather than being decided again: it is what stops such a row from being read back as
-         * having filled the combination it was composed for.
-         */
-        record Offer(GeneratedRow row, int[] where, souther.compiler.coverage.Observation seen)
-                implements Witness {}
+        /** A row seen filling the combination, carrying the witness — that being the only value
+         *  which says so. */
+        record Certified(GeneratedRow row, CellSelection.CertifiedWitness by) implements Witness {}
+
+        /** A row nothing could watch, offered on the strength of the reading alone. */
+        record Unconfirmed(GeneratedRow row, int[] where) implements Witness {}
 
         /** No row to offer, and why. Never a statement that none exists. */
         record None(List<String> classes, UnresolvedCombination.Reason reason, String detail,
@@ -974,14 +1007,19 @@ public final class Generator {
             GeneratedRow named = new GeneratedRow(labels(axes, cell, at), last.row().inputs());
             switch (trial.run(named.inputs())) {
                 // Nothing can say where it went, so nothing certifies it and nothing refutes it.
-                // Offered as it was before anything ran, with an empty account of itself.
-                case Watched.NotRun _ -> {
-                    return new Witness.Offer(named, at,
-                            souther.compiler.coverage.Observation.NONE);
+                // Offered as it was before anything ran, and said to be. Both of the ways that
+                // happens come here: nothing applied the row, or nothing was recording while it
+                // was applied.
+                case Watched.NotRun _, Watched.Unrecorded _ -> {
+                    return new Witness.Unconfirmed(named, at);
                 }
-                case Watched.Ran(souther.compiler.coverage.Observation seen) -> {
-                    if (selection.certifiedBy(seen)) {
-                        return new Witness.Offer(named, at, seen);
+                case Watched.Ran ran -> {
+                    // Through the one thing that can say a row filled a combination, which is the
+                    // same thing a row already in the file is put through.
+                    Optional<CellSelection.CertifiedWitness> found =
+                            selection.certifying(at, ran.seen());
+                    if (found.isPresent()) {
+                        return new Witness.Certified(named, found.get());
                     }
                     missed = true;
                 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -56,6 +56,17 @@ public final class Generator {
      * parameter with something held in reserve is walked twice, each pass under this bound. */
     private static final int MAX_TUPLES = 256;
 
+    /**
+     * How many rows one combination is composed for before the search gives up on it.
+     *
+     * <p>What a combination leaves open is often several assignments, and the first of them is
+     * chosen for what else it covers rather than for reaching the meeting — so a second is worth
+     * trying where the first went somewhere else. What this bounds is how much of the search one
+     * combination may spend: a group whose reading is wrong misses at every assignment, and without
+     * a bound it would work its way through the whole space while every other group waited.
+     */
+    private static final int MOST_CANDIDATES = 3;
+
     /** How deep a record is built. Past this a value stops being anything an author recognises as one
      * input, and a type that refers to itself would not stop at all. */
     private static final int MAX_DEPTH = 8;
@@ -184,6 +195,16 @@ public final class Generator {
              * apart from the one above it because they were there, which is not what that says. */
             LINKAGE_FAILED,
             /**
+             * Every row this composed for the combination ran and went somewhere else.
+             *
+             * <p>Not a proof that the combination is unreachable, and nothing reads it as one. It
+             * says this many candidates were tried and none of them was a witness, which is a fact
+             * about the candidates — and, where the reading that named the combination is wrong,
+             * about that reading. Either way the combination stays untried rather than being
+             * counted as offered (ADR-0091).
+             */
+            NO_CERTIFIED_WITNESS,
+            /**
              * A strategy that takes this class produced neither a row nor a reason for it.
              *
              * <p>Which is this compiler failing to say, and not something established about the
@@ -261,6 +282,45 @@ public final class Generator {
         CandidateCheck ANY = (_, _) -> Optional.empty();
     }
 
+    /**
+     * A way to run a composed row and see what it did.
+     *
+     * <p>The other thing a generator cannot work out for itself, and the one this issue is about.
+     * Which combination a row sits in is settled by running it: everything before that is a reading
+     * of the body, and a reading is what may be wrong.
+     *
+     * <p>Separate from {@link CandidateCheck} because the questions are. That one is asked of one
+     * value at one position while the row is being composed, and answers whether the value can be
+     * built at all; this is asked of the whole row afterwards, and answers where it went.
+     */
+    @FunctionalInterface
+    public interface Trial {
+
+        /** What running {@code inputs} through the behavior came to. */
+        Watched run(List<FixtureTemplate> inputs);
+
+        /** Nothing runs here — what a caller with no runtime to run against uses. */
+        Trial NOTHING_RUNS = _ -> new Watched.NotRun();
+    }
+
+    /**
+     * What came of running one composed row.
+     *
+     * <p>A sum, so that a caller has to say which of the two it has. Not having run a row and having
+     * run one that reached nothing are the same value read from a set of places and are not the same
+     * fact: the first leaves every combination as untried as it was, and the second is a row that
+     * missed.
+     */
+    public sealed interface Watched {
+
+        /** It ran, and this is what it was seen doing. Also what a row that aborted part way comes
+         *  back as: it went where it went before it stopped, and that is recorded. */
+        record Ran(souther.compiler.coverage.Observation seen) implements Watched {}
+
+        /** Nothing ran it. Never a statement about the row. */
+        record NotRun() implements Watched {}
+    }
+
     // --- filling the pairs ----------------------------------------------------------------------
 
     /**
@@ -289,6 +349,25 @@ public final class Generator {
     public static GenerationResult fill(Subject subject, List<ObservedRow> existing,
                                         CandidateCheck check,
                                         List<souther.compiler.interaction.Interaction> groups) {
+        return fill(subject, existing, check, groups, Trial.NOTHING_RUNS);
+    }
+
+    /**
+     * The same, running each row composed for a combination to see whether it got there.
+     *
+     * <p>Which is the only thing that can say so. A row is composed by narrowing each position to
+     * the classes the combination leaves it, and every step of that narrowing is a reading of the
+     * body — so a row that misses is what a reading being wrong looks like, and a row that misses
+     * looks like one that arrives until something watches it.
+     *
+     * <p>A row that missed is not offered and the combination stays untried. It is not evidence
+     * that the combination is unreachable: what was shown is that these candidates were not
+     * witnesses (ADR-0091).
+     */
+    public static GenerationResult fill(Subject subject, List<ObservedRow> existing,
+                                        CandidateCheck check,
+                                        List<souther.compiler.interaction.Interaction> groups,
+                                        Trial trial) {
         List<Axis> ordered = ordered(subject);
         // A position where some row's value could not be read is a position nothing is known about.
         // A row generated for a class there may be a row that is already written, and telling an
@@ -333,6 +412,7 @@ public final class Generator {
         // there is no count of how many of a group to prepare, so a combination a written row
         // already sits in costs no row and does not stand in for one that would have.
         boolean anyLeft = true;
+        boolean unconfirmed = false;
         while (anyLeft && rows.size() < MAX_ROWS) {
             anyLeft = false;
             for (int g = 0; g < byGroup.size() && rows.size() < MAX_ROWS; g++) {
@@ -347,28 +427,27 @@ public final class Generator {
                     // combination the body has a path to and there is nothing to ask for.
                     continue;
                 }
-                InteractionCells.Cell cell = selection.cell();
                 if (fills(written, selection)) {
                     // A combination a row was seen filling is one nothing is owed for. Sitting in
                     // its classes is not that, and is not enough.
                     continue;
                 }
-                int[] where = assign(axes, pairs, cell);
-                Attempt built = build(subject, axes, where, check);
-                if (built.row() == null) {
-                    unresolved.add(new UnresolvedCombination(labels(axes, cell, where),
-                            built.reason(), built.detail(), built.said()));
-                    continue;
+                switch (witnessFor(subject, axes, pairs, selection, check, trial)) {
+                    case Witness.None none -> unresolved.add(new UnresolvedCombination(
+                            none.classes(), none.reason(), none.detail(), none.said()));
+                    case Witness.Offer offer -> {
+                        rows.add(offer.row());
+                        written.add(new Placement(offer.where(), offer.seen()));
+                        cover(pairs, singles, axes, offer.where());
+                        if (offer.seen().taken().isEmpty()
+                                && offer.seen().comparisons().isEmpty()) {
+                            // Nothing watched it, so what it is offered for is what the reading
+                            // says and not what anything saw. Said once for the behavior rather
+                            // than once a row: it is one fact about this generation.
+                            unconfirmed = true;
+                        }
+                    }
                 }
-                // Named for the cell it was composed for, which is the positions the decisions
-                // read. What the pass below filled the rest of the row with is what this row turns
-                // out to settle beside that, and a name carrying it would move when nothing about
-                // the row had.
-                rows.add(new GeneratedRow(labels(axes, cell, where), built.row().inputs()));
-                // Counted against the pairs, which are about where a row's values sit, and against
-                // no combination: nothing ran this, so it was seen filling none of them.
-                written.add(new Placement(where, souther.compiler.coverage.Observation.NONE));
-                cover(pairs, singles, axes, where);
             }
         }
         int cellsLeft = 0;
@@ -410,6 +489,9 @@ public final class Generator {
         if (cellsLeft + pairsLeft > 0) {
             reasons.add(new GenerationReason.SearchLimit(axes.get(0).id().behavior(),
                     cellsLeft + pairsLeft));
+        }
+        if (unconfirmed) {
+            reasons.add(new GenerationReason.RowsNotConfirmed(axes.get(0).id().behavior()));
         }
         return new GenerationResult(rows, unresolved, reasons);
     }
@@ -830,6 +912,149 @@ public final class Generator {
         String left = label(axes.get(pair.left()), pair.leftClass());
         return pair.alone() ? List.of(left)
                 : List.of(left, label(axes.get(pair.right()), pair.rightClass()));
+    }
+
+    // --- looking for a row that fills a combination ----------------------------------------------
+
+    /** What the search for a row filling one combination came to. */
+    private sealed interface Witness {
+
+        /**
+         * A row to offer, where it sits, and what it was seen doing.
+         *
+         * <p>What it was seen doing is empty where nothing ran it, and that travels with the row
+         * rather than being decided again: it is what stops such a row from being read back as
+         * having filled the combination it was composed for.
+         */
+        record Offer(GeneratedRow row, int[] where, souther.compiler.coverage.Observation seen)
+                implements Witness {}
+
+        /** No row to offer, and why. Never a statement that none exists. */
+        record None(List<String> classes, UnresolvedCombination.Reason reason, String detail,
+                    Optional<String> said) implements Witness {}
+    }
+
+    /**
+     * A row that fills {@code selection}, looked for among the assignments it leaves open.
+     *
+     * <p>Composing and confirming are one act here and are two questions. A candidate is composed by
+     * fixing every position, which the combination settles for some of them and the pair search
+     * settles for the rest; then it is run, and what it did is held against what the combination
+     * says a row filling it does. A candidate that went elsewhere is dropped and another assignment
+     * is tried, because which assignment was chosen is a choice this made rather than something the
+     * combination said.
+     *
+     * <p>What a run of candidates that all missed establishes is that they were not witnesses. It is
+     * not that the combination is unreachable, and it is not by itself that the reading naming the
+     * combination is wrong — the assignments were this search's, and so was the number of them.
+     */
+    private static Witness witnessFor(Subject subject, List<Axis> axes, Set<Pair> uncovered,
+                                      CellSelection selection, CandidateCheck check, Trial trial) {
+        InteractionCells.Cell cell = selection.cell();
+        List<int[]> tried = new ArrayList<>();
+        Attempt last = null;
+        int[] where = null;
+        boolean missed = false;
+        for (int candidate = 0; candidate < MOST_CANDIDATES; candidate++) {
+            int[] at = assignment(axes, uncovered, cell, candidate, tried);
+            if (at == null) {
+                break;   // the combination leaves nothing this has not already tried
+            }
+            tried.add(at);
+            where = at;
+            last = build(subject, axes, at, check);
+            if (last.row() == null) {
+                continue;   // nothing composed here; another assignment may compose
+            }
+            // Named for the combination it was composed for, which is the positions the decisions
+            // read. What the pair search filled the rest of the row with is what this row turns out
+            // to settle beside that, and a name carrying it would move when nothing about the row
+            // had.
+            GeneratedRow named = new GeneratedRow(labels(axes, cell, at), last.row().inputs());
+            switch (trial.run(named.inputs())) {
+                // Nothing can say where it went, so nothing certifies it and nothing refutes it.
+                // Offered as it was before anything ran, with an empty account of itself.
+                case Watched.NotRun _ -> {
+                    return new Witness.Offer(named, at,
+                            souther.compiler.coverage.Observation.NONE);
+                }
+                case Watched.Ran(souther.compiler.coverage.Observation seen) -> {
+                    if (selection.certifiedBy(seen)) {
+                        return new Witness.Offer(named, at, seen);
+                    }
+                    missed = true;
+                }
+            }
+        }
+        List<String> named = where == null ? List.of() : labels(axes, cell, where);
+        if (missed) {
+            return new Witness.None(named, UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS, null,
+                    Optional.empty());
+        }
+        if (last != null && last.row() == null) {
+            return new Witness.None(named, last.reason(), last.detail(), last.said());
+        }
+        // Nothing was composed and nothing was refused, which takes the combination leaving no
+        // assignment at all. Named rather than guessed at, the same way every other empty result
+        // here is.
+        return new Witness.None(named, UnresolvedCombination.Reason.NO_REASON_RECORDED, null,
+                Optional.empty());
+    }
+
+    /**
+     * The {@code candidate}th assignment to try for {@code cell}, or null where it leaves none this
+     * has not tried.
+     *
+     * <p>The first is the pair search's: every position the combination does not settle goes to
+     * whichever class brings in the most combinations nothing covers yet, which is what makes the
+     * rows a combination needs rows the pair space wanted anyway. The rest are the assignments the
+     * combination admits, counted off in order — a fixed order, so the same model offers the same
+     * rows twice.
+     *
+     * <p>Bounded by how many have been tried rather than by a walk over the space: at most
+     * {@link #MOST_CANDIDATES} assignments are ever tried, so one of the first that many is one
+     * that has not been.
+     */
+    private static int[] assignment(List<Axis> axes, Set<Pair> uncovered,
+                                    InteractionCells.Cell cell, int candidate, List<int[]> tried) {
+        if (candidate == 0) {
+            return assign(axes, uncovered, cell);
+        }
+        List<List<Integer>> admitted = new ArrayList<>();
+        for (int i = 0; i < axes.size(); i++) {
+            List<Integer> here = new ArrayList<>();
+            for (int c = 0; c < axes.get(i).classes().size(); c++) {
+                if (cell.admits(i, c)) {
+                    here.add(c);
+                }
+            }
+            if (here.isEmpty()) {
+                return null;   // a position with nothing in it is not a combination
+            }
+            admitted.add(here);
+        }
+        for (int index = 0; index < MOST_CANDIDATES; index++) {
+            int[] where = new int[axes.size()];
+            int left = index;
+            for (int i = 0; i < axes.size(); i++) {
+                List<Integer> here = admitted.get(i);
+                where[i] = here.get(left % here.size());
+                left /= here.size();
+            }
+            if (!alreadyTried(tried, where)) {
+                return where;
+            }
+        }
+        return null;
+    }
+
+    private static boolean alreadyTried(List<int[]> tried, int[] where) {
+        for (int[] each : tried) {
+            if (java.util.Arrays.equals(each, where)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     // --- turning classes into a row -------------------------------------------------------------

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -314,13 +314,14 @@ public final class Generator {
                 if (taken[g] >= group.size()) {
                     continue;
                 }
-                InteractionCells.Cell cell = group.at(taken[g]++);
+                CellSelection selection = group.at(taken[g]++);
                 anyLeft = true;
-                if (cell == null) {
+                if (selection == null) {
                     // The factors this choice takes leave a position nothing, so it is not a
                     // combination the body has a path to and there is nothing to ask for.
                     continue;
                 }
+                InteractionCells.Cell cell = selection.cell();
                 if (sits(written, cell)) {
                     // A cell a row already sits in is a cell nothing is owed for.
                     continue;

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -442,11 +442,11 @@ public final class Generator {
                     // combination the body has a path to and there is nothing to ask for.
                     continue;
                 }
-                Standing standing = standingOf(written, selection);
-                if (standing instanceof Standing.Filled) {
+                CombinationStanding standing = standingOf(written, selection);
+                if (standing instanceof CombinationStanding.Filled) {
                     continue;   // a row was seen filling it, so nothing is owed
                 }
-                if (standing instanceof Standing.MayBeWritten) {
+                if (standing instanceof CombinationStanding.MayBeWritten) {
                     // Not filled and not offered: a row in the file sits where one filling this
                     // would, and nothing could say whether it does. Counted so that it is said —
                     // an author told nothing here would read it as a combination covered.
@@ -810,6 +810,10 @@ public final class Generator {
     /**
      * Where one combination stands before anything is composed for it.
      *
+     * <p>Named at length because {@link Standing} beside it is where a value stands against a line,
+     * and a nested type sharing that word would answer to it inside this file and to the other one
+     * everywhere else.
+     *
      * <p>Three answers because two questions are being asked of the rows, and folding them into one
      * is what this issue is about. Whether a combination is filled is a question about evidence, and
      * only a run answers it. Whether a row for it is worth putting in front of an author is a
@@ -821,17 +825,17 @@ public final class Generator {
      * showed to be filled, so it is not counted as such and it is not passed over in silence: it is
      * said, and what it says is that a row in the file may fill it and nothing here could tell.
      */
-    private sealed interface Standing {
+    private sealed interface CombinationStanding {
 
         /** A row was seen filling it. The witness is what says so and the only thing that can. */
-        record Filled(CellSelection.CertifiedWitness by) implements Standing {}
+        record Filled(CellSelection.CertifiedWitness by) implements CombinationStanding {}
 
         /** A row already in the author's file sits where one filling this would, and nothing could
          *  say whether it does. Not evidence, and not silence either. */
-        record MayBeWritten() implements Standing {}
+        record MayBeWritten() implements CombinationStanding {}
 
         /** Nothing here says anything about it. */
-        record Owed() implements Standing {}
+        record Owed() implements CombinationStanding {}
     }
 
     /**
@@ -842,20 +846,20 @@ public final class Generator {
      * answer it. Only where nothing was established does whose row it is come into it, and then it
      * decides what to offer rather than what is true.
      */
-    private static Standing standingOf(List<Placement> written, CellSelection selection) {
+    private static CombinationStanding standingOf(List<Placement> written, CellSelection selection) {
         boolean maybe = false;
         for (Placement row : written) {
             if (row.watched() instanceof Watched.Ran ran) {
                 Optional<CellSelection.CertifiedWitness> found =
                         selection.certifying(row.where(), ran.seen());
                 if (found.isPresent()) {
-                    return new Standing.Filled(found.get());
+                    return new CombinationStanding.Filled(found.get());
                 }
             } else if (row instanceof Placement.Written && selection.cell().holds(row.where())) {
                 maybe = true;
             }
         }
-        return maybe ? new Standing.MayBeWritten() : new Standing.Owed();
+        return maybe ? new CombinationStanding.MayBeWritten() : new CombinationStanding.Owed();
     }
 
     /** Every position fixed: the seed's two as the seed says, and each of the rest at whichever class

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -388,7 +388,8 @@ public final class GuardThresholds {
             // line off one, so this is here. Required rather than looked up leniently: a line whose
             // comparison has no site is this reader and the plan disagreeing about what a condition
             // is made of.
-            int site = plan.requireComparisonSiteOf(each.comparison());
+            souther.compiler.coverage.ComparisonOccurrence site =
+                    plan.requireComparisonAt(each.comparison());
             // What the comparison cuts is one question with one answer ({@link Cutting}). What is
             // added here is what meeting the line takes, which is a guard's own answer and no other
             // rule's.

--- a/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
@@ -106,6 +106,21 @@ public final class InteractionCells {
     }
 
     /**
+     * What one way of settling something leaves open, and what a run that settled it that way would
+     * be seen to have done.
+     *
+     * <p>The pair travels together from here on. Kept apart, the classes and the claims would be two
+     * lists indexed alike, and an outcome dropped from one of them for narrowing nothing would leave
+     * the other saying what a different outcome takes.
+     */
+    public record Placed(Cell cell, List<souther.compiler.coverage.ControlClaim> claims) {
+
+        public Placed {
+            claims = List.copyOf(claims);
+        }
+    }
+
+    /**
      * One group's combinations, as somewhere to read them from rather than as a list.
      *
      * <p>Nothing is built until it is asked for. Which combinations get offered is the row budget's
@@ -116,7 +131,7 @@ public final class InteractionCells {
      * @param reach    what the path to the meeting leaves open, which every combination is under
      * @param byFactor what each outcome of each factor leaves open, one list per factor
      */
-    public record Group(Cell reach, List<List<Cell>> byFactor) {
+    public record Group(Placed reach, List<List<Placed>> byFactor) {
 
         public Group {
             byFactor = List.copyOf(byFactor);
@@ -131,7 +146,7 @@ public final class InteractionCells {
          */
         public int size() {
             long size = 1;
-            for (List<Cell> factor : byFactor) {
+            for (List<Placed> factor : byFactor) {
                 size *= factor.size();
                 if (size >= MOST_CELLS) {
                     return MOST_CELLS;
@@ -147,17 +162,21 @@ public final class InteractionCells {
          * <p>Leaving a position nothing is not a combination the body refuses. There is no path
          * through the body that takes both, so there is nothing there to ask for.
          */
-        public Cell at(int index) {
-            Cell cell = reach;
+        public CellSelection at(int index) {
+            Cell cell = reach.cell();
+            List<souther.compiler.coverage.ControlClaim> claims =
+                    new ArrayList<>(reach.claims());
             int left = index;
-            for (List<Cell> factor : byFactor) {
-                cell = cell.and(factor.get(left % factor.size()));
+            for (List<Placed> factor : byFactor) {
+                Placed taken = factor.get(left % factor.size());
+                cell = cell.and(taken.cell());
                 if (cell == null) {
                     return null;
                 }
+                claims.addAll(taken.claims());
                 left /= factor.size();
             }
-            return cell;
+            return new CellSelection(cell, claims);
         }
 
         /** How many cells the group has from {@code from} on, which is what a stopped search left. */
@@ -176,11 +195,11 @@ public final class InteractionCells {
     public static List<Group> of(List<Interaction> groups, List<Axis> axes) {
         List<Group> out = new ArrayList<>();
         for (Interaction group : groups) {
-            Cell reach = narrowedBy(constraintsOf(group.reach()), axes);
+            Placed reach = placedBy(group.reach(), axes);
             if (reach == null) {
                 continue;
             }
-            List<List<Cell>> placed = factorsOf(group, axes);
+            List<List<Placed>> placed = factorsOf(group, axes);
             if (placed == null || productOf(placed) >= MOST_CELLS) {
                 continue;
             }
@@ -193,9 +212,9 @@ public final class InteractionCells {
     }
 
     /** How far the product runs, stopping where it is past anything that would be offered. */
-    private static long productOf(List<List<Cell>> placed) {
+    private static long productOf(List<List<Placed>> placed) {
         long size = 1;
-        for (List<Cell> factor : placed) {
+        for (List<Placed> factor : placed) {
             size *= factor.size();
             if (size >= MOST_CELLS) {
                 return MOST_CELLS;
@@ -205,12 +224,12 @@ public final class InteractionCells {
     }
 
     /** What each outcome of each factor leaves open, or null where the group is not one to offer. */
-    private static List<List<Cell>> factorsOf(Interaction group, List<Axis> axes) {
-        List<List<Cell>> out = new ArrayList<>();
+    private static List<List<Placed>> factorsOf(Interaction group, List<Axis> axes) {
+        List<List<Placed>> out = new ArrayList<>();
         for (Factor factor : group.factors()) {
-            List<Cell> outcomes = new ArrayList<>();
+            List<Placed> outcomes = new ArrayList<>();
             for (Outcome outcome : factor.outcomes()) {
-                Cell at = narrowedBy(constraintsOf(outcome.holds()), axes);
+                Placed at = placedBy(outcome.holds(), axes);
                 if (at == null || alreadyThere(outcomes, at)) {
                     return null;
                 }
@@ -221,9 +240,22 @@ public final class InteractionCells {
         return out;
     }
 
-    /** What a run of decisions takes of the inputs, which is this reader's half of each of them. */
-    private static List<Condition> constraintsOf(List<souther.compiler.interaction.Decision> made) {
-        return made.stream().map(souther.compiler.interaction.Decision::constrains).toList();
+    /**
+     * What {@code made} leaves open and what a run that made it would be seen to have done, or null
+     * where any of it narrows nothing or narrows it away.
+     *
+     * <p>One walk over the decisions for both halves. The classes are this reader's own reading of
+     * what the decisions take of the inputs; the claims are carried through untouched, being the
+     * reading that owns them. Which decisions are here is decided once, so the claims cannot end up
+     * being of a different set of them than the classes are.
+     */
+    private static Placed placedBy(List<souther.compiler.interaction.Decision> made,
+                                   List<Axis> axes) {
+        Cell cell = narrowedBy(
+                made.stream().map(souther.compiler.interaction.Decision::constrains).toList(), axes);
+        return cell == null ? null
+                : new Placed(cell, made.stream()
+                        .map(souther.compiler.interaction.Decision::claims).toList());
     }
 
     /** What {@code holds} leaves open, or null where any of it narrows nothing or narrows it away. */
@@ -242,9 +274,9 @@ public final class InteractionCells {
         return cell;
     }
 
-    private static boolean alreadyThere(List<Cell> outcomes, Cell at) {
-        for (Cell each : outcomes) {
-            if (each.sameAs(at)) {
+    private static boolean alreadyThere(List<Placed> outcomes, Placed at) {
+        for (Placed each : outcomes) {
+            if (each.cell().sameAs(at.cell())) {
                 return true;
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
@@ -100,6 +100,22 @@ public final class InteractionCells {
             return cls >= 0 && cls < allowed[axis].length && allowed[axis][cls];
         }
 
+        /**
+         * Whether a row sitting at {@code where} — one class per position, in the order the axes
+         * are ordered — is one this leaves room for.
+         *
+         * <p>A position this says nothing about admits whatever the row has there. What it does not
+         * admit is a class it narrowed away, which is the whole of what a cell is.
+         */
+        public boolean holds(int[] where) {
+            for (int axis = 0; axis < allowed.length; axis++) {
+                if (narrows(axis) && !(axis < where.length && admits(axis, where[axis]))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         public boolean sameAs(Cell other) {
             return Arrays.deepEquals(allowed, other.allowed);
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
@@ -176,7 +176,7 @@ public final class InteractionCells {
     public static List<Group> of(List<Interaction> groups, List<Axis> axes) {
         List<Group> out = new ArrayList<>();
         for (Interaction group : groups) {
-            Cell reach = narrowedBy(group.reach(), axes);
+            Cell reach = narrowedBy(constraintsOf(group.reach()), axes);
             if (reach == null) {
                 continue;
             }
@@ -210,7 +210,7 @@ public final class InteractionCells {
         for (Factor factor : group.factors()) {
             List<Cell> outcomes = new ArrayList<>();
             for (Outcome outcome : factor.outcomes()) {
-                Cell at = narrowedBy(outcome.holds(), axes);
+                Cell at = narrowedBy(constraintsOf(outcome.holds()), axes);
                 if (at == null || alreadyThere(outcomes, at)) {
                     return null;
                 }
@@ -219,6 +219,11 @@ public final class InteractionCells {
             out.add(outcomes);
         }
         return out;
+    }
+
+    /** What a run of decisions takes of the inputs, which is this reader's half of each of them. */
+    private static List<Condition> constraintsOf(List<souther.compiler.interaction.Decision> made) {
+        return made.stream().map(souther.compiler.interaction.Decision::constrains).toList();
     }
 
     /** What {@code holds} leaves open, or null where any of it narrows nothing or narrows it away. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
@@ -1,5 +1,6 @@
 package souther.compiler.partition;
 
+import souther.compiler.coverage.ComparisonOccurrence;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.interaction.Condition;
 import souther.compiler.interaction.Factor;
@@ -266,11 +267,11 @@ public final class InteractionCells {
                 if (axis < 0) {
                     return null;
                 }
-                Cut line = cutAt(axes.get(axis), one.site());
+                Cut line = cutAt(axes.get(axis), one.comparison());
                 if (line == null) {
                     return null;
                 }
-                OriginRef.GuardOrigin guard = guardOf(line, one.site());
+                OriginRef.GuardOrigin guard = guardOf(line, one.comparison());
                 int home = holding(axes.get(axis), line);
                 if (home < 0) {
                     return null;
@@ -333,9 +334,9 @@ public final class InteractionCells {
     }
 
     /** The cut this reading of the comparison drew, or null where it drew none. */
-    private static Cut cutAt(Axis axis, int site) {
+    private static Cut cutAt(Axis axis, ComparisonOccurrence comparison) {
         for (Cut each : axis.cuts()) {
-            if (guardOf(each, site) != null) {
+            if (guardOf(each, comparison) != null) {
                 return each;
             }
         }
@@ -343,9 +344,10 @@ public final class InteractionCells {
     }
 
     /** Which rule of the cut this reading of the comparison is. */
-    private static OriginRef.GuardOrigin guardOf(Cut cut, int site) {
+    private static OriginRef.GuardOrigin guardOf(Cut cut, ComparisonOccurrence comparison) {
         for (OriginRef origin : cut.origins()) {
-            if (origin instanceof OriginRef.GuardOrigin guard && guard.read().site() == site) {
+            if (origin instanceof OriginRef.GuardOrigin guard
+                    && guard.read().comparison().equals(comparison)) {
                 return guard;
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
@@ -100,15 +100,18 @@ public sealed interface OriginRef {
          *
          * @param guard which {@code if} — by the arms it owns, which is what says which class of
          *              the partition a row landed in
-         * @param site  where the comparison's own value is recorded. Required, and this is what
-         *              meeting the line is measured against: a row met it by getting the comparison
-         *              to answer, which is not what any arm records. A condition stops as soon as
-         *              it is settled, so under {@code A && B} the arm where the condition failed
-         *              holds rows that made {@code B} false and rows that never reached {@code B}
+         * @param comparison which comparison this reads. Required, and this is what meeting the line
+         *              is measured against: a row met it by getting the comparison to answer, which
+         *              is not what any arm records. A condition stops as soon as it is settled, so
+         *              under {@code A && B} the arm where the condition failed holds rows that made
+         *              {@code B} false and rows that never reached {@code B}. The comparison and not
+         *              the number it is instrumented under — two readers agreeing that they mean one
+         *              place should not come down to their having been handed the same int
          * @param at    where the fork is written, which is where a reader is sent. A rule with no
          *              name is pointed at instead of being called something
          */
-        public record Read(CoverageSites.GuardRef guard, int site, Citation at) {}
+        public record Read(CoverageSites.GuardRef guard,
+                           souther.compiler.coverage.ComparisonOccurrence comparison, Citation at) {}
 
         /** Which arms a row that reached this comparison can be in. */
         public enum Witness {
@@ -338,8 +341,8 @@ public sealed interface OriginRef {
     }
 
     /**
-     * Where the comparison's own value is recorded, for a rule that meeting takes more than writing
-     * the value.
+     * Which comparison a row has to get an answer out of, for a rule that meeting takes more than
+     * writing the value.
      *
      * <p>Asked of the rule rather than matched on which kind it is, because the two are not the same
      * question and reading one for the other is what puts a new rule on whichever arm the code was
@@ -349,13 +352,13 @@ public sealed interface OriginRef {
      * about the values themselves. An invariant refuses everything outside its bound, so nothing
      * exists that could have missed it; a clause states a relation, and what covers where the
      * relation changes is the input written at it. For those, writing the value is the whole of what
-     * there is to reach and there is no site to look at.
+     * there is to reach and there is no comparison to look at.
      */
-    default java.util.OptionalInt comparisonSite() {
+    default java.util.Optional<souther.compiler.coverage.ComparisonOccurrence> comparisonAt() {
         return switch (this) {
-            case GuardOrigin g -> java.util.OptionalInt.of(g.read().site());
-            case NarrowedOrigin n -> n.bound().comparisonSite();
-            case InvariantOrigin _, EnsuresOrigin _ -> java.util.OptionalInt.empty();
+            case GuardOrigin g -> java.util.Optional.of(g.read().comparison());
+            case NarrowedOrigin n -> n.bound().comparisonAt();
+            case InvariantOrigin _, EnsuresOrigin _ -> java.util.Optional.empty();
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -421,7 +421,7 @@ public final class Partitions {
                     // Asked of the comparison, where the rule is met by having produced one. A
                     // clause has no comparison a path can arrive at: it is checked whenever the
                     // behavior answers, so nothing about which branch a body took drops its line.
-                    .filter(t -> t.origin().comparisonSite().stream()
+                    .filter(t -> t.origin().comparisonAt().stream()
                             .noneMatch(arrives::dividesNothing))
                     .toList();
             // What the term is, not what an invariant said about it. There is a bound to read only

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1488,6 +1488,7 @@ public final class Adequacy {
                     // with. They are said in their own words elsewhere and answer nothing here.
                     case souther.compiler.partition.GenerationReason.PositionWithheld _,
                             souther.compiler.partition.GenerationReason.SearchLimit _,
+                            souther.compiler.partition.GenerationReason.RowsNotConfirmed _,
                             souther.compiler.partition.GenerationReason.RowsNotRead _ -> null;
                 };
                 if (said != null) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1586,8 +1586,13 @@ public final class Adequacy {
             Generator.CandidateCheck check = building == null ? Generator.CandidateCheck.ANY
                     : (at, candidate) -> building.refuse(sig.ins().get(at), candidate.value());
 
-            List<Map<AxisId, Classification>> existing = rows.stream()
-                    .map(row -> RowClasses.of(row, inputs, partitioning.axes())).toList();
+            // Where each row's values sit, and what its run did. Both come off the one outcome:
+            // the first is what a pair count is taken over, the second is what says which of the
+            // body's combinations the row was seen filling.
+            List<Generator.ObservedRow> existing = rows.stream()
+                    .map(row -> new Generator.ObservedRow(
+                            RowClasses.of(row, inputs, partitioning.axes()), seenBy(row)))
+                    .toList();
             return Generator.fill(subject, existing, check,
                     souther.compiler.interaction.Interactions.of(body, plan, domain, symbols));
         }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1494,6 +1494,7 @@ public final class Adequacy {
                     case souther.compiler.partition.GenerationReason.PositionWithheld _,
                             souther.compiler.partition.GenerationReason.SearchLimit _,
                             souther.compiler.partition.GenerationReason.RowsNotConfirmed _,
+                            souther.compiler.partition.GenerationReason.CombinationsWithheld _,
                             souther.compiler.partition.GenerationReason.RowsNotRead _ -> null;
                 };
                 if (said != null) {
@@ -1582,7 +1583,7 @@ public final class Adequacy {
                     .run(inputs.stream()
                             .map(souther.compiler.partition.FixtureTemplate::value).toList())
                     .<Generator.Watched>map(Generator.Watched.Ran::new)
-                    .orElseGet(Generator.Watched.NotRun::new);
+                    .orElseGet(Generator.Watched.NoAccount::new);
         }
 
         private static Generator.GenerationResult pairsFor(
@@ -2606,14 +2607,14 @@ public final class Adequacy {
                                                                         boolean recording) {
         if (!recording) {
             // The row ran — every row of an evaluated source does — and nothing was recording it.
-            // Answered as that rather than as a run with an empty account of itself, which is what
-            // a row that reached nothing leaves and is a different thing to have found out.
-            return new souther.compiler.partition.Generator.Watched.Unrecorded();
+            // Answered as having no account rather than as a run with an empty one, which is what a
+            // row that reached nothing leaves and is a different thing to have found out.
+            return new souther.compiler.partition.Generator.Watched.NoAccount();
         }
         return switch (row.run().counting()) {
             case Counting.Read read ->
                     new souther.compiler.partition.Generator.Watched.Ran(read.observation());
-            case Counting.Unread _ -> new souther.compiler.partition.Generator.Watched.NotRun();
+            case Counting.Unread _ -> new souther.compiler.partition.Generator.Watched.NoAccount();
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -523,7 +523,7 @@ public final class Adequacy {
             Set<Integer> lit = new LinkedHashSet<>();
             for (Observed observed : rowsOf(db, name).values()) {
                 for (RowOutcome row : observed.rows()) {
-                    lit.addAll(litBy(row));
+                    lit.addAll(seenBy(row).taken());
                 }
             }
             Map<String, souther.compiler.check.PathReachability.Answers.AsRun> out =
@@ -1007,7 +1007,7 @@ public final class Adequacy {
             Set<Integer> lit = new LinkedHashSet<>();
             for (Observed observed : byTarget.values()) {
                 for (RowOutcome row : observed.rows()) {
-                    lit.addAll(litBy(row));
+                    lit.addAll(seenBy(row).taken());
                 }
             }
 
@@ -2513,17 +2513,17 @@ public final class Adequacy {
     private Adequacy() {}
 
     /**
-     * The sites a row is known to have gone through.
+     * What a row is known to have done.
      *
      * <p>Read as a {@code switch} so that a counting this does not know about is a compile error
-     * here rather than a row silently counted as having lit nothing. A row whose counting was never
-     * read lights none that anything here can name, and that it was left undecided is said where the
-     * row is reported.
+     * here rather than a row silently counted as having done nothing. A row whose counting was never
+     * read is known to have done none of it, and that it was left undecided is said where the row is
+     * reported.
      */
-    private static java.util.Set<Integer> litBy(RowOutcome row) {
+    private static souther.compiler.coverage.Observation seenBy(RowOutcome row) {
         return switch (row.run().counting()) {
-            case Counting.Read read -> read.hits();
-            case Counting.Unread _ -> java.util.Set.of();
+            case Counting.Read read -> read.observation();
+            case Counting.Unread _ -> souther.compiler.coverage.Observation.NONE;
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1300,6 +1300,10 @@ public final class Adequacy {
             Map<String, Filling> out = new LinkedHashMap<>();
             FixtureReader.Construction building = constructing(db, name,
                     prepared.value().forExamples(), symbols);
+            // One for the module, so the classes a candidate is built and applied in are defined
+            // once however many behaviors are searched.
+            souther.compiler.examples.RowTrial.Trials trials = trialling(db, name,
+                    prepared.value().forExamples(), symbols);
             for (Hir.BehaviorDef behavior : prepared.value().behaviors()) {
                 if (!(behavior instanceof Hir.SpecBehavior spec)) {
                     continue;
@@ -1315,7 +1319,7 @@ public final class Adequacy {
                     pairs = pairsFor(spec, sig, symbols, bodies.get(spec.name()), plan,
                             byTarget.getOrDefault(spec.name(), Observed.NONE), building,
                             domainOf(readInputs, spec), arrivalsOf(arrives, spec),
-                            statedOf(declared, spec));
+                            statedOf(declared, spec), runningRowsOf(trials, spec.name(), sig));
                 } catch (LinkageError _) {
                     // The generated classes would not link, so nothing can be built to find out
                     // what a model admits. Saying so is not the same as saying the combinations are
@@ -1559,12 +1563,33 @@ public final class Adequacy {
                     stopped.stream().distinct().toList());
         }
 
+        /**
+         * A way to run this behavior's composed rows, said in the generator's words.
+         *
+         * <p>Two seams and one adaptation, the way the check that a value can be built already is.
+         * What runs a row is the evaluation's business and speaks in what a fixture states; what a
+         * generator has is a template it composed. Neither has to know the other's word for a row.
+         */
+        private static Generator.Trial runningRowsOf(
+                souther.compiler.examples.RowTrial.Trials trials, String behavior, Sig sig) {
+            if (trials == null) {
+                return Generator.Trial.NOTHING_RUNS;
+            }
+            souther.compiler.examples.RowTrial.Application application =
+                    trials.forBehavior(behavior, sig);
+            return inputs -> application
+                    .run(inputs.stream()
+                            .map(souther.compiler.partition.FixtureTemplate::value).toList())
+                    .<Generator.Watched>map(Generator.Watched.Ran::new)
+                    .orElseGet(Generator.Watched.NotRun::new);
+        }
+
         private static Generator.GenerationResult pairsFor(
                 Hir.SpecBehavior spec, Sig sig, Symbols symbols, souther.compiler.core.Core body,
                 souther.compiler.coverage.CoverageSites.Plan plan, Observed observed,
                 FixtureReader.Construction building, InputDomain domain,
                 souther.compiler.check.PathReachability.Answers arrives,
-                souther.compiler.check.StatedContract stated) {
+                souther.compiler.check.StatedContract stated, Generator.Trial trial) {
             if (observed.someRowsUnseen()) {
                 // Rows exist that nothing read. What they cover is unknown, so what is left uncovered
                 // is unknown too — and a generated row is a specific piece of work handed to a person,
@@ -1595,7 +1620,8 @@ public final class Adequacy {
                             RowClasses.of(row, inputs, partitioning.axes()), seenBy(row)))
                     .toList();
             return Generator.fill(subject, existing, check,
-                    souther.compiler.interaction.Interactions.of(body, plan, domain, symbols));
+                    souther.compiler.interaction.Interactions.of(body, plan, domain, symbols),
+                    trial);
         }
     }
 
@@ -1626,6 +1652,38 @@ public final class Adequacy {
         // value builds at this module's boundary is the decoder's answer, and nothing here runs.
         return FixtureReader.constructing(written, symbols, classes,
                 Output.evaluationLoader(db), values == null ? Map.of() : values);
+    }
+
+    /**
+     * A way to run rows against this module's own classes, or nothing where none can be run.
+     *
+     * <p>Nothing where the compile is not measuring, which is the one condition worth stating
+     * outright. Classes emitted without the calls that record where a run went give a run nothing
+     * was recorded of, and that reads exactly like a run that went nowhere — so a search told to
+     * confirm its candidates against them would find every one of them missing and offer nothing at
+     * all. Where they are absent the search says its rows went unconfirmed, which is what happened.
+     *
+     * <p>A budget is installed here, unlike where values are only built. A row this composed is a
+     * row nobody wrote, so a model that does not finish on one is this search's to stop.
+     */
+    static souther.compiler.examples.RowTrial.Trials trialling(Db db, String module,
+            souther.compiler.check.Prepared.ExampleExecution written, Symbols symbols) {
+        if (!levelOf(db).measuresArms()) {
+            return null;
+        }
+        souther.compiler.generated.EvaluationArtifact artifact =
+                db.ask(new Output.EvaluationLinked(module, coverageAsked(db))).value();
+        if (artifact == null || artifact.implementations() == null) {
+            return null;
+        }
+        Map<String, Hir.FnDef> values = db.ask(new Bodies.ModuleDefinitions(module)).value();
+        souther.compiler.examples.EvaluationPolicy steps = db.ask(new Front.Policy()).value();
+        if (steps == null) {
+            return null;
+        }
+        return souther.compiler.examples.RowTrial.over(written, symbols, artifact.classes(),
+                Output.evaluationLoader(db), values == null ? Map.of() : values,
+                artifact.implementations(), steps);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1319,7 +1319,8 @@ public final class Adequacy {
                     pairs = pairsFor(spec, sig, symbols, bodies.get(spec.name()), plan,
                             byTarget.getOrDefault(spec.name(), Observed.NONE), building,
                             domainOf(readInputs, spec), arrivalsOf(arrives, spec),
-                            statedOf(declared, spec), runningRowsOf(trials, spec.name(), sig));
+                            statedOf(declared, spec), runningRowsOf(trials, spec.name(), sig),
+                            levelOf(db).measuresArms());
                 } catch (LinkageError _) {
                     // The generated classes would not link, so nothing can be built to find out
                     // what a model admits. Saying so is not the same as saying the combinations are
@@ -1589,7 +1590,8 @@ public final class Adequacy {
                 souther.compiler.coverage.CoverageSites.Plan plan, Observed observed,
                 FixtureReader.Construction building, InputDomain domain,
                 souther.compiler.check.PathReachability.Answers arrives,
-                souther.compiler.check.StatedContract stated, Generator.Trial trial) {
+                souther.compiler.check.StatedContract stated, Generator.Trial trial,
+                boolean recording) {
             if (observed.someRowsUnseen()) {
                 // Rows exist that nothing read. What they cover is unknown, so what is left uncovered
                 // is unknown too — and a generated row is a specific piece of work handed to a person,
@@ -1617,7 +1619,8 @@ public final class Adequacy {
             // body's combinations the row was seen filling.
             List<Generator.ObservedRow> existing = rows.stream()
                     .map(row -> new Generator.ObservedRow(
-                            RowClasses.of(row, inputs, partitioning.axes()), seenBy(row)))
+                            RowClasses.of(row, inputs, partitioning.axes()),
+                            watched(row, recording)))
                     .toList();
             return Generator.fill(subject, existing, check,
                     souther.compiler.interaction.Interactions.of(body, plan, domain, symbols),
@@ -2588,6 +2591,29 @@ public final class Adequacy {
         return switch (row.run().counting()) {
             case Counting.Read read -> read.observation();
             case Counting.Unread _ -> souther.compiler.coverage.Observation.NONE;
+        };
+    }
+
+    /**
+     * What came of running {@code row}, as something that says which of the two nothings it is.
+     *
+     * <p>A row whose counting was never read, and a compile that records nothing of any row, both
+     * leave an empty account — and neither of them is a row that went nowhere. Handed over as an
+     * account, the difference is gone by the time anything acts on it, and a combination the row
+     * may well fill reads as one it was shown not to.
+     */
+    private static souther.compiler.partition.Generator.Watched watched(RowOutcome row,
+                                                                        boolean recording) {
+        if (!recording) {
+            // The row ran — every row of an evaluated source does — and nothing was recording it.
+            // Answered as that rather than as a run with an empty account of itself, which is what
+            // a row that reached nothing leaves and is a different thing to have found out.
+            return new souther.compiler.partition.Generator.Watched.Unrecorded();
+        }
+        return switch (row.run().counting()) {
+            case Counting.Read read ->
+                    new souther.compiler.partition.Generator.Watched.Ran(read.observation());
+            case Counting.Unread _ -> new souther.compiler.partition.Generator.Watched.NotRun();
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -499,7 +499,7 @@ final class Coverages {
         // guard's line is about a place in a body and is reached or not; an invariant's and a
         // clause's are about the values — one refuses everything outside its bound, the other states
         // a relation — so for both of those writing the value is the whole of what there is to reach.
-        boolean guard = border.origin().comparisonSite().isPresent();
+        boolean guard = border.origin().comparisonAt().isPresent();
         ItemAssessment.Coverage.Reason absent = guard
                 ? whyNoGuardLine(observed.rows(), armsAsked, observed.armsUnseen(),
                         observed.someRowsUnseen())
@@ -537,7 +537,8 @@ final class Coverages {
                                             boolean knownWritable, Probe probe,
                                             LevelRealizer realizer) {
         BorderQuantity quantity = border.cut().of();
-        java.util.OptionalInt site = border.origin().comparisonSite();
+        java.util.Optional<souther.compiler.coverage.ComparisonOccurrence> site =
+                border.origin().comparisonAt();
         return new OneShapeOfBorder() {
 
             @Override
@@ -593,18 +594,21 @@ final class Coverages {
      * belong to the rows: that a row nothing could read leaves the item undecided rather than missed,
      * and that a line a fork drew is met by getting the comparison to answer as well.
      *
-     * @param site where the comparison's own value is recorded, for a rule that meeting takes more
-     *             than standing at the level. Empty where standing there is the whole of it
+     * @param site which comparison a row has to have got an answer out of, for a rule that meeting
+     *             takes more than standing at the level. Empty where standing there is the whole
+     *             of it
      */
     private static Met metOn(BorderQuantity quantity, BehaviorInputs where, List<RowOutcome> rows,
-                             Criterion criterion, java.util.OptionalInt site) {
+                             Criterion criterion,
+                             java.util.Optional<souther.compiler.coverage.ComparisonOccurrence>
+                                     site) {
         boolean unreadable = false;
         for (RowOutcome row : rows) {
             switch (quantity.standsAt(criterion, path -> where.valueAt(row, path))) {
                 case UNREADABLE -> unreadable = true;
                 case NO -> { }
                 case YES -> {
-                    if (site.stream().allMatch(litBy(row)::contains)) {
+                    if (site.stream().allMatch(seenBy(row)::reached)) {
                         return Met.YES;
                     }
                 }
@@ -837,17 +841,17 @@ final class Coverages {
     private Coverages() {}
 
     /**
-     * The sites a row is known to have gone through.
+     * What a row is known to have done.
      *
      * <p>Read as a {@code switch} so that a counting this does not know about is a compile error
-     * here rather than a row silently counted as having lit nothing. A row whose counting was never
-     * read lights none that anything here can name, and that it was left undecided is said where the
-     * row is reported.
+     * here rather than a row silently counted as having done nothing. A row whose counting was never
+     * read is known to have done none of it, and that it was left undecided is said where the row is
+     * reported.
      */
-    private static java.util.Set<Integer> litBy(RowOutcome row) {
+    private static souther.compiler.coverage.Observation seenBy(RowOutcome row) {
         return switch (row.run().counting()) {
-            case Counting.Read read -> read.hits();
-            case Counting.Unread _ -> java.util.Set.of();
+            case Counting.Read read -> read.observation();
+            case Counting.Unread _ -> souther.compiler.coverage.Observation.NONE;
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1084,8 +1084,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             case NOTHING_TO_BUILD_AGAINST -> "there was nothing to build a candidate against";
             case LINKAGE_FAILED -> "the generated classes would not link";
             case NO_CERTIFIED_WITNESS ->
-                    "every row composed for " + at + " ran and went somewhere else, which does not"
-                            + " make the combination unreachable";
+                    "no row composed for " + at + " was seen reaching it, which does not make the"
+                            + " combination unreachable";
             case NO_REASON_RECORDED -> "nothing was recorded about why";
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1083,6 +1083,9 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     "the rules leave no value at " + at;
             case NOTHING_TO_BUILD_AGAINST -> "there was nothing to build a candidate against";
             case LINKAGE_FAILED -> "the generated classes would not link";
+            case NO_CERTIFIED_WITNESS ->
+                    "every row composed for " + at + " ran and went somewhere else, which does not"
+                            + " make the combination unreachable";
             case NO_REASON_RECORDED -> "nothing was recorded about why";
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -455,7 +455,7 @@ public final class GeneratedRows {
                             + " combination impossible";
             case SEARCH_LIMIT -> "the search stopped before reaching it";
             case NO_CERTIFIED_WITNESS ->
-                    "every row composed for it ran and went somewhere else, which does not make the"
+                    "no row composed for it was seen reaching it, which does not make the"
                             + " combination unreachable";
             case THE_RULES_LEAVE_NOTHING_THERE ->
                     "the rules leave no value here, and every combination they do leave was tried";

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -364,6 +364,13 @@ public final class GeneratedRows {
                 // Not a stop. The rows above it are there and are worth writing; what is said is
                 // that nothing ran them, so what each is offered for is a reading of the body
                 // rather than something anything watched.
+                // Not a stop either. What is said is that rows were held back over rows already
+                // here, and that whether those fill what they sit in was not established.
+                case GenerationReason.CombinationsWithheld withheld -> String.format(
+                        "// %d %s for `%s` offered no row: one already written sits where a row"
+                                + " filling it would, and nothing ran to say whether it does%n",
+                        withheld.combinations(), withheld.behavior(),
+                        withheld.combinations() == 1 ? "combination" : "combinations");
                 case GenerationReason.RowsNotConfirmed unconfirmed -> String.format(
                         "// rows offered for `%s` were not run, so which combination each reaches"
                                 + " is read off the body rather than observed%n",

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -369,8 +369,9 @@ public final class GeneratedRows {
                 case GenerationReason.CombinationsWithheld withheld -> String.format(
                         "// %d %s for `%s` offered no row: one already written sits where a row"
                                 + " filling it would, and nothing ran to say whether it does%n",
-                        withheld.combinations(), withheld.behavior(),
-                        withheld.combinations() == 1 ? "combination" : "combinations");
+                        withheld.combinations(),
+                        withheld.combinations() == 1 ? "combination" : "combinations",
+                        withheld.behavior());
                 case GenerationReason.RowsNotConfirmed unconfirmed -> String.format(
                         "// rows offered for `%s` were not run, so which combination each reaches"
                                 + " is read off the body rather than observed%n",

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -361,6 +361,13 @@ public final class GeneratedRows {
                         "// generation stopped for `%s`: the generated classes would not link, so"
                                 + " the decoders a candidate is built through were out of reach%n",
                         failed.behavior());
+                // Not a stop. The rows above it are there and are worth writing; what is said is
+                // that nothing ran them, so what each is offered for is a reading of the body
+                // rather than something anything watched.
+                case GenerationReason.RowsNotConfirmed unconfirmed -> String.format(
+                        "// rows offered for `%s` were not run, so which combination each reaches"
+                                + " is read off the body rather than observed%n",
+                        unconfirmed.behavior());
                 // The reasons it rests on rather than a word of its own. What was not read is a
                 // measurement's answer and is already said in those words; saying it again in the
                 // generator's would be the same fact under two spellings, read side by side.
@@ -447,6 +454,9 @@ public final class GeneratedRows {
                     "every value tried was refused at construction, which does not make the"
                             + " combination impossible";
             case SEARCH_LIMIT -> "the search stopped before reaching it";
+            case NO_CERTIFIED_WITNESS ->
+                    "every row composed for it ran and went somewhere else, which does not make the"
+                            + " combination unreachable";
             case THE_RULES_LEAVE_NOTHING_THERE ->
                     "the rules leave no value here, and every combination they do leave was tried";
             case NOTHING_TO_BUILD_AGAINST ->

--- a/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
@@ -102,7 +102,8 @@ class AGenerationThatWentOnDoesNotSayItStoppedTest {
         row.put(second.id(), Classification.in(second.classes().get(0).id()));
 
         Generator.GenerationResult filled =
-                Generator.fill(subject, List.of(row), Generator.CandidateCheck.ANY);
+                Generator.fill(subject, List.of(Generator.ObservedRow.unseen(row)),
+                        Generator.CandidateCheck.ANY);
 
         assertFalse(filled.rows().isEmpty(), "the positions it could read were filled");
         assertInstanceOf(GenerationReason.PositionWithheld.class, filled.reasons().get(0));

--- a/souther-compiler/src/test/java/souther/compiler/ARowOfferedForACombinationIsRunWhereAnythingCanRunItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowOfferedForACombinationIsRunWhereAnythingCanRunItTest.java
@@ -1,0 +1,99 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.partition.GenerationReason;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Whether a build confirms the rows it offers, and what it says where it cannot.
+ *
+ * <p>What confirms one is running it, and running one records where it went only in classes emitted
+ * with the calls that record it. A build that does not measure the arms has no such classes, so its
+ * rows are offered on the strength of a reading of the body and it says so. A build that does has
+ * them, and every row it offers for a combination is one that was seen reaching it.
+ *
+ * <p>The two are asserted together because either alone would pass on a mistake. Confirming nothing
+ * would leave the first true and the second silent; confirming against classes with no calls in them
+ * would leave every candidate missing, offer nothing, and leave the second true by having no rows to
+ * be unconfirmed about.
+ */
+class ARowOfferedForACombinationIsRunWhereAnythingCanRunItTest {
+
+    /** Two decisions consumed into one value, and no row written for any of their combinations. */
+    private static final String SHIPPING = """
+            module example.shipping
+
+            data Membership = Premium | Standard
+
+            data Delivery = Express | Regular
+
+            data Fee = Int
+                invariant value >= 0
+
+            behavior shippingFee : (member: Membership, delivery: Delivery) -> Fee
+                constructs Fee
+
+            let baseFee (tier: Membership): Int =
+                match tier with
+                    | Premium -> 0
+                    | Standard -> 500
+
+            let expressFee (speed: Delivery): Int =
+                match speed with
+                    | Express -> 500
+                    | Regular -> 0
+
+            let shippingFee (member, delivery) =
+                Fee(baseFee(member) + expressFee(delivery))
+            """;
+
+    @Test
+    void aBuildThatMeasuresTheArmsConfirmsTheRowsItOffers() {
+        Adequacy.Filling filling = generationOf(Adequacy.Level.ALL);
+
+        assertFalse(filling.pairs().rows().isEmpty(), "there are rows to offer");
+        assertEquals(List.of(), unconfirmed(filling),
+                "and each was run and seen reaching what it is offered for");
+    }
+
+    @Test
+    void aBuildThatDoesNotMeasureTheArmsSaysItsRowsWereNotRun() {
+        Adequacy.Filling filling = generationOf(Adequacy.Level.WITNESS);
+
+        assertFalse(filling.pairs().rows().isEmpty(),
+                "the rows are still offered, being worth writing either way");
+        assertEquals(1, unconfirmed(filling).size(),
+                "and the generation says once that nothing ran them: " + filling.pairs().reasons());
+    }
+
+    private static List<GenerationReason> unconfirmed(Adequacy.Filling filling) {
+        return filling.pairs().reasons().stream()
+                .filter(GenerationReason.RowsNotConfirmed.class::isInstance).toList();
+    }
+
+    private static Adequacy.Filling generationOf(Adequacy.Level level) {
+        Compilation compilation = Compilation.ofSource(SHIPPING, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly(level));
+        compilation.answerEverything();
+        Map<String, Adequacy.Filling> filled = compilation.db()
+                .ask(new Adequacy.Generated(compilation.modules().get(0))).value();
+        assertNotNull(filled, "the model under test compiles and is measured");
+        Adequacy.Filling filling = filled.get("shippingFee");
+        assertNotNull(filling, "the behavior under test was generated for");
+        assertTrue(filling.pairs().unresolved().stream().noneMatch(each -> each.reason()
+                        == souther.compiler.partition.Generator.UnresolvedCombination.Reason
+                                .NO_CERTIFIED_WITNESS),
+                "nothing missed: " + filling.pairs().unresolved());
+        return filling;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/ARowOfferedForACombinationIsRunWhereAnythingCanRunItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowOfferedForACombinationIsRunWhereAnythingCanRunItTest.java
@@ -147,6 +147,30 @@ class ARowOfferedForACombinationIsRunWhereAnythingCanRunItTest {
                 "what is left to write does not turn on whether the build was measuring");
     }
 
+    /**
+     * A combination held back over a row already written is said, not passed over.
+     *
+     * <p>The row is not offered, which is right: it may be work the author has done. What is not
+     * right is silence, because silence here reads as a combination covered — and nothing
+     * established that. So the generation says how many it held back and why, and an author reading
+     * it can tell "all done" from "nothing here could tell".
+     *
+     * <p>The measuring build holds nothing back: there the written rows either fill the
+     * combinations or leave them owed, and either way something was established.
+     */
+    @Test
+    void aCombinationHeldBackOverAWrittenRowIsSaid() {
+        assertEquals(1, withheld(generationOf(WRITTEN, "shippingFee", Adequacy.Level.WITNESS)).size(),
+                "a build that could watch nothing says what it held back");
+        assertEquals(List.of(), withheld(generationOf(WRITTEN, "shippingFee", Adequacy.Level.ALL)),
+                "and one that could watch holds nothing back");
+    }
+
+    private static List<GenerationReason> withheld(Adequacy.Filling filling) {
+        return filling.pairs().reasons().stream()
+                .filter(GenerationReason.CombinationsWithheld.class::isInstance).toList();
+    }
+
     private static List<String> offeredBy(Adequacy.Level level) {
         return generationOf(WRITTEN, "shippingFee", level).pairs().rows().stream()
                 .map(souther.compiler.partition.Generator.GeneratedRow::description).toList();

--- a/souther-compiler/src/test/java/souther/compiler/ARowOfferedForACombinationIsRunWhereAnythingCanRunItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowOfferedForACombinationIsRunWhereAnythingCanRunItTest.java
@@ -76,19 +76,100 @@ class ARowOfferedForACombinationIsRunWhereAnythingCanRunItTest {
                 "and the generation says once that nothing ran them: " + filling.pairs().reasons());
     }
 
+    /** The same two decisions, in a behavior that depends on another. */
+    private static final String DEPENDING = """
+            module example.postage
+
+            data Membership = Premium | Standard
+
+            data Delivery = Express | Regular
+
+            data Fee = Int
+                invariant value >= 0
+
+            behavior surcharge : (member: Membership) -> Fee
+
+            behavior postageFor : (member: Membership, delivery: Delivery) -> Fee
+                constructs Fee
+                depends on surcharge
+
+            let expressFee (speed: Delivery): Int =
+                match speed with
+                    | Express -> 500
+                    | Regular -> 0
+
+            let baseFee (tier: Membership): Int =
+                match tier with
+                    | Premium -> 0
+                    | Standard -> 500
+
+            let postageFor (member, delivery, surcharge) =
+                Fee(baseFee(member) + expressFee(delivery) + surcharge(member).value)
+            """;
+
+    /**
+     * A behavior nothing can apply for a composed row is unconfirmed, not missed.
+     *
+     * <p>A row composed here names no fakes, so a behavior that depends on another has nothing to
+     * stand in for what it depends on and cannot be applied at all. Read as a run, that is a row
+     * which reached nothing — and every combination would come back as one every candidate missed,
+     * which says the search found something out about the model. It found nothing out.
+     */
+    @Test
+    void aBehaviorNothingCanApplyHasItsRowsOfferedUnconfirmed() {
+        Adequacy.Filling filling = generationOf(DEPENDING, "postageFor", Adequacy.Level.ALL);
+
+        assertFalse(filling.pairs().rows().isEmpty(), "the rows are offered");
+        assertEquals(1, unconfirmed(filling).size(),
+                "and are said to be unconfirmed: " + filling.pairs().reasons());
+    }
+
+    /** The shipping model with two of its four combinations already written. */
+    private static final String WRITTEN = SHIPPING + """
+
+            example shippingFee
+                | (Premium, Express) -> Fee(500)
+                | (Standard, Regular) -> Fee(500)
+            """;
+
+
+    /**
+     * A row the author already wrote is not offered back to them because nothing watched it.
+     *
+     * <p>Where nothing can say what a row did, the two kinds of row part. An author's row is in the
+     * file whatever this establishes about it, so passing over a combination it may fill costs a
+     * combination left owed; offering one costs them work they have already done. A row this search
+     * composed is in nobody's file and gets no such benefit.
+     */
+    @Test
+    void aWrittenRowIsNotOfferedBackWhereNothingCouldWatchIt() {
+        assertEquals(offeredBy(Adequacy.Level.ALL), offeredBy(Adequacy.Level.WITNESS),
+                "what is left to write does not turn on whether the build was measuring");
+    }
+
+    private static List<String> offeredBy(Adequacy.Level level) {
+        return generationOf(WRITTEN, "shippingFee", level).pairs().rows().stream()
+                .map(souther.compiler.partition.Generator.GeneratedRow::description).toList();
+    }
+
     private static List<GenerationReason> unconfirmed(Adequacy.Filling filling) {
         return filling.pairs().reasons().stream()
                 .filter(GenerationReason.RowsNotConfirmed.class::isInstance).toList();
     }
 
     private static Adequacy.Filling generationOf(Adequacy.Level level) {
-        Compilation compilation = Compilation.ofSource(SHIPPING, "Main");
+        return generationOf(SHIPPING, "shippingFee", level);
+    }
+
+    private static Adequacy.Filling generationOf(String source, String behavior,
+                                                 Adequacy.Level level) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.measure(Adequacy.Asked.reportOnly(level));
         compilation.answerEverything();
         Map<String, Adequacy.Filling> filled = compilation.db()
                 .ask(new Adequacy.Generated(compilation.modules().get(0))).value();
         assertNotNull(filled, "the model under test compiles and is measured");
-        Adequacy.Filling filling = filled.get("shippingFee");
+        Adequacy.Filling filling = filled.get(behavior);
         assertNotNull(filling, "the behavior under test was generated for");
         assertTrue(filling.pairs().unresolved().stream().noneMatch(each -> each.reason()
                         == souther.compiler.partition.Generator.UnresolvedCombination.Reason

--- a/souther-compiler/src/test/java/souther/compiler/ARowSaysWhatAppliedTheBehaviorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowSaysWhatAppliedTheBehaviorTest.java
@@ -153,7 +153,7 @@ class ARowSaysWhatAppliedTheBehaviorTest {
 
         Counting.Read counted = assertInstanceOf(Counting.Read.class, held.run().counting());
         assertTrue(counted.steps() >= 0, "the count is this compile's own reading");
-        assertFalse(counted.hits().isEmpty(),
+        assertFalse(counted.observation().taken().isEmpty(),
                 "and so are the arms it went through, this compile having emitted what counts them");
     }
 
@@ -189,7 +189,7 @@ class ARowSaysWhatAppliedTheBehaviorTest {
                 () -> new RowOutcome(ran.at(), ran.target(), ran.identity(), Stage.FIXTURES_VALIDATED,
                         ran.disposition(), ran.failurePhase(), ran.expectedArm(), ran.resultArm(),
                         ran.inputCases(), ran.inputs(),
-                        new Run(new Applied.GeneratedHere(), new Counting.Read(1L, Set.of()))),
+                        new Run(new Applied.GeneratedHere(), new Counting.Read(1L, souther.compiler.coverage.Observation.NONE))),
                 "and one that did not has nothing to say applied it");
         assertThrows(NullPointerException.class,
                 () -> new RowOutcome(ran.at(), ran.target(), ran.identity(), ran.stage(),

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonSaysWhichWayItCameOutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AComparisonSaysWhichWayItCameOutTest.java
@@ -1,0 +1,204 @@
+package souther.compiler.coverage;
+
+import souther.compiler.Emitted;
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.generated.MemoryClassLoader;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Output;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a run says about the comparisons it evaluated.
+ *
+ * <p>Three states and not two. A comparison of an instrumented condition can have come out one way,
+ * come out the other, or not have been reached at all — and a condition stops as soon as it is
+ * settled, so the third happens whenever an earlier operand decides the answer.
+ *
+ * <p>The model is one {@code guard} over a conjunction, which is what makes this about the
+ * comparisons rather than about the arms. Two of the three inputs take the same way out of the fork:
+ * a reading that worked out which way a comparison went from the arm below it would give those two
+ * the same answer, and they did different things.
+ */
+class AComparisonSaysWhichWayItCameOutTest {
+
+    private static final String MODEL = """
+            module example.trip
+
+            data Submitted = { cost: Int }
+            data Waiting = { cost: Int }
+
+            behavior submit : (cost: Int) -> Submitted | Waiting
+                constructs Submitted, Waiting
+
+            let submit (cost) = {
+                guard cost >= 0 && cost <= 100 else Waiting { cost = 0 }
+                Submitted { cost = cost }
+            }
+            """;
+
+    /**
+     * The two ways of failing one conjunction are told apart, and the arms cannot tell them apart.
+     *
+     * <p>{@code -1} settles the condition at the first comparison and never reaches the second;
+     * {@code 500} answers both. Both leave through the same arm, so the arms they lit are the same
+     * set — and what the run recorded about the comparisons is not.
+     */
+    @Test
+    void twoWaysOfFailingOneConditionAreNotOneObservation() {
+        Compilation compilation = compiled();
+        CoverageSites.Plan plan =
+                Output.Evaluated.planOf(compilation.db(), compilation.modules().get(0));
+        Behavior submit = new Behavior(probed(compilation));
+
+        Observation early = submit.observing(-1L);
+        Observation late = submit.observing(500L);
+
+        assertEquals(armsOf(early, plan), armsOf(late, plan),
+                "both rows leave through the same arm, which is why the arm cannot say this");
+        assertNotEquals(early.comparisons(), late.comparisons(),
+                "and the comparisons they answered are not the same");
+    }
+
+    /**
+     * A comparison an operand short-circuited past is absent, rather than recorded as having failed.
+     *
+     * <p>The half of the vocabulary that a set of sites cannot hold. Absent and false are different
+     * facts about a row — one says the row never got there, the other that it got there and went the
+     * other way — and a claim about a comparison is answerable only where the two are apart.
+     */
+    @Test
+    void aComparisonNeverReachedIsAbsentAndNotFalse() {
+        Compilation compilation = compiled();
+        Behavior submit = new Behavior(probed(compilation));
+
+        Observation early = submit.observing(-1L);
+
+        assertEquals(1, early.comparisons().size(),
+                "the condition settled at the first comparison, so one comparison answered");
+        ComparisonOutcome first = early.comparisons().iterator().next();
+        assertFalse(first.held(), "and it answered by failing");
+
+        Observation late = submit.observing(500L);
+        ComparisonOutcome second = late.comparisons().stream()
+                .filter(each -> !each.at().equals(first.at()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "the row that answered both comparisons reached the second one"));
+        assertFalse(early.reached(second.at()),
+                "which the row that short-circuited never reached");
+        assertFalse(early.saw(new ComparisonOutcome(second.at(), true)),
+                "so it did not come out one way");
+        assertFalse(early.saw(new ComparisonOutcome(second.at(), false)),
+                "nor the other");
+    }
+
+    /** Both ways out of one comparison are recorded, each of the row that took it. */
+    @Test
+    void aComparisonIsRecordedComingOutEitherWay() {
+        Compilation compilation = compiled();
+        Behavior submit = new Behavior(probed(compilation));
+
+        Observation refused = submit.observing(500L);
+        Observation accepted = submit.observing(50L);
+
+        ComparisonOutcome failed = refused.comparisons().stream()
+                .filter(each -> !each.held())
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("the second comparison failed for this row"));
+        assertTrue(accepted.saw(new ComparisonOutcome(failed.at(), true)),
+                "and the row inside the range answered the same comparison the other way");
+        assertFalse(accepted.saw(failed), "which is not the way this one came out");
+    }
+
+    /**
+     * A comparison recorded as having come out a way is a comparison recorded as reached.
+     *
+     * <p>Held by how the recording is written rather than by the emitter keeping to it: one call
+     * records both. So a run that has the first without the second is one nothing produces, and
+     * whoever reads the sites and whoever reads the ways out are reading one run.
+     */
+    @Test
+    void awayOutImpliesItsComparisonWasReached() {
+        Behavior submit = new Behavior(probed(compiled()));
+
+        for (long cost : new long[] {-1L, 50L, 500L}) {
+            Observation seen = submit.observing(cost);
+            for (ComparisonOutcome each : seen.comparisons()) {
+                assertTrue(seen.reached(each.at()),
+                        "a way out of " + each.at() + " was recorded, so it was reached");
+            }
+        }
+    }
+
+    /** The sites of {@code seen} that are arms, which is what a branch measure counts. */
+    private static Set<Integer> armsOf(Observation seen, CoverageSites.Plan plan) {
+        Set<Integer> arms = new LinkedHashSet<>();
+        for (CoverageSites.Site site : plan.sites()) {
+            if (site.isArm() && seen.lit(site.index())) {
+                arms.add(site.index());
+            }
+        }
+        return arms;
+    }
+
+    private static Compilation compiled() {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    private static Map<String, byte[]> probed(Compilation compilation) {
+        souther.compiler.generated.EvaluationArtifact artifact = compilation.db()
+                .ask(new Output.Evaluated(compilation.modules().get(0),
+                        Output.CoverageMode.ARMS)).value();
+        assertNotNull(artifact, "the model under test compiles");
+        return artifact.classes();
+    }
+
+    /** One set of generated classes, loaded and applied. */
+    private static final class Behavior {
+
+        private final Object instance;
+        private final Method apply;
+
+        Behavior(Map<String, byte[]> classes) {
+            assertNotNull(classes, "the model under test compiles");
+            ClassLoader loader = new MemoryClassLoader(classes,
+                    AComparisonSaysWhichWayItCameOutTest.class.getClassLoader());
+            try {
+                Class<?> impl = Emitted.behavior(loader, "example.trip", "submit");
+                Constructor<?> ctor = impl.getDeclaredConstructor();
+                ctor.setAccessible(true);
+                this.instance = ctor.newInstance();
+                this.apply = impl.getDeclaredMethod("apply", Object.class);
+                this.apply.setAccessible(true);
+            } catch (ReflectiveOperationException e) {
+                throw new AssertionError(e);
+            }
+        }
+
+        Observation observing(long cost) {
+            Probe.begin();
+            try {
+                apply.invoke(instance, cost);
+                return Probe.snapshot();
+            } catch (ReflectiveOperationException e) {
+                throw new AssertionError(e);
+            } finally {
+                Probe.end();
+            }
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AnObservationHoldsWhatItSaysAboutItselfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AnObservationHoldsWhatItSaysAboutItselfTest.java
@@ -1,0 +1,47 @@
+package souther.compiler.coverage;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a record of a run may say, held where the record is made rather than where it is written.
+ *
+ * <p>The one producer today records a comparison being reached and the way it came out in a single
+ * call, so nothing it makes can break this. That is how the producer is written and producers get
+ * rewritten; what every reader of a run is entitled to is that a way out of a comparison means the
+ * comparison was reached, because a claim about a place is certified against exactly that.
+ */
+class AnObservationHoldsWhatItSaysAboutItselfTest {
+
+    @Test
+    void awayOutOfAComparisonMeansTheComparisonWasReached() {
+        ComparisonOutcome held = new ComparisonOutcome(new ComparisonOccurrence(7), true);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> new Observation(Set.of(), Set.of(held)),
+                "a run that saw a comparison come out one way reached it");
+        assertTrue(new Observation(Set.of(7), Set.of(held)).saw(held),
+                "and one that holds both says so");
+    }
+
+    /**
+     * Both ways out of one comparison are not a contradiction.
+     *
+     * <p>A place a run comes back to is evaluated more than once and may come out either way on
+     * different times round. A record that refused to hold both would be saying less than the run
+     * showed, which is the opposite of what it is for.
+     */
+    @Test
+    void bothWaysOutOfOneComparisonAreARunThatCameBackToIt() {
+        ComparisonOccurrence twice = new ComparisonOccurrence(3);
+        Observation seen = new Observation(Set.of(3),
+                Set.of(new ComparisonOutcome(twice, true), new ComparisonOutcome(twice, false)));
+
+        assertTrue(seen.saw(new ComparisonOutcome(twice, true)));
+        assertTrue(seen.saw(new ComparisonOutcome(twice, false)));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
@@ -120,7 +120,7 @@ class ProbedBytecodeTest {
             Probe.begin();
             submit.apply(50L);
             Set<Integer> there = elsewhere.submit(() -> submit.armsFor(500L)).get();
-            Set<Integer> here = Probe.taken();
+            Set<Integer> here = Probe.snapshot().taken();
             Probe.end();
 
             assertNotEquals(here, there);
@@ -137,7 +137,7 @@ class ProbedBytecodeTest {
 
         submit.apply(50L);   // outside begin()/end()
 
-        assertEquals(Set.of(), Probe.taken());
+        assertEquals(Set.of(), Probe.snapshot().taken());
     }
 
     // --- what the shipped classes do not mention -------------------------------------------------
@@ -259,7 +259,7 @@ class ProbedBytecodeTest {
             Probe.begin();
             try {
                 apply(cost);
-                return Probe.taken();
+                return Probe.snapshot().taken();
             } finally {
                 Probe.end();
             }

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARecordedRowIsRunAgainstABoundImplementationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARecordedRowIsRunAgainstABoundImplementationTest.java
@@ -193,7 +193,7 @@ class ARecordedRowIsRunAgainstABoundImplementationTest {
         for (RowOutcome row : evaluated(ANSWERS).rows()) {
             Counting.Read read = assertInstanceOf(Counting.Read.class, row.run().counting(),
                     "the counting was read");
-            assertEquals(java.util.Set.of(), read.hits(),
+            assertEquals(java.util.Set.of(), read.observation().taken(),
                     "and lit no branch, there being no body to light one");
         }
     }

--- a/souther-compiler/src/test/java/souther/compiler/interaction/AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/interaction/AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest.java
@@ -1,0 +1,204 @@
+package souther.compiler.interaction;
+
+import souther.compiler.Emitted;
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.coverage.Observation;
+import souther.compiler.coverage.Probe;
+import souther.compiler.generated.MemoryClassLoader;
+import souther.compiler.inputs.InputDomain;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Output;
+import souther.compiler.query.Scopes;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * What a group says about a run, held against a run.
+ *
+ * <p>A group is read off the body: these decisions are consumed into one value, and each of them can
+ * be settled these ways. Everything downstream acts on that reading — a row is composed to settle
+ * each factor one way and is then offered, and named, for the combination. Until the reading can be
+ * held to something, every step of it is a statement nothing can be found to disagree with, which is
+ * how four separate misreadings of it came to look alike.
+ *
+ * <p>So each way of settling a decision carries what a run that settled it would be seen to have
+ * done. This drives the behavior at each of the four combinations of a model with two decisions and
+ * asks the run: for every row, exactly one way of settling each factor is one the run did, and the
+ * four rows did four different things. A reading that named the wrong place, or named a place under
+ * a condition no row can be steered into, does not come out that way.
+ */
+class AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest {
+
+    /** Two decisions consumed into one value, one per input, so each row settles both. */
+    private static final String FEE = """
+            module example.charge
+
+            data Fee = Int
+                invariant value >= 0
+
+            behavior chargeFor : (spend: Int, bonus: Int) -> Fee
+                constructs Fee
+
+            let chargeFor (spend, bonus) =
+                Fee((if spend > 100 then 10 else 20) + (if bonus > 5 then 1 else 2))
+            """;
+
+    /**
+     * What the run did is what the reading said settling the factor that way takes.
+     *
+     * <p>Three things held against each other and not two. Each way of settling a factor says what
+     * it takes of an input — this position, this side of this comparison — and what a run that did
+     * it would be seen to have done. The rows below are chosen so that the first is known from the
+     * source: at {@code (500, 50)} the model's two comparisons come out true and true, and so on
+     * round the four.
+     *
+     * <p>So the way the run is seen to have settled each factor is looked up, and what that way says
+     * about the inputs is read back out and held against what the row actually was. A claim naming
+     * the wrong place, the wrong side of the right place, or a place the row cannot be steered into
+     * comes apart here — the first two by disagreeing with the row, the last by no way of settling
+     * the factor holding at all.
+     */
+    @Test
+    void whatARunIsSeenToDoIsWhatTheWayItSettledTheFactorTakes() {
+        Model model = Model.of(FEE, "chargeFor");
+        List<Interaction> found = model.groups();
+        assertEquals(1, found.size(), "the two decisions meet once: " + found);
+        Interaction group = found.get(0);
+        assertEquals(2, group.factors().size(), "one factor per decision: " + group);
+
+        for (long spend : new long[] {500L, 5L}) {
+            for (long bonus : new long[] {50L, 1L}) {
+                assertEquals(Map.of("spend", spend > 100, "bonus", bonus > 5),
+                        takenBy(group, model.observing(spend, bonus)),
+                        "the row (" + spend + ", " + bonus + ") was seen settling the factors the "
+                                + "way the model settles them for it");
+            }
+        }
+    }
+
+    /**
+     * The way in is what a run has to have done as well.
+     *
+     * <p>Empty here, this meeting standing in no arm. Asserted so that the half of a group that says
+     * how to arrive is read at all: a group is a path to the meeting as much as the outcomes at it,
+     * and a reading that dropped the path would be one nothing here would notice.
+     */
+    @Test
+    void theWayInIsHeldToTheSameRun() {
+        Model model = Model.of(FEE, "chargeFor");
+        Interaction group = model.groups().get(0);
+
+        Observation seen = model.observing(500L, 50L);
+        assertEquals(List.of(), group.reachClaims().stream()
+                        .filter(claim -> !claim.satisfiedBy(seen)).toList(),
+                "a row that reaches the meeting did everything the way in names");
+    }
+
+    /**
+     * Which side of which position each factor was seen settled at.
+     *
+     * <p>Exactly one way per factor, in both directions. Two of them holding of one run would say
+     * they are not ways of settling the same thing; none holding would say the reading named
+     * something no row reaches, which is the shape every misreading of a group ends in.
+     */
+    private static Map<String, Boolean> takenBy(Interaction group, Observation seen) {
+        Map<String, Boolean> settled = new java.util.LinkedHashMap<>();
+        for (Factor factor : group.factors()) {
+            List<Outcome> did = factor.outcomes().stream()
+                    .filter(outcome -> satisfied(outcome, seen))
+                    .toList();
+            assertEquals(1, did.size(), "the run settled this factor one way: " + factor);
+            assertEquals(1, did.get(0).holds().size(),
+                    "and this factor is one decision: " + did.get(0));
+            Condition what = did.get(0).holds().get(0).constrains();
+            Condition.Side side = assertInstanceOf(Condition.Side.class, what,
+                    "which the model makes by comparing");
+            settled.put(side.at().toString(), side.held());
+        }
+        return settled;
+    }
+
+    private static boolean satisfied(Outcome outcome, Observation seen) {
+        return outcome.claims().stream().allMatch(claim -> claim.satisfiedBy(seen));
+    }
+
+    /** One model, read the way the generator reads it and run the way an example row is. */
+    private record Model(List<Interaction> groups, Behavior behavior) {
+
+        static Model of(String source, String name) {
+            Compilation compilation = Compilation.ofSource(source, "Main");
+            compilation.answerEverything();
+            String module = compilation.modules().get(0);
+            Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
+            assertNotNull(checked, "the model under test compiles");
+            Core body = checked.behaviorBodies().get(name);
+            assertNotNull(body, "the behavior under test has a body");
+            // The emitter's plan, which is the numbering the classes below were lit against. A plan
+            // built here again would be the same numbering and would be a second thing to be right.
+            CoverageSites.Plan plan = Output.Evaluated.planOf(compilation.db(), module);
+            Symbols symbols = Scopes.derived(compilation.db(), module).value();
+            InputDomain inputs =
+                    compilation.db().ask(new Adequacy.Inputs(module)).value().get(name);
+            souther.compiler.generated.EvaluationArtifact artifact = compilation.db()
+                    .ask(new Output.Evaluated(module, Output.CoverageMode.ARMS)).value();
+            assertNotNull(artifact, "the model under test emits measured classes");
+            return new Model(Interactions.of(body, plan, inputs, symbols),
+                    new Behavior(artifact.classes(), module, name));
+        }
+
+        Observation observing(Object... arguments) {
+            return behavior.observing(arguments);
+        }
+    }
+
+    /** One set of generated classes, loaded and applied. */
+    private static final class Behavior {
+
+        private final Object instance;
+        private final Method apply;
+
+        Behavior(Map<String, byte[]> classes, String module, String name) {
+            assertNotNull(classes, "the model under test compiles");
+            ClassLoader loader = new MemoryClassLoader(classes,
+                    AClaimIsWhatARunThatSettledItWouldBeSeenToDoTest.class.getClassLoader());
+            try {
+                Class<?> impl = Emitted.behavior(loader, module, name);
+                Constructor<?> ctor = impl.getDeclaredConstructor();
+                ctor.setAccessible(true);
+                this.instance = ctor.newInstance();
+                this.apply = java.util.Arrays.stream(impl.getDeclaredMethods())
+                        .filter(each -> each.getName().equals("apply"))
+                        .findFirst()
+                        .orElseThrow(() -> new AssertionError("the behavior is applied by `apply`"));
+                this.apply.setAccessible(true);
+            } catch (ReflectiveOperationException e) {
+                throw new AssertionError(e);
+            }
+        }
+
+        Observation observing(Object... arguments) {
+            Probe.begin();
+            try {
+                apply.invoke(instance, arguments);
+                return Probe.snapshot();
+            } catch (ReflectiveOperationException e) {
+                throw new AssertionError(e);
+            } finally {
+                Probe.end();
+            }
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/interaction/AGroupIsOnlyOfferedWhereARunPassesItOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/interaction/AGroupIsOnlyOfferedWhereARunPassesItOnceTest.java
@@ -1,0 +1,172 @@
+package souther.compiler.interaction;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Scopes;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.inputs.InputDomain;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What may be claimed of a run, given what a run's record can hold.
+ *
+ * <p>A record says which places a run passed. It does not say how many times it passed each, so
+ * nothing read off one can tell two facts about a place a run came back to from two facts about a
+ * place it passed once. A group says more than that: that these decisions were settled these ways
+ * and were consumed into one value together — which is about one passing, and about their outcomes
+ * being that passing's.
+ *
+ * <p>So a group is offered only where a run passes the meeting once. Today nothing forms one
+ * anywhere else, because the reading does not go inside a function value at all; that is how the
+ * property is met and is not the property. Stated the other way round, a reading that started going
+ * in there would quietly begin offering rows for combinations nothing could ever be shown to sit in.
+ */
+class AGroupIsOnlyOfferedWhereARunPassesItOnceTest {
+
+    /** Two forks, one inside a function value handed to a combinator and one outside it. */
+    private static final String DOUBLING = """
+            module example.tally
+
+            data Ns = { values: List<Int> }
+
+            behavior doubled : (ns: Ns, loud: Bool) -> Ns
+                constructs Ns
+
+            let doubled (ns, loud) =
+                if loud then
+                    Ns { values = List.map(x -> if x > 10 then x * 2 else x, ns.values) }
+                else
+                    Ns { values = ns.values }
+            """;
+
+    /** One meeting of two decisions, standing where a run passes it once. */
+    private static final String SHIPPING = """
+            module example.shipping
+
+            data Membership = Premium | Standard
+
+            data Delivery = Express | Regular
+
+            data Fee = Int
+                invariant value >= 0
+
+            behavior shippingFee : (member: Membership, delivery: Delivery) -> Fee
+                constructs Fee
+
+            let baseFee (tier: Membership): Int =
+                match tier with
+                    | Premium -> 0
+                    | Standard -> 500
+
+            let expressFee (speed: Delivery): Int =
+                match speed with
+                    | Express -> 500
+                    | Regular -> 0
+
+            let shippingFee (member, delivery) =
+                Fee(baseFee(member) + expressFee(delivery))
+            """;
+
+    /**
+     * A run may come back to what is inside a function value, and may not to what is outside one.
+     *
+     * <p>How many times a combinator applies what it was handed is that combinator's business, so
+     * everything written in there is somewhere a run may come back to. The fork above it stands in
+     * the body and is passed once.
+     */
+    @Test
+    void whatStandsInsideAFunctionValueIsSomewhereARunMayComeBackTo() {
+        Model model = Model.of(DOUBLING, "doubled");
+
+        List<Core> forks = List.copyOf(model.plan().byNode().keySet());
+        assertEquals(2, forks.size(), "the body under test has two forks");
+        assertEquals(1, forks.stream().filter(model.plan()::mayRepeat).count(),
+                "and one of them stands where a run may come back to");
+    }
+
+    /** A meeting a run passes once is offered, which is what the next test takes away. */
+    @Test
+    void aMeetingPassedOnceIsOffered() {
+        Model model = Model.of(SHIPPING, "shippingFee");
+
+        assertFalse(model.groups().isEmpty(),
+                "two decisions are consumed into one value here, and a run passes the meeting once");
+    }
+
+    /**
+     * The same meeting, where a run may come back to it, is not offered.
+     *
+     * <p>The same body and the same decisions, so what changed is only what may be established about
+     * a run that reaches them. Written this way round because the reading does not go inside a
+     * function value today: a model whose meeting stands in one produces no group whether or not
+     * anything asks this question, and a test over one would pass with the question deleted.
+     */
+    @Test
+    void aMeetingARunMayComeBackToIsNotOffered() {
+        Model model = Model.of(SHIPPING, "shippingFee");
+
+        List<Interaction> asIfRepeated = Interactions.of(model.body(),
+                model.planWhereEverythingRepeats(), model.inputs(), model.symbols());
+
+        assertTrue(asIfRepeated.isEmpty(),
+                "nothing could show a row to sit in one of these, so none is offered");
+    }
+
+    /** One model, read the way the generator reads it. */
+    private record Model(Core body, CoverageSites.Plan plan, InputDomain inputs, Symbols symbols) {
+
+        static Model of(String source, String behavior) {
+            Compilation compilation = Compilation.ofSource(source, "Main");
+            compilation.answerEverything();
+            String module = compilation.modules().get(0);
+            Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
+            assertNotNull(checked, "the model under test compiles");
+            Core body = checked.behaviorBodies().get(behavior);
+            assertNotNull(body, "the behavior under test has a body");
+            return new Model(body, CoverageSites.of(checked.behaviorBodies()),
+                    compilation.db().ask(new Adequacy.Inputs(module)).value().get(behavior),
+                    Scopes.derived(compilation.db(), module).value());
+        }
+
+        List<Interaction> groups() {
+            return Interactions.of(body, plan, inputs, symbols);
+        }
+
+        /** The same plan, answering that a run may come back to anywhere. What the walk cannot be
+         *  made to produce today, which is why it is stated rather than arranged. */
+        CoverageSites.Plan planWhereEverythingRepeats() {
+            return new CoverageSites.Plan(plan.sites(), plan.guards(), plan.byNode(),
+                    plan.byComparison(), plan.armsByNode(), plan.controlByComparison(),
+                    new AbstractSet<>() {
+
+                        @Override
+                        public boolean contains(Object node) {
+                            return true;
+                        }
+
+                        @Override
+                        public Iterator<Core> iterator() {
+                            return java.util.Collections.emptyIterator();
+                        }
+
+                        @Override
+                        public int size() {
+                            return 0;
+                        }
+                    });
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/interaction/AGroupIsOnlyOfferedWhereARunPassesItOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/interaction/AGroupIsOnlyOfferedWhereARunPassesItOnceTest.java
@@ -148,25 +148,26 @@ class AGroupIsOnlyOfferedWhereARunPassesItOnceTest {
         /** The same plan, answering that a run may come back to anywhere. What the walk cannot be
          *  made to produce today, which is why it is stated rather than arranged. */
         CoverageSites.Plan planWhereEverythingRepeats() {
+            AbstractSet<Core> everywhere = new AbstractSet<>() {
+
+                @Override
+                public boolean contains(Object node) {
+                    return true;
+                }
+
+                @Override
+                public Iterator<Core> iterator() {
+                    return java.util.Collections.emptyIterator();
+                }
+
+                @Override
+                public int size() {
+                    return 0;
+                }
+            };
             return new CoverageSites.Plan(plan.sites(), plan.guards(), plan.byNode(),
                     plan.byComparison(), plan.armsByNode(), plan.controlByComparison(),
-                    new AbstractSet<>() {
-
-                        @Override
-                        public boolean contains(Object node) {
-                            return true;
-                        }
-
-                        @Override
-                        public Iterator<Core> iterator() {
-                            return java.util.Collections.emptyIterator();
-                        }
-
-                        @Override
-                        public int size() {
-                            return 0;
-                        }
-                    });
+                    everywhere, plan.forkByNode());
         }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACandidateThatMissedIsNotOfferedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACandidateThatMissedIsNotOfferedTest.java
@@ -1,0 +1,235 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.coverage.ComparisonOutcome;
+import souther.compiler.coverage.ControlClaim;
+import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.coverage.Observation;
+import souther.compiler.inputs.InputDomain;
+import souther.compiler.interaction.Interaction;
+import souther.compiler.interaction.Interactions;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A row composed for a combination, run, and held to what the combination says.
+ *
+ * <p>Which is the step that was missing. A row is composed by narrowing each position to the classes
+ * the combination leaves it and choosing one; every part of that is a reading of the body, and a row
+ * that goes somewhere else is what any of those readings being wrong produces. Offered without being
+ * run it is named for a combination nobody confirmed it sits in.
+ *
+ * <p>The rows a combination admits are more than one here — one position takes no part in the
+ * decisions, so it is free — which is what makes trying another assignment a thing that can happen
+ * rather than a branch nothing reaches.
+ */
+class ACandidateThatMissedIsNotOfferedTest {
+
+    private static final String SHIPPING = """
+            module example.shipping
+
+            data Membership = Premium | Standard
+
+            data Delivery = Express | Regular
+
+            data Fee = Int
+                invariant value >= 0
+
+            behavior shippingFee : (member: Membership, delivery: Delivery, rush: Bool) -> Fee
+                constructs Fee
+
+            let baseFee (tier: Membership): Int =
+                match tier with
+                    | Premium -> 0
+                    | Standard -> 500
+
+            let expressFee (speed: Delivery): Int =
+                match speed with
+                    | Express -> 500
+                    | Regular -> 0
+
+            let shippingFee (member, delivery, rush) =
+                Fee(baseFee(member) + expressFee(delivery))
+            """;
+
+    /** A run that did nothing at all, which is a run that missed every combination. */
+    private static final Generator.Watched MISSED =
+            new Generator.Watched.Ran(Observation.NONE);
+
+    /**
+     * A combination every candidate missed is not offered, and is not called impossible.
+     *
+     * <p>Both halves. Offering it would hand an author a row named for a combination it does not
+     * reach; recording it as impossible would say the model settles something it does not. What is
+     * said is that the candidates tried were not witnesses.
+     */
+    @Test
+    void aCombinationEveryCandidateMissedIsLeftUntried() {
+        Model model = Model.of(SHIPPING, "shippingFee");
+
+        Generator.GenerationResult filled = fill(model, _ -> MISSED);
+
+        assertTrue(filled.unresolved().stream().anyMatch(each -> each.reason()
+                        == Generator.UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS),
+                "the combinations were left untried: " + filled.unresolved());
+        assertTrue(filled.unresolved().stream().noneMatch(each -> each.reason()
+                        == Generator.UnresolvedCombination.Reason.THE_RULES_LEAVE_NOTHING_THERE),
+                "and nothing was said to be impossible: " + filled.unresolved());
+    }
+
+    /** A run that did what the combination names takes it out of the offer, by being a witness. */
+    @Test
+    void aCandidateThatArrivedIsOffered() {
+        Model model = Model.of(SHIPPING, "shippingFee");
+        Observation everything = doing(everyClaimOf(model));
+
+        Generator.GenerationResult filled =
+                fill(model, _ -> new Generator.Watched.Ran(everything));
+
+        assertTrue(filled.unresolved().stream().noneMatch(each -> each.reason()
+                        == Generator.UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS),
+                "nothing missed: " + filled.unresolved());
+        assertFalse(filled.rows().isEmpty(), "and the rows are offered");
+    }
+
+    /**
+     * Another assignment is tried, and they are different rows.
+     *
+     * <p>A combination leaves the free position either of its classes, and which one the first
+     * candidate took was this search's choice rather than the combination's. So a candidate that
+     * missed is not the combination's answer — another assignment is composed and run, and the two
+     * are different rows rather than the same one twice.
+     */
+    @Test
+    void anotherAssignmentIsTriedAndItIsADifferentRow() {
+        Model model = Model.of(SHIPPING, "shippingFee");
+        List<List<String>> ran = new ArrayList<>();
+
+        fill(model, inputs -> {
+            ran.add(inputs.stream().map(FixtureTemplate::text).toList());
+            return MISSED;
+        });
+
+        // The two positions the decisions read say which combination a candidate was composed for;
+        // the third is the one they leave free, and is where another assignment differs. Counted
+        // this way and not by how many candidates ran in all: one candidate at each of four
+        // combinations is four runs and no second try.
+        Map<List<String>, Set<List<String>>> byCombination = new java.util.LinkedHashMap<>();
+        for (List<String> row : ran) {
+            byCombination.computeIfAbsent(row.subList(0, 2), _ -> new LinkedHashSet<>()).add(row);
+        }
+        assertFalse(byCombination.isEmpty(), "candidates were composed and run");
+        assertTrue(byCombination.values().stream().anyMatch(rows -> rows.size() > 1),
+                "a combination whose first candidate missed had another composed for it: " + ran);
+        assertEquals(ran.size(), new LinkedHashSet<>(ran).size(),
+                "and no row was run twice: " + ran);
+    }
+
+    /**
+     * Where nothing runs a row, the rows are still offered and the generation says so.
+     *
+     * <p>Silence would read as confirmation. A row nothing ran is worth writing — this is the
+     * account a generation could always give of one — but what it is offered for is a reading of
+     * the body rather than something anything watched, and an author acting on it is acting on
+     * that reading.
+     */
+    @Test
+    void rowsNothingRanAreOfferedAndSaidToBeUnconfirmed() {
+        Model model = Model.of(SHIPPING, "shippingFee");
+
+        Generator.GenerationResult filled = fill(model, Generator.Trial.NOTHING_RUNS);
+
+        assertFalse(filled.rows().isEmpty(), "the rows are offered");
+        assertEquals(1, filled.reasons().stream()
+                        .filter(GenerationReason.RowsNotConfirmed.class::isInstance).count(),
+                "and the generation says once that nothing ran them: " + filled.reasons());
+    }
+
+    private static Generator.GenerationResult fill(Model model, Generator.Trial trial) {
+        return Generator.fill(model.subject(), List.of(), Generator.CandidateCheck.ANY,
+                model.groups(), trial);
+    }
+
+    /** Every claim any combination of the model makes, so that one run answers all of them. */
+    private static List<ControlClaim> everyClaimOf(Model model) {
+        List<ControlClaim> out = new ArrayList<>();
+        for (InteractionCells.Group group : InteractionCells.of(model.groups(),
+                model.subject().axes())) {
+            for (int index = 0; index < group.size(); index++) {
+                CellSelection selection = group.at(index);
+                if (selection != null) {
+                    out.addAll(selection.claims());
+                }
+            }
+        }
+        assertFalse(out.isEmpty(), "the model has combinations to claim anything about");
+        return out;
+    }
+
+    /** A run that did everything {@code claims} names. */
+    private static Observation doing(List<ControlClaim> claims) {
+        Set<Integer> taken = new LinkedHashSet<>();
+        Set<ComparisonOutcome> ways = new LinkedHashSet<>();
+        for (ControlClaim claim : claims) {
+            switch (claim.at()) {
+                case ControlPointId.ArmOccurrence arm -> taken.add(arm.probe().getAsInt());
+                case ControlPointId.ComparisonPoint point -> {
+                    taken.add(point.at().emissionSite());
+                    ways.add(point.way());
+                }
+            }
+        }
+        return new Observation(taken, ways);
+    }
+
+    private record Model(Generator.Subject subject, List<Interaction> groups) {
+
+        static Model of(String source, String behavior) {
+            Compilation compilation = Compilation.ofSource(source, "Main");
+            compilation.answerEverything();
+            String module = compilation.modules().get(0);
+            Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+            Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+            Symbols symbols = Scopes.derived(compilation.db(), module).value();
+            Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
+            assertNotNull(prepared);
+            assertNotNull(sigs);
+            assertNotNull(checked);
+            Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                    .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
+            Sig sig = sigs.get(behavior);
+            InputDomain inputs =
+                    compilation.db().ask(new Adequacy.Inputs(module)).value().get(behavior);
+            assertNotNull(inputs, "the behavior's inputs were read");
+            Core body = checked.behaviorBodies().get(behavior);
+            assertNotNull(body, "the behavior under test has a body");
+            return new Model(new Generator.Subject(
+                    new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
+                            sig.inputTypes(), symbols),
+                    Partitions.of(spec.name(), inputs, symbols).axes()),
+                    Interactions.of(body, CoverageSites.of(checked.behaviorBodies()), inputs,
+                            symbols));
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACandidateThatMissedIsNotOfferedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACandidateThatMissedIsNotOfferedTest.java
@@ -226,8 +226,10 @@ class ACandidateThatMissedIsNotOfferedTest {
             assertNotNull(body, "the behavior under test has a body");
             return new Model(new Generator.Subject(
                     new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
-                            sig.inputTypes(), symbols),
-                    Partitions.of(spec.name(), inputs, symbols).axes()),
+                            sig.inputTypes(), symbols,
+                            souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
+                    Partitions.of(spec.name(), inputs, symbols,
+                            souther.compiler.query.ReadAs.THE_COMPILATION_DOES).axes()),
                     Interactions.of(body, CoverageSites.of(checked.behaviorBodies()), inputs,
                             symbols));
         }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
@@ -9,9 +9,9 @@ import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.ComparisonOutcome;
 import souther.compiler.coverage.ControlClaim;
+import souther.compiler.coverage.Observation;
 import souther.compiler.coverage.ControlPointId;
 import souther.compiler.coverage.CoverageSites;
-import souther.compiler.coverage.Observation;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.interaction.Interaction;
 import souther.compiler.interaction.Interactions;
@@ -75,15 +75,16 @@ class ARowNothingRanFillsNoCombinationTest {
             """;
 
     /**
-     * A row nothing ran leaves every combination owed; the same row, run, fills the one it did.
+     * A row is counted against a combination on what a run says, and on what kind of row it is.
      *
-     * <p>The two halves are one assertion made twice, because either alone says nothing. That the
-     * unseen row leaves the combination owed could be a generator that offers it regardless; that
-     * the seen row takes it away could be a generator that counts any row sitting in the classes.
-     * Together they say the difference is the run.
+     * <p>Three rows, one set of values. Seen doing what the combination names, it fills it. Seen
+     * doing something else, it does not — which is the whole of this issue: the values sit in the
+     * classes either way, and the reading that put them there is what was wrong. And where nothing
+     * could watch it, an author's row is given the benefit of it, because a combination re-offered
+     * over a row already in the file is a specific piece of work handed to someone who has done it.
      */
     @Test
-    void aRowIsCountedAgainstACombinationOnlyWhereARunSaysItFilledIt() {
+    void aRowIsCountedAgainstACombinationOnWhatARunSaysAndOnWhoseRowItIs() {
         Model model = Model.of(SHIPPING, "shippingFee");
         List<InteractionCells.Group> groups =
                 InteractionCells.of(model.groups(), model.subject().axes());
@@ -93,22 +94,25 @@ class ARowNothingRanFillsNoCombinationTest {
         assertFalse(first.claims().isEmpty(), "which a run can be held to");
 
         Map<AxisId, Classification> sitting = at(model.subject().axes(), first);
-
-        List<String> unseen = classesOffered(model, Generator.ObservedRow.unseen(sitting));
-        List<String> seen = classesOffered(model,
-                new Generator.ObservedRow(sitting, doing(first.claims())));
-
         String combination = labelOf(model.subject().axes(), sitting);
-        assertTrue(unseen.contains(combination),
-                "a row nothing ran fills no combination, so this one is still owed: " + unseen);
-        assertFalse(seen.contains(combination),
-                "and the same row, seen doing what the combination names, fills it: " + seen);
+
+        assertFalse(offeredFor(model, new Generator.Watched.Ran(doing(first.claims())))
+                        .contains(combination),
+                "a row seen doing what the combination names fills it");
+        assertTrue(offeredFor(model, new Generator.Watched.Ran(Observation.NONE))
+                        .contains(combination),
+                "a row seen doing something else leaves it owed, sit where its values may");
+        assertFalse(offeredFor(model, new Generator.Watched.Unrecorded()).contains(combination),
+                "and a row of the author's that nothing could watch is given the benefit of it");
     }
 
-    /** What the generator offers, as the classes each row is offered for. */
-    private static List<String> classesOffered(Model model, Generator.ObservedRow written) {
-        return Generator.fill(model.subject(), List.of(written), Generator.CandidateCheck.ANY,
-                        model.groups())
+    /** What the generator offers when this row is already written, as the classes of each. */
+    private static List<String> offeredFor(Model model, Generator.Watched watched) {
+        List<InteractionCells.Group> groups =
+                InteractionCells.of(model.groups(), model.subject().axes());
+        Map<AxisId, Classification> sitting = at(model.subject().axes(), groups.get(0).at(0));
+        return Generator.fill(model.subject(), List.of(new Generator.ObservedRow(sitting, watched)),
+                        Generator.CandidateCheck.ANY, model.groups())
                 .rows().stream().map(Generator.GeneratedRow::description).toList();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
@@ -181,14 +181,15 @@ class ARowNothingRanFillsNoCombinationTest {
                     .ask(new souther.compiler.query.Adequacy.Inputs(module)).value()
                     .get(behavior);
             assertNotNull(inputs, "the behavior's inputs were read");
-            Partitions.Partitioning partitioning =
-                    Partitions.of(spec.name(), inputs, symbols);
+            Partitions.Partitioning partitioning = Partitions.of(spec.name(), inputs, symbols,
+                    souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
             Core body = checked.behaviorBodies().get(behavior);
             assertNotNull(body, "the behavior under test has a body");
             CoverageSites.Plan plan = CoverageSites.of(checked.behaviorBodies());
             return new Model(new Generator.Subject(
                     new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
-                            sig.inputTypes(), symbols),
+                            sig.inputTypes(), symbols,
+                            souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
                     partitioning.axes()),
                     Interactions.of(body, plan, inputs, symbols));
         }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
@@ -1,0 +1,192 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.coverage.ComparisonOutcome;
+import souther.compiler.coverage.ControlClaim;
+import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.coverage.Observation;
+import souther.compiler.inputs.InputDomain;
+import souther.compiler.interaction.Interaction;
+import souther.compiler.interaction.Interactions;
+import souther.compiler.observe.Classification;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What fills a combination of a body's decisions, and what only looks like it.
+ *
+ * <p>A combination is a path through the body and an outcome at each decision that meets on it. What
+ * fills one is a run that took that path and settled them those ways. Sitting in the classes the
+ * combination leaves open is what the reading expected of such a run — and the step from the
+ * decisions to the classes is a reading, which can be wrong while looking right.
+ *
+ * <p>So this puts the same row in twice, once with a run behind it and once with nothing, and asks
+ * what is still owed. The row's values are the same both times; only whether anything watched it
+ * differs.
+ */
+class ARowNothingRanFillsNoCombinationTest {
+
+    /** Two decisions, one per input, consumed into one value. Both are matched on, so the classes a
+     * row sits in are the declared cases and no threshold is needed to divide anything. */
+    private static final String SHIPPING = """
+            module example.shipping
+
+            data Membership = Premium | Standard
+
+            data Delivery = Express | Regular
+
+            data Fee = Int
+                invariant value >= 0
+
+            behavior shippingFee : (member: Membership, delivery: Delivery) -> Fee
+                constructs Fee
+
+            let baseFee (tier: Membership): Int =
+                match tier with
+                    | Premium -> 0
+                    | Standard -> 500
+
+            let expressFee (speed: Delivery): Int =
+                match speed with
+                    | Express -> 500
+                    | Regular -> 0
+
+            let shippingFee (member, delivery) =
+                Fee(baseFee(member) + expressFee(delivery))
+            """;
+
+    /**
+     * A row nothing ran leaves every combination owed; the same row, run, fills the one it did.
+     *
+     * <p>The two halves are one assertion made twice, because either alone says nothing. That the
+     * unseen row leaves the combination owed could be a generator that offers it regardless; that
+     * the seen row takes it away could be a generator that counts any row sitting in the classes.
+     * Together they say the difference is the run.
+     */
+    @Test
+    void aRowIsCountedAgainstACombinationOnlyWhereARunSaysItFilledIt() {
+        Model model = Model.of(SHIPPING, "shippingFee");
+        List<InteractionCells.Group> groups =
+                InteractionCells.of(model.groups(), model.subject().axes());
+        assertEquals(1, groups.size(), "the two decisions meet once");
+        CellSelection first = groups.get(0).at(0);
+        assertNotNull(first, "and its first choice is a combination");
+        assertFalse(first.claims().isEmpty(), "which a run can be held to");
+
+        Map<AxisId, Classification> sitting = at(model.subject().axes(), first);
+
+        List<String> unseen = classesOffered(model, Generator.ObservedRow.unseen(sitting));
+        List<String> seen = classesOffered(model,
+                new Generator.ObservedRow(sitting, doing(first.claims())));
+
+        String combination = labelOf(model.subject().axes(), sitting);
+        assertTrue(unseen.contains(combination),
+                "a row nothing ran fills no combination, so this one is still owed: " + unseen);
+        assertFalse(seen.contains(combination),
+                "and the same row, seen doing what the combination names, fills it: " + seen);
+    }
+
+    /** What the generator offers, as the classes each row is offered for. */
+    private static List<String> classesOffered(Model model, Generator.ObservedRow written) {
+        return Generator.fill(model.subject(), List.of(written), Generator.CandidateCheck.ANY,
+                        model.groups())
+                .rows().stream().map(Generator.GeneratedRow::description).toList();
+    }
+
+    /** One class per divided position, taken from the one class the combination leaves there. */
+    private static Map<AxisId, Classification> at(List<Axis> axes, CellSelection selection) {
+        Map<AxisId, Classification> out = new java.util.LinkedHashMap<>();
+        for (int i = 0; i < axes.size(); i++) {
+            out.put(axes.get(i).id(), Classification.in(axes.get(i).classes().get(only(selection, i))
+                    .id()));
+        }
+        return out;
+    }
+
+    /** Which single class the combination leaves the position, the model having one per outcome. */
+    private static int only(CellSelection selection, int axis) {
+        for (int c = 0; c < selection.cell().allowed()[axis].length; c++) {
+            if (selection.cell().admits(axis, c)) {
+                return c;
+            }
+        }
+        throw new AssertionError("a combination leaves every position something");
+    }
+
+    /** How the generator names a row sitting at these classes. */
+    private static String labelOf(List<Axis> axes, Map<AxisId, Classification> sitting) {
+        List<String> parts = axes.stream()
+                .map(axis -> axis.term() + "="
+                        + ((Classification.Classified) sitting.get(axis.id())).classId())
+                .toList();
+        return String.join(" x ", parts);
+    }
+
+    /** A run that did everything {@code claims} names and nothing else. */
+    private static Observation doing(List<ControlClaim> claims) {
+        Set<Integer> taken = new LinkedHashSet<>();
+        Set<ComparisonOutcome> ways = new LinkedHashSet<>();
+        for (ControlClaim claim : claims) {
+            switch (claim.at()) {
+                case ControlPointId.ArmOccurrence arm -> taken.add(arm.probe().getAsInt());
+                case ControlPointId.ComparisonPoint point -> {
+                    taken.add(point.at().emissionSite());
+                    ways.add(point.way());
+                }
+            }
+        }
+        return new Observation(taken, ways);
+    }
+
+    private record Model(Generator.Subject subject, List<Interaction> groups) {
+
+        static Model of(String source, String behavior) {
+            Compilation compilation = Compilation.ofSource(source, "Main");
+            compilation.answerEverything();
+            String module = compilation.modules().get(0);
+            Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+            Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+            Symbols symbols = Scopes.derived(compilation.db(), module).value();
+            Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
+            assertNotNull(prepared);
+            assertNotNull(sigs);
+            assertNotNull(checked);
+            Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                    .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
+            Sig sig = sigs.get(behavior);
+            InputDomain inputs = compilation.db()
+                    .ask(new souther.compiler.query.Adequacy.Inputs(module)).value()
+                    .get(behavior);
+            assertNotNull(inputs, "the behavior's inputs were read");
+            Partitions.Partitioning partitioning =
+                    Partitions.of(spec.name(), inputs, symbols);
+            Core body = checked.behaviorBodies().get(behavior);
+            assertNotNull(body, "the behavior under test has a body");
+            CoverageSites.Plan plan = CoverageSites.of(checked.behaviorBodies());
+            return new Model(new Generator.Subject(
+                    new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
+                            sig.inputTypes(), symbols),
+                    partitioning.axes()),
+                    Interactions.of(body, plan, inputs, symbols));
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
@@ -102,8 +102,8 @@ class ARowNothingRanFillsNoCombinationTest {
         assertTrue(offeredFor(model, new Generator.Watched.Ran(Observation.NONE))
                         .contains(combination),
                 "a row seen doing something else leaves it owed, sit where its values may");
-        assertFalse(offeredFor(model, new Generator.Watched.Unrecorded()).contains(combination),
-                "and a row of the author's that nothing could watch is given the benefit of it");
+        assertFalse(offeredFor(model, new Generator.Watched.NoAccount()).contains(combination),
+                "and a row of the author's nothing could watch is withheld over, not counted");
     }
 
     /** What the generator offers when this row is already written, as the classes of each. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ASelectionsClassesAndClaimsAreOfTheSameChoiceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ASelectionsClassesAndClaimsAreOfTheSameChoiceTest.java
@@ -1,0 +1,131 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.coverage.ControlClaim;
+import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.Observation;
+
+import java.util.List;
+import java.util.OptionalInt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A combination's classes and its claims are two halves of one choice.
+ *
+ * <p>Which combination of a group is being asked for is an index counted off the ways of settling
+ * each factor. Both halves are read off that index — which classes are left open, and what a run
+ * that settled the factors those ways would be seen to have done — so the two are the same choice
+ * only for as long as they are counted off the same way. Read apart they would agree for a group of
+ * one factor, agree for a square group by luck, and part on the first group whose factors have
+ * different numbers of ways.
+ *
+ * <p>Built here rather than read off a model. A group of two factors with different widths and
+ * choices that leave a position nothing is a shape a model in the corpus need not have, and a
+ * mechanism is untested for shapes its data never takes.
+ */
+class ASelectionsClassesAndClaimsAreOfTheSameChoiceTest {
+
+    /** One position with four classes; nothing said about it yet. */
+    private static InteractionCells.Cell holding(int... classes) {
+        boolean[] allowed = new boolean[4];
+        for (int each : classes) {
+            allowed[each] = true;
+        }
+        return new InteractionCells.Cell(new boolean[][] {allowed});
+    }
+
+    /** A place a run can be recorded at, told from its neighbours by the probe it carries. */
+    private static ControlClaim at(int probe) {
+        return ControlClaim.of(new ControlPointId.ArmOccurrence(probe, OptionalInt.of(probe),
+                        null, null))
+                .orElseThrow(() -> new AssertionError("an arm with a probe can be claimed"));
+    }
+
+    private static Observation lit(int... probes) {
+        java.util.Set<Integer> taken = new java.util.LinkedHashSet<>();
+        for (int each : probes) {
+            taken.add(each);
+        }
+        return new Observation(taken, java.util.Set.of());
+    }
+
+    /**
+     * Every combination's claims are the claims of the ways it settles the factors.
+     *
+     * <p>The factors have three ways and two, so an index read off them in a different order picks a
+     * different pair — which is what makes the classes that survive say which pair was picked. Each
+     * of the six is checked, so a swap that happens to be its own inverse for one of them does not
+     * pass.
+     */
+    @Test
+    void aCombinationsClaimsAreOfTheWaysItsClassesCameFrom() {
+        InteractionCells.Group group = new InteractionCells.Group(
+                new InteractionCells.Placed(holding(0, 1, 2, 3), List.of(at(9))),
+                List.of(
+                        List.of(new InteractionCells.Placed(holding(0, 1), List.of(at(10))),
+                                new InteractionCells.Placed(holding(2), List.of(at(11))),
+                                new InteractionCells.Placed(holding(3), List.of(at(12)))),
+                        List.of(new InteractionCells.Placed(holding(0, 2, 3), List.of(at(20))),
+                                new InteractionCells.Placed(holding(1, 2, 3), List.of(at(21))))));
+
+        assertEquals(6, group.size(), "three ways and two ways");
+        List<List<Integer>> byIndex = List.of(
+                List.of(0, 9, 10, 20), List.of(2, 9, 11, 20), List.of(3, 9, 12, 20),
+                List.of(1, 9, 10, 21), List.of(2, 9, 11, 21), List.of(3, 9, 12, 21));
+        for (int index = 0; index < byIndex.size(); index++) {
+            CellSelection selection = group.at(index);
+            List<Integer> expected = byIndex.get(index);
+            assertTrue(selection.cell().admits(0, expected.get(0)),
+                    "combination " + index + " leaves the class its two ways share");
+            assertEquals(expected.subList(1, expected.size()).stream().map(
+                            ASelectionsClassesAndClaimsAreOfTheSameChoiceTest::at).toList(),
+                    selection.claims(),
+                    "and claims the way in and the two ways it settles the factors");
+        }
+    }
+
+    /** A choice whose ways leave the position nothing is not a combination, and carries no claim. */
+    @Test
+    void aChoiceWithNothingLeftIsNotACombination() {
+        InteractionCells.Group group = new InteractionCells.Group(
+                new InteractionCells.Placed(holding(0, 1, 2, 3), List.of()),
+                List.of(
+                        List.of(new InteractionCells.Placed(holding(0), List.of(at(10))),
+                                new InteractionCells.Placed(holding(1), List.of(at(11)))),
+                        List.of(new InteractionCells.Placed(holding(0), List.of(at(20))),
+                                new InteractionCells.Placed(holding(1), List.of(at(21))))));
+
+        assertEquals(2, group.left(0), "two of the four choices are combinations");
+        assertNull(group.at(1), "the first way of one factor and the second of the other agree "
+                + "on nothing");
+        assertNull(group.at(2), "nor the other way round");
+    }
+
+    /**
+     * A combination is certified by a run that did everything it names, and by nothing less.
+     *
+     * <p>What is missing is answered rather than only whether anything is: a row that did not take
+     * the way in and a row that took it and settled a factor the other way are two different things
+     * to be told, and a reading that answered `no` to both would send the same sentence for each.
+     */
+    @Test
+    void aCombinationIsCertifiedByARunThatDidEverythingItNames() {
+        InteractionCells.Group group = new InteractionCells.Group(
+                new InteractionCells.Placed(holding(0, 1, 2, 3), List.of(at(9))),
+                List.of(List.of(new InteractionCells.Placed(holding(0, 1), List.of(at(10))),
+                        new InteractionCells.Placed(holding(2, 3), List.of(at(11))))));
+        CellSelection selection = group.at(0);
+
+        assertTrue(selection.certifiedBy(lit(9, 10)), "a run that did both did this combination");
+        assertEquals(List.of(at(10)), selection.missedBy(lit(9, 11)),
+                "a run that reached the meeting and settled the factor the other way missed that");
+        assertEquals(List.of(at(9)), selection.missedBy(lit(10)),
+                "and one that settled the factor without taking the way in missed the way in");
+        assertFalse(selection.certifiedBy(lit(9)), "neither of which certifies it");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ASelectionsClassesAndClaimsAreOfTheSameChoiceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ASelectionsClassesAndClaimsAreOfTheSameChoiceTest.java
@@ -107,6 +107,33 @@ class ASelectionsClassesAndClaimsAreOfTheSameChoiceTest {
     }
 
     /**
+     * A witness is made out of a run, and out of nothing else.
+     *
+     * <p>What a witness says is that this row filled this combination, which is the one conclusion
+     * here a reader may act on. A caller holding the classes a row sits in cannot reach for one, so
+     * the reading that composed a row cannot come back as evidence for itself.
+     */
+    @Test
+    void aWitnessIsMadeOnlyFromARunThatDidWhatTheCombinationNames() {
+        InteractionCells.Group group = new InteractionCells.Group(
+                new InteractionCells.Placed(holding(0, 1, 2, 3), List.of(at(9))),
+                List.of(List.of(new InteractionCells.Placed(holding(0, 1), List.of(at(10))),
+                        new InteractionCells.Placed(holding(2, 3), List.of(at(11))))));
+        CellSelection selection = group.at(0);
+        int[] where = {0};
+
+        assertTrue(selection.certifying(where, lit(9, 10)).isPresent(),
+                "a run that did both makes one");
+        assertTrue(selection.certifying(where, lit(9, 11)).isEmpty(),
+                "a run that settled the factor the other way makes none");
+        assertTrue(selection.certifying(where, lit(10)).isEmpty(),
+                "nor one that never took the way in");
+        assertEquals(selection,
+                selection.certifying(where, lit(9, 10)).orElseThrow().of(),
+                "and the one it makes says which combination it filled");
+    }
+
+    /**
      * A combination is certified by a run that did everything it names, and by nothing less.
      *
      * <p>What is missing is answered rather than only whether anything is: a row that did not take

--- a/souther-compiler/src/test/java/souther/compiler/partition/ASelectionsClassesAndClaimsAreOfTheSameChoiceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ASelectionsClassesAndClaimsAreOfTheSameChoiceTest.java
@@ -12,6 +12,7 @@ import java.util.OptionalInt;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -104,6 +105,43 @@ class ASelectionsClassesAndClaimsAreOfTheSameChoiceTest {
         assertNull(group.at(1), "the first way of one factor and the second of the other agree "
                 + "on nothing");
         assertNull(group.at(2), "nor the other way round");
+    }
+
+    /**
+     * A witness takes both halves: the row sits where the combination leaves room, and the run did
+     * what it names.
+     *
+     * <p>Either alone is a different statement. A run that did everything the combination names,
+     * paired with a row sitting somewhere the combination excludes, is a witness that some row
+     * filled it and not that this one did — and the value would be handed on to a reader who cannot
+     * tell the difference.
+     */
+    @Test
+    void aWitnessIsOfARowTheCombinationLeavesRoomFor() {
+        InteractionCells.Group group = new InteractionCells.Group(
+                new InteractionCells.Placed(holding(0, 1, 2, 3), List.of(at(9))),
+                List.of(List.of(new InteractionCells.Placed(holding(0, 1), List.of(at(10))),
+                        new InteractionCells.Placed(holding(2, 3), List.of(at(11))))));
+        CellSelection selection = group.at(0);
+
+        assertTrue(selection.certifying(new int[] {1}, lit(9, 10)).isPresent(),
+                "a row the combination leaves room for, seen doing what it names");
+        assertTrue(selection.certifying(new int[] {2}, lit(9, 10)).isEmpty(),
+                "and one sitting where it leaves none is no witness, whatever the run did");
+    }
+
+    /**
+     * A combination of decisions is something a run can be held to.
+     *
+     * <p>Allowed to claim nothing, it would be a combination every run certifies — including one
+     * that did nothing at all. A claim dropped by whatever reads the body would then come back not
+     * as a combination nothing can witness, which is loud, but as one everything does, which is
+     * silent and wrong.
+     */
+    @Test
+    void aCombinationClaimingNothingIsNotOne() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new CellSelection(holding(0, 1), List.of()));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
@@ -161,7 +161,8 @@ class GeneratorTest {
                 new AxisId("submit", "request.urgent"), Classification.in("true"));
 
         Generator.GenerationResult filled =
-                Generator.fill(subject, List.of(written), Generator.CandidateCheck.ANY);
+                Generator.fill(subject, List.of(Generator.ObservedRow.unseen(written)),
+                        Generator.CandidateCheck.ANY);
 
         assertEquals(3, filled.rows().size());
         assertTrue(filled.rows().stream()

--- a/souther-compiler/src/test/java/souther/compiler/report/WhatAGenerationHeldBackIsSaidInWordsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/WhatAGenerationHeldBackIsSaidInWordsTest.java
@@ -1,0 +1,50 @@
+package souther.compiler.report;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.partition.GenerationReason;
+import souther.compiler.partition.Generator;
+import souther.compiler.query.Adequacy;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a generation that held work back says to the author.
+ *
+ * <p>The sentence is the whole of why this reason exists. A combination passed over because a row
+ * already written sits where a filling row would is one nothing established anything about, and
+ * saying nothing about it reads as one that is covered. So the line is held to word for word:
+ * printed with its parts in the wrong places it names a behavior where a count belongs and reads as
+ * being about something else entirely, which is a sentence that says nothing and looks like it says
+ * something.
+ */
+class WhatAGenerationHeldBackIsSaidInWordsTest {
+
+    @Test
+    void oneCombinationHeldBackNamesItsBehaviorAndSaysWhatIsUnknown() {
+        assertTrue(said(new GenerationReason.CombinationsWithheld("shippingFee", 1)).contains(
+                        "// 1 combination for `shippingFee` offered no row: one already written"
+                                + " sits where a row filling it would, and nothing ran to say"
+                                + " whether it does"),
+                said(new GenerationReason.CombinationsWithheld("shippingFee", 1)));
+    }
+
+    @Test
+    void severalAreCountedAsSeveral() {
+        assertTrue(said(new GenerationReason.CombinationsWithheld("shippingFee", 3))
+                        .contains("// 3 combinations for `shippingFee` offered no row:"),
+                said(new GenerationReason.CombinationsWithheld("shippingFee", 3)));
+    }
+
+    private static String said(GenerationReason why) {
+        return GeneratedRows.of("example.shipping",
+                Map.of("shippingFee", new Adequacy.Filling(
+                        new Generator.GenerationResult(List.of(), List.of(), List.of(why)),
+                        Generator.GenerationResult.NONE, List.of())),
+                Map.of(), false, SourceNameResolver.identity());
+    }
+}


### PR DESCRIPTION
Closes #909.

## What was wrong

`Generator` composes a row for a combination of a body's decisions by narrowing
each input position to the classes the combination admits, choosing one, and
building a value in it. Nothing afterwards asked whether running the behavior on
that row took the path the combination names and settled each factor at the
outcome it names. The row was offered, and named, for a combination nobody
confirmed it sits in.

Every step from the decisions to the classes is a reading of the body, and a row
whose values sit in the classes while its run goes elsewhere is what any of those
readings being wrong produces — indistinguishable from a row that arrives. That
is why four separate misreadings in the review of #905 all came out looking
alike: there was no boundary at which a reading could be shown wrong.

So the change is not a probe check bolted onto the generator. It is the
distinction between what a reading admits and what a run certifies, made
structural.

## What is now held to

**A coverage item's evidence is decided by what kind of item it is.** Of the
places something becomes covered or stops being owed, some name a path through
the body (arms, borders, interaction cells) and some name only where an input's
value sits (pairs, axis classes). Certification applies to the first; requiring
it of the second would be inventing a claim they do not have. Arms were already
run-certified; cells are now.

**Observation is its own vocabulary.** A claim is an occurrence and a way out,
independent of how the search happens to classify decisions. Nothing recovers a
claim from control flow: the emitter hands the comparison's value over.

**A claim proved by a set is a claim about a place a run passes once.** A
recording says which places a run passed, not how many times. Stated as that
rather than as "the reading does not go inside a function value", which is the
current means of satisfying it.

**A row is counted only where a run says it filled something.** `CertifiedWitness`
is produced by `CellSelection` out of an observation and by nothing else, so a
caller holding a row's classes cannot assert that it fills a combination.

## Changes

- `ComparisonOccurrence` / `ComparisonOutcome` / `Observation`; `Probe` keeps one
  recording per thread and answers with a snapshot. `Probe.compared` records the
  comparison reached and the way it came out in one call, so the implication
  between them holds by construction. Site numbering is unchanged.
- `ForkOccurrence`, minted with the arms it belongs to. Outside `codegen` no bare
  number is used as a semantic join key any more — `Observation` still holds the
  sites a run lit as ints, which is what a recording is; what changed is that
  nothing decides what a place *means* by matching one.
- `Decision` pairs a `Condition` with a `ControlClaim`, made together off the node
  the walk is looking at. A decision whose place carries no probe cannot be named,
  and what was being built on it goes.
- `CellSelection` carries a combination's classes and its claims, read off one
  index at one point.
- `Generator.sits` splits into `admits` and `fills`. Existing rows bring their run
  with their classes; a row this generation composed and nothing ran fills nothing.
- `Trial` runs a composed row; a candidate that missed is dropped and another
  distinct assignment is tried, bounded per combination.
  `NO_CERTIFIED_WITNESS` leaves the combination untried and writes nothing into
  proven-impossible (ADR-0091). Where nothing can run a row, the rows are offered
  as before and the generation says once that nothing watched them.
- `RowTrial` runs them against this module's own classes. A build not measuring
  the arms gets no trial at all: classes without the recording calls give a run
  that reads exactly like one that went nowhere, and confirming against them would
  offer nothing.

## What is proved, and what is merely not offered

Only a `CertifiedWitness` says a combination is filled, and only a run makes one.
Separately from that, a row already in the author's file may address a
combination — and where nothing could say whether it does, offering another would
hand back work already done. That withholding is not evidence and is not silent:
the generation says how many combinations it held back and why, so an author can
tell "all done" from "nothing here could tell". A build that measures withholds
nothing, its written rows either filling the combinations or leaving them owed.

## Where a row is offered without being certified

A build that does not measure the arms records nothing of any run, so nothing
about it can be certified. Its rows are offered as they always were, named for
the combination the reading says they fill, and the generation says once that
nothing watched them. So this is not a guarantee that every row named for a
combination was seen reaching it — read as *never offer an uncertified row*,
this is the exception, and it is deliberate.

What it does not do is let such a row stand as evidence. A row nothing could
watch certifies no combination, so coverage is decided by the same rule either
way; what differs is only what is offered and what is said about it.

## Evidence

`CI=1 mvn -o clean verify -Plint` green across the reactor, 9,144 tests.

Over the suite the live path runs 226 composed rows and every one of them
arrived — the first evidence that the reading of the body and what the rows
actually do agree.

Every new test was checked by breaking the mechanism it is about:
inverting a recorded outcome, recording no outcome, recording an outcome without
its site, removing the repetition guard and its marking, letting certification
through, allowing one candidate only, removing the measuring gate, and making a
witness out of any run, certifying a row the combination excludes, allowing a
combination that claims nothing, letting an `Observation` hold a way out of a
comparison it says was never reached, and removing the answer that says nothing
applied the row.

One measurement changed the change: a gate deciding from a behavior's
declaration that it could not be run turned out never to be needed, because the
layer that applies a row already says so precisely. Two answers to one question,
and the redundant one is gone.

## Deliberately left out

Accumulating what candidates missed, so that a repeated miss reads as a suspect
inference. It would add a reported category and four exhaustive-switch arms to
carry nothing: there are no misses in the corpus. It becomes worth having the
first time a real one appears, when `NO_CERTIFIED_WITNESS` saying only "no row
here" is what gets in the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

