### PR TITLE
Carry a rule across rather than composing what each reading answered

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -630,15 +630,53 @@ public final class FieldDomains {
         }
 
         /**
-         * Whether a range is taken of this coordinate here, which is whether a rule about it could
-         * have been read into these at all.
+         * The numeric rules these came to, about the same numbers under a caller's names.
          *
-         * <p>Asked so that a caller can put the part of a form this can answer for on its own. A
-         * form with one coordinate this never named is one nothing can be said about as a whole, and
-         * said that way the rules relating the coordinates beside it are lost with it.
+         * <p>For a caller that holds the readings of several values at once and has to say what they
+         * leave together. What a rule says is a relation between numbers, and it says the same thing
+         * whatever the numbers are called — so what is handed over is these rules renamed
+         * ({@link NumericDomain#over}) and never a fresh reading of the declaration.
+         *
+         * <p><b>Every number a rule is about is carried, whether or not the caller has a coordinate
+         * for it.</b> A reading relates numbers at coordinates and numbers at none, and a rule
+         * reaching one of the latter still holds two of the former apart: left behind, that rule
+         * would be gone and what the rules leave would come back wider than it is. So a number with
+         * no coordinate is named by {@code otherwise}, out of the subject itself, and the caller is
+         * given something to be equal to rather than something to read — what makes two of them one
+         * number was settled here, and a caller inventing its own answer to that would put two
+         * numbers together or take one apart.
+         *
+         * <p>Only the numbers. What else a reading proved — which values a position admits, which
+         * predicates hold, where an ordering stops — relates the positions of one value and reaches
+         * no vocabulary a caller out here has, so it stays where it was proved and is asked for
+         * there ({@link #holdsNothing}).
          */
-        public boolean names(Coordinate at) {
-            return (at.measured() ? countAt.get(at.path()) : atomAt.get(at.path())) != null;
+        public <B> NumericDomain<B> numbersOver(java.util.function.Function<Coordinate, B> named,
+                                                java.util.function.Function<Object, B> otherwise) {
+            Map<FactSubject, Coordinate> where = new LinkedHashMap<>();
+            atomAt.forEach((path, atom) -> at(where, atom, new Coordinate(path, false)));
+            countAt.forEach((path, atom) -> at(where, atom, new Coordinate(path, true)));
+            return constraints.numbers().over(atom -> {
+                Coordinate coordinate = where.get(atom);
+                return coordinate == null ? otherwise.apply(atom) : named.apply(coordinate);
+            });
+        }
+
+        /**
+         * One number filed at one coordinate.
+         *
+         * <p>Refused rather than overwritten where a subject arrives at two of them. Two coordinates
+         * that are one number is this reading saying something a caller has two names for, and
+         * whichever of them went unnamed would be a coordinate the constraints say nothing about —
+         * so what the caller was told the rules leave there would be everything.
+         */
+        private static void at(Map<FactSubject, Coordinate> where, FactSubject atom,
+                               Coordinate coordinate) {
+            Coordinate had = where.put(atom, coordinate);
+            if (had != null && !had.equals(coordinate)) {
+                throw new IllegalStateException("one number is at `" + had.path() + "` and at `"
+                        + coordinate.path() + "`, so neither name is the whole of it");
+            }
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputAtom.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputAtom.java
@@ -1,0 +1,78 @@
+package souther.compiler.inputs;
+
+/**
+ * One number the rules reaching a behavior's input are about, in the words of the input rather than
+ * of the value a rule was written on.
+ *
+ * <p>The rules relating a behavior's positions are read one parameter at a time, of the declaration
+ * each parameter holds, and what they are about there are that declaration's own positions. Asked
+ * about as rules of the input, they are about the same numbers under other names — so what is here
+ * is the vocabulary those rules are carried into, and carrying them is a renaming
+ * ({@link souther.compiler.numeric.NumericDomain#over}) rather than a second reading of them.
+ *
+ * <p><b>Two kinds, and the second is what keeps the carrying from widening.</b> A reading of a
+ * declaration relates numbers the input has a term for and numbers it has none for, and a rule
+ * reaching one of the latter still holds two of the former apart. Dropped on the way across, that
+ * rule would be gone and what the rules leave would come back wider than it is — the one direction
+ * nothing downstream can see. So a number the input cannot name is carried under a name of its own
+ * and stays in the constraints, where it goes on relating what it relates and is never asked about.
+ */
+sealed interface InputAtom {
+
+    /**
+     * A number this input has a term for, which is what a caller asks about.
+     *
+     * <p>Held as where the number sits and which number of that place it is, and not as the term
+     * itself. A term carries how the count was written — which standard-library measure was taken —
+     * and that is a fact about the expression a rule was read out of rather than about the number:
+     * held in the name, one number arriving from the declaration's reading and from a caller's form
+     * would be two, and a rule about it would say nothing about the form that names it.
+     *
+     * @param parameter which of the behavior's inputs this sits under
+     * @param path      the steps under that parameter, joined the way a coordinate joins them
+     * @param measured  whether this is the count taken of the place rather than its own value. Two
+     *                  numbers at one place, and a rule about one says nothing about the other
+     */
+    record Named(String parameter, String path, boolean measured) implements InputAtom {
+
+        public Named {
+            if (parameter == null || path == null) {
+                throw new IllegalArgumentException("a named number sits somewhere");
+            }
+        }
+
+        @Override
+        public String toString() {
+            String at = path.isEmpty() ? parameter : parameter + "." + path;
+            return measured ? "|" + at + "|" : at;
+        }
+    }
+
+    /**
+     * A number one parameter's rules are about that this input has no term for.
+     *
+     * <p>Held by the reading's own subject, kept as something to be equal to and nothing more: what
+     * makes two of these one number is what made the two subjects one, and that was settled where
+     * the declaration was read. Nothing here reads it, and the type it is is not this layer's to
+     * name — carried as anything else, two numbers of one reading would become one or one would
+     * become two, and either way a rule would end up about a number nobody asked about.
+     *
+     * <p>The parameter is part of it because two parameters are read apart. One subject arriving
+     * from two readings is two numbers, and without the parameter their rules would be put together
+     * as rules about one.
+     */
+    record Anonymous(String parameter, Object subject) implements InputAtom {
+
+        public Anonymous {
+            if (parameter == null || subject == null) {
+                throw new IllegalArgumentException(
+                        "a number with no term of this input is still one parameter's");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return parameter + ":<" + subject + ">";
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -199,7 +199,7 @@ public final class InputDomain {
             byParameter.computeIfAbsent(parameter.name(),
                     _ -> PlacedRules.of(parameter.type(), symbols, policy));
         }
-        return ReadQuantities.of(byParameter, byParameter.keySet(), byPath);
+        return ReadQuantities.of(byParameter, byParameter.keySet(), byPath, symbols);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/NumericTerm.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/NumericTerm.java
@@ -76,9 +76,19 @@ public sealed interface NumericTerm {
      * <p>A size is a whole number whatever it is a size of, so the term answers this and not the
      * position: a rule about the length of a string is counted as an {@code Int} at a position no
      * line is drawn on.
+     *
+     * <p>Which is why {@code positionType} may be absent. A caller reading a term under more steps
+     * than the walk that finds an input's positions goes down has no position to ask, and a size
+     * there is a whole number all the same — asked for the type first, a caller would either have
+     * nothing to pass or would write out the rule above a second time, at whichever call site
+     * noticed. What is null there is a term measured by its own values, which is the one case the
+     * position was the answer to.
      */
     default Carrier carrierAt(Type positionType, Symbols symbols) {
-        return this instanceof SizeOf ? Carrier.WHOLE : Carrier.ofValue(positionType, symbols);
+        if (this instanceof SizeOf) {
+            return Carrier.WHOLE;
+        }
+        return positionType == null ? null : Carrier.ofValue(positionType, symbols);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -219,12 +219,18 @@ final class ReadQuantities implements Quantities {
         if (had != null) {
             return had;
         }
+        // What the term guarantees of itself, before anything is looked up. A count is a whole
+        // number whatever it is a count of ({@link NumericTerm#carrierAt}), and asking the position
+        // for it would make a fact the term owns depend on whether the walk that reads this input
+        // reached the place the term sits at — a path two levels down has no position, and the floor
+        // under a count there would be dropped for having nowhere to ask.
+        if (term instanceof NumericTerm.SizeOf) {
+            return souther.compiler.numeric.Granularity.DISCRETE;
+        }
         Position at = byPath.get(term.path());
         if (at == null || symbols == null) {
             return null;
         }
-        // Asked of the term and not of the position: a size is a whole number whatever it is a size
-        // of, so a rule about the length of a string is counted where the string is not.
         souther.compiler.check.Carrier carrier = term.carrierAt(at.type(), symbols);
         return carrier == null ? null : carrier.spacing();
     }
@@ -252,11 +258,25 @@ final class ReadQuantities implements Quantities {
         return only == null ? projected : meeting(projected, whereOneTermRuns(only));
     }
 
-    /** A form of this input's terms, as one over the numbers the rules are about. */
+    /**
+     * A form of this input's terms, as one over the numbers the rules are about.
+     *
+     * <p><b>Added and not overwritten, because this is a fold and not a renaming.</b> A term carries
+     * which measure was written and a number does not, so two terms can be one number — and where a
+     * form weighs both of them, what that number is weighed by is the two coefficients together.
+     * Written as a renaming, {@code List.length(p.xs) + Set.size(p.xs)} would come back weighing
+     * that count once, which is a form the caller did not write and a range that is not the one they
+     * asked about.
+     *
+     * <p>The other way round from {@link souther.compiler.numeric.NumericDomain#over}, and the two
+     * are not the same act. Carrying a rule across may not put two positions under one name — that
+     * would say they are one number, which nobody said. Reading a caller's form may, because the
+     * caller wrote two spellings of a number this input has one of.
+     */
     private static NumericDomain.LinearForm<InputAtom> over(
             NumericDomain.LinearForm<NumericTerm> form) {
         Map<InputAtom, BigDecimal> coefs = new LinkedHashMap<>();
-        form.coefs().forEach((term, coef) -> coefs.put(called(term), coef));
+        form.coefs().forEach((term, coef) -> coefs.merge(called(term), coef, BigDecimal::add));
         return new NumericDomain.LinearForm<>(form.constant(), coefs);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -219,19 +219,19 @@ final class ReadQuantities implements Quantities {
         if (had != null) {
             return had;
         }
-        // What the term guarantees of itself, before anything is looked up. A count is a whole
-        // number whatever it is a count of ({@link NumericTerm#carrierAt}), and asking the position
-        // for it would make a fact the term owns depend on whether the walk that reads this input
-        // reached the place the term sits at — a path two levels down has no position, and the floor
-        // under a count there would be dropped for having nowhere to ask.
-        if (term instanceof NumericTerm.SizeOf) {
-            return souther.compiler.numeric.Granularity.DISCRETE;
-        }
-        Position at = byPath.get(term.path());
-        if (at == null || symbols == null) {
+        if (symbols == null) {
             return null;
         }
-        souther.compiler.check.Carrier carrier = term.carrierAt(at.type(), symbols);
+        // Asked of the term, which is what knows. A count is a whole number whatever it is a count
+        // of and a position measured by its own values is spaced by its type, and both of those are
+        // {@link NumericTerm#carrierAt}'s one answer — so the position is looked up to be handed
+        // over rather than to decide anything. Asked of the position instead, a fact the term owns
+        // would depend on whether the walk that reads this input reached the place the term sits
+        // at, and a count under more steps than that walk goes down would lose the floor every
+        // count has.
+        Position at = byPath.get(term.path());
+        souther.compiler.check.Carrier carrier =
+                term.carrierAt(at == null ? null : at.type(), symbols);
         return carrier == null ? null : carrier.spacing();
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -6,7 +6,6 @@ import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.Rational;
 import souther.compiler.numeric.RationalCut;
-import souther.compiler.numeric.Reach;
 
 import java.math.BigDecimal;
 import java.util.LinkedHashMap;
@@ -25,6 +24,10 @@ import java.util.Set;
 final class ReadQuantities implements Quantities {
 
     private final Map<String, PlacedRules> byParameter;
+    /** What says how the values of a position are spaced, which the arithmetic needs of every
+     *  number it is told a bound on. Held rather than asked for per question: the reading of an
+     *  input is what a caller has, and where a position's values step is a fact about its type. */
+    private final souther.compiler.check.Symbols symbols;
     /** What the behavior takes, which is what a path of this input starts at. */
     private final Set<String> parameters;
     /** Every position that was read, by where it sits. What one of them was read to hold is what
@@ -49,6 +52,19 @@ final class ReadQuantities implements Quantities {
      * reading of is what this refinement fixed.
      */
     private volatile Map<String, FieldDomains.Settled> conditioned;
+    /**
+     * Every rule reaching this input, about this input's own numbers, in one place.
+     *
+     * <p>Not one reading per parameter with the answers added afterwards. Adding per-parameter
+     * answers is the composition a rule spanning two parameters cannot survive, and where such a
+     * rule comes from is not this layer's business — what is here is a constraint space over the
+     * input, and where one parameter's positions run is a projection out of it rather than a
+     * reading of its own.
+     *
+     * <p>Worked out when something is asked and kept, the same as {@link #conditioned}: it is a
+     * reading of what this refinement fixed, so it belongs to this value and not to a shared table.
+     */
+    private volatile souther.compiler.numeric.NumericDomain<InputAtom> constraints;
 
     /** The values fixed at one term, kept as their least and greatest so that what was fixed does
      *  not depend on the order it arrived in. */
@@ -65,7 +81,9 @@ final class ReadQuantities implements Quantities {
     }
 
     private ReadQuantities(Map<String, PlacedRules> byParameter, Set<String> parameters,
-                           Map<TermPath, Position> byPath, Map<NumericTerm, Fixed> fixed) {
+                           Map<TermPath, Position> byPath, Map<NumericTerm, Fixed> fixed,
+                           souther.compiler.check.Symbols symbols) {
+        this.symbols = symbols;
         // In the order the behavior declares its parameters. A proof of emptiness names one of them
         // and a report is a document compared against the one written last time, so an order read
         // off a hash would move which parameter is named between runs.
@@ -82,8 +100,9 @@ final class ReadQuantities implements Quantities {
 
     /** Before anything is fixed. */
     static ReadQuantities of(Map<String, PlacedRules> byParameter, Set<String> parameters,
-                             Map<TermPath, Position> byPath) {
-        return new ReadQuantities(byParameter, parameters, byPath, Map.of());
+                             Map<TermPath, Position> byPath,
+                             souther.compiler.check.Symbols symbols) {
+        return new ReadQuantities(byParameter, parameters, byPath, Map.of(), symbols);
     }
 
     /** Each parameter's rules read with what is fixed under it, once. */
@@ -99,30 +118,146 @@ final class ReadQuantities implements Quantities {
         return read;
     }
 
+    /**
+     * The rules of every parameter, renamed into this input's numbers and said together.
+     *
+     * <p>Renamed and not read again ({@link FieldDomains.Settled#numbersOver}). What a rule says is
+     * a relation between numbers, and it says the same thing whatever they are called — so what
+     * reaches here is each parameter's reading, under names this input can spell, and a number it
+     * cannot spell under a name of its own so that the rules through it are not lost.
+     *
+     * <p>Said together, which is what makes this a constraint space rather than a product of them.
+     * Two parameters are related by nothing the declarations say, so meeting their rules leaves
+     * every answer where it was; what it does is leave somewhere for a rule that relates them to be
+     * said at all.
+     *
+     * <p>And what each number is on its own goes in here rather than being met on afterwards.
+     * Projecting does not distribute over meeting: a rule holding two numbers at one apiece says
+     * nothing about a form that also names a third the rules leave unbounded, and met afterwards
+     * against a floor this reading did have, the rule is gone.
+     */
+    private souther.compiler.numeric.NumericDomain<InputAtom> constraints() {
+        souther.compiler.numeric.NumericDomain<InputAtom> read = constraints;
+        if (read != null) {
+            return read;
+        }
+        souther.compiler.numeric.NumericDomain<InputAtom> made =
+                souther.compiler.numeric.NumericDomain.top();
+        for (Map.Entry<String, FieldDomains.Settled> each : conditioned().entrySet()) {
+            String parameter = each.getKey();
+            made = made.meet(each.getValue().numbersOver(
+                    at -> called(parameter, at),
+                    subject -> new InputAtom.Anonymous(parameter, subject)));
+        }
+        read = made;
+        constraints = read;
+        return read;
+    }
+
+    /** What this input calls the number at one of a parameter's coordinates. */
+    private static InputAtom called(String parameter, FieldDomains.Coordinate at) {
+        return new InputAtom.Named(parameter, at.path(), at.measured());
+    }
+
+    /** The same, of a term this input holds. One number under one name whichever side it arrives
+     *  from — the reading of a declaration, or a form a caller wrote. */
+    private static InputAtom.Named called(NumericTerm term) {
+        FieldDomains.Coordinate at = coordinateOf(term);
+        return new InputAtom.Named(term.path().head(), at.path(), at.measured());
+    }
+
+    /**
+     * The rules with what one term is on its own taken in.
+     *
+     * <p>Three things, and none of them is a clause: a value the caller fixed it at, what the
+     * position measured at it was read to hold, and what the term guarantees of itself. All three
+     * are true whether or not any clause ever named the coordinate, and they are put onto the rules
+     * rather than met against the answer so that they are solved together with the relations.
+     *
+     * <p>Ends that are not numbers are left out, because what is being added to is the arithmetic. A
+     * position ordered by its own values has ends that are values — a string stops at {@code "A"} —
+     * and that end survives where a form is one term taken as itself ({@link #runsBetween}), which
+     * is the only shape such a position is ever asked in.
+     */
+    private souther.compiler.numeric.NumericDomain<InputAtom> holding(
+            souther.compiler.numeric.NumericDomain<InputAtom> rules, NumericTerm term) {
+        NumericDomain.Bounds runs = whereOneTermRuns(term);
+        if (runs == null || (asCut(runs.min()) == null && asCut(runs.max()) == null)) {
+            return rules;
+        }
+        InputAtom atom = called(term);
+        souther.compiler.numeric.Granularity spaced = spacingOf(rules, term, atom);
+        if (spaced == null) {
+            return rules;
+        }
+        return rules.assuming(atom, numbersOf(runs), Map.of(atom, spaced));
+    }
+
+    /** A range with only the ends the arithmetic has a number for. */
+    private static NumericDomain.Bounds numbersOf(NumericDomain.Bounds runs) {
+        return new NumericDomain.Bounds(
+                asCut(runs.min()) == null ? null : runs.min(),
+                asCut(runs.max()) == null ? null : runs.max());
+    }
+
+    /**
+     * How the values of one term are spaced.
+     *
+     * <p>What the rules already record about it where they record anything, and what its type says
+     * where they do not. Asked of the rules first because that is where the two could disagree, and
+     * one number spaced two ways is the naming and the typing disagreeing rather than something to
+     * pick the safer of.
+     *
+     * <p>Null where nothing says. A bound may not be taken in on a number whose spacing is guessed —
+     * a strict bound is either wrongly sharpened on it or silently left blunt — so what is not
+     * known is left out, and what the rules leave is then wider rather than wrong.
+     */
+    private souther.compiler.numeric.Granularity spacingOf(
+            souther.compiler.numeric.NumericDomain<InputAtom> rules, NumericTerm term,
+            InputAtom atom) {
+        souther.compiler.numeric.Granularity had = rules.spacingOf(atom);
+        if (had != null) {
+            return had;
+        }
+        Position at = byPath.get(term.path());
+        if (at == null || symbols == null) {
+            return null;
+        }
+        // Asked of the term and not of the position: a size is a whole number whatever it is a size
+        // of, so a rule about the length of a string is counted where the string is not.
+        souther.compiler.check.Carrier carrier = term.carrierAt(at.type(), symbols);
+        return carrier == null ? null : carrier.spacing();
+    }
+
     @Override
     public NumericDomain.Bounds runsBetween(NumericDomain.LinearForm<NumericTerm> form) {
         if (form.coefs().isEmpty()) {
             return null;
         }
         form.coefs().keySet().forEach(this::held);
+        // Projected out of the rules, which is one question with one answer. The rules of every
+        // parameter are said together and what each number is on its own is said onto them, so what
+        // a form runs between is read off that space rather than assembled out of per-parameter
+        // answers — assembling is what a rule spanning two parameters cannot survive.
+        souther.compiler.numeric.NumericDomain<InputAtom> rules = constraints();
+        for (NumericTerm term : form.coefs().keySet()) {
+            rules = holding(rules, term);
+        }
+        NumericDomain.Bounds projected = rules.boundsOf(over(form));
         // One term taken as itself, which is the arithmetic being the identity rather than a second
         // answer to the same question. It is also the only shape a position the arithmetic cannot
         // count is ever asked in — a form adds its terms together and two strings have no sum — so
         // this is where a floor written as a value rather than as a number survives at all.
         NumericTerm only = onlyTermOf(form);
-        if (only != null) {
-            // The relation still applies: what the rules leave one position under what is fixed is
-            // the question a search asks between two steps, and it is the arithmetic that is the
-            // identity here rather than the reading.
-            return meeting(whereOneTermRuns(only), relatedTo(only));
-        }
-        // Added up out of parts, each holding as much as anything here can say about it, and never
-        // met as two totals. Meeting does not distribute over addition — everything each term is on
-        // its own, met against everything the relations leave the whole form, is wider than the sum
-        // of the parts each met on its own — so one part nothing can be said about would take the
-        // rules relating every other part down with it.
-        return boundsOf(Reach.of(partsOf(form), Rational.of(form.constant()),
-                part -> reachOf(part, form)));
+        return only == null ? projected : meeting(projected, whereOneTermRuns(only));
+    }
+
+    /** A form of this input's terms, as one over the numbers the rules are about. */
+    private static NumericDomain.LinearForm<InputAtom> over(
+            NumericDomain.LinearForm<NumericTerm> form) {
+        Map<InputAtom, BigDecimal> coefs = new LinkedHashMap<>();
+        form.coefs().forEach((term, coef) -> coefs.put(called(term), coef));
+        return new NumericDomain.LinearForm<>(form.constant(), coefs);
     }
 
     @Override
@@ -136,7 +271,7 @@ final class ReadQuantities implements Quantities {
             both.merge(term, new Fixed(each.getValue(), each.getValue()),
                     (had, one) -> had.and(one.least()));
         }
-        return new ReadQuantities(byParameter, parameters, byPath, both);
+        return new ReadQuantities(byParameter, parameters, byPath, both, symbols);
     }
 
     /**
@@ -282,80 +417,6 @@ final class ReadQuantities implements Quantities {
         return out;
     }
 
-    /**
-     * A part of a form that is answered on its own: the terms of one parameter the reading has a
-     * coordinate for, or the ones it has none for.
-     *
-     * <p>The finest unit a relation survives in. What relates two positions is read of the value
-     * they sit in, so a form reaching two parameters has a part in each; and within one, a
-     * coordinate the reading never named is one no relation can be asked about, so what is known of
-     * it is added beside the answer rather than taken into it.
-     */
-    private record Part(String parameter, boolean named) {}
-
-    /** Which part of a form a term belongs to. */
-    private Part partOf(NumericTerm term) {
-        String parameter = term.path().head();
-        FieldDomains.Settled rules = conditioned().get(parameter);
-        return new Part(parameter, rules != null && rules.names(coordinateOf(term)));
-    }
-
-    /** The parts a form is made of, each contributing what it comes to once. */
-    private Map<Part, Rational> partsOf(NumericDomain.LinearForm<NumericTerm> form) {
-        Map<Part, Rational> parts = new LinkedHashMap<>();
-        form.coefs().keySet().forEach(term -> parts.put(partOf(term), Rational.ONE));
-        return parts;
-    }
-
-    /**
-     * What one part of a form comes to: its terms on their own, and where the reading can be asked
-     * about them, met with what its rules leave them together.
-     *
-     * <p>Met here and not at the end. What relates the positions is what the terms alone cannot say,
-     * and what a term is on its own is what the relation need not have been told — held together at
-     * the part, both survive whatever the part beside it came to.
-     */
-    private Reach reachOf(Part part, NumericDomain.LinearForm<NumericTerm> form) {
-        Map<NumericTerm, Rational> mine = new LinkedHashMap<>();
-        form.coefs().forEach((term, coef) -> {
-            if (partOf(term).equals(part)) {
-                mine.put(term, Rational.of(coef));
-            }
-        });
-        Reach alone = Reach.of(mine, Rational.ZERO, this::atOneTerm);
-        return part.named() ? tighter(alone, reachOf(relationallyOf(part.parameter(), form)))
-                : alone;
-    }
-
-    /**
-     * What the rules of one parameter leave the part of {@code form} they can be asked about.
-     *
-     * <p>The coordinates this reading names and no others. A form with one it never named is one
-     * nothing can be said about as a whole, and asked that way the rules relating the coordinates
-     * beside it are lost with it.
-     */
-    private NumericDomain.Bounds relationallyOf(String parameter,
-                                                NumericDomain.LinearForm<NumericTerm> form) {
-        FieldDomains.Settled rules = conditioned().get(parameter);
-        if (rules == null) {
-            return null;
-        }
-        Map<FieldDomains.Coordinate, BigDecimal> named = new LinkedHashMap<>();
-        // And what each of those terms is on its own, put in rather than met on afterwards. The
-        // rules relate the coordinates and a term guarantees things about itself that no clause
-        // writes down; solved together they hold each other up, and taken apart and met the rule
-        // over two of them says nothing as soon as a third is one the rules leave unbounded.
-        Map<FieldDomains.Coordinate, NumericDomain.Bounds> ends = new LinkedHashMap<>();
-        form.coefs().forEach((term, coef) -> {
-            FieldDomains.Coordinate at = coordinateOf(term);
-            if (term.path().head().equals(parameter) && rules.names(at)) {
-                named.merge(at, coef, BigDecimal::add);
-                ends.putIfAbsent(at, whereOneTermRuns(term));
-            }
-        });
-        return rules.within(ends).boundsOf(named);
-    }
-
     /** The coordinate of one term, in the words the rules of its parameter are read in. */
     private static FieldDomains.Coordinate coordinateOf(NumericTerm term) {
         return new FieldDomains.Coordinate(String.join(".", term.path().fields()),
@@ -369,17 +430,6 @@ final class ReadQuantities implements Quantities {
         }
         Map.Entry<NumericTerm, BigDecimal> one = form.coefs().entrySet().iterator().next();
         return one.getValue().compareTo(BigDecimal.ONE) == 0 ? one.getKey() : null;
-    }
-
-    /**
-     * What the rules relating this term to others leave it, or null where the reading cannot name
-     * the coordinate.
-     *
-     * <p>The same question {@link #relationallyOf} asks of a form, of a form that is one term. Read
-     * as bounds rather than as something to add up, because nothing is being added.
-     */
-    private NumericDomain.Bounds relatedTo(NumericTerm term) {
-        return relationallyOf(term.path().head(), NumericDomain.LinearForm.atom(term));
     }
 
     /**
@@ -445,48 +495,9 @@ final class ReadQuantities implements Quantities {
      * position the reading measured by its own value is a different quantity — answered with the
      * position's, a body measuring the length of a string would be told where the string stops.
      */
-    private Reach atOneTerm(NumericTerm term) {
-        return reachOf(whereOneTermRuns(term));
-    }
-
-    private static Reach reachOf(NumericDomain.Bounds bounds) {
-        return bounds == null ? Reach.ANYWHERE
-                : Reach.between(asCut(bounds.min()), asCut(bounds.max()));
-    }
-
     private static RationalCut asCut(Endpoint end) {
         return end == null || !(end.at() instanceof Count at) ? null
                 : new RationalCut(Rational.of(at.at()), end.inclusive());
     }
 
-    private static Reach tighter(Reach one, Reach other) {
-        return new Reach(RationalCut.tighterLower(one.least(), other.least()),
-                RationalCut.tighterUpper(one.most(), other.most()));
-    }
-
-    private static NumericDomain.Bounds boundsOf(Reach runs) {
-        if (runs.least() == null && runs.most() == null) {
-            return null;
-        }
-        return new NumericDomain.Bounds(written(runs.least(), false), written(runs.most(), true));
-    }
-
-    private static Endpoint written(RationalCut cut, boolean upper) {
-        if (cut == null) {
-            return null;
-        }
-        BigDecimal exactly = cut.at().asWrittenDecimal();
-        if (exactly != null) {
-            return new Endpoint(new Count(exactly), cut.inclusive());
-        }
-        // Rounded the way that widens, so what is handed over admits everything the rules admit and
-        // a hair besides. Refusing a value the rules leave is the failure nothing downstream sees.
-        return new Endpoint(new Count(cut.at().asDecimal(
-                upper ? java.math.RoundingMode.CEILING : java.math.RoundingMode.FLOOR,
-                DIGITS_WHEN_IT_IS_NOT_A_DECIMAL)), true);
-    }
-
-    /** How far a derived end is written out where the division that makes it does not end. Any
-     *  number of them is sound while the rounding goes outward. */
-    private static final int DIGITS_WHEN_IT_IS_NOT_A_DECIMAL = 32;
 }

--- a/souther-compiler/src/main/java/souther/compiler/numeric/AffineConstraint.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/AffineConstraint.java
@@ -52,6 +52,25 @@ public sealed interface AffineConstraint<A> {
         };
     }
 
+    /**
+     * The same rule over positions called something else.
+     *
+     * <p>Here rather than at each shape, because renaming is one act and the three shapes differ
+     * only in what they hold their sum against — and none of that moves when the positions are
+     * called something else. Written per shape, a fourth shape would be one more place to remember
+     * it, and the reading that forgot would hand back a rule about the positions it started with.
+     *
+     * <p>What is renamed is the form and never the threshold. A bound is a number and a number is
+     * not in anybody's vocabulary.
+     */
+    default <B> AffineConstraint<B> over(Function<A, B> naming) {
+        return switch (this) {
+            case HalfSpace<A> half -> new HalfSpace<>(half.form().over(naming), half.bound());
+            case Equality<A> at -> new Equality<>(at.form().over(naming), at.at());
+            case Disequality<A> hole -> new Disequality<>(hole.form().over(naming), hole.at());
+        };
+    }
+
     /** The sum held no higher than a bound it may or may not reach. */
     record HalfSpace<A>(CanonicalForm<A> form, RationalCut bound) implements AffineConstraint<A> {
 

--- a/souther-compiler/src/main/java/souther/compiler/numeric/AffineConstraint.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/AffineConstraint.java
@@ -63,7 +63,7 @@ public sealed interface AffineConstraint<A> {
      * <p>What is renamed is the form and never the threshold. A bound is a number and a number is
      * not in anybody's vocabulary.
      */
-    default <B> AffineConstraint<B> over(Function<A, B> naming) {
+    default <B> AffineConstraint<B> over(Renaming<A, B> naming) {
         return switch (this) {
             case HalfSpace<A> half -> new HalfSpace<>(half.form().over(naming), half.bound());
             case Equality<A> at -> new Equality<>(at.form().over(naming), at.at());

--- a/souther-compiler/src/main/java/souther/compiler/numeric/CanonicalForm.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/CanonicalForm.java
@@ -92,6 +92,42 @@ public record CanonicalForm<A>(Map<A, Rational> coefs) {
         return AdditiveImage.of(coefs, spacing);
     }
 
+    /**
+     * The same form over positions called something else.
+     *
+     * <p>A renaming and nothing more. What a form says is a relation between the positions it
+     * weighs, and calling them by the names of another vocabulary leaves that relation where it
+     * was — so this is how a rule read of one value is asked about as a rule of the thing that
+     * holds it, rather than being re-derived there.
+     *
+     * <p>Still canonical, because canonical is a fact about the coefficients and this touches none
+     * of them.
+     *
+     * <p><b>The naming has to be one-to-one.</b> Two positions called by one name is not a wider
+     * reading of this rule, it is a different rule: the coefficients would be added together and
+     * {@code a - b <= 0}, which says one is no larger than the other, would come back weighing
+     * nothing at all. Refused rather than merged, for the same reason a second spacing under one
+     * key is refused — the naming and the form disagree about how many positions there are, and
+     * neither of them is this record's to correct.
+     */
+    public <B> CanonicalForm<B> over(Function<A, B> naming) {
+        Map<B, Rational> out = new LinkedHashMap<>();
+        coefs.forEach((atom, coef) -> {
+            B called = naming.apply(atom);
+            if (called == null) {
+                throw new IllegalArgumentException(
+                        "a position with no name in the vocabulary asked for is one this form"
+                                + " cannot be written in: " + atom);
+            }
+            if (out.put(called, coef) != null) {
+                throw new IllegalArgumentException(
+                        "two positions of this form are called `" + called + "`, so the form over"
+                                + " those names weighs fewer positions than this one does");
+            }
+        });
+        return new CanonicalForm<>(out);
+    }
+
     /** This form with every coefficient turned around, which is what reading a comparison the other
      *  way produces. Still canonical: negating leaves what the coefficients share. */
     public CanonicalForm<A> negated() {

--- a/souther-compiler/src/main/java/souther/compiler/numeric/CanonicalForm.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/CanonicalForm.java
@@ -103,28 +103,15 @@ public record CanonicalForm<A>(Map<A, Rational> coefs) {
      * <p>Still canonical, because canonical is a fact about the coefficients and this touches none
      * of them.
      *
-     * <p><b>The naming has to be one-to-one.</b> Two positions called by one name is not a wider
-     * reading of this rule, it is a different rule: the coefficients would be added together and
-     * {@code a - b <= 0}, which says one is no larger than the other, would come back weighing
-     * nothing at all. Refused rather than merged, for the same reason a second spacing under one
-     * key is refused — the naming and the form disagree about how many positions there are, and
-     * neither of them is this record's to correct.
+     * <p><b>Nothing is checked here.</b> Whether two positions have been called one name is a fact
+     * about the naming over every position the rules speak of, and a form knows its own and no
+     * others — asked here, it would catch a collision that fell inside one form and miss every
+     * collision between two. {@link Renaming} is one-to-one by construction, which is what makes
+     * this safe to be as simple as it looks.
      */
-    public <B> CanonicalForm<B> over(Function<A, B> naming) {
+    public <B> CanonicalForm<B> over(Renaming<A, B> naming) {
         Map<B, Rational> out = new LinkedHashMap<>();
-        coefs.forEach((atom, coef) -> {
-            B called = naming.apply(atom);
-            if (called == null) {
-                throw new IllegalArgumentException(
-                        "a position with no name in the vocabulary asked for is one this form"
-                                + " cannot be written in: " + atom);
-            }
-            if (out.put(called, coef) != null) {
-                throw new IllegalArgumentException(
-                        "two positions of this form are called `" + called + "`, so the form over"
-                                + " those names weighs fewer positions than this one does");
-            }
-        });
+        coefs.forEach((atom, coef) -> out.put(naming.of(atom), coef));
         return new CanonicalForm<>(out);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
@@ -217,6 +217,88 @@ public final class NumericDomain<A> {
                 : new NumericDomain<>(rules, Map.copyOf(next), readARuleNothingSatisfies);
     }
 
+    // --- renaming and joining ---------------------------------------------------------------------
+
+    /**
+     * The same rules over positions called something else.
+     *
+     * <p>For a reader that holds the rules of a value and is asked about them as rules of the thing
+     * that holds it. What a rule says is a relation between positions, and a relation does not move
+     * when the positions are called by another vocabulary's names — so this is a renaming and not a
+     * second reading, and nothing about what the rules leave changes.
+     *
+     * <p>Every position a rule weighs has to have a name, and no two of them the same
+     * ({@link CanonicalForm#over}). A rule reaching a position the caller's vocabulary cannot spell
+     * is a rule that cannot be carried across, and dropping it here would hand back a domain that
+     * leaves more than these rules do — which is the one direction a reader downstream cannot see.
+     * So the caller is the one that decides what such a position is called, and it may call it
+     * something opaque; what it may not do is leave it unnamed and be given a wider answer.
+     *
+     * <p>The spacing goes with the names, since it is a fact about the position rather than about
+     * the word for it.
+     */
+    public <B> NumericDomain<B> over(java.util.function.Function<A, B> naming) {
+        Map<B, Granularity> called = new LinkedHashMap<>();
+        kinds.forEach((atom, spacing) -> {
+            B name = naming.apply(atom);
+            if (name == null) {
+                throw new IllegalArgumentException(
+                        "no name in the vocabulary asked for was given to `" + atom + "`");
+            }
+            Granularity had = called.put(name, spacing);
+            if (had != null && had != spacing) {
+                throw new IllegalStateException(
+                        "two positions called `" + name + "` are " + had + " and " + spacing);
+            }
+        });
+        List<AffineConstraint<B>> out = new ArrayList<>();
+        for (AffineConstraint<A> rule : rules) {
+            AffineConstraint<B> renamed = rule.over(naming);
+            if (!out.contains(renamed)) {
+                out.add(renamed);
+            }
+        }
+        return new NumericDomain<>(List.copyOf(out), Map.copyOf(called),
+                readARuleNothingSatisfies);
+    }
+
+    /**
+     * Everything both of these say.
+     *
+     * <p>Saying two sets of rules together, which is what a caller holding rules read of two values
+     * at once has. Nothing is derived here — the rules are kept as they arrived and what they leave
+     * is worked out when it is asked for, the same as when they arrive one at a time.
+     *
+     * <p>A rule in both is one rule, for the reason {@link #keeping} gives: a rule said twice is the
+     * same rule, and an answer that depended on how often each was said would depend on how the
+     * caller came by them.
+     *
+     * <p>Spacings are checked rather than merged. Two readings calling one position by one name and
+     * spacing it two ways is the naming and the typing disagreeing, and picking the safer of the two
+     * would answer about a position neither reading was about.
+     */
+    public NumericDomain<A> meet(NumericDomain<A> other) {
+        if (other == null || (other.rules.isEmpty() && other.kinds.isEmpty()
+                && !other.readARuleNothingSatisfies)) {
+            return this;
+        }
+        Map<A, Granularity> both = new LinkedHashMap<>(kinds);
+        other.kinds.forEach((atom, spacing) -> {
+            Granularity had = both.put(atom, spacing);
+            if (had != null && had != spacing) {
+                throw new IllegalStateException("atom `" + atom + "` is " + had + " and " + spacing);
+            }
+        });
+        List<AffineConstraint<A>> out = new ArrayList<>(rules);
+        for (AffineConstraint<A> rule : other.rules) {
+            if (!out.contains(rule)) {
+                out.add(rule);
+            }
+        }
+        return new NumericDomain<>(List.copyOf(out), Map.copyOf(both),
+                readARuleNothingSatisfies || other.readARuleNothingSatisfies);
+    }
+
     // --- what the rules leave, worked out once ----------------------------------------------------
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
@@ -228,37 +228,33 @@ public final class NumericDomain<A> {
      * second reading, and nothing about what the rules leave changes.
      *
      * <p>Every position a rule weighs has to have a name, and no two of them the same
-     * ({@link CanonicalForm#over}). A rule reaching a position the caller's vocabulary cannot spell
+     * ({@link Renaming}). A rule reaching a position the caller's vocabulary cannot spell
      * is a rule that cannot be carried across, and dropping it here would hand back a domain that
      * leaves more than these rules do — which is the one direction a reader downstream cannot see.
      * So the caller is the one that decides what such a position is called, and it may call it
      * something opaque; what it may not do is leave it unnamed and be given a wider answer.
      *
      * <p>The spacing goes with the names, since it is a fact about the position rather than about
-     * the word for it.
+     * the word for it. Every position a rule weighs is one this records a spacing for, so naming
+     * them all is naming everything the rules are about — a rule reaching one this has no spacing
+     * for is refused rather than carried across unnamed.
      */
     public <B> NumericDomain<B> over(java.util.function.Function<A, B> naming) {
-        Map<B, Granularity> called = new LinkedHashMap<>();
-        kinds.forEach((atom, spacing) -> {
-            B name = naming.apply(atom);
-            if (name == null) {
-                throw new IllegalArgumentException(
-                        "no name in the vocabulary asked for was given to `" + atom + "`");
-            }
-            Granularity had = called.put(name, spacing);
-            if (had != null && had != spacing) {
-                throw new IllegalStateException(
-                        "two positions called `" + name + "` are " + had + " and " + spacing);
-            }
-        });
+        // Settled once, over every position these rules speak of, which is what this holds and no
+        // rule of it does. A rule asked whether a naming is one-to-one can only answer about its own
+        // positions, so two independent rules would be carried across as two rules about one number
+        // and a box holding something would come back holding nothing.
+        Renaming<A, B> called = Renaming.of(kinds.keySet(), naming);
+        Map<B, Granularity> spacing = new LinkedHashMap<>();
+        kinds.forEach((atom, spaced) -> spacing.put(called.of(atom), spaced));
         List<AffineConstraint<B>> out = new ArrayList<>();
         for (AffineConstraint<A> rule : rules) {
-            AffineConstraint<B> renamed = rule.over(naming);
+            AffineConstraint<B> renamed = rule.over(called);
             if (!out.contains(renamed)) {
                 out.add(renamed);
             }
         }
-        return new NumericDomain<>(List.copyOf(out), Map.copyOf(called),
+        return new NumericDomain<>(List.copyOf(out), Map.copyOf(spacing),
                 readARuleNothingSatisfies);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/numeric/Renaming.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/Renaming.java
@@ -1,0 +1,85 @@
+package souther.compiler.numeric;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * What one vocabulary's positions are called in another, one-to-one.
+ *
+ * <p>A value rather than a function, because a function is not a naming. Two positions called by one
+ * name is not a wider reading of the rules about them — it is a claim that they are one number, and
+ * a claim nobody made: {@code x <= 0} and {@code y >= 1} say nothing against each other, and under
+ * one name they say nothing at all. That is a domain holding something coming back holding nothing,
+ * which no reader downstream can see and none would think to look for.
+ *
+ * <p><b>Whether it is one-to-one is a fact about the positions the rules speak of, so it is settled
+ * where that set is known.</b> A rule knows its own positions and no others, so a rule asked to
+ * check this catches a collision that happens to fall inside one of them and misses every collision
+ * between two — which is exactly the shape a reading of two independent rules takes. Stated at the
+ * finer unit, the obligation was written down where it could not be met.
+ *
+ * <p>So it is met once, here, and what comes out is something that cannot be anything else. A reader
+ * handed one of these has nothing left to check and nothing left to forget, and a second reading of
+ * rules — another domain, another algebra — takes the same value rather than remembering the same
+ * rule.
+ *
+ * <p><b>And it is asked of each position once.</b> Applied where it is used, a naming would be asked
+ * the same question several times and is under no obligation to answer alike; two answers would put
+ * one rule's positions under names another rule's are not, which is the same identification arriving
+ * by a different road.
+ */
+public final class Renaming<A, B> {
+
+    private final Map<A, B> called;
+
+    private Renaming(Map<A, B> called) {
+        this.called = called;
+    }
+
+    /**
+     * {@code naming} over {@code positions}, or a refusal where it is not one-to-one on them.
+     *
+     * <p>Every position named, and no two named alike. Both refusals rather than a widening: a
+     * position with no name is one the rules about it cannot be carried across, and dropping those
+     * rules leaves what the rules leave wider than it is; two positions with one name leaves it
+     * narrower. Neither shows up anywhere near where the naming was written.
+     */
+    public static <A, B> Renaming<A, B> of(Set<A> positions, Function<A, B> naming) {
+        Map<A, B> out = new LinkedHashMap<>();
+        Map<B, A> back = new LinkedHashMap<>();
+        for (A position : positions) {
+            B name = naming.apply(position);
+            if (name == null) {
+                throw new IllegalArgumentException(
+                        "no name in the vocabulary asked for was given to `" + position + "`");
+            }
+            A had = back.put(name, position);
+            if (had != null && !had.equals(position)) {
+                throw new IllegalArgumentException(
+                        "`" + had + "` and `" + position + "` are both called `" + name
+                                + "`, which says they are one number rather than naming two");
+            }
+            out.put(position, name);
+        }
+        return new Renaming<>(Map.copyOf(out));
+    }
+
+    /**
+     * What {@code position} is called.
+     *
+     * <p>A refusal for one this was not made over, rather than a name made up on the spot. Such a
+     * position is one the caller did not know its rules were about, and carrying its rules across
+     * under an invented name — or dropping them — is answering a question nobody established the
+     * terms of.
+     */
+    public B of(A position) {
+        B name = called.get(position);
+        if (name == null) {
+            throw new IllegalArgumentException(
+                    "`" + position + "` is not one of the positions this naming was made over");
+        }
+        return name;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/WhatIsKnownOfOneTermSurvivesWhatIsUnknownBesideItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/WhatIsKnownOfOneTermSurvivesWhatIsUnknownBesideItTest.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * What is known of one term is not given up for what is unknown beside it.
@@ -110,6 +111,103 @@ class WhatIsKnownOfOneTermSurvivesWhatIsUnknownBesideItTest {
 
         assertEquals(Endpoint.inclusive(count(0)), runs.min(),
                 "each of them is at least none, so their sum is");
+    }
+
+    /** A collection under more steps than the walk that reads an input goes down. */
+    private static final String DEEPER_THAN_THE_WALK = """
+            module example.deep
+
+            data N = Int
+                invariant atLeastNone = value >= 0
+                invariant atMostFive  = value <= 5
+
+            data Inner = { xs: List<Int> }
+            data Mid = { inner: Inner }
+
+            data P = { m: Mid, n: N, ys: List<Int> }
+
+            data Taken
+
+            behavior take : (p: P) -> Taken
+            """;
+
+    /**
+     * A count under more steps than the walk goes down is still never negative.
+     *
+     * <p>Owned is not the same as known about. The walk that reads an input's positions stops where
+     * a report stops being about anything an author would call one input, and nothing stops a rule
+     * from naming what is under that — so a term down there is answered for with what it guarantees
+     * of itself and nothing else.
+     *
+     * <p>What it guarantees is the term's to say and not the position's. A count is a whole number
+     * whatever it is a count of, and a reading that asked the position how its values are spaced
+     * would have nowhere to ask here and would drop the floor for it — leaving a sum of two things
+     * each at least none with no floor at all.
+     */
+    @Test
+    void aCountUnderMoreStepsThanTheWalkGoesDownKeepsItsFloor() {
+        Read read = read(DEEPER_THAN_THE_WALK);
+        TermPath deep = TermPath.of("p").then("m").then("inner").then("xs");
+        assertNull(read.inputs().at(deep), "the walk does not reach this far");
+        NumericTerm buried = new NumericTerm.SizeOf(
+                souther.compiler.check.NumericMeasures.takenOf(
+                        read.inputs().at(TermPath.of("p").then("ys")).type(), read.symbols()),
+                deep);
+        NumericTerm n = read.inputs().at(TermPath.of("p").then("n")).term();
+        Map<NumericTerm, BigDecimal> coefs = new LinkedHashMap<>();
+        coefs.put(n, BigDecimal.ONE);
+        coefs.put(buried, BigDecimal.ONE);
+
+        NumericDomain.Bounds runs = read.quantities()
+                .runsBetween(new NumericDomain.LinearForm<>(BigDecimal.ZERO, coefs));
+
+        assertEquals(Endpoint.inclusive(count(0)), runs.min(),
+                "each of them is at least none, so their sum is");
+    }
+
+    /** A collection a clause counts, so what its count runs between has both ends. */
+    private static final String COUNTED = """
+            module example.counted
+
+            data P = { xs: List<Int> }
+                invariant few = List.length(xs) <= 5
+
+            data Taken
+
+            behavior take : (p: P) -> Taken
+            """;
+
+    /**
+     * Two spellings of one count weigh it twice.
+     *
+     * <p>A term carries which measure was written and a number does not, so a form can name one
+     * number twice. What it is weighed by is then the two coefficients together — read as a
+     * renaming, the form would come back weighing that count once, which is a range for a form the
+     * caller did not write.
+     *
+     * <p>No model reaches this today: which measure is taken of a position is settled by its type,
+     * so a body has one to write. It is held here because the reading turns a finer key into a
+     * coarser one, and a translation that loses a key has to say what it does with the two values
+     * rather than keeping whichever arrived last.
+     */
+    @Test
+    void twoSpellingsOfOneCountWeighItTwice() {
+        Read read = read(COUNTED);
+        NumericTerm one = size(read, "xs");
+        NumericTerm other = new NumericTerm.SizeOf(
+                souther.compiler.types.ValueName.Stdlib.operation("Set", "size"),
+                TermPath.of("p").then("xs"));
+        Map<NumericTerm, BigDecimal> coefs = new LinkedHashMap<>();
+        coefs.put(one, BigDecimal.ONE);
+        coefs.put(other, BigDecimal.ONE);
+
+        NumericDomain.Bounds twice = read.quantities()
+                .runsBetween(new NumericDomain.LinearForm<>(BigDecimal.ZERO, coefs));
+
+        assertEquals(Endpoint.inclusive(count(5)), read.quantities().runsBetween(one).max(),
+                "the clause counts it at five");
+        assertEquals(Endpoint.inclusive(count(10)), twice.max(),
+                "and a form naming it twice runs to twice that");
     }
 
     /** Two positions the record relates, beside a collection no clause counts. */

--- a/souther-compiler/src/test/java/souther/compiler/inputs/WhatIsKnownOfOneTermSurvivesWhatIsUnknownBesideItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/WhatIsKnownOfOneTermSurvivesWhatIsUnknownBesideItTest.java
@@ -31,14 +31,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * the reading that relates positions, the other three are answered only where that reading happens
  * to have a name for the coordinate — and where it does not, an answer that was in hand is dropped.
  *
- * <p>Which it does for whole reasons at a time. A form is one question per parameter, so a
- * coordinate the reading cannot name takes the answer about every other coordinate of that
- * parameter down with it: two positions each known to be at least none add up to something with no
- * floor.
+ * <p>And it gives them up for whole reasons at a time. The clauses relating positions are read one
+ * value at a time, so a coordinate that reading cannot name is one it can say nothing about — and an
+ * answer that gave up on its account would give up on every coordinate beside it too: two positions
+ * each known to be at least none would add up to something with no floor.
  *
- * <p>So what each term runs between is composed first, from everything about that term alone, and
- * what the rules relating them leave the form is met onto it. Meeting only narrows, so an answer is
- * never wider than the term's own — which is the direction the whole boundary is written in.
+ * <p>So all four go in beside each other and the answer is read out of the four together. Taking one
+ * in only narrows, so what comes back is never wider than what the term alone says — which is the
+ * direction the whole boundary is written in. What these hold to is the answer and not the way it is
+ * arrived at: a fact in hand may not be dropped because the mechanism asked for it declined.
  */
 class WhatIsKnownOfOneTermSurvivesWhatIsUnknownBesideItTest {
 
@@ -134,11 +135,12 @@ class WhatIsKnownOfOneTermSurvivesWhatIsUnknownBesideItTest {
     /**
      * And the rule relating two terms survives a third the reading cannot name.
      *
-     * <p>The part that keeps a relation is the terms the reading has a coordinate for, and the rest
-     * is added beside it. Met as two totals instead — everything each term is on its own against
-     * everything the relations leave the whole form — one unnameable term makes the relational
-     * total say nothing, and the relation between the two terms beside it is lost with it. Meeting
-     * does not distribute over addition, so which unit it happens at is which answer comes out.
+     * <p>A term the reading has no coordinate for is one no relation can be asked about, and that is
+     * the whole of what it costs. Asked as two totals instead — everything each term is on its own,
+     * against everything the relations leave the whole form — the unnameable term makes the
+     * relational total say nothing and takes the relation between the two beside it with it. Meeting
+     * does not distribute over addition, so the unit an answer is assembled at is which answer comes
+     * out.
      *
      * <p>Held here and not at a report, because no report reaches it today. A coordinate the reading
      * of a value never named is in practice a count nothing takes, and a position whose values are

--- a/souther-compiler/src/test/java/souther/compiler/numeric/RulesReadOfOneValueAreCarriedAndSaidTogetherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/RulesReadOfOneValueAreCarriedAndSaidTogetherTest.java
@@ -1,0 +1,154 @@
+package souther.compiler.numeric;
+
+import souther.compiler.numeric.NumericDomain.Bounds;
+import souther.compiler.numeric.NumericDomain.LinearForm;
+import souther.compiler.numeric.NumericDomain.Rel;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Rules read of one value, asked about as rules of something that holds it.
+ *
+ * <p>A caller holding the readings of several values at once has to say what they leave together,
+ * and each of those readings is about its own value's positions. What a rule says is a relation
+ * between numbers and it says the same thing whatever the numbers are called, so carrying one
+ * across is a renaming and saying two of them together is keeping both — neither is a second
+ * derivation of anything, and that is what makes an answer assembled this way the same answer.
+ */
+class RulesReadOfOneValueAreCarriedAndSaidTogetherTest {
+
+    private static LinearForm<String> atom(String a) {
+        return LinearForm.<String>atom(a);
+    }
+
+    private static LinearForm<String> num(long n) {
+        return LinearForm.<String>constant(BigDecimal.valueOf(n));
+    }
+
+    private static Map<String, Granularity> whole(String... atoms) {
+        Map<String, Granularity> out = new LinkedHashMap<>();
+        for (String each : atoms) {
+            out.put(each, Granularity.DISCRETE);
+        }
+        return out;
+    }
+
+    /** The rules of one value, under the names the thing holding it calls those numbers by. */
+    @Test
+    void aRuleSaysTheSameThingUnderOtherNames() {
+        NumericDomain<String> read = NumericDomain.<String>top()
+                .assume(atom("x").plus(atom("y")).minus(num(5)), Rel.LE, whole("x", "y"))
+                .assume(atom("x"), Rel.GE, whole("x"))
+                .assume(atom("y"), Rel.GE, whole("y"));
+
+        NumericDomain<String> carried = read.over(name -> "p." + name);
+
+        assertEquals(Endpoint.inclusive(Count.of(5)),
+                carried.boundsOf(atom("p.x").plus(atom("p.y"))).max());
+        assertEquals(Endpoint.inclusive(Count.of(0)), carried.boundsOf(atom("p.x")).min());
+    }
+
+    /**
+     * A relation through a number the caller cannot spell still holds the two it relates apart.
+     *
+     * <p>Which is why carrying one across may not drop it. The rule below says nothing about either
+     * of the names on its own, and taking it away leaves their difference unbounded — the one
+     * direction a reader downstream cannot see.
+     */
+    @Test
+    void aRelationThroughAnUnspellableNumberIsCarriedToo() {
+        NumericDomain<String> read = NumericDomain.<String>top()
+                .assume(atom("x").minus(atom("hidden")), Rel.LE, whole("x", "hidden"))
+                .assume(atom("hidden").minus(atom("y")), Rel.LE, whole("hidden", "y"));
+
+        NumericDomain<String> carried =
+                read.over(name -> name.equals("hidden") ? "<1>" : "p." + name);
+
+        assertTrue(carried.entails(atom("p.x").minus(atom("p.y")), Rel.LE),
+                "what the two of them are held apart by went through the number in between");
+        // And nothing else says it. Half the relation is half of nothing: neither rule names both
+        // of them, so a carrying that kept only the rules it could spell would leave this open.
+        assertFalse(NumericDomain.<String>top()
+                        .assume(atom("p.x").minus(atom("p.hidden")), Rel.LE, whole("p.x", "p.hidden"))
+                        .entails(atom("p.x").minus(atom("p.y")), Rel.LE),
+                "one half of the relation proves nothing about the pair");
+    }
+
+    /** Two names for one number is a different rule, not a wider reading of this one. */
+    @Test
+    void twoPositionsCalledOneNameIsRefused() {
+        NumericDomain<String> read = NumericDomain.<String>top()
+                .assume(atom("x").minus(atom("y")), Rel.LE, whole("x", "y"));
+
+        assertThrows(IllegalArgumentException.class, () -> read.over(_ -> "one"));
+    }
+
+    /** Saying two readings together says everything either of them says. */
+    @Test
+    void whatIsSaidTogetherIsEverythingBothSay() {
+        NumericDomain<String> one = NumericDomain.<String>top()
+                .assume(atom("a").minus(num(3)), Rel.LE, whole("a"));
+        NumericDomain<String> other = NumericDomain.<String>top()
+                .assume(atom("b").minus(num(4)), Rel.LE, whole("b"));
+
+        Bounds sum = one.meet(other).boundsOf(atom("a").plus(atom("b")));
+
+        assertEquals(Endpoint.inclusive(Count.of(7)), sum.max());
+        assertNull(sum.min());
+    }
+
+    /**
+     * Whichever way round, and however often.
+     *
+     * <p>The property the whole arrangement leans on: what the rules leave is a function of which
+     * rules were said and not of how a caller came by them. A reading that depended on the order
+     * would make which parameter was read first part of what the model says.
+     */
+    @Test
+    void sayingThemTheOtherWayRoundSaysTheSameThing() {
+        NumericDomain<String> one = NumericDomain.<String>top()
+                .assume(atom("a").plus(atom("b")).minus(num(5)), Rel.LE, whole("a", "b"));
+        NumericDomain<String> other = NumericDomain.<String>top()
+                .assume(atom("a").minus(num(1)), Rel.GE, whole("a"));
+
+        LinearForm<String> asked = atom("a").plus(atom("b"));
+
+        assertEquals(one.meet(other).boundsOf(asked), other.meet(one).boundsOf(asked));
+        assertEquals(one.meet(other).boundsOf(asked),
+                one.meet(other).meet(one).boundsOf(asked),
+                "a rule said twice is the same rule");
+    }
+
+    /** Two readings that cannot both hold leave nothing, which is what a caller acts on. */
+    @Test
+    void twoReadingsThatContradictLeaveNothing() {
+        NumericDomain<String> one = NumericDomain.<String>top()
+                .assume(atom("a").minus(num(3)), Rel.LE, whole("a"));
+        NumericDomain<String> other = NumericDomain.<String>top()
+                .assume(atom("a").minus(num(9)), Rel.GE, whole("a"));
+
+        assertTrue(one.meet(other).isBottom());
+    }
+
+    /** One number spaced two ways is the naming and the typing disagreeing, and neither is the
+     *  safer of the two to pick. */
+    @Test
+    void oneNumberSpacedTwoWaysIsRefused() {
+        NumericDomain<String> stepping = NumericDomain.<String>top()
+                .assume(atom("a"), Rel.GE, whole("a"));
+        NumericDomain<String> filling = NumericDomain.<String>top()
+                .assume(atom("a"), Rel.GE, Map.of("a", Granularity.DENSE));
+
+        assertThrows(IllegalStateException.class, () -> stepping.meet(filling));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/numeric/RulesReadOfOneValueAreCarriedAndSaidTogetherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/RulesReadOfOneValueAreCarriedAndSaidTogetherTest.java
@@ -93,6 +93,27 @@ class RulesReadOfOneValueAreCarriedAndSaidTogetherTest {
         assertThrows(IllegalArgumentException.class, () -> read.over(_ -> "one"));
     }
 
+    /**
+     * Two positions no one rule names together are still two positions.
+     *
+     * <p>The case the check inside a form cannot see. Injectivity is a fact about the naming over
+     * everything the rules are about, and a form knows only its own atoms — so a naming that calls
+     * two of them one name is caught where they stand side by side and nowhere else. Left there,
+     * two independent rules would come back as two rules about one number, and a domain that holds
+     * something would come back holding nothing.
+     */
+    @Test
+    void twoPositionsCalledOneNameAreRefusedWhereNoRuleNamesBoth() {
+        NumericDomain<String> read = NumericDomain.<String>top()
+                .assume(atom("x"), Rel.LE, whole("x"))
+                .assume(atom("y").minus(num(1)), Rel.GE, whole("y"));
+
+        assertFalse(read.isBottom(), "nothing here contradicts: x is at nought or below, y at one"
+                + " or above");
+        assertThrows(IllegalArgumentException.class, () -> read.over(_ -> "z"),
+                "calling both of them `z` is identifying two numbers, not renaming them");
+    }
+
     /** Saying two readings together says everything either of them says. */
     @Test
     void whatIsSaidTogetherIsEverythingBothSay() {


### PR DESCRIPTION
Preparation for #911, and it changes no answer on its own.

## What was wrong

The rules reaching a behavior's input are read one parameter at a time, and what
a form over several positions runs between was assembled by solving each
parameter's part of it and adding the results. That composition rests on two
parameters being related by nothing — which is true of the declarations, and of
nothing a body writes. ADR-0110 says so outright: *"A day when a behavior's own
clauses relate its parameters is the day that composition has to change, and it
is the only place it does."*

#911 needs a guard's cut in the box a search walks, and a guard relates
parameters. There was nowhere for such a rule to be said.

## What this does

Each parameter's declaration-derived numeric rules are carried into one
vocabulary and said together, and what a form runs between is projected out of
that space.

* `CanonicalForm.over` / `AffineConstraint.over` / `NumericDomain.over` — a
  renaming. What a rule says is a relation between numbers and it says the same
  thing whatever they are called, so this is not a second reading of the
  declaration.
* `NumericDomain.meet` — two sets of rules said together.
* `FieldDomains.Settled.numbersOver` — hands the numeric rules over in a
  caller's names. **Every number a rule is about is carried**, including ones the
  caller has no coordinate for: a rule reaching one of those still holds two
  named numbers apart, and dropping it would leave the answer wider than it is.
* `InputAtom` — the vocabulary. `Named` is keyed by coordinate (parameter, path,
  measured) and not by `NumericTerm`, because a term carries which measure was
  written and that would make one number two.
* `ReadQuantities` — one `NumericDomain<InputAtom>` instead of per-parameter
  composition.

Non-numeric emptiness stays per parameter. Which values a position admits, which
predicates hold, where an ordering stops — none of that relates two parameters,
and it is asked where it was proved.

Removed with the composition it belonged to: `Part`, `partsOf`, `reachOf`,
`relationallyOf`, `relatedTo`, `atOneTerm`, `tighter`, and
`FieldDomains.Settled.names`. `Settled.within` stays — a test measures the
ADR-0110 property through it.

## What was measured

`mvn -Plint clean verify`, then the full suite from clean: 6130 pass, no
checked-in answer file moved.

**The corpus is not a control for this, and saying so is the point.** With
`NumericDomain.meet` deliberately made a no-op — every declaration rule dropped
from the state — `TheAnswersAboutEachConformanceCorpusAreTheOnesCheckedInTest`
stayed green. Five assertions in `inputs` went red and nothing else did. The
corpus asks no multi-term relational question: a single term is answered by
`whereOneTermRuns` and never reaches the meet.

So what holds this change is `WhatIsFixedIsAskedTogetherHoweverItArrivedTest`,
`WhatIsKnownOfOneTermSurvivesWhatIsUnknownBesideItTest`, and the algebra
properties added here — a renaming that is not one-to-one is refused, saying two
readings together is order-independent and idempotent, a contradiction leaves
nothing, one number spaced two ways is refused.

The same holds for the follow-on: a guard's region will not move a corpus answer
either, so #911 has to bring its own checked-in test.

Refs #911.

🤖 Generated with [Claude Code](https://claude.com/claude-code)