### PR TITLE
Settle what a module emits from expanding it, not from predicting it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ast/Hir.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Hir.java
@@ -332,6 +332,18 @@ public interface Hir {
      * impossible. The arity says something has to be passed; that it is this module's own is what a
      * reader of the rebuild has to see, which is why every one of them names it.
      */
+    /**
+     * A module at whatever stage the pass holding it has reached.
+     *
+     * <p>{@code takenOn} is the methods a lowered module emits beyond the ones it declared: a
+     * recursion an expansion of it could not remove, and a value minted for one of its rows. It is
+     * empty at every stage before lowering and is written there and nowhere else. It once carried a
+     * prediction — worked out by walking the places a module writes expressions, before any of those
+     * expressions had been expanded — and a tree that walk did not know to look at contributed
+     * nothing, which is how a rule reaching a quantifier came to be compiled without the fold it
+     * became. What a module emits follows from expanding it, so it is not knowable here until it has
+     * been.
+     */
     record Module(String name,
                   List<String> exposing,
                   Map<String, RetType> exposedOutputs,

--- a/souther-compiler/src/main/java/souther/compiler/ast/Hir.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Hir.java
@@ -313,13 +313,20 @@ public interface Hir {
      *
      * <p>{@code fns} is what the source wrote, and it stays that at every stage. {@code takenOn} is
      * what the module emits as methods of its own without having written them, which is two kinds of
-     * definition: a recursive helper it reaches, which cannot be inlined and has to be lowered
-     * somewhere, and a definition minted for what a row writes at a position, which has no call site
-     * to be inlined into. The first may be declared by the standard library or by a module that
-     * published it; the second is this module's own and is no {@code let}. Only {@code fns} is
-     * declared here, and no rule reads a name to tell any of them apart — {@code List.foldFrom} is
-     * reached under the library's alias and declared in {@code souther.list}, and a row's method is
-     * spelled in no source at all ({@link FnDef#role}).
+     * definition: a recursion an expansion of this module could not remove, which has to be lowered
+     * somewhere because expanding it would not terminate, and a definition minted for what a row
+     * writes at a position, which has no call site to be inlined into. The first may be declared by
+     * the standard library or by a module that published it; the second is this module's own and is
+     * no {@code let}. Only {@code fns} is declared here, and no rule reads a name to tell any of
+     * them apart — {@code List.foldFrom} is reached under the library's alias and declared in
+     * {@code souther.list}, and a row's method is spelled in no source at all ({@link FnDef#role}).
+     *
+     * <p>{@code takenOn} is written where the module is lowered and nowhere else, and is empty at
+     * every stage before that. What a module emits follows from expanding it, so it is not knowable
+     * earlier: it once carried a prediction, worked out by walking the places a module writes
+     * expressions before any of them had been expanded, and a tree that walk did not know to look at
+     * contributed nothing — which is how a rule reaching a quantifier came to be compiled without
+     * the fold it became.
      *
      * <p>Two components rather than one list a later pass appends to. Appended, every reader asking
      * what the module declared got what it declared before {@link
@@ -331,18 +338,6 @@ public interface Hir {
      * methods its bodies call missing, which is the failure this separation is here to make
      * impossible. The arity says something has to be passed; that it is this module's own is what a
      * reader of the rebuild has to see, which is why every one of them names it.
-     */
-    /**
-     * A module at whatever stage the pass holding it has reached.
-     *
-     * <p>{@code takenOn} is the methods a lowered module emits beyond the ones it declared: a
-     * recursion an expansion of it could not remove, and a value minted for one of its rows. It is
-     * empty at every stage before lowering and is written there and nowhere else. It once carried a
-     * prediction — worked out by walking the places a module writes expressions, before any of those
-     * expressions had been expanded — and a tree that walk did not know to look at contributed
-     * nothing, which is how a rule reaching a quantifier came to be compiled without the fold it
-     * became. What a module emits follows from expanding it, so it is not knowable here until it has
-     * been.
      */
     record Module(String name,
                   List<String> exposing,

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -577,12 +577,24 @@ public final class CallElaborator {
             }
             return applySignature(call, fn, ca, expected, env, ctx).result();
         }
-        // A library name that matched no builtin or intrinsic above is a wrong stdlib call
-        // (spec §stdlib) — reported as that, not as a missing behavior. Asked of which kind
-        // of name this reaches and not of whether the spelling holds a dot: a field read
-        // applied (`deps.count(x)`) is quoted with a dot in it and reaches a binding, and
-        // what is wrong with it is that it is not a function, which the report below says.
+        // A library name that matched no builtin or intrinsic above. Which of the two it is the
+        // library says, and the two are not one report. A name it declares reached here without
+        // having been expanded or bound, and neither is something an author can write or undo —
+        // it is this compiler disagreeing with itself, which is what the helper arm below says of
+        // the same failure and is said the same way here. A spelling it declares nothing under is
+        // a wrong stdlib call (spec §stdlib) and is reported as that, not as a missing behavior.
+        //
+        // A sugar declares nothing, so a call of one that got this far is a call the rewrite did
+        // not take: `List.fold` written with two arguments is not the three-argument call it is
+        // sugar for, and what is wrong with it is what was written.
+        //
+        // Asked of which kind of name this reaches and not of whether the spelling holds a dot: a
+        // field read applied (`deps.count(x)`) is quoted with a dot in it and reaches a binding,
+        // and what is wrong with it is that it is not a function, which the report below says.
         if (callee.reachedAs() instanceof ReachName.OfLibrary) {
+            if (entry != null) {
+                throw unelaborated("a standard-library function", call);
+            }
             throw CompileException.of(Diagnostic
                             .at(call.appliedAt()).say(new NameMessage.NotAStandardLibraryFunction(call.written())).build());
         }
@@ -591,9 +603,8 @@ public final class CallElaborator {
         // which is this compiler having failed to do one of them rather than anything the
         // author wrote. Said outright: reported as a wrong library call, it named a library
         // the author never wrote.
-        if (callee.denotes() instanceof ValueName.Helper helper) {
-            throw new IllegalStateException("`" + helper + "` was neither expanded nor"
-                    + " bound before the call to it at " + call.pos() + " was typed");
+        if (callee.denotes() instanceof ValueName.Helper) {
+            throw unelaborated("a helper", call);
         }
         // a required behavior called inline (spec §unmarked-output, §fn), or one that requires nothing and
         // is called by name (spec [#calling-a-behavior]). Both are typed against the callee's

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseHelpers.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseHelpers.java
@@ -51,10 +51,14 @@ public final class ClauseHelpers {
      * the spelling the table is keyed by — {@link HelperNames#qualifyImports} does it again for the
      * bodies below, and says the same thing both times.
      */
-    static Hir.Module withSettledInvariants(Hir.Module m, Symbols symbols,
-                                            Map<String, Hir.FnDef> published) {
+    static Expansion<Hir.Module> withSettledInvariants(Hir.Module m, Symbols symbols,
+                                                       Map<String, Hir.FnDef> published) {
         Hir.Module settled = settled(m, symbols);
-        return withInlinedInvariants(HelperInliner.forModule(settled, published), settled);
+        HelperInliner inliner = HelperInliner.forModule(settled, published);
+        // What these expansions could not remove comes back with what they produced. A clause is the
+        // one place a module writes an expression that is not a definition, so a recursion reached
+        // from one is reached from nowhere a reader of the module's declarations would look.
+        return new Expansion<>(withInlinedInvariants(inliner, settled), inliner.leftStanding());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Expansion.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Expansion.java
@@ -1,0 +1,45 @@
+package souther.compiler.check;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.SequencedSet;
+
+/**
+ * What an expansion produced, and what it could not remove.
+ *
+ * <p>Expanding a tree answers with the tree, and with the recursive helpers it left calls to
+ * standing. The second is a requirement: a call left standing is a call to a method, and the method
+ * has to be emitted wherever the tree ends up. It is made by the expansion — the decision to leave a
+ * call standing is the moment it becomes true — so it is carried out of the expansion beside what
+ * the expansion produced, rather than worked out again by a reader looking at the module the tree
+ * came from.
+ *
+ * <p>Only what this expansion met. A helper left standing has a body of its own that may reach
+ * further recursions; following that is the call graph's ({@link HelperGraph#reachedFrom}), and a
+ * caller that wants the closure asks for it there. Two answers, because what a tree holds and what
+ * is reachable from what it holds are two questions, and only the first is this one's to know.
+ *
+ * <p>{@code standing} is a {@link SequencedSet} because the order is part of what it says: a reader
+ * reporting one of a mutually-recursive group reports the one it reached first.
+ *
+ * @param value what the expansion produced
+ * @param standing every recursive helper it left a call to, in the order they were met
+ */
+public record Expansion<T>(T value, SequencedSet<String> standing) {
+
+    public Expansion {
+        standing = Collections.unmodifiableSequencedSet(new LinkedHashSet<>(standing));
+    }
+
+    /** An expansion that left nothing standing — what a caller with nothing to expand answers. */
+    public static <T> Expansion<T> of(T value) {
+        return new Expansion<>(value, new LinkedHashSet<>());
+    }
+
+    /** The same value, with {@code more} joined to what this left standing. */
+    public Expansion<T> and(SequencedSet<String> more) {
+        SequencedSet<String> joined = new LinkedHashSet<>(standing);
+        joined.addAll(more);
+        return new Expansion<>(value, joined);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Expansion.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Expansion.java
@@ -15,12 +15,15 @@ import java.util.SequencedSet;
  * came from.
  *
  * <p>Only what this expansion met. A helper left standing has a body of its own that may reach
- * further recursions; following that is the call graph's ({@link HelperGraph#reachedFrom}), and a
- * caller that wants the closure asks for it there. Two answers, because what a tree holds and what
- * is reachable from what it holds are two questions, and only the first is this one's to know.
+ * further recursions; a caller that wants those expands that body and asks it the same question.
+ * Two answers, because what a tree holds and what is reachable from what it holds are two
+ * questions, and only the first is this one's to know — and the second is not a graph's to answer
+ * either, since a body reaches a recursion by reading a value as well as by calling it.
  *
- * <p>{@code standing} is a {@link SequencedSet} because the order is part of what it says: a reader
- * reporting one of a mutually-recursive group reports the one it reached first.
+ * <p>{@code standing} is a {@link SequencedSet} so that a walk over it happens in the order the
+ * expansion met them, which is what keeps a walk driven by several of these from depending on hash
+ * order. It is not what decides how anything is reported: two of these compare as sets, and a reader
+ * that reports in declaration order puts them in it.
  *
  * @param value what the expansion produced
  * @param standing every recursive helper it left a call to, in the order they were met
@@ -29,17 +32,5 @@ public record Expansion<T>(T value, SequencedSet<String> standing) {
 
     public Expansion {
         standing = Collections.unmodifiableSequencedSet(new LinkedHashSet<>(standing));
-    }
-
-    /** An expansion that left nothing standing — what a caller with nothing to expand answers. */
-    public static <T> Expansion<T> of(T value) {
-        return new Expansion<>(value, new LinkedHashSet<>());
-    }
-
-    /** The same value, with {@code more} joined to what this left standing. */
-    public Expansion<T> and(SequencedSet<String> more) {
-        SequencedSet<String> joined = new LinkedHashSet<>(standing);
-        joined.addAll(more);
-        return new Expansion<>(value, joined);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -188,11 +188,10 @@ public final class HelperInliner {
      * The same, with the definitions other modules publish to this one — each under the qualified name
      * it is reached by here, and each already closed by the module that declares it.
      *
-     * <p>They join the inlining map but not {@code own}, which is what makes a recursive one come back
-     * from {@link #injectedRecursiveHelpers} beside the recursive prelude helpers: neither is this
-     * module's to declare, and both are this module's to emit. A module that reaches one only through
-     * another module's body reaches it here too, because the walk that finds them follows calls rather
-     * than imports.
+     * <p>They join the inlining map but not {@code own}: a definition another module published is
+     * one this module expands and not one it declared. Which of them this module ends up emitting is
+     * no part of this — it follows from what expanding this module's trees leaves standing, and is
+     * answered where that is collected.
      */
     public static HelperInliner forModule(Hir.Module module, Map<String, Hir.FnDef> imported) {
         HelperTable table = HelperTable.of(module, imported, InliningPolicy.FULL);
@@ -202,12 +201,11 @@ public final class HelperInliner {
     /**
      * The inlining an expansion needs, over the helpers alone.
      *
-     * <p>Which helper a call expands to, and which calls are left standing because the helper recurses,
-     * follow from the helpers and nothing else — so a body is expanded without reading the bodies
-     * beside it. What does read the whole module is {@link #injectedRecursiveHelpers}: which prelude
-     * recursive helpers a module emits as its own methods is a fact about the module, not about any
-     * one call, and {@link #forModule} is what answers it. A module that has already taken those on as
-     * its own fns has them here like any other helper, so both say the same thing about it.
+     * <p>Which helper a call expands to, and which calls are left standing because the helper
+     * recurses, follow from the helpers and nothing else — so a body is expanded without reading the
+     * bodies beside it. What a module emits is not read here and is not read anywhere from a table:
+     * it is what its expansions left standing, taken from {@link #leftStanding} by whoever drove
+     * them.
      */
     public static HelperInliner forHelpers(String module, Map<String, Hir.FnDef> own) {
         return forHelpers(module, own, InliningPolicy.FULL);

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -346,6 +346,19 @@ public final class HelperInliner {
     private final Set<String> takenOnRecursive = new java.util.LinkedHashSet<>();
 
     /**
+     * Every recursive helper this expansion left a call to standing, by the name it was reached by.
+     *
+     * <p>What the expansion did, not what it was predicted to have to do. A call is left standing
+     * because expanding it would not terminate, and the method it stays a call to has to be
+     * somewhere — so the requirement is made at the moment the decision is, by whoever made it,
+     * rather than worked out again from the places a module writes expressions.
+     *
+     * <p>In the order they were met, because a reader reporting one of a group reports the one it
+     * reached first.
+     */
+    private final java.util.SequencedSet<String> leftStanding = new java.util.LinkedHashSet<>();
+
+    /**
      * Walks everything the module writes — its fn bodies, its data invariants, its rows — collecting
      * the recursive helpers it reaches and does not declare. Those it must emit as methods of its own.
      *
@@ -419,6 +432,22 @@ public final class HelperInliner {
         }
         result.addAll(takenOnRecursive);
         return result;
+    }
+
+    /**
+     * What this expansion left standing: every recursive helper a call of it survived to, in the
+     * order they were met.
+     *
+     * <p>Read off the expansion that made them. An inliner is made fresh for the tree it expands, so
+     * this answers for that tree and for nothing beside it — the caller that drove the expansion is
+     * the one that knows which tree that was, and it is the one that carries the answer onwards.
+     *
+     * <p>What a call reaches from here is not in it. A helper left standing has a body of its own
+     * that may reach further recursions, and following that is the call graph's to answer
+     * ({@link HelperGraph#reachedFrom}) rather than something to re-walk here.
+     */
+    public java.util.SequencedSet<String> leftStanding() {
+        return java.util.Collections.unmodifiableSequencedSet(leftStanding);
     }
 
     /** The recursive helpers this module reaches and does not declare, renamed to the qualified names
@@ -497,17 +526,50 @@ public final class HelperInliner {
      * directly. */
     private static final Map<String, Integer> BLOCK_ARG = Map.of("List.foldFrom", 0);
 
+    /**
+     * The rewrite {@code call} takes, or null where it takes none.
+     *
+     * <p>The one place that decides it, because more than one reader needs the same answer and they
+     * are not allowed to differ: the pass that writes the rewrite out, the walk that reads the call
+     * graph, and the check that holds an argument to the parameter it lands on. A sugar is the call
+     * it becomes with some arguments already supplied, so one written with a different number of
+     * them is not that call at all — and a reader that took the rewrite anyway would credit an edge
+     * to a declaration this call never reaches.
+     *
+     * <p>Which names are sugar is the library's ({@link Prelude#rewriteOf}) and is asked there.
+     * Written out here instead, the answer stopped agreeing with the library the day a second sugar
+     * was added, and the disagreement is an edge quietly missing from the call graph.
+     */
+    private static Prelude.Rewrite rewriteTaken(Hir.Apply call) {
+        if (call.answered() == null) {
+            return null;   // it reaches no library name, so there is no sugar to write out
+        }
+        Prelude.Rewrite rewrite = Prelude.rewriteOf(call.answered().reaches());
+        return rewrite != null && call.args().size() == rewrite.keptArgs() ? rewrite : null;
+    }
+
+    /**
+     * The helper {@code call} applies, by the name a table is keyed by — the callee's own, or what a
+     * sugar it takes rewrites to. Null where what is applied is not a name that reaches a
+     * declaration: a binding holding a lambda is applied by the expression and reaches nothing.
+     */
+    private static String calledHelper(Hir.Apply call) {
+        if (!(call.answered() instanceof Hir.Var.Denoting callee)
+                || callee.denotes() instanceof ValueName.Local) {
+            return null;
+        }
+        Prelude.Rewrite rewrite = rewriteTaken(call);
+        return rewrite != null ? rewrite.target().qualified() : callee.reaches();
+    }
+
     /** The call a sugared name becomes, written out: what it becomes and what it supplies are the
      * library's to say ({@link Prelude#rewriteOf}), and this is where it is done. {@code List.fold(step,
      * seed, xs)} is {@code List.foldFrom(step, seed, xs, 0)} — the walk from the head. Rewriting here,
      * before inlining, means the step reaches {@code foldFrom} (the one recursive helper) directly
      * rather than through a wrapper that would pass the function on as a value. */
     private static Hir.Apply desugar(Hir.Apply call) {
-        if (call.answered() == null) {
-            return call;   // it reaches no library name, so there is no sugar to write out
-        }
-        Prelude.Rewrite rewrite = Prelude.rewriteOf(call.answered().reaches());
-        if (rewrite == null || call.args().size() != rewrite.keptArgs()) {
+        Prelude.Rewrite rewrite = rewriteTaken(call);
+        if (rewrite == null) {
             return call;
         }
         List<Hir.Expr> args = new ArrayList<>(call.args());
@@ -674,8 +736,8 @@ public final class HelperInliner {
         if (call.answered() == null) {
             return null;   // it reaches no declaration, so none of them declares anything
         }
-        Prelude.Rewrite rewrite = Prelude.rewriteOf(call.answered().reaches());
-        if (rewrite != null && call.args().size() == rewrite.keptArgs()) {
+        Prelude.Rewrite rewrite = rewriteTaken(call);
+        if (rewrite != null) {
             Hir.FnDef target = table.reached(rewrite.target().qualified());
             return target == null ? null : target.params().subList(0, rewrite.keptArgs());
         }
@@ -1075,6 +1137,11 @@ public final class HelperInliner {
         boolean standing = callee != null
                 && !(callee.denotes() instanceof ValueName.Local)
                 && graph.recurses(callee.reaches());
+        if (standing) {
+            // The requirement this expansion just made: the call stays a call, so a method of that
+            // name has to be emitted wherever this tree ends up.
+            leftStanding.add(callee.reaches());
+        }
         if (helper == null || standing) {
             // builtin, injected behavior, a function-typed parameter, or a recursive helper —
             // a recursive helper is lowered to a method, so its call stays a Call (spec §fn-declaration);
@@ -2010,12 +2077,10 @@ public final class HelperInliner {
      */
     private static void helpersNamedIn(Hir.Expr e, Map<String, Hir.FnDef> table, Set<String> out) {
         switch (e) {
-            // `List.fold` desugars to `List.foldFrom` before inlining, so a body that folds reaches
-            // the recursive `foldFrom` and not the wrapper it wrote.
-            case Hir.Apply call when call.answered() instanceof Hir.Var.Denoting callee
-                    && !(callee.denotes() instanceof ValueName.Local) -> {
-                String fn = "List.fold".equals(callee.reaches())
-                        ? "List.foldFrom" : callee.reaches();
+            // A sugar is written out before inlining, so a body that folds reaches the recursive
+            // `foldFrom` and not the wrapper it wrote.
+            case Hir.Apply call when calledHelper(call) != null -> {
+                String fn = calledHelper(call);
                 if (table.containsKey(fn)) {
                     out.add(fn);
                 }
@@ -2043,12 +2108,10 @@ public final class HelperInliner {
         // whatever else bears that name. The call carries what it resolved to, so it is asked rather
         // than matched against the helper table — a parameter named like a helper was reaching the
         // graph as a call to that helper, which made `let f (g: (Int) -> Int) = g(1)` recursive.
-        if (e instanceof Hir.Apply call && call.answered() instanceof Hir.Var.Denoting callee
-                && !(callee.denotes() instanceof ValueName.Local)) {
-            // `List.fold` desugars to `List.foldFrom` before inlining, so a body that folds reaches the
-            // recursive `foldFrom` — recursion classification and prelude-injection must see that.
-            String fn = "List.fold".equals(callee.reaches())
-                    ? "List.foldFrom" : callee.reaches();
+        if (e instanceof Hir.Apply call && calledHelper(call) != null) {
+            // A sugar is written out before inlining, so a body that folds reaches the recursive
+            // `foldFrom` — recursion classification and what a module has to emit must see that.
+            String fn = calledHelper(call);
             if (table.containsKey(fn)) {
                 out.add(fn);
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -196,9 +196,7 @@ public final class HelperInliner {
      */
     public static HelperInliner forModule(Hir.Module module, Map<String, Hir.FnDef> imported) {
         HelperTable table = HelperTable.of(module, imported, InliningPolicy.FULL);
-        HelperInliner inliner = new HelperInliner(table, HelperGraph.of(table));
-        inliner.computeTakenOnRecursive(module);
-        return inliner;
+        return new HelperInliner(table, HelperGraph.of(table));
     }
 
     /**
@@ -334,92 +332,28 @@ public final class HelperInliner {
     }
 
     /**
-     * The recursive helpers this module reaches and does not declare, by the qualified name it
-     * reaches each of them by ({@code List.foldFrom}, {@code pricing.sumDown}).
-     *
-     * <p>A recursive helper is not inlined — it would expand forever — so it is emitted as one of
-     * this module's own methods, exactly like a recursive helper the module declared (see {@link
-     * #injectedRecursiveHelpers}). That holds whoever declared it: the standard library, or a module
-     * that published one, or published something that calls one. Only the ones actually reached are
-     * emitted.
-     */
-    private final Set<String> takenOnRecursive = new java.util.LinkedHashSet<>();
-
-    /**
      * Every recursive helper this expansion left a call to standing, by the name it was reached by.
      *
-     * <p>What the expansion did, not what it was predicted to have to do. A call is left standing
-     * because expanding it would not terminate, and the method it stays a call to has to be
-     * somewhere — so the requirement is made at the moment the decision is, by whoever made it,
-     * rather than worked out again from the places a module writes expressions.
+     * <p>What the expansion did. A call is left standing because expanding it would not terminate,
+     * and the method it stays a call to has to be somewhere — so the requirement is made at the
+     * moment the decision is, by whoever made it.
      *
      * <p>In the order they were met, because a reader reporting one of a group reports the one it
      * reached first.
      */
     private final java.util.SequencedSet<String> leftStanding = new java.util.LinkedHashSet<>();
 
-    /**
-     * Walks everything the module writes — its fn bodies, its data invariants, its rows — collecting
-     * the recursive helpers it reaches and does not declare. Those it must emit as methods of its own.
-     *
-     * <p>Reached, which is wider than called. A helper written where a value goes is eta-expanded into
-     * a call, and a value's body stands wherever the value is named, so a helper is reached through
-     * either. Both were once left to a caller that joined the definitions this module's imports
-     * publish into what it has as fns of its own: that join answered yes for every published helper
-     * whether this module reached it or not, and so covered what this walk was not finding.
-     */
-    private void computeTakenOnRecursive(Hir.Module module) {
-        Set<String> named = new LinkedHashSet<>();
-        Deque<Hir.Expr> work = new ArrayDeque<>();
-        for (Hir.FnDef fn : module.fns()) {
-            work.add(fn.writtenBody());
-        }
-        for (Hir.Def d : module.defs()) {
-            if (d instanceof Hir.Data data) {
-                for (Hir.InvariantClause clause : data.invariants()) {
-                    work.add(clause.expr());
-                }
-            }
-        }
-        forEachExampleExpr(module, work::add);
-        followingValues(work, table.reachable(),
-                e -> helpersNamedIn(e, table.reachable(), named));
-        for (String name : graph.reachedFrom(named)) {
-            if (graph.recurses(name) && !table.held().containsKey(name)) {
-                takenOnRecursive.add(name);
-            }
-        }
+    /** Every recursion in reach, which is exactly what {@link #inline} leaves a call standing to —
+     *  this module's own, what its imports publish to it, and the library underneath both. What a
+     *  standing call can be typed against, whatever this module turns out to reach. */
+    public java.util.SequencedSet<String> recursiveInReach() {
+        return graph.recursive();
     }
 
-    /** Every expression an {@code example} or a {@code fake} of {@code module} writes: a row's inputs,
-     * its {@code with} values, its expected result, and a fake table's inputs and outputs. A helper
-     * named in any of them is applied when the row is evaluated, so all of them are read here. */
-    private static void forEachExampleExpr(Hir.Module module, java.util.function.Consumer<Hir.Expr> f) {
-        for (Hir.Example ex : module.examples()) {
-            for (Hir.ExampleRow row : ex.rows()) {
-                row.inputs().forEach(f);
-                for (Hir.With w : row.withs()) {
-                    f.accept(w.value());
-                }
-                f.accept(row.expected());
-            }
-        }
-        for (Hir.Fake fake : module.fakes()) {
-            for (Hir.FakeRow row : fake.rows()) {
-                if (row.inputs() != null) {   // a default row matches anything and writes none
-                    row.inputs().forEach(f);
-                }
-                f.accept(row.output());
-            }
-        }
-    }
-
-
-    /** The recursive helpers this module emits as methods: the ones it declares, plus the ones it
-     * reaches and took on to emit — a library one, or one another module published (spec §fn-declaration). A
-     * call to any of them is left standing by {@link #inline}. The graph's own {@code recursive} set
-     * additionally holds recursive helpers the module does not reach at all, so {@code inline} never
-     * expands one that slips in through a nested body.
+    /** The recursive helpers this module declares. A call to one of them is left standing by
+     * {@link #inline}, as is a call to any recursion in reach — the graph's own {@code recursive}
+     * set is what {@code inline} asks, so one this module does not declare is left standing too and
+     * is answered for by whoever collects what an expansion could not remove.
      *
      * <p>Answered in declaration order, which is the order a check reporting one of them reports in.
      * The order is the graph's and is carried, not rebuilt. */
@@ -430,7 +364,6 @@ public final class HelperInliner {
                 result.add(name);
             }
         }
-        result.addAll(takenOnRecursive);
         return result;
     }
 
@@ -448,20 +381,6 @@ public final class HelperInliner {
      */
     public java.util.SequencedSet<String> leftStanding() {
         return java.util.Collections.unmodifiableSequencedSet(leftStanding);
-    }
-
-    /** The recursive helpers this module reaches and does not declare, renamed to the qualified names
-     * it reaches them by so they are emitted as the module's own methods — a library {@code let
-     * foldFrom} is reached as {@code List.foldFrom}, and its self-call already reads {@code
-     * List.foldFrom}. Which module declared one is not in that name and is read off the declaration
-     * ({@link Hir.FnDef#declaredIn}). */
-    public Map<String, Hir.FnDef> injectedRecursiveHelpers() {
-        Map<String, Hir.FnDef> out = new java.util.LinkedHashMap<>();
-        for (String qualified : takenOnRecursive) {
-            Hir.FnDef def = table.reached(qualified);
-            out.put(qualified, def.reachedAs(qualified));
-        }
-        return out;
     }
 
     /**
@@ -2036,65 +1955,6 @@ public final class HelperInliner {
         return found[0];
     }
 
-    /**
-     * Runs {@code collect} over everything {@code work} reaches, following the values it reads.
-     *
-     * <p>An expression alone stops at the reference. A value is substituted where it is named
-     * (ADR-0072), so the body of a value a body reads stands in that body — what that body names is
-     * named there, and a declaration reached only through a value is reached. The bodies are followed
-     * as far as they name each other, which is how a chain of values holds.
-     *
-     * <p>What is collected is the caller's question and not this walk's: which helpers a row applies
-     * is one question, which declarations a module reaches at all is another. {@code work} is drained,
-     * and what is seeded into it is the caller's too.
-     */
-    static void followingValues(Deque<Hir.Expr> work, Map<String, Hir.FnDef> table,
-                                java.util.function.Consumer<Hir.Expr> collect) {
-        Set<String> read = new LinkedHashSet<>();
-        while (!work.isEmpty()) {
-            Hir.Expr e = work.poll();
-            collect.accept(e);
-            Set<String> named = new LinkedHashSet<>();
-            ValueCycles.valuesRead(e, table, named);
-            for (String value : named) {
-                Hir.FnDef def = table.get(value);
-                if (def != null && def.params().isEmpty()
-                        && def.body() instanceof Hir.FnBody.Written w && read.add(value)) {
-                    work.add(w.expr());
-                }
-            }
-        }
-    }
-
-    /**
-     * The declarations {@code e} names, applied or not.
-     *
-     * <p>Which declarations a module reaches, which is what decides the methods it has to emit. A
-     * recursive helper written where a value goes — {@code apply1(spin, n)} — is reached as surely as
-     * one that is called: the expansion eta-expands it, and what stands there afterwards is a call to
-     * a method that has to be somewhere. Asked of what a name denotes, so a parameter spelled like a
-     * helper is the parameter.
-     */
-    private static void helpersNamedIn(Hir.Expr e, Map<String, Hir.FnDef> table, Set<String> out) {
-        switch (e) {
-            // A sugar is written out before inlining, so a body that folds reaches the recursive
-            // `foldFrom` and not the wrapper it wrote.
-            case Hir.Apply call when calledHelper(call) != null -> {
-                String fn = calledHelper(call);
-                if (table.containsKey(fn)) {
-                    out.add(fn);
-                }
-            }
-            case Hir.Var.Denoting v when v.denotes() instanceof ValueName.Helper
-                    || v.denotes() instanceof ValueName.Stdlib -> {
-                if (table.containsKey(v.reaches())) {
-                    out.add(v.reaches());
-                }
-            }
-            default -> { }
-        }
-        forEachChild(e, c -> helpersNamedIn(c, table, out));
-    }
 
     /**
      * The helpers of {@code table} that {@code e} calls, added to {@code out}.

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -64,7 +64,10 @@ final class HelperParams {
         Set<String> recursive = inliner.recursiveHelpers();
         Map<String, Type> recursiveHelperFns;
         try {
-            recursiveHelperFns = HelperTyping.recursiveHelperSigs(inliner, symbols);
+            // Every recursion in reach, not only what this module declares: settling reads a body
+            // with its calls expanded, and a call the expansion left standing has to be typeable
+            // there whether or not this module has taken the callee on.
+            recursiveHelperFns = HelperTyping.recursiveCallSigs(inliner, symbols);
         } catch (CompileException _) {
             // One recursive helper that does not declare its types costs the signatures of all of
             // them, which is not observable: the check builds this same map outside its recovery, so

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -46,7 +46,7 @@ public final class HelperTyping {
      * {@code depends on} checks are the caller's (the helper is inlined there), so they are not
      * repeated here.
      */
-    static void checkHelpers(HelperInliner inliner, Symbols symbols,
+    static void checkHelpers(HelperInliner inliner, Map<String, Hir.FnDef> toCheck, Symbols symbols,
                                      Map<ValueName.Behavior, ReqSig> reqSigs, Map<String, Type> recursiveHelperFns,
                                      Map<String, Hir.Expr> loweredBodies,
                                      TypeChecker.Elaborated elaborated) {
@@ -56,7 +56,7 @@ public final class HelperTyping {
         Map<ValueName, Type> settledTypes = new HashMap<>();
         Map<ValueName, Object> settledConstants = new HashMap<>();
         Preserved standing = Preserved.valuesAlreadySettled(settledTypes::get);
-        for (Hir.FnDef h : valuesBeforeTheValuesThatNameThem(inliner)) {
+        for (Hir.FnDef h : valuesBeforeTheValuesThatNameThem(toCheck)) {
             boolean recursive = recursiveHelperFns.containsKey(h.name());
             // Where this definition stands, or null where it stands nowhere: the one thing every
             // rule below that is about a row's operand asks, read off the definition the rule is
@@ -244,8 +244,7 @@ public final class HelperTyping {
      * written, each copying the other, which is the answer this pass gave before there was an order
      * at all.
      */
-    private static List<Hir.FnDef> valuesBeforeTheValuesThatNameThem(HelperInliner inliner) {
-        Map<String, Hir.FnDef> held = inliner.held();
+    private static List<Hir.FnDef> valuesBeforeTheValuesThatNameThem(Map<String, Hir.FnDef> held) {
         Map<String, Set<String>> names = new LinkedHashMap<>();
         for (Map.Entry<String, Hir.FnDef> e : held.entrySet()) {
             if (!(e.getValue().body() instanceof Hir.FnBody.Written written)) {

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -385,6 +385,11 @@ public final class HelperTyping {
      * same either way, so it is worked out once here rather than beside each question — two readings
      * of one declaration would agree only until one of them was edited.
      */
+    static Map<String, Type> recursiveCallSigs(HelperInliner inliner, Symbols symbols) {
+        return sigsOf(inliner.recursiveInReach(), inliner::helper, symbols);
+    }
+
+    /** The same, read off a table rather than off an inliner over it. */
     static Map<String, Type> recursiveCallSigs(HelperTable table,
                                                java.util.Collection<String> names, Symbols symbols) {
         return sigsOf(names, table::reached, symbols);

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -367,16 +367,6 @@ public final class HelperTyping {
     }
 
     /**
-     * Signatures of the module's recursive helpers, each a {@link Type.FnOf} from its declared
-     * parameter types to its declared return type. A recursive helper must declare its return type:
-     * the type can't be inferred through the cycle. Registered in a body's environment so a self- or
-     * mutual call type-checks (spec §fn-declaration).
-     */
-    static Map<String, Type> recursiveHelperSigs(HelperInliner inliner, Symbols symbols) {
-        return sigsOf(inliner.recursiveHelpers(), inliner::helper, symbols);
-    }
-
-    /**
      * The same, for the recursive helpers a caller names and reads out of {@code table}.
      *
      * <p>Which recursive helpers a signature is wanted for is the caller's question and there is more
@@ -386,28 +376,45 @@ public final class HelperTyping {
      * of one declaration would agree only until one of them was edited.
      */
     static Map<String, Type> recursiveCallSigs(HelperInliner inliner, Symbols symbols) {
-        return sigsOf(inliner.recursiveInReach(), inliner::helper, symbols);
+        return sigsOf(inliner.recursiveInReach(), inliner::helper, symbols, inliner.moduleName());
     }
 
     /** The same, read off a table rather than off an inliner over it. */
     static Map<String, Type> recursiveCallSigs(HelperTable table,
                                                java.util.Collection<String> names, Symbols symbols) {
-        return sigsOf(names, table::reached, symbols);
+        return sigsOf(names, table::reached, symbols, table.module());
     }
 
+    /**
+     * @param ownModule the module these are being read for. A declaration it wrote is held to
+     *     declaring its types, and is told so at the line it was written on. One it did not write is
+     *     another module's to hold to that, and is reported there while that module is compiled — so
+     *     an unreadable one contributes no signature here rather than a report about a file this
+     *     compile does not own. A call that needed it fails where the call is written, which is in
+     *     this module and is a place its author can act on.
+     */
     private static Map<String, Type> sigsOf(java.util.Collection<String> names,
                                             java.util.function.Function<String, Hir.FnDef> declaring,
-                                            Symbols symbols) {
+                                            Symbols symbols, String ownModule) {
         Map<String, Type> sigs = new HashMap<>();
         for (String name : names) {
             Hir.FnDef h = declaring.apply(name);
+            boolean ours = h.declaredBy(ownModule);
             if (h.declaredReturn() == null) {
+                if (!ours) {
+                    continue;
+                }
                 throw CompileException.of(Diagnostic
                                 .at(h.pos()).say(new NameMessage.ARecursiveHelperMustDeclareItsReturnType(name)).build());
             }
             List<Type> params = new ArrayList<>();
+            boolean readable = true;
             for (Hir.FnParam p : h.params()) {
                 if (p.type() == null) {
+                    if (!ours) {
+                        readable = false;
+                        break;
+                    }
                     throw CompileException.of(Diagnostic.at(p.written().reportedAt())
                             .say(new HelperMessage.AParameterNeedsItsType(name, p.name()))
                             .build());
@@ -415,6 +422,9 @@ public final class HelperTyping {
                 // a recursive helper is a static method taking its parameters as values; a function
                 // parameter is passed as a first-class Fn (a closure), applied inside the method.
                 params.add(TypeOps.resolveParamType(p.type()));
+            }
+            if (!readable) {
+                continue;
             }
             sigs.put(name, Type.fn(params, TypeOps.successType(h.declaredReturn())));
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -374,9 +374,29 @@ public final class HelperTyping {
      * mutual call type-checks (spec §fn-declaration).
      */
     static Map<String, Type> recursiveHelperSigs(HelperInliner inliner, Symbols symbols) {
+        return sigsOf(inliner.recursiveHelpers(), inliner::helper, symbols);
+    }
+
+    /**
+     * The same, for the recursive helpers a caller names and reads out of {@code table}.
+     *
+     * <p>Which recursive helpers a signature is wanted for is the caller's question and there is more
+     * than one answer to it: what a module has taken on to emit is one, and what could stand
+     * unexpanded anywhere in a representation is another and is wider. What a signature is is the
+     * same either way, so it is worked out once here rather than beside each question — two readings
+     * of one declaration would agree only until one of them was edited.
+     */
+    static Map<String, Type> recursiveCallSigs(HelperTable table,
+                                               java.util.Collection<String> names, Symbols symbols) {
+        return sigsOf(names, table::reached, symbols);
+    }
+
+    private static Map<String, Type> sigsOf(java.util.Collection<String> names,
+                                            java.util.function.Function<String, Hir.FnDef> declaring,
+                                            Symbols symbols) {
         Map<String, Type> sigs = new HashMap<>();
-        for (String name : inliner.recursiveHelpers()) {
-            Hir.FnDef h = inliner.helper(name);
+        for (String name : names) {
+            Hir.FnDef h = declaring.apply(name);
             if (h.declaredReturn() == null) {
                 throw CompileException.of(Diagnostic
                                 .at(h.pos()).say(new NameMessage.ARecursiveHelperMustDeclareItsReturnType(name)).build());

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantSettled.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantSettled.java
@@ -170,14 +170,22 @@ public final class InvariantSettled {
         }
     }
 
+    /**
+     * Both of what this answers with. The standing set is not derived from the tree by anything that
+     * reads this — it is what the expansion that produced the tree met on the way — so a state
+     * carrying a different one is a different answer, whatever the trees compare as. Left out, the
+     * store would find a recomputed answer equal to the one it held and leave everything that reads
+     * the standing set on the old one.
+     */
     @Override
     public boolean equals(Object o) {
-        return o instanceof InvariantSettled other && module.equals(other.module);
+        return o instanceof InvariantSettled other && module.equals(other.module)
+                && standing.equals(other.standing);
     }
 
     @Override
     public int hashCode() {
-        return module.hashCode();
+        return module.hashCode() * 31 + standing.hashCode();
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantSettled.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantSettled.java
@@ -49,9 +49,11 @@ import java.util.Map;
 public final class InvariantSettled {
 
     private final Hir.Module module;
+    private final java.util.SequencedSet<String> standing;
 
-    private InvariantSettled(Hir.Module module) {
-        this.module = module;
+    private InvariantSettled(Expansion<Hir.Module> expanded) {
+        this.module = expanded.value();
+        this.standing = expanded.standing();
     }
 
     /**
@@ -68,6 +70,18 @@ public final class InvariantSettled {
         Hir.Module derived = Deriver.derive(expandable.module(), scope);
         return new InvariantSettled(
                 ClauseHelpers.withSettledInvariants(derived, scope, published));
+    }
+
+    /**
+     * Every recursive helper the clauses of this module left a call to standing.
+     *
+     * <p>A module's declarations are in the table a call graph is built over, so what one of their
+     * bodies reaches is answered by following edges. A clause is not a declaration and is in no
+     * table, so what it reaches is known only to the expansion that read it — which is here, and is
+     * why this travels with the settled module rather than being looked for again afterwards.
+     */
+    public java.util.SequencedSet<String> standingRecursiveCalls() {
+        return standing;
     }
 
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Lower.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Lower.java
@@ -57,7 +57,7 @@ public final class Lower {
      * parameter, not a same-named user helper), which is what {@code recursive} says. A helper that is
      * neither is fully inlined at its call sites and never emitted, so nothing asks for it here.
      */
-    public static Hir.FnDef body(Hir.FnDef fn, HelperInliner inliner, boolean recursive) {
+    public static Expansion<Hir.FnDef> body(Hir.FnDef fn, HelperInliner inliner, boolean recursive) {
         return body(fn, inliner, recursive, Set.of());
     }
 
@@ -66,12 +66,15 @@ public final class Lower {
      * on} — the names that arrive as the {@code let}'s trailing parameters (spec §depends-on). A
      * helper has none, and neither has a recursive helper's own body.
      */
-    public static Hir.FnDef body(Hir.FnDef fn, HelperInliner inliner, boolean recursive,
-                                 Set<String> dependencies) {
+    public static Expansion<Hir.FnDef> body(Hir.FnDef fn, HelperInliner inliner, boolean recursive,
+                                            Set<String> dependencies) {
         Hir.Expr expanded = recursive
                 ? inliner.inlineRecursiveBody(fn)
                 : inliner.inline(fn.writtenBody(), dependencies(fn, dependencies), inliner.bodyOf(fn.name()));
-        return fn.withBody(new Hir.FnBody.Written(desugar(expanded)));
+        // What this expansion could not remove travels with what it produced. The inliner was made
+        // for this body, so what it left standing is this body's and nothing else's.
+        return new Expansion<>(fn.withBody(new Hir.FnBody.Written(desugar(expanded))),
+                inliner.leftStanding());
     }
 
     /** Which bindings the {@code depends on} names are: the trailing parameters that carry them. A

--- a/souther-compiler/src/main/java/souther/compiler/check/Prepared.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Prepared.java
@@ -125,21 +125,16 @@ public final class Prepared {
         }
         Prepared written = new Prepared(desugared, fns, examples, fakes, List.of(), List.of(),
                 Map.of());
-        HelperInliner inliner = HelperInliner.forModule(written.module(), published);
-        // What this module emits and did not declare: a recursive helper it reaches, which cannot
-        // be expanded into whoever calls it. A row names no more than a body does — its operands are
-        // definitions of this module and the helpers they call are expanded into them — so a row
-        // adds nothing here beyond the recursion any of its calls reaches.
-        Map<String, Hir.FnDef> injected = new LinkedHashMap<>(inliner.injectedRecursiveHelpers());
         // What each row operand computes, emitted beside the module's own so a row runs its operand
         // in the program the behavior it is about is applied in. Which method is whose is kept with
         // the module: it is decided here and read wherever a row is run, never counted out again.
         RowFixtures.Emitted rows = RowFixtures.emitted(written.module(), scope, signatures);
-        // Beside what the module declared, not among it. Both are emitted and only the first was
-        // written here, and a reader asking which is which asks the component it is in rather than
-        // the shape of a name.
-        return injected.isEmpty() && rows.defs().isEmpty() ? written
-                : new Prepared(desugared, fns, examples, fakes, List.copyOf(injected.values()),
+        // Which recursions this module has to emit is not decided here and is not carried from here.
+        // It follows from what expanding this module's trees leaves standing, which none of them has
+        // been through yet — worked out here, it was a prediction about work not yet done, and it
+        // was wrong for every tree the prediction did not know to look at.
+        return rows.defs().isEmpty() ? written
+                : new Prepared(desugared, fns, examples, fakes, List.of(),
                         List.copyOf(rows.defs().values()), rows.methods());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Prepared.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Prepared.java
@@ -44,6 +44,16 @@ public final class Prepared {
     private final List<Rows> examples;
     private final List<FakeTable> fakes;
     private final List<Hir.FnDef> takenOn;
+    /**
+     * The definitions minted for this module's row operands.
+     *
+     * <p>Their own component, and not among what the module took on. A row's operand is a value this
+     * compilation writes for it, reached from a row and from nothing a source can spell — so it is
+     * not a declaration a name resolves to, and a table of what names reach has no business holding
+     * one. Carried here beside the correspondence they were built with, which is the one walk that
+     * knows both.
+     */
+    private final List<Hir.FnDef> rowDefs;
     /** Which method each row operand's value runs as, by the operand — the correspondence the
      *  emission constructed, held so the reader that invokes a method never counts the rows for
      *  itself. Keyed on operand identity, over the very nodes {@link Rows#read} answers with. */
@@ -52,14 +62,20 @@ public final class Prepared {
     private volatile Hir.Module projected;
 
     private Prepared(Desugared.Module desugared, List<Desugared.Fn> fns, List<Rows> examples,
-                     List<FakeTable> fakes, List<Hir.FnDef> takenOn,
+                     List<FakeTable> fakes, List<Hir.FnDef> takenOn, List<Hir.FnDef> rowDefs,
                      Map<Hir.Expr, String> operandMethods) {
         this.desugared = desugared;
         this.fns = List.copyOf(fns);
         this.examples = List.copyOf(examples);
         this.fakes = List.copyOf(fakes);
         this.takenOn = List.copyOf(takenOn);
+        this.rowDefs = List.copyOf(rowDefs);
         this.operandMethods = operandMethods;
+    }
+
+    /** The definitions this module's row operands are, in the order they were emitted. */
+    public List<Hir.FnDef> rowDefs() {
+        return rowDefs;
     }
 
     /**
@@ -107,7 +123,8 @@ public final class Prepared {
         for (Hir.Fake table : desugared.module().fakes()) {
             fakes.add(new FakeTable(HelperNames.qualifyImportsIn(table, self)));
         }
-        Prepared written = new Prepared(desugared, fns, examples, fakes, List.of(), Map.of());
+        Prepared written = new Prepared(desugared, fns, examples, fakes, List.of(), List.of(),
+                Map.of());
         HelperInliner inliner = HelperInliner.forModule(written.module(), published);
         // What this module emits and did not declare: a recursive helper it reaches, which cannot
         // be expanded into whoever calls it. A row names no more than a body does — its operands are
@@ -118,13 +135,12 @@ public final class Prepared {
         // in the program the behavior it is about is applied in. Which method is whose is kept with
         // the module: it is decided here and read wherever a row is run, never counted out again.
         RowFixtures.Emitted rows = RowFixtures.emitted(written.module(), scope, signatures);
-        rows.defs().forEach(injected::putIfAbsent);
         // Beside what the module declared, not among it. Both are emitted and only the first was
         // written here, and a reader asking which is which asks the component it is in rather than
         // the shape of a name.
-        return injected.isEmpty() ? written
+        return injected.isEmpty() && rows.defs().isEmpty() ? written
                 : new Prepared(desugared, fns, examples, fakes, List.copyOf(injected.values()),
-                        rows.methods());
+                        List.copyOf(rows.defs().values()), rows.methods());
     }
 
     /** What the module is called. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Prepared.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Prepared.java
@@ -442,13 +442,32 @@ public final class Prepared {
         return module();
     }
 
+    /**
+     * Everything this state answers with.
+     *
+     * <p>Not the projection alone. The tree carries what the module declared and what it writes; the
+     * definitions minted for its rows are beside it and are in no tree, so two states whose trees
+     * compare equal can still say different things about the rows. They do, and without touching the
+     * source: a row's operand is wrapped in the type the position it stands at contributes, and that
+     * position comes from a behavior's signature — which an edit to an imported module can change
+     * while this module's text stays as it was.
+     *
+     * <p>A state is a query's answer, and a store decides whether anything downstream has to be
+     * asked again by comparing the answer it recomputed with the one it held. An answer that leaves
+     * out what it answers with is one the store cannot tell has changed.
+     *
+     * <p>The correspondence between an operand and its method is left out on purpose: it is keyed on
+     * operand identity, over the very nodes the tree hands out, so it says nothing a tree and the
+     * definitions built from it do not already say.
+     */
     @Override
     public boolean equals(Object o) {
-        return o instanceof Prepared other && module().equals(other.module());
+        return o instanceof Prepared other && module().equals(other.module())
+                && rowDefs.equals(other.rowDefs);
     }
 
     @Override
     public int hashCode() {
-        return module().hashCode();
+        return module().hashCode() * 31 + rowDefs.hashCode();
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Scope.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Scope.java
@@ -12,24 +12,34 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * What a body may name where an expression is being typed: the bindings in force, and the
- * declarations a name reaches without one.
+ * What a body may name where an expression is being typed: the bindings in force, the declarations
+ * an author can name without one, and the signatures a call left standing is typed against.
  *
- * <p>The two are held apart, and which of them a name reads is decided by what the name denotes. A
- * binding is found by the binding it is, not by how it is spelled — an expansion splices a body
- * written in one scope into another, so a name in the copy would otherwise be answered by whatever
- * the scope it landed in binds under that spelling. That is not shadowing: the copy's names were
- * settled where they were written, and moving the code does not change what they mean.
+ * <p>The bindings are held apart from the rest, and which of them a name reads is decided by what
+ * the name denotes. A binding is found by the binding it is, not by how it is spelled — an expansion
+ * splices a body written in one scope into another, so a name in the copy would otherwise be
+ * answered by whatever the scope it landed in binds under that spelling. That is not shadowing: the
+ * copy's names were settled where they were written, and moving the code does not change what they
+ * mean.
+ *
+ * <p>{@code visible} and {@code standing} are held apart for a different reason, and it is not about
+ * how they are found. Both are consulted by {@link #of}, so either can type a name. Only
+ * {@code visible} is a vocabulary — what an author could have written here, which is what a
+ * did-you-mean offers. A recursive helper reached under the name the library or another module is
+ * reached by is typeable and unwritable at once: {@code List.foldFrom} is behind every list
+ * quantifier and no caller outside the reserved namespace may name it. Held in one map, it was
+ * offered to authors as something they might have meant.
  *
  * <p>A spelling is still what an author reads, so a name is kept beside each binding for a
  * diagnostic to quote and for a did-you-mean to offer. Nothing is found by it.
  */
-public record Scope(Map<BindingId, Binding> bindings, Map<String, Type> declared,
-                    Substitution decisions) {
+public record Scope(Map<BindingId, Binding> bindings, Map<String, Type> visible,
+                    Map<String, Type> standing, Substitution decisions) {
 
     /** A scope with no application's decisions in force over it. */
-    public Scope(Map<BindingId, Binding> bindings, Map<String, Type> declared) {
-        this(bindings, declared, null);
+    public Scope(Map<BindingId, Binding> bindings, Map<String, Type> visible,
+                 Map<String, Type> standing) {
+        this(bindings, visible, standing, null);
     }
 
     /**
@@ -41,36 +51,45 @@ public record Scope(Map<BindingId, Binding> bindings, Map<String, Type> declared
      * it, and reads them from here rather than deciding them again.
      */
     public Scope deciding(Substitution decided) {
-        return new Scope(bindings, declared, decided);
+        return new Scope(bindings, visible, standing, decided);
     }
 
     /** One binding in force: what it is, and what it is called. */
     public record Binding(String name, Type type) {}
 
-    public static final Scope NONE = new Scope(Map.of(), Map.of(), null);
+    public static final Scope NONE = new Scope(Map.of(), Map.of(), Map.of(), null);
 
     /** The bindings a body starts with — a helper's parameters, a declaration's fields. */
     public static Scope of(Map<BindingId, Binding> bindings) {
-        return new Scope(Map.copyOf(bindings), Map.of(), null);
+        return new Scope(Map.copyOf(bindings), Map.of(), Map.of(), null);
     }
 
-    /** The same, with the signatures of the declarations a name may reach without a binding: a
-     * recursive helper, which is emitted as a method rather than expanded. */
-    public Scope reaching(Map<String, Type> declarations) {
-        return new Scope(bindings, Map.copyOf(declarations), decisions);
+    /** The same, with the signatures a call left standing is typed against: a recursive helper,
+     * which is emitted as a method rather than expanded. Not a vocabulary — the name one is reached
+     * by here is not always a name that may be written here. */
+    public Scope reaching(Map<String, Type> standingCalls) {
+        return new Scope(bindings, visible, Map.copyOf(standingCalls), decisions);
+    }
+
+    /** The same, with declarations an author can name here without a binding — an injected behavior
+     * a block captured, reached by the name it is declared under. */
+    public Scope naming(Map<String, Type> declarations) {
+        return new Scope(bindings, Map.copyOf(declarations), standing, decisions);
     }
 
     /**
      * The type of what {@code denotes} names here, or null where nothing here does.
      *
      * <p>{@code reachedBy} is how a declaration is written here, which is the namespace the
-     * signatures are keyed by. Which namespace to look in is the denotation's to decide.
+     * signatures are keyed by. Which namespace to look in is the denotation's to decide, and the
+     * denotation is also what separates the two: a behavior a block captured is a name its author
+     * wrote, and a helper or a library operation reaching here is one a call was left standing on.
      */
     public Type of(ValueName denotes, String reachedBy) {
         return switch (denotes) {
             case ValueName.Local local -> typeOf(local.id());
-            case ValueName.Helper _, ValueName.Stdlib _, ValueName.Behavior _ ->
-                    declared.get(reachedBy);
+            case ValueName.Behavior _ -> visible.get(reachedBy);
+            case ValueName.Helper _, ValueName.Stdlib _ -> standing.get(reachedBy);
             case ValueName.OfType _, ValueName.Builtin _ -> null;
             case null -> null;
         };
@@ -94,31 +113,35 @@ public record Scope(Map<BindingId, Binding> bindings, Map<String, Type> declared
     public Scope with(BindingId binding, String name, Type type) {
         Map<BindingId, Binding> next = new LinkedHashMap<>(bindings);
         next.put(binding, new Binding(name, type));
-        return new Scope(next, declared, decisions);
+        return new Scope(next, visible, standing, decisions);
     }
 
     /** The same, for several at once. */
     public Scope withAll(Map<BindingId, Binding> more) {
         Map<BindingId, Binding> next = new LinkedHashMap<>(bindings);
         next.putAll(more);
-        return new Scope(next, declared, decisions);
+        return new Scope(next, visible, standing, decisions);
     }
 
     /** What the names in force are called — for a diagnostic that offers what the author might have
-     * meant, and for nothing else. */
+     * meant, and for nothing else. What a standing call is typed against is not among them: the name
+     * such a call is reached by is the one this compilation emits a method under, and offering it
+     * would answer a misspelling with a name that cannot be written. */
     public List<String> spellings() {
         List<String> names = new ArrayList<>();
         for (Binding bound : bindings.values()) {
             names.add(bound.name());
         }
-        names.addAll(declared.keySet());
+        names.addAll(visible.keySet());
         return names;
     }
 
     /** A name-to-type view of the bindings, for a reader that has only a spelling to go on. Two
-     * bindings of one spelling collapse, which is why nothing that decides meaning may use it. */
+     * bindings of one spelling collapse, which is why nothing that decides meaning may use it. What
+     * a standing call is typed against is left out for the reason {@link #spellings} leaves it out:
+     * this is a view keyed by what was written. */
     public Map<String, Type> byName() {
-        Map<String, Type> byName = new HashMap<>(declared);
+        Map<String, Type> byName = new HashMap<>(visible);
         for (Binding bound : bindings.values()) {
             byName.put(bound.name(), bound.type());
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -199,6 +199,20 @@ public final class TypeChecker {
         // declared it or took it on to emit, and one missing here is a helper checked against a body
         // it does not have.
         Map<String, Hir.Expr> loweredBodies = new HashMap<>();
+        // Which definitions this module processes, read off what it lowered rather than off what it
+        // was predicted to have to lower. A recursion an expansion of this module left standing is
+        // one this module emits, so it is one this module checks — and the two answers were allowed
+        // to differ while the second was a walk over the places a module writes expressions.
+        // Which definitions this module checks standing on their own: every helper it declared,
+        // whether or not anything survives to call it, and what it emits beyond them. The second is
+        // read off what it lowered rather than off what it was predicted to have to lower — a
+        // recursion an expansion of this module left standing is one this module emits, so it is one
+        // this module checks, and the two answers were allowed to differ while the second was a walk
+        // over the places a module writes expressions. A helper is a fn whose name is no behavior's,
+        // which is the reading both of these are keyed by.
+        Map<String, Hir.FnDef> toCheck =
+                new java.util.LinkedHashMap<>(HelperInliner.helpersOf(module));
+        toCheck.putAll(HelperInliner.takenOnBy(lowered));
         for (Hir.FnDef fn : lowered.fns()) {
             loweredBodies.put(fn.name(), fn.writtenBody());
         }
@@ -454,7 +468,7 @@ public final class TypeChecker {
         // settled with the rest — and held to the position it stands at by the type its wrapper
         // declares, which is the same check every other definition of this module gets. There is
         // nothing left here for a reading of its own to ask.
-        collect(errors, abandoned, () -> HelperTyping.checkHelpers(inliner, symbols, reqSigs,
+        collect(errors, abandoned, () -> HelperTyping.checkHelpers(inliner, toCheck, symbols, reqSigs,
                 recursiveHelperFns, loweredBodies, elaborated));
         // Recursion is total by default (spec §fn-declaration): a non-`partial` recursive helper must
         // be structurally recursive, so its examples terminate at compile time.

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -121,12 +121,6 @@ public final class TypeChecker {
                 inliner, recursiveHelperFns, recHelperConstructs, warnings);
     }
 
-    /** The signatures of a module's recursive helpers — what a self- or mutual call is typed
-     * against, and what a body that calls one reads. */
-    public static Map<String, Type> recursiveHelperSigs(HelperInliner inliner, Symbols symbols) {
-        return HelperTyping.recursiveHelperSigs(inliner, symbols);
-    }
-
     /** The signatures every recursive helper a representation can reach would be called under —
      *  what typing a call left standing needs, whether or not this module turned out to reach it. */
     public static Map<String, Type> recursiveCallSigs(HelperTable table,
@@ -221,8 +215,8 @@ public final class TypeChecker {
         }
         // The imported definitions join the table this module's bodies are expanded against: a
         // published helper is expanded at its call sites here exactly as one of this module's own is,
-        // and it is not one of this module's own — which is what keeps a recursive one of them in
-        // `injectedRecursiveHelpers`, to be emitted here rather than declared here.
+        // and it is not one of this module's own — which is why a recursive one of them is emitted
+        // here rather than declared here.
         // A helper is checked standing on its own as well as expanded into what calls it, and both
         // readings answer the same about a behavior's name: it becomes the function value it names,
         // which a helper may then not apply (E1818). Told nothing, the standalone reading would

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -127,6 +127,14 @@ public final class TypeChecker {
         return HelperTyping.recursiveHelperSigs(inliner, symbols);
     }
 
+    /** The signatures every recursive helper a representation can reach would be called under —
+     *  what typing a call left standing needs, whether or not this module turned out to reach it. */
+    public static Map<String, Type> recursiveCallSigs(HelperTable table,
+                                                      java.util.Collection<String> names,
+                                                      Symbols symbols) {
+        return HelperTyping.recursiveCallSigs(table, names, symbols);
+    }
+
     /** What each recursive helper constructs, transitively. A recursive helper is not inlined, so its
      * constructions are attributed to the behavior that calls it (spec §blocks). */
     public static Map<String, DataChecker.Constructs> recursiveHelperConstructs(

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -144,9 +144,11 @@ public final class Backend {
                                                Map<String, List<BehaviorRequirement>> requirements,
                                                Bodies.Elaborated checked,
                                                Map<TypeSymbol, List<Hir.InvariantClause>> dischargeInvariants,
-                                               Map<ValueName.Behavior, EnsuresEnforcement> checks) {
+                                               Map<ValueName.Behavior, EnsuresEnforcement> checks,
+                                               Map<String, Type> standingCalls) {
         return generate(module, symbols, typePackage, sigs, importedSigs, importedInjected, calleeSigs,
-                requirements, checked, dischargeInvariants, checks, Instrumentation.NONE);
+                requirements, checked, dischargeInvariants, checks, standingCalls,
+                Instrumentation.NONE);
     }
 
     /**
@@ -172,10 +174,12 @@ public final class Backend {
                                                Bodies.Elaborated checked,
                                                Map<TypeSymbol, List<Hir.InvariantClause>> dischargeInvariants,
                                                Map<ValueName.Behavior, EnsuresEnforcement> checks,
+                                               Map<String, Type> standingCalls,
                                                Instrumentation instrumentation) {
         try {
             return generating(module, symbols, typePackage, sigs, importedSigs, importedInjected,
-                    calleeSigs, requirements, checked, dischargeInvariants, checks, instrumentation);
+                    calleeSigs, requirements, checked, dischargeInvariants, checks, standingCalls,
+                    instrumentation);
         } catch (IllegalArgumentException e) {
             // Something the writer would not hold, from a member no definition here claimed — a
             // synthesised class, a shared one. It belongs to the module, which is as near as anything
@@ -194,6 +198,7 @@ public final class Backend {
                                                   Bodies.Elaborated checked,
                                                   Map<TypeSymbol, List<Hir.InvariantClause>> dischargeInvariants,
                                                   Map<ValueName.Behavior, EnsuresEnforcement> checks,
+                                                  Map<String, Type> standingCalls,
                                                   Instrumentation instrumentation) {
         Map<String, List<GeneratedClass>> caseToSums = new HashMap<>();
         for (Hir.Def def : module.defs()) {
@@ -222,7 +227,7 @@ public final class Backend {
             }
         }
         CodegenContext ctx = new CodegenContext(module.name(), symbols, caseToSums, typePackage,
-                module.exposing().isEmpty(), exposed, recHelpers);
+                module.exposing().isEmpty(), exposed, recHelpers, standingCalls);
         ctx.setDischargeInvariants(dischargeInvariants);
         ctx.setEnsuresChecks(checks);
         ctx.setCoveragePlan(instrumentation.coverage());

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -1914,30 +1914,26 @@ final class BodyGen {
         private Scope bound() {
             Map<BindingId, Scope.Binding> held = new LinkedHashMap<>();
             locals.forEach((binding, v) -> held.put(binding, new Scope.Binding(v.name(), v.type())));
-            Map<String, Type> declared = new HashMap<>();
-            captured.forEach((name, v) -> declared.put(name, v.type()));
-            return Scope.of(held).reaching(declared);
+            Map<String, Type> named = new HashMap<>();
+            captured.forEach((name, v) -> named.put(name, v.type()));
+            return Scope.of(held).naming(named);
         }
 
-        /** {@link #bound} plus the recursive helpers' signatures, so re-typing an expression that
-         * calls one (a nested {@code foldFrom} in a fold's seed) resolves it as a function. Only a
-         * recursive helper's signature can be read here, and a recursive helper declares its return
-         * type (spec §fn-declaration); an example-applied helper is emitted beside them without declaring one, and
-         * no standing call names it — it is expanded wherever a body calls it. */
+        /** {@link #bound} plus what a call left standing is typed against, so re-typing an
+         * expression that holds one (a nested {@code foldFrom} in a fold's seed) resolves it as a
+         * function.
+         *
+         * <p>Read from the check's own answer rather than from the methods this module emits. Which
+         * names a standing call can hold follows from the declarations in reach; which methods are
+         * emitted follows from what this module turned out to need. Typing against the second
+         * answered that a rule reaching a fold had no fold to call, in a module whose only reach to
+         * one was that rule. A name a block captured wins over it, as it did before: the author
+         * wrote that one. */
         private Scope scope() {
             Scope held = bound();
-            Map<String, Type> declared = new HashMap<>(held.declared());
-            ctx.emittedHelpers.forEach((name, h) -> {
-                if (declared.containsKey(name) || h.declaredReturn() == null) {
-                    return;
-                }
-                List<Type> params = new ArrayList<>();
-                for (Hir.FnParam p : h.params()) {
-                    params.add(TypeOps.resolveParamType(p.type()));
-                }
-                declared.put(name, Type.fn(params, successType(h.declaredReturn())));
-            });
-            return held.reaching(declared);
+            Map<String, Type> standing = new HashMap<>(ctx.standingCalls);
+            standing.keySet().removeAll(held.visible().keySet());
+            return held.reaching(standing);
         }
 
         /** Emits a function value from its elaborated node: the parameter and result types are the

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -1927,13 +1927,16 @@ final class BodyGen {
          * names a standing call can hold follows from the declarations in reach; which methods are
          * emitted follows from what this module turned out to need. Typing against the second
          * answered that a rule reaching a fold had no fold to call, in a module whose only reach to
-         * one was that rule. A name a block captured wins over it, as it did before: the author
-         * wrote that one. */
+         * one was that rule.
+         *
+         * <p>Nothing is taken out of it for what a block captured. The two are looked up by what the
+         * name denotes — a behavior reaches what the author wrote, a helper or a library operation
+         * reaches what a call was left standing on — so one cannot stand where the other is asked
+         * for, and there is no precedence to arrange. Arranged anyway, by removing the captured
+         * spellings from these, a captured name that denoted a helper would have been deleted from
+         * the only map it could have been found in. */
         private Scope scope() {
-            Scope held = bound();
-            Map<String, Type> standing = new HashMap<>(ctx.standingCalls);
-            standing.keySet().removeAll(held.visible().keySet());
-            return held.reaching(standing);
+            return bound().reaching(ctx.standingCalls);
         }
 
         /** Emits a function value from its elaborated node: the parameter and result types are the

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodegenContext.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodegenContext.java
@@ -44,6 +44,16 @@ final class CodegenContext {
      * by helper name. A call to one is an {@code invokestatic}, not an inlined body. */
     final Map<String, Hir.FnDef> emittedHelpers;
 
+    /**
+     * What a call this module leaves standing is typed against, by the name it is reached by.
+     *
+     * <p>The same answer the check typed those calls against, handed over rather than worked out
+     * again. The emitter re-types the expressions it emits — a clause, a rule — and a table built
+     * here out of what this module happens to emit would answer for the methods written rather than
+     * for the names a call can hold, which is a narrower question and not the one being asked.
+     */
+    final Map<String, Type> standingCalls;
+
     /** Synthetic {@code Fn} classes generated for escaping lambdas (spec §blocks), merged into the
      * module output once every behavior is generated. */
     private final Map<GeneratedClass, byte[]> synthClasses = new LinkedHashMap<>();
@@ -316,7 +326,7 @@ final class CodegenContext {
 
     CodegenContext(String pkg, Symbols symbols, Map<String, List<GeneratedClass>> caseToSums,
                    Map<String, String> typePackage, boolean exposeAll, Set<String> exposed,
-                   Map<String, Hir.FnDef> emittedHelpers) {
+                   Map<String, Hir.FnDef> emittedHelpers, Map<String, Type> standingCalls) {
         this.pkg = pkg;
         this.symbols = symbols;
         this.caseToSums = caseToSums;
@@ -324,6 +334,7 @@ final class CodegenContext {
         this.exposeAll = exposeAll;
         this.exposed = exposed;
         this.emittedHelpers = emittedHelpers;
+        this.standingCalls = standingCalls;
     }
 
     /** {@code ACC_PUBLIC} when the name is exposed (or the module exposes all), else 0. */

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -1498,11 +1498,11 @@ public final class Bodies {
      * expressions is a second statement of what a module is made of, and the one that was here
      * answered that a rule reaching a fold needed nothing.
      *
-     * <p>Wider than {@link RecursiveHelperSigs}, and not a replacement for it. That one answers which
-     * helpers this module has taken on to process and emit, which is what a reader wanting a body
-     * needs; this one answers which names can be typed, which is what a reader holding a call needs.
-     * Kept apart because a signature for a helper nobody called costs an entry in a map, and a body
-     * for one costs a body that does not exist.
+     * <p>Wider than {@link RequiredRecursiveDefs}, and not a replacement for it. That one answers
+     * which helpers this module processes and emits, which is what a reader wanting a body needs;
+     * this one answers which names can be typed, which is what a reader holding a call needs. Kept
+     * apart because a signature for a helper nobody called costs an entry in a map, and a body for
+     * one costs a body that does not exist.
      *
      * <p>Keyed by the policy as {@link Expanding} is: the discharge representation leaves the
      * language's own operations standing rather than expanding them into the fold they become, so its
@@ -1539,8 +1539,8 @@ public final class Bodies {
      *
      * <p>Made of what the expansions did, not of a prediction about what they would do. Every tree
      * this module is made of is expanded somewhere, and each of those expansions answers with the
-     * recursions it could not remove ({@link Expansion}); this is those answers joined, closed over
-     * the call graph, and narrowed to what recurses.
+     * recursions it could not remove ({@link Expansion}); this is those answers joined, and the
+     * bodies of what they name expanded in turn until nothing new is named.
      *
      * <p>The seeds are the trees, and there are two kinds. A definition's body is expanded by {@link
      * LoweredBody}, which answers with what it left standing. A clause — a data's {@code invariant},
@@ -1549,10 +1549,17 @@ public final class Bodies {
      * walk that was here instead listed the places a module writes expressions and did not list
      * {@code ensures}, so a rule reaching a fold asked for no fold.
      *
-     * <p>The closure is the call graph's and is taken once. What a required helper's own body
-     * reaches is an edge of that graph, already there because the graph is built over every
-     * declaration in reach — so a helper reached only through a non-recursive one, and every member
-     * of a mutually-recursive group, arrive without a second round.
+     * <p>The closure is the expansion's, not the call graph's. A body reaches a recursion by
+     * applying it and by reading a value whose own body applies it, and only the first is a call —
+     * so a graph of calls answers about a narrower relation than the one that decides this, and a
+     * recursion behind a value is reached by the expansion and by nothing that could see it. Each
+     * required recursion is therefore expanded in its turn: it is emitted as a method, so its body
+     * is expanded on its own rather than into anything, and what that leaves standing is required
+     * too.
+     *
+     * <p>Being required and having been read are two things. A recursion this module declared is
+     * required before the walk begins, and its body still goes through it — a walk that took its
+     * result set for its work list would never read one.
      *
      * <p>A helper this module declared is here whether or not anything reaches it: its source is
      * this module's to check and to publish, which is not a question about use. Only what it did not

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -1176,24 +1176,6 @@ public final class Bodies {
         return fn;
     }
 
-    /** The helpers a module emits as methods rather than expanding: the ones that recurse (spec
-     * 13.1), including the prelude ones it has taken on as its own. Answered in declaration order:
-     * a check that reports one member of a mutual cycle reports the first, so the order is part of
-     * the answer and is said in the type. */
-    public record RecursiveHelpers(String name) implements Key<SequencedSet<String>> {
-        @Override
-        public String module() {
-            return name;
-        }
-
-        @Override
-        public Answer<SequencedSet<String>> compute(Db db) {
-            Answer<HelperInliner> inliner = expanding(db, name, InliningPolicy.FULL);
-            return inliner.present() ? Answer.of(inliner.value().recursiveHelpers())
-                    : Answer.absent();
-        }
-    }
-
     /**
      * What a body of {@code module} is expanded against: which declaration each name reaches, and
      * which of them recurse.
@@ -1396,18 +1378,22 @@ public final class Bodies {
         @Override
         public Answer<Hir.FnDef> compute(Db db) {
             Answer<Hir.FnDef> def = db.ask(new SettledFn(module, fn));
-            Answer<HelperInliner> inliner = expanding(db, module, InliningPolicy.DISCHARGE);
-            Answer<SequencedSet<String>> recursive = db.ask(new RecursiveHelpers(module));
+            Answer<Expanding.Of> against = db.ask(new Expanding(module, InliningPolicy.DISCHARGE));
             Answer<Map<ValueName.Behavior, Integer>> behaviors =
                     db.ask(new NamedBehaviorArity(module));
-            if (!def.present() || !inliner.present() || !recursive.present()
-                    || !behaviors.present()) {
+            if (!def.present() || !against.present() || !behaviors.present()) {
                 return Answer.absent();
             }
+            // Whether this body is a recursion, asked of the graph of the representation it is being
+            // read in. A recursion is a cycle among the declarations in reach, and which
+            // declarations those are is what the policy decides.
+            HelperInliner inliner = HelperInliner.over(against.value().table(),
+                    against.value().graph());
+            boolean recursive = against.value().graph().recurses(fn);
             try {
                 return Answer.of(Lower.body(def.value(),
-                        inliner.value().namingBehaviors(behaviors.value()),
-                        recursive.value().contains(fn), dependencyParams(db, module, fn)).value());
+                        inliner.namingBehaviors(behaviors.value()),
+                        recursive, dependencyParams(db, module, fn)).value());
             } catch (CompileException e) {
                 return Answer.absent(e);
             }
@@ -1584,67 +1570,92 @@ public final class Bodies {
             Answer<Hir.Module> settled = db.ask(new Settled(name));
             Answer<souther.compiler.check.InvariantSettled> settling =
                     db.ask(new Shapes.Settling(name));
-            if (!against.present() || !settled.present() || !settling.present()) {
-                return Answer.absent();
-            }
-            // A row's operand is a definition of this module too — minted for it rather than
-            // written, and expanded the way any body is. Which definitions those are is the row
-            // machinery's to say and is asked there.
             Answer<Set<String>> rows = db.ask(new RowMethods(name));
-            if (!rows.present()) {
+            if (!against.present() || !settled.present() || !settling.present()
+                    || !rows.present()) {
                 return Answer.absent();
             }
-            SequencedSet<String> seeds =
-                    new LinkedHashSet<>(settling.value().standingRecursiveCalls());
-            SequencedSet<String> expanded = new LinkedHashSet<>();
-            for (Hir.FnDef fn : settled.value().fns()) {
-                expanded.add(fn.name());
+            HelperGraph graph = against.value().graph();
+            Set<String> required = new LinkedHashSet<>();
+            Deque<String> pending = new ArrayDeque<>();
+            Set<String> processed = new HashSet<>();
+
+            // What this module declared that recurses. Required whether or not anything reaches it:
+            // its source is this module's to check and to publish, which is not a question about
+            // use. Its body still goes through the walk below — being required is not being read.
+            for (String declared : against.value().table().declarations().keySet()) {
+                if (graph.recurses(declared)) {
+                    require(graph, required, pending, declared);
+                }
             }
-            expanded.addAll(rows.value());
-            for (String fn : expanded) {
-                Answer<Expansion<Hir.FnDef>> body = db.ask(new LoweredBody(name, fn));
+            // The trees that survive to run: a behavior's implementation, a row's operand, and the
+            // clauses. Nothing else is a root. A helper that does not recurse is expanded into
+            // whatever reaches it, so what it leaves standing is answered by that expansion — and a
+            // helper nothing reaches leaves nothing standing anywhere, which is why one that folds
+            // and is never called asks for no fold.
+            for (String standing : settling.value().standingRecursiveCalls()) {
+                require(graph, required, pending, standing);
+            }
+            Set<String> behaviors = Names.behaviorNames(settled.value());
+            Set<String> roots = new LinkedHashSet<>(rows.value());
+            for (Hir.FnDef fn : settled.value().fns()) {
+                if (behaviors.contains(fn.name())) {
+                    roots.add(fn.name());
+                }
+            }
+            for (String root : roots) {
+                Answer<Expansion<Hir.FnDef>> body = db.ask(new LoweredBody(name, root));
                 if (!body.present()) {
                     // Why is the body's to say, and it said it where it went wrong.
                     return Answer.absent();
                 }
-                seeds.addAll(body.value().standing());
-            }
-            HelperGraph graph = against.value().graph();
-            Set<String> reached = graph.reachedFrom(seeds);
-            SequencedSet<String> required = new LinkedHashSet<>();
-            // In the graph's order, which is declaration order: a check reporting one member of a
-            // mutual cycle reports the first, and the order is part of the answer.
-            for (String recursive : graph.recursive()) {
-                if (reached.contains(recursive)
-                        || against.value().table().declarations().containsKey(recursive)) {
-                    required.add(recursive);
+                for (String standing : body.value().standing()) {
+                    require(graph, required, pending, standing);
                 }
             }
-            return Answer.of(Collections.unmodifiableSequencedSet(required));
-        }
-    }
-
-    /** The signatures of a module's recursive helpers — what a self- or mutual call is typed
-     * against, and what every body that calls one reads. */
-    public record RecursiveHelperSigs(String name) implements Key<Map<String, Type>> {
-        @Override
-        public String module() {
-            return name;
-        }
-
-        @Override
-        public Answer<Map<String, Type>> compute(Db db) {
-            Answer<HelperInliner> inliner = expanding(db, name, InliningPolicy.FULL);
-            Answer<Symbols> scope = Names.derivedSymbols(db, name);
-            if (!inliner.present() || !scope.present()) {
-                return Answer.absent();
+            // A required definition is emitted as a method, so its own body is expanded on its own
+            // rather than into anything — and what that expansion leaves standing is required too.
+            // Followed here, by expanding it, and not by reading edges off the call graph: a body
+            // reaches a recursion by applying it and by reading a value whose body applies it, and
+            // only the first is a call. Reading the graph instead, a recursion behind a value was
+            // reached by the expansion and by nothing that could see it.
+            while (!pending.isEmpty()) {
+                String next = pending.removeFirst();
+                if (!processed.add(next)) {
+                    continue;
+                }
+                Answer<Expansion<Hir.FnDef>> body = db.ask(new LoweredBody(name, next));
+                if (!body.present()) {
+                    return Answer.absent();
+                }
+                for (String standing : body.value().standing()) {
+                    require(graph, required, pending, standing);
+                }
             }
-            try {
-                return Answer.of(TypeChecker.recursiveHelperSigs(inliner.value(), scope.value()));
-            } catch (CompileException e) {
-                // A recursive helper that does not say what it returns costs the signatures of all of
-                // them, and there is no module to check without them.
-                return Answer.absent(e);
+            // In the graph's order, which is declaration order: a check reporting one member of a
+            // mutual cycle reports the first, and the order is part of the answer. The walk above
+            // finds them in the order it happened to reach them, which is not that.
+            SequencedSet<String> ordered = new LinkedHashSet<>();
+            for (String recursive : graph.recursive()) {
+                if (required.contains(recursive)) {
+                    ordered.add(recursive);
+                }
+            }
+            return Answer.of(Collections.unmodifiableSequencedSet(ordered));
+        }
+
+        /** Takes {@code standing} on, and queues its body to be expanded the first time. */
+        private static void require(HelperGraph graph, Set<String> required, Deque<String> pending,
+                                    String standing) {
+            if (!graph.recurses(standing)) {
+                // An expansion answers with what it left standing, and a call is left standing
+                // because its callee recurses. One that does not is this compiler disagreeing with
+                // itself about why the call is still a call, and nothing here can be right about it.
+                throw new IllegalStateException("`" + standing + "` was left standing by an"
+                        + " expansion and does not recurse");
+            }
+            if (required.add(standing)) {
+                pending.addLast(standing);
             }
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -942,10 +942,11 @@ public final class Bodies {
                 return Answer.absent();
             }
             Map<String, Hir.FnDef> helpers = new LinkedHashMap<>(imported.value());
-            // What this module has, both components of it: a body may name a helper it took on to
-            // emit exactly as it names one it declared, and a row may apply either.
+            // What this module declared. A recursion it emits without having declared one is not
+            // here: it is reached under the name of the module that wrote it, which is a name this
+            // table already answers with that declaration, and which of them this module emits is
+            // settled after its trees are expanded rather than being carried here.
             helpers.putAll(HelperInliner.helpersOf(settled.value()));
-            helpers.putAll(HelperInliner.takenOnBy(settled.value()));
             return Answer.of(helpers);
         }
     }
@@ -1322,14 +1323,10 @@ public final class Bodies {
             if (!settled.present()) {
                 return Answer.absent();
             }
-            // Either component: a body is asked for by name, and a helper the module took on to emit
-            // has one to expand exactly as one it declared does.
-            for (List<Hir.FnDef> component : List.of(
-                    settled.value().fns(), settled.value().takenOn())) {
-                for (Hir.FnDef candidate : component) {
-                    if (candidate.name().equals(fn)) {
-                        return Answer.of(candidate);
-                    }
+            // What this module wrote.
+            for (Hir.FnDef candidate : settled.value().fns()) {
+                if (candidate.name().equals(fn)) {
+                    return Answer.of(candidate);
                 }
             }
             // A definition minted for a row, which is no declaration and is in no table.
@@ -1664,13 +1661,16 @@ public final class Bodies {
         @Override
         public Answer<Map<String, DataChecker.Constructs>> compute(Db db) {
             Answer<HelperInliner> inliner = expanding(db, name, InliningPolicy.FULL);
-            Answer<Map<String, Type>> sigs = db.ask(new RecursiveHelperSigs(name));
+            // The recursions this module processes, which is what has bodies here. A signature is a
+            // wider answer — it says what a call could be typed against, including a recursion
+            // nothing here reaches — and a body for one of those is a body nobody wrote.
+            Answer<SequencedSet<String>> required = db.ask(new RequiredRecursiveDefs(name));
             Answer<Symbols> scope = Names.derivedSymbols(db, name);
-            if (!inliner.present() || !sigs.present() || !scope.present()) {
+            if (!inliner.present() || !required.present() || !scope.present()) {
                 return Answer.absent();
             }
             Map<String, Hir.Expr> bodies = new LinkedHashMap<>();
-            for (String helper : sigs.value().keySet()) {
+            for (String helper : required.value()) {
                 Answer<Expansion<Hir.FnDef>> body = db.ask(new LoweredBody(name, helper));
                 if (!body.present()) {
                     return Answer.absent();
@@ -1678,7 +1678,7 @@ public final class Bodies {
                 bodies.put(helper, body.value().value().writtenBody());
             }
             try {
-                return Answer.of(TypeChecker.recursiveHelperConstructs(sigs.value().keySet(), bodies,
+                return Answer.of(TypeChecker.recursiveHelperConstructs(required.value(), bodies,
                         inliner.value(), scope.value()));
             } catch (CompileException e) {
                 return Answer.absent(e);

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -343,7 +343,7 @@ public final class Bodies {
             Answer<Lower.Lowered> lowering = db.ask(new Lowering(name));
             Answer<Symbols> scope = Names.derivedSymbols(db, name);
             Answer<Map<String, Sig>> signatures = db.ask(new Signatures(name));
-            Answer<Map<String, Type>> helpers = db.ask(new RecursiveHelperSigs(name));
+            Answer<Map<String, Type>> helpers = db.ask(new RecursiveCallSigs(name, InliningPolicy.FULL));
             if (!lowering.present() || !scope.present() || !signatures.present()
                     || !helpers.present()) {
                 return Answer.absent();
@@ -631,7 +631,7 @@ public final class Bodies {
             Answer<souther.compiler.check.Expandable> expandable = db.ask(new Shapes.Expandable(name));
             Answer<Symbols> scope = Names.derivedSymbols(db, name);
             Answer<Map<String, Sig>> signatures = db.ask(new Signatures(name));
-            Answer<Map<String, Type>> helpers = db.ask(new RecursiveHelperSigs(name));
+            Answer<Map<String, Type>> helpers = db.ask(new RecursiveCallSigs(name, InliningPolicy.FULL));
             if (!expandable.present() || !scope.present() || !signatures.present()
                     || !helpers.present()) {
                 return Answer.absent();
@@ -1602,7 +1602,7 @@ public final class Bodies {
                     db.ask(new CalleeSigsForBody(module, behavior));
             Answer<Map<ValueName.Behavior, ReqSig>> reqSigs = db.ask(new ReqSigs(module));
             Answer<HelperInliner> inliner = expanding(db, module, InliningPolicy.FULL);
-            Answer<Map<String, Type>> sigs = db.ask(new RecursiveHelperSigs(module));
+            Answer<Map<String, Type>> sigs = db.ask(new RecursiveCallSigs(module, InliningPolicy.FULL));
             Answer<Map<String, DataChecker.Constructs>> constructs =
                     db.ask(new RecursiveHelperConstructs(module));
             Answer<Hir.FnDef> discharge = db.ask(new BodyForInvariantDischarge(module, behavior));
@@ -1754,7 +1754,7 @@ public final class Bodies {
             Answer<Map<String, Sig>> signatures = db.ask(new Signatures(name));
             Answer<Set<ValueName.Behavior>> injected = db.ask(new ImportedInjected(name));
             Answer<Map<ValueName.Behavior, ReqSig>> reqSigs = db.ask(new ReqSigs(name));
-            Answer<Map<String, Type>> sigs = db.ask(new RecursiveHelperSigs(name));
+            Answer<Map<String, Type>> sigs = db.ask(new RecursiveCallSigs(name, InliningPolicy.FULL));
             Answer<Map<ValueName.Behavior, ReqSig>> calleeSigs = db.ask(new CalleeSigs(name));
             Answer<Map<String, Hir.FnDef>> published = db.ask(new ImportedDefinitions(name));
             if (!lowering.present() || !scope.present()

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -11,6 +11,7 @@ import souther.compiler.check.StatedContract;
 import souther.compiler.check.ContractDischarge;
 import souther.compiler.check.DataChecker;
 import souther.compiler.check.HelperInliner;
+import souther.compiler.check.Expansion;
 import souther.compiler.check.HelperGraph;
 import souther.compiler.check.HelperNames;
 import souther.compiler.check.HelperTable;
@@ -1306,23 +1307,28 @@ public final class Bodies {
      * <p>What it reads is the fn itself and the helpers around it, so editing another body in the same
      * module does not expand this one again.
      */
-    public record LoweredBody(String module, String fn) implements Key<Hir.FnDef> {
+    public record LoweredBody(String module, String fn) implements Key<Expansion<Hir.FnDef>> {
 
         @Override
-        public Answer<Hir.FnDef> compute(Db db) {
+        public Answer<Expansion<Hir.FnDef>> compute(Db db) {
             Answer<Hir.FnDef> def = db.ask(new SettledFn(module, fn));
-            Answer<HelperInliner> inliner = expanding(db, module, InliningPolicy.FULL);
-            Answer<SequencedSet<String>> recursive = db.ask(new RecursiveHelpers(module));
+            Answer<Expanding.Of> against = db.ask(new Expanding(module, InliningPolicy.FULL));
             Answer<Map<ValueName.Behavior, Integer>> behaviors =
                     db.ask(new NamedBehaviorArity(module));
-            if (!def.present() || !inliner.present() || !recursive.present()
-                    || !behaviors.present()) {
+            if (!def.present() || !against.present() || !behaviors.present()) {
                 return Answer.absent();
             }
+            // Whether this body is a recursion, asked of the graph rather than of the set the module
+            // took on. The two agree for every fn that has a body here, and the graph does not have
+            // to be told what the module reaches — which is what makes what the module reaches
+            // askable in terms of this.
+            boolean recursive = against.value().graph().recurses(fn);
             try {
+                HelperInliner inliner = HelperInliner.over(against.value().table(),
+                        against.value().graph());
                 return Answer.of(Lower.body(def.value(),
-                        inliner.value().namingBehaviors(behaviors.value()),
-                        recursive.value().contains(fn), dependencyParams(db, module, fn)));
+                        inliner.namingBehaviors(behaviors.value()),
+                        recursive, dependencyParams(db, module, fn)));
             } catch (CompileException e) {
                 return Answer.absent(e);
             }
@@ -1354,7 +1360,7 @@ public final class Bodies {
             try {
                 return Answer.of(Lower.body(def.value(),
                         inliner.value().namingBehaviors(behaviors.value()),
-                        recursive.value().contains(fn), dependencyParams(db, module, fn)));
+                        recursive.value().contains(fn), dependencyParams(db, module, fn)).value());
             } catch (CompileException e) {
                 return Answer.absent(e);
             }
@@ -1408,13 +1414,13 @@ public final class Bodies {
                     if (!taken.add(fn.name())) {
                         continue;
                     }
-                    Answer<Hir.FnDef> body = db.ask(new LoweredBody(name, fn.name()));
+                    Answer<Expansion<Hir.FnDef>> body = db.ask(new LoweredBody(name, fn.name()));
                     if (!body.present()) {
                         // Why is the body's to say, and it said it. A module with a body that does
                         // not expand has none to emit.
                         return Answer.absent();
                     }
-                    fns.add(body.value());
+                    fns.add(body.value().value());
                 }
                 lowered.add(fns);
             }
@@ -1513,11 +1519,11 @@ public final class Bodies {
             }
             Map<String, Hir.Expr> bodies = new LinkedHashMap<>();
             for (String helper : sigs.value().keySet()) {
-                Answer<Hir.FnDef> body = db.ask(new LoweredBody(name, helper));
+                Answer<Expansion<Hir.FnDef>> body = db.ask(new LoweredBody(name, helper));
                 if (!body.present()) {
                     return Answer.absent();
                 }
-                bodies.put(helper, body.value().writtenBody());
+                bodies.put(helper, body.value().value().writtenBody());
             }
             try {
                 return Answer.of(TypeChecker.recursiveHelperConstructs(sigs.value().keySet(), bodies,
@@ -1593,7 +1599,7 @@ public final class Bodies {
         public Answer<Core> compute(Db db) {
             Answer<Hir.SpecBehavior> spec = db.ask(new Spec(module, behavior));
             Answer<Hir.FnDef> fn = db.ask(new SettledFn(module, behavior));
-            Answer<Hir.FnDef> body = db.ask(new LoweredBody(module, behavior));
+            Answer<Expansion<Hir.FnDef>> body = db.ask(new LoweredBody(module, behavior));
             Answer<Symbols> scope = Names.derivedSymbols(db, module);
             // What this body names, and not what its module happens to have callable in it: a
             // signature it never names is no part of what it is checked against, and depending on
@@ -1628,7 +1634,8 @@ public final class Bodies {
                     : null;
             List<Diagnostic> warnings = new ArrayList<>();
             try {
-                Core core = TypeChecker.checkBehavior(spec.value(), fn.value(), body.value().writtenBody(),
+                Core core = TypeChecker.checkBehavior(spec.value(), fn.value(),
+                        body.value().value().writtenBody(),
                         db.ask(new Front.Reading()).value(),
                         dischargeSource, scope.value(), calleeSigs.value(), reqSigs.value(),
                         inliner.value(), sigs.value(), constructs.value(),

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -1423,6 +1423,52 @@ public final class Bodies {
         }
     }
 
+    /**
+     * The signatures every recursive helper this representation can reach would be called under.
+     *
+     * <p>What typing a call left standing needs, and nothing about what this module turned out to
+     * reach. A call is left standing because its callee recurses — which is a fact about the
+     * declarations in reach and is what {@link HelperGraph#recursive()} answers — so the names a body
+     * of this module could hold a standing call to are those, whether or not any body holds one. Read
+     * off the table rather than found by walking the module: a walk over the places a module writes
+     * expressions is a second statement of what a module is made of, and the one that was here
+     * answered that a rule reaching a fold needed nothing.
+     *
+     * <p>Wider than {@link RecursiveHelperSigs}, and not a replacement for it. That one answers which
+     * helpers this module has taken on to process and emit, which is what a reader wanting a body
+     * needs; this one answers which names can be typed, which is what a reader holding a call needs.
+     * Kept apart because a signature for a helper nobody called costs an entry in a map, and a body
+     * for one costs a body that does not exist.
+     *
+     * <p>Keyed by the policy as {@link Expanding} is: the discharge representation leaves the
+     * language's own operations standing rather than expanding them into the fold they become, so its
+     * table holds none of the library and its recursive set is not the emitted representation's.
+     */
+    public record RecursiveCallSigs(String name, InliningPolicy policy)
+            implements Key<Map<String, Type>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, Type>> compute(Db db) {
+            Answer<Expanding.Of> against = db.ask(new Expanding(name, policy));
+            Answer<Symbols> scope = Names.derivedSymbols(db, name);
+            if (!against.present() || !scope.present()) {
+                return Answer.absent();
+            }
+            try {
+                return Answer.of(TypeChecker.recursiveCallSigs(against.value().table(),
+                        against.value().graph().recursive(), scope.value()));
+            } catch (CompileException e) {
+                // A recursive helper that does not say what it returns costs the signatures of all of
+                // them, and there is no module to check without them.
+                return Answer.absent(e);
+            }
+        }
+    }
+
     /** The signatures of a module's recursive helpers — what a self- or mutual call is typed
      * against, and what every body that calls one reads. */
     public record RecursiveHelperSigs(String name) implements Key<Map<String, Type>> {

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -1245,6 +1245,40 @@ public final class Bodies {
     }
 
     /**
+     * The definitions a module's row operands are, by the name each is emitted under.
+     *
+     * <p>Their own family. A row's operand is a value this compilation writes for the row, reached
+     * from a row and from nothing a source can spell, so it is not a declaration a name resolves to
+     * — which is why it is not among what the module has as fns of its own and is not in the table a
+     * call expands against. It rode there once, to be carried through the passes a fn is carried
+     * through, and every rule keyed on what the module holds had a synthetic method among its
+     * subjects.
+     *
+     * <p>Read from the one walk that built them, which built the correspondence beside them
+     * ({@link RowMethods}) — a second reading would be a second numbering, and a row would run the
+     * operand beside the one it wrote.
+     */
+    public record RowFixtureDefs(String name) implements Key<Map<String, Hir.FnDef>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, Hir.FnDef>> compute(Db db) {
+            Answer<souther.compiler.check.Prepared> prepared = db.ask(new Shapes.Prepared(name));
+            if (!prepared.present()) {
+                return Answer.absent();
+            }
+            Map<String, Hir.FnDef> out = new LinkedHashMap<>();
+            for (Hir.FnDef def : prepared.value().rowDefs()) {
+                out.put(def.name(), def);
+            }
+            return Answer.of(Ordered.map(out));
+        }
+    }
+
+    /**
      * The methods a module emits for its rows: one per operand, answering with the value that
      * operand is.
      *
@@ -1297,6 +1331,11 @@ public final class Bodies {
                         return Answer.of(candidate);
                     }
                 }
+            }
+            // A definition minted for a row, which is no declaration and is in no table.
+            Answer<Map<String, Hir.FnDef>> rows = db.ask(new RowFixtureDefs(module));
+            if (rows.present() && rows.value().containsKey(fn)) {
+                return Answer.of(rows.value().get(fn));
             }
             // A declaration this module reaches and has not taken on. Its body is the declaring
             // module's and was settled there; what changes here is the name it answers to, which is
@@ -1428,11 +1467,11 @@ public final class Bodies {
             }
             // A row's operand is a definition minted for it, and it is emitted beside these for the
             // same reason: nothing inlines it, because nothing calls it.
-            for (Hir.FnDef fn : settled.value().takenOn()) {
-                if (rowMethods.value().contains(fn.name())) {
-                    beyond.add(fn);
-                }
+            Answer<Map<String, Hir.FnDef>> rows = db.ask(new RowFixtureDefs(name));
+            if (!rows.present()) {
+                return Answer.absent();
             }
+            beyond.addAll(rows.value().values());
             // Both, and each stays where it was: what becomes a method is one question and what this
             // module declared is another, and the backend reads the first while every rule about the
             // declaring module reads the second.

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -1297,7 +1298,17 @@ public final class Bodies {
                     }
                 }
             }
-            return Answer.absent();
+            // A declaration this module reaches and has not taken on. Its body is the declaring
+            // module's and was settled there; what changes here is the name it answers to, which is
+            // the name this module reaches it by and the name a method is emitted under. Read from
+            // the table rather than from a component, so asking for a body does not depend on the
+            // module having already been told it needs one.
+            Answer<Expanding.Of> against = db.ask(new Expanding(module, InliningPolicy.FULL));
+            if (!against.present()) {
+                return Answer.absent();
+            }
+            Hir.FnDef reached = against.value().table().reached(fn);
+            return reached == null ? Answer.absent() : Answer.of(reached.reachedAs(fn));
         }
     }
 
@@ -1384,7 +1395,7 @@ public final class Bodies {
         @Override
         public Answer<Lower.Lowered> compute(Db db) {
             Answer<Hir.Module> settled = db.ask(new Settled(name));
-            Answer<SequencedSet<String>> recursive = db.ask(new RecursiveHelpers(name));
+            Answer<SequencedSet<String>> recursive = db.ask(new RequiredRecursiveDefs(name));
             Answer<Set<String>> rowMethods = db.ask(new RowMethods(name));
             if (!settled.present() || !recursive.present() || !rowMethods.present()) {
                 return Answer.absent();
@@ -1396,11 +1407,36 @@ public final class Bodies {
             // that took on a helper it also declares would otherwise emit two of it.
             Set<String> taken = new LinkedHashSet<>();
             List<List<Hir.FnDef>> lowered = new ArrayList<>();
+            // What this module emits and did not declare: every recursion its own expansions left
+            // standing that it has no declaration for, under the name it reaches each by — which is
+            // the name a call in the emitted tree already holds, and so the name the method is
+            // written under. This is the one place a declaration of another module becomes a method
+            // of this one, so it is the one place the renaming happens.
+            List<Hir.FnDef> beyond = new ArrayList<>();
+            Set<String> declaredHere = new LinkedHashSet<>();
+            for (Hir.FnDef fn : settled.value().fns()) {
+                declaredHere.add(fn.name());
+            }
+            for (String required : recursive.value()) {
+                if (!declaredHere.contains(required)) {
+                    Answer<Hir.FnDef> def = db.ask(new SettledFn(name, required));
+                    if (!def.present()) {
+                        return Answer.absent();
+                    }
+                    beyond.add(def.value());
+                }
+            }
+            // A row's operand is a definition minted for it, and it is emitted beside these for the
+            // same reason: nothing inlines it, because nothing calls it.
+            for (Hir.FnDef fn : settled.value().takenOn()) {
+                if (rowMethods.value().contains(fn.name())) {
+                    beyond.add(fn);
+                }
+            }
             // Both, and each stays where it was: what becomes a method is one question and what this
             // module declared is another, and the backend reads the first while every rule about the
             // declaring module reads the second.
-            for (List<Hir.FnDef> component : List.of(
-                    settled.value().fns(), settled.value().takenOn())) {
+            for (List<Hir.FnDef> component : List.of(settled.value().fns(), beyond)) {
                 List<Hir.FnDef> fns = new ArrayList<>();
                 for (Hir.FnDef fn : component) {
                     // A non-recursive helper is fully inlined at its call sites and never
@@ -1472,6 +1508,83 @@ public final class Bodies {
                 // them, and there is no module to check without them.
                 return Answer.absent(e);
             }
+        }
+    }
+
+    /**
+     * The recursive helpers this module has to process and emit: the ones it declared, and the ones
+     * an expansion of its own left a call standing to.
+     *
+     * <p>Made of what the expansions did, not of a prediction about what they would do. Every tree
+     * this module is made of is expanded somewhere, and each of those expansions answers with the
+     * recursions it could not remove ({@link Expansion}); this is those answers joined, closed over
+     * the call graph, and narrowed to what recurses.
+     *
+     * <p>The seeds are the trees, and there are two kinds. A definition's body is expanded by {@link
+     * LoweredBody}, which answers with what it left standing. A clause — a data's {@code invariant},
+     * a behavior's {@code ensures} — is not a definition and is in no table, so what it reaches is
+     * known only to the expansion that read it, and it travels out of {@link Shapes.Settling}. The
+     * walk that was here instead listed the places a module writes expressions and did not list
+     * {@code ensures}, so a rule reaching a fold asked for no fold.
+     *
+     * <p>The closure is the call graph's and is taken once. What a required helper's own body
+     * reaches is an edge of that graph, already there because the graph is built over every
+     * declaration in reach — so a helper reached only through a non-recursive one, and every member
+     * of a mutually-recursive group, arrive without a second round.
+     *
+     * <p>A helper this module declared is here whether or not anything reaches it: its source is
+     * this module's to check and to publish, which is not a question about use. Only what it did not
+     * declare is decided by use.
+     */
+    public record RequiredRecursiveDefs(String name) implements Key<SequencedSet<String>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<SequencedSet<String>> compute(Db db) {
+            Answer<Expanding.Of> against = db.ask(new Expanding(name, InliningPolicy.FULL));
+            Answer<Hir.Module> settled = db.ask(new Settled(name));
+            Answer<souther.compiler.check.InvariantSettled> settling =
+                    db.ask(new Shapes.Settling(name));
+            if (!against.present() || !settled.present() || !settling.present()) {
+                return Answer.absent();
+            }
+            // A row's operand is a definition of this module too — minted for it rather than
+            // written, and expanded the way any body is. Which definitions those are is the row
+            // machinery's to say and is asked there.
+            Answer<Set<String>> rows = db.ask(new RowMethods(name));
+            if (!rows.present()) {
+                return Answer.absent();
+            }
+            SequencedSet<String> seeds =
+                    new LinkedHashSet<>(settling.value().standingRecursiveCalls());
+            SequencedSet<String> expanded = new LinkedHashSet<>();
+            for (Hir.FnDef fn : settled.value().fns()) {
+                expanded.add(fn.name());
+            }
+            expanded.addAll(rows.value());
+            for (String fn : expanded) {
+                Answer<Expansion<Hir.FnDef>> body = db.ask(new LoweredBody(name, fn));
+                if (!body.present()) {
+                    // Why is the body's to say, and it said it where it went wrong.
+                    return Answer.absent();
+                }
+                seeds.addAll(body.value().standing());
+            }
+            HelperGraph graph = against.value().graph();
+            Set<String> reached = graph.reachedFrom(seeds);
+            SequencedSet<String> required = new LinkedHashSet<>();
+            // In the graph's order, which is declaration order: a check reporting one member of a
+            // mutual cycle reports the first, and the order is part of the answer.
+            for (String recursive : graph.recursive()) {
+                if (reached.contains(recursive)
+                        || against.value().table().declarations().containsKey(recursive)) {
+                    required.add(recursive);
+                }
+            }
+            return Answer.of(Collections.unmodifiableSequencedSet(required));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -79,7 +79,7 @@ public final class Output {
                         shipped(in), in.scope(), in.typePackages(), in.sigs(), in.imported(),
                         in.injected(),
                         in.callees(), in.requirements(), in.checked(), in.dischargeClauses(),
-                        in.checks());
+                        in.checks(), in.standingCalls());
                 stamp(db, emitted);
                 return Answer.of(Ordered.map(emitted.byBinaryName()));
             } catch (CompileException e) {
@@ -123,7 +123,8 @@ public final class Output {
                       Bodies.Elaborated checked,
                       Map<TypeSymbol, List<Hir.InvariantClause>> dischargeClauses,
                       Map<ValueName.Behavior, EnsuresEnforcement> checks,
-                      Set<String> rowMethods) {}
+                      Set<String> rowMethods,
+                      Map<String, souther.compiler.types.Type> standingCalls) {}
 
         static Inputs inputs(Db db, String name) {
             Answer<Bodies.Elaborated> checked = db.ask(new Bodies.Checked(name));
@@ -147,10 +148,16 @@ public final class Output {
             Answer<Map<TypeSymbol, List<Hir.InvariantClause>>> dischargeClauses =
                     db.ask(new Shapes.InvariantsForDischarge(name));
             Answer<Map<String, BehaviorContract>> contracts = db.ask(new Bodies.Contracts(name));
+            // What a call left standing is typed against — the same answer the check typed it
+            // against. The emitter re-types the expressions it emits (a clause, a rule), so a
+            // signature table of its own would be a second reading of what a name means, and the two
+            // would agree only until one of them was edited.
+            Answer<Map<String, souther.compiler.types.Type>> standing =
+                    db.ask(new Bodies.RecursiveCallSigs(name, souther.compiler.check.InliningPolicy.FULL));
             if (!checked.present() || !lowering.present() || !scope.present() || !imported.present()
                     || !signatures.present() || !injected.present() || !callees.present()
                     || !prepared.present() || !requirements.present() || !dischargeClauses.present()
-                    || !contracts.present()) {
+                    || !contracts.present() || !standing.present()) {
                 return null;
             }
             return new Inputs(lowering.value().lowered(), scope.value(),
@@ -158,7 +165,7 @@ public final class Output {
                     injected.value(),
                     callees.value(), requirements.value(), checked.value(), dischargeClauses.value(),
                     checksOf(lowering.value().lowered(), injected.value(), contracts.value()),
-                    Set.copyOf(prepared.value().operandMethods().values()));
+                    Set.copyOf(prepared.value().operandMethods().values()), standing.value());
         }
 
         /**
@@ -379,7 +386,7 @@ public final class Output {
                         in.lowered(), in.scope(), in.typePackages(), in.sigs(), in.imported(),
                         in.injected(),
                         in.callees(), in.requirements(), in.checked(), in.dischargeClauses(),
-                        in.checks(), instrumentation);
+                        in.checks(), in.standingCalls(), instrumentation);
                 Classes.stamp(db, name, emitted);
                 // The classes and what they implement, from the one emission that decided both.
                 return Answer.of(new EvaluationArtifact(Ordered.map(emitted.byBinaryName()),

--- a/souther-compiler/src/test/java/souther/compiler/ARuleReachingAQuantifierGetsTheFoldItBecomesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleReachingAQuantifierGetsTheFoldItBecomesTest.java
@@ -1,0 +1,124 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * A rule may quantify over a collection, and the fold that becomes is the module's to emit.
+ *
+ * <p>{@code List.all} and the rest of the quantifiers are ordinary library helpers derived from the
+ * fold, so a rule naming one holds a call to the library's one recursion once it has been expanded —
+ * and a recursion cannot be expanded away, so the module holding that rule emits a method for it.
+ * That is true of a rule for exactly the reason it is true of a body, and a module reaching a
+ * quantifier from a rule and from nowhere else was not being given the method: what it had to emit
+ * was worked out by listing the places a module writes expressions, and a rule was not one of them.
+ *
+ * <p>Held end to end, because the middle is where it went wrong in three different ways as the
+ * answer moved: no signature to type the call against, then no method to call, then no elaborated
+ * body to emit the method from. What settles it is that the program runs.
+ */
+class ARuleReachingAQuantifierGetsTheFoldItBecomesTest {
+
+    private static final String ONLY_FROM_A_RULE = """
+            module quantified
+
+            data Age = Int
+                invariant value >= 0
+
+            data Person = { age: Age }
+
+            data Count = Int
+                invariant value >= 0
+
+            behavior countAdults : (people: List<Person>) -> Count
+                ensures grown = List.all(p -> p.age.value >= 18, people) && value.value >= 0
+            """;
+
+    /** Every emitted class, loaded — which is where the JVM verifies each method it holds. */
+    private static Class<?> loadingAll(Map<String, byte[]> classes, String named) {
+        BytesClassLoader loader = new BytesClassLoader(classes,
+                ARuleReachingAQuantifierGetsTheFoldItBecomesTest.class.getClassLoader());
+        for (String name : classes.keySet()) {
+            assertDoesNotThrow(() -> Class.forName(name, true, loader), name);
+        }
+        return assertDoesNotThrow(() -> Class.forName(named, true, loader));
+    }
+
+    @Test
+    void aModuleWhoseOnlyQuantifierIsInARuleCompiles() {
+        assertDoesNotThrow(() -> Compiler.compile(ONLY_FROM_A_RULE));
+    }
+
+    /** And emits the fold, which is the method the expanded rule holds a call to. */
+    @Test
+    void andEmitsTheFoldTheRuleExpandedTo() throws Exception {
+        Map<String, byte[]> classes = Compiler.compile(ONLY_FROM_A_RULE);
+        Class<?> fns = loadingAll(classes, "quantified.$Fns");
+
+        Method fold = fns.getDeclaredMethod("List$foldFrom",
+                Object.class, Object.class, Object.class, Object.class);
+        assertNotNull(fold);
+        fold.setAccessible(true);
+
+        souther.runtime.Fn step = args -> (Boolean) args[0] && (Long) args[1] >= 18L;
+        assertEquals(Boolean.TRUE, fold.invoke(null, step, Boolean.TRUE, List.of(20L, 30L), 0L));
+        assertEquals(Boolean.FALSE, fold.invoke(null, step, Boolean.TRUE, List.of(20L, 7L), 0L));
+    }
+
+    /**
+     * A recursion another module published, reached from a rule and from nowhere else. The same
+     * mistake, and it did not even reach a report: the call was typed against nothing and the check
+     * failed inside this compiler.
+     */
+    @Test
+    void andSoDoesARuleReachingARecursionAnotherModulePublished() {
+        String lib = """
+                module chart exposing ( Emp, depth )
+
+                data Emp = { boss: Emp? }
+
+                let depth (e: Emp) : Int =
+                    match e.boss with
+                        | Some b -> 1 + depth(b)
+                        | None   -> 0
+                """;
+        String user = """
+                module reports
+
+                import chart as Chart ( Emp, depth )
+
+                data Rank = Int
+
+                behavior rankOf : (e: Emp) -> Rank
+                    ensures deep = value.value >= depth(e)
+                """;
+
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of(lib, user)));
+    }
+
+    /**
+     * And where something else in the module reaches the same quantifier, which is how the mistake
+     * stayed hidden: the fold arrived for the other reader's sake and the rule was carried by it.
+     */
+    @Test
+    void andWhereADefinitionReachesTheSameQuantifierToo() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module both
+
+                data Count = Int
+                    invariant value >= 0
+
+                behavior countIt : (xs: List<Int>) -> Count
+                    ensures nonNegative = List.all(x -> x >= 0, xs) && value.value >= 0
+
+                let anyNegative (ys: List<Int>) : Bool = List.any(y -> y < 0, ys)
+                """));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AnAnswersIdentityCoversEverythingItAnswersWithTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnAnswersIdentityCoversEverythingItAnswersWithTest.java
@@ -1,0 +1,184 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.instruction.FieldInstruction;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * A state a query answers with is a value, and its identity is everything it answers with.
+ *
+ * <p>The store decides whether anything downstream has to be asked again by comparing the answer it
+ * recomputed against the one it held: equal means nothing changed, and nothing that read it is asked
+ * again. So a state whose {@code equals} leaves out something a reader can get out of it is a state
+ * the store cannot tell has changed — the reader keeps the old one, and nothing anywhere reports
+ * that it did.
+ *
+ * <p>Written by hand, an identity is a copy of the field list, and a field added later is not in it.
+ * That has happened twice: a settled module gained the recursions its clauses left standing, and a
+ * prepared module gained the definitions minted for its rows, and both were added beside an identity
+ * that went on comparing what it compared before. Neither is visible in a diff of the identity,
+ * because the identity is what did not change.
+ *
+ * <p>So it is read off the compiled class rather than off the source: which fields a class has is
+ * the class's own answer, and which of them {@code equals} reaches is what the method actually
+ * does. Reaches, and not loads directly — an identity here is usually written of a projection, and
+ * comparing what a state hands over as a tree covers everything that tree is built from. A field is
+ * uncovered only where nothing {@code equals} reaches ever loads it.
+ *
+ * <p>Two kinds of field are not part of an identity and are named here rather than guessed at. A
+ * {@code volatile} field is a worked-out answer kept beside the state — writing it changes nothing
+ * anybody can observe, and it is derived from the fields that are covered. A field a record
+ * declares is covered by the identity the record already has, so a record is not asked about at all.
+ */
+class AnAnswersIdentityCoversEverythingItAnswersWithTest {
+
+    /** Where a state's identity may leave a field out, and why. Nothing else may. */
+    private static final Map<String, String> ALLOWED = Map.of(
+            "souther.compiler.check.Term.hash",
+            "the hash is of the shape and the parts, and is compared first as a way of saying no",
+            "souther.compiler.check.Prepared.operandMethods",
+            "keyed on operand identity, over the very nodes the tree hands out — it says nothing"
+                    + " the tree and the definitions built from it do not already say");
+
+    @Test
+    void everyHandWrittenIdentityReadsEveryFieldItsStateHolds() throws IOException {
+        Map<String, String> uncovered = new TreeMap<>();
+        int asked = 0;
+        for (Path each : classesOfTheCheck()) {
+            ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+            MethodModel equals = declaredEquals(model);
+            if (equals == null) {
+                continue;
+            }
+            asked++;
+            Set<String> read = fieldsReadBy(model, equals);
+            for (String field : instanceFieldsOf(model)) {
+                String qualified = model.thisClass().asInternalName().replace('/', '.')
+                        .replace('$', '.') + "." + field;
+                if (!read.contains(field) && !ALLOWED.containsKey(qualified)) {
+                    uncovered.put(qualified, "held but never read by `equals`");
+                }
+            }
+        }
+        assertFalse(asked == 0, "no hand-written identity was read at all, so this says nothing");
+        assertEquals(Map.of(), uncovered,
+                "a state that answers with something its identity leaves out is one the store"
+                        + " cannot tell has changed, and every reader of it keeps the old answer");
+    }
+
+    /** The class's own {@code equals(Object)}, or null where it inherits one. */
+    private static MethodModel declaredEquals(ClassModel model) {
+        for (MethodModel method : model.methods()) {
+            if (method.methodName().stringValue().equals("equals")
+                    && method.methodType().stringValue().equals("(Ljava/lang/Object;)Z")) {
+                return method;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Every field {@code equals} reaches, through the methods of its own class that it calls.
+     *
+     * <p>Following the calls, because an identity here is usually written of a projection rather
+     * than of the fields: comparing what the state hands over as a tree covers everything the tree
+     * is built from. A field is left out only where nothing {@code equals} reaches ever loads it.
+     */
+    private static Set<String> fieldsReadBy(ClassModel model, MethodModel equals) {
+        Set<String> read = new LinkedHashSet<>();
+        Set<String> walked = new LinkedHashSet<>();
+        Deque<MethodModel> pending = new ArrayDeque<>();
+        pending.add(equals);
+        String self = model.thisClass().asInternalName();
+        while (!pending.isEmpty()) {
+            MethodModel method = pending.removeFirst();
+            if (!walked.add(method.methodName().stringValue()
+                    + method.methodType().stringValue())) {
+                continue;
+            }
+            method.code().ifPresent(code -> code.forEach(element -> {
+                if (element instanceof FieldInstruction field) {
+                    read.add(field.name().stringValue());
+                }
+                if (element instanceof InvokeInstruction call
+                        && call.owner().asInternalName().equals(self)) {
+                    for (MethodModel candidate : model.methods()) {
+                        if (candidate.methodName().stringValue().equals(call.name().stringValue())
+                                && candidate.methodType().stringValue()
+                                        .equals(call.type().stringValue())) {
+                            pending.add(candidate);
+                        }
+                    }
+                }
+            }));
+        }
+        return read;
+    }
+
+    /**
+     * The instance fields the state holds, less the ones an identity is not made of: a
+     * {@code volatile} answer worked out from the others, and the synthetic references a nested
+     * class carries.
+     */
+    private static List<String> instanceFieldsOf(ClassModel model) {
+        List<String> fields = new ArrayList<>();
+        model.fields().forEach(field -> {
+            java.lang.reflect.AccessFlag[] flags =
+                    field.flags().flags().toArray(new java.lang.reflect.AccessFlag[0]);
+            boolean statik = false;
+            boolean unstable = false;
+            boolean synthetic = false;
+            for (java.lang.reflect.AccessFlag flag : flags) {
+                statik |= flag == java.lang.reflect.AccessFlag.STATIC;
+                unstable |= flag == java.lang.reflect.AccessFlag.VOLATILE;
+                synthetic |= flag == java.lang.reflect.AccessFlag.SYNTHETIC;
+            }
+            if (!statik && !unstable && !synthetic
+                    && !field.fieldName().stringValue().startsWith("this$")) {
+                fields.add(field.fieldName().stringValue());
+            }
+        });
+        return fields;
+    }
+
+    /**
+     * The compiled classes of the check, records left out.
+     *
+     * <p>Read from the build and not from the sources: which fields a class has and which of them a
+     * method loads are what the class file says, and a reading of the text would be answering the
+     * same question a second way.
+     */
+    private static List<Path> classesOfTheCheck() throws IOException {
+        Path root = Path.of("target", "classes", "souther", "compiler", "check").toAbsolutePath();
+        try (Stream<Path> walk = Files.walk(root)) {
+            List<Path> out = new ArrayList<>();
+            for (Path each : walk.filter(p -> p.toString().endsWith(".class")).toList()) {
+                ClassModel model = ClassFile.of().parse(Files.readAllBytes(each));
+                if (model.superclass().isEmpty()
+                        || !model.superclass().get().asInternalName().equals("java/lang/Record")) {
+                    out.add(each);
+                }
+            }
+            return out;
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/TheCallGraphReadsASugarFromTheLibraryThatDeclaresItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TheCallGraphReadsASugarFromTheLibraryThatDeclaresItTest.java
@@ -1,0 +1,102 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.ConstructionOrigin;
+import souther.compiler.types.ReachName;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A sugar is a call to something else, and the call graph has to know which something else.
+ *
+ * <p>{@code List.fold} has no declaration of its own: it is {@code List.foldFrom} with the index the
+ * walk starts from already supplied. So a body that folds reaches the library's one recursion, and an
+ * edge to it is what says the module holding that body needs the method. Read from the library, which
+ * is where the rewrite is declared — written out beside it, the two agreed until a second sugar was
+ * added, and the disagreement is an edge quietly missing from a graph nothing else re-derives.
+ *
+ * <p>The condition is the rewrite's own. A sugar written with a different number of arguments than
+ * it stands for is not that call, the rewrite is not taken, and no edge is owed — crediting one
+ * would put a declaration into what a module has to emit on the strength of a call that never
+ * reaches it.
+ *
+ * <p>Every sugar the library declares is asked about, so this covers the next one on the day it is
+ * added rather than the day someone remembers this file.
+ */
+class TheCallGraphReadsASugarFromTheLibraryThatDeclaresItTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    /** A call of {@code qualified} applied to {@code args} integers. */
+    private static Hir.Expr callTo(String qualified, int args) {
+        int dot = qualified.lastIndexOf('.');
+        ValueName.Stdlib name =
+                new ValueName.Stdlib(qualified.substring(0, dot), qualified.substring(dot + 1));
+        List<Hir.Expr> given = new ArrayList<>();
+        for (int i = 0; i < args; i++) {
+            given.add(new Hir.IntLit(i, POS, null));
+        }
+        return new Hir.Apply(qualified, name, new ReachName.OfLibrary(name), given,
+                ConstructionOrigin.own(), POS, null);
+    }
+
+    private static Set<String> callsIn(Hir.Expr e) {
+        Set<String> out = new LinkedHashSet<>();
+        HelperInliner.helperCallsIn(e, Prelude.helpers(), out);
+        return out;
+    }
+
+    @Test
+    void theLibraryDeclaresAtLeastOneSugarForThisToBeAbout() {
+        assertFalse(Prelude.rewrites().isEmpty(),
+                "a claim about every sugar says nothing where there are none");
+    }
+
+    @Test
+    void aSugarWrittenWithWhatItStandsForReachesWhatItRewritesTo() {
+        Prelude.rewrites().forEach((sugar, rewrite) -> {
+            Set<String> reached = callsIn(callTo(sugar, rewrite.keptArgs()));
+
+            assertEquals(Set.of(rewrite.target().qualified()), reached,
+                    sugar + " is " + rewrite.target().qualified() + " with "
+                            + rewrite.supplied().size() + " argument(s) supplied");
+        });
+    }
+
+    @Test
+    void andOneWrittenWithAnotherNumberOfArgumentsReachesNothing() {
+        Prelude.rewrites().forEach((sugar, rewrite) -> {
+            assertEquals(Set.of(), callsIn(callTo(sugar, rewrite.keptArgs() + 1)),
+                    sugar + " written with one argument too many is not the call it stands for");
+            if (rewrite.keptArgs() > 0) {
+                assertEquals(Set.of(), callsIn(callTo(sugar, rewrite.keptArgs() - 1)),
+                        sugar + " written with one too few is not it either");
+            }
+        });
+    }
+
+    /** And what the sugar rewrites to is a recursion, which is why the edge decides anything. */
+    @Test
+    void whatASugarRewritesToIsSomethingAModuleWouldHaveToEmit() {
+        HelperTable table = HelperTable.of("probe", Map.of(), Map.of(), Map.of(),
+                InliningPolicy.FULL);
+        HelperGraph graph = HelperGraph.of(table);
+
+        Prelude.rewrites().forEach((sugar, rewrite) ->
+                assertTrue(graph.recurses(rewrite.target().qualified()),
+                        sugar + " rewrites to " + rewrite.target().qualified()
+                                + ", which a module emits as a method only because it recurses"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/TheCallGraphReadsASugarFromTheLibraryThatDeclaresItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TheCallGraphReadsASugarFromTheLibraryThatDeclaresItTest.java
@@ -16,6 +16,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -87,16 +88,25 @@ class TheCallGraphReadsASugarFromTheLibraryThatDeclaresItTest {
         });
     }
 
-    /** And what the sugar rewrites to is a recursion, which is why the edge decides anything. */
+    /**
+     * And why the edge decides anything, for the one sugar the library has: {@code List.fold}
+     * rewrites to a recursion, so a body that folds holds a call nothing can expand away and the
+     * module holding it emits a method.
+     *
+     * <p>Of that sugar and not of every sugar. Nothing in {@link Prelude.Rewrite} says a rewrite
+     * target recurses — one onto an ordinary helper would be a rewrite like any other — so a claim
+     * made of all of them would refuse the next sugar for being unlike this one.
+     */
     @Test
-    void whatASugarRewritesToIsSomethingAModuleWouldHaveToEmit() {
+    void theFoldSugarRewritesToSomethingAModuleWouldHaveToEmit() {
         HelperTable table = HelperTable.of("probe", Map.of(), Map.of(), Map.of(),
                 InliningPolicy.FULL);
         HelperGraph graph = HelperGraph.of(table);
+        Prelude.Rewrite fold = Prelude.rewriteOf("List.fold");
 
-        Prelude.rewrites().forEach((sugar, rewrite) ->
-                assertTrue(graph.recurses(rewrite.target().qualified()),
-                        sugar + " rewrites to " + rewrite.target().qualified()
-                                + ", which a module emits as a method only because it recurses"));
+        assertNotNull(fold, "`List.fold` is sugar for the fold the combinators are derived from");
+        assertEquals("List.foldFrom", fold.target().qualified());
+        assertTrue(graph.recurses("List.foldFrom"),
+                "a module emits it as a method only because it recurses");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatCanBeTypedHereIsNotWhatCouldHaveBeenWrittenHereTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatCanBeTypedHereIsNotWhatCouldHaveBeenWrittenHereTest.java
@@ -1,0 +1,76 @@
+package souther.compiler.check;
+
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A scope answers two questions, and one answer does not serve both.
+ *
+ * <p>What a name means here is asked by the check, of every name a body holds. What could have been
+ * written here is asked by a report offering an author what they might have meant. A call left
+ * standing on a recursive helper belongs to the first and not the second: it is reached under the
+ * name a method is emitted for, and that name is the library's own or another module's. The library
+ * keeps {@code List.foldFrom} to itself and it stands behind every list quantifier, so it is in
+ * every module's typing environment and in no module's vocabulary.
+ *
+ * <p>Held together in one map, it was in both — every report offering a candidate could offer a
+ * caller a member the language forbids them to write.
+ */
+class WhatCanBeTypedHereIsNotWhatCouldHaveBeenWrittenHereTest {
+
+    private static final Type FOLD = Type.fn(java.util.List.of(Type.INT), Type.INT);
+
+    /** A scope as a body reaching the library's recursion is read under. */
+    private static Scope standingOnTheFold() {
+        return Scope.NONE.reaching(Map.of("List.foldFrom", FOLD));
+    }
+
+    @Test
+    void aStandingCallOnALibraryRecursionIsTyped() {
+        assertNotNull(standingOnTheFold().of(new ValueName.Stdlib("List", "foldFrom"),
+                        "List.foldFrom"),
+                "a call the expansion left standing has to be typeable where it stands");
+    }
+
+    @Test
+    void andIsOfferedToNobodyAsSomethingTheyMightHaveMeant() {
+        assertFalse(standingOnTheFold().spellings().contains("List.foldFrom"),
+                "offered: " + standingOnTheFold().spellings());
+        assertFalse(standingOnTheFold().byName().containsKey("List.foldFrom"),
+                "a view keyed by what was written holds nothing nobody wrote");
+    }
+
+    /**
+     * A behavior a block captured is the other kind. The author wrote its name, so it is typed here
+     * and is a candidate here — which is the difference the two maps are for, rather than one of them
+     * being the private half of the other.
+     */
+    @Test
+    void aCapturedBehaviorIsBothTypeableAndSomethingAnAuthorCouldHaveWritten() {
+        Scope scope = Scope.NONE.naming(Map.of("settle", FOLD));
+
+        assertNotNull(scope.of(new ValueName.Behavior("m", "settle"), "settle"));
+        assertTrue(scope.spellings().contains("settle"), "offered: " + scope.spellings());
+        assertEquals(FOLD, scope.byName().get("settle"));
+    }
+
+    /** Neither displaces the other: a scope carrying both answers for both. */
+    @Test
+    void theTwoAreCarriedTogether() {
+        Scope scope = Scope.NONE.naming(Map.of("settle", FOLD))
+                .reaching(Map.of("List.foldFrom", FOLD));
+
+        assertNotNull(scope.of(new ValueName.Behavior("m", "settle"), "settle"));
+        assertNotNull(scope.of(new ValueName.Stdlib("List", "foldFrom"), "List.foldFrom"));
+        assertEquals(java.util.List.of("settle"), scope.spellings());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhetherAWrongLibraryCallIsTheAuthorsIsTheLibrarysToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhetherAWrongLibraryCallIsTheAuthorsIsTheLibrarysToSayTest.java
@@ -1,0 +1,108 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.ConstructionOrigin;
+import souther.compiler.types.ReachName;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A call under a library qualifier that reached call elaboration applying nothing is one of two
+ * things, and which of them is not read off the spelling.
+ *
+ * <p>The library declares a member of that name, or it does not. Where it does, the call was to be
+ * expanded or bound before anything typed it and neither happened — which is this compiler
+ * disagreeing with itself, and nothing an author wrote or can undo. Where it does not, the author
+ * named an operation the library has no member for, and that is theirs. Told apart here rather than
+ * both being said as the second: a member the library keeps to itself is one a caller may not write,
+ * and the report for a name nobody wrote sends the reader to look for a mistake in their own text.
+ *
+ * <p>A {@code private} declaration is a member for this question. Whether a caller may write the
+ * name and whether the library has one are two questions, and this is the second — which is why a
+ * failure to expand {@code List.foldFrom} is answered here as the compiler's rather than as a
+ * misspelling of something in the published surface.
+ *
+ * <p>A sugar declares nothing. It is a rewrite onto a name that does, so a call still spelled as the
+ * sugar is one the rewrite did not take — {@code List.fold} written with two arguments is not the
+ * three-argument call it stands for — and what is wrong with it is what was written.
+ *
+ * <p>That such a call is refused at all is {@link
+ * AnUnexpandedCallIsOnlyTypedWhereARepresentationKeepsItTest}'s; which refusal it is, is this.
+ */
+class WhetherAWrongLibraryCallIsTheAuthorsIsTheLibrarysToSayTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    /** A call of {@code qualifier.operation} applied to {@code args} integers, standing unexpanded. */
+    private static Hir.Expr callTo(String qualifier, String operation, int args) {
+        ValueName.Stdlib name = new ValueName.Stdlib(qualifier, operation);
+        List<Hir.Expr> given = new java.util.ArrayList<>();
+        for (int i = 0; i < args; i++) {
+            given.add(new Hir.IntLit(i, POS, null));
+        }
+        return new Hir.Apply(name.qualified(), name, new ReachName.OfLibrary(name), given,
+                ConstructionOrigin.own(), POS, null);
+    }
+
+    private static RuntimeException refusing(Hir.Expr call) {
+        return assertThrows(RuntimeException.class,
+                () -> Elaborator.elaborate(call, Scope.NONE, CheckContext.of(Symbols.none())));
+    }
+
+    /**
+     * The recursive helper the fold combinators are derived from, applied to what it declares. It is
+     * reached only through the library's own bodies, so a call of it standing here is an expansion
+     * this compiler owed and did not make.
+     */
+    @Test
+    void aNameTheLibraryDeclaresIsThisCompilersMistake() {
+        RuntimeException refused = refusing(callTo("List", "foldFrom", 4));
+
+        assertTrue(refused instanceof IllegalStateException,
+                "a name the library declares is not something an author can be told about, and was: "
+                        + refused);
+        assertTrue(refused.getMessage().contains("List.foldFrom"),
+                "and the failure names what was not expanded: " + refused.getMessage());
+    }
+
+    /** A published one says the same thing: which member it is decides nothing here. */
+    @Test
+    void andSoIsOneItPublishes() {
+        assertTrue(refusing(callTo("List", "map", 2)) instanceof IllegalStateException);
+    }
+
+    /** A spelling under a library qualifier that the library has no member for. */
+    @Test
+    void aNameItDeclaresNothingUnderIsTheAuthorsAndIsReportedAsThat() {
+        RuntimeException refused = refusing(callTo("List", "mapp", 2));
+
+        assertTrue(refused instanceof CompileException,
+                "a misspelling is the author's to fix, and was: " + refused);
+        assertEquals("E1506", ((CompileException) refused).code());
+    }
+
+    /**
+     * A sugar written with fewer arguments than it is sugar for. The rewrite is not taken, so what
+     * stands is a name the library declares nothing under — and the reader is told about the call
+     * they wrote rather than about the one it would have become.
+     */
+    @Test
+    void aSugarTheRewriteDidNotTakeIsTheAuthorsToo() {
+        RuntimeException refused = refusing(callTo("List", "fold", 2));
+
+        assertTrue(refused instanceof CompileException,
+                "a sugar has no declaration to have failed to expand: " + refused);
+        assertEquals("E1506", ((CompileException) refused).code());
+        assertTrue(refused.getMessage().contains("List.fold"),
+                "and it is named as it was written: " + refused.getMessage());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest.java
@@ -169,11 +169,11 @@ class WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest {
      * one over either, so the fns of a module are exactly where a declaration it only took on to emit
      * turns up.
      *
-     * <p>The body below is the declaration as its own module wrote it, which is the shape
-     * {@link HelperInliner#injectedRecursiveHelpers} puts into a reader's fns for a library helper:
-     * it reads {@code Prelude.helpers()}, whose bodies were never closed. A body that <em>was</em> closed cannot carry this at all — the expansion
-     * eta-expands a helper named where a value goes — so this rule and the one above meet a foreign
-     * declaration by different routes and need the same scope either way.
+     * <p>The body below is the declaration as its own module wrote it, which is the shape a reader
+     * meets a library helper in: those come from {@code Prelude.helpers()}, whose bodies were never
+     * closed. A body that <em>was</em> closed cannot carry this at all — the expansion eta-expands a
+     * helper named where a value goes — so this rule and the one above meet a foreign declaration by
+     * different routes and need the same scope either way.
      */
     @Test
     void aHelperTakenOnToEmitIsNotReReadForAPartialHandedOver() {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhichRuleAppliesIsReadFromWhatADefinitionWasMadeAsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhichRuleAppliesIsReadFromWhatADefinitionWasMadeAsTest.java
@@ -72,18 +72,19 @@ class WhichRuleAppliesIsReadFromWhatADefinitionWasMadeAsTest {
         return answer.value();
     }
 
-    private static Hir.FnDef definition(Hir.Module module, String name) {
-        for (Hir.FnDef fn : module.takenOn()) {
-            if (fn.name().equals(name)) {
-                return fn;
+    /** A definition of the module, wherever this compilation keeps it: what it declared, what it
+     * took on, or a value minted for one of its rows. */
+    private static Hir.FnDef definition(Prepared state, String name) {
+        List<List<Hir.FnDef>> families =
+                List.of(state.tree().takenOn(), state.tree().fns(), state.rowDefs());
+        for (List<Hir.FnDef> family : families) {
+            for (Hir.FnDef fn : family) {
+                if (fn.name().equals(name)) {
+                    return fn;
+                }
             }
         }
-        for (Hir.FnDef fn : module.fns()) {
-            if (fn.name().equals(name)) {
-                return fn;
-            }
-        }
-        throw new AssertionError("`" + name + "` is not a definition of " + module.name());
+        throw new AssertionError("`" + name + "` is not a definition of " + state.name());
     }
 
     @Test
@@ -92,14 +93,14 @@ class WhichRuleAppliesIsReadFromWhatADefinitionWasMadeAsTest {
 
         for (String method : state.operandMethods().values()) {
             assertInstanceOf(DefinitionRole.RowValue.class,
-                    definition(state.tree(), method).role(), method);
+                    definition(state, method).role(), method);
         }
     }
 
     @Test
     void aDefinitionAnotherModuleWroteIsOrdinaryHoweverThisOneNamesIt() {
         Prepared state = prepared();
-        Hir.FnDef taken = definition(state.tree(), "rules.depth");
+        Hir.FnDef taken = definition(state, "rules.depth");
 
         assertInstanceOf(DefinitionRole.Ordinary.class, taken.role());
         assertFalse(taken.written().authored(),
@@ -109,7 +110,7 @@ class WhichRuleAppliesIsReadFromWhatADefinitionWasMadeAsTest {
     @Test
     void aDefinitionTheModuleWroteIsOrdinaryToo() {
         assertInstanceOf(DefinitionRole.Ordinary.class,
-                definition(prepared().tree(), "run").role());
+                definition(prepared(), "run").role());
     }
 
     @Test
@@ -120,7 +121,7 @@ class WhichRuleAppliesIsReadFromWhatADefinitionWasMadeAsTest {
         Prepared state = prepared();
         List<RowPosition> positions = new ArrayList<>();
         for (String method : state.operandMethods().values()) {
-            positions.add(((DefinitionRole.RowValue) definition(state.tree(), method).role())
+            positions.add(((DefinitionRole.RowValue) definition(state, method).role())
                     .position());
         }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/WhichRuleAppliesIsReadFromWhatADefinitionWasMadeAsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhichRuleAppliesIsReadFromWhatADefinitionWasMadeAsTest.java
@@ -64,9 +64,13 @@ class WhichRuleAppliesIsReadFromWhatADefinitionWasMadeAsTest {
                 | "a row applies a recursion" : (In { n = depth(Item { rank = 0 }) }) -> Out { m = 0 }
             """;
 
-    private static Prepared prepared() {
-        Db db = Compilation.ofDocuments(Map.of("rules.sou", RULES, "app.sou", APP),
+    private static Db db() {
+        return Compilation.ofDocuments(Map.of("rules.sou", RULES, "app.sou", APP),
                 Set.of(), ModulePath.EMPTY).db();
+    }
+
+    private static Prepared prepared() {
+        Db db = db();
         Answer<Prepared> answer = db.ask(new Shapes.Prepared("app"));
         assertTrue(answer.present(), "prepared of app: " + answer.reports());
         return answer.value();
@@ -97,10 +101,17 @@ class WhichRuleAppliesIsReadFromWhatADefinitionWasMadeAsTest {
         }
     }
 
+    /**
+     * Asked of the compilation rather than of the prepared tree. A definition another module wrote
+     * becomes one of this module's methods because an expansion here left a call to it standing,
+     * which is settled after this module's trees have been expanded and not before.
+     */
     @Test
     void aDefinitionAnotherModuleWroteIsOrdinaryHoweverThisOneNamesIt() {
-        Prepared state = prepared();
-        Hir.FnDef taken = definition(state, "rules.depth");
+        Answer<Hir.FnDef> answer =
+                db().ask(new souther.compiler.query.Bodies.SettledFn("app", "rules.depth"));
+        assertTrue(answer.present(), "`rules.depth` is a definition `app` emits");
+        Hir.FnDef taken = answer.value();
 
         assertInstanceOf(DefinitionRole.Ordinary.class, taken.role());
         assertFalse(taken.written().authored(),

--- a/souther-compiler/src/test/java/souther/compiler/core/AnAcceptedSourceBuildsOnlyBoundedDepthTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/core/AnAcceptedSourceBuildsOnlyBoundedDepthTest.java
@@ -331,7 +331,7 @@ class AnAcceptedSourceBuildsOnlyBoundedDepthTest {
                 for (String behavior : compilation.declaredBehaviors(module)) {
                     say(tooDeep, one.what(), behavior, "the Hir it expanded",
                             depthOf(compilation.db()
-                                    .ask(new Bodies.LoweredBody(module, behavior)).value()));
+                                    .ask(new Bodies.LoweredBody(module, behavior)).value().value()));
                     say(tooDeep, one.what(), behavior, "the Core it elaborated",
                             Depth.of(compilation.db()
                                     .ask(new Bodies.CheckedBehavior(module, behavior)).value()));

--- a/souther-compiler/src/test/java/souther/compiler/query/AReachNameSurvivesWhereARewriteCannotGoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AReachNameSurvivesWhereARewriteCannotGoTest.java
@@ -58,7 +58,8 @@ class AReachNameSurvivesWhereARewriteCannotGoTest {
         byId.put("lib.sou", LIB);
         byId.put("app.sou", APP);
         Compilation c = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
-        Hir.FnDef def = c.db().ask(new Bodies.LoweredBody("app", "lib.flatten")).value();
+        Hir.FnDef def =
+                c.db().ask(new Bodies.LoweredBody("app", "lib.flatten")).value().value();
         return ((Hir.FnBody.Written) def.body()).expr();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/query/ARowExpandsWhatItNamesAndTakesOnOnlyWhatItCannotTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ARowExpandsWhatItNamesAndTakesOnOnlyWhatItCannotTest.java
@@ -81,10 +81,12 @@ class ARowExpandsWhatItNamesAndTakesOnOnlyWhatItCannotTest {
         assertTrue(answer.present(), "prepared of app: " + answer.reports());
         Prepared state = answer.value();
 
-        Set<String> beyond = new LinkedHashSet<>(HelperInliner.takenOnBy(state.tree()).keySet());
+        Set<String> beyond = new LinkedHashSet<>(db.ask(new Bodies.RequiredRecursiveDefs("app")).value());
+        beyond.removeAll(HelperInliner.helpersOf(db.ask(new Bodies.Settled("app")).value()).keySet());
         beyond.removeAll(state.operandMethods().values());
 
-        assertEquals(db.ask(new Bodies.RecursiveHelpers("app")).value(), beyond);
+        assertEquals(Set.of(), new LinkedHashSet<>(HelperInliner.takenOnBy(state.tree()).keySet()),
+                "a prepared module carries no emission list; what it emits is settled after it is expanded");
         return beyond;
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/query/AnExpansionAnswersWithTheRecursionsItLeftStandingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnExpansionAnswersWithTheRecursionsItLeftStandingTest.java
@@ -1,0 +1,113 @@
+package souther.compiler.query;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.HelperGraph;
+import souther.compiler.check.HelperInliner;
+import souther.compiler.check.HelperTable;
+import souther.compiler.check.InliningPolicy;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.types.BindingOwner;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An expansion knows which recursions it could not remove, and says so.
+ *
+ * <p>A call to a helper that recurses is left as a call — expanding it would not terminate — so a
+ * method of that name has to be emitted wherever the tree ends up. That is a requirement, and the
+ * expansion is what makes it. Worked out instead by walking the places a module writes expressions,
+ * the answer was a prediction about work not yet done, and it was wrong for every place the walk did
+ * not know about.
+ *
+ * <p>The requirement is made at the decision, not at a shape. A recursion written where a value goes
+ * is eta-expanded into a call before anything else happens to it, so both the call and the value
+ * reach the one place that decides to leave a call standing. Held here so that a change to how a
+ * function reference is represented fails this rather than quietly collecting fewer requirements:
+ * what has to stay true is that a recursion surviving into the tree is a recursion this answers
+ * with, however it was written.
+ */
+class AnExpansionAnswersWithTheRecursionsItLeftStandingTest {
+
+    private static final String CALLED = """
+            module called
+
+            data Emp = { boss: Emp? }
+
+            let depth (e: Emp) : Int =
+                match e.boss with
+                    | Some b -> 1 + depth(b)
+                    | None   -> 0
+
+            let deep (e: Emp) : Bool = depth(e) > 3
+            """;
+
+    private static final String AS_A_VALUE = """
+            module handed
+
+            data Emp = { boss: Emp? }
+
+            let depth (e: Emp) : Int =
+                match e.boss with
+                    | Some b -> 1 + depth(b)
+                    | None   -> 0
+
+            let all (es: List<Emp>) : List<Int> = List.map(depth, es)
+            """;
+
+    private static final String NEITHER = """
+            module neither
+
+            let twice (n: Int) : Int = n * 2
+
+            let four (n: Int) : Int = twice(twice(n))
+            """;
+
+    /** What expanding {@code fn}'s body of {@code module} left standing. */
+    private static Set<String> leftStandingIn(String module, String source, String fn) {
+        Db db = Compilation.ofDocuments(Map.of(module + ".sou", source), Set.of(), ModulePath.EMPTY)
+                .db();
+        HelperTable table = db.ask(new Bodies.Expanding(module, InliningPolicy.FULL)).value().table();
+        Hir.FnDef def = HelperInliner.helpersOf(db.ask(new Bodies.Settled(module)).value()).get(fn);
+        assertTrue(def != null, fn + " is a helper of " + module);
+
+        HelperInliner inliner = HelperInliner.over(table, HelperGraph.of(table));
+        inliner.inline(def.writtenBody(), new BindingOwner.OfValue(module, fn));
+        return inliner.leftStanding();
+    }
+
+    @Test
+    void aRecursionCalledIsAnsweredWith() {
+        assertEquals(Set.of("depth"), leftStandingIn("called", CALLED, "deep"));
+    }
+
+    /** The same recursion handed to a combinator rather than called. */
+    @Test
+    void andSoIsOneHandedOverAsAValue() {
+        Set<String> standing = leftStandingIn("handed", AS_A_VALUE, "all");
+
+        assertTrue(standing.contains("depth"),
+                "a recursion reaches the tree however it was written, and left: " + standing);
+    }
+
+    /**
+     * And the library's own, which the combinator became. A body that folds holds a call to the one
+     * recursion the library has, whether or not anything else in the module reaches it.
+     */
+    @Test
+    void andTheLibrarysOwnWhereACombinatorBecameAFold() {
+        assertTrue(leftStandingIn("handed", AS_A_VALUE, "all").contains("List.foldFrom"),
+                leftStandingIn("handed", AS_A_VALUE, "all").toString());
+    }
+
+    /** An expansion that removed everything answers with nothing. */
+    @Test
+    void anExpansionThatRemovedEverythingAnswersWithNothing() {
+        assertEquals(Set.of(), leftStandingIn("neither", NEITHER, "four"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/BodyForInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/BodyForInvariantDischargeTest.java
@@ -36,10 +36,18 @@ class BodyForInvariantDischargeTest {
             """;
 
     private static Hir.Expr body(Key<Hir.FnDef> key) {
+        return db().ask(key).value().writtenBody();
+    }
+
+    /** The same, for a body that answers with what its expansion could not remove beside it. */
+    private static Hir.Expr lowered(Key<souther.compiler.check.Expansion<Hir.FnDef>> key) {
+        return db().ask(key).value().value().writtenBody();
+    }
+
+    private static Db db() {
         Map<String, String> byId = new LinkedHashMap<>();
         byId.put("a.sou", SOURCE);
-        Compilation c = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
-        return c.db().ask(key).value().writtenBody();
+        return Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY).db();
     }
 
     private static List<String> calls(Hir.Expr e) {
@@ -71,7 +79,7 @@ class BodyForInvariantDischargeTest {
 
     @Test
     void theEmittedBodyHasExpandedTheOperationAway() {
-        List<String> fns = calls(body(new Bodies.LoweredBody("m.a", "shift")));
+        List<String> fns = calls(lowered(new Bodies.LoweredBody("m.a", "shift")));
         assertFalse(fns.contains("List.map"),
                 "the backend emits folds, not operations: " + fns);
     }

--- a/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
@@ -63,7 +63,7 @@ class ProbeMappingTest {
         IllegalStateException stopped = assertThrows(IllegalStateException.class,
                 () -> Backend.generate(in.lowered(), in.scope(), in.typePackages(), in.sigs(),
                         in.imported(), in.injected(), in.callees(), in.requirements(), in.checked(),
-                        in.dischargeClauses(), in.checks(),
+                        in.dischargeClauses(), in.checks(), in.standingCalls(),
                         Instrumentation.NONE.measuring(somewhereElse)));
 
         assertTrue(stopped.getMessage().contains("no probe was planned"), stopped.getMessage());
@@ -97,7 +97,7 @@ class ProbeMappingTest {
         IllegalStateException stopped = assertThrows(IllegalStateException.class,
                 () -> Backend.generate(in.lowered(), in.scope(), in.typePackages(), in.sigs(),
                         in.imported(), in.injected(), in.callees(), in.requirements(), in.checked(),
-                        in.dischargeClauses(), in.checks(),
+                        in.dischargeClauses(), in.checks(), in.standingCalls(),
                         Instrumentation.NONE.measuring(overcounted)));
 
         assertTrue(stopped.getMessage().contains("nothing emitted"), stopped.getMessage());

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleDeclaresDoesNotChangeWithTheStageTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleDeclaresDoesNotChangeWithTheStageTest.java
@@ -45,12 +45,17 @@ class WhatAModuleDeclaresDoesNotChangeWithTheStageTest {
             """;
 
     private static final String APP = """
-            module app exposing ( own )
+            module app exposing ( own, Bag, run )
 
             import lib ( flatten )
 
+            data Bag = List<Int>
+
             let own (xs: List<Int>) : List<Int> = List.map({ (x) -> x + 1 }, xs)
             let both (xs: List<List<Int>>) : List<Int> = own(flatten(xs))
+
+            behavior run : (xs: List<List<Int>>) -> Bag constructs Bag
+            let run (xs) = Bag { value = both(xs) }
             """;
 
     private static Db db() {
@@ -193,7 +198,7 @@ class WhatAModuleDeclaresDoesNotChangeWithTheStageTest {
                         .value().table();
         rowMethods.forEach(method ->
                 assertFalse(table.reaches(method), method + " is reachable by name"));
-        assertEquals(Set.of(), db.ask(new Bodies.RecursiveHelpers("app")).value(),
+        assertEquals(Set.of(), Set.copyOf(db.ask(new Bodies.RequiredRecursiveDefs("app")).value()),
                 "and nothing here recurses, so nothing else needs a method");
         assertEquals(rowMethods,
                 db.ask(new Bodies.Lowering("app")).value().lowered().takenOn().stream()

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleDeclaresDoesNotChangeWithTheStageTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleDeclaresDoesNotChangeWithTheStageTest.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -137,17 +138,18 @@ class WhatAModuleDeclaresDoesNotChangeWithTheStageTest {
     }
 
     /**
-     * What a module takes on is a method per row operand, and the helper the row names is not among
-     * them: the operand is a definition of this module and the call in it is expanded into it, the
-     * way a call in a body is.
+     * A row is emitted as a method per operand, and the helper the row names is not one of them: the
+     * operand is a definition of this module and the call in it is expanded into it, the way a call
+     * in a body is. So nothing is taken on for a row at all.
      *
-     * <p>The two are told apart by what each was made as. A row's method is declared by this module
-     * and is no {@code let} anybody wrote, so {@link Hir.FnDef#declaredIn} does not separate it from
-     * a declaration and the shape of its name does not separate it from a definition another module
-     * wrote — which is the confusion this axis exists to remove.
+     * <p>The row's own methods are a family of their own and not among what the module holds. A row
+     * operand is reached from a row and from nothing a source can spell, so it is no declaration a
+     * name resolves to — and it is told from one by what it was made as. Its declaration cannot tell
+     * them apart: this module is what declared it, so {@link Hir.FnDef#declaredIn} says the same of
+     * both, and the shape of its name says nothing either.
      */
     @Test
-    void whatIsTakenOnForARowIsTheRowsOwnMethodAndNotTheHelperItNames() {
+    void aRowIsEmittedAsItsOwnMethodsAndNothingIsTakenOnForIt() {
         Db db = Compilation.ofDocuments(Map.of("rules.sou", """
                 module rules exposing ( doubled )
 
@@ -175,15 +177,25 @@ class WhatAModuleDeclaresDoesNotChangeWithTheStageTest {
         // off the correspondence the preparation constructed rather than spelled here.
         Set<String> rowMethods = Set.copyOf(state.operandMethods().values());
         assertEquals(2, rowMethods.size(), "one input and one expectation, each emitted for the row");
-        assertEquals(rowMethods, HelperInliner.takenOnBy(prepared).keySet(),
-                "`rules.doubled` is expanded into the operand, not taken on beside it");
+        assertEquals(Set.of(), HelperInliner.takenOnBy(prepared).keySet(),
+                "`rules.doubled` is expanded into the operand, and nothing is taken on beside it");
+        assertEquals(rowMethods, db.ask(new Bodies.RowFixtureDefs("app")).value().keySet(),
+                "the operands' methods are their own family");
+        // And not in the table a call expands against. Nothing a source can write reaches one, so a
+        // name has nothing to resolve to there — and every rule keyed on what that table holds had a
+        // synthetic method among its subjects while it did.
+        souther.compiler.check.HelperTable table =
+                db.ask(new Bodies.Expanding("app", souther.compiler.check.InliningPolicy.FULL))
+                        .value().table();
+        rowMethods.forEach(method ->
+                assertFalse(table.reaches(method), method + " is reachable by name"));
         assertEquals(Set.of(), db.ask(new Bodies.RecursiveHelpers("app")).value(),
                 "and nothing here recurses, so nothing else needs a method");
         assertEquals(rowMethods,
                 db.ask(new Bodies.Lowering("app")).value().lowered().takenOn().stream()
                         .map(Hir.FnDef::name).collect(java.util.stream.Collectors.toSet()));
         // Each of them says what it is. The declaration cannot: this module is what declared them.
-        HelperInliner.takenOnBy(prepared).values().forEach(fn -> {
+        db.ask(new Bodies.RowFixtureDefs("app")).value().values().forEach(fn -> {
             assertTrue(fn.declaredBy("app"), fn.name() + " is emitted into `app`'s own program");
             assertInstanceOf(DefinitionRole.RowValue.class, fn.role(), fn.name());
         });

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleDeclaresDoesNotChangeWithTheStageTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleDeclaresDoesNotChangeWithTheStageTest.java
@@ -97,15 +97,19 @@ class WhatAModuleDeclaresDoesNotChangeWithTheStageTest {
     }
 
     /**
-     * And this module does take helpers on, so no stage passes by having none to confuse a
-     * declaration with. Asked of what the module emits, which is a different question and a different
-     * answer.
+     * And this module does emit helpers it did not declare, so no stage passes by having none to
+     * confuse a declaration with. What it emits is a different question from what it declares, and
+     * it is answered after its trees have been expanded rather than before: a recursion is emitted
+     * here because an expansion of this module could not remove a call to it.
      */
     @Test
-    void theModuleTakesOnHelpersItDidNotDeclare() {
+    void theModuleEmitsHelpersItDidNotDeclare() {
         Db db = db();
         assertEquals(Set.of("List.foldFrom", "lib.flatten"),
-                db.ask(new Bodies.RecursiveHelpers("app")).value());
+                db.ask(new Bodies.RequiredRecursiveDefs("app")).value());
+        assertEquals(Set.of("own", "both"),
+                HelperInliner.helpersOf(db.ask(new Bodies.Settled("app")).value()).keySet(),
+                "and what it declares is unchanged by that");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest.java
@@ -1,0 +1,143 @@
+package souther.compiler.query;
+
+import souther.compiler.meta.ModulePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.SequencedSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Which recursive helpers a module has to process and emit, answered from what its expansions did.
+ *
+ * <p>Every tree the module is made of is expanded somewhere, and each expansion answers with the
+ * recursions it could not remove. Joined and closed over the call graph, that is the set. The answer
+ * it replaces was a prediction: a walk listing the places a module writes expressions, made before
+ * any of those expansions ran, and it did not list {@code ensures}.
+ *
+ * <p>So the two are held against each other here. Where the prediction was right they agree, and the
+ * cases below are the ones it was right about — a fold in a {@code let}, in an {@code invariant}, in
+ * an example row, a recursion the module declared. Where it was wrong they differ, and the
+ * difference is the whole of what this changes.
+ */
+class WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest {
+
+    private static Db dbOf(String module, String source) {
+        return Compilation.ofDocuments(Map.of(module + ".sou", source), Set.of(), ModulePath.EMPTY)
+                .db();
+    }
+
+    private static SequencedSet<String> required(Db db, String module) {
+        Answer<SequencedSet<String>> answer = db.ask(new Bodies.RequiredRecursiveDefs(module));
+        assertTrue(answer.present(), "required of " + module + ": " + answer.reports());
+        return answer.value();
+    }
+
+    private static SequencedSet<String> predicted(Db db, String module) {
+        return db.ask(new Bodies.RecursiveHelpers(module)).value();
+    }
+
+    /** A fold in a `let`, which the walk did list. */
+    @Test
+    void aFoldInADefinitionIsFoundBothWays() {
+        Db db = dbOf("inlet", """
+                module inlet
+
+                let total (xs: List<Int>) : Bool = List.all(x -> x >= 0, xs)
+                """);
+
+        assertEquals(Set.of("List.foldFrom"), required(db, "inlet"));
+        assertEquals(predicted(db, "inlet"), required(db, "inlet"));
+    }
+
+    /** And in an `invariant`, which it also listed. */
+    @Test
+    void aFoldInAnInvariantIsFoundBothWays() {
+        Db db = dbOf("ininv", """
+                module ininv
+
+                data AllPos = List<Int>
+                    invariant List.all(x -> x >= 0, value)
+                """);
+
+        assertEquals(Set.of("List.foldFrom"), required(db, "ininv"));
+        assertEquals(predicted(db, "ininv"), required(db, "ininv"));
+    }
+
+    /** And in an example row. */
+    @Test
+    void aFoldInARowIsFoundBothWays() {
+        Db db = dbOf("inrow", """
+                module inrow
+
+                data Flag = { on: Bool }
+
+                behavior mark : (xs: List<Int>) -> Flag
+                let mark (xs) = Flag { on = true }
+
+                example mark
+                    | "a row folds" : ([ 1, 2 ]) -> Flag { on = List.all(x -> x >= 0, [ 1 ]) }
+                """);
+
+        assertTrue(required(db, "inrow").contains("List.foldFrom"), required(db, "inrow").toString());
+        assertEquals(predicted(db, "inrow"), required(db, "inrow"));
+    }
+
+    /** A recursion the module declared is its own to check and publish, reached or not. */
+    @Test
+    void aDeclaredRecursionIsRequiredWhetherOrNotAnythingReachesIt() {
+        Db db = dbOf("owned", """
+                module owned exposing ( Emp, depth )
+
+                data Emp = { boss: Emp? }
+
+                let depth (e: Emp) : Int =
+                    match e.boss with
+                        | Some b -> 1 + depth(b)
+                        | None   -> 0
+                """);
+
+        assertEquals(Set.of("depth"), required(db, "owned"));
+        assertEquals(predicted(db, "owned"), required(db, "owned"));
+    }
+
+    /** A module that folds nowhere needs nothing, and neither answer says otherwise. */
+    @Test
+    void aModuleThatFoldsNowhereRequiresNothing() {
+        Db db = dbOf("plain", """
+                module plain
+
+                data Count = Int
+
+                behavior countIt : (n: Int) -> Count
+                let countIt (n) = Count { value = n }
+                """);
+
+        assertEquals(Set.of(), required(db, "plain"));
+        assertEquals(predicted(db, "plain"), required(db, "plain"));
+    }
+
+    /**
+     * And the case the prediction was wrong about: a rule is the module's only reach to a fold. The
+     * fold is required, and the walk said nothing was.
+     */
+    @Test
+    void aFoldReachedOnlyFromARuleIsRequiredAndWasNotPredicted() {
+        Db db = dbOf("inrule", """
+                module inrule
+
+                data Count = Int
+
+                behavior countIt : (xs: List<Int>) -> Count
+                    ensures List.all(x -> x >= 0, xs) && value.value >= 0
+                """);
+
+        assertEquals(Set.of("List.foldFrom"), required(db, "inrule"));
+        assertEquals(Set.of(), predicted(db, "inrule"),
+                "the walk that listed where a module writes expressions did not list `ensures`");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest.java
@@ -16,9 +16,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Which recursive helpers a module has to process and emit, answered from what its expansions did.
  *
  * <p>Every tree the module is made of is expanded somewhere, and each expansion answers with the
- * recursions it could not remove. Joined and closed over the call graph, that is the set. The answer
- * it replaces was a prediction: a walk listing the places a module writes expressions, made before
- * any of those expansions ran, and it did not list {@code ensures}.
+ * recursions it could not remove. Joined, and the bodies of what they name expanded in turn until
+ * nothing new is named, that is the set. The answer it replaces was a prediction: a walk listing the
+ * places a module writes expressions, made before any of those expansions ran, and it did not list
+ * {@code ensures}.
  *
  * <p>The cases below are the ones the prediction was right about — a fold in a {@code let}, in an
  * {@code invariant}, in an example row, a recursion the module declared — and the one it was wrong

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest.java
@@ -4,6 +4,7 @@ import souther.compiler.meta.ModulePath;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 import java.util.SequencedSet;
 import java.util.Set;
@@ -19,10 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * it replaces was a prediction: a walk listing the places a module writes expressions, made before
  * any of those expansions ran, and it did not list {@code ensures}.
  *
- * <p>So the two are held against each other here. Where the prediction was right they agree, and the
- * cases below are the ones it was right about — a fold in a {@code let}, in an {@code invariant}, in
- * an example row, a recursion the module declared. Where it was wrong they differ, and the
- * difference is the whole of what this changes.
+ * <p>The cases below are the ones the prediction was right about — a fold in a {@code let}, in an
+ * {@code invariant}, in an example row, a recursion the module declared — and the one it was wrong
+ * about, which is a module whose only reach to a quantifier is a rule. They are here together
+ * because what has to hold is that moving the answer changed nothing except the last.
  */
 class WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest {
 
@@ -37,13 +38,9 @@ class WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest {
         return answer.value();
     }
 
-    private static SequencedSet<String> predicted(Db db, String module) {
-        return db.ask(new Bodies.RecursiveHelpers(module)).value();
-    }
-
-    /** A fold in a `let`, which the walk did list. */
+    /** A fold in a `let`. */
     @Test
-    void aFoldInADefinitionIsFoundBothWays() {
+    void aFoldInADefinitionIsRequired() {
         Db db = dbOf("inlet", """
                 module inlet
 
@@ -51,12 +48,11 @@ class WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest {
                 """);
 
         assertEquals(Set.of("List.foldFrom"), required(db, "inlet"));
-        assertEquals(predicted(db, "inlet"), required(db, "inlet"));
     }
 
-    /** And in an `invariant`, which it also listed. */
+    /** And in an `invariant`. */
     @Test
-    void aFoldInAnInvariantIsFoundBothWays() {
+    void aFoldInAnInvariantIsRequired() {
         Db db = dbOf("ininv", """
                 module ininv
 
@@ -65,12 +61,11 @@ class WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest {
                 """);
 
         assertEquals(Set.of("List.foldFrom"), required(db, "ininv"));
-        assertEquals(predicted(db, "ininv"), required(db, "ininv"));
     }
 
     /** And in an example row. */
     @Test
-    void aFoldInARowIsFoundBothWays() {
+    void aFoldInARowIsRequired() {
         Db db = dbOf("inrow", """
                 module inrow
 
@@ -84,7 +79,6 @@ class WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest {
                 """);
 
         assertTrue(required(db, "inrow").contains("List.foldFrom"), required(db, "inrow").toString());
-        assertEquals(predicted(db, "inrow"), required(db, "inrow"));
     }
 
     /** A recursion the module declared is its own to check and publish, reached or not. */
@@ -102,10 +96,9 @@ class WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest {
                 """);
 
         assertEquals(Set.of("depth"), required(db, "owned"));
-        assertEquals(predicted(db, "owned"), required(db, "owned"));
     }
 
-    /** A module that folds nowhere needs nothing, and neither answer says otherwise. */
+    /** A module that folds nowhere needs nothing. */
     @Test
     void aModuleThatFoldsNowhereRequiresNothing() {
         Db db = dbOf("plain", """
@@ -118,15 +111,36 @@ class WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest {
                 """);
 
         assertEquals(Set.of(), required(db, "plain"));
-        assertEquals(predicted(db, "plain"), required(db, "plain"));
+    }
+
+    /**
+     * Nothing is emitted before the module is lowered. What it emits follows from expanding its
+     * trees, so a stage that has not expanded them has nothing to say about it — and the prediction
+     * that used to be written here answered before any of them had run.
+     */
+    @Test
+    void aModuleCarriesNoEmissionListUntilItIsLowered() {
+        Db db = dbOf("inlet", """
+                module inlet
+
+                let total (xs: List<Int>) : Bool = List.all(x -> x >= 0, xs)
+                """);
+
+        assertEquals(List.of(), db.ask(new Bodies.Settled("inlet")).value().takenOn(),
+                "a settled module takes nothing on");
+        assertEquals(Set.of("List.foldFrom"),
+                db.ask(new Bodies.Lowering("inlet")).value().lowered().takenOn().stream()
+                        .map(souther.compiler.ast.Hir.FnDef::name)
+                        .collect(java.util.stream.Collectors.toSet()),
+                "and the lowered one carries what its expansions could not remove");
     }
 
     /**
      * And the case the prediction was wrong about: a rule is the module's only reach to a fold. The
-     * fold is required, and the walk said nothing was.
+     * fold is required, and the walk that listed where a module writes expressions said nothing was.
      */
     @Test
-    void aFoldReachedOnlyFromARuleIsRequiredAndWasNotPredicted() {
+    void aFoldReachedOnlyFromARuleIsRequired() {
         Db db = dbOf("inrule", """
                 module inrule
 
@@ -137,7 +151,5 @@ class WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest {
                 """);
 
         assertEquals(Set.of("List.foldFrom"), required(db, "inrule"));
-        assertEquals(Set.of(), predicted(db, "inrule"),
-                "the walk that listed where a module writes expressions did not list `ensures`");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest.java
@@ -38,16 +38,94 @@ class WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest {
         return answer.value();
     }
 
-    /** A fold in a `let`. */
+    /**
+     * A fold behind a helper that does not recurse. The helper is expanded into the behavior that
+     * reaches it, so the fold is left standing in the behavior's own tree and the requirement comes
+     * from there — the helper is not a root and does not need to be one.
+     */
     @Test
-    void aFoldInADefinitionIsRequired() {
+    void aFoldBehindAHelperAnEmittedRootReachesIsRequired() {
         Db db = dbOf("inlet", """
                 module inlet
 
+                data Flag = { on: Bool }
+
                 let total (xs: List<Int>) : Bool = List.all(x -> x >= 0, xs)
+
+                behavior mark : (xs: List<Int>) -> Flag constructs Flag
+                let mark (xs) = Flag { on = total(xs) }
                 """);
 
         assertEquals(Set.of("List.foldFrom"), required(db, "inlet"));
+    }
+
+    /**
+     * And the same fold behind a helper nothing reaches asks for nothing. Nothing expands it into a
+     * tree that runs, so no expansion leaves the fold standing anywhere, and a method for it would
+     * be one nothing invokes.
+     *
+     * <p>It is still checked, on its own, against a signature for the fold — what a call can be
+     * typed against is what the declarations in reach say, and what is emitted is what an expansion
+     * left behind. Held together here because the helper being checked and the fold not being
+     * emitted are the same module.
+     */
+    @Test
+    void aFoldBehindAHelperNothingReachesIsNotRequired() {
+        Db db = dbOf("dead", """
+                module dead
+
+                data Count = Int
+
+                let unused (xs: List<Int>) : Bool = List.all(x -> x >= 0, xs)
+
+                behavior countIt : (n: Int) -> Count constructs Count
+                let countIt (n) = Count { value = n }
+                """);
+
+        assertEquals(Set.of(), required(db, "dead"));
+        assertEquals(Set.of(), db.ask(new Bodies.Lowering("dead")).value().lowered().takenOn()
+                        .stream().map(souther.compiler.ast.Hir.FnDef::name)
+                        .collect(java.util.stream.Collectors.toSet()),
+                "and no method is emitted for it");
+    }
+
+    /**
+     * A recursion this module emits is expanded on its own, and what that expansion leaves standing
+     * is required too. It is required from the start — the module declared it — so a walk that took
+     * its result set for its work list would never read its body, and a fold it reaches through a
+     * value it names would be asked for by nobody.
+     *
+     * <p>Through a value on purpose. A body reaches a recursion by applying it and by reading a
+     * value whose body applies it, and only the first is a call: the call graph has no edge here, so
+     * nothing but expanding the body finds this.
+     */
+    @Test
+    void whatARequiredRecursionsOwnBodyReachesIsRequired() {
+        Db db = dbOf("deep", """
+                module deep
+
+                data Node = { kid: Node? }
+                data Count = Int
+
+                let allPositive = List.all(x -> x >= 0, [ 1 ])
+
+                let size (n: Node) : Int =
+                    match n.kid with
+                        | Some k -> (if allPositive then 1 else 0) + size(k)
+                        | None   -> 0
+
+                behavior countIt : (n: Node) -> Count constructs Count
+                let countIt (n) = Count { value = size(n) }
+                """);
+
+        assertEquals(Set.of("size"),
+                db.ask(new Bodies.Expanding("deep", souther.compiler.check.InliningPolicy.FULL))
+                        .value().graph().calls("size"),
+                "`size` calls itself and reads a value; the fold is behind the value and is no call");
+        assertTrue(required(db, "deep").contains("size"), required(db, "deep").toString());
+        assertTrue(required(db, "deep").contains("List.foldFrom"),
+                "the fold `size` reaches is required, and the call graph has no edge to it: "
+                        + required(db, "deep"));
     }
 
     /** And in an `invariant`. */
@@ -123,7 +201,12 @@ class WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest {
         Db db = dbOf("inlet", """
                 module inlet
 
+                data Flag = { on: Bool }
+
                 let total (xs: List<Int>) : Bool = List.all(x -> x >= 0, xs)
+
+                behavior mark : (xs: List<Int>) -> Flag constructs Flag
+                let mark (xs) = Flag { on = total(xs) }
                 """);
 
         assertEquals(List.of(), db.ask(new Bodies.Settled("inlet")).value().takenOn(),
@@ -133,6 +216,7 @@ class WhatAModuleMustEmitIsWhatItsExpansionsCouldNotRemoveTest {
                         .map(souther.compiler.ast.Hir.FnDef::name)
                         .collect(java.util.stream.Collectors.toSet()),
                 "and the lowered one carries what its expansions could not remove");
+
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatCanStandUnexpandedIsWiderThanWhatAModuleTookOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatCanStandUnexpandedIsWiderThanWhatAModuleTookOnTest.java
@@ -81,8 +81,8 @@ class WhatCanStandUnexpandedIsWiderThanWhatAModuleTookOnTest {
 
         assertTrue(canStand(db, "plain", InliningPolicy.FULL).containsKey("List.foldFrom"),
                 "what can stand: " + canStand(db, "plain", InliningPolicy.FULL).keySet());
-        assertEquals(Set.of(), db.ask(new Bodies.RecursiveHelpers("plain")).value(),
-                "and this module took nothing on");
+        assertEquals(Set.of(), Set.copyOf(db.ask(new Bodies.RequiredRecursiveDefs("plain")).value()),
+                "and this module emits none of it");
     }
 
     /**
@@ -105,7 +105,7 @@ class WhatCanStandUnexpandedIsWiderThanWhatAModuleTookOnTest {
 
         assertTrue(canStand(db, "owned", InliningPolicy.FULL).containsKey("depth"),
                 "what can stand: " + canStand(db, "owned", InliningPolicy.FULL).keySet());
-        assertTrue(db.ask(new Bodies.RecursiveHelpers("owned")).value().contains("depth"));
+        assertTrue(db.ask(new Bodies.RequiredRecursiveDefs("owned")).value().contains("depth"));
     }
 
     /** And a signature is the declaration's own, not something worked out from the call sites. */

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatCanStandUnexpandedIsWiderThanWhatAModuleTookOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatCanStandUnexpandedIsWiderThanWhatAModuleTookOnTest.java
@@ -1,0 +1,121 @@
+package souther.compiler.query;
+
+import souther.compiler.check.InliningPolicy;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.types.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Which recursive helpers a body could hold a standing call to, and which ones this module turned
+ * out to reach, are two questions with two answers.
+ *
+ * <p>A call is left standing because its callee recurses, and which declarations recurse follows
+ * from the declarations in reach — the module's own, what its imports publish to it, and the
+ * library underneath both. Nothing about any one body decides it. So the names a call here could be
+ * written under are those, whether or not this module writes one.
+ *
+ * <p>What the module reaches is narrower and is a different reader's question: a helper it reaches
+ * has to be processed and emitted as a method of its own, and one it does not reach has no body
+ * anybody wants. Answering the first question with the second is what left a rule reaching a fold
+ * with no signature for the fold it becomes, and answering the second with the first costs a body
+ * that does not exist.
+ *
+ * <p>Held here rather than at either reader, because the whole of the claim is that the two answers
+ * differ — a module that reaches nothing still has the library's recursion in the first.
+ */
+class WhatCanStandUnexpandedIsWiderThanWhatAModuleTookOnTest {
+
+    /** A module that reaches no fold at all, and so takes nothing on. */
+    private static final String REACHES_NOTHING = """
+            module plain
+
+            data Count = Int
+
+            behavior countIt : (n: Int) -> Count
+            let countIt (n) = Count { value = n }
+            """;
+
+    /** The same, with a recursion of its own. */
+    private static final String ITS_OWN_RECURSION = """
+            module owned
+
+            data Emp = { boss: Emp? }
+            data Count = Int
+
+            let depth (e: Emp) : Int =
+                match e.boss with
+                    | Some b -> 1 + depth(b)
+                    | None   -> 0
+
+            behavior countIt : (e: Emp) -> Count
+            let countIt (e) = Count { value = depth(e) }
+            """;
+
+    private static Db dbOf(String module, String source) {
+        return Compilation.ofDocuments(Map.of(module + ".sou", source), Set.of(), ModulePath.EMPTY)
+                .db();
+    }
+
+    private static Map<String, Type> canStand(Db db, String module, InliningPolicy policy) {
+        Answer<Map<String, Type>> answer = db.ask(new Bodies.RecursiveCallSigs(module, policy));
+        assertTrue(answer.present(), "signatures for " + module + ": " + answer.reports());
+        return answer.value();
+    }
+
+    /**
+     * The library's one recursion is behind every list quantifier, so a call of it can stand in any
+     * module of the emitted representation. That this module reaches none is a separate answer, and
+     * here it is empty.
+     */
+    @Test
+    void theLibrarysRecursionCanStandInAModuleThatReachesNothing() {
+        Db db = dbOf("plain", REACHES_NOTHING);
+
+        assertTrue(canStand(db, "plain", InliningPolicy.FULL).containsKey("List.foldFrom"),
+                "what can stand: " + canStand(db, "plain", InliningPolicy.FULL).keySet());
+        assertEquals(Set.of(), db.ask(new Bodies.RecursiveHelpers("plain")).value(),
+                "and this module took nothing on");
+    }
+
+    /**
+     * The discharge representation leaves the language's own operations standing rather than
+     * expanding them into the fold they become, so its table holds none of the library and the fold
+     * is not among the names a call there could be written under.
+     */
+    @Test
+    void andCannotStandInTheRepresentationThatNeverExpandsAQuantifier() {
+        Db db = dbOf("plain", REACHES_NOTHING);
+
+        assertFalse(canStand(db, "plain", InliningPolicy.DISCHARGE).containsKey("List.foldFrom"),
+                "what can stand: " + canStand(db, "plain", InliningPolicy.DISCHARGE).keySet());
+    }
+
+    /** A module's own recursion is in both answers: it can stand, and this module holds its body. */
+    @Test
+    void aModulesOwnRecursionIsInBothAnswers() {
+        Db db = dbOf("owned", ITS_OWN_RECURSION);
+
+        assertTrue(canStand(db, "owned", InliningPolicy.FULL).containsKey("depth"),
+                "what can stand: " + canStand(db, "owned", InliningPolicy.FULL).keySet());
+        assertTrue(db.ask(new Bodies.RecursiveHelpers("owned")).value().contains("depth"));
+    }
+
+    /** And a signature is the declaration's own, not something worked out from the call sites. */
+    @Test
+    void aSignatureIsTheOneTheDeclarationWasWrittenWith() {
+        Type fold = canStand(dbOf("plain", REACHES_NOTHING), "plain", InliningPolicy.FULL)
+                .get("List.foldFrom");
+
+        assertTrue(fold instanceof Type.FnOf, "the fold is typed as a function, and was: " + fold);
+        assertEquals(4, ((Type.FnOf) fold).params().size(),
+                "the step, the seed, the list and the index it walks from");
+    }
+}


### PR DESCRIPTION
Closes #913.

## What was wrong

A module whose only reach to a standard-library quantifier was an `ensures` clause did not compile. `List.all` is an ordinary library helper derived from the fold, so a rule naming one holds a call to `List.foldFrom` once it has been expanded — and the module was never given that method.

The cause is not a missing case in a traversal. `Prepared` **predicted** which recursions a module would have to emit, by walking the places a module writes expressions, before any of those expressions had been expanded. `ensures` was not one of the places it listed. The same `HelperInliner` instance then left the `List.foldFrom` call standing inside `ClauseHelpers.withInlinedEnsures` a few lines later — the fact was already there, and a second ledger was predicting it.

Two exits, one cause. From the library it was reported as E1506, blaming the author for a private name they never wrote and are not allowed to write. From another module's published recursion it was an `IllegalStateException`.

## What `takenOn` was carrying

One `List<FnDef>` held four independent relations:

| | now |
|---|---|
| which names a standing call can be typed against | `RecursiveCallSigs(module, policy)` — from the declarations in reach |
| which recursions this module processes | `RequiredRecursiveDefs` — from what its expansions could not remove |
| which methods it emits | the same answer |
| the definitions minted for its rows | `RowFixtureDefs` |

The first is wider than the rest and always was: what *can* stand follows from the table, and what is emitted follows from use. Answering the first with the second is what left a rule with no fold to call.

## Shape

Each expansion answers with the recursions it could not remove (`Expansion<T>`), and the requirement is made at the decision that creates it rather than recovered afterwards.

The roots are the trees that survive to run — behavior implementations, row operands, clause expansions. A helper that does not recurse is no root: it is expanded into whatever reaches it, and that expansion answers for what it left standing. A fold behind a helper nothing reaches is therefore not emitted, which falls out rather than being excluded.

The closure is the **expansion's**, taken to a fixed point — not the call graph's. A body reaches a recursion by applying it and by reading a zero-argument value whose own body applies it, and only the first is a call, so a graph of calls answers about a narrower relation than the one that decides this. Each required recursion is expanded in its turn; being required and having been read are two things, so a recursion this module declared is queued like any other.

`HelperGraph` keeps one job: whether a declaration is on a call cycle, which is what decides that a call is left standing at all.

No traversal over "where a module writes expressions" survives. Adding a construct that can hold an expression needs only the code that lowers it.

`Hir.Module.takenOn` remains as what it always was on a *lowered* module — the methods emitted beyond the declared ones — and is empty at every stage before that, which a test holds it to.

## A state's identity

A query's answer is a value, and the store decides what to re-ask by comparing the answer it recomputed with the one it held. Twice here a state gained a component while its hand-written identity went on comparing what it compared before — a settled module's standing recursions, and a prepared module's row definitions, which are built from a behavior's signature and so change while this module's text does not.

Both are fixed, and the pattern is now checked against the class rather than against a reading of it: every field a state holds must be reached by its `equals`, through the projections it compares. A field left out is named with its reason or it is a failure.

## Verified

- 6040 tests in `souther-compiler`; `CI=1 mvn -Plint clean verify` green across all modules.
- The regression test loads every emitted class, which is where the JVM verifies each method, and applies the emitted fold.
- Told apart from a silent skip throughout: a module with a plain type error in a body stays refused with E1317 at every step. That control caught two regressions while the check's input set was being moved, and the suite caught a third that the control could not (101 checks stopped firing).
- Each regression test was made to fail for its own reason before being kept.

## Notes for review

- `Prelude.entry` is the discriminator for E1506, not `isLibraryFunction`: a sugar has no declaration, so `List.fold` written with the wrong number of arguments is the author's mistake and must stay a diagnostic.
- `RecursiveHelperSigs` was not widened in place. Doing so makes `RecursiveHelperConstructs` absent and removes the behavior body check entirely, with no diagnostic. It is deleted now, along with `RecursiveHelpers`.
- A sugar's edge in the call graph comes from `Prelude.rewriteOf` rather than from the spelling `List.fold` written out in two walks.
- `sigsOf` throws only for a declaration this module wrote; a foreign one that cannot be read contributes no signature and is reported by its owner. A valid foreign declaration still gets its signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)