### PR TITLE
Read what an expression comes to apart from what its ways are called

### DIFF
--- a/docs/adr/0109-an-outcome-is-a-path-to-a-value-and-carries-what-the-value-is.md
+++ b/docs/adr/0109-an-outcome-is-a-path-to-a-value-and-carries-what-the-value-is.md
@@ -72,17 +72,54 @@ condition of a fork is not one of those. The rule is read where it is written in
 it is given a name first. That is a limit of the numbering and not of this reading, and it is
 recorded in a test so that it is something said rather than a silence.
 
-A second limit, and it is in front of all of this rather than beside it. Whether an expression can
-answer a value at all is read before any of these paths are, and that reading takes an operator
-which stops early to be strict in both its sides. So `a > 1 && abort` is answered as reaching no
-value, when a run with a small `a` reaches one — and everything under the fork on it, both arms
-included, goes unwalked. Which paths a short circuit has is exactly the question this decides, and
-the reading that decides it here cannot be the one asked there: it is built on the numbering, and
-the numbering is built on that answer. What is owed is a reading of what an expression can come to
-that needs no numbering, told apart from what it knows — a comparison this cannot evaluate is not
-the same as one that comes out both ways, and `1 > 2 || abort` answers no value while `a > 2 ||
-abort` may. Under-reading is where it is left until then, which is the direction everything else
-here takes.
+Whether an expression arrives at a value at all is read before any of these paths are, and that
+reading was taking an operator which stops early to be strict in both its sides. So `a > 1 && abort`
+was answered as reaching no value, when a run with a small `a` reaches one — and everything under the
+fork on it, both arms included, went unwalked. It was written down here as a limit of this reading
+and it was not one: which paths a short circuit has is exactly the question decided above, and the
+reason it could not be asked there was that this reading is built on the numbering while the reading
+that answers what arrives is what the numbering is built on.
+
+That is now the same reading asked without a numbering, and what made it one reading is that three
+facts were being carried as two. Whether a run arrives at a value, what a boolean value comes to, and
+whether a way to it can be written down in the numbering's words are three, and the third had been
+folded into the second: a comparison the plan could not place was answered as a comparison with no
+value, so a fork on it lost its arms and an operator over it lost its paths. Held apart, the reading
+of what arrives is the reading of the paths with the naming taken away, and there is no second
+account of the body to keep in step with the first.
+
+Four things hold of it, and they are what the separation is.
+
+A naming decides what a way is called and never whether there is one. Swapped for another, the same
+nodes arrive and the same values are worked out; what moves is how a way is written and whether it is
+written whole. A way the naming has no words for is carried as one written in part, not left out — so
+an arm reached by a condition nothing can place is still an arm, and only the reader that steers rows
+turns the incompleteness away.
+
+Not knowing is never both. A value this reading has worked out no truth for settles nothing: it does
+not send an operator into its right and it does not stop one there, and no path is offered on the
+strength of it. A way to a value that arrives is offered where the way is worked out or where what
+follows it arrives anyway.
+
+A value is answered as known only where a value of what it is over stands behind it. Not a rule about
+the shape of the node: `a == a` is a comparison and comes out one way, `1 > 2` is a comparison and
+comes out one way, and a reading answering "a comparison comes out both ways" would offer each of
+them a path no run takes and say the expression arrives where every run aborts. So each way is asked
+about on its own, against the range of the position compared — which for a whole number is read off
+the ends, so a number at the end of the range closes the way past it. A way nothing whole stands
+behind is not offered, and where nothing stands behind either the value is answered as one this
+reading has nothing to say about. Under-read, and the direction everything here takes.
+
+A way found twice is one way. The reading answers a set for that reason: what is counted anywhere
+downstream is what the body does and not how many times the reading got there.
+
+What is still not read is what correlates two paths. Under
+`(if a > 0 then true else abort) && (if a <= 0 then true else abort)` no run arrives, and each side is
+read on its own and arrives — so the operator is answered as arriving. The same holds of the model's
+own rules: a behavior requiring `a > 1` has no run with a small `a`, and `a > 1 && abort` is answered
+as arriving all the same. Both are the liberty this reading has always taken with arms of a fork,
+which are counted without anything having asked whether the condition can come out that way, and
+neither is decided here.
 
 Two ways in that settle one decision opposite ways describe no run, so the walk does not go that
 way rather than going and leaving what it finds to be thrown out later. Which decision it is is not
@@ -136,6 +173,9 @@ settled one way, which asks for nothing".
 ## Consequences
 
 Rows are added and none are taken away, which is ADR-0108's shape and holds for the same reason.
+A fork on an operator that stops early is one of the places they are added: both of its arms were
+going unwalked, and every meeting standing in either of them is now offered under the way in that
+reaches it.
 A fork on a chain of comparisons varies as many ways as the chain has of settling rather than two,
 so a value made out of it is a factor of that many; the arms of such a fork and the operands after
 the first are walked into, so the groups standing in them are offered where they were not offered

--- a/docs/adr/0109-an-outcome-is-a-path-to-a-value-and-carries-what-the-value-is.md
+++ b/docs/adr/0109-an-outcome-is-a-path-to-a-value-and-carries-what-the-value-is.md
@@ -90,25 +90,33 @@ account of the body to keep in step with the first.
 
 Four things hold of it, and they are what the separation is.
 
-A naming decides what a way is called and never whether there is one. Swapped for another, the same
-nodes arrive and the same values are worked out; what moves is how a way is written and whether it is
-written whole. A way the naming has no words for is carried as one written in part, not left out — so
-an arm reached by a condition nothing can place is still an arm, and only the reader that steers rows
-turns the incompleteness away.
+A naming decides what a way is called and never whether there is one, and it is a structure and not a
+rule to keep. What the body does is read with no naming at all, and the naming reaches only the list
+of ways: a condition it has no words for leaves a way written in part, a pair of conditions it sees
+settle one decision opposite ways leaves a way out, and more ways than it will hold apart leave the
+list saying nothing. None of those can move what arrives or what a value comes to, because that half
+was never computed with a naming in it. Said as a rule instead, two of the three went on moving it —
+a naming that could see two arms of one decision contradict answered that no value arrives where the
+reading without one answered that a value does.
 
 Not knowing is never both. A value this reading has worked out no truth for settles nothing: it does
 not send an operator into its right and it does not stop one there, and no path is offered on the
 strength of it. A way to a value that arrives is offered where the way is worked out or where what
-follows it arrives anyway.
+follows it arrives anyway. Which is a different question from whether an arm of a fork stands, and it
+is asked differently: an arm stands unless the reading worked out that the condition never comes out
+its way, so a value with no truth worked out leaves both arms standing. Two questions and two names
+for them, because one name for both is how not-knowing gets widened into both.
 
 A value is answered as known only where a value of what it is over stands behind it. Not a rule about
-the shape of the node: `a == a` is a comparison and comes out one way, `1 > 2` is a comparison and
-comes out one way, and a reading answering "a comparison comes out both ways" would offer each of
-them a path no run takes and say the expression arrives where every run aborts. So each way is asked
-about on its own, against the range of the position compared — which for a whole number is read off
-the ends, so a number at the end of the range closes the way past it. A way nothing whole stands
-behind is not offered, and where nothing stands behind either the value is answered as one this
-reading has nothing to say about. Under-read, and the direction everything here takes.
+the shape of the node, in either direction: `a == a` is a comparison and comes out one way, `1 > 2` is
+a comparison and comes out one way, and a position of the input holding a truth is no comparison at
+all and comes out both ways. A reading answering "a comparison comes out both ways" would offer the
+first two a path no run takes; one asking the question only of comparisons would answer that
+`flag && abort` arrives nowhere, when every run with a false `flag` arrives. So each way is asked
+about on its own, against the range of what is compared — which for a whole number is read off the
+ends, so a number at the end of the range closes the way past it. A way nothing stands behind is not
+offered, and where nothing stands behind either the value is answered as one this reading has nothing
+to say about. Under-read, and the direction everything here takes.
 
 A way found twice is one way. The reading answers a set for that reason: what is counted anywhere
 downstream is what the body does and not how many times the reading got there.
@@ -172,10 +180,13 @@ settled one way, which asks for nothing".
 
 ## Consequences
 
-Rows are added and none are taken away, which is ADR-0108's shape and holds for the same reason.
-A fork on an operator that stops early is one of the places they are added: both of its arms were
-going unwalked, and every meeting standing in either of them is now offered under the way in that
-reaches it.
+Rows are added, and one kind is taken away. A fork on an operator that stops early is where they are
+added: both of its arms were going unwalked, and every meeting standing in either of them is now
+offered under the way in that reaches it. What is taken away is an arm the condition never comes out
+the way of — `if true then … else …` has one arm a run enters and a comparison against the largest
+whole number has the other, and numbering the one nothing enters is a row owed for a combination the
+body has no run at. Read from the same place everything else about arms is read from, so the
+numbering and the walk into an arm cannot come to differ about which arms there are.
 A fork on a chain of comparisons varies as many ways as the chain has of settling rather than two,
 so a value made out of it is a factor of that many; the arms of such a fork and the operands after
 the first are walked into, so the groups standing in them are offered where they were not offered

--- a/souther-compiler/src/main/java/souther/compiler/claims/UnreachableClaims.java
+++ b/souther-compiler/src/main/java/souther/compiler/claims/UnreachableClaims.java
@@ -57,7 +57,7 @@ public final class UnreachableClaims {
             return NONE;
         }
         List<Claim> found = new ArrayList<>();
-        claimedUnder(body, InputReads.of(read), symbols, plan, found);
+        claimedUnder(body, InputReads.of(read), symbols, plan, NormalReturn.ofBody(body), found);
         return found.isEmpty() ? NONE : new UnreachableClaims(found);
     }
 
@@ -70,16 +70,16 @@ public final class UnreachableClaims {
      */
     private static void claimedUnder(Core e, InputReads reads, Symbols symbols,
                                      souther.compiler.coverage.CoverageSites.Plan plan,
-                                     List<Claim> found) {
+                                     NormalReturn answering, List<Claim> found) {
         if (e == null) {
             return;
         }
         InputReads inside = e instanceof Core.LetIn let ? reads.and(let.binder(), let.value())
                 : reads;
         if (e instanceof Core.Match match) {
-            claimedIn(match, inside, symbols, plan, found);
+            claimedIn(match, inside, symbols, plan, answering, found);
         }
-        Core.forEachChild(e, child -> claimedUnder(child, inside, symbols, plan, found));
+        Core.forEachChild(e, child -> claimedUnder(child, inside, symbols, plan, answering, found));
     }
 
     /**
@@ -90,7 +90,7 @@ public final class UnreachableClaims {
      */
     private static void claimedIn(Core.Match match, InputReads reads, Symbols symbols,
                                   souther.compiler.coverage.CoverageSites.Plan plan,
-                                  List<Claim> found) {
+                                  NormalReturn answering, List<Claim> found) {
         TermPath path = reads.pathOf(match.scrutinee(), symbols);
         if (path == null) {
             return;
@@ -98,14 +98,14 @@ public final class UnreachableClaims {
         souther.compiler.coverage.ControlPointId.ArmOccurrence[] arms = plan.armsOf(match);
         for (int i = 0; i < match.cases().size(); i++) {
             Core.Case arm = match.cases().get(i);
-            if (NormalReturn.of(arm.body())) {
+            if (answering.at(arm.body())) {
                 continue;
             }
             if (arms == null || i >= arms.length) {
                 continue;   // a fork this plan holds no arms for is one nothing can be asked about
             }
             souther.compiler.coverage.ControlPointId.ArmOccurrence where = arms[i];
-            List<UnreachableReasons.Said> said = UnreachableReasons.said(arm.body());
+            List<UnreachableReasons.Said> said = UnreachableReasons.said(arm.body(), answering);
             List<String> why = said.stream().map(UnreachableReasons.Said::reason).distinct().toList();
             // Cases written together on one arm are one run of code, and it declares the same thing
             // about every one of them.

--- a/souther-compiler/src/main/java/souther/compiler/claims/UnreachableClaims.java
+++ b/souther-compiler/src/main/java/souther/compiler/claims/UnreachableClaims.java
@@ -57,7 +57,8 @@ public final class UnreachableClaims {
             return NONE;
         }
         List<Claim> found = new ArrayList<>();
-        claimedUnder(body, InputReads.of(read), symbols, plan, NormalReturn.ofBody(body), found);
+        claimedUnder(body, InputReads.of(read), symbols, plan, NormalReturn.ofBody(body), true,
+                found);
         return found.isEmpty() ? NONE : new UnreachableClaims(found);
     }
 
@@ -70,16 +71,23 @@ public final class UnreachableClaims {
      */
     private static void claimedUnder(Core e, InputReads reads, Symbols symbols,
                                      souther.compiler.coverage.CoverageSites.Plan plan,
-                                     NormalReturn answering, List<Claim> found) {
+                                     NormalReturn answering, boolean reachable, List<Claim> found) {
         if (e == null) {
             return;
         }
-        InputReads inside = e instanceof Core.LetIn let ? reads.and(let.binder(), let.value())
+        InputReads names = e instanceof Core.LetIn let ? reads.and(let.binder(), let.value())
                 : reads;
-        if (e instanceof Core.Match match) {
-            claimedIn(match, inside, symbols, plan, answering, found);
+        // Whether a run gets here, which is about the way in and not about this. A body every arm of
+        // which aborts arrives nowhere and is still where its claims are written; what is inside such
+        // a part is what nothing reaches, so a claim found further in would be one about a fork
+        // behind an abort — a case nobody can be asked for a row at and a gap that would stay open
+        // for ever. The same rule, and the same reading, the numbering stops on.
+        if (reachable && e instanceof Core.Match match) {
+            claimedIn(match, names, symbols, plan, answering, found);
         }
-        Core.forEachChild(e, child -> claimedUnder(child, inside, symbols, plan, answering, found));
+        boolean inside = reachable && answering.at(e);
+        Core.forEachChild(e,
+                child -> claimedUnder(child, names, symbols, plan, answering, inside, found));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/claims/UnreachableReasons.java
+++ b/souther-compiler/src/main/java/souther/compiler/claims/UnreachableReasons.java
@@ -38,56 +38,56 @@ public final class UnreachableReasons {
      * disagree about which paths answer nothing. Repeats are kept, so that two arms aborting with
      * the same words still have two places between them; a caller wanting the reasons drops them.
      */
-    public static List<Said> said(Core e) {
+    public static List<Said> said(Core e, NormalReturn answering) {
         List<Said> found = new java.util.ArrayList<>();
-        collect(e, found);
+        collect(e, answering, found);
         return List.copyOf(found);
     }
 
-    private static void collect(Core e, List<Said> into) {
-        if (NormalReturn.of(e)) {
+    private static void collect(Core e, NormalReturn answering, List<Said> into) {
+        if (e == null || answering.at(e)) {
             return;
         }
         switch (e) {
             case Core.Unreachable u -> into.add(new Said(u.reason(), u.pos()));
             case Core.LetIn li -> collect(
-                    NormalReturn.of(li.value()) ? li.body() : li.value(), into);
+                    answering.at(li.value()) ? li.body() : li.value(), answering, into);
             case Core.If iff -> {
-                if (!NormalReturn.of(iff.cond())) {
-                    collect(iff.cond(), into);
+                if (!answering.at(iff.cond())) {
+                    collect(iff.cond(), answering, into);
                 } else {
-                    collect(iff.then(), into);
-                    collect(iff.els(), into);
+                    collect(iff.then(), answering, into);
+                    collect(iff.els(), answering, into);
                 }
             }
             case Core.Match m -> {
-                if (!NormalReturn.of(m.scrutinee())) {
-                    collect(m.scrutinee(), into);
+                if (!answering.at(m.scrutinee())) {
+                    collect(m.scrutinee(), answering, into);
                 } else {
-                    m.cases().forEach(arm -> collect(arm.body(), into));
+                    m.cases().forEach(arm -> collect(arm.body(), answering, into));
                 }
             }
             case Core.Construct nd -> {
-                Core stops = evaluated(nd);
+                Core stops = evaluated(nd, answering);
                 if (stops != null) {
-                    collect(stops, into);
+                    collect(stops, answering, into);
                 }
             }
             case Core.IfConstructed ic -> {
-                Core stops = evaluated(ic.construct());
+                Core stops = evaluated(ic.construct(), answering);
                 if (stops != null) {
-                    collect(stops, into);
+                    collect(stops, answering, into);
                 } else {
-                    collect(ic.then(), into);
-                    ic.els().forEach(arm -> collect(arm.body(), into));
+                    collect(ic.then(), answering, into);
+                    ic.els().forEach(arm -> collect(arm.body(), answering, into));
                 }
             }
             // Anything else answers nothing because something it evaluates first does, and the rest
             // of what is written in it never runs.
             default -> {
-                Core stops = firstThatAborts(Evaluated.inOrder(e));
+                Core stops = firstThatAborts(Evaluated.inOrder(e), answering);
                 if (stops != null) {
-                    collect(stops, into);
+                    collect(stops, answering, into);
                 }
             }
         }
@@ -100,15 +100,15 @@ public final class UnreachableReasons {
      * the construction settled that when it was built, so what stops it is asked here rather than
      * worked out again from how the fields were written.
      */
-    private static Core evaluated(Core.Construct nd) {
-        return firstThatAborts(Evaluated.inOrder(nd));
+    private static Core evaluated(Core.Construct nd, NormalReturn answering) {
+        return firstThatAborts(Evaluated.inOrder(nd), answering);
     }
 
     /** The first of a run of strict positions that does not answer, which is where evaluation stops
      * and where every reason below it stops being one. */
-    private static Core firstThatAborts(List<Core> evaluated) {
+    private static Core firstThatAborts(List<Core> evaluated, NormalReturn answering) {
         for (Core each : evaluated) {
-            if (!NormalReturn.of(each)) {
+            if (!answering.at(each)) {
                 return each;
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -370,11 +370,13 @@ public final class CoverageSites {
         /**
          * One arm, or {@link #NO_SITE} where no row that stands can be in it.
          *
-         * <p>Two things have to hold. The arm has to be able to answer a value, and it has to stand
+         * <p>Three things have to hold. The arm has to be able to answer a value; it has to stand
          * somewhere a row can get to — an arm of a {@code match} written after a binding that aborts
-         * is a fork nothing reaches, however ordinary the arm itself looks. A row that gets as far as
-         * an {@code unreachable} is E1911 and states nothing, so an arm only such a row could go
-         * through is an arm no row will ever be recorded in.
+         * is a fork nothing reaches, however ordinary the arm itself looks; and the condition above
+         * it has to be able to come out its way, since a fork on something the reading settles to one
+         * truth sends every run down one arm and leaves the other an arm nothing enters. A row that
+         * gets as far as an {@code unreachable} is E1911 and states nothing, so an arm only such a
+         * row could go through is an arm no row will ever be recorded in.
          */
         private ControlPointId.ArmOccurrence armOf(SourceOutcome outcome, Core owner,
                                                    CoverageOrigin origin, int part, Core arm,
@@ -382,7 +384,7 @@ public final class CoverageSites {
             // The arm is made either way. Whether a run through it can be recorded is the second
             // question and only the probe turns on it — an arm nothing could record is still an arm,
             // and the readings that judge one need to be able to name it.
-            int probe = reachable && answers(arm)
+            int probe = reachable && answers(arm) && answering.mayEnter(owner, part)
                     ? site(outcome, owner, origin, part) : NO_SITE;
             return new ControlPointId.ArmOccurrence(controls++,
                     probe == NO_SITE ? OptionalInt.empty() : OptionalInt.of(probe),

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -332,7 +332,9 @@ public final class CoverageSites {
                 new IdentityHashMap<>();
         private final IdentityHashMap<Core, ForkOccurrence> forkByNode = new IdentityHashMap<>();
         private final IdentityHashMap<Core, Integer> controlByComparison = new IdentityHashMap<>();
-        private final IdentityHashMap<Core, Boolean> answering = new IdentityHashMap<>();
+        /** The reading of the body being walked, which every question about a node in it is asked
+         *  of. Rooted at the body because what a name reads is settled by what bound it. */
+        private NormalReturn answering = NormalReturn.ofBody(null);
         /** The nodes one run can pass more than once. Kept by identity, like everything else here:
          *  two arms that look the same are equal records and this is about this one. */
         private final java.util.Set<Core> mayRepeat =
@@ -361,6 +363,7 @@ public final class CoverageSites {
         void behavior(String name, Core body) {
             this.behavior = name;
             this.ordinal = 0;
+            this.answering = NormalReturn.ofBody(body);
             walk(body, true);
         }
 
@@ -379,7 +382,7 @@ public final class CoverageSites {
             // The arm is made either way. Whether a run through it can be recorded is the second
             // question and only the probe turns on it — an arm nothing could record is still an arm,
             // and the readings that judge one need to be able to name it.
-            int probe = reachable && NormalReturn.of(arm)
+            int probe = reachable && answers(arm)
                     ? site(outcome, owner, origin, part) : NO_SITE;
             return new ControlPointId.ArmOccurrence(controls++,
                     probe == NO_SITE ? OptionalInt.empty() : OptionalInt.of(probe),
@@ -414,21 +417,14 @@ public final class CoverageSites {
         }
 
         /**
-         * Whether {@code e} answers a value, asked once per node.
+         * Whether {@code e} answers a value, asked of the reading of the body it stands in.
          *
          * <p>The walk asks this of every node it passes and of every arm it makes, and the answer is
-         * read off the whole subtree — so without this the walk would be quadratic in the size of a
-         * body. Keyed by identity, like {@link Plan#byNode}: two arms that look the same are equal
-         * records, and what is being remembered is about this one.
+         * read off the whole subtree — so the reading settles every occurrence in the body once and
+         * the walk asks it rather than reading a subtree again per node.
          */
         private boolean answers(Core e) {
-            Boolean known = answering.get(e);
-            if (known != null) {
-                return known;
-            }
-            boolean found = NormalReturn.of(e);
-            answering.put(e, found);
-            return found;
+            return answering.at(e);
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/coverage/NormalReturn.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/NormalReturn.java
@@ -1,8 +1,9 @@
 package souther.compiler.coverage;
 
 import souther.compiler.core.Core;
-
-import java.util.List;
+import souther.compiler.flow.Anonymous;
+import souther.compiler.flow.AnonymousPath;
+import souther.compiler.flow.ValueArrivals;
 
 /**
  * Whether evaluating an expression can answer a value.
@@ -11,6 +12,12 @@ import java.util.List;
  * one on its way answers none either. This is what tells an arm the rows can be in from an arm that
  * only states a combination the model rules out — the first is a fork a row takes, the second is not
  * an arm at all.
+ *
+ * <p>A projection of {@link ValueArrivals} and not a reading of its own. Whether a value arrives and
+ * what it comes to are one question wherever an operator stops as soon as its answer is settled:
+ * {@code a > 1 && unreachable} arrives for every small {@code a} and never for a large one, and
+ * nothing reading only the shape of the node can say which. So there is one reading, and this is that
+ * reading asked whether there is any way at all.
  *
  * <p>Read off the tree and not off the types. An {@code unreachable} is written as {@code Never}, but
  * the position it stands in usually states a shape, and that shape is what the elaborator records on
@@ -25,52 +32,36 @@ import java.util.List;
  */
 public final class NormalReturn {
 
+    private final ValueArrivals<AnonymousPath> reading;
+
+    private NormalReturn(ValueArrivals<AnonymousPath> reading) {
+        this.reading = reading;
+    }
+
     /**
-     * Whether {@code e} can be evaluated to a value.
+     * The reading of one body, which every question about a node in it is asked of.
      *
-     * <p>Everything strict is required — an expression whose operand answers nothing answers nothing
-     * — and a fork also needs one of the paths that leave it to answer something. Written as an
-     * exhaustive switch: a node kind added to the IR should stop here and be decided about rather
-     * than fall into a default and be assumed to answer.
+     * <p>Rooted, because what a name reads is not a fact about the node that reads it. A
+     * {@code Core.Read} standing under a {@code let} that bound it to a number written out is settled
+     * by that number; the same node standing in a body that binds nothing is a position of the input.
+     * Asking about a subtree on its own would answer the second of those about the first.
+     */
+    public static NormalReturn ofBody(Core body) {
+        return new NormalReturn(ValueArrivals.ofBody(body, Anonymous.NAMING));
+    }
+
+    /** Whether {@code e}, standing where it stands in this body, can be evaluated to a value. */
+    public boolean at(Core e) {
+        return reading.arrivesAt(e);
+    }
+
+    /**
+     * Whether {@code e} can be evaluated to a value, read as a body of its own.
+     *
+     * <p>For a caller that has an expression and nothing above it. Every name in it is free, which is
+     * what it means for nothing to have bound them.
      */
     public static boolean of(Core e) {
-        return switch (e) {
-            case Core.Unreachable _ -> false;
-            case Core.Int _, Core.Decimal _, Core.Str _, Core.Bool _, Core.Temporal _, Core.Read _,
-                 Core.UnitValue _, Core.OptionNone _ -> true;
-            case Core.Neg n -> of(n.operand());
-            case Core.FieldAccess fa -> of(fa.target());
-            case Core.Binary b -> of(b.left()) && of(b.right());
-            case Core.OptionSome s -> of(s.value());
-            case Core.TupleGet tg -> of(tg.tuple());
-            case Core.Tuple t -> all(t.elements());
-            case Core.ListLit lit -> all(lit.elements());
-            case Core.Construct nd -> nd.values().stream().allMatch(given -> of(given.value()));
-            // The callee's own body is not read; its arguments are evaluated before it is reached.
-            case Core.Call c -> all(c.args());
-            case Core.Apply a -> all(a.args());
-            case Core.PreservedCall p -> throw p.unexpectedIn("normal-return analysis");
-            // The value is evaluated before the body it binds is.
-            case Core.LetIn li -> of(li.value()) && of(li.body());
-            // A function value, not a body being run here: a block is a step handed to a combinator
-            // or a lambda a `let` binds, and evaluating this position makes the function rather than
-            // calling it. What happens when it is called is the call's business, and a call is not
-            // read through. Reading the body here says a step that aborts on an element it is never
-            // handed makes the expression around it answer nothing — which would take a class a row
-            // does sit in out of the denominator.
-            case Core.Block _ -> true;
-            case Core.If iff -> of(iff.cond()) && (of(iff.then()) || of(iff.els()));
-            case Core.Match m -> of(m.scrutinee())
-                    && m.cases().stream().anyMatch(arm -> of(arm.body()));
-            case Core.IfConstructed ic ->
-                    ic.construct().values().stream().allMatch(given -> of(given.value()))
-                            && (of(ic.then()) || ic.els().stream().anyMatch(arm -> of(arm.body())));
-        };
+        return ofBody(e).at(e);
     }
-
-    private static boolean all(List<Core> each) {
-        return each.stream().allMatch(NormalReturn::of);
-    }
-
-    private NormalReturn() {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/coverage/NormalReturn.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/NormalReturn.java
@@ -56,6 +56,24 @@ public final class NormalReturn {
     }
 
     /**
+     * Whether a run can go down arm {@code part} of {@code fork}.
+     *
+     * <p>A second question about an arm and not the same one. An arm whose body answers a value is
+     * still an arm no run enters where the condition never comes out its way — {@code true} sends
+     * every run to the first, and a comparison against the largest whole number sends every run to
+     * the second. Asked of the reading rather than worked out again here, because which arms a
+     * condition can reach is what that reading already answers and two accounts of it would be two
+     * answers to keep in step.
+     *
+     * <p>Anything but a fork on a value answers yes. Which arm of a {@code match} a run takes is
+     * which case the value is, and which arm of an attempted construction it takes is whether the
+     * thing was made — neither is a truth this reading has anything to say about.
+     */
+    public boolean mayEnter(Core fork, int part) {
+        return !(fork instanceof Core.If iff) || reading.comesAt(iff.cond()).mayCome(part == 0);
+    }
+
+    /**
      * Whether {@code e} can be evaluated to a value, read as a body of its own.
      *
      * <p>For a caller that has an expression and nothing above it. Every name in it is free, which is

--- a/souther-compiler/src/main/java/souther/compiler/flow/Anonymous.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/Anonymous.java
@@ -36,7 +36,7 @@ public final class Anonymous implements Naming<AnonymousPath> {
     }
 
     @Override
-    public AnonymousPath side(Core.Binary comparison, boolean held) {
+    public AnonymousPath side(Core value, boolean held) {
         return AnonymousPath.INSTANCE;
     }
 
@@ -50,10 +50,15 @@ public final class Anonymous implements Naming<AnonymousPath> {
         return AnonymousPath.INSTANCE;
     }
 
+    /**
+     * No bound, because this is the reading everything else's answers about the body come from.
+     *
+     * <p>It needs none. Every path here is the same path, so what a node is settled as is at most one
+     * way per {@link Truth} and the count cannot run away. A bound would be a way for this half to
+     * say less, and this is the half nothing is allowed to take away from.
+     */
     @Override
     public int mostArrivals() {
-        // Three truths and one path, so nothing here can go over it. Written down all the same: a
-        // reader takes the bound from the naming and does not ask which naming it has.
-        return 3;
+        return Integer.MAX_VALUE;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/flow/Anonymous.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/Anonymous.java
@@ -1,0 +1,59 @@
+package souther.compiler.flow;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.core.Core;
+
+/**
+ * The naming with no words for anything.
+ *
+ * <p>What a reader asking only whether an expression arrives at a value uses. Every path is the same
+ * path, so the arrivals of a node collapse to what they come to and no further — at most one per
+ * {@link Truth}, which is what keeps this reading linear in the size of the body.
+ *
+ * <p>Nothing here is {@link Completeness#PARTIAL}. A naming that has no words for conditions has none
+ * missing either: what it writes down is all it set out to write down, and a reader that wanted the
+ * conditions would not be using this one.
+ */
+public final class Anonymous implements Naming<AnonymousPath> {
+
+    public static final Anonymous NAMING = new Anonymous();
+
+    private Anonymous() {}
+
+    @Override
+    public AnonymousPath nowhere() {
+        return AnonymousPath.INSTANCE;
+    }
+
+    @Override
+    public AnonymousPath join(AnonymousPath held, AnonymousPath more) {
+        return AnonymousPath.INSTANCE;
+    }
+
+    @Override
+    public Naming<AnonymousPath> under(Hir.Binder binder, Core value) {
+        return this;
+    }
+
+    @Override
+    public AnonymousPath side(Core.Binary comparison, boolean held) {
+        return AnonymousPath.INSTANCE;
+    }
+
+    @Override
+    public AnonymousPath matchCase(Core.Match match, int part) {
+        return AnonymousPath.INSTANCE;
+    }
+
+    @Override
+    public AnonymousPath forkArm(Core fork, int part) {
+        return AnonymousPath.INSTANCE;
+    }
+
+    @Override
+    public int mostArrivals() {
+        // Three truths and one path, so nothing here can go over it. Written down all the same: a
+        // reader takes the bound from the naming and does not ask which naming it has.
+        return 3;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/flow/AnonymousPath.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/AnonymousPath.java
@@ -1,0 +1,20 @@
+package souther.compiler.flow;
+
+/**
+ * The path of a reading that names nothing.
+ *
+ * <p>A value rather than an absence. What a reading with no numbering behind it knows about the way
+ * to a value is that there was one, and that is a thing to say and not a thing missing — written as
+ * null it would put a hole in every path this reading answers with and make "no conditions" and "no
+ * path" the same shape.
+ */
+public enum AnonymousPath {
+
+    /** The one path such a reading has words for. */
+    INSTANCE;
+
+    @Override
+    public String toString() {
+        return "(unnamed)";
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/flow/Arrival.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/Arrival.java
@@ -1,0 +1,28 @@
+package souther.compiler.flow;
+
+/**
+ * One way an expression arrives at a value: what it comes to, and what got a run there.
+ *
+ * <p>A value, and compared as one. Two arrivals that say the same thing are one way and not two, so
+ * a reading that produced the same way twice offers nothing twice — which is what keeps a count of
+ * these a count of what the body does rather than a count of how the reading got there.
+ *
+ * @param value      what the path comes to, where this reading can say
+ * @param provenance what got a run down it, in the naming's words
+ */
+public record Arrival<P>(Truth value, Provenance<P> provenance) {
+
+    public Arrival {
+        if (value == null || provenance == null) {
+            throw new IllegalArgumentException("an arrival is a value reached by a path");
+        }
+    }
+
+    public P path() {
+        return provenance.path();
+    }
+
+    public boolean isComplete() {
+        return provenance.isComplete();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/flow/Comes.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/Comes.java
@@ -1,0 +1,51 @@
+package souther.compiler.flow;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * What a body does at one position: whether a run arrives at a value there, and what it comes to.
+ *
+ * <p>Said in no words the numbering has, and that is the point of it. This is the reading with no
+ * naming behind it, and every reader asking what the body does is answered from it — so a naming
+ * cannot move the answer, because the answer was never computed with one.
+ *
+ * <p>Empty means no run arrives. {@link Truth#UNREAD} standing in here means a run arrives and this
+ * reading did not work out which value it came to; it does not mean both, and nothing widens it into
+ * both.
+ */
+public record Comes(Set<Truth> truths) {
+
+    public Comes {
+        truths = truths.isEmpty() ? Set.of()
+                : Collections.unmodifiableSet(EnumSet.copyOf(truths));
+    }
+
+    /** No run arrives at a value here. */
+    public static final Comes NOWHERE = new Comes(Set.of());
+
+    /** Whether a run can arrive at a value. */
+    public boolean arrives() {
+        return !truths.isEmpty();
+    }
+
+    /**
+     * Whether this reading can say a run never comes out {@code want} here.
+     *
+     * <p>The question an arm of a fork is there for, and not the question of what the value is. An
+     * arm stands unless the reading worked out that the condition never comes out its way, so a value
+     * whose truth is unread leaves both arms standing — which is this reading having nothing to say
+     * about them and is why the answer is not spelled as a truth.
+     */
+    public boolean mayCome(boolean want) {
+        return truths.contains(Truth.UNREAD) || truths.contains(Truth.of(want));
+    }
+
+    /** The values this reading worked out, which is what it will be held to. */
+    public Set<Truth> known() {
+        Set<Truth> out = EnumSet.noneOf(Truth.class);
+        truths.stream().filter(each -> each != Truth.UNREAD).forEach(out::add);
+        return Collections.unmodifiableSet(out);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/flow/Completeness.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/Completeness.java
@@ -1,0 +1,28 @@
+package souther.compiler.flow;
+
+/**
+ * Whether a path is one the naming could write down whole.
+ *
+ * <p>Not a fact about the body and not a fact about the value. A path is there and arrives whichever
+ * of these it is; what differs is whether what got a run down it can be said in the naming's own
+ * words, which is what a reader steering a run needs and what a reader asking what a value comes to
+ * does not.
+ *
+ * <p>Held apart from {@link Truth} because running them together is what made a reading of the
+ * numbering into a reading of the body: a comparison the numbering could not place was answered as a
+ * comparison whose value was unknown, and everything downstream of it was then read as having no
+ * value rather than as having one nothing could name.
+ */
+public enum Completeness {
+
+    /** Every condition on the way here was named. */
+    COMPLETE,
+
+    /** Something on the way here was not, so the conditions held do not say what got a run down it. */
+    PARTIAL;
+
+    /** Complete only where both are. */
+    public Completeness and(Completeness other) {
+        return this == COMPLETE && other == COMPLETE ? COMPLETE : PARTIAL;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/flow/Naming.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/Naming.java
@@ -13,9 +13,11 @@ import souther.compiler.core.Core;
  * what happened when a comparison the numbering could not place was answered as a comparison with no
  * value.
  *
- * <p>So: swapping the naming may turn a {@link Completeness#COMPLETE} path into a
- * {@link Completeness#PARTIAL} one and may write the conditions differently. It may not change how
- * many arrivals there are or what any of them comes to. There is a test that holds it to that.
+ * <p>So: a naming reaches {@link Paths} and reaches nothing else. It may write the conditions
+ * differently, it may turn a {@link Completeness#COMPLETE} path into a {@link Completeness#PARTIAL}
+ * one, it may leave out a way it can see no run takes, and it may decline to hold more ways apart
+ * than it will. What none of that touches is {@link Comes}, which is computed with no naming at all —
+ * so this is a structure rather than a claim, and there is nothing here for a test to catch.
  *
  * <p>{@code P} is a value. Two of them that stand for the same way are equal, because that is what
  * makes a way found twice one way rather than two.
@@ -37,13 +39,18 @@ public interface Naming<P> {
     Naming<P> under(Hir.Binder binder, Core value);
 
     /**
-     * That {@code comparison} came out {@code held}, or null where this naming has no words for it.
+     * That {@code value} came out {@code held}, or null where this naming has no words for it.
      *
-     * <p>Null does not stop the value being read. A comparison this cannot place still comes out the
-     * way it comes out; what is missing is a way to say so, and the path carrying it is
+     * <p>Null does not stop the value being read. A value this cannot place still comes out the way
+     * it comes out; what is missing is a way to say so, and the path carrying it is
      * {@link Completeness#PARTIAL} rather than absent.
+     *
+     * <p>Any value the reading worked a truth out for, which is not only a comparison: a position of
+     * the input holding a truth comes out both ways too. A naming with words for one shape and not
+     * the other answers null for the other, which costs the path its completeness and costs the
+     * reading nothing.
      */
-    P side(Core.Binary comparison, boolean held);
+    P side(Core value, boolean held);
 
     /** That a run took case {@code part} of {@code match}, or null where this has no words for it. */
     P matchCase(Core.Match match, int part);

--- a/souther-compiler/src/main/java/souther/compiler/flow/Naming.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/Naming.java
@@ -1,0 +1,56 @@
+package souther.compiler.flow;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.core.Core;
+
+/**
+ * How a reading writes down what got a run to a value.
+ *
+ * <p>The one part of {@link ValueArrivals} that differs between its readers, and the only part. A
+ * naming decides what a path is written as and which conditions it has words for; it decides nothing
+ * about whether an expression arrives or about what a value comes to. Those are read off the body,
+ * and a naming that could move them would be the numbering deciding what the body does — which is
+ * what happened when a comparison the numbering could not place was answered as a comparison with no
+ * value.
+ *
+ * <p>So: swapping the naming may turn a {@link Completeness#COMPLETE} path into a
+ * {@link Completeness#PARTIAL} one and may write the conditions differently. It may not change how
+ * many arrivals there are or what any of them comes to. There is a test that holds it to that.
+ *
+ * <p>{@code P} is a value. Two of them that stand for the same way are equal, because that is what
+ * makes a way found twice one way rather than two.
+ */
+public interface Naming<P> {
+
+    /** The path with nothing settled on it, which is what a value nothing forks arrives by. */
+    P nowhere();
+
+    /**
+     * Both sets of conditions, or null where between them they settle one decision two ways.
+     *
+     * <p>Null is no path and not an unnamed one: a run that took the first cannot have taken the
+     * second, so there is nothing here to name.
+     */
+    P join(P held, P more);
+
+    /** The naming inside a {@code let}, which may have words for the name it binds. */
+    Naming<P> under(Hir.Binder binder, Core value);
+
+    /**
+     * That {@code comparison} came out {@code held}, or null where this naming has no words for it.
+     *
+     * <p>Null does not stop the value being read. A comparison this cannot place still comes out the
+     * way it comes out; what is missing is a way to say so, and the path carrying it is
+     * {@link Completeness#PARTIAL} rather than absent.
+     */
+    P side(Core.Binary comparison, boolean held);
+
+    /** That a run took case {@code part} of {@code match}, or null where this has no words for it. */
+    P matchCase(Core.Match match, int part);
+
+    /** That a run took arm {@code part} of {@code fork}, said of the fork itself, or null. */
+    P forkArm(Core fork, int part);
+
+    /** How many arrivals one node is read as before the reading gives up on enumerating them. */
+    int mostArrivals();
+}

--- a/souther-compiler/src/main/java/souther/compiler/flow/Paths.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/Paths.java
@@ -1,0 +1,42 @@
+package souther.compiler.flow;
+
+import java.util.List;
+
+/**
+ * The ways to a value, where the naming could hold them apart.
+ *
+ * <p>The half of a reading that the naming has anything to do with. What a body does is answered
+ * beside this and never out of it: a naming that has no words for a condition, that sees two
+ * conditions settle one decision opposite ways, or that is asked to hold more ways apart than it
+ * will — each of those leaves this saying less, and none of them may leave the reading of what
+ * arrives or of what a value comes to saying anything different.
+ *
+ * <p>So {@link Beyond} is the only degradation there is, and it is an answer about this list rather
+ * than about the body: these ways are not something this reading will enumerate. A reader wanting to
+ * steer a run down one of them has nothing here; a reader asking whether a value arrives was never
+ * asking this.
+ */
+public sealed interface Paths<P> {
+
+    /**
+     * These ways and no others.
+     *
+     * <p>Empty exactly where no run arrives at a value. A list emptied by the naming having seen that
+     * no run takes any of these is not this — it is {@link Beyond}, because the body still arrives
+     * and a list saying otherwise would be the naming answering a question that is not its.
+     */
+    record Held<P>(List<Arrival<P>> arrivals) implements Paths<P> {
+
+        public Held {
+            arrivals = List.copyOf(arrivals);
+        }
+    }
+
+    /** Which ways there are is not something this reading will hold apart. */
+    record Beyond<P>() implements Paths<P> { }
+
+    /** The ways, or none where this reading will not hold them apart. */
+    default List<Arrival<P>> orNone() {
+        return this instanceof Held<P> held ? held.arrivals() : List.of();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/flow/Provenance.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/Provenance.java
@@ -1,0 +1,33 @@
+package souther.compiler.flow;
+
+/**
+ * What got a run down a path, in whatever words the naming has for it, and whether they say all of
+ * it.
+ *
+ * <p>Two fields and not one, because the second is about the naming and the first is about the run.
+ * A reading that steers rows takes both; a reading that asks what a value comes to takes neither.
+ *
+ * @param path         the conditions along the way, as the naming writes them
+ * @param completeness whether the naming could write all of them
+ */
+public record Provenance<P>(P path, Completeness completeness) {
+
+    public Provenance {
+        if (path == null) {
+            throw new IllegalArgumentException("a path with nothing on it is still a path");
+        }
+        if (completeness == null) {
+            throw new IllegalArgumentException("a path is either named whole or it is not: " + path);
+        }
+    }
+
+    /** The same path, with something on the way to it that the naming could not write down. */
+    public Provenance<P> partial() {
+        return completeness == Completeness.PARTIAL
+                ? this : new Provenance<>(path, Completeness.PARTIAL);
+    }
+
+    public boolean isComplete() {
+        return completeness == Completeness.COMPLETE;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/flow/Truth.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/Truth.java
@@ -1,0 +1,31 @@
+package souther.compiler.flow;
+
+/**
+ * What one path arrives with.
+ *
+ * <p>Three answers and not two truths and a set. A path that arrives is a path whichever value it
+ * came to, and {@link #UNREAD} says this reading has no answer for which of the two it was — it does
+ * not say the path is missing and it does not say both are reachable. There is no way to spell "both"
+ * here on purpose: a value that comes out both ways is two paths, and a reading that could summarise
+ * it as one answer would be a place for "either, I cannot tell" and "each of them, I have seen a way"
+ * to be written the same.
+ *
+ * <p>So {@link #TRUE} and {@link #FALSE} are only ever put on a path this reading worked out a value
+ * for. Nothing widens {@link #UNREAD} into them and nothing reads a missing path as one of them.
+ */
+public enum Truth {
+
+    /** This path arrives with true. */
+    TRUE,
+
+    /** This path arrives with false. */
+    FALSE,
+
+    /** This path arrives with a value, and which value is not something this reading says. */
+    UNREAD;
+
+    /** The truth of a value written out. */
+    public static Truth of(boolean value) {
+        return value ? TRUE : FALSE;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/flow/ValueArrivals.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/ValueArrivals.java
@@ -1,0 +1,623 @@
+package souther.compiler.flow;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.core.Core;
+import souther.compiler.types.BindingId;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The ways an expression arrives at a value, read off the body it is written in.
+ *
+ * <p>One reading for three questions that were being answered separately and had to agree: whether
+ * an expression can be evaluated to a value at all, what that value is where it is a truth, and
+ * under what conditions each way there holds. The first two are read off the body and are the same
+ * whoever is asking; the third is written in whatever words the {@link Naming} has, and a naming
+ * with no words for a condition leaves the path {@link Completeness#PARTIAL} rather than leaving the
+ * arrival out. So what the numbering can place decides how a way is written down and never whether
+ * there is one.
+ *
+ * <p><b>Rooted at a body.</b> What a name reads is not a fact about the node that reads it: the same
+ * {@code Core.Read} is a position of the input in one body and a {@code let} away from a number
+ * written out in another. So the body is read once, every occurrence in it is settled under what the
+ * binders above it bound, and a caller asks about a node it already has. A node this was not rooted
+ * at is read as its own body, which is the honest answer for one — every name in it is free, because
+ * nothing here bound them.
+ *
+ * <p><b>An arrival is a value.</b> Two that say the same thing are one way. The answers are sets for
+ * that reason and not as an optimisation: a way found twice by a reading that got there two ways is
+ * still one way in, and anything counting these is counting what the body does.
+ */
+public final class ValueArrivals<P> {
+
+    private final Naming<P> naming;
+
+    /**
+     * What each occurrence was settled as, keyed by identity.
+     *
+     * <p>Sound because a node occurs once, and what is in scope at it is what the reading had when
+     * it got there — so the environment is a function of the position and not a second key.
+     */
+    private final IdentityHashMap<Core, Set<Arrival<P>>> settled = new IdentityHashMap<>();
+
+    private ValueArrivals(Naming<P> naming) {
+        this.naming = naming;
+    }
+
+    /** The reading of {@code body}, with every occurrence in it settled under what binds it. */
+    public static <P> ValueArrivals<P> ofBody(Core body, Naming<P> naming) {
+        ValueArrivals<P> reading = new ValueArrivals<>(naming);
+        if (body != null) {
+            reading.fill(body, naming, Map.of());
+        }
+        return reading;
+    }
+
+    /** Whether {@code e} can be evaluated to a value. */
+    public static boolean arrives(Core body, Core e) {
+        return ofBody(body, Anonymous.NAMING).arrivesAt(e);
+    }
+
+    /** The ways {@code e} arrives at a value, empty where no run arrives at one. */
+    public Set<Arrival<P>> at(Core e) {
+        if (e == null) {
+            return Set.of();
+        }
+        Set<Arrival<P>> already = settled.get(e);
+        if (already != null) {
+            return already;
+        }
+        // Not rooted here, so read as its own body: nothing above it bound anything.
+        fill(e, naming, Map.of());
+        return settled.getOrDefault(e, Set.of());
+    }
+
+    /** Whether {@code e} can be evaluated to a value. */
+    public boolean arrivesAt(Core e) {
+        return !at(e).isEmpty();
+    }
+
+    /**
+     * Whether {@code e} can come out {@code want}.
+     *
+     * <p>Read off what the arrivals come to and nothing else, so it is the same answer whichever
+     * naming is asking. A way whose value is unread may be either, so it answers for both — which is
+     * this reading having nothing to say and not this reading saying both.
+     */
+    public boolean comesOut(Core e, boolean want) {
+        return comesOut(at(e), want);
+    }
+
+    /** The same, of arrivals already in hand. */
+    private static <P> boolean comesOut(Set<Arrival<P>> arrivals, boolean want) {
+        for (Arrival<P> each : arrivals) {
+            if (each.value() == Truth.UNREAD || each.value() == Truth.of(want)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The ways {@code e} is settled to {@code want}, or that this reading cannot enumerate them.
+     *
+     * <p>All of them or none. One arrival whose value is unread may be among the ways to either
+     * truth, and one whose path the naming could not write down whole is a way nothing can be
+     * steered along — either way no list of them is complete, and an incomplete list is worse here
+     * than no list because whatever takes one reads the ways it does not hold as ways the body has
+     * not got.
+     */
+    public Ways<P> waysTo(Core e, boolean want) {
+        return waysTo(at(e), want);
+    }
+
+    /** The same, of arrivals already in hand. */
+    private static <P> Ways<P> waysTo(Set<Arrival<P>> arrivals, boolean want) {
+        List<P> paths = new ArrayList<>();
+        for (Arrival<P> each : arrivals) {
+            if (each.value() == Truth.UNREAD || !each.isComplete()) {
+                return new Ways.Unknown<>();
+            }
+            if (each.value() == Truth.of(want)) {
+                paths.add(each.path());
+            }
+        }
+        return new Ways.Known<>(paths);
+    }
+
+    // ---------------------------------------------------------------- filling
+
+    /**
+     * Settle {@code e} and everything written inside it, each under what binds it.
+     *
+     * <p>Into the parts as they are written and not as they are evaluated. A {@code Block} is a
+     * function value and what it comes to is not read through, but its body is written here and a
+     * caller may ask about a node in it — so it is settled too, under its own parameters, and the
+     * answer for the block itself stays what it is.
+     */
+    private void fill(Core e, Naming<P> naming, Map<BindingId, Bound<P>> bound) {
+        if (e == null || settled.containsKey(e)) {
+            return;
+        }
+        read(e, naming, bound);
+        switch (e) {
+            case Core.LetIn let -> {
+                fill(let.value(), naming, bound);
+                fill(let.body(), naming.under(let.binder(), let.value()),
+                        with(bound, let.binder(), read(let.value(), naming, bound), let.value()));
+            }
+            case Core.Block block -> {
+                Map<BindingId, Bound<P>> inner = bound;
+                for (Hir.Binder param : block.params()) {
+                    inner = with(inner, param, oneWay(), null);
+                }
+                fill(block.body(), naming, inner);
+            }
+            case Core.Match match -> {
+                fill(match.scrutinee(), naming, bound);
+                for (Core.Case arm : match.cases()) {
+                    fill(arm.body(), naming, with(bound, arm.binding(), oneWay(), null));
+                }
+            }
+            case Core.IfConstructed constructed -> {
+                constructed.construct().values()
+                        .forEach(given -> fill(given.value(), naming, bound));
+                fill(constructed.then(), naming, with(bound, constructed.binder(), oneWay(), null));
+                constructed.els().forEach(arm -> fill(arm.body(), naming, bound));
+            }
+            default -> {
+                for (Core child : partsOf(e)) {
+                    fill(child, naming, bound);
+                }
+            }
+        }
+    }
+
+    /**
+     * {@code bound} widened by one binder, or itself where the binder is not there.
+     *
+     * <p>Two things about the name and not one. What it was settled to is what a reading of its value
+     * takes; what it was written as is what a reading asking which position it is about takes, and a
+     * name bound to nothing this can read — a parameter, an arm's binding — is a position in its own
+     * right rather than a name with no answer.
+     */
+    private Map<BindingId, Bound<P>> with(Map<BindingId, Bound<P>> bound, Hir.Binder binder,
+                                          Set<Arrival<P>> arrivals, Core settledBy) {
+        if (binder == null) {
+            return bound;
+        }
+        Map<BindingId, Bound<P>> inner = new java.util.HashMap<>(bound);
+        inner.put(binder.binding(), new Bound<>(arrivals, settledBy));
+        return Map.copyOf(inner);
+    }
+
+    /**
+     * What a name in scope stands for: the ways its value arrives, and the expression it was settled
+     * to where the body settled it to one.
+     *
+     * @param settledBy null for a name nothing here bound a value to, which is a position of whatever
+     *                  the body is handed
+     */
+    private record Bound<P>(Set<Arrival<P>> arrivals, Core settledBy) { }
+
+    // ---------------------------------------------------------------- reading
+
+    private Set<Arrival<P>> read(Core e, Naming<P> naming, Map<BindingId, Bound<P>> bound) {
+        if (e == null) {
+            // A body the checker refused a clause of arrives with a hole where the clause was.
+            // Nothing is evaluated there and nothing arrives.
+            return Set.of();
+        }
+        Set<Arrival<P>> already = settled.get(e);
+        if (already != null) {
+            return already;
+        }
+        Refusals refused = new Refusals();
+        Set<Arrival<P>> answer = reading(e, naming, bound, refused);
+        if (answer.isEmpty() && refused.any) {
+            // No arrival is not a proof that no value arrives, and this is not the reading that
+            // could give one. Where every way out of here settles a decision the way in settled the
+            // other way, what is missing is this reading following a correlation and not the body
+            // having a path. So it is answered as one this has nothing to say about.
+            answer = oneWay();
+        }
+        settled.put(e, answer);
+        return answer;
+    }
+
+    private Set<Arrival<P>> reading(Core e, Naming<P> naming, Map<BindingId, Bound<P>> bound,
+                                    Refusals refused) {
+        return switch (e) {
+            case Core.Unreachable ignored -> Set.of();
+            case Core.Bool literal -> one(Truth.of(literal.value()), whole(naming.nowhere()));
+            case Core.Read read -> {
+                Bound<P> named = bound.get(read.binding());
+                yield named != null ? named.arrivals() : oneWay();
+            }
+            // A function value, not a body being run here. What happens when a call applies it is
+            // that call's business, and a call is not read through either.
+            case Core.Block ignored -> oneWay();
+            // The value is evaluated before the body it binds is.
+            case Core.LetIn let -> {
+                Set<Arrival<P>> value = read(let.value(), naming, bound);
+                yield value.isEmpty() ? Set.of()
+                        : read(let.body(), naming.under(let.binder(), let.value()),
+                                with(bound, let.binder(), value, let.value()));
+            }
+            case Core.Binary binary when shortCircuits(binary.op()) ->
+                    through(binary, naming, bound, refused);
+            case Core.If iff -> fork(iff, naming, bound, refused);
+            case Core.Match match -> arms(match, naming, bound, refused);
+            case Core.IfConstructed constructed -> attempted(constructed, naming, bound, refused);
+            case Core.PreservedCall preserved -> throw preserved.unexpectedIn("value-flow analysis");
+            default -> built(e, naming, bound, refused);
+        };
+    }
+
+    /**
+     * A value made out of several, settled every way its parts are settled together.
+     *
+     * <p>One rule and not a case each: what it does not cover is exactly what forks, what stops
+     * early, what names, and what comes out one of two ways against another value. A part that
+     * arrives at no value leaves the whole arriving at none, which is what makes this the reading of
+     * everything strict as well.
+     */
+    private Set<Arrival<P>> built(Core e, Naming<P> naming, Map<BindingId, Bound<P>> bound,
+                                  Refusals refused) {
+        Set<Arrival<P>> out = oneWay();
+        for (Core part : partsOf(e)) {
+            Set<Arrival<P>> each = read(part, naming, bound);
+            if (each.isEmpty()) {
+                return Set.of();
+            }
+            out = product(out, each, naming, refused);
+            if (out.size() > naming.mostArrivals()) {
+                return oneWay();
+            }
+        }
+        if (e instanceof Core.Binary comparison && compares(comparison.op()) && out.size() == 1) {
+            Set<Arrival<P>> settledTwoWays = comparedOut(comparison, out.iterator().next(), naming,
+                    read -> {
+                        Bound<P> named = bound.get(read.binding());
+                        return named == null ? null : named.settledBy();
+                    });
+            if (settledTwoWays != null) {
+                return settledTwoWays;
+            }
+        }
+        return out;
+    }
+
+    /**
+     * A comparison split into the ways it comes out, or null where none of them is witnessed.
+     *
+     * <p>Asked one way at a time. There is no rule here that a comparison comes out both ways: each
+     * way is answered for on its own, by whether a value of what is compared brings it out that way,
+     * and a way nothing stands behind is not among these. That is what keeps {@code 1 > 2} and
+     * {@code a == a} from being read as values that vary.
+     *
+     * <p>Asked where nothing under the comparison was already saying the value varies, so what is
+     * read here is added to the reading and nothing is taken out of it.
+     */
+    private Set<Arrival<P>> comparedOut(Core.Binary comparison, Arrival<P> under, Naming<P> naming,
+                                        java.util.function.Function<Core.Read, Core> settledBy) {
+        boolean holds = Witnessed.comesOut(comparison, true, settledBy);
+        boolean fails = Witnessed.comesOut(comparison, false, settledBy);
+        if (!holds && !fails) {
+            return null;
+        }
+        Set<Arrival<P>> out = new LinkedHashSet<>();
+        if (holds) {
+            side(comparison, true, under, naming, out);
+        }
+        if (fails) {
+            side(comparison, false, under, naming, out);
+        }
+        return out.isEmpty() ? null : out;
+    }
+
+    private void side(Core.Binary comparison, boolean held, Arrival<P> under, Naming<P> naming,
+                      Set<Arrival<P>> out) {
+        P named = naming.side(comparison, held);
+        if (named == null) {
+            // The way is there and this naming has no words for it.
+            out.add(new Arrival<>(Truth.of(held), under.provenance().partial()));
+            return;
+        }
+        P both = naming.join(under.path(), named);
+        if (both == null) {
+            return;
+        }
+        out.add(new Arrival<>(Truth.of(held),
+                new Provenance<>(both, under.provenance().completeness())));
+    }
+
+    /**
+     * The ways to the value of an operator that stops as soon as its answer is settled.
+     *
+     * <p>Not a product of the two sides. {@code &&} comes to false wherever the left does and never
+     * looks at the right, and comes to whatever the right does wherever the left went through — so
+     * the ways are the left's settling ones as they stand, and the left's going-through ones each
+     * extended by every way of the right.
+     *
+     * <p>A left way this reading cannot value is not one of either. Whether the right ran at all is
+     * what the left's value would have said, so the way arrives where the right does and nowhere
+     * this reading can point at otherwise: where the right arrives at no value, claiming this way
+     * arrives would be reading "I cannot say which" as "it comes out the way that stops here".
+     */
+    private Set<Arrival<P>> through(Core.Binary binary, Naming<P> naming,
+                                    Map<BindingId, Bound<P>> bound, Refusals refused) {
+        Truth goesOn = binary.op() == Hir.BinOp.AND ? Truth.TRUE : Truth.FALSE;
+        Set<Arrival<P>> left = read(binary.left(), naming, bound);
+        Set<Arrival<P>> right = read(binary.right(), naming, bound);
+        Set<Arrival<P>> out = new LinkedHashSet<>();
+        for (Arrival<P> each : left) {
+            if (each.value() == goesOn) {
+                under(each.provenance(), right, naming, out, refused);
+            } else if (each.value() == Truth.UNREAD) {
+                if (!right.isEmpty()) {
+                    out.add(each);
+                }
+            } else {
+                out.add(each);
+            }
+            if (out.size() > naming.mostArrivals()) {
+                return oneWay();
+            }
+        }
+        return out;
+    }
+
+    private Set<Arrival<P>> fork(Core.If iff, Naming<P> naming,
+                                 Map<BindingId, Bound<P>> bound, Refusals refused) {
+        // Numbered where they are written and not where they survive: the arm a fork answers on is
+        // its place among the arms, and one that answers nothing is skipped rather than closing the
+        // gap and letting the next arm be called the first.
+        Core[] arms = {iff.then(), iff.els()};
+        Set<Arrival<P>> cond = read(iff.cond(), naming, bound);
+        Set<Arrival<P>> out = new LinkedHashSet<>();
+        for (int part = 0; part < arms.length; part++) {
+            boolean want = part == 0;
+            if (!comesOut(cond, want)) {
+                continue;
+            }
+            Set<Arrival<P>> body = read(arms[part], naming, bound);
+            if (body.isEmpty()) {
+                continue;
+            }
+            for (Provenance<P> way : waysIn(cond, iff, part, want, naming)) {
+                under(way, body, naming, out, refused);
+            }
+            if (out.size() > naming.mostArrivals()) {
+                return oneWay();
+            }
+        }
+        return out;
+    }
+
+    /**
+     * The ways into arm {@code part}, as the condition's ways of coming out that way where they can
+     * all be written down, and as the arm itself where they cannot.
+     *
+     * <p>Which arms there are is settled before this, off what the condition comes out as. This
+     * settles only how a way into one is written, so a naming with no words for the fork leaves the
+     * way {@link Completeness#PARTIAL} and takes no arm away.
+     */
+    private List<Provenance<P>> waysIn(Set<Arrival<P>> cond, Core.If iff, int part, boolean want,
+                                       Naming<P> naming) {
+        if (waysTo(cond, want) instanceof Ways.Known<P> known && !known.paths().isEmpty()) {
+            return known.paths().stream().map(this::whole).toList();
+        }
+        return List.of(armWay(iff, part, naming));
+    }
+
+    /** The arm itself as the one way in, for a condition whose ways cannot all be written down. */
+    private Provenance<P> armWay(Core fork, int part, Naming<P> naming) {
+        P named = naming.forkArm(fork, part);
+        return named == null
+                ? new Provenance<>(naming.nowhere(), Completeness.PARTIAL) : whole(named);
+    }
+
+    private Set<Arrival<P>> arms(Core.Match match, Naming<P> naming,
+                                 Map<BindingId, Bound<P>> bound, Refusals refused) {
+        if (read(match.scrutinee(), naming, bound).isEmpty()) {
+            return Set.of();
+        }
+        Set<Arrival<P>> out = new LinkedHashSet<>();
+        for (int part = 0; part < match.cases().size(); part++) {
+            Core.Case arm = match.cases().get(part);
+            Set<Arrival<P>> body = read(arm.body(), naming, with(bound, arm.binding(), oneWay(), null));
+            if (body.isEmpty()) {
+                continue;
+            }
+            P named = naming.matchCase(match, part);
+            Provenance<P> way = named == null
+                    ? new Provenance<>(naming.nowhere(), Completeness.PARTIAL) : whole(named);
+            under(way, body, naming, out, refused);
+            if (out.size() > naming.mostArrivals()) {
+                return oneWay();
+            }
+        }
+        return out;
+    }
+
+    private Set<Arrival<P>> attempted(Core.IfConstructed constructed, Naming<P> naming,
+                                      Map<BindingId, Bound<P>> bound, Refusals refused) {
+        for (Core.FieldValue given : constructed.construct().values()) {
+            if (read(given.value(), naming, bound).isEmpty()) {
+                return Set.of();
+            }
+        }
+        List<Core> arms = new ArrayList<>();
+        arms.add(constructed.then());
+        constructed.els().forEach(arm -> arms.add(arm.body()));
+        Set<Arrival<P>> out = new LinkedHashSet<>();
+        for (int part = 0; part < arms.size(); part++) {
+            Map<BindingId, Bound<P>> inner =
+                    part == 0 ? with(bound, constructed.binder(), oneWay(), null) : bound;
+            Set<Arrival<P>> body = read(arms.get(part), naming, inner);
+            if (body.isEmpty()) {
+                continue;
+            }
+            under(armWay(constructed, part, naming), body, naming, out, refused);
+            if (out.size() > naming.mostArrivals()) {
+                return oneWay();
+            }
+        }
+        return out;
+    }
+
+    // ------------------------------------------------------------ putting ways together
+
+    /** Each arrival held to what already holds along the way to it, into {@code out}. */
+    private void under(Provenance<P> holds, Set<Arrival<P>> arrivals, Naming<P> naming,
+                       Set<Arrival<P>> out, Refusals refused) {
+        for (Arrival<P> each : arrivals) {
+            P both = naming.join(holds.path(), each.path());
+            if (both == null) {
+                refused.any = true;
+                continue;
+            }
+            out.add(new Arrival<>(each.value(), new Provenance<>(both,
+                    holds.completeness().and(each.provenance().completeness()))));
+        }
+    }
+
+    /**
+     * Every way the two can be settled together, which is not every pairing of them.
+     *
+     * <p>A binding read twice is one decision read twice, and pairing its ways without asking
+     * whether the two agree would report a value settled nine ways that is settled three.
+     *
+     * <p>What the parts of a value come to is not what the value comes to. A thing built out of
+     * several is the constructor's answer and no way to it carries a truth of its own, so these
+     * arrive with nothing said about which of the two they are.
+     */
+    private Set<Arrival<P>> product(Set<Arrival<P>> left, Set<Arrival<P>> right, Naming<P> naming,
+                                    Refusals refused) {
+        Set<Arrival<P>> out = new LinkedHashSet<>();
+        for (Arrival<P> one : left) {
+            for (Arrival<P> other : right) {
+                P both = naming.join(one.path(), other.path());
+                if (both == null) {
+                    refused.any = true;
+                    continue;
+                }
+                out.add(new Arrival<>(Truth.UNREAD, new Provenance<>(both,
+                        one.provenance().completeness().and(other.provenance().completeness()))));
+                if (out.size() > naming.mostArrivals()) {
+                    return out;
+                }
+            }
+        }
+        return out;
+    }
+
+    /** What a value nothing forks is settled by, which is the same thing however it is written. */
+    private Set<Arrival<P>> oneWay() {
+        return one(Truth.UNREAD, whole(naming.nowhere()));
+    }
+
+    private Set<Arrival<P>> one(Truth value, Provenance<P> by) {
+        return Set.of(new Arrival<>(value, by));
+    }
+
+    private Provenance<P> whole(P path) {
+        return new Provenance<>(path, Completeness.COMPLETE);
+    }
+
+    /** Whether a way was put aside because nothing takes it, which is not the same as none. */
+    private static final class Refusals {
+        private boolean any;
+    }
+
+    // ------------------------------------------------------------------- the tree
+
+    /** Whether the operator settles its answer without evaluating both sides. */
+    public static boolean shortCircuits(Hir.BinOp op) {
+        return op == Hir.BinOp.AND || op == Hir.BinOp.OR;
+    }
+
+    /** Whether the operator answers with which way two values came out against each other. */
+    public static boolean compares(Hir.BinOp op) {
+        return switch (op) {
+            case EQ, NE, LT, LE, GT, GE -> true;
+            case AND, OR, ADD, SUB, MUL, DIV, CONCAT -> false;
+        };
+    }
+
+    /**
+     * Every value this node is built out of, in the order it is written.
+     *
+     * <p>Exhaustive and with no fallback. A node kind added to the IR should stop here and be
+     * decided about rather than fall in with the ones every part of which is evaluated whenever the
+     * node is.
+     */
+    private static List<Core> partsOf(Core node) {
+        return switch (node) {
+            case Core.Int ignored -> List.of();
+            case Core.Decimal ignored -> List.of();
+            case Core.Str ignored -> List.of();
+            case Core.Bool ignored -> List.of();
+            case Core.Temporal ignored -> List.of();
+            case Core.Read ignored -> List.of();
+            case Core.UnitValue ignored -> List.of();
+            case Core.OptionNone ignored -> List.of();
+            case Core.Unreachable ignored -> List.of();
+            case Core.Neg neg -> present(neg.operand());
+            case Core.FieldAccess access -> present(access.target());
+            case Core.TupleGet get -> present(get.tuple());
+            case Core.OptionSome option -> present(option.value());
+            case Core.Binary binary -> present(binary.left(), binary.right());
+            // The callee's own body is not read; its arguments are evaluated before it is reached.
+            case Core.Call call -> call.args();
+            case Core.PreservedCall call -> call.args();
+            case Core.Apply apply -> apply.args();
+            case Core.ListLit list -> list.elements();
+            case Core.Tuple tuple -> tuple.elements();
+            case Core.Construct construct ->
+                    construct.values().stream().map(Core.FieldValue::value).toList();
+            case Core.If iff -> present(iff.cond(), iff.then(), iff.els());
+            case Core.LetIn let -> present(let.value(), let.body());
+            // Not the body. Evaluating this makes the function.
+            case Core.Block ignored -> List.of();
+            case Core.Match match -> {
+                List<Core> out = new ArrayList<>();
+                out.add(match.scrutinee());
+                match.cases().forEach(each -> out.add(each.body()));
+                yield out;
+            }
+            case Core.IfConstructed constructed -> {
+                List<Core> out = new ArrayList<>();
+                out.add(constructed.construct());
+                out.add(constructed.then());
+                constructed.els().forEach(arm -> out.add(arm.body()));
+                yield out;
+            }
+        };
+    }
+
+    /**
+     * The parts that are there.
+     *
+     * <p>A body the checker refused a clause of arrives with a hole where the clause was, and a
+     * reading that is not the checker has nothing to say about it. Used where the parts are read
+     * together and not where they are numbered — an arm's place among the arms is what says which
+     * way the fork came out, and a list with the missing one taken out would call the second arm the
+     * first.
+     */
+    private static List<Core> present(Core... parts) {
+        List<Core> out = new ArrayList<>();
+        for (Core each : parts) {
+            if (each != null) {
+                out.add(each);
+            }
+        }
+        return out;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/flow/ValueArrivals.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/ValueArrivals.java
@@ -176,12 +176,12 @@ public final class ValueArrivals<P> {
         if (e == null || !walked.add(e)) {
             return;
         }
-        read(e, naming, bound);
+        settle(e, naming, bound);
         switch (e) {
             case Core.LetIn let -> {
                 fill(let.value(), naming, bound);
                 fill(let.body(), naming.under(let.binder(), let.value()),
-                        with(bound, let.binder(), read(let.value(), naming, bound), let.value()));
+                        with(bound, let.binder(), settle(let.value(), naming, bound), let.value()));
             }
             case Core.Block block -> {
                 Map<BindingId, Bound<P>> inner = bound;
@@ -218,12 +218,12 @@ public final class ValueArrivals<P> {
      * right rather than a name with no answer.
      */
     private Map<BindingId, Bound<P>> with(Map<BindingId, Bound<P>> bound, Hir.Binder binder,
-                                          List<Arrival<P>> arrivals, Core settledBy) {
+                                          Paths<P> ways, Core settledBy) {
         if (binder == null) {
             return bound;
         }
         Map<BindingId, Bound<P>> inner = new java.util.HashMap<>(bound);
-        inner.put(binder.binding(), new Bound<>(arrivals, settledBy));
+        inner.put(binder.binding(), new Bound<>(ways, settledBy));
         return Map.copyOf(inner);
     }
 
@@ -233,14 +233,9 @@ public final class ValueArrivals<P> {
      *
      * @param settledBy null for a name nothing here bound a value to, which is a position of whatever
      *                  the body is handed
-     */
-    private record Bound<P>(List<Arrival<P>> arrivals, Core settledBy) { }
+     */    private record Bound<P>(Paths<P> ways, Core settledBy) { }
 
     // ---------------------------------------------------------------- reading
-
-    private List<Arrival<P>> read(Core e, Naming<P> naming, Map<BindingId, Bound<P>> bound) {
-        return settle(e, naming, bound).orNone();
-    }
 
     private Paths<P> settle(Core e, Naming<P> naming, Map<BindingId, Bound<P>> bound) {
         if (e == null) {
@@ -252,46 +247,44 @@ public final class ValueArrivals<P> {
         if (already != null) {
             return already;
         }
-        Paths<P> answer = held(e, reading(e, naming, bound));
+        Paths<P> answer = normalised(e, reading(e, naming, bound));
         settled.put(e, answer);
         return answer;
     }
 
     /**
-     * The ways as this naming was able to hold them, or that it was not.
+     * A list the naming emptied is one it enumerated nothing of, and not an absence.
      *
-     * <p>The one place a naming's limits are turned into an answer, and they are turned into an
-     * answer about the list. Over what it will hold apart, and it holds none of them; emptied by
-     * ways it refused where the body arrives all the same, and it has enumerated nothing rather than
-     * established that nothing arrives — which is a claim only the other half makes.
+     * <p>Where every way out of a node settles a decision the way in settled the other way, what is
+     * missing is this half following a correlation that the other half does not — the body arrives
+     * all the same, and a list saying otherwise would be the naming answering a question that is not
+     * its. Said at the one place a reading is answered rather than at each shape that can produce it.
      */
-    private Paths<P> held(Core e, List<Arrival<P>> out) {
+    private Paths<P> normalised(Core e, Paths<P> answer) {
         if (semantics == null) {
             // This reading is what arriving means, so there is nothing here to be held to.
-            return new Paths.Held<>(out);
+            return answer;
         }
-        if (out.size() > naming.mostArrivals() || (out.isEmpty() && semantics.arrivesAt(e))) {
-            return new Paths.Beyond<>();
-        }
-        return new Paths.Held<>(out);
+        return answer.orNone().isEmpty() && semantics.arrivesAt(e)
+                ? new Paths.Beyond<>() : answer;
     }
 
-    private List<Arrival<P>> reading(Core e, Naming<P> naming, Map<BindingId, Bound<P>> bound) {
+    private Paths<P> reading(Core e, Naming<P> naming, Map<BindingId, Bound<P>> bound) {
         return switch (e) {
-            case Core.Unreachable ignored -> List.of();
+            case Core.Unreachable ignored -> new Paths.Held<>(List.of());
             case Core.Bool literal -> one(Truth.of(literal.value()), whole(naming.nowhere()));
             case Core.Read read when bound.containsKey(read.binding()) ->
-                    bound.get(read.binding()).arrivals();
+                    bound.get(read.binding()).ways();
             // A function value, not a body being run here. What happens when a call applies it is
             // that call's business, and a call is not read through either.
             case Core.Block ignored -> oneWay();
             // The value is evaluated before the body it binds is.
             case Core.LetIn let -> {
-                List<Arrival<P>> value = read(let.value(), naming, bound);
+                Paths<P> value = settle(let.value(), naming, bound);
                 yield arrivesAt(let.value())
-                        ? read(let.body(), naming.under(let.binder(), let.value()),
+                        ? settle(let.body(), naming.under(let.binder(), let.value()),
                                 with(bound, let.binder(), value, let.value()))
-                        : List.of();
+                        : new Paths.Held<>(List.of());
             }
             case Core.Binary binary when shortCircuits(binary.op()) ->
                     through(binary, naming, bound);
@@ -311,17 +304,20 @@ public final class ValueArrivals<P> {
      * arrives at no value leaves the whole arriving at none, which is what makes this the reading of
      * everything strict as well.
      */
-    private List<Arrival<P>> built(Core e, Naming<P> naming, Map<BindingId, Bound<P>> bound) {
-        List<Arrival<P>> out = oneWay();
+    private Paths<P> built(Core e, Naming<P> naming, Map<BindingId, Bound<P>> bound) {
+        Paths<P> out = oneWay();
         for (Core part : partsOf(e)) {
-            List<Arrival<P>> each = read(part, naming, bound);
+            Paths<P> each = settle(part, naming, bound);
             if (!arrivesAt(part)) {
-                return List.of();
+                return new Paths.Held<>(List.of());
             }
             out = product(out, each, naming);
+            if (out instanceof Paths.Beyond) {
+                return out;
+            }
         }
-        if (out.size() == 1) {
-            List<Arrival<P>> settledTwoWays = comparedOut(e, out.get(0), naming,
+        if (out.orNone().size() == 1) {
+            Paths<P> settledTwoWays = comparedOut(e, out.orNone().get(0), naming,
                     read -> {
                         Bound<P> named = bound.get(read.binding());
                         return named == null ? null : named.settledBy();
@@ -334,46 +330,45 @@ public final class ValueArrivals<P> {
     }
 
     /**
-     * A comparison split into the ways it comes out, or null where none of them is witnessed.
+     * A value split into the ways it comes out, or null where none of them is witnessed.
      *
      * <p>Asked one way at a time. There is no rule here that a comparison comes out both ways: each
      * way is answered for on its own, by whether a value of what is compared brings it out that way,
      * and a way nothing stands behind is not among these. That is what keeps {@code 1 > 2} and
      * {@code a == a} from being read as values that vary.
      *
-     * <p>Asked where nothing under the comparison was already saying the value varies, so what is
-     * read here is added to the reading and nothing is taken out of it.
+     * <p>Asked where nothing under the value was already saying it varies, so what is read here is
+     * added to the reading and nothing is taken out of it.
      */
-    private List<Arrival<P>> comparedOut(Core value, Arrival<P> under, Naming<P> naming,
-                                         java.util.function.Function<Core.Read, Core> settledBy) {
+    private Paths<P> comparedOut(Core value, Arrival<P> under, Naming<P> naming,
+                                 java.util.function.Function<Core.Read, Core> settledBy) {
         boolean holds = Witnessed.comesOut(value, true, settledBy);
         boolean fails = Witnessed.comesOut(value, false, settledBy);
         if (!holds && !fails) {
             return null;
         }
-        List<Arrival<P>> out = new ArrayList<>();
+        Gathered out = new Gathered();
         if (holds) {
             side(value, true, under, naming, out);
         }
         if (fails) {
             side(value, false, under, naming, out);
         }
-        return out.isEmpty() ? null : out;
+        return out.none() ? null : out.paths();
     }
 
-    private void side(Core value, boolean held, Arrival<P> under, Naming<P> naming,
-                      List<Arrival<P>> out) {
+    private void side(Core value, boolean held, Arrival<P> under, Naming<P> naming, Gathered out) {
         P named = naming.side(value, held);
         if (named == null) {
             // The way is there and this naming has no words for it.
-            add(out, new Arrival<>(Truth.of(held), under.provenance().partial()));
+            out.add(new Arrival<>(Truth.of(held), under.provenance().partial()));
             return;
         }
         P both = naming.join(under.path(), named);
         if (both == null) {
             return;
         }
-        add(out, new Arrival<>(Truth.of(held),
+        out.add(new Arrival<>(Truth.of(held),
                 new Provenance<>(both, under.provenance().completeness())));
     }
 
@@ -390,49 +385,64 @@ public final class ValueArrivals<P> {
      * this reading can point at otherwise: where the right arrives at no value, claiming this way
      * arrives would be reading "I cannot say which" as "it comes out the way that stops here".
      */
-    private List<Arrival<P>> through(Core.Binary binary, Naming<P> naming,
-                                     Map<BindingId, Bound<P>> bound) {
+    private Paths<P> through(Core.Binary binary, Naming<P> naming,
+                             Map<BindingId, Bound<P>> bound) {
         Truth goesOn = binary.op() == Hir.BinOp.AND ? Truth.TRUE : Truth.FALSE;
-        List<Arrival<P>> left = read(binary.left(), naming, bound);
-        List<Arrival<P>> right = read(binary.right(), naming, bound);
+        Paths<P> left = settle(binary.left(), naming, bound);
+        Paths<P> right = settle(binary.right(), naming, bound);
+        if (left instanceof Paths.Beyond) {
+            return left;
+        }
         boolean rightArrives = arrivesAt(binary.right());
-        List<Arrival<P>> out = new ArrayList<>();
-        for (Arrival<P> each : left) {
+        Gathered out = new Gathered();
+        for (Arrival<P> each : left.orNone()) {
             if (each.value() == goesOn) {
-                under(each.provenance(), right, naming, out);
+                if (right instanceof Paths.Beyond) {
+                    return right;
+                }
+                out.under(each.provenance(), right.orNone(), naming);
             } else if (each.value() == Truth.UNREAD) {
                 if (rightArrives) {
-                    add(out, each);
+                    out.add(each);
                 }
             } else {
-                add(out, each);
+                out.add(each);
+            }
+            if (out.isBeyond()) {
+                return out.paths();
             }
         }
-        return out;
+        return out.paths();
     }
 
-    private List<Arrival<P>> fork(Core.If iff, Naming<P> naming, Map<BindingId, Bound<P>> bound) {
+    private Paths<P> fork(Core.If iff, Naming<P> naming, Map<BindingId, Bound<P>> bound) {
         // Numbered where they are written and not where they survive: the arm a fork answers on is
         // its place among the arms, and one that answers nothing is skipped rather than closing the
         // gap and letting the next arm be called the first.
         Core[] arms = {iff.then(), iff.els()};
-        read(iff.cond(), naming, bound);
+        settle(iff.cond(), naming, bound);
         Comes cond = comesAt(iff.cond());
-        List<Arrival<P>> out = new ArrayList<>();
+        Gathered out = new Gathered();
         for (int part = 0; part < arms.length; part++) {
             boolean want = part == 0;
             if (!cond.mayCome(want)) {
                 continue;
             }
-            List<Arrival<P>> body = read(arms[part], naming, bound);
+            Paths<P> body = settle(arms[part], naming, bound);
             if (!arrivesAt(arms[part])) {
                 continue;
             }
+            if (body instanceof Paths.Beyond) {
+                return body;
+            }
             for (Provenance<P> way : waysIn(iff, part, want, naming)) {
-                under(way, body, naming, out);
+                out.under(way, body.orNone(), naming);
+                if (out.isBeyond()) {
+                    return out.paths();
+                }
             }
         }
-        return out;
+        return out.paths();
     }
 
     /**
@@ -457,64 +467,121 @@ public final class ValueArrivals<P> {
                 ? new Provenance<>(naming.nowhere(), Completeness.PARTIAL) : whole(named);
     }
 
-    private List<Arrival<P>> arms(Core.Match match, Naming<P> naming,
-                                  Map<BindingId, Bound<P>> bound) {
-        read(match.scrutinee(), naming, bound);
+    private Paths<P> arms(Core.Match match, Naming<P> naming, Map<BindingId, Bound<P>> bound) {
+        settle(match.scrutinee(), naming, bound);
         if (!arrivesAt(match.scrutinee())) {
-            return List.of();
+            return new Paths.Held<>(List.of());
         }
-        List<Arrival<P>> out = new ArrayList<>();
+        Gathered out = new Gathered();
         for (int part = 0; part < match.cases().size(); part++) {
             Core.Case arm = match.cases().get(part);
-            List<Arrival<P>> body =
-                    read(arm.body(), naming, with(bound, arm.binding(), oneWay(), null));
+            Paths<P> body =
+                    settle(arm.body(), naming, with(bound, arm.binding(), oneWay(), null));
             if (!arrivesAt(arm.body())) {
                 continue;
+            }
+            if (body instanceof Paths.Beyond) {
+                return body;
             }
             P named = naming.matchCase(match, part);
             Provenance<P> way = named == null
                     ? new Provenance<>(naming.nowhere(), Completeness.PARTIAL) : whole(named);
-            under(way, body, naming, out);
+            out.under(way, body.orNone(), naming);
+            if (out.isBeyond()) {
+                return out.paths();
+            }
         }
-        return out;
+        return out.paths();
     }
 
-    private List<Arrival<P>> attempted(Core.IfConstructed constructed, Naming<P> naming,
-                                       Map<BindingId, Bound<P>> bound) {
+    private Paths<P> attempted(Core.IfConstructed constructed, Naming<P> naming,
+                               Map<BindingId, Bound<P>> bound) {
         for (Core.FieldValue given : constructed.construct().values()) {
-            read(given.value(), naming, bound);
+            settle(given.value(), naming, bound);
             if (!arrivesAt(given.value())) {
-                return List.of();
+                return new Paths.Held<>(List.of());
             }
         }
         List<Core> arms = new ArrayList<>();
         arms.add(constructed.then());
         constructed.els().forEach(arm -> arms.add(arm.body()));
-        List<Arrival<P>> out = new ArrayList<>();
+        Gathered out = new Gathered();
         for (int part = 0; part < arms.size(); part++) {
             Map<BindingId, Bound<P>> inner =
                     part == 0 ? with(bound, constructed.binder(), oneWay(), null) : bound;
-            List<Arrival<P>> body = read(arms.get(part), naming, inner);
+            Paths<P> body = settle(arms.get(part), naming, inner);
             if (!arrivesAt(arms.get(part))) {
                 continue;
             }
-            under(armWay(constructed, part, naming), body, naming, out);
+            if (body instanceof Paths.Beyond) {
+                return body;
+            }
+            out.under(armWay(constructed, part, naming), body.orNone(), naming);
+            if (out.isBeyond()) {
+                return out.paths();
+            }
         }
-        return out;
+        return out.paths();
     }
 
     // ------------------------------------------------------------ putting ways together
 
-    /** Each arrival held to what already holds along the way to it, into {@code out}. */
-    private void under(Provenance<P> holds, List<Arrival<P>> arrivals, Naming<P> naming,
-                       List<Arrival<P>> out) {
-        for (Arrival<P> each : arrivals) {
-            P both = naming.join(holds.path(), each.path());
-            if (both == null) {
-                continue;
+    /**
+     * The ways as they are being put together, which stops being a list the moment there are too
+     * many of them.
+     *
+     * <p>Where the bound lives, and it lives here because it is a rule about the work and not a
+     * property of the answer. Checked after the fact it stops nothing: fifteen independently forked
+     * parts of one value have thirty-two thousand combinations, and a reading that builds them all
+     * and then says it will not hold them apart has already done what the bound was written to
+     * prevent. So nothing here can be added past it — every rule puts its ways in through this, and
+     * once there are too many the list is gone and further adds do nothing.
+     *
+     * <p>{@link Comes} is no part of this. What the body does goes on being read exactly, and what
+     * stops is the enumeration of the ways to it.
+     */
+    private final class Gathered {
+
+        private final List<Arrival<P>> ways = new ArrayList<>();
+        private boolean beyond;
+
+        boolean isBeyond() {
+            return beyond;
+        }
+
+        boolean none() {
+            return !beyond && ways.isEmpty();
+        }
+
+        /** One way, where it is not one this already holds and there is still room for it. */
+        void add(Arrival<P> way) {
+            if (beyond || ways.contains(way)) {
+                return;
             }
-            add(out, new Arrival<>(each.value(), new Provenance<>(both,
-                    holds.completeness().and(each.provenance().completeness()))));
+            if (ways.size() >= naming.mostArrivals()) {
+                beyond = true;
+                ways.clear();
+                return;
+            }
+            ways.add(way);
+        }
+
+        /** Each arrival held to what already holds along the way to it. */
+        void under(Provenance<P> holds, List<Arrival<P>> arrivals, Naming<P> naming) {
+            for (Arrival<P> each : arrivals) {
+                if (beyond) {
+                    return;
+                }
+                P both = naming.join(holds.path(), each.path());
+                if (both != null) {
+                    add(new Arrival<>(each.value(), new Provenance<>(both,
+                            holds.completeness().and(each.provenance().completeness()))));
+                }
+            }
+        }
+
+        Paths<P> paths() {
+            return beyond ? new Paths.Beyond<>() : new Paths.Held<>(ways);
         }
     }
 
@@ -527,37 +594,38 @@ public final class ValueArrivals<P> {
      * <p>What the parts of a value come to is not what the value comes to. A thing built out of
      * several is the constructor's answer and no way to it carries a truth of its own, so these
      * arrive with nothing said about which of the two they are.
+     *
+     * <p>A side this reading will not hold the ways of leaves the product one it will not hold
+     * either, and it is answered before the pairing is taken rather than after.
      */
-    private List<Arrival<P>> product(List<Arrival<P>> left, List<Arrival<P>> right,
-                                     Naming<P> naming) {
-        List<Arrival<P>> out = new ArrayList<>();
-        for (Arrival<P> one : left) {
-            for (Arrival<P> other : right) {
+    private Paths<P> product(Paths<P> left, Paths<P> right, Naming<P> naming) {
+        if (left instanceof Paths.Beyond || right instanceof Paths.Beyond) {
+            return new Paths.Beyond<>();
+        }
+        Gathered out = new Gathered();
+        for (Arrival<P> one : left.orNone()) {
+            for (Arrival<P> other : right.orNone()) {
                 P both = naming.join(one.path(), other.path());
                 if (both != null) {
-                    add(out, new Arrival<>(Truth.UNREAD, new Provenance<>(both,
+                    out.add(new Arrival<>(Truth.UNREAD, new Provenance<>(both,
                             one.provenance().completeness()
                                     .and(other.provenance().completeness()))));
                 }
+                if (out.isBeyond()) {
+                    return out.paths();
+                }
             }
         }
-        return out;
-    }
-
-    /** One way, where it is not one this list already holds. */
-    private void add(List<Arrival<P>> out, Arrival<P> way) {
-        if (!out.contains(way)) {
-            out.add(way);
-        }
+        return out.paths();
     }
 
     /** What a value nothing forks is settled by, which is the same thing however it is written. */
-    private List<Arrival<P>> oneWay() {
+    private Paths<P> oneWay() {
         return one(Truth.UNREAD, whole(naming.nowhere()));
     }
 
-    private List<Arrival<P>> one(Truth value, Provenance<P> by) {
-        return List.of(new Arrival<>(value, by));
+    private Paths<P> one(Truth value, Provenance<P> by) {
+        return new Paths.Held<>(List.of(new Arrival<>(value, by)));
     }
 
     private Provenance<P> whole(P path) {

--- a/souther-compiler/src/main/java/souther/compiler/flow/ValueArrivals.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/ValueArrivals.java
@@ -5,8 +5,8 @@ import souther.compiler.core.Core;
 import souther.compiler.types.BindingId;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.IdentityHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -16,26 +16,42 @@ import java.util.Set;
  *
  * <p>One reading for three questions that were being answered separately and had to agree: whether
  * an expression can be evaluated to a value at all, what that value is where it is a truth, and
- * under what conditions each way there holds. The first two are read off the body and are the same
- * whoever is asking; the third is written in whatever words the {@link Naming} has, and a naming
- * with no words for a condition leaves the path {@link Completeness#PARTIAL} rather than leaving the
- * arrival out. So what the numbering can place decides how a way is written down and never whether
- * there is one.
+ * under what conditions each way there holds.
+ *
+ * <p><b>Two halves, and only one of them has a naming in it.</b> {@link Comes} says what the body
+ * does and is computed with no naming at all — it is what the reading with no numbering behind it
+ * answers, and every reader asking whether a value arrives or what it comes to is answered from
+ * there. {@link Paths} says what the ways are called, and it is the only half a naming touches: a
+ * condition it has no words for leaves a way {@link Completeness#PARTIAL}, a pair of conditions it
+ * sees settle one decision opposite ways leaves a way out, and more ways than it will hold apart
+ * leave {@link Paths.Beyond}. None of those can move the other half, because the other half was
+ * never computed with a naming to begin with.
+ *
+ * <p>Which is stronger than saying it. Before, the naming reached the answer three ways — a way it
+ * could not name, a pair of ways it refused, a count it would not hold — and two of them were still
+ * changing whether a value arrives. A reading of the numbering was deciding what the body does,
+ * which is the thing this was made to end.
  *
  * <p><b>Rooted at a body.</b> What a name reads is not a fact about the node that reads it: the same
  * {@code Core.Read} is a position of the input in one body and a {@code let} away from a number
  * written out in another. So the body is read once, every occurrence in it is settled under what the
- * binders above it bound, and a caller asks about a node it already has. A node this was not rooted
- * at is read as its own body, which is the honest answer for one — every name in it is free, because
- * nothing here bound them.
+ * binders above it bound, and a caller asks about a node it already has.
  *
- * <p><b>An arrival is a value.</b> Two that say the same thing are one way. The answers are sets for
- * that reason and not as an optimisation: a way found twice by a reading that got there two ways is
- * still one way in, and anything counting these is counting what the body does.
+ * <p><b>An arrival is a value.</b> Two that say the same thing are one way, so a way found twice by a
+ * reading that got there two ways is still one way, and anything counting these is counting what the
+ * body does.
  */
 public final class ValueArrivals<P> {
 
     private final Naming<P> naming;
+
+    /**
+     * The reading with no naming behind it, which is what this one's answers about the body are.
+     *
+     * <p>Null in that reading itself, where the question is not passed on because this is where it
+     * stops: what a value arrives at is what this half says it arrives at.
+     */
+    private final ValueArrivals<AnonymousPath> semantics;
 
     /**
      * What each occurrence was settled as, keyed by identity.
@@ -43,64 +59,75 @@ public final class ValueArrivals<P> {
      * <p>Sound because a node occurs once, and what is in scope at it is what the reading had when
      * it got there — so the environment is a function of the position and not a second key.
      */
-    private final IdentityHashMap<Core, Set<Arrival<P>>> settled = new IdentityHashMap<>();
+    private final IdentityHashMap<Core, Paths<P>> settled = new IdentityHashMap<>();
 
-    private ValueArrivals(Naming<P> naming) {
+    /**
+     * Which occurrences have been descended into.
+     *
+     * <p>Not the same as which have been settled, and held apart because running them together left
+     * the reading short. Settling a node reads what it is made of, which is not everything written
+     * inside it — a fork's arm the condition never comes out the way of is not read, and neither is
+     * the body of a block. So an ancestor settling a node would have stopped the descent into it,
+     * and the nodes below it would have been left with no answer while the claim that every
+     * occurrence has one went on being made.
+     */
+    private final Set<Core> walked =
+            java.util.Collections.newSetFromMap(new IdentityHashMap<>());
+
+    private ValueArrivals(Naming<P> naming, ValueArrivals<AnonymousPath> semantics) {
         this.naming = naming;
+        this.semantics = semantics;
     }
 
     /** The reading of {@code body}, with every occurrence in it settled under what binds it. */
     public static <P> ValueArrivals<P> ofBody(Core body, Naming<P> naming) {
-        ValueArrivals<P> reading = new ValueArrivals<>(naming);
+        ValueArrivals<AnonymousPath> semantics =
+                naming == Anonymous.NAMING ? null : ofBody(body, Anonymous.NAMING);
+        ValueArrivals<P> reading = new ValueArrivals<>(naming, semantics);
         if (body != null) {
             reading.fill(body, naming, Map.of());
         }
         return reading;
     }
 
-    /** Whether {@code e} can be evaluated to a value. */
-    public static boolean arrives(Core body, Core e) {
-        return ofBody(body, Anonymous.NAMING).arrivesAt(e);
+    /**
+     * The ways {@code e} arrives at a value, as far as this naming holds them apart.
+     *
+     * <p>Asked of a node this was rooted at, and it raises for one it was not. Reading such a node as
+     * a body of its own would answer with every name in it free, which is a different question and
+     * one whose answer can differ — so a caller holding a node from somewhere else would be told
+     * something true about a body it is not asking about. Rooting a reading at that node is how to
+     * ask it.
+     */
+    public Paths<P> waysAt(Core e) {
+        if (e == null) {
+            return new Paths.Held<>(List.of());
+        }
+        Paths<P> already = settled.get(e);
+        if (already == null) {
+            throw new IllegalArgumentException(
+                    "this reading was not rooted at the body holding this "
+                            + e.getClass().getSimpleName() + " at " + e.pos());
+        }
+        return already;
     }
 
-    /** The ways {@code e} arrives at a value, empty where no run arrives at one. */
-    public Set<Arrival<P>> at(Core e) {
+    /** What the body does at {@code e}: whether a run arrives, and what it comes to. */
+    public Comes comesAt(Core e) {
         if (e == null) {
-            return Set.of();
+            return Comes.NOWHERE;
         }
-        Set<Arrival<P>> already = settled.get(e);
-        if (already != null) {
-            return already;
+        if (semantics != null) {
+            return semantics.comesAt(e);
         }
-        // Not rooted here, so read as its own body: nothing above it bound anything.
-        fill(e, naming, Map.of());
-        return settled.getOrDefault(e, Set.of());
+        Set<Truth> truths = EnumSet.noneOf(Truth.class);
+        waysAt(e).orNone().forEach(each -> truths.add(each.value()));
+        return new Comes(truths);
     }
 
     /** Whether {@code e} can be evaluated to a value. */
     public boolean arrivesAt(Core e) {
-        return !at(e).isEmpty();
-    }
-
-    /**
-     * Whether {@code e} can come out {@code want}.
-     *
-     * <p>Read off what the arrivals come to and nothing else, so it is the same answer whichever
-     * naming is asking. A way whose value is unread may be either, so it answers for both — which is
-     * this reading having nothing to say and not this reading saying both.
-     */
-    public boolean comesOut(Core e, boolean want) {
-        return comesOut(at(e), want);
-    }
-
-    /** The same, of arrivals already in hand. */
-    private static <P> boolean comesOut(Set<Arrival<P>> arrivals, boolean want) {
-        for (Arrival<P> each : arrivals) {
-            if (each.value() == Truth.UNREAD || each.value() == Truth.of(want)) {
-                return true;
-            }
-        }
-        return false;
+        return comesAt(e).arrives();
     }
 
     /**
@@ -111,21 +138,26 @@ public final class ValueArrivals<P> {
      * steered along — either way no list of them is complete, and an incomplete list is worse here
      * than no list because whatever takes one reads the ways it does not hold as ways the body has
      * not got.
+     *
+     * <p>An empty list says the value is never settled that way, so it is only ever answered where
+     * the reading of what the body does agrees. A naming that dropped every way to a truth the body
+     * comes to has enumerated nothing, not established an absence.
      */
     public Ways<P> waysTo(Core e, boolean want) {
-        return waysTo(at(e), want);
-    }
-
-    /** The same, of arrivals already in hand. */
-    private static <P> Ways<P> waysTo(Set<Arrival<P>> arrivals, boolean want) {
+        if (!(waysAt(e) instanceof Paths.Held<P> held)) {
+            return new Ways.Unknown<>();
+        }
         List<P> paths = new ArrayList<>();
-        for (Arrival<P> each : arrivals) {
+        for (Arrival<P> each : held.arrivals()) {
             if (each.value() == Truth.UNREAD || !each.isComplete()) {
                 return new Ways.Unknown<>();
             }
             if (each.value() == Truth.of(want)) {
                 paths.add(each.path());
             }
+        }
+        if (paths.isEmpty() && comesAt(e).mayCome(want)) {
+            return new Ways.Unknown<>();
         }
         return new Ways.Known<>(paths);
     }
@@ -141,7 +173,7 @@ public final class ValueArrivals<P> {
      * answer for the block itself stays what it is.
      */
     private void fill(Core e, Naming<P> naming, Map<BindingId, Bound<P>> bound) {
-        if (e == null || settled.containsKey(e)) {
+        if (e == null || !walked.add(e)) {
             return;
         }
         read(e, naming, bound);
@@ -165,16 +197,15 @@ public final class ValueArrivals<P> {
                 }
             }
             case Core.IfConstructed constructed -> {
-                constructed.construct().values()
-                        .forEach(given -> fill(given.value(), naming, bound));
+                fill(constructed.construct(), naming, bound);
                 fill(constructed.then(), naming, with(bound, constructed.binder(), oneWay(), null));
                 constructed.els().forEach(arm -> fill(arm.body(), naming, bound));
             }
-            default -> {
-                for (Core child : partsOf(e)) {
-                    fill(child, naming, bound);
-                }
-            }
+            // Everything else through the enumeration the language keeps for itself. A list written
+            // out here would be a copy of that one, agreeing with it until one of them changed — and
+            // the two slots it had already stopped agreeing about are exactly the ones nothing here
+            // could have noticed: a name a call applies, and the construction an attempt is of.
+            default -> Core.forEachChild(e, child -> fill(child, naming, bound));
         }
     }
 
@@ -187,7 +218,7 @@ public final class ValueArrivals<P> {
      * right rather than a name with no answer.
      */
     private Map<BindingId, Bound<P>> with(Map<BindingId, Bound<P>> bound, Hir.Binder binder,
-                                          Set<Arrival<P>> arrivals, Core settledBy) {
+                                          List<Arrival<P>> arrivals, Core settledBy) {
         if (binder == null) {
             return bound;
         }
@@ -203,59 +234,72 @@ public final class ValueArrivals<P> {
      * @param settledBy null for a name nothing here bound a value to, which is a position of whatever
      *                  the body is handed
      */
-    private record Bound<P>(Set<Arrival<P>> arrivals, Core settledBy) { }
+    private record Bound<P>(List<Arrival<P>> arrivals, Core settledBy) { }
 
     // ---------------------------------------------------------------- reading
 
-    private Set<Arrival<P>> read(Core e, Naming<P> naming, Map<BindingId, Bound<P>> bound) {
+    private List<Arrival<P>> read(Core e, Naming<P> naming, Map<BindingId, Bound<P>> bound) {
+        return settle(e, naming, bound).orNone();
+    }
+
+    private Paths<P> settle(Core e, Naming<P> naming, Map<BindingId, Bound<P>> bound) {
         if (e == null) {
             // A body the checker refused a clause of arrives with a hole where the clause was.
             // Nothing is evaluated there and nothing arrives.
-            return Set.of();
+            return new Paths.Held<>(List.of());
         }
-        Set<Arrival<P>> already = settled.get(e);
+        Paths<P> already = settled.get(e);
         if (already != null) {
             return already;
         }
-        Refusals refused = new Refusals();
-        Set<Arrival<P>> answer = reading(e, naming, bound, refused);
-        if (answer.isEmpty() && refused.any) {
-            // No arrival is not a proof that no value arrives, and this is not the reading that
-            // could give one. Where every way out of here settles a decision the way in settled the
-            // other way, what is missing is this reading following a correlation and not the body
-            // having a path. So it is answered as one this has nothing to say about.
-            answer = oneWay();
-        }
+        Paths<P> answer = held(e, reading(e, naming, bound));
         settled.put(e, answer);
         return answer;
     }
 
-    private Set<Arrival<P>> reading(Core e, Naming<P> naming, Map<BindingId, Bound<P>> bound,
-                                    Refusals refused) {
+    /**
+     * The ways as this naming was able to hold them, or that it was not.
+     *
+     * <p>The one place a naming's limits are turned into an answer, and they are turned into an
+     * answer about the list. Over what it will hold apart, and it holds none of them; emptied by
+     * ways it refused where the body arrives all the same, and it has enumerated nothing rather than
+     * established that nothing arrives — which is a claim only the other half makes.
+     */
+    private Paths<P> held(Core e, List<Arrival<P>> out) {
+        if (semantics == null) {
+            // This reading is what arriving means, so there is nothing here to be held to.
+            return new Paths.Held<>(out);
+        }
+        if (out.size() > naming.mostArrivals() || (out.isEmpty() && semantics.arrivesAt(e))) {
+            return new Paths.Beyond<>();
+        }
+        return new Paths.Held<>(out);
+    }
+
+    private List<Arrival<P>> reading(Core e, Naming<P> naming, Map<BindingId, Bound<P>> bound) {
         return switch (e) {
-            case Core.Unreachable ignored -> Set.of();
+            case Core.Unreachable ignored -> List.of();
             case Core.Bool literal -> one(Truth.of(literal.value()), whole(naming.nowhere()));
-            case Core.Read read -> {
-                Bound<P> named = bound.get(read.binding());
-                yield named != null ? named.arrivals() : oneWay();
-            }
+            case Core.Read read when bound.containsKey(read.binding()) ->
+                    bound.get(read.binding()).arrivals();
             // A function value, not a body being run here. What happens when a call applies it is
             // that call's business, and a call is not read through either.
             case Core.Block ignored -> oneWay();
             // The value is evaluated before the body it binds is.
             case Core.LetIn let -> {
-                Set<Arrival<P>> value = read(let.value(), naming, bound);
-                yield value.isEmpty() ? Set.of()
-                        : read(let.body(), naming.under(let.binder(), let.value()),
-                                with(bound, let.binder(), value, let.value()));
+                List<Arrival<P>> value = read(let.value(), naming, bound);
+                yield arrivesAt(let.value())
+                        ? read(let.body(), naming.under(let.binder(), let.value()),
+                                with(bound, let.binder(), value, let.value()))
+                        : List.of();
             }
             case Core.Binary binary when shortCircuits(binary.op()) ->
-                    through(binary, naming, bound, refused);
-            case Core.If iff -> fork(iff, naming, bound, refused);
-            case Core.Match match -> arms(match, naming, bound, refused);
-            case Core.IfConstructed constructed -> attempted(constructed, naming, bound, refused);
+                    through(binary, naming, bound);
+            case Core.If iff -> fork(iff, naming, bound);
+            case Core.Match match -> arms(match, naming, bound);
+            case Core.IfConstructed constructed -> attempted(constructed, naming, bound);
             case Core.PreservedCall preserved -> throw preserved.unexpectedIn("value-flow analysis");
-            default -> built(e, naming, bound, refused);
+            default -> built(e, naming, bound);
         };
     }
 
@@ -267,21 +311,17 @@ public final class ValueArrivals<P> {
      * arrives at no value leaves the whole arriving at none, which is what makes this the reading of
      * everything strict as well.
      */
-    private Set<Arrival<P>> built(Core e, Naming<P> naming, Map<BindingId, Bound<P>> bound,
-                                  Refusals refused) {
-        Set<Arrival<P>> out = oneWay();
+    private List<Arrival<P>> built(Core e, Naming<P> naming, Map<BindingId, Bound<P>> bound) {
+        List<Arrival<P>> out = oneWay();
         for (Core part : partsOf(e)) {
-            Set<Arrival<P>> each = read(part, naming, bound);
-            if (each.isEmpty()) {
-                return Set.of();
+            List<Arrival<P>> each = read(part, naming, bound);
+            if (!arrivesAt(part)) {
+                return List.of();
             }
-            out = product(out, each, naming, refused);
-            if (out.size() > naming.mostArrivals()) {
-                return oneWay();
-            }
+            out = product(out, each, naming);
         }
-        if (e instanceof Core.Binary comparison && compares(comparison.op()) && out.size() == 1) {
-            Set<Arrival<P>> settledTwoWays = comparedOut(comparison, out.iterator().next(), naming,
+        if (out.size() == 1) {
+            List<Arrival<P>> settledTwoWays = comparedOut(e, out.get(0), naming,
                     read -> {
                         Bound<P> named = bound.get(read.binding());
                         return named == null ? null : named.settledBy();
@@ -304,36 +344,36 @@ public final class ValueArrivals<P> {
      * <p>Asked where nothing under the comparison was already saying the value varies, so what is
      * read here is added to the reading and nothing is taken out of it.
      */
-    private Set<Arrival<P>> comparedOut(Core.Binary comparison, Arrival<P> under, Naming<P> naming,
-                                        java.util.function.Function<Core.Read, Core> settledBy) {
-        boolean holds = Witnessed.comesOut(comparison, true, settledBy);
-        boolean fails = Witnessed.comesOut(comparison, false, settledBy);
+    private List<Arrival<P>> comparedOut(Core value, Arrival<P> under, Naming<P> naming,
+                                         java.util.function.Function<Core.Read, Core> settledBy) {
+        boolean holds = Witnessed.comesOut(value, true, settledBy);
+        boolean fails = Witnessed.comesOut(value, false, settledBy);
         if (!holds && !fails) {
             return null;
         }
-        Set<Arrival<P>> out = new LinkedHashSet<>();
+        List<Arrival<P>> out = new ArrayList<>();
         if (holds) {
-            side(comparison, true, under, naming, out);
+            side(value, true, under, naming, out);
         }
         if (fails) {
-            side(comparison, false, under, naming, out);
+            side(value, false, under, naming, out);
         }
         return out.isEmpty() ? null : out;
     }
 
-    private void side(Core.Binary comparison, boolean held, Arrival<P> under, Naming<P> naming,
-                      Set<Arrival<P>> out) {
-        P named = naming.side(comparison, held);
+    private void side(Core value, boolean held, Arrival<P> under, Naming<P> naming,
+                      List<Arrival<P>> out) {
+        P named = naming.side(value, held);
         if (named == null) {
             // The way is there and this naming has no words for it.
-            out.add(new Arrival<>(Truth.of(held), under.provenance().partial()));
+            add(out, new Arrival<>(Truth.of(held), under.provenance().partial()));
             return;
         }
         P both = naming.join(under.path(), named);
         if (both == null) {
             return;
         }
-        out.add(new Arrival<>(Truth.of(held),
+        add(out, new Arrival<>(Truth.of(held),
                 new Provenance<>(both, under.provenance().completeness())));
     }
 
@@ -350,51 +390,46 @@ public final class ValueArrivals<P> {
      * this reading can point at otherwise: where the right arrives at no value, claiming this way
      * arrives would be reading "I cannot say which" as "it comes out the way that stops here".
      */
-    private Set<Arrival<P>> through(Core.Binary binary, Naming<P> naming,
-                                    Map<BindingId, Bound<P>> bound, Refusals refused) {
+    private List<Arrival<P>> through(Core.Binary binary, Naming<P> naming,
+                                     Map<BindingId, Bound<P>> bound) {
         Truth goesOn = binary.op() == Hir.BinOp.AND ? Truth.TRUE : Truth.FALSE;
-        Set<Arrival<P>> left = read(binary.left(), naming, bound);
-        Set<Arrival<P>> right = read(binary.right(), naming, bound);
-        Set<Arrival<P>> out = new LinkedHashSet<>();
+        List<Arrival<P>> left = read(binary.left(), naming, bound);
+        List<Arrival<P>> right = read(binary.right(), naming, bound);
+        boolean rightArrives = arrivesAt(binary.right());
+        List<Arrival<P>> out = new ArrayList<>();
         for (Arrival<P> each : left) {
             if (each.value() == goesOn) {
-                under(each.provenance(), right, naming, out, refused);
+                under(each.provenance(), right, naming, out);
             } else if (each.value() == Truth.UNREAD) {
-                if (!right.isEmpty()) {
-                    out.add(each);
+                if (rightArrives) {
+                    add(out, each);
                 }
             } else {
-                out.add(each);
-            }
-            if (out.size() > naming.mostArrivals()) {
-                return oneWay();
+                add(out, each);
             }
         }
         return out;
     }
 
-    private Set<Arrival<P>> fork(Core.If iff, Naming<P> naming,
-                                 Map<BindingId, Bound<P>> bound, Refusals refused) {
+    private List<Arrival<P>> fork(Core.If iff, Naming<P> naming, Map<BindingId, Bound<P>> bound) {
         // Numbered where they are written and not where they survive: the arm a fork answers on is
         // its place among the arms, and one that answers nothing is skipped rather than closing the
         // gap and letting the next arm be called the first.
         Core[] arms = {iff.then(), iff.els()};
-        Set<Arrival<P>> cond = read(iff.cond(), naming, bound);
-        Set<Arrival<P>> out = new LinkedHashSet<>();
+        read(iff.cond(), naming, bound);
+        Comes cond = comesAt(iff.cond());
+        List<Arrival<P>> out = new ArrayList<>();
         for (int part = 0; part < arms.length; part++) {
             boolean want = part == 0;
-            if (!comesOut(cond, want)) {
+            if (!cond.mayCome(want)) {
                 continue;
             }
-            Set<Arrival<P>> body = read(arms[part], naming, bound);
-            if (body.isEmpty()) {
+            List<Arrival<P>> body = read(arms[part], naming, bound);
+            if (!arrivesAt(arms[part])) {
                 continue;
             }
-            for (Provenance<P> way : waysIn(cond, iff, part, want, naming)) {
-                under(way, body, naming, out, refused);
-            }
-            if (out.size() > naming.mostArrivals()) {
-                return oneWay();
+            for (Provenance<P> way : waysIn(iff, part, want, naming)) {
+                under(way, body, naming, out);
             }
         }
         return out;
@@ -408,9 +443,8 @@ public final class ValueArrivals<P> {
      * settles only how a way into one is written, so a naming with no words for the fork leaves the
      * way {@link Completeness#PARTIAL} and takes no arm away.
      */
-    private List<Provenance<P>> waysIn(Set<Arrival<P>> cond, Core.If iff, int part, boolean want,
-                                       Naming<P> naming) {
-        if (waysTo(cond, want) instanceof Ways.Known<P> known && !known.paths().isEmpty()) {
+    private List<Provenance<P>> waysIn(Core.If iff, int part, boolean want, Naming<P> naming) {
+        if (waysTo(iff.cond(), want) instanceof Ways.Known<P> known && !known.paths().isEmpty()) {
             return known.paths().stream().map(this::whole).toList();
         }
         return List.of(armWay(iff, part, naming));
@@ -423,51 +457,48 @@ public final class ValueArrivals<P> {
                 ? new Provenance<>(naming.nowhere(), Completeness.PARTIAL) : whole(named);
     }
 
-    private Set<Arrival<P>> arms(Core.Match match, Naming<P> naming,
-                                 Map<BindingId, Bound<P>> bound, Refusals refused) {
-        if (read(match.scrutinee(), naming, bound).isEmpty()) {
-            return Set.of();
+    private List<Arrival<P>> arms(Core.Match match, Naming<P> naming,
+                                  Map<BindingId, Bound<P>> bound) {
+        read(match.scrutinee(), naming, bound);
+        if (!arrivesAt(match.scrutinee())) {
+            return List.of();
         }
-        Set<Arrival<P>> out = new LinkedHashSet<>();
+        List<Arrival<P>> out = new ArrayList<>();
         for (int part = 0; part < match.cases().size(); part++) {
             Core.Case arm = match.cases().get(part);
-            Set<Arrival<P>> body = read(arm.body(), naming, with(bound, arm.binding(), oneWay(), null));
-            if (body.isEmpty()) {
+            List<Arrival<P>> body =
+                    read(arm.body(), naming, with(bound, arm.binding(), oneWay(), null));
+            if (!arrivesAt(arm.body())) {
                 continue;
             }
             P named = naming.matchCase(match, part);
             Provenance<P> way = named == null
                     ? new Provenance<>(naming.nowhere(), Completeness.PARTIAL) : whole(named);
-            under(way, body, naming, out, refused);
-            if (out.size() > naming.mostArrivals()) {
-                return oneWay();
-            }
+            under(way, body, naming, out);
         }
         return out;
     }
 
-    private Set<Arrival<P>> attempted(Core.IfConstructed constructed, Naming<P> naming,
-                                      Map<BindingId, Bound<P>> bound, Refusals refused) {
+    private List<Arrival<P>> attempted(Core.IfConstructed constructed, Naming<P> naming,
+                                       Map<BindingId, Bound<P>> bound) {
         for (Core.FieldValue given : constructed.construct().values()) {
-            if (read(given.value(), naming, bound).isEmpty()) {
-                return Set.of();
+            read(given.value(), naming, bound);
+            if (!arrivesAt(given.value())) {
+                return List.of();
             }
         }
         List<Core> arms = new ArrayList<>();
         arms.add(constructed.then());
         constructed.els().forEach(arm -> arms.add(arm.body()));
-        Set<Arrival<P>> out = new LinkedHashSet<>();
+        List<Arrival<P>> out = new ArrayList<>();
         for (int part = 0; part < arms.size(); part++) {
             Map<BindingId, Bound<P>> inner =
                     part == 0 ? with(bound, constructed.binder(), oneWay(), null) : bound;
-            Set<Arrival<P>> body = read(arms.get(part), naming, inner);
-            if (body.isEmpty()) {
+            List<Arrival<P>> body = read(arms.get(part), naming, inner);
+            if (!arrivesAt(arms.get(part))) {
                 continue;
             }
-            under(armWay(constructed, part, naming), body, naming, out, refused);
-            if (out.size() > naming.mostArrivals()) {
-                return oneWay();
-            }
+            under(armWay(constructed, part, naming), body, naming, out);
         }
         return out;
     }
@@ -475,15 +506,14 @@ public final class ValueArrivals<P> {
     // ------------------------------------------------------------ putting ways together
 
     /** Each arrival held to what already holds along the way to it, into {@code out}. */
-    private void under(Provenance<P> holds, Set<Arrival<P>> arrivals, Naming<P> naming,
-                       Set<Arrival<P>> out, Refusals refused) {
+    private void under(Provenance<P> holds, List<Arrival<P>> arrivals, Naming<P> naming,
+                       List<Arrival<P>> out) {
         for (Arrival<P> each : arrivals) {
             P both = naming.join(holds.path(), each.path());
             if (both == null) {
-                refused.any = true;
                 continue;
             }
-            out.add(new Arrival<>(each.value(), new Provenance<>(both,
+            add(out, new Arrival<>(each.value(), new Provenance<>(both,
                     holds.completeness().and(each.provenance().completeness()))));
         }
     }
@@ -498,42 +528,40 @@ public final class ValueArrivals<P> {
      * several is the constructor's answer and no way to it carries a truth of its own, so these
      * arrive with nothing said about which of the two they are.
      */
-    private Set<Arrival<P>> product(Set<Arrival<P>> left, Set<Arrival<P>> right, Naming<P> naming,
-                                    Refusals refused) {
-        Set<Arrival<P>> out = new LinkedHashSet<>();
+    private List<Arrival<P>> product(List<Arrival<P>> left, List<Arrival<P>> right,
+                                     Naming<P> naming) {
+        List<Arrival<P>> out = new ArrayList<>();
         for (Arrival<P> one : left) {
             for (Arrival<P> other : right) {
                 P both = naming.join(one.path(), other.path());
-                if (both == null) {
-                    refused.any = true;
-                    continue;
-                }
-                out.add(new Arrival<>(Truth.UNREAD, new Provenance<>(both,
-                        one.provenance().completeness().and(other.provenance().completeness()))));
-                if (out.size() > naming.mostArrivals()) {
-                    return out;
+                if (both != null) {
+                    add(out, new Arrival<>(Truth.UNREAD, new Provenance<>(both,
+                            one.provenance().completeness()
+                                    .and(other.provenance().completeness()))));
                 }
             }
         }
         return out;
     }
 
+    /** One way, where it is not one this list already holds. */
+    private void add(List<Arrival<P>> out, Arrival<P> way) {
+        if (!out.contains(way)) {
+            out.add(way);
+        }
+    }
+
     /** What a value nothing forks is settled by, which is the same thing however it is written. */
-    private Set<Arrival<P>> oneWay() {
+    private List<Arrival<P>> oneWay() {
         return one(Truth.UNREAD, whole(naming.nowhere()));
     }
 
-    private Set<Arrival<P>> one(Truth value, Provenance<P> by) {
-        return Set.of(new Arrival<>(value, by));
+    private List<Arrival<P>> one(Truth value, Provenance<P> by) {
+        return List.of(new Arrival<>(value, by));
     }
 
     private Provenance<P> whole(P path) {
         return new Provenance<>(path, Completeness.COMPLETE);
-    }
-
-    /** Whether a way was put aside because nothing takes it, which is not the same as none. */
-    private static final class Refusals {
-        private boolean any;
     }
 
     // ------------------------------------------------------------------- the tree
@@ -541,14 +569,6 @@ public final class ValueArrivals<P> {
     /** Whether the operator settles its answer without evaluating both sides. */
     public static boolean shortCircuits(Hir.BinOp op) {
         return op == Hir.BinOp.AND || op == Hir.BinOp.OR;
-    }
-
-    /** Whether the operator answers with which way two values came out against each other. */
-    public static boolean compares(Hir.BinOp op) {
-        return switch (op) {
-            case EQ, NE, LT, LE, GT, GE -> true;
-            case AND, OR, ADD, SUB, MUL, DIV, CONCAT -> false;
-        };
     }
 
     /**
@@ -577,6 +597,7 @@ public final class ValueArrivals<P> {
             // The callee's own body is not read; its arguments are evaluated before it is reached.
             case Core.Call call -> call.args();
             case Core.PreservedCall call -> call.args();
+            // What is applied is a name holding a function, which is loaded and not run here.
             case Core.Apply apply -> apply.args();
             case Core.ListLit list -> list.elements();
             case Core.Tuple tuple -> tuple.elements();

--- a/souther-compiler/src/main/java/souther/compiler/flow/Ways.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/Ways.java
@@ -1,0 +1,24 @@
+package souther.compiler.flow;
+
+import java.util.List;
+
+/**
+ * The ways a value is settled to one truth, or that this reading cannot enumerate them.
+ *
+ * <p>All of them or none of them, and the type is what holds it to that. A list with ways missing
+ * from it reads as a whole one: whatever takes it steers no run down the ways it does not hold, so
+ * one way this reading could not write down whole makes the enumeration {@link Unknown} rather than
+ * quietly leaving itself out of a {@link Known} one.
+ *
+ * <p>{@code Known} holding nothing is an answer and not an absence. It says the value is never
+ * settled that way, which is how an arm no run reaches is told from an arm this reading has nothing
+ * to say about.
+ */
+public sealed interface Ways<P> {
+
+    /** These ways to that truth, and no others. */
+    record Known<P>(List<P> paths) implements Ways<P> { }
+
+    /** Which ways come to that truth is not something this reading can say. */
+    record Unknown<P>() implements Ways<P> { }
+}

--- a/souther-compiler/src/main/java/souther/compiler/flow/Ways.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/Ways.java
@@ -17,7 +17,12 @@ import java.util.List;
 public sealed interface Ways<P> {
 
     /** These ways to that truth, and no others. */
-    record Known<P>(List<P> paths) implements Ways<P> { }
+    record Known<P>(List<P> paths) implements Ways<P> {
+
+        public Known {
+            paths = List.copyOf(paths);
+        }
+    }
 
     /** Which ways come to that truth is not something this reading can say. */
     record Unknown<P>() implements Ways<P> { }

--- a/souther-compiler/src/main/java/souther/compiler/flow/Witnessed.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/Witnessed.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.function.Function;
 
 /**
- * Whether a comparison has a value of what it is over that brings it out a given way.
+ * Whether a value of what an expression is over brings it out a given way.
  *
  * <p>Asked once per way and never as "a comparison comes out both ways". That rule reads a value
  * this reading cannot work out as a value it has worked out to be two things, and the two are what
@@ -17,6 +17,12 @@ import java.util.function.Function;
  * one way, and a rule about the shape of the node would say both come out two. A way with nothing
  * standing behind it is not answered here, and the caller reads that as having nothing to say rather
  * than as the way being closed.
+ *
+ * <p>Asked of an expression and not of a comparison, because what is being asked is whether a value
+ * stands behind a way and that is not a question about which node kind is written. A position of the
+ * input that holds a truth is such a value on its own: {@code flag} comes out both ways for the same
+ * reason {@code a > b} does, and reading it as a value this cannot work out would answer that
+ * {@code flag && abort} arrives nowhere while every run with a false {@code flag} arrives.
  *
  * <p>What stands behind a way is a value of the position the comparison is over, so the two sides
  * have to be positions this can name a range for and positions that do not settle each other. Such a
@@ -47,12 +53,15 @@ final class Witnessed {
      * @param settledBy what a name was bound to, or null where the body bound it to nothing this can
      *                  read — a parameter, an arm's binding, a value handed in from outside
      */
-    static boolean comesOut(Core.Binary comparison, boolean want,
-                            Function<Core.Read, Core> settledBy) {
+    static boolean comesOut(Core e, boolean want, Function<Core.Read, Core> settledBy) {
+        if (!(e instanceof Core.Binary comparison) || !compares(comparison.op())) {
+            // A position holding a truth, which can be given either of them.
+            return e.type() == Type.Prim.BOOL && positionOf(e, settledBy) != null;
+        }
         Core left = comparison.left();
         Core right = comparison.right();
-        List<Object> here = positionOf(left, settledBy);
-        List<Object> there = positionOf(right, settledBy);
+        List<Object> here = wholeNumberPosition(left, settledBy);
+        List<Object> there = wholeNumberPosition(right, settledBy);
         if (here != null && there != null) {
             // Two positions nothing settles against each other: they can be given the same value
             // and they can be given different ones, so every way of every comparison stands.
@@ -107,9 +116,6 @@ final class Witnessed {
      * comparison between them has a value behind it.
      */
     private static List<Object> positionOf(Core e, Function<Core.Read, Core> settledBy) {
-        if (!isWholeNumber(e.type())) {
-            return null;
-        }
         List<Object> taken = new ArrayList<>();
         Core at = e;
         while (true) {
@@ -139,8 +145,21 @@ final class Witnessed {
         }
     }
 
+    /** The position {@code e} reads where it holds a whole number, and null otherwise. */
+    private static List<Object> wholeNumberPosition(Core e, Function<Core.Read, Core> settledBy) {
+        return isWholeNumber(e.type()) ? positionOf(e, settledBy) : null;
+    }
+
     private static boolean isWholeNumber(Type type) {
         return type == Type.Prim.INT;
+    }
+
+    /** Whether the operator answers with which way two values came out against each other. */
+    private static boolean compares(Hir.BinOp op) {
+        return switch (op) {
+            case EQ, NE, LT, LE, GT, GE -> true;
+            case AND, OR, ADD, SUB, MUL, DIV, CONCAT -> false;
+        };
     }
 
     private Witnessed() {}

--- a/souther-compiler/src/main/java/souther/compiler/flow/Witnessed.java
+++ b/souther-compiler/src/main/java/souther/compiler/flow/Witnessed.java
@@ -1,0 +1,147 @@
+package souther.compiler.flow;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.core.Core;
+import souther.compiler.types.Type;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Whether a comparison has a value of what it is over that brings it out a given way.
+ *
+ * <p>Asked once per way and never as "a comparison comes out both ways". That rule reads a value
+ * this reading cannot work out as a value it has worked out to be two things, and the two are what
+ * this whole reading exists to keep apart: {@code a == a} comes out one way, {@code 1 > 2} comes out
+ * one way, and a rule about the shape of the node would say both come out two. A way with nothing
+ * standing behind it is not answered here, and the caller reads that as having nothing to say rather
+ * than as the way being closed.
+ *
+ * <p>What stands behind a way is a value of the position the comparison is over, so the two sides
+ * have to be positions this can name a range for and positions that do not settle each other. Such a
+ * position is a name nothing settled, together with whatever is reached from one by taking fields and
+ * elements of it: {@code total.value} is as free as {@code total} is.
+ *
+ * <p>Read through the names the body bound, because a name is not a position. A helper spliced into a
+ * body binds the call's argument to the helper's own parameter, so the {@code total} inside it is the
+ * caller's {@code total} and is free for the same reason that one is; a name bound to a number
+ * written out is settled by that number and is not a position at all. Which of the two a name is is
+ * what the resolver answers, and nothing here works it out from how the name was spelled.
+ *
+ * <p>Whole numbers only. A range is what a way is witnessed against, and the ranges this can be sure
+ * of without asking the model anything are the primitive's. A position whose type is a data
+ * declaration has whatever range that declaration was written with, which is not read here — so
+ * nothing is claimed about it. Under-reading, and the direction this reading takes everywhere.
+ *
+ * <p>What is not read is the model's own rules. A behavior that requires {@code a > 1} has no run
+ * with a small {@code a}, and this says a way to false stands behind {@code a > 1} all the same. That
+ * is the same liberty the reading of what arrives has always taken — an arm of a fork is counted
+ * without anything having asked whether the condition can come out that way — and not a new one.
+ */
+final class Witnessed {
+
+    /**
+     * Whether a value of what is compared brings {@code comparison} out {@code want}.
+     *
+     * @param settledBy what a name was bound to, or null where the body bound it to nothing this can
+     *                  read — a parameter, an arm's binding, a value handed in from outside
+     */
+    static boolean comesOut(Core.Binary comparison, boolean want,
+                            Function<Core.Read, Core> settledBy) {
+        Core left = comparison.left();
+        Core right = comparison.right();
+        List<Object> here = positionOf(left, settledBy);
+        List<Object> there = positionOf(right, settledBy);
+        if (here != null && there != null) {
+            // Two positions nothing settles against each other: they can be given the same value
+            // and they can be given different ones, so every way of every comparison stands.
+            return !here.equals(there);
+        }
+        if (here != null) {
+            return right instanceof Core.Int written && isWholeNumber(written.type())
+                    && against(comparison.op(), written.value(), want);
+        }
+        if (there != null && left instanceof Core.Int written && isWholeNumber(written.type())) {
+            return against(mirrored(comparison.op()), written.value(), want);
+        }
+        return false;
+    }
+
+    /**
+     * Whether some whole number brings {@code position op written} out {@code want}.
+     *
+     * <p>Read off the ends of the range and not by trying values. What closes a way is the number
+     * written being the last one on the side the way needs, which is the only thing about a range of
+     * every whole number that can close one.
+     */
+    private static boolean against(Hir.BinOp op, long written, boolean want) {
+        return switch (op) {
+            // Equal to it, and every other whole number is not.
+            case EQ, NE -> true;
+            case GT -> !want || written < Long.MAX_VALUE;
+            case GE -> want || written > Long.MIN_VALUE;
+            case LT -> !want || written > Long.MIN_VALUE;
+            case LE -> want || written < Long.MAX_VALUE;
+            case AND, OR, ADD, SUB, MUL, DIV, CONCAT -> false;
+        };
+    }
+
+    /** The same comparison written the other way round, so the number is always on the right. */
+    private static Hir.BinOp mirrored(Hir.BinOp op) {
+        return switch (op) {
+            case LT -> Hir.BinOp.GT;
+            case LE -> Hir.BinOp.GE;
+            case GT -> Hir.BinOp.LT;
+            case GE -> Hir.BinOp.LE;
+            default -> op;
+        };
+    }
+
+    /**
+     * Which position of the input {@code e} reads, or null where it reads none this can be sure of.
+     *
+     * <p>The name at the root, after every name the body settled has been read through, and what was
+     * taken out of it — which together are what says whether two of these are the same position. Two that are equal are settled by one value, so nothing about a
+     * comparison between them varies; two that differ are settled by two, and every way of every
+     * comparison between them has a value behind it.
+     */
+    private static List<Object> positionOf(Core e, Function<Core.Read, Core> settledBy) {
+        if (!isWholeNumber(e.type())) {
+            return null;
+        }
+        List<Object> taken = new ArrayList<>();
+        Core at = e;
+        while (true) {
+            switch (at) {
+                case Core.FieldAccess access -> {
+                    taken.add(access.field());
+                    at = access.target();
+                }
+                case Core.TupleGet get -> {
+                    taken.add(get.index());
+                    at = get.tuple();
+                }
+                case Core.Read read -> {
+                    Core to = settledBy.apply(read);
+                    if (to != null) {
+                        at = to;
+                        continue;
+                    }
+                    taken.add(read.binding());
+                    java.util.Collections.reverse(taken);
+                    return taken;
+                }
+                default -> {
+                    return null;
+                }
+            }
+        }
+    }
+
+    private static boolean isWholeNumber(Type type) {
+        return type == Type.Prim.INT;
+    }
+
+    private Witnessed() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/interaction/CoverageNaming.java
+++ b/souther-compiler/src/main/java/souther/compiler/interaction/CoverageNaming.java
@@ -1,0 +1,220 @@
+package souther.compiler.interaction;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.coverage.ComparisonOccurrence;
+import souther.compiler.coverage.ControlClaim;
+import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.coverage.ForkOccurrence;
+import souther.compiler.flow.Naming;
+import souther.compiler.inputs.InputReads;
+import souther.compiler.inputs.TermPath;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The conditions along a path, said of the input positions they are about and of the places a run
+ * that took them would be seen at.
+ *
+ * <p>What a group is composed against, and the only part of reading a body that the numbering has
+ * anything to do with. Nothing here decides whether an expression arrives at a value or what a value
+ * comes to: a condition this has no words for comes back as null, the reading marks the path
+ * {@link souther.compiler.flow.Completeness#PARTIAL}, and the arm or the way is still there. That is
+ * the whole of the separation — before it, a comparison the plan could not place was read as a
+ * comparison with no value, and everything standing under it went with it.
+ *
+ * <p>A value per position and not one object walked along: what a name reads widens inside a
+ * {@code let}, so {@link #under} answers a new one and the reading holds each where it belongs.
+ */
+final class CoverageNaming implements Naming<Outcome> {
+
+    /**
+     * How many ways one value is read as being settled before the reading gives up on enumerating
+     * them.
+     *
+     * <p>A product taken at one node. What bounds how many ways in a position is read under is a
+     * different bound on a different product, and the two multiply with the nesting of a body.
+     */
+    static final int MOST_OUTCOMES = 64;
+
+    private final CoverageSites.Plan plan;
+    private final Symbols symbols;
+    private final InputReads reads;
+
+    CoverageNaming(CoverageSites.Plan plan, Symbols symbols, InputReads reads) {
+        this.plan = plan;
+        this.symbols = symbols;
+        this.reads = reads;
+    }
+
+    /** What a name reads here, which a caller walking the body needs for its own naming. */
+    InputReads reads() {
+        return reads;
+    }
+
+    @Override
+    public Outcome nowhere() {
+        return new Outcome(List.of());
+    }
+
+    @Override
+    public Outcome join(Outcome held, Outcome more) {
+        List<Decision> both = merge(held.holds(), more.holds());
+        return both == null ? null : new Outcome(both);
+    }
+
+    @Override
+    public CoverageNaming under(Hir.Binder binder, Core value) {
+        return new CoverageNaming(plan, symbols, reads.and(binder, value));
+    }
+
+    /**
+     * That {@code comparison} came out {@code held}, said of the position it is about, or null where
+     * this cannot say which position that is or where no run through it could be recorded.
+     *
+     * <p>The comparison and not the arm. A condition stops as soon as it is settled, so under
+     * {@code A && B} the arm taken when the condition fails is reached both by a value that made
+     * {@code B} false and by one that never evaluated {@code B}: a row is steered by getting the
+     * comparison to answer, which no arm records.
+     */
+    @Override
+    public Outcome side(Core.Binary comparison, boolean held) {
+        ComparisonOccurrence site = plan.comparisonAt(comparison).orElse(null);
+        TermPath at = firstOf(reads.pathOf(comparison.left(), symbols),
+                reads.pathOf(comparison.right(), symbols));
+        if (site == null || at == null) {
+            return null;
+        }
+        return plan.outcomeOf(comparison, held)
+                .flatMap(ControlClaim::of)
+                .map(claim -> one(new Decision(new Condition.Side(at, site, held), claim)))
+                .orElse(null);
+    }
+
+    /** Which case of the union this arm is, said of the position matched on where there is one, or
+     *  null where no run through the arm could be recorded. */
+    @Override
+    public Outcome matchCase(Core.Match match, int part) {
+        ControlClaim claim = armClaim(match, part);
+        if (claim == null) {
+            return null;
+        }
+        TermPath at = reads.pathOf(match.scrutinee(), symbols);
+        if (at == null) {
+            Condition fork = forkOf(match, part);
+            return fork == null ? null : one(new Decision(fork, claim));
+        }
+        List<String> names = match.cases().get(part).pattern().selectors().stream()
+                .map(selector -> selector.name().name()).toList();
+        return one(new Decision(new Condition.Case(at, String.join("|", names)), claim));
+    }
+
+    /**
+     * That a run went down arm {@code part}, where nothing said which comparison sent it there.
+     *
+     * <p>What the reading falls back on. Where the condition's ways can be enumerated they are what
+     * names the way in, on the comparisons a row is steered by; this is the answer for a condition
+     * whose ways cannot all be written down, and it is the answer every fork used to get.
+     *
+     * <p>An arm places at no class of any input, so a group offered under one of these goes. That it
+     * is here at all is what says the reading found a way in it could not name.
+     */
+    @Override
+    public Outcome forkArm(Core fork, int part) {
+        ControlClaim claim = armClaim(fork, part);
+        if (claim == null) {
+            return null;
+        }
+        if (fork instanceof Core.If iff) {
+            TermPath read = reads.pathOf(iff.cond(), symbols);
+            Condition what = read == null ? forkOf(fork, part)
+                    : new Condition.Case(read, part == 0 ? "true" : "false");
+            return what == null ? null : one(new Decision(what, claim));
+        }
+        Condition what = forkOf(fork, part);
+        return what == null ? null : one(new Decision(what, claim));
+    }
+
+    @Override
+    public int mostArrivals() {
+        return MOST_OUTCOMES;
+    }
+
+    /** One arm of a fork, where a run through it can be recorded, and null where it cannot. */
+    private ControlClaim armClaim(Core fork, int part) {
+        ControlPointId.ArmOccurrence[] arms = plan.armsOf(fork);
+        if (arms == null || part >= arms.length) {
+            return null;
+        }
+        return ControlClaim.of(arms[part]).orElse(null);
+    }
+
+    /** The fork itself, for a decision this cannot name a position for, or null where the plan named
+     *  no fork here. */
+    private Condition forkOf(Core fork, int part) {
+        ForkOccurrence named = plan.forkAt(fork);
+        return named == null ? null : new Condition.Arm(named, part);
+    }
+
+    private static Outcome one(Decision decision) {
+        return new Outcome(List.of(decision));
+    }
+
+    private static TermPath firstOf(TermPath left, TermPath right) {
+        return left != null ? left : right;
+    }
+
+    /**
+     * Both sets of conditions, or null where between them they settle one decision two ways.
+     *
+     * <p>One rule for every place two of these are put together: the parts of a value, a way in held
+     * to the way in above it, the left of an operator that stops early held to what runs after it. A
+     * decision read twice is one decision, and one settled two ways is no path.
+     */
+    static List<Decision> merge(List<Decision> holds, List<Decision> more) {
+        List<Decision> both = new ArrayList<>(holds);
+        for (Decision each : more) {
+            if (both.contains(each)) {
+                continue;
+            }
+            if (disagrees(both, each)) {
+                return null;
+            }
+            both.add(each);
+        }
+        return both;
+    }
+
+    /**
+     * Whether {@code added} settles a decision the conditions already settle the other way.
+     *
+     * <p>The same decision and a different way out of it, which is two things and not one. A decision
+     * named twice and settled the same way is one run doing one thing twice over —
+     * {@code if a then (if a then …)} is written as two forks and no row takes one of them without
+     * the other — and reading that as a contradiction would take away a path the body has.
+     *
+     * <p>Which decision it is is not which place a run is recorded at. Two forks on one flag are two
+     * places and one decision, so what is compared is what the condition is about and never the claim
+     * beside it.
+     */
+    private static boolean disagrees(List<Decision> holds, Decision added) {
+        for (Decision already : holds) {
+            Condition each = already.constrains();
+            boolean otherWay = switch (added.constrains()) {
+                case Condition.Case one -> each instanceof Condition.Case other
+                        && other.at().equals(one.at()) && !other.name().equals(one.name());
+                case Condition.Side one -> each instanceof Condition.Side other
+                        && other.comparison().equals(one.comparison()) && other.held() != one.held();
+                case Condition.Arm one -> each instanceof Condition.Arm other
+                        && other.fork().equals(one.fork()) && other.part() != one.part();
+            };
+            if (otherWay) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/interaction/CoverageNaming.java
+++ b/souther-compiler/src/main/java/souther/compiler/interaction/CoverageNaming.java
@@ -81,7 +81,12 @@ final class CoverageNaming implements Naming<Outcome> {
      * comparison to answer, which no arm records.
      */
     @Override
-    public Outcome side(Core.Binary comparison, boolean held) {
+    public Outcome side(Core value, boolean held) {
+        if (!(value instanceof Core.Binary comparison)) {
+            // A position holding a truth comes out both ways and the plan places no comparison at
+            // it, so there is nothing here to say. The fork on it is named where the way in is.
+            return null;
+        }
         ComparisonOccurrence site = plan.comparisonAt(comparison).orElse(null);
         TermPath at = firstOf(reads.pathOf(comparison.left(), symbols),
                 reads.pathOf(comparison.right(), symbols));

--- a/souther-compiler/src/main/java/souther/compiler/interaction/Interactions.java
+++ b/souther-compiler/src/main/java/souther/compiler/interaction/Interactions.java
@@ -3,19 +3,16 @@ package souther.compiler.interaction;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
-import souther.compiler.coverage.ControlPointId;
 import souther.compiler.coverage.CoverageSites;
-import souther.compiler.coverage.NormalReturn;
+import souther.compiler.flow.Arrival;
+import souther.compiler.flow.ValueArrivals;
+import souther.compiler.flow.Ways;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.InputReads;
-import souther.compiler.inputs.TermPath;
-import souther.compiler.types.BindingId;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -39,11 +36,12 @@ import java.util.Set;
  * questions: {@code InputReads} says which position a name points at, and the bindings here say
  * what the value at a name was settled by.
  *
- * <p>A path to a value and what the value is are two questions, and this answers both. The second is
- * about the reading rather than about the body and is what an operator stopping as soon as its
- * answer is settled turns on: which of its left's paths go on to the right is which value each of
- * them comes to. Answered by the same walk that answers the first, because two walks over one tree
- * are two answers that have to agree and one place for them to stop agreeing.
+ * <p>A path to a value and what the value is are two questions, and neither is asked here. Both are
+ * {@link ValueArrivals}'s, read off the body once and asked of by whoever needs them — this walk and
+ * the reading of whether an arm answers anything included. What is added here is the third question:
+ * what to call a way, which is where the numbering comes in and is the only place it does. A
+ * condition this can find no words for leaves a way {@link souther.compiler.flow.Completeness#PARTIAL}
+ * and takes nothing away from what the body was read to do.
  *
  * <p>Under-reading is the safe direction. A group nothing formed is an obligation nobody is asked
  * for, which is where a product over the input positions already leaves things; a group formed too
@@ -51,26 +49,16 @@ import java.util.Set;
  * can be settled more ways than the reading will tell apart is answered as settled one way, and a
  * position reached more ways than it will read at once is read the one way it used to be.
  */
-public final class Interactions {
 
-    /**
-     * How many ways one value may be settled before the reading stops telling them apart.
-     *
-     * <p>A value built out of several is settled every way its parts are settled together, so a
-     * record of fifteen independently forked fields has thirty-two thousand of them and every
-     * enclosing operator would fold over all of them again. What is measurable before the work is
-     * the size of the product as it is taken, so that is what is bounded — and a value over the
-     * bound is answered as settled one way, which asks for nothing rather than asking for a number
-     * of rows nobody would read.
-     */
-    private static final int MOST_OUTCOMES = 64;
+public final class Interactions {
 
     /**
      * How many path contexts one position of the body will be read under.
      *
-     * <p>A second amplification and not the one above. {@link #MOST_OUTCOMES} bounds the outcomes
-     * of one value, which is a product taken at one node; this bounds how many ways in one position
-     * is read under, which is a product taken along the way down to it. A condition that fails four
+     * <p>A second amplification and not the one beside it. {@link CoverageNaming#MOST_OUTCOMES}
+     * bounds the ways one value is read as being settled, which is a product taken at one node; this
+     * bounds how many ways in one position is read under, which is a product taken along the way
+     * down to it. A condition that fails four
      * ways standing inside another one is a meeting read sixteen times, so the two multiply with the
      * nesting of the body and neither bound holds what the other does.
      *
@@ -98,70 +86,13 @@ public final class Interactions {
     private static final int MOST_WAYS_IN = 16;
 
     private final CoverageSites.Plan plan;
-    private final Symbols symbols;
 
-    /**
-     * What each node was settled by, so an enclosing meeting does not fold over it again.
-     *
-     * <p>Keyed by identity and sound because a node occurs once: what is in scope at it is what the
-     * walk had when it got there, so the environments are a function of the position and not a
-     * second key.
-     */
-    private final IdentityHashMap<Core, List<Arrival>> settled = new IdentityHashMap<>();
+    /** What the body was read to arrive at, and by which ways. Read once, before the walk starts. */
+    private final ValueArrivals<Outcome> reading;
 
-    /**
-     * A path to a value, and what this reading knows the value at the end of it to be.
-     *
-     * <p>Two questions, and the second is about the reading rather than about the body. An operator
-     * that stops as soon as its answer is settled needs it: which of the left's paths go on to the
-     * right is which value each of them comes to, and a reading holding conditions alone has no way
-     * to ask.
-     *
-     * @param by         the conditions that hold along the path, which is what {@link Outcome} is
-     * @param knownTruth what the value is, where this reading can say
-     */
-    private record Arrival(Outcome by, Truth knownTruth) { }
-
-    /**
-     * What this reading knows a path's value to be.
-     *
-     * <p>{@link #UNKNOWN} is not a third truth and not a path that arrives nowhere. The path is
-     * there and it comes to a value; what is missing is this reading's answer for which of the two
-     * it came to. A value nothing here forks arrives just as much as one it does.
-     */
-    private enum Truth { TRUE, FALSE, UNKNOWN }
-
-    /**
-     * The ways a value is settled to one truth, or that this reading cannot enumerate them.
-     *
-     * <p>All of them or none of them, and the type is what holds it to that. A list with paths
-     * missing from it reads as a whole one: what takes it will steer no row down the paths it does
-     * not hold and offer no group under them, which is the reading saying the body has not got them.
-     * So one arrival whose truth is unread makes the whole enumeration {@link Unknown} rather than
-     * quietly dropping itself out of a {@link Known} one.
-     *
-     * <p>{@code Known} holding nothing is an answer and not an absence. It says the value is never
-     * settled that way, which is how an arm no row reaches is told from an arm this reading has
-     * nothing to say about — the first is not walked and the second is walked under the arm itself.
-     * Which is why a value with no arrivals at all never gets this far: it would be read here as
-     * settled to neither truth and take both arms away, and no arrivals is not something this
-     * reading proves.
-     */
-    private sealed interface Ways {
-
-        /** These paths to that truth, and no others. */
-        record Known(List<List<Decision>> paths) implements Ways { }
-
-        /** Which paths come to that truth is not something this reading can say. */
-        record Unknown() implements Ways { }
-    }
-
-    /** Which nodes are paths to a value, for the same reason the settlings are kept. */
-    private final IdentityHashMap<Core, Boolean> reaches = new IdentityHashMap<>();
-
-    private Interactions(CoverageSites.Plan plan, Symbols symbols) {
+    private Interactions(CoverageSites.Plan plan, ValueArrivals<Outcome> reading) {
         this.plan = plan;
-        this.symbols = symbols;
+        this.reading = reading;
     }
 
     /**
@@ -176,25 +107,27 @@ public final class Interactions {
     public static List<Interaction> of(Core body, CoverageSites.Plan plan, InputDomain inputs,
                                        Symbols symbols) {
         List<Interaction> found = new ArrayList<>();
-        new Interactions(plan, symbols).walk(body, InputReads.of(inputs), Map.of(),
-                java.util.Collections.newSetFromMap(new IdentityHashMap<>()),
-                List.of(List.of()), found);
+        CoverageNaming naming = new CoverageNaming(plan, symbols, InputReads.of(inputs));
+        new Interactions(plan, ValueArrivals.ofBody(body, naming))
+                .walk(body, naming, java.util.Collections.newSetFromMap(new IdentityHashMap<>()),
+                        List.of(List.of()), found);
         return List.copyOf(found);
     }
+
 
     /**
      * @param reaches every way in this position is reached by, together rather than one at a time,
      *                because how many there are is what {@link #MOST_WAYS_IN} bounds and no one of
      *                them can say. Empty where nothing reaches here, and never longer than the bound
      */
-    private void walk(Core node, InputReads reads, Map<BindingId, List<Arrival>> bound,
-                      Set<Core> absorbed, List<List<Decision>> reaches, List<Interaction> found) {
+    private void walk(Core node, CoverageNaming naming, Set<Core> absorbed,
+                      List<List<Decision>> reaches, List<Interaction> found) {
         if (reaches.isEmpty()) {
             // Every way that would have led here settles a decision one of the ways above it
             // settled the other way, so no run arrives and there is nothing in here to offer.
             return;
         }
-        if (!answers(node)) {
+        if (!reading.arrivesAt(node)) {
             // The same invariant the outcomes are read under, and the walk is where it is decided
             // whether there is a group here at all. A subtree that arrives at no value is one no
             // row observes: the decisions inside an arm that aborts are made and then thrown away
@@ -207,17 +140,15 @@ public final class Interactions {
             // A name given to a decision is still that decision, and a name given to a position is
             // still that position. Both environments widen here and neither answers the other's
             // question. Nothing about getting here changes: a binding is not a fork.
-            walk(let.value(), reads, bound, absorbed, reaches, found);
-            Map<BindingId, List<Arrival>> inner = new HashMap<>(bound);
-            inner.put(let.binder().binding(), arrivalsOf(let.value(), reads, bound));
-            walk(let.body(), reads.and(let.binder(), let.value()), inner, absorbed, reaches, found);
+            walk(let.value(), naming, absorbed, reaches, found);
+            walk(let.body(), naming.under(let.binder(), let.value()), absorbed, reaches, found);
             return;
         }
         List<Core> meeting = absorbed.contains(node) ? null : meetingAt(node, absorbed);
         if (meeting != null) {
             List<Factor> factors = new ArrayList<>();
             for (Core operand : meeting) {
-                List<Outcome> outcomes = outcomesOf(operand, reads, bound);
+                List<Outcome> outcomes = outcomesOf(operand);
                 // One outcome is no decision: the operand answers the same way however the row is
                 // written, so nothing about it can be varied against the other operand.
                 if (outcomes.size() > 1) {
@@ -245,8 +176,9 @@ public final class Interactions {
                 }
             }
         }
-        descend(node, reads, bound, absorbed, reaches, found);
+        descend(node, naming, absorbed, reaches, found);
     }
+
 
     /**
      * Into each part that runs when this is evaluated, under what holds on the way into it.
@@ -262,42 +194,39 @@ public final class Interactions {
      * because that is the assumption this walk was making about all of them and it was wrong for
      * two.
      */
-    private void descend(Core node, InputReads reads, Map<BindingId, List<Arrival>> bound,
-                         Set<Core> absorbed, List<List<Decision>> reaches,
-                         List<Interaction> found) {
+    private void descend(Core node, CoverageNaming naming, Set<Core> absorbed,
+                         List<List<Decision>> reaches, List<Interaction> found) {
         switch (node) {
             // A way in nobody can name stops the walk into that arm, whether what could not be named
             // is the position the decision is about or the place a run that took it would be seen at.
             // A group found in there would be under a condition nothing can steer a row into or hold
             // a run to, and offering it asks for a row that may never arrive.
             case Core.If iff -> {
-                walk(iff.cond(), reads, bound, absorbed, reaches, found);
+                walk(iff.cond(), naming, absorbed, reaches, found);
                 Core[] arms = {iff.then(), iff.els()};
                 for (int part = 0; part < arms.length; part++) {
                     // As many ways in as the condition has of coming out that way, held to every
                     // context the fork itself is reached under: a row that failed the first
                     // comparison and one that held it and failed the second both arrive here, and
                     // they arrive by different paths.
-                    walk(arms[part], reads, bound, absorbed,
-                            waysInTo(iff, part, reads, bound, reaches), found);
+                    walk(arms[part], naming, absorbed,
+                            waysInTo(iff, part, naming, reaches), found);
                 }
             }
             case Core.Match match -> {
-                TermPath at = reads.pathOf(match.scrutinee(), symbols);
-                walk(match.scrutinee(), reads, bound, absorbed, reaches, found);
+                walk(match.scrutinee(), naming, absorbed, reaches, found);
                 for (int part = 0; part < match.cases().size(); part++) {
-                    Core.Case each = match.cases().get(part);
-                    Decision went = caseCondition(at, each, match, part);
+                    Outcome went = naming.matchCase(match, part);
                     if (went == null) {
                         continue;
                     }
                     // One way in and never more, so nothing here can go over the bound.
-                    walk(each.body(), reads, bound, absorbed,
-                            heldTo(reaches, List.of(List.of(went))), found);
+                    walk(match.cases().get(part).body(), naming, absorbed,
+                            heldTo(reaches, List.of(went.holds())), found);
                 }
             }
-            case Core.Binary binary when shortCircuits(binary.op()) -> {
-                walk(binary.left(), reads, bound, absorbed, reaches, found);
+            case Core.Binary binary when ValueArrivals.shortCircuits(binary.op()) -> {
+                walk(binary.left(), naming, absorbed, reaches, found);
                 // The right runs only where the left did not settle the answer, and which of the
                 // left's paths those are is which value each of them comes to. Where the reading
                 // cannot enumerate them the walk does not go in: a way in it could name only some
@@ -306,11 +235,11 @@ public final class Interactions {
                 // Over the bound the walk does not go in either. There is no arm here to fall back
                 // on — what leads to the right of one of these is the left having come out a way,
                 // and nothing records a value coming out a way.
-                if (waysTo(binary.left(), binary.op() == Hir.BinOp.AND, reads, bound)
-                        instanceof Ways.Known through) {
-                    List<List<Decision>> ways = heldTo(reaches, through.paths());
+                if (reading.waysTo(binary.left(), binary.op() == Hir.BinOp.AND)
+                        instanceof Ways.Known<Outcome> through) {
+                    List<List<Decision>> ways = heldTo(reaches, holdsOf(through.paths()));
                     if (ways.size() <= MOST_WAYS_IN) {
-                        walk(binary.right(), reads, bound, absorbed, ways, found);
+                        walk(binary.right(), naming, absorbed, ways, found);
                     }
                 }
             }
@@ -320,7 +249,7 @@ public final class Interactions {
                 // is not walked: a row cannot be steered to either of them, and one offered for a
                 // group in there would be offered for a combination it may not sit in.
                 for (Core.FieldValue given : constructed.construct().values()) {
-                    walk(given.value(), reads, bound, absorbed, reaches, found);
+                    walk(given.value(), naming, absorbed, reaches, found);
                 }
             }
             case Core.Block ignored -> {
@@ -329,9 +258,8 @@ public final class Interactions {
                 // behavior, so a group in there has no way in this can name.
             }
             case Core.LetIn let -> {
-                walk(let.value(), reads, bound, absorbed, reaches, found);
-                walk(let.body(), reads.and(let.binder(), let.value()), bound, absorbed, reaches,
-                        found);
+                walk(let.value(), naming, absorbed, reaches, found);
+                walk(let.body(), naming.under(let.binder(), let.value()), absorbed, reaches, found);
             }
             case Core.Int ignored -> { }
             case Core.Decimal ignored -> { }
@@ -344,36 +272,35 @@ public final class Interactions {
             case Core.Unreachable ignored -> { }
             // Everything the node is made of is evaluated, and under what the node itself was.
             case Core.Neg neg ->
-                    walkAll(some(neg.operand()), reads, bound, absorbed, reaches, found);
+                    walkAll(some(neg.operand()), naming, absorbed, reaches, found);
             case Core.FieldAccess access ->
-                    walkAll(some(access.target()), reads, bound, absorbed, reaches, found);
+                    walkAll(some(access.target()), naming, absorbed, reaches, found);
             case Core.TupleGet get ->
-                    walkAll(some(get.tuple()), reads, bound, absorbed, reaches, found);
+                    walkAll(some(get.tuple()), naming, absorbed, reaches, found);
             case Core.OptionSome option ->
-                    walkAll(some(option.value()), reads, bound, absorbed, reaches, found);
-            case Core.Binary binary -> walkAll(some(binary.left(), binary.right()), reads, bound,
-                    absorbed, reaches, found);
+                    walkAll(some(option.value()), naming, absorbed, reaches, found);
+            case Core.Binary binary -> walkAll(some(binary.left(), binary.right()), naming, absorbed,
+                    reaches, found);
             case Core.Call call ->
-                    walkAll(call.args(), reads, bound, absorbed, reaches, found);
+                    walkAll(call.args(), naming, absorbed, reaches, found);
             case Core.PreservedCall call ->
-                    walkAll(call.args(), reads, bound, absorbed, reaches, found);
+                    walkAll(call.args(), naming, absorbed, reaches, found);
             case Core.Apply apply ->
-                    walkAll(apply.args(), reads, bound, absorbed, reaches, found);
+                    walkAll(apply.args(), naming, absorbed, reaches, found);
             case Core.ListLit list ->
-                    walkAll(list.elements(), reads, bound, absorbed, reaches, found);
+                    walkAll(list.elements(), naming, absorbed, reaches, found);
             case Core.Tuple tuple ->
-                    walkAll(tuple.elements(), reads, bound, absorbed, reaches, found);
+                    walkAll(tuple.elements(), naming, absorbed, reaches, found);
             case Core.Construct construct -> walkAll(
                     construct.values().stream().map(Core.FieldValue::value).toList(),
-                    reads, bound, absorbed, reaches, found);
+                    naming, absorbed, reaches, found);
         }
     }
 
-    private void walkAll(List<Core> parts, InputReads reads, Map<BindingId, List<Arrival>> bound,
-                         Set<Core> absorbed, List<List<Decision>> reaches,
-                         List<Interaction> found) {
+    private void walkAll(List<Core> parts, CoverageNaming naming, Set<Core> absorbed,
+                         List<List<Decision>> reaches, List<Interaction> found) {
         for (Core each : parts) {
-            walk(each, reads, bound, absorbed, reaches, found);
+            walk(each, naming, absorbed, reaches, found);
         }
     }
 
@@ -390,18 +317,18 @@ public final class Interactions {
      * again from the arm having no way in that can be named, which is also empty and is where the
      * walk stops for the reason it always did.
      */
-    private List<List<Decision>> waysInTo(Core.If iff, int part, InputReads reads,
-                                          Map<BindingId, List<Arrival>> bound,
+    private List<List<Decision>> waysInTo(Core.If iff, int part, CoverageNaming naming,
                                           List<List<Decision>> reaches) {
-        List<List<Decision>> ways = heldTo(reaches, waysInFor(iff, part, reads, bound));
+        List<List<Decision>> ways = heldTo(reaches, waysInFor(iff, part, naming));
         if (ways.size() <= MOST_WAYS_IN) {
             return ways;
         }
         // Over the bound, and read the one way it was read before the ways in were told apart. The
         // fallback is one way in per context, so what comes back is no longer than what came in and
         // the bound holds by induction rather than by anything counted along the way.
-        return heldTo(reaches, fallbackWayIn(iff, part, reads));
+        return heldTo(reaches, fallbackWayIn(iff, part, naming));
     }
+
 
     /**
      * The ways the condition comes out for arm {@code part}, or the arm itself where it cannot say.
@@ -410,19 +337,20 @@ public final class Interactions {
      * condition, and holding it to what already held is the caller's, which the outcomes of a value
      * and the walk into an arm do differently.
      */
-    private List<List<Decision>> waysInFor(Core.If iff, int part, InputReads reads,
-                                           Map<BindingId, List<Arrival>> bound) {
-        if (waysTo(iff.cond(), part == 0, reads, bound) instanceof Ways.Known known) {
-            return known.paths();
+    private List<List<Decision>> waysInFor(Core.If iff, int part, CoverageNaming naming) {
+        if (reading.waysTo(iff.cond(), part == 0) instanceof Ways.Known<Outcome> known) {
+            return holdsOf(known.paths());
         }
-        return fallbackWayIn(iff, part, reads);
+        return fallbackWayIn(iff, part, naming);
     }
 
+
     /** The arm itself as the one way in, for a condition this reading cannot value. */
-    private List<List<Decision>> fallbackWayIn(Core.If iff, int part, InputReads reads) {
-        Decision back = armFallback(iff, part, reads);
-        return back == null ? List.of() : List.of(List.of(back));
+    private List<List<Decision>> fallbackWayIn(Core.If iff, int part, CoverageNaming naming) {
+        Outcome back = naming.forkArm(iff, part);
+        return back == null ? List.of() : List.of(back.holds());
     }
+
 
     /**
      * Each way in held to each context it is reached under, leaving out the ones that contradict.
@@ -436,7 +364,7 @@ public final class Interactions {
         List<List<Decision>> out = new ArrayList<>();
         for (List<Decision> reach : reaches) {
             for (List<Decision> way : ways) {
-                List<Decision> merged = merge(reach, way);
+                List<Decision> merged = CoverageNaming.merge(reach, way);
                 if (merged != null) {
                     out.add(merged);
                 }
@@ -445,26 +373,33 @@ public final class Interactions {
         return out;
     }
 
-    /**
-     * Both sets of conditions, or null where between them they settle one decision two ways.
-     *
-     * <p>One rule for every place two of these are put together: the parts of a value, a way in
-     * held to the way in above it, the left of an operator that stops early held to what runs after
-     * it. A decision read twice is one decision, and one settled two ways is no path.
-     */
-    private static List<Decision> merge(List<Decision> holds, List<Decision> more) {
-        List<Decision> both = new ArrayList<>(holds);
-        for (Decision each : more) {
-            if (both.contains(each)) {
-                continue;
-            }
-            if (disagrees(both, each)) {
-                return null;
-            }
-            both.add(each);
-        }
-        return both;
+    /** The conditions of each way, which is what the walk carries a reach as. */
+    private static List<List<Decision>> holdsOf(List<Outcome> ways) {
+        return ways.stream().map(Outcome::holds).toList();
     }
+
+    /**
+     * The ways {@code e} can be settled that a group can be composed against.
+     *
+     * <p>A projection of the reading and not a second walk. Two ways written down the same are one
+     * way: a value settled twice over by the reading getting there twice is settled once, and a
+     * factor counting the second would report a value varying where it does not.
+     *
+     * <p>A way the naming could not write down whole is not one of these. What a factor offers is a
+     * combination a row is steered into, and the conditions of such a way do not say what would
+     * steer one there — so it is left out, and where that leaves none the value is answered as
+     * varying in no way this can compose against rather than as varying in one nobody can reach.
+     */
+    private List<Outcome> outcomesOf(Core e) {
+        List<Outcome> out = new ArrayList<>();
+        for (Arrival<Outcome> each : reading.at(e)) {
+            if (each.isComplete() && !out.contains(each.path())) {
+                out.add(each.path());
+            }
+        }
+        return out;
+    }
+
 
     /**
      * The parts of a node that are there.
@@ -496,7 +431,7 @@ public final class Interactions {
      */
     private static List<Core> meetingAt(Core node, Set<Core> absorbed) {
         return switch (node) {
-            case Core.Binary binary when shortCircuits(binary.op()) -> null;
+            case Core.Binary binary when ValueArrivals.shortCircuits(binary.op()) -> null;
             case Core.Binary binary -> {
                 List<Core> operands = new ArrayList<>();
                 List<Core> inner = new ArrayList<>();
@@ -515,28 +450,6 @@ public final class Interactions {
         };
     }
 
-    /**
-     * Whether the operator settles its answer without evaluating both sides.
-     *
-     * <p>{@code &&} stops at a left that is false and {@code ||} at a left that is true, so the two
-     * sides are not consumed into one value and a product of them would ask for the combinations
-     * the short circuit never reaches. Not a meeting, and it has paths to a value all the same:
-     * the left settling the answer on its own, and the left going through with the right settling
-     * it. Which of the left's paths go through is which value each comes to, which is why the
-     * reading answers that as well as the conditions.
-     */
-    private static boolean shortCircuits(Hir.BinOp op) {
-        return op == Hir.BinOp.AND || op == Hir.BinOp.OR;
-    }
-
-    /** Whether the operator answers with which way two values came out against each other. */
-    private static boolean compares(Hir.BinOp op) {
-        return switch (op) {
-            case EQ, NE, LT, LE, GT, GE -> true;
-            case AND, OR, ADD, SUB, MUL, DIV, CONCAT -> false;
-        };
-    }
-
     /** The values one run of {@code op} is over, and the nodes the run is written as. */
     private static void run(Core e, Hir.BinOp op, List<Core> operands, List<Core> inner) {
         if (e instanceof Core.Binary binary && binary.op() == op) {
@@ -546,461 +459,5 @@ public final class Interactions {
         } else if (e != null) {
             operands.add(e);
         }
-    }
-
-    /** What a value nothing forks is settled by, which is the same thing however it is written. */
-    private static List<Arrival> oneWay() {
-        return List.of(new Arrival(new Outcome(List.of()), Truth.UNKNOWN));
-    }
-
-    /**
-     * Whether {@code e} is a path to a value, which is what an outcome has to be.
-     *
-     * <p>The invariant the whole reading turns on. An outcome is a way the operand <em>arrives at a
-     * value</em>, and a branch of the syntax is not that on its own: an arm answering
-     * {@code unreachable} answers nothing and aborts, so counting it as a way the operand is settled
-     * says the value varies where it does not — and the group it makes asks for rows at a
-     * combination the body has no path to, which is the defect this reading exists to remove.
-     *
-     * <p>{@link NormalReturn} is the reading that owns the question and the one the arms of a body
-     * are already told apart by. Answered here for the node the walk is at and for each arm it
-     * enumerates, which are the two places a branch could be taken for a path.
-     *
-     * <p>Kept because it is asked at every node and answers about the whole subtree under it.
-     */
-    private boolean answers(Core e) {
-        if (e == null) {
-            return false;
-        }
-        Boolean already = reaches.get(e);
-        if (already != null) {
-            return already;
-        }
-        boolean answer = NormalReturn.of(e);
-        reaches.put(e, answer);
-        return answer;
-    }
-
-    /**
-     * The ways {@code e} can be settled, as the conditions that hold when it is.
-     *
-     * <p>A projection of {@link #arrivalsOf} and not a second reading of the tree. What a value
-     * comes to is asked of the same walk that asks under what conditions, because two walks over
-     * one tree are two answers that have to agree and one place for them to stop agreeing.
-     */
-    private List<Outcome> outcomesOf(Core e, InputReads reads,
-                                     Map<BindingId, List<Arrival>> bound) {
-        return arrivalsOf(e, reads, bound).stream().map(Arrival::by).toList();
-    }
-
-    /**
-     * The paths {@code e} arrives at a value by, each saying what it comes to where that is known.
-     *
-     * <p>Four shapes are read off the node and the rest is one rule rather than a case each: a
-     * value built out of several is settled every way its parts are settled together, which is
-     * their product. That is a rule about every other node and not an arm nobody filled in — what
-     * it does not cover is exactly what forks, what stops early, what names, and what comes out one
-     * of two ways against another value.
-     */
-    private List<Arrival> arrivalsOf(Core e, InputReads reads,
-                                     Map<BindingId, List<Arrival>> bound) {
-        if (e == null) {
-            return oneWay();
-        }
-        List<Arrival> already = settled.get(e);
-        if (already != null) {
-            return already;
-        }
-        List<Arrival> answer = reading(e, reads, bound);
-        if (answer.isEmpty()) {
-            // No arrival is not a proof that no value arrives, and this is not the reading that
-            // could give one. Two parts of a value whose every settling contradicts the other's
-            // leave nothing here — under {@code (if a then x else abort) + (if a then abort else y)}
-            // each part answers on its own and no run has both answering — and whether that is the
-            // body having no path or this reading not following one is a question about path
-            // correlation that nothing here asks.
-            //
-            // So it is normalised away rather than published. Handed on, it would reach the reader
-            // that asks which ways a value comes to a truth, where an empty enumeration is an
-            // answer and says the value never comes to it — a claim this reading has not made and
-            // one that would take both arms of a fork on such a value away.
-            answer = oneWay();
-        }
-        settled.put(e, answer);
-        return answer;
-    }
-
-    private List<Arrival> reading(Core e, InputReads reads, Map<BindingId, List<Arrival>> bound) {
-        if (!answers(e)) {
-            // Nothing arrives at a value here, so there is no way this is settled to enumerate.
-            return oneWay();
-        }
-        if (e instanceof Core.Bool literal) {
-            // One path, and the reading knows where it goes. Nothing about the inputs is on it.
-            return List.of(new Arrival(new Outcome(List.of()),
-                    literal.value() ? Truth.TRUE : Truth.FALSE));
-        }
-        if (e instanceof Core.Binary binary && shortCircuits(binary.op())) {
-            return through(binary, reads, bound);
-        }
-        if (e instanceof Core.Match match) {
-            TermPath at = reads.pathOf(match.scrutinee(), symbols);
-            List<Arrival> out = new ArrayList<>();
-            for (int part = 0; part < match.cases().size(); part++) {
-                Core.Case each = match.cases().get(part);
-                if (!answers(each.body())) {
-                    continue;
-                }
-                Decision when = caseCondition(at, each, match, part);
-                if (when == null) {
-                    continue;
-                }
-                under(List.of(when), arrivalsOf(each.body(), reads, bound), out);
-                if (out.size() > MOST_OUTCOMES) {
-                    return oneWay();
-                }
-            }
-            return out;
-        }
-        if (e instanceof Core.If iff) {
-            // Numbered where they are written and not where they survive: the arm a fork answers on
-            // is its place among the arms, and one that answers nothing is skipped rather than
-            // closing the gap and letting the next arm be called the first.
-            Core[] arms = {iff.then(), iff.els()};
-            List<Arrival> out = new ArrayList<>();
-            for (int part = 0; part < arms.length; part++) {
-                if (!answers(arms[part])) {
-                    continue;
-                }
-                // One way in per way the condition comes out that way, and the arm is settled every
-                // way it is settled under each of them. Held under the outcome bound and not the
-                // one on the ways in: this is a product taken at one node, which is what that bound
-                // is about.
-                for (List<Decision> way : waysInFor(iff, part, reads, bound)) {
-                    under(way, arrivalsOf(arms[part], reads, bound), out);
-                }
-                if (out.size() > MOST_OUTCOMES) {
-                    return oneWay();
-                }
-            }
-            return out;
-        }
-        if (e instanceof Core.IfConstructed constructed) {
-            // A fork, and not a value made of its arms — a product over them would say it is
-            // settled every way they are together. Which arm is taken is whether the values made
-            // the thing, which no position of the input names, so the ways it comes out are said
-            // of the fork and a group over them is not offered.
-            List<Core> arms = new ArrayList<>();
-            arms.add(constructed.then());
-            constructed.els().forEach(each -> arms.add(each.body()));
-            List<Arrival> out = new ArrayList<>();
-            for (int part = 0; part < arms.size(); part++) {
-                if (!answers(arms.get(part))) {
-                    continue;
-                }
-                Decision when = forkDecision(constructed, part);
-                if (when == null) {
-                    continue;
-                }
-                under(List.of(when), arrivalsOf(arms.get(part), reads, bound), out);
-                if (out.size() > MOST_OUTCOMES) {
-                    return oneWay();
-                }
-            }
-            return out;
-        }
-        if (e instanceof Core.Read read) {
-            List<Arrival> named = bound.get(read.binding());
-            return named != null ? named : oneWay();
-        }
-        if (e instanceof Core.LetIn let) {
-            Map<BindingId, List<Arrival>> inner = new HashMap<>(bound);
-            inner.put(let.binder().binding(), arrivalsOf(let.value(), reads, bound));
-            return arrivalsOf(let.body(), reads.and(let.binder(), let.value()), inner);
-        }
-        List<Arrival> out = oneWay();
-        for (Core child : childrenOf(e)) {
-            out = product(out, arrivalsOf(child, reads, bound));
-            if (out.size() > MOST_OUTCOMES) {
-                return oneWay();
-            }
-        }
-        // A comparison whose two ways can both be named is a value this reading knows the truth of,
-        // said of the position the comparison is about because that is what a row is steered by.
-        //
-        // Both ways or neither. With one of them the other's absence reads as a truth the value
-        // never comes to, and a fork on it would be told one of its arms is never reached.
-        //
-        // Asked where nothing under the comparison was already saying the value varies, so that
-        // what is read here is added to the reading and nothing is taken out of it: under
-        // {@code a > f(b)} the fold has the ways {@code f(b)} is settled, and they are about
-        // positions this would say nothing about.
-        if (out.size() == 1 && e instanceof Core.Binary comparison && compares(comparison.op())) {
-            Decision held = sideDecision(comparison, true, reads);
-            Decision failed = sideDecision(comparison, false, reads);
-            if (held != null && failed != null) {
-                List<Decision> under = out.get(0).by().holds();
-                List<Decision> whenHeld = merge(under, List.of(held));
-                List<Decision> whenFailed = merge(under, List.of(failed));
-                if (whenHeld != null && whenFailed != null) {
-                    return List.of(new Arrival(new Outcome(whenHeld), Truth.TRUE),
-                            new Arrival(new Outcome(whenFailed), Truth.FALSE));
-                }
-            }
-        }
-        return out;
-    }
-
-    /**
-     * The paths to the value of an operator that stops as soon as its answer is settled.
-     *
-     * <p>Not a product of the two sides. {@code &&} comes to false wherever the left does and never
-     * looks at the right, and comes to whatever the right does wherever the left went through — so
-     * the paths are the left's settling ones as they stand, and the left's going-through ones each
-     * extended by every path of the right.
-     *
-     * <p>A left path this reading cannot value stops where a settling one stops. Whether the right
-     * ran at all is what the left's value would have said, so nothing is known about what comes
-     * after it and the path is left saying what it already says.
-     */
-    private List<Arrival> through(Core.Binary binary, InputReads reads,
-                                  Map<BindingId, List<Arrival>> bound) {
-        Truth goesOn = binary.op() == Hir.BinOp.AND ? Truth.TRUE : Truth.FALSE;
-        List<Arrival> out = new ArrayList<>();
-        for (Arrival left : arrivalsOf(binary.left(), reads, bound)) {
-            if (left.knownTruth() != goesOn) {
-                out.add(left);
-                continue;
-            }
-            under(left.by().holds(), arrivalsOf(binary.right(), reads, bound), out);
-            if (out.size() > MOST_OUTCOMES) {
-                return oneWay();
-            }
-        }
-        return out;
-    }
-
-    /** Each arrival held to what already holds along the way to it, into {@code out}. */
-    private static void under(List<Decision> holds, List<Arrival> arrivals, List<Arrival> out) {
-        for (Arrival each : arrivals) {
-            List<Decision> both = merge(holds, each.by().holds());
-            if (both != null) {
-                out.add(new Arrival(new Outcome(both), each.knownTruth()));
-            }
-        }
-    }
-
-    /**
-     * The ways {@code e} is settled to {@code want}, or that this reading cannot enumerate them.
-     *
-     * <p>All of them or none. One arrival whose truth is unread is a path that may be among the
-     * ways to either truth, so no list of them is complete while it is there — and an incomplete
-     * list is worse here than no list, because whatever takes one reads the paths it does not hold
-     * as paths the body has not got.
-     */
-    private Ways waysTo(Core e, boolean want, InputReads reads,
-                        Map<BindingId, List<Arrival>> bound) {
-        List<List<Decision>> paths = new ArrayList<>();
-        for (Arrival each : arrivalsOf(e, reads, bound)) {
-            if (each.knownTruth() == Truth.UNKNOWN) {
-                return new Ways.Unknown();
-            }
-            if ((each.knownTruth() == Truth.TRUE) == want) {
-                paths.add(each.by().holds());
-            }
-        }
-        return new Ways.Known(paths);
-    }
-
-    /** Which case of the union this arm is, said of the position matched on where there is one, or
-     *  null where no run through the arm could be recorded. */
-    private Decision caseCondition(TermPath at, Core.Case arm, Core.Match match, int part) {
-        souther.compiler.coverage.ControlClaim claim = armClaim(match, part);
-        if (claim == null) {
-            return null;
-        }
-        if (at == null) {
-            Condition fork = forkArm(match, part);
-            return fork == null ? null : new Decision(fork, claim);
-        }
-        List<String> names = arm.pattern().selectors().stream()
-                .map(selector -> selector.name().name()).toList();
-        return new Decision(new Condition.Case(at, String.join("|", names)), claim);
-    }
-
-    /**
-     * That a run went down arm {@code part}, where nothing said which comparison sent it there.
-     *
-     * <p>What the walk falls back on. Where the condition's ways can be enumerated they are what
-     * names the way in, on the comparisons a row is steered by; this is the answer for a condition
-     * whose value this reading cannot say, and it is the answer every fork used to get.
-     *
-     * <p>An arm places at no class of any input, so a group offered under one of these goes. That
-     * it is here at all is what says the reading found a way in it could not name.
-     */
-    private Decision armFallback(Core.If iff, int part, InputReads reads) {
-        souther.compiler.coverage.ControlClaim claim = armClaim(iff, part);
-        if (claim == null) {
-            return null;
-        }
-        TermPath read = reads.pathOf(iff.cond(), symbols);
-        Condition what = read == null ? forkArm(iff, part)
-                : new Condition.Case(read, part == 0 ? "true" : "false");
-        return what == null ? null : new Decision(what, claim);
-    }
-
-    /**
-     * That {@code comparison} came out {@code held}, said of the position it is about, or null
-     * where this reading cannot say which position that is or where no run could be shown to have
-     * reached it.
-     *
-     * <p>The comparison and not the arm. A condition stops as soon as it is settled, so under
-     * {@code A && B} the arm taken when the condition fails is reached both by a value that made
-     * {@code B} false and by one that never evaluated {@code B}: a row is steered by getting the
-     * comparison to answer, which no arm records.
-     */
-    private Decision sideDecision(Core.Binary comparison, boolean held, InputReads reads) {
-        souther.compiler.coverage.ComparisonOccurrence site =
-                plan.comparisonAt(comparison).orElse(null);
-        TermPath at = firstOf(reads.pathOf(comparison.left(), symbols),
-                reads.pathOf(comparison.right(), symbols));
-        if (site == null || at == null) {
-            return null;
-        }
-        return plan.outcomeOf(comparison, held)
-                .flatMap(souther.compiler.coverage.ControlClaim::of)
-                .map(claim -> new Decision(new Condition.Side(at, site, held), claim))
-                .orElse(null);
-    }
-
-    /** One arm of a fork, where a run through it can be recorded, and null where it cannot. */
-    private souther.compiler.coverage.ControlClaim armClaim(Core fork, int part) {
-        ControlPointId.ArmOccurrence[] arms = plan.armsOf(fork);
-        if (arms == null || part >= arms.length) {
-            return null;
-        }
-        return souther.compiler.coverage.ControlClaim.of(arms[part]).orElse(null);
-    }
-
-    /** The fork itself, for a decision this reading cannot name a position for, or null where the
-     *  plan named no fork here. */
-    private Condition forkArm(Core fork, int part) {
-        souther.compiler.coverage.ForkOccurrence named = plan.forkAt(fork);
-        return named == null ? null : new Condition.Arm(named, part);
-    }
-
-    /** A fork coming out one way and nothing said about which position, or null where no run
-     *  through the arm could be recorded. */
-    private Decision forkDecision(Core fork, int part) {
-        souther.compiler.coverage.ControlClaim claim = armClaim(fork, part);
-        Condition what = forkArm(fork, part);
-        return claim == null || what == null ? null : new Decision(what, claim);
-    }
-
-    private static TermPath firstOf(TermPath left, TermPath right) {
-        return left != null ? left : right;
-    }
-
-    /**
-     * Every way the two can be settled together, which is not every pairing of them.
-     *
-     * <p>A binding read twice is one decision read twice, and pairing its outcomes without asking
-     * whether the two agree would report a value settled nine ways that is settled three.
-     *
-     * <p>What the parts of a value come to is not what the value comes to. A thing built out of
-     * several is the constructor's answer and no path of it carries a truth of its own, so these
-     * arrive with nothing said about which of the two they are — which is what a comparison over
-     * the whole of it goes on to say, where it can.
-     */
-    private static List<Arrival> product(List<Arrival> left, List<Arrival> right) {
-        List<Arrival> out = new ArrayList<>();
-        for (Arrival one : left) {
-            for (Arrival other : right) {
-                List<Decision> holds = merge(one.by().holds(), other.by().holds());
-                if (holds != null) {
-                    out.add(new Arrival(new Outcome(holds), Truth.UNKNOWN));
-                }
-                if (out.size() > MOST_OUTCOMES) {
-                    return out;
-                }
-            }
-        }
-        return out;
-    }
-
-    /**
-     * Whether {@code added} settles a decision the conditions already settle the other way.
-     *
-     * <p>The same decision and a different way out of it, which is two things and not one. A
-     * decision named twice and settled the same way is one run doing one thing twice over —
-     * {@code if a then (if a then …)} is written as two forks and no row takes one of them without
-     * the other — and reading that as a contradiction would take away a path the body has.
-     *
-     * <p>Which decision it is is not which place a run is recorded at. Two forks on one flag are
-     * two places and one decision, so what is compared is what the condition is about and never the
-     * claim beside it.
-     */
-    private static boolean disagrees(List<Decision> holds, Decision added) {
-        for (Decision already : holds) {
-            Condition each = already.constrains();
-            boolean otherWay = switch (added.constrains()) {
-                case Condition.Case one -> each instanceof Condition.Case other
-                        && other.at().equals(one.at()) && !other.name().equals(one.name());
-                case Condition.Side one -> each instanceof Condition.Side other
-                        && other.comparison().equals(one.comparison()) && other.held() != one.held();
-                case Condition.Arm one -> each instanceof Condition.Arm other
-                        && other.fork().equals(one.fork()) && other.part() != one.part();
-            };
-            if (otherWay) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /** Every value this node is built out of, in the order it is written. */
-    private static List<Core> childrenOf(Core node) {
-        return switch (node) {
-            case Core.Int ignored -> List.of();
-            case Core.Decimal ignored -> List.of();
-            case Core.Str ignored -> List.of();
-            case Core.Bool ignored -> List.of();
-            case Core.Temporal ignored -> List.of();
-            case Core.Read ignored -> List.of();
-            case Core.UnitValue ignored -> List.of();
-            case Core.OptionNone ignored -> List.of();
-            case Core.Unreachable ignored -> List.of();
-            case Core.Neg neg -> some(neg.operand());
-            case Core.FieldAccess access -> some(access.target());
-            case Core.TupleGet get -> some(get.tuple());
-            case Core.OptionSome option -> some(option.value());
-            case Core.Binary binary -> some(binary.left(), binary.right());
-            case Core.Call call -> call.args();
-            case Core.PreservedCall call -> call.args();
-            case Core.Apply apply -> apply.args();
-            case Core.ListLit list -> list.elements();
-            case Core.Tuple tuple -> tuple.elements();
-            case Core.Construct construct ->
-                    construct.values().stream().map(Core.FieldValue::value).toList();
-            case Core.If iff -> some(iff.cond(), iff.then(), iff.els());
-            case Core.LetIn let -> some(let.value(), let.body());
-            // Not the body. Evaluating this makes the function, and what the body comes to when
-            // something calls it is that call's business — the same stance the reading of whether a
-            // value arrives takes, and for the same reason.
-            case Core.Block ignored -> List.of();
-            case Core.Match match -> {
-                List<Core> out = new ArrayList<>();
-                out.add(match.scrutinee());
-                match.cases().forEach(each -> out.add(each.body()));
-                yield out;
-            }
-            case Core.IfConstructed constructed -> {
-                List<Core> out = new ArrayList<>();
-                out.add(constructed.construct());
-                out.add(constructed.then());
-                constructed.els().forEach(arm -> out.add(arm.body()));
-                yield out;
-            }
-        };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/interaction/Interactions.java
+++ b/souther-compiler/src/main/java/souther/compiler/interaction/Interactions.java
@@ -338,6 +338,12 @@ public final class Interactions {
      * and the walk into an arm do differently.
      */
     private List<List<Decision>> waysInFor(Core.If iff, int part, CoverageNaming naming) {
+        // Whether the arm is there at all is the reading of what the body does, and it is asked
+        // first. An arm the condition never comes out the way of is no arm to walk into, and falling
+        // back to naming it would offer whatever is inside it under a reach no run takes.
+        if (!reading.comesAt(iff.cond()).mayCome(part == 0)) {
+            return List.of();
+        }
         if (reading.waysTo(iff.cond(), part == 0) instanceof Ways.Known<Outcome> known) {
             return holdsOf(known.paths());
         }
@@ -392,7 +398,7 @@ public final class Interactions {
      */
     private List<Outcome> outcomesOf(Core e) {
         List<Outcome> out = new ArrayList<>();
-        for (Arrival<Outcome> each : reading.at(e)) {
+        for (Arrival<Outcome> each : reading.waysAt(e).orNone()) {
             if (each.isComplete() && !out.contains(each.path())) {
                 out.add(each.path());
             }

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AnOperatorThatStopsEarlyIsNotStrictInBothItsSidesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AnOperatorThatStopsEarlyIsNotStrictInBothItsSidesTest.java
@@ -1,0 +1,120 @@
+package souther.compiler.coverage;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.core.Core;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What an operator that settles its answer on the left arrives at.
+ *
+ * <p>{@code &&} never evaluates its right where the left is false, so an expression whose right
+ * aborts still arrives at a value on every run that gets the left to false — and reading the operator
+ * as strict in both its sides answers that it arrives nowhere, which takes every arm under a fork on
+ * it out of what is measured.
+ *
+ * <p>Which runs those are is what the left comes out as, so this is the reading of what a value comes
+ * to as much as it is the reading of whether one arrives. The two halves are held apart here: a way
+ * the reading has worked out a value for settles the answer, and a way it has not is not widened into
+ * one that does. {@code a.value > 1} has a value behind each of its ways and {@code 1 > 2} has one
+ * behind neither, and a rule reading both as coming out two ways would say the second arrives when no
+ * run gets past it.
+ */
+class AnOperatorThatStopsEarlyIsNotStrictInBothItsSidesTest {
+
+    private static final String TYPES = """
+            module example.probe
+
+            data Amount = Int
+            data Answer = Int
+
+            behavior pick : (a: Amount) -> Answer
+                constructs Answer
+
+            """;
+
+    /**
+     * Whether a body forking on {@code condition} arrives at a value.
+     *
+     * <p>Asked of the body and not of the condition on its own, because that is how every reader asks
+     * it: the fork arrives wherever its condition does, and both arms answer.
+     */
+    private static boolean arrives(String condition) {
+        String source = TYPES + "let pick (a) = Answer(if " + condition + " then 1 else 2)\n";
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        Bodies.Elaborated checked = compilation.db()
+                .ask(new Bodies.Checked(compilation.modules().get(0))).value();
+        assertNotNull(checked, "the model under test compiles: " + condition);
+        Core body = checked.behaviorBodies().get("pick");
+        assertNotNull(body, "the behavior under test has a body");
+        return NormalReturn.of(body);
+    }
+
+    @Test
+    void aLeftThatSettlesTheAnswerLeavesTheRightUnevaluated() {
+        assertTrue(arrives("false && unreachable \"never asked\""));
+        assertTrue(arrives("true || unreachable \"never asked\""));
+    }
+
+    @Test
+    void aLeftThatGoesThroughLeavesTheAnswerToTheRight() {
+        assertFalse(arrives("true && unreachable \"always reached\""));
+        assertFalse(arrives("false || unreachable \"always reached\""));
+    }
+
+    @Test
+    void aComparisonWithAValueBehindEachOfItsWaysSettlesTheAnswerOnOneOfThem() {
+        assertTrue(arrives("a.value > 1 && unreachable \"no large a reaches here\""));
+        assertTrue(arrives("a.value > 1 || unreachable \"no small a reaches here\""));
+    }
+
+    /**
+     * A comparison the reading cannot value is not one that comes out both ways.
+     *
+     * <p>The two are one answer apart and the difference is the whole of the direction this reading
+     * takes. Nothing stands behind either way of {@code 1 > 2} — the reading does not work out which
+     * way it comes out, and it does not read that as coming out both — so the way that would settle
+     * the answer on the left is not there and the right is what the expression arrives by.
+     */
+    @Test
+    void aWayNothingStandsBehindDoesNotSettleTheAnswer() {
+        assertFalse(arrives("1 > 2 || unreachable \"always reached\""));
+        assertFalse(arrives("1 > 2 && unreachable \"under-read\""));
+    }
+
+    /**
+     * A comparison of a position against itself comes out one way, and nothing here says which.
+     *
+     * <p>The tripwire for a rule about the shape of the node. Read as a comparison and therefore as
+     * coming out both ways, {@code a.value == a.value} would offer a way to false that no run takes,
+     * and the expression would be answered as arriving on runs it aborts on.
+     */
+    @Test
+    void aPositionComparedAgainstItselfStandsBehindNeitherWay() {
+        assertFalse(arrives("a.value == a.value && unreachable \"always reached\""));
+        assertFalse(arrives("a.value /= a.value || unreachable \"always reached\""));
+    }
+
+    /**
+     * A way is witnessed against the range of what is compared, so a number at the end of one closes
+     * the way past it.
+     *
+     * <p>Read off the ends and not by trying values. Nothing whole is greater than the largest whole
+     * number, so the only way {@code a.value > that} comes out is false — which settles {@code &&} on
+     * the left and sends {@code ||} on to a right no run gets past. Every whole number is at most it,
+     * so {@code a.value <= that} comes out true only, and the two operators swap.
+     */
+    @Test
+    void aNumberAtTheEndOfTheRangeClosesTheWayPastIt() {
+        assertTrue(arrives("a.value > 9223372036854775807 && unreachable \"never reached\""));
+        assertFalse(arrives("a.value > 9223372036854775807 || unreachable \"always reached\""));
+        assertTrue(arrives("a.value <= 9223372036854775807 || unreachable \"never reached\""));
+        assertFalse(arrives("a.value <= 9223372036854775807 && unreachable \"always reached\""));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/coverage/AnOperatorThatStopsEarlyIsNotStrictInBothItsSidesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/AnOperatorThatStopsEarlyIsNotStrictInBothItsSidesTest.java
@@ -33,7 +33,7 @@ class AnOperatorThatStopsEarlyIsNotStrictInBothItsSidesTest {
             data Amount = Int
             data Answer = Int
 
-            behavior pick : (a: Amount) -> Answer
+            behavior pick : (a: Amount, flag: Bool) -> Answer
                 constructs Answer
 
             """;
@@ -45,7 +45,8 @@ class AnOperatorThatStopsEarlyIsNotStrictInBothItsSidesTest {
      * it: the fork arrives wherever its condition does, and both arms answer.
      */
     private static boolean arrives(String condition) {
-        String source = TYPES + "let pick (a) = Answer(if " + condition + " then 1 else 2)\n";
+        String source = TYPES
+                + "let pick (a, flag) = Answer(if " + condition + " then 1 else 2)\n";
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         Bodies.Elaborated checked = compilation.db()
@@ -99,6 +100,20 @@ class AnOperatorThatStopsEarlyIsNotStrictInBothItsSidesTest {
     void aPositionComparedAgainstItselfStandsBehindNeitherWay() {
         assertFalse(arrives("a.value == a.value && unreachable \"always reached\""));
         assertFalse(arrives("a.value /= a.value || unreachable \"always reached\""));
+    }
+
+    /**
+     * A position holding a truth comes out both ways, and is not a comparison.
+     *
+     * <p>What stands behind a way is a value of what the expression is over, and that is not a
+     * question about which node kind is written. A rule asked only of comparisons would answer that
+     * {@code flag && abort} arrives nowhere, when every run with a false {@code flag} arrives — the
+     * same failure the operator itself had, one shape along.
+     */
+    @Test
+    void aPositionHoldingATruthComesOutBothWays() {
+        assertTrue(arrives("flag && unreachable \"no true flag reaches here\""));
+        assertTrue(arrives("flag || unreachable \"no false flag reaches here\""));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/coverage/CoverageSitesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/CoverageSitesTest.java
@@ -195,6 +195,38 @@ class CoverageSitesTest {
                 plan.probesOf(inner), "the emitter still finds it, and finds nothing to light");
     }
 
+    /**
+     * An arm the condition never sends a run down is not an arm to cover.
+     *
+     * <p>Nothing whole is greater than the largest whole number, so the condition comes out false on
+     * every run and the first arm is one nobody enters. Numbered, it is a gap that stays open for
+     * ever — a row is owed for a combination the body has no run at — which is the same fault as
+     * counting an arm behind an abort and is caught by the same reading.
+     *
+     * <p>Read from the reading and not worked out here. Which arms a condition can reach is what the
+     * reading of what the body does already answers, and a second account of it in the numbering
+     * would be two answers to keep in step.
+     */
+    @Test
+    void anArmTheConditionNeverComesOutTheWayOfIsNotAnArmToCover() {
+        CoverageSites.Plan plan = planOf("""
+                module example.pinned
+
+                data Score = Int
+
+                behavior scoreFor : (a: Int) -> Score
+                    constructs Score
+
+                let scoreFor (a) =
+                    if a > 9223372036854775807 then Score(1) else Score(2)
+                """);
+
+        // The comparison keeps its site either way, which is deliberate and is said where the
+        // numbering is: a comparison is numbered wider than what any boundary is later drawn on.
+        assertEquals(List.of("else", "GT"), labels(plan),
+                "the condition holds on no run, so only the arm it fails into is one to cover");
+    }
+
     private static Core.Match innerMatch(Core arm) {
         Core at = arm;
         while (!(at instanceof Core.Match)) {

--- a/souther-compiler/src/test/java/souther/compiler/flow/ANamingDecidesHowAWayIsWrittenAndNotWhetherThereIsOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/flow/ANamingDecidesHowAWayIsWrittenAndNotWhetherThereIsOneTest.java
@@ -1,0 +1,293 @@
+package souther.compiler.flow;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.conformance.ConformanceCorpus;
+import souther.compiler.core.Core;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Swapping the naming moves what a way is called and nothing else.
+ *
+ * <p>The claim the whole separation rests on. Before it, a comparison the numbering could not place
+ * was answered as a comparison with no value, so everything standing under it was read as reaching
+ * nothing — a limit of what could be written down turning into a claim about what the body does.
+ *
+ * <p>So two readings of one body are taken here and what they agree about is checked rather than
+ * described: every node arrives in one exactly where it arrives in the other, and a truth one of them
+ * worked out is a truth the reading with no numbering behind it worked out too. A naming may leave a
+ * way {@link Completeness#PARTIAL} and it may see that two conditions on a way settle one decision
+ * opposite ways and drop it — the second is why a truth may be missing where the reading answers that
+ * it has nothing to say, and never why one may be there that the body has not got.
+ *
+ * <p>Two namings beside the plain one, so both directions are covered: one that names everything and
+ * so refuses more ways than the coverage numbering ever will, and one that names nothing and so
+ * leaves every way partial.
+ */
+class ANamingDecidesHowAWayIsWrittenAndNotWhetherThereIsOneTest {
+
+    /**
+     * Bodies with the shapes this reading tells apart, beside what the corpus is written with.
+     *
+     * <p>The corpus is what the language is checked against and is written to be ordinary. What
+     * decides this claim is the shapes where a naming has something to lose: an operator stopping on
+     * a side the reading worked a value out for, a chain of them, an arm nothing reaches, and a
+     * helper spliced in so that a position arrives under a name of its own.
+     */
+    private static final List<String> WRITTEN = List.of("""
+            module example.fee
+
+            data Amount = Int
+            data Answer = Int
+
+            behavior fee : (a: Amount, c: Amount, d: Amount) -> Answer
+                constructs Answer
+
+            let fee (a, c, d) =
+                Answer(if a.value > 1 && unreachable "no large a reaches here"
+                    then 0
+                    else (if c.value > 3 then 1 else 0) + (if d.value > 4 then 10 else 0))
+            """,
+            """
+            module example.chain
+
+            data Amount = Int
+            data Answer = Int
+
+            behavior rank : (a: Amount, b: Amount) -> Answer
+                constructs Answer
+
+            let rank (a, b) =
+                Answer(if a.value > 1 && a.value < 9 && b.value /= 0 then 1
+                    else if a.value > 1 || b.value > 2 then 2
+                    else 3)
+            """,
+            """
+            module example.arms
+
+            data On
+            data Off
+            data Flag = On | Off
+            data Answer = Int
+
+            behavior pick : (f: Flag, g: Flag) -> Answer
+                constructs Answer
+
+            let pick (f, g) =
+                Answer(match f with
+                    | On -> match g with
+                        | On -> 1
+                        | Off -> unreachable "an Off never arrives beside an On"
+                    | Off -> 2)
+            """,
+            """
+            module example.shipping
+
+            data Total = Int
+                invariant value >= 0
+                invariant value <= 1000000
+
+            data Membership = Premium | Standard
+
+            data Delivery = Express | Regular
+
+            data Fee = Int
+                invariant value >= 0
+
+            behavior shippingFee : (total: Total, member: Membership, delivery: Delivery) -> Fee
+                constructs Fee
+
+            let baseFee (total: Total, member: Membership): Int =
+                match member with
+                    | Premium -> 0
+                    | Standard -> if total.value >= 5000 then 0 else 500
+
+            let expressFee (delivery: Delivery): Int =
+                match delivery with
+                    | Express -> 500
+                    | Regular -> 0
+
+            let shippingFee (total, member, delivery) =
+                Fee(baseFee(total, member) + expressFee(delivery))
+            """);
+
+    /** What a reading says about one node, in the words every reading of it has. */
+    private record Says(boolean arrives, Set<Truth> comesTo) { }
+
+    @Test
+    void everyBodyIsReadTheSameWhateverItsWaysAreCalled() {
+        Read read = new Read();
+        for (ConformanceCorpus corpus : ConformanceCorpus.all()) {
+            bodiesOf(corpus).forEach(body -> compare(body, read));
+        }
+        for (String source : WRITTEN) {
+            bodiesOf(source).forEach(body -> compare(body, read));
+        }
+        // Not a measure of anything, and here so that a claim about what two readings agree on is not
+        // quietly a claim about two readings that read nothing. What the shapes above were written
+        // for is the second of these: a value this reading works a truth out for is where a naming
+        // has something to lose, and a run with none of them agrees for no reason.
+        assertTrue(read.nodes > 100, "something was put in front of this: " + read.nodes + " nodes");
+        assertTrue(read.valued > 10,
+                "some of it was a value this reading works a truth out for: " + read.valued);
+    }
+
+    /** How much was read, so that agreement about nothing is not mistaken for agreement. */
+    private static final class Read {
+        private int nodes;
+        private int valued;
+    }
+
+    /** Every node of {@code body}, read three ways and compared. */
+    private void compare(Core body, Read read) {
+        ValueArrivals<AnonymousPath> plain = ValueArrivals.ofBody(body, Anonymous.NAMING);
+        List<ValueArrivals<Marks>> others =
+                List.of(ValueArrivals.ofBody(body, new Marking(true)),
+                        ValueArrivals.ofBody(body, new Marking(false)));
+        List<Core> all = new ArrayList<>();
+        each(body, all);
+        read.nodes += all.size();
+        for (Core node : all) {
+            Says loose = says(plain.at(node));
+            if (loose.comesTo().contains(Truth.TRUE) || loose.comesTo().contains(Truth.FALSE)) {
+                read.valued++;
+            }
+            for (ValueArrivals<Marks> other : others) {
+                Says tight = says(other.at(node));
+                assertEquals(loose.arrives(), tight.arrives(),
+                        "a naming decided whether a " + node.getClass().getSimpleName()
+                                + " arrives at a value");
+                for (Truth each : tight.comesTo()) {
+                    assertTrue(each == Truth.UNREAD || loose.comesTo().contains(each),
+                            "a naming worked out a value nothing else could: " + each + " at a "
+                                    + node.getClass().getSimpleName());
+                }
+            }
+        }
+    }
+
+    private static <P> Says says(Set<Arrival<P>> arrivals) {
+        Set<Truth> comesTo = new LinkedHashSet<>();
+        arrivals.forEach(each -> comesTo.add(each.value()));
+        return new Says(!arrivals.isEmpty(), comesTo);
+    }
+
+    private static void each(Core node, List<Core> into) {
+        into.add(node);
+        Core.forEachChild(node, child -> {
+            if (child != null) {
+                each(child, into);
+            }
+        });
+    }
+
+    private static List<Core> bodiesOf(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        return bodiesIn(compilation, source);
+    }
+
+    private static List<Core> bodiesOf(ConformanceCorpus corpus) {
+        return bodiesIn(corpus.analyse().compilation(), corpus.toString());
+    }
+
+    private static List<Core> bodiesIn(Compilation compilation, String what) {
+        List<Core> out = new ArrayList<>();
+        compilation.modules().forEach(module -> {
+            Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
+            if (checked != null) {
+                checked.behaviorBodies().values().stream().filter(body -> body != null)
+                        .forEach(out::add);
+            }
+        });
+        assertFalse(out.isEmpty(), "the model under test has behavior bodies: " + what);
+        return out;
+    }
+
+    /** The conditions on a way, written out as whatever named them. */
+    private record Marks(List<String> of) { }
+
+    /**
+     * A naming with words for everything, or for nothing.
+     *
+     * <p>The first is stricter than the coverage numbering, which has words for a fork the plan named
+     * and for a comparison it could place and for nothing else: every way that one refuses this
+     * refuses too, and it refuses ways besides. The second is the other end — every way partial,
+     * nothing ever refused — and between them they move every part of a naming that can move.
+     */
+    private static final class Marking implements Naming<Marks> {
+
+        private final boolean names;
+        private final IdentityHashMap<Core, Integer> numbered = new IdentityHashMap<>();
+
+        private Marking(boolean names) {
+            this.names = names;
+        }
+
+        @Override
+        public Marks nowhere() {
+            return new Marks(List.of());
+        }
+
+        @Override
+        public Marks join(Marks held, Marks more) {
+            TreeSet<String> both = new TreeSet<>(held.of());
+            for (String each : more.of()) {
+                String decision = each.substring(0, each.lastIndexOf('/') + 1);
+                for (String already : both) {
+                    if (already.startsWith(decision) && !already.equals(each)) {
+                        return null;   // one decision, two ways out of it, and no run doing both
+                    }
+                }
+                both.add(each);
+            }
+            return new Marks(List.copyOf(both));
+        }
+
+        @Override
+        public Naming<Marks> under(Hir.Binder binder, Core value) {
+            return this;
+        }
+
+        @Override
+        public Marks side(Core.Binary comparison, boolean held) {
+            return mark(comparison, "cmp", held ? 1 : 0);
+        }
+
+        @Override
+        public Marks matchCase(Core.Match match, int part) {
+            return mark(match, "case", part);
+        }
+
+        @Override
+        public Marks forkArm(Core fork, int part) {
+            return mark(fork, "arm", part);
+        }
+
+        private Marks mark(Core at, String what, int part) {
+            if (!names) {
+                return null;
+            }
+            int which = numbered.computeIfAbsent(at, ignored -> numbered.size());
+            return new Marks(List.of(what + "@" + which + "/" + part));
+        }
+
+        @Override
+        public int mostArrivals() {
+            return 64;
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/flow/ANamingDecidesHowAWayIsWrittenAndNotWhetherThereIsOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/flow/ANamingDecidesHowAWayIsWrittenAndNotWhetherThereIsOneTest.java
@@ -10,9 +10,7 @@ import souther.compiler.query.Compilation;
 
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,20 +20,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Swapping the naming moves what a way is called and nothing else.
  *
- * <p>The claim the whole separation rests on. Before it, a comparison the numbering could not place
- * was answered as a comparison with no value, so everything standing under it was read as reaching
- * nothing — a limit of what could be written down turning into a claim about what the body does.
+ * <p>The claim the whole separation rests on, and it is a structure rather than a hope: what the body
+ * does is read with no naming at all, and a naming reaches only the list of ways. Checked all the
+ * same, because the structure is one a later change could give up without anything else noticing.
  *
- * <p>So two readings of one body are taken here and what they agree about is checked rather than
- * described: every node arrives in one exactly where it arrives in the other, and a truth one of them
- * worked out is a truth the reading with no numbering behind it worked out too. A naming may leave a
- * way {@link Completeness#PARTIAL} and it may see that two conditions on a way settle one decision
- * opposite ways and drop it — the second is why a truth may be missing where the reading answers that
- * it has nothing to say, and never why one may be there that the body has not got.
+ * <p>Three namings beside the plain one, and each of them is a way a naming can fall short. One names
+ * everything and so refuses ways nothing else refuses. One names nothing and so leaves every way
+ * partial. One counts two forks on the same name as one decision, which is what the coverage
+ * numbering does and is where this went wrong before: a body whose two arms contradict left that
+ * naming with no way at all, and the reading answered that no value arrives — while the reading with
+ * no numbering behind it, which does not follow that correlation, answered that one does.
  *
- * <p>Two namings beside the plain one, so both directions are covered: one that names everything and
- * so refuses more ways than the coverage numbering ever will, and one that names nothing and so
- * leaves every way partial.
+ * <p>And the list is held to the other half rather than allowed to speak for it. An enumeration of
+ * the ways to a truth that holds none of them says the value is never settled that way, so it is only
+ * ever answered where the reading of what the body does agrees.
  */
 class ANamingDecidesHowAWayIsWrittenAndNotWhetherThereIsOneTest {
 
@@ -122,10 +120,23 @@ class ANamingDecidesHowAWayIsWrittenAndNotWhetherThereIsOneTest {
 
             let shippingFee (total, member, delivery) =
                 Fee(baseFee(total, member) + expressFee(delivery))
-            """);
+            """,
+            """
+            module example.opposed
 
-    /** What a reading says about one node, in the words every reading of it has. */
-    private record Says(boolean arrives, Set<Truth> comesTo) { }
+            data On
+            data Off
+            data Flag = On | Off
+
+            behavior pick : (a: Flag) -> Int
+
+            let pick (a) =
+                if ((match a with | On -> true | Off -> false)
+                        && (match a with | On -> false | Off -> true))
+                        || unreachable "the operator above never comes to false"
+                    then 1
+                    else 2
+            """);
 
     @Test
     void everyBodyIsReadTheSameWhateverItsWaysAreCalled() {
@@ -151,38 +162,36 @@ class ANamingDecidesHowAWayIsWrittenAndNotWhetherThereIsOneTest {
         private int valued;
     }
 
-    /** Every node of {@code body}, read three ways and compared. */
+    /** Every node of {@code body}, read four ways and compared. */
     private void compare(Core body, Read read) {
         ValueArrivals<AnonymousPath> plain = ValueArrivals.ofBody(body, Anonymous.NAMING);
-        List<ValueArrivals<Marks>> others =
-                List.of(ValueArrivals.ofBody(body, new Marking(true)),
-                        ValueArrivals.ofBody(body, new Marking(false)));
+        List<ValueArrivals<Marks>> others = List.of(
+                ValueArrivals.ofBody(body, new Marking(Marking.Words.EVERY, false)),
+                ValueArrivals.ofBody(body, new Marking(Marking.Words.NONE, false)),
+                ValueArrivals.ofBody(body, new Marking(Marking.Words.EVERY, true)));
         List<Core> all = new ArrayList<>();
         each(body, all);
         read.nodes += all.size();
         for (Core node : all) {
-            Says loose = says(plain.at(node));
-            if (loose.comesTo().contains(Truth.TRUE) || loose.comesTo().contains(Truth.FALSE)) {
+            Comes loose = plain.comesAt(node);
+            if (!loose.known().isEmpty()) {
                 read.valued++;
             }
             for (ValueArrivals<Marks> other : others) {
-                Says tight = says(other.at(node));
-                assertEquals(loose.arrives(), tight.arrives(),
-                        "a naming decided whether a " + node.getClass().getSimpleName()
-                                + " arrives at a value");
-                for (Truth each : tight.comesTo()) {
-                    assertTrue(each == Truth.UNREAD || loose.comesTo().contains(each),
-                            "a naming worked out a value nothing else could: " + each + " at a "
-                                    + node.getClass().getSimpleName());
+                assertEquals(loose.truths(), other.comesAt(node).truths(),
+                        "a naming moved what the body does at a "
+                                + node.getClass().getSimpleName());
+                for (boolean want : List.of(true, false)) {
+                    if (other.waysTo(node, want) instanceof Ways.Known<Marks> known
+                            && known.paths().isEmpty()) {
+                        assertFalse(loose.mayCome(want),
+                                "an enumeration holding no way said a value the body comes to is "
+                                        + "never settled that way, at a "
+                                        + node.getClass().getSimpleName());
+                    }
                 }
             }
         }
-    }
-
-    private static <P> Says says(Set<Arrival<P>> arrivals) {
-        Set<Truth> comesTo = new LinkedHashSet<>();
-        arrivals.forEach(each -> comesTo.add(each.value()));
-        return new Says(!arrivals.isEmpty(), comesTo);
     }
 
     private static void each(Core node, List<Core> into) {
@@ -221,20 +230,28 @@ class ANamingDecidesHowAWayIsWrittenAndNotWhetherThereIsOneTest {
     private record Marks(List<String> of) { }
 
     /**
-     * A naming with words for everything, or for nothing.
+     * A naming with words for everything or for nothing, telling decisions apart by the node or by
+     * the name the node is about.
      *
-     * <p>The first is stricter than the coverage numbering, which has words for a fork the plan named
-     * and for a comparison it could place and for nothing else: every way that one refuses this
-     * refuses too, and it refuses ways besides. The second is the other end — every way partial,
-     * nothing ever refused — and between them they move every part of a naming that can move.
+     * <p>Four namings out of two choices, and each choice is a way a naming falls short. Words for
+     * nothing leaves every way partial and refuses none. Words for everything refuses ways the
+     * coverage numbering never sees. Telling two forks on one name apart is what a naming keyed on
+     * the node does; running them together is what a naming keyed on the position does, and that is
+     * the coverage numbering — two {@code match a} in one body are two places and one decision, so a
+     * way through opposite arms of them is no way and comes out.
      */
     private static final class Marking implements Naming<Marks> {
 
-        private final boolean names;
+        /** Whether this naming has words for a condition at all. */
+        private enum Words { EVERY, NONE }
+
+        private final Words words;
+        private final boolean byName;
         private final IdentityHashMap<Core, Integer> numbered = new IdentityHashMap<>();
 
-        private Marking(boolean names) {
-            this.names = names;
+        private Marking(Words words, boolean byName) {
+            this.words = words;
+            this.byName = byName;
         }
 
         @Override
@@ -263,25 +280,28 @@ class ANamingDecidesHowAWayIsWrittenAndNotWhetherThereIsOneTest {
         }
 
         @Override
-        public Marks side(Core.Binary comparison, boolean held) {
-            return mark(comparison, "cmp", held ? 1 : 0);
+        public Marks side(Core value, boolean held) {
+            return mark(value, value instanceof Core.Binary comparison ? comparison.left() : value,
+                    "cmp", held ? 1 : 0);
         }
 
         @Override
         public Marks matchCase(Core.Match match, int part) {
-            return mark(match, "case", part);
+            return mark(match, match.scrutinee(), "case", part);
         }
 
         @Override
         public Marks forkArm(Core fork, int part) {
-            return mark(fork, "arm", part);
+            return mark(fork, fork instanceof Core.If iff ? iff.cond() : fork, "arm", part);
         }
 
-        private Marks mark(Core at, String what, int part) {
-            if (!names) {
+        private Marks mark(Core at, Core about, String what, int part) {
+            if (words == Words.NONE) {
                 return null;
             }
-            int which = numbered.computeIfAbsent(at, ignored -> numbered.size());
+            String which = byName && about instanceof Core.Read read
+                    ? read.binding().toString()
+                    : String.valueOf(numbered.computeIfAbsent(at, ignored -> numbered.size()));
             return new Marks(List.of(what + "@" + which + "/" + part));
         }
 

--- a/souther-compiler/src/test/java/souther/compiler/flow/TheBoundOnWaysStopsTheWorkAndNotOnlyTheAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/flow/TheBoundOnWaysStopsTheWorkAndNotOnlyTheAnswerTest.java
@@ -1,0 +1,168 @@
+package souther.compiler.flow;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.core.Core;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The bound on how many ways one value is read as being settled stops the work.
+ *
+ * <p>A rule about the work and not a property of the answer, which is the whole of why it is there.
+ * Fifteen independently forked parts of one value have thirty-two thousand combinations, and a
+ * reading that builds all of them and then says it will not hold them apart has already done the
+ * thing the bound was written to prevent — the answer is the same and the reading is the one nobody
+ * can afford.
+ *
+ * <p>So this counts. A time is not what is being claimed: the claim is that the reading stops
+ * putting ways together once there are too many, which is a fact about how many times it asks the
+ * naming to put two of them together and would go on being true on a faster machine.
+ *
+ * <p>And the other half goes on being read exactly. What the bound cuts off is the enumeration of
+ * the ways to a value, never whether a value arrives — the two are separate readings and only one of
+ * them has a bound in it.
+ */
+class TheBoundOnWaysStopsTheWorkAndNotOnlyTheAnswerTest {
+
+    /** How many independently forked parts one value is made of. */
+    private static final int PARTS = 15;
+
+    /** What a reading that built the combinations before giving up would ask for. */
+    private static final int WITHOUT_A_BOUND = 1 << PARTS;
+
+    /**
+     * One value made of fifteen independently forked parts.
+     *
+     * <p>One node and not fifteen. A sum written out is fifteen nested operators, and a reading that
+     * bounds what it holds at each of them stops at the first — what the bound is for is the node
+     * whose parts are all put together at once, which is what a construction is.
+     */
+    private static String source() {
+        String params = IntStream.rangeClosed(1, PARTS)
+                .mapToObj(each -> "a" + each + ": Int").collect(Collectors.joining(", "));
+        String names = IntStream.rangeClosed(1, PARTS)
+                .mapToObj(each -> "a" + each).collect(Collectors.joining(", "));
+        String fields = IntStream.rangeClosed(1, PARTS)
+                .mapToObj(each -> "f" + each + ": Int").collect(Collectors.joining(", "));
+        String given = IntStream.rangeClosed(1, PARTS)
+                .mapToObj(each -> "f" + each + " = if a" + each + " > 1 then 1 else 0")
+                .collect(Collectors.joining(", "));
+        return """
+                module example.wide
+
+                data Wide = { %s }
+
+                behavior fee : (%s) -> Wide
+                    constructs Wide
+
+                let fee (%s) = Wide { %s }
+                """.formatted(fields, params, names, given);
+    }
+
+    @Test
+    void aValueSettledMoreWaysThanTheBoundHoldsIsNotBuiltFirst() {
+        Core body = bodyOf(source());
+        Counting naming = new Counting();
+        ValueArrivals<Marks> reading = ValueArrivals.ofBody(body, naming);
+
+        assertTrue(reading.waysAt(body) instanceof Paths.Beyond,
+                "the ways are more than this naming will hold apart");
+        // Loose on purpose. What it is here to catch is a reading that builds the whole product
+        // first, which asks for the joins of every combination and is three orders of magnitude
+        // above anything a reading that stops can spend.
+        assertTrue(naming.joins < WITHOUT_A_BOUND / 8,
+                "the ways were put together " + naming.joins + " times, and a reading that built "
+                        + "them all before giving up would take at least " + WITHOUT_A_BOUND);
+    }
+
+    /**
+     * The value arrives, and the bound had nothing to say about that.
+     *
+     * <p>The coupling the two halves are held to. A bound on the enumeration that reached the other
+     * half would answer that a body with fifteen forks in one value arrives nowhere.
+     */
+    @Test
+    void whatTheBodyDoesIsReadWhateverTheBoundSays() {
+        Core body = bodyOf(source());
+        ValueArrivals<Marks> reading = ValueArrivals.ofBody(body, new Counting());
+
+        assertEquals(new Comes(java.util.Set.of(Truth.UNREAD)).truths(),
+                reading.comesAt(body).truths(),
+                "the value arrives, and which truth is not a question about a whole number");
+    }
+
+    private static Core bodyOf(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        Bodies.Elaborated checked = compilation.db()
+                .ask(new Bodies.Checked(compilation.modules().get(0))).value();
+        assertNotNull(checked, "the model under test compiles");
+        Core body = checked.behaviorBodies().get("fee");
+        assertNotNull(body, "the behavior under test has a body");
+        return body;
+    }
+
+    /** The conditions on a way, and nothing else about them matters here. */
+    private record Marks(List<String> of) { }
+
+    /** A naming that holds two ways apart and counts how often it is asked to put two together. */
+    private static final class Counting implements Naming<Marks> {
+
+        private int joins;
+        private final java.util.IdentityHashMap<Core, Integer> numbered =
+                new java.util.IdentityHashMap<>();
+
+        @Override
+        public Marks nowhere() {
+            return new Marks(List.of());
+        }
+
+        @Override
+        public Marks join(Marks held, Marks more) {
+            joins++;
+            java.util.List<String> both = new java.util.ArrayList<>(held.of());
+            more.of().stream().filter(each -> !both.contains(each)).forEach(both::add);
+            return new Marks(List.copyOf(both));
+        }
+
+        @Override
+        public Naming<Marks> under(Hir.Binder binder, Core value) {
+            return this;
+        }
+
+        @Override
+        public Marks side(Core value, boolean held) {
+            return mark(value, "cmp", held ? 1 : 0);
+        }
+
+        @Override
+        public Marks matchCase(Core.Match match, int part) {
+            return mark(match, "case", part);
+        }
+
+        @Override
+        public Marks forkArm(Core fork, int part) {
+            return mark(fork, "arm", part);
+        }
+
+        private Marks mark(Core at, String what, int part) {
+            int which = numbered.computeIfAbsent(at, ignored -> numbered.size());
+            return new Marks(List.of(what + "@" + which + "/" + part));
+        }
+
+        @Override
+        public int mostArrivals() {
+            return 2;
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/interaction/AnArmUnderAnOperatorThatStopsEarlyIsWalkedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/interaction/AnArmUnderAnOperatorThatStopsEarlyIsWalkedTest.java
@@ -1,0 +1,100 @@
+package souther.compiler.interaction;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.inputs.InputDomain;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * A fork on an operator whose right aborts is a fork, and what is under its arms is read.
+ *
+ * <p>{@code a > 1 && unreachable} arrives at a value on every run that gets {@code a > 1} to fail:
+ * the operator never evaluates its right there, so the expression comes to false and the fork below
+ * it is reached. Read as strict in both its sides it arrives nowhere, and then the fork is a fork
+ * nothing gets to — so both of its arms go unwalked, and every group standing in either of them is
+ * one nobody is asked for.
+ *
+ * <p>Which is not a limit of what a group can be composed against. The way into the arm is the
+ * comparison having failed, which is a decision a row is steered by and a place a run is recorded at,
+ * so the group inside the arm is offered under it in the ordinary way.
+ */
+class AnArmUnderAnOperatorThatStopsEarlyIsWalkedTest {
+
+    /** A meeting in the arm reached by the left of the operator settling the answer. */
+    private static final String STOPS_ON_THE_LEFT = """
+            module example.stops
+
+            behavior fee : (a: Int, c: Int, d: Int) -> Int
+
+            let fee (a, c, d) =
+                if a > 1 && unreachable "no large a reaches here"
+                    then 0
+                    else (if c > 3 then 1 else 0) + (if d > 4 then 10 else 0)
+            """;
+
+    /**
+     * The two forks in the arm are one meeting of two decisions, and it is offered.
+     *
+     * <p>One group and not none. Both operands of the sum vary two ways, which is the shape a row is
+     * owed for; a reading that answered nothing here would be reporting that the body has no
+     * combination to fill, which is a claim about the model and not about what could be read.
+     */
+    @Test
+    void theMeetingInTheArmIsFound() {
+        List<Interaction> found = read(STOPS_ON_THE_LEFT, "fee");
+        assertEquals(List.of(List.of(2, 2)), shape(found),
+                "the arm the comparison fails into holds one meeting of two two-way decisions");
+    }
+
+    /**
+     * The way in is the comparison having failed, and not the arm it sent the run down.
+     *
+     * <p>A row is steered by getting the comparison to answer, so that is what the group is offered
+     * under. Named by the arm instead it would place at no class of any input, and the group would go.
+     */
+    @Test
+    void theWayInIsTheComparisonAndNotTheArm() {
+        List<Interaction> found = read(STOPS_ON_THE_LEFT, "fee");
+        assertEquals(List.of(List.of("Side")), reachKinds(found));
+    }
+
+    private static List<Interaction> read(String source, String behavior) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
+        assertNotNull(checked, "the model under test compiles");
+        Core body = checked.behaviorBodies().get(behavior);
+        assertNotNull(body, "the behavior under test has a body");
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        InputDomain inputs = compilation.db().ask(new Adequacy.Inputs(module)).value().get(behavior);
+        return Interactions.of(body, CoverageSites.of(checked.behaviorBodies()), inputs, symbols);
+    }
+
+    /** The sizes of each group's factors, which is the shape of the space a row is owed for. */
+    private static List<List<Integer>> shape(List<Interaction> found) {
+        return found.stream()
+                .map(group -> group.factors().stream().map(f -> f.outcomes().size()).toList())
+                .toList();
+    }
+
+    /** What each group's way in is made of, said by the kind of condition each decision is. */
+    private static List<List<String>> reachKinds(List<Interaction> found) {
+        return found.stream()
+                .map(group -> group.reach().stream()
+                        .map(decision -> decision.constrains().getClass().getSimpleName())
+                        .toList())
+                .toList();
+    }
+}


### PR DESCRIPTION
Closes #922.

`NormalReturn` was reading `A && B` as strict in both its sides, so
`a > 1 && unreachable "..."` was answered as reaching no value — when every run
with a small `a` reaches one. The fork below such a condition was then a fork
nothing gets to, and both of its arms went unwalked along with every group
standing in them.

It could not be fixed where it was found. The right answer needs to know what
the left can evaluate to, and the reading that had that was built on
`CoverageSites.Plan`, which is built on `NormalReturn`.

## What changed

Three facts were being carried as two: whether a run arrives at a value, what a
boolean value comes to, and whether a way to it can be written down in the
numbering's words. The third had been folded into the second — a comparison the
plan could not place was answered as a comparison with no value — so a limit of
what could be written down was making claims about what the body does.

`souther.compiler.flow` holds the reading, over `Core` alone, with the naming as
its only parameter. `NormalReturn` and `Interactions` are both projections of
it, so there is no second account of the body to keep in step with the first.
`Interactions` loses 738 lines and keeps the walk that finds the meetings and
what to call a way; `flow` has no dependency on `coverage`.

Four things hold, and there is a test for each:

- A naming decides what a way is called and never whether there is one. A
  condition it has no words for leaves the way `PARTIAL` rather than leaving the
  arrival out.
- Not knowing is never both. A value the reading worked out no truth for settles
  nothing and sends nothing anywhere.
- A value is answered as known only where a value of what it is over stands
  behind each way, asked one way at a time. `1 > 2` comes out one way and
  `a == a` comes out one way, and a rule about the shape of the node would offer
  each of them a way no run takes. Whole numbers only, read off the ends of the
  range — so a number at the end of one closes the way past it.
- A way found twice is one way. The answers are sets.

The reading is rooted at a body, because what a name reads is not a fact about
the node that reads it: a helper spliced in binds the call's argument to the
helper's own parameter, and a name bound to a number written out is settled by
that number. Every occurrence is settled once under what binds it, and
`CoverageSites`, `UnreachableClaims` and `UnreachableReasons` share the reading
rather than reading a subtree again per node.

## What this does not read

What correlates two paths. Under
`(if a > 0 then true else abort) && (if a <= 0 then true else abort)` no run
arrives, each side is read on its own and arrives, and the operator is answered
as arriving. The same holds of the model's own rules: a behavior requiring
`a > 1` has no run with a small `a`, and `a > 1 && abort` is answered as
arriving all the same. Both are the liberty the reading of what arrives has
always taken with arms of a fork, and neither is decided here.

## Measured

`mvn -Plint clean verify`: 6087 tests, BUILD SUCCESS. The conformance corpus's
checked-in answers are unchanged, which says there is no regression and not that
there is an improvement — the corpus has nothing of this shape in it.

The example from the issue now answers with one group of two two-way factors,
offered under the comparison having failed. Breaking the witness rule turns
three tests red and breaking the short-circuit rule turns two red.

ADR-0109's second limit is rewritten: it was the numbering's and not the
reading's, and it is recorded as what it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)