### PR TITLE
Search for a row where the rules on the way to the border leave one

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/inputs/EmptyInput.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/EmptyInput.java
@@ -64,4 +64,17 @@ public sealed interface EmptyInput {
      * proved. Widening this is one edit, in the translation above.
      */
     record ProvedByTheDeclarationsReading() implements EmptyInput {}
+
+    /**
+     * The rules and what a caller took in on the way leave nothing together.
+     *
+     * <p>Apart from the reading's own proof because it is a different fact. What a declaration
+     * refuses it refuses of every value, and this is about a place — a row that would have to be
+     * both inside a region and at a level nothing in that region reaches. Read as the first, an
+     * author would be sent to a declaration that says nothing of the sort.
+     *
+     * <p>Nowhere in particular. What contradicts is the rules taken together, and naming one of
+     * them would be picking whichever the arithmetic happened to close on.
+     */
+    record ProvedByTheRulesTakenTogether() implements EmptyInput {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Quantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Quantities.java
@@ -97,6 +97,18 @@ public sealed interface Quantities permits ReadQuantities {
     }
 
     /**
+     * Where a row may be written, before anything a body says is taken in.
+     *
+     * <p>The one way over to {@link SearchRegion}, and it is one way. What the declarations leave is
+     * where the borders are read from, and a region is where a row for one of them is looked for —
+     * so a caller may go from the first to the second and nothing can come back. Read the other way,
+     * a region narrowed by the conditions on the way to one border would reach the reader that
+     * decides which borders exist, and an obligation would go away for this compiler having read
+     * more of the body.
+     */
+    SearchRegion region();
+
+    /**
      * Why the rules leave no value under what is fixed, or empty where nothing proved they leave
      * none.
      *

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -348,6 +348,18 @@ final class ReadQuantities implements Quantities {
 
     @Override
     public Quantities given(Map<NumericTerm, Count> more) {
+        return fixing(more);
+    }
+
+    /**
+     * The same, answered as this reading rather than as one of the faces it wears.
+     *
+     * <p>What refining hands back is the state, and {@link Quantities} and {@link SearchRegion} are
+     * two ways of asking it. Typed by either of them, the other has to put back what it knows —
+     * which is a cast, and a cast is a check the compiler is not doing. The two faces stay apart
+     * because they answer different questions; what they refine is one thing and is typed as one.
+     */
+    ReadQuantities fixing(Map<NumericTerm, Count> more) {
         if (more.isEmpty()) {
             return this;
         }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -44,6 +44,14 @@ final class ReadQuantities implements Quantities {
      */
     private final Map<NumericTerm, Fixed> fixed;
     /**
+     * What a caller has taken in about this input beyond what the declarations say.
+     *
+     * <p>Reached only through {@link SearchRegion}, which is what keeps a reading of the
+     * declarations from acquiring one. Kept as what was said and not as what it came to: taking in
+     * accumulates, and what the whole of it leaves is worked out where everything else is.
+     */
+    private final List<Assumed> assumed;
+    /**
      * The rules read with everything fixed, worked out when something is asked and not before.
      *
      * <p>One reading per parameter and not one per question. A search asks where a position runs and
@@ -66,6 +74,9 @@ final class ReadQuantities implements Quantities {
      */
     private volatile souther.compiler.numeric.NumericDomain<InputAtom> constraints;
 
+    /** One thing taken in about a form of this input's terms: {@code form rel 0}. */
+    private record Assumed(NumericDomain.LinearForm<NumericTerm> form, NumericDomain.Rel rel) {}
+
     /** The values fixed at one term, kept as their least and greatest so that what was fixed does
      *  not depend on the order it arrived in. */
     private record Fixed(Count least, Count most) {
@@ -82,8 +93,9 @@ final class ReadQuantities implements Quantities {
 
     private ReadQuantities(Map<String, PlacedRules> byParameter, Set<String> parameters,
                            Map<TermPath, Position> byPath, Map<NumericTerm, Fixed> fixed,
-                           souther.compiler.check.Symbols symbols) {
+                           souther.compiler.check.Symbols symbols, List<Assumed> assumed) {
         this.symbols = symbols;
+        this.assumed = List.copyOf(assumed);
         // In the order the behavior declares its parameters. A proof of emptiness names one of them
         // and a report is a document compared against the one written last time, so an order read
         // off a hash would move which parameter is named between runs.
@@ -102,7 +114,7 @@ final class ReadQuantities implements Quantities {
     static ReadQuantities of(Map<String, PlacedRules> byParameter, Set<String> parameters,
                              Map<TermPath, Position> byPath,
                              souther.compiler.check.Symbols symbols) {
-        return new ReadQuantities(byParameter, parameters, byPath, Map.of(), symbols);
+        return new ReadQuantities(byParameter, parameters, byPath, Map.of(), symbols, List.of());
     }
 
     /** Each parameter's rules read with what is fixed under it, once. */
@@ -116,6 +128,43 @@ final class ReadQuantities implements Quantities {
             conditioned = read;
         }
         return read;
+    }
+
+    @Override
+    public SearchRegion region() {
+        return new ReadRegion(this);
+    }
+
+    /**
+     * The same rules, with {@code form rel 0} taken in as well.
+     *
+     * <p>Reached only through {@link ReadRegion}, so what comes back is a region and never a reading
+     * of the declarations. What is kept is the assertion and not what it came to: two of them said
+     * in either order are the same two, and one said twice is one.
+     *
+     * <p>This value back where the arithmetic cannot take the assertion in — a form over a position
+     * whose values it has no spacing for. Kept anyway, it would sit in the state as a rule about a
+     * number nothing knows how to space, which {@link souther.compiler.numeric.NumericDomain#assume}
+     * refuses outright; declined here, the region stays wider than what reaches the border, which is
+     * the direction every reader of it depends on.
+     */
+    ReadQuantities assuming(NumericDomain.LinearForm<NumericTerm> form, NumericDomain.Rel rel) {
+        if (form == null || form.coefs().isEmpty()) {
+            return this;
+        }
+        for (NumericTerm term : form.coefs().keySet()) {
+            held(term);
+            if (spacingOf(constraints(), term, called(term)) == null) {
+                return this;
+            }
+        }
+        Assumed taking = new Assumed(form, rel);
+        if (assumed.contains(taking)) {
+            return this;
+        }
+        List<Assumed> both = new java.util.ArrayList<>(assumed);
+        both.add(taking);
+        return new ReadQuantities(byParameter, parameters, byPath, fixed, symbols, both);
     }
 
     /**
@@ -148,6 +197,23 @@ final class ReadQuantities implements Quantities {
             made = made.meet(each.getValue().numbersOver(
                     at -> called(parameter, at),
                     subject -> new InputAtom.Anonymous(parameter, subject)));
+        }
+        // And what the caller took in, onto the same rules rather than met against the answer
+        // afterwards. A condition relating two positions says nothing about either of them alone,
+        // so met afterwards it would be gone.
+        for (Assumed each : assumed) {
+            Map<InputAtom, souther.compiler.numeric.Granularity> spacing = new LinkedHashMap<>();
+            for (NumericTerm term : each.form().coefs().keySet()) {
+                souther.compiler.numeric.Granularity spaced = spacingOf(made, term, called(term));
+                if (spaced == null) {
+                    spacing = null;
+                    break;
+                }
+                spacing.put(called(term), spaced);
+            }
+            if (spacing != null) {
+                made = made.assume(over(each.form()), each.rel(), spacing);
+            }
         }
         read = made;
         constraints = read;
@@ -291,7 +357,7 @@ final class ReadQuantities implements Quantities {
             both.merge(term, new Fixed(each.getValue(), each.getValue()),
                     (had, one) -> had.and(one.least()));
         }
-        return new ReadQuantities(byParameter, parameters, byPath, both, symbols);
+        return new ReadQuantities(byParameter, parameters, byPath, both, symbols, assumed);
     }
 
     /**
@@ -332,7 +398,12 @@ final class ReadQuantities implements Quantities {
                 return here;
             }
         }
-        return Optional.empty();
+        // And what the rules leave once they are all said together, which is the only place a
+        // contradiction between two parameters — or between a declaration and something a caller
+        // took in — can be seen at all. Last, so that a proof one parameter's own reading can name a
+        // place for is the one a caller hears about.
+        return constraints().isBottom()
+                ? Optional.of(new EmptyInput.ProvedByTheRulesTakenTogether()) : Optional.empty();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadRegion.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadRegion.java
@@ -27,8 +27,8 @@ record ReadRegion(ReadQuantities within) implements SearchRegion {
 
     @Override
     public SearchRegion given(Map<NumericTerm, Count> fixed) {
-        Quantities taken = within.given(fixed);
-        return taken == within ? this : new ReadRegion((ReadQuantities) taken);
+        ReadQuantities taken = within.fixing(fixed);
+        return taken == within ? this : new ReadRegion(taken);
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadRegion.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadRegion.java
@@ -1,0 +1,43 @@
+package souther.compiler.inputs;
+
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.NumericDomain;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A region of one input's values, read off the same rules the input's quantities are read off.
+ *
+ * <p>One state and two faces. What a region is refined by is a superset of what a reading of the
+ * declarations is refined by — a body's conditions as well as a caller's fixings — and the algebra
+ * that answers both is the same one, so what differs is which of them each face lets a caller say.
+ * Written as two states, a region and the reading it came from could come to disagree about what
+ * the declarations leave, which is a disagreement about the model made out of an arrangement of
+ * this compiler.
+ */
+record ReadRegion(ReadQuantities within) implements SearchRegion {
+
+    @Override
+    public SearchRegion assuming(NumericDomain.LinearForm<NumericTerm> form,
+                                 NumericDomain.Rel rel) {
+        ReadQuantities taken = within.assuming(form, rel);
+        return taken == within ? this : new ReadRegion(taken);
+    }
+
+    @Override
+    public SearchRegion given(Map<NumericTerm, Count> fixed) {
+        Quantities taken = within.given(fixed);
+        return taken == within ? this : new ReadRegion((ReadQuantities) taken);
+    }
+
+    @Override
+    public NumericDomain.Bounds runsBetween(NumericDomain.LinearForm<NumericTerm> form) {
+        return within.runsBetween(form);
+    }
+
+    @Override
+    public Optional<EmptyInput> emptiness() {
+        return within.emptiness();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/SearchRegion.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/SearchRegion.java
@@ -1,0 +1,81 @@
+package souther.compiler.inputs;
+
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.NumericDomain;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Where a row for one coverage item has to be written.
+ *
+ * <p><b>Not a {@link Quantities}, on purpose.</b> What the declarations leave an input is what says
+ * which borders the rows are owed at; where a row for one of those borders is looked for is
+ * narrower, because a rule a row has to pass before it reaches the border narrows the search and
+ * settles nothing about whether the border exists. Those are two questions, and a type that
+ * answered both would let the second's answer reach the first's readers — where it would take
+ * obligations away as this compiler learned more, which is the one direction a coverage measure may
+ * not move in.
+ *
+ * <p>So the two are apart and neither is the other's subtype. What they share is the algebra
+ * underneath, which is where sharing costs nothing: a renaming, a meeting and a projection are the
+ * same acts whoever is asking. A subtype would put one of these back where the other is expected,
+ * and the boundary would be a thing to remember rather than a thing that holds.
+ *
+ * <p><b>Never wider than the declarations, and never narrower than what arrives.</b> Refining is
+ * narrowing and only that ({@code R.assuming(c)} is inside {@code R}), and a condition this cannot
+ * read narrows nothing rather than being approximated — so
+ *
+ * <pre>what reaches the border ⊆ this ⊆ what the declarations leave</pre>
+ *
+ * holds however much of a body was read. The left inclusion is what lets a walk of the whole of this
+ * that reaches nothing prove the item is out of reach; the right is why a search that gives up
+ * proves nothing. Neither survives a reading that narrowed on a condition it had not established.
+ *
+ * <p>Which also says what this is not: it is not the set of rows that reach the border. A condition
+ * of a shape the arithmetic has no word for leaves this wider than that set, so a row found here is
+ * a row to try and not a row shown to arrive — what shows that is running it.
+ */
+public interface SearchRegion {
+
+    /**
+     * The same region, with {@code form rel 0} taken in.
+     *
+     * <p>A refinement of where a row may be written and not a new reading of anything. Taking in
+     * accumulates, so the order the conditions on the way to a border arrived in does not reach the
+     * answer, and taking one in twice is taking it in once.
+     *
+     * <p>Where the arithmetic has nothing to say about a condition — a form over a position whose
+     * values it cannot count, a subject it has no spacing for — what comes back is this region
+     * unchanged. Which is the direction that keeps the inclusions above: a condition nothing took in
+     * leaves the region wider than the rows that arrive, and a region narrowed on a condition
+     * nothing established would leave it narrower than they are.
+     */
+    SearchRegion assuming(NumericDomain.LinearForm<NumericTerm> form, NumericDomain.Rel rel);
+
+    /** The same region, with these positions standing at these values. */
+    SearchRegion given(Map<NumericTerm, Count> fixed);
+
+    /** The same, of one position. */
+    default SearchRegion given(NumericTerm term, Count fixed) {
+        return given(Map.of(term, fixed));
+    }
+
+    /** Where the values of {@code form} run inside this region, or null at either end where
+     *  nothing bounds them. */
+    NumericDomain.Bounds runsBetween(NumericDomain.LinearForm<NumericTerm> form);
+
+    /** The same, of one term — the one-term case of the question above and not a second answer to
+     *  it. */
+    default NumericDomain.Bounds runsBetween(NumericTerm term) {
+        return runsBetween(NumericDomain.LinearForm.atom(term));
+    }
+
+    /**
+     * Why nothing is left here, or empty where nothing proved it.
+     *
+     * <p>Empty is not "there is a value", the same as everywhere else. A search reading it that way
+     * would take the absence of a proof for one.
+     */
+    Optional<EmptyInput> emptiness();
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Condition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Condition.java
@@ -1,0 +1,93 @@
+package souther.compiler.partition;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.core.Core;
+import souther.compiler.inputs.InputReads;
+
+/**
+ * What a condition of a body is made of.
+ *
+ * <p><b>One reading, because three readers were each making their own.</b> Which comparisons a fork
+ * turns on, what each of them stands under, and what an arm proves are three questions about one
+ * structure — and each was answered by matching on the shape of the {@link Core} node in front of
+ * it. So each knew, on its own, which shapes are transparent, which combine, which are something to
+ * say about, and which are where this compiler stops. A shape one of them learned to see through was
+ * a shape the others still could not.
+ *
+ * <p>They came apart where a helper is called in a condition. An expanded helper binds the call's
+ * argument to its own parameter, so what stands in the condition is a binding around the comparison
+ * rather than the comparison — and the reading that finds comparisons anywhere in a condition saw it
+ * and reported it as a rule written in a form this compiler does not read, while the reading that
+ * draws lines never reached it at all. One line went missing, the position it divides came back
+ * divided no way, and the region a guard beside it is searched in lost what that comparison
+ * establishes. All from moving a comparison into a {@code let}, which changes nothing about what the
+ * model says.
+ *
+ * <p>So the vocabulary is here and the readers fold over it. Four shapes:
+ *
+ * <ul>
+ *   <li>{@link Both} and {@link Either} — the two operators a condition is built from, each of
+ *       which stops as soon as it is settled;
+ *   <li>{@link Compares} — one comparison, with the reading of the names in force where it stands;
+ *   <li>{@link NotRead} — where this stops. A condition can be anything a {@code Bool} is, and what
+ *       is not one of the shapes above says nothing here rather than being guessed at.
+ * </ul>
+ *
+ * <p><b>A binding is transparent and is not one of the shapes.</b> What a {@code let} contributes is
+ * where the names in its body point, which is why {@link Compares} carries the reading rather than
+ * every reader threading one alongside. Carried as a shape instead, each reader would have to know
+ * to look through it, which is the arrangement this replaces.
+ *
+ * <p>What is not here is which comparisons appear <em>anywhere</em> in a condition — inside an
+ * argument to a call, under an operator this does not read. That is a different question, asked of
+ * the whole subtree rather than of the condition's structure, and it is answered where it is asked
+ * ({@code GuardThresholds.compared}). Reading one for the other is how a comparison nothing could
+ * turn into a line would come back as a line.
+ */
+sealed interface Condition {
+
+    /** Both, and the right one runs only where the left held. */
+    record Both(Condition left, Condition right) implements Condition {}
+
+    /** Either, and the right one runs only where the left did not hold. */
+    record Either(Condition left, Condition right) implements Condition {}
+
+    /**
+     * One comparison, and where the names in it point.
+     *
+     * @param reads the reading in force where this comparison stands, which is the outer one with
+     *              every binding between here and the top taken in. A comparison inside an expanded
+     *              helper is about the argument the call handed it, and read against the outer names
+     *              it is about nothing
+     */
+    record Compares(Core.Binary at, InputReads reads) implements Condition {}
+
+    /** Where this reading stops: a condition of a shape it has no words for. */
+    record NotRead(Core at) implements Condition {}
+
+    /**
+     * {@code e} read as a condition, under {@code reads}.
+     *
+     * <p>Bindings are looked through and their names taken in; the two operators are taken apart;
+     * everything else is either one comparison or nowhere this reading goes.
+     */
+    static Condition of(Core e, InputReads reads) {
+        if (e instanceof Core.LetIn let) {
+            return of(let.body(), reads.and(let.binder(), let.value()));
+        }
+        if (e instanceof Core.Binary binary && combines(binary.op())) {
+            Condition left = of(binary.left(), reads);
+            Condition right = of(binary.right(), reads);
+            return binary.op() == Hir.BinOp.AND ? new Both(left, right) : new Either(left, right);
+        }
+        if (e instanceof Core.Binary comparison) {
+            return new Compares(comparison, reads);
+        }
+        return new NotRead(e);
+    }
+
+    /** Whether an operator joins two conditions rather than comparing two values. */
+    static boolean combines(Hir.BinOp op) {
+        return op == Hir.BinOp.AND || op == Hir.BinOp.OR;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -73,10 +73,12 @@ public final class GuardThresholds {
     public record Guards(List<Threshold> thresholds,
                          List<UnreadRule> unread, List<Singled> singled,
                          List<LineDrawn> between,
-                         List<AtAPosition> accounting) {
+                         List<AtAPosition> accounting,
+                         ReachingCuts reaching) {
 
         public static final Guards NONE =
-                new Guards(List.of(), List.of(), List.of(), List.of(), List.of());
+                new Guards(List.of(), List.of(), List.of(), List.of(), List.of(),
+                        ReachingCuts.NONE);
 
         /**
          * One comparison's accounting, and the position a reader is sent to for it.
@@ -152,9 +154,10 @@ public final class GuardThresholds {
         List<Guards.AtAPosition> accounting = new ArrayList<>();
         List<Guards.Singled> singled = new ArrayList<>();
         List<LineDrawn> between = new ArrayList<>();
+        ReachingCuts.Collected cuts = new ReachingCuts.Collected();
         walk(behavior, body, plan, InputReads.of(inputs), symbols, quantities,
-                found, unread, singled, between, accounting);
-        return new Guards(found, unread, singled, between, accounting);
+                found, unread, singled, between, accounting, List.of(), cuts);
+        return new Guards(found, unread, singled, between, accounting, cuts.made());
     }
 
     private static void walk(String behavior, Core e, CoverageSites.Plan plan,
@@ -162,10 +165,12 @@ public final class GuardThresholds {
                              List<Threshold> out,
                              List<UnreadRule> unread,
                              List<Guards.Singled> singled, List<LineDrawn> between,
-                             List<Guards.AtAPosition> accounting) {
+                             List<Guards.AtAPosition> accounting,
+                             List<ReachingCuts.Cut> assumed, ReachingCuts.Collected cuts) {
+        List<Placed> comparisons = e instanceof Core.If iff ? comparisonsIn(iff.cond()) : List.of();
         if (e instanceof Core.If iff) {
             List<Core> read = read(behavior, iff, plan, reads, symbols, quantities, out, singled,
-                    between, accounting);
+                    between, accounting, comparisons, assumed, cuts);
             // Every comparison this condition holds that nothing turned into a line — asked of the
             // comparisons and not of the positions. One position carries more than one statement,
             // and a line read at it says nothing about the rest: kept per position, a threshold on
@@ -185,8 +190,45 @@ public final class GuardThresholds {
         // walk that did not follow the binding would find its comparisons about nothing.
         InputReads inside = e instanceof Core.LetIn let ? reads.and(let.binder(), let.value())
                 : reads;
+        if (e instanceof Core.If iff) {
+            // The arms under what each of them proves of the condition, and the condition itself
+            // under what stood above the fork. A comparison inside a condition is not below the
+            // fork: it runs to decide it.
+            walk(behavior, iff.cond(), plan, inside, symbols, quantities, out, unread, singled,
+                    between, accounting, assumed, cuts);
+            walk(behavior, iff.then(), plan, inside, symbols, quantities, out, unread, singled,
+                    between, accounting,
+                    taking(comparisons, true, assumed, inside, symbols), cuts);
+            walk(behavior, iff.els(), plan, inside, symbols, quantities, out, unread, singled,
+                    between, accounting,
+                    taking(comparisons, false, assumed, inside, symbols), cuts);
+            return;
+        }
         Core.forEachChild(e, child -> walk(behavior, child, plan, inside, symbols, quantities,
-                out, unread, singled, between, accounting));
+                out, unread, singled, between, accounting, assumed, cuts));
+    }
+
+    /**
+     * What stands inside one arm of a fork: what stood above it, and what that arm proves of the
+     * comparisons the condition is made of.
+     *
+     * <p>Each comparison on its own terms. A conjunction's {@code then} arm proves every one of them
+     * held and its {@code else} arm proves nothing about any of them; a disjunction is the other way
+     * round. Read off the arm instead of off each comparison's place in the condition, an arm would
+     * carry a condition half the rows in it never failed — and a region built out of that excludes
+     * rows that reach the guard, which is the direction that takes a coverage item away.
+     */
+    private static List<ReachingCuts.Cut> taking(List<Placed> comparisons, boolean onThen,
+                                                 List<ReachingCuts.Cut> assumed, InputReads reads,
+                                                 Symbols symbols) {
+        List<ReachingCuts.Cut> out = assumed;
+        for (Placed each : comparisons) {
+            if (onThen ? each.trueThen() : each.falseElse()) {
+                out = ReachingCuts.and(out,
+                        ReachingCuts.of(each.comparison(), onThen, reads, symbols));
+            }
+        }
+        return out;
     }
 
     /**
@@ -387,7 +429,8 @@ public final class GuardThresholds {
                                    souther.compiler.inputs.Quantities quantities,
                                    List<Threshold> out,
                                    List<Guards.Singled> singled, List<LineDrawn> between,
-                                   List<Guards.AtAPosition> accounting) {
+                                   List<Guards.AtAPosition> accounting, List<Placed> comparisons,
+                                   List<ReachingCuts.Cut> assumed, ReachingCuts.Collected cuts) {
         // The comparisons a line came of, and not the positions they were about. A position carries
         // more than one statement and reading one of them settles nothing about the others.
         List<Core> made = new ArrayList<>();
@@ -399,13 +442,16 @@ public final class GuardThresholds {
         if (guard == null) {
             return made;   // no site for this `if`: nothing could answer for it
         }
-        for (Placed each : comparisonsIn(iff.cond())) {
+        for (Placed each : comparisons) {
             // The plan numbered every comparison of an instrumented condition before anything read a
             // line off one, so this is here. Required rather than looked up leniently: a line whose
             // comparison has no site is this reader and the plan disagreeing about what a condition
             // is made of.
             souther.compiler.coverage.ComparisonOccurrence site =
                     plan.requireComparisonAt(each.comparison());
+            // What a row had to satisfy to arrive here, filed where it was assumed. A border read
+            // off this comparison is searched for inside it.
+            cuts.reached(site, assumed);
             // What the comparison cuts is one question with one answer ({@link Cutting}). What is
             // added here is what meeting the line takes, which is a guard's own answer and no other
             // rule's.
@@ -615,8 +661,20 @@ public final class GuardThresholds {
                 iff.origin().kind(), Citation.of(comparison.pos()));
     }
 
-    /** One comparison of a condition, and which arms of the {@code if} prove it was evaluated. */
-    private record Placed(Core.Binary comparison, OriginRef.GuardOrigin.Witness witness) {}
+    /**
+     * One comparison of a condition, and what its place in that condition settles.
+     *
+     * <p>Which arms prove it was evaluated, and which arms prove what it came to. The two are not
+     * one answer: under {@code A && B} the {@code else} arm holds rows that reached {@code B} and
+     * rows that never did, so it proves {@code B} was evaluated nowhere and proves {@code A} false
+     * nowhere either. A reader that took the first for the second would assume, of every row in an
+     * arm, a condition half of them never failed.
+     *
+     * @param trueThen  whether reaching the {@code then} arm proves this comparison held
+     * @param falseElse whether reaching the {@code else} arm proves it did not
+     */
+    private record Placed(Core.Binary comparison, OriginRef.GuardOrigin.Witness witness,
+                          boolean trueThen, boolean falseElse) {}
 
     /**
      * The comparisons a condition is made of, each with what its own place leaves as evidence.
@@ -699,7 +757,8 @@ public final class GuardThresholds {
             return;
         }
         if (e instanceof Core.Binary comparison && !combines(comparison.op())) {
-            out.add(new Placed(comparison, reached.witness()));
+            out.add(new Placed(comparison, reached.witness(), reached.trueThen(),
+                    reached.falseElse()));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -169,8 +169,13 @@ public final class GuardThresholds {
                              List<ReachingCuts.Cut> assumed, ReachingCuts.Collected cuts) {
         List<Placed> comparisons = e instanceof Core.If iff ? comparisonsIn(iff.cond()) : List.of();
         if (e instanceof Core.If iff) {
+            // What a row had already satisfied when each of this condition's comparisons ran,
+            // filed where it was assumed. Asked of the condition rather than of the fork: a
+            // condition stops as soon as it is settled, so what stands when the second comparison
+            // runs is not what stood when the first did.
+            ReachingCuts.collect(iff.cond(), assumed, plan, reads, symbols, cuts);
             List<Core> read = read(behavior, iff, plan, reads, symbols, quantities, out, singled,
-                    between, accounting, comparisons, assumed, cuts);
+                    between, accounting, comparisons);
             // Every comparison this condition holds that nothing turned into a line — asked of the
             // comparisons and not of the positions. One position carries more than one statement,
             // and a line read at it says nothing about the rest: kept per position, a threshold on
@@ -198,10 +203,10 @@ public final class GuardThresholds {
                     between, accounting, assumed, cuts);
             walk(behavior, iff.then(), plan, inside, symbols, quantities, out, unread, singled,
                     between, accounting,
-                    taking(comparisons, true, assumed, inside, symbols), cuts);
+                    taking(iff.cond(), true, assumed, inside, symbols), cuts);
             walk(behavior, iff.els(), plan, inside, symbols, quantities, out, unread, singled,
                     between, accounting,
-                    taking(comparisons, false, assumed, inside, symbols), cuts);
+                    taking(iff.cond(), false, assumed, inside, symbols), cuts);
             return;
         }
         Core.forEachChild(e, child -> walk(behavior, child, plan, inside, symbols, quantities,
@@ -210,25 +215,23 @@ public final class GuardThresholds {
 
     /**
      * What stands inside one arm of a fork: what stood above it, and what that arm proves of the
-     * comparisons the condition is made of.
+     * condition.
      *
-     * <p>Each comparison on its own terms. A conjunction's {@code then} arm proves every one of them
-     * held and its {@code else} arm proves nothing about any of them; a disjunction is the other way
-     * round. Read off the arm instead of off each comparison's place in the condition, an arm would
-     * carry a condition half the rows in it never failed — and a region built out of that excludes
-     * rows that reach the guard, which is the direction that takes a coverage item away.
+     * <p>Asked of {@link ReachingCuts#stating}, which is the same rule that says what reaching the
+     * right operand of a condition establishes. Both are "this subtree came out this way, so what
+     * follows", and written apart they would agree by having been derived alike — until one of them
+     * learned to read a shape of condition the other did not.
      */
-    private static List<ReachingCuts.Cut> taking(List<Placed> comparisons, boolean onThen,
+    private static List<ReachingCuts.Cut> taking(Core condition, boolean onThen,
                                                  List<ReachingCuts.Cut> assumed, InputReads reads,
                                                  Symbols symbols) {
-        List<ReachingCuts.Cut> out = assumed;
-        for (Placed each : comparisons) {
-            if (onThen ? each.trueThen() : each.falseElse()) {
-                out = ReachingCuts.and(out,
-                        ReachingCuts.of(each.comparison(), onThen, reads, symbols));
-            }
+        List<ReachingCuts.Cut> arm = ReachingCuts.stating(condition, onThen, reads, symbols);
+        if (arm.isEmpty()) {
+            return assumed;
         }
-        return out;
+        List<ReachingCuts.Cut> out = new ArrayList<>(assumed);
+        out.addAll(arm);
+        return List.copyOf(out);
     }
 
     /**
@@ -429,8 +432,8 @@ public final class GuardThresholds {
                                    souther.compiler.inputs.Quantities quantities,
                                    List<Threshold> out,
                                    List<Guards.Singled> singled, List<LineDrawn> between,
-                                   List<Guards.AtAPosition> accounting, List<Placed> comparisons,
-                                   List<ReachingCuts.Cut> assumed, ReachingCuts.Collected cuts) {
+                                   List<Guards.AtAPosition> accounting,
+                                   List<Placed> comparisons) {
         // The comparisons a line came of, and not the positions they were about. A position carries
         // more than one statement and reading one of them settles nothing about the others.
         List<Core> made = new ArrayList<>();
@@ -449,9 +452,6 @@ public final class GuardThresholds {
             // is made of.
             souther.compiler.coverage.ComparisonOccurrence site =
                     plan.requireComparisonAt(each.comparison());
-            // What a row had to satisfy to arrive here, filed where it was assumed. A border read
-            // off this comparison is searched for inside it.
-            cuts.reached(site, assumed);
             // What the comparison cuts is one question with one answer ({@link Cutting}). What is
             // added here is what meeting the line takes, which is a guard's own answer and no other
             // rule's.
@@ -661,20 +661,8 @@ public final class GuardThresholds {
                 iff.origin().kind(), Citation.of(comparison.pos()));
     }
 
-    /**
-     * One comparison of a condition, and what its place in that condition settles.
-     *
-     * <p>Which arms prove it was evaluated, and which arms prove what it came to. The two are not
-     * one answer: under {@code A && B} the {@code else} arm holds rows that reached {@code B} and
-     * rows that never did, so it proves {@code B} was evaluated nowhere and proves {@code A} false
-     * nowhere either. A reader that took the first for the second would assume, of every row in an
-     * arm, a condition half of them never failed.
-     *
-     * @param trueThen  whether reaching the {@code then} arm proves this comparison held
-     * @param falseElse whether reaching the {@code else} arm proves it did not
-     */
-    private record Placed(Core.Binary comparison, OriginRef.GuardOrigin.Witness witness,
-                          boolean trueThen, boolean falseElse) {}
+    /** One comparison of a condition, and which arms of the {@code if} prove it was evaluated. */
+    private record Placed(Core.Binary comparison, OriginRef.GuardOrigin.Witness witness) {}
 
     /**
      * The comparisons a condition is made of, each with what its own place leaves as evidence.
@@ -757,8 +745,7 @@ public final class GuardThresholds {
             return;
         }
         if (e instanceof Core.Binary comparison && !combines(comparison.op())) {
-            out.add(new Placed(comparison, reached.witness(), reached.trueThen(),
-                    reached.falseElse()));
+            out.add(new Placed(comparison, reached.witness()));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -167,13 +167,18 @@ public final class GuardThresholds {
                              List<Guards.Singled> singled, List<LineDrawn> between,
                              List<Guards.AtAPosition> accounting,
                              List<ReachingCuts.Cut> assumed, ReachingCuts.Collected cuts) {
-        List<Placed> comparisons = e instanceof Core.If iff ? comparisonsIn(iff.cond()) : List.of();
+        // One reading of this condition, folded by everything that asks about it. Made here so the
+        // comparisons, what stands where each of them runs, and what each arm proves are three
+        // answers about one structure rather than three walks that agree by having been written
+        // alike.
+        Condition asked = e instanceof Core.If iff ? Condition.of(iff.cond(), reads) : null;
+        List<Placed> comparisons = asked == null ? List.of() : comparisonsIn(asked, plan);
         if (e instanceof Core.If iff) {
             // What a row had already satisfied when each of this condition's comparisons ran,
             // filed where it was assumed. Asked of the condition rather than of the fork: a
             // condition stops as soon as it is settled, so what stands when the second comparison
             // runs is not what stood when the first did.
-            ReachingCuts.collect(iff.cond(), assumed, plan, reads, symbols, cuts);
+            ReachingCuts.collect(asked, assumed, plan, symbols, cuts);
             List<Core> read = read(behavior, iff, plan, reads, symbols, quantities, out, singled,
                     between, accounting, comparisons);
             // Every comparison this condition holds that nothing turned into a line — asked of the
@@ -203,10 +208,10 @@ public final class GuardThresholds {
                     between, accounting, assumed, cuts);
             walk(behavior, iff.then(), plan, inside, symbols, quantities, out, unread, singled,
                     between, accounting,
-                    taking(iff.cond(), true, assumed, inside, symbols), cuts);
+                    taking(asked, true, assumed, symbols), cuts);
             walk(behavior, iff.els(), plan, inside, symbols, quantities, out, unread, singled,
                     between, accounting,
-                    taking(iff.cond(), false, assumed, inside, symbols), cuts);
+                    taking(asked, false, assumed, symbols), cuts);
             return;
         }
         Core.forEachChild(e, child -> walk(behavior, child, plan, inside, symbols, quantities,
@@ -222,10 +227,9 @@ public final class GuardThresholds {
      * follows", and written apart they would agree by having been derived alike — until one of them
      * learned to read a shape of condition the other did not.
      */
-    private static List<ReachingCuts.Cut> taking(Core condition, boolean onThen,
-                                                 List<ReachingCuts.Cut> assumed, InputReads reads,
-                                                 Symbols symbols) {
-        List<ReachingCuts.Cut> arm = ReachingCuts.stating(condition, onThen, reads, symbols);
+    private static List<ReachingCuts.Cut> taking(Condition condition, boolean onThen,
+                                                 List<ReachingCuts.Cut> assumed, Symbols symbols) {
+        List<ReachingCuts.Cut> arm = ReachingCuts.stating(condition, onThen, symbols);
         if (arm.isEmpty()) {
             return assumed;
         }
@@ -455,9 +459,9 @@ public final class GuardThresholds {
             // What the comparison cuts is one question with one answer ({@link Cutting}). What is
             // added here is what meeting the line takes, which is a guard's own answer and no other
             // rule's.
-            Cutting cutting = Cutting.of(behavior, each.comparison(), reads, symbols, quantities);
+            Cutting cutting = Cutting.of(behavior, each.comparison(), each.reads(), symbols, quantities);
             if (cutting == null) {
-                raisesNoLine(accounting, behavior, iff, each.comparison(), reads, symbols);
+                raisesNoLine(accounting, behavior, iff, each.comparison(), each.reads(), symbols);
                 continue;
             }
             OriginRef.GuardOrigin origin = new OriginRef.GuardOrigin(
@@ -479,22 +483,22 @@ public final class GuardThresholds {
                 // line — so a second rule over one form left the first one's run going to the end
                 // of the order, past it.
                 if (!Border.reaches(cutting.target(), cutting.within())) {
-                    raisesNoLine(accounting, behavior, iff, each.comparison(), reads,
+                    raisesNoLine(accounting, behavior, iff, each.comparison(), each.reads(),
                             symbols);
                     continue;
                 }
                 between.add(new LineDrawn(cutting, origin));
                 List<TermPath> named = new ArrayList<>();
-                mentioned(each.comparison().left(), reads, symbols, named);
-                mentioned(each.comparison().right(), reads, symbols, named);
+                mentioned(each.comparison().left(), each.reads(), symbols, named);
+                mentioned(each.comparison().right(), each.reads(), symbols, named);
                 if (named.isEmpty()) {
                     continue;   // a comparison about no position of the input raises nothing
                 }
                 // Filed at the position the reading names first, which is the one a line between two
                 // would be read `on`. One comparison is one line however many positions it mentions.
                 raises(accounting, behavior, iff, each.comparison(), named.get(0),
-                        comparedTerm(each.comparison(), reads, symbols),
-                        subjectsOf(each.comparison(), reads, symbols, null),
+                        comparedTerm(each.comparison(), each.reads(), symbols),
+                        subjectsOf(each.comparison(), each.reads(), symbols, null),
                         new Required.LineRead.ALineBetweenTwoPositions());
                 continue;
             }
@@ -523,7 +527,7 @@ public final class GuardThresholds {
                 between.add(new LineDrawn(cutting, origin));
             }
             raises(accounting, behavior, iff, each.comparison(), divided.path(), divided,
-                    subjectsOf(each.comparison(), reads, symbols, null),
+                    subjectsOf(each.comparison(), each.reads(), symbols, null),
                     new Required.LineRead.ALineOnThePosition());
         }
         return made;
@@ -661,8 +665,16 @@ public final class GuardThresholds {
                 iff.origin().kind(), Citation.of(comparison.pos()));
     }
 
-    /** One comparison of a condition, and which arms of the {@code if} prove it was evaluated. */
-    private record Placed(Core.Binary comparison, OriginRef.GuardOrigin.Witness witness) {}
+    /**
+     * One comparison of a condition, which arms of the {@code if} prove it was evaluated, and where
+     * the names in it point.
+     *
+     * <p>The reading travels with the comparison because it is not the same at every one of them: a
+     * comparison inside an expanded helper is about the argument the call handed it, and read
+     * against the names outside the binding it is about nothing at all.
+     */
+    private record Placed(Core.Binary comparison, InputReads reads,
+                          OriginRef.GuardOrigin.Witness witness) {}
 
     /**
      * The comparisons a condition is made of, each with what its own place leaves as evidence.
@@ -678,12 +690,28 @@ public final class GuardThresholds {
      * evaluated at all on a given arm, and whether reaching that arm forces the subtree's own value
      * — because it is the second that says whether the operand to its left was true, which is what
      * decides whether the operand to its right ran.
+     *
+     * <p><b>The ones the plan numbered, which is not all of them.</b> Meeting a guard's line takes
+     * getting the comparison to answer, and whether it answered is what a site records — so a
+     * comparison with no site is one no row could ever be shown to have reached, and a border drawn
+     * on it would owe a row nothing can measure.
+     *
+     * <p>Which is where a comparison inside a helper called in a condition falls today: the plan
+     * numbers the conditions of a body and an expanded helper's comparison is not one of them, so it
+     * raises nothing ({@code AComparisonInsideAHelperRaisesNothingTest}). That is a gap of its own
+     * and not this reading's to close.
+     *
+     * <p>It does not follow that such a comparison says nothing. What a condition <em>establishes</em>
+     * is a fact about the model and wants no instrumentation — a helper returning true is its body
+     * holding — so {@link ReachingCuts} takes it in over the whole reading and only this, which is
+     * about what a row is owed, asks the plan.
      */
-    private static List<Placed> comparisonsIn(Core condition) {
+    private static List<Placed> comparisonsIn(Condition condition, CoverageSites.Plan plan) {
         List<Placed> out = new ArrayList<>();
         // At the top there is nothing above to have stopped the condition, and the arm taken is the
         // condition's own value.
         placed(condition, new Reached(true, true, true, true), out);
+        out.removeIf(each -> plan.comparisonAt(each.comparison()).isEmpty());
         return out;
     }
 
@@ -722,13 +750,15 @@ public final class GuardThresholds {
         }
     }
 
-    private static boolean combines(Hir.BinOp op) {
-        return op == Hir.BinOp.AND || op == Hir.BinOp.OR;
-    }
-
-    private static void placed(Core e, Reached reached, List<Placed> out) {
-        if (e instanceof Core.Binary binary && combines(binary.op())) {
-            boolean and = binary.op() == Hir.BinOp.AND;
+    private static void placed(Condition e, Reached reached, List<Placed> out) {
+        if (e instanceof Condition.Compares one) {
+            out.add(new Placed(one.at(), one.reads(), reached.witness()));
+            return;
+        }
+        if (e instanceof Condition.Both || e instanceof Condition.Either) {
+            boolean and = e instanceof Condition.Both;
+            Condition leftOf = and ? ((Condition.Both) e).left() : ((Condition.Either) e).left();
+            Condition rightOf = and ? ((Condition.Both) e).right() : ((Condition.Either) e).right();
             // A conjunction's value being true makes both its operands true; a disjunction's being
             // false makes both false. Neither says anything the other way round.
             Reached left = new Reached(reached.onThen(), reached.onElse(),
@@ -740,12 +770,8 @@ public final class GuardThresholds {
                     and && reached.onThen() && reached.trueThen(),
                     !and && reached.onElse() && reached.falseElse(),
                     and && reached.trueThen(), !and && reached.falseElse());
-            placed(binary.left(), left, out);
-            placed(binary.right(), right, out);
-            return;
-        }
-        if (e instanceof Core.Binary comparison && !combines(comparison.op())) {
-            out.add(new Placed(comparison, reached.witness()));
+            placed(leftOf, left, out);
+            placed(rightOf, right, out);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/LevelRealizer.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LevelRealizer.java
@@ -80,28 +80,86 @@ public final class LevelRealizer {
      */
     private Realization ofTwo(Standing.OfTwoOnOneCarrier two,
                               souther.compiler.inputs.SearchRegion within) {
-        Place common = commonPlace(bounds(within, two.on()), bounds(within, two.against()), two.of(),
+        NumericDomain.Bounds on = bounds(within, two.on());
+        NumericDomain.Bounds together = commonRange(on, bounds(within, two.against()), two.of(),
                 two.where().anchor().asACount());
-        if (common == null) {
-            return new Realization.Unknown(Realization.Unknown.Reason.NOTHING_COMPOSED_ONE);
+        for (Place common : alongTheLine(together, two.of())) {
+            // Where the first has to stand relative to the second: the place the level's distance
+            // from it, and then whatever the item asks of that place. Arithmetic on the carrier's
+            // counts and not a walk along it — a walk is an addition that only exists where the
+            // order has a smallest step, so a rule over two decimals had no pair anything could
+            // compose.
+            // Null where the carrier's arithmetic could not put the item's levels beside the place
+            // the other position stands at — read on, an item with no level in it was handed to a
+            // reader that asks where its level falls.
+            Criterion here = relativeTo(two.where(), common, two.of());
+            Place at = here == null ? null : placeMeeting(here, two.of(), on);
+            if (at == null) {
+                continue;
+            }
+            Map<NumericTerm, Place> fixing = new LinkedHashMap<>();
+            fixing.put(two.on(), at);
+            fixing.put(two.against(), common);
+            if (found(fixing, within) instanceof Realization.Found made) {
+                return made;
+            }
         }
-        // Where the first has to stand relative to the second: the place the level's distance from
-        // it, and then whatever the item asks of that place. Arithmetic on the carrier's counts and
-        // not a walk along it — a walk is an addition that only exists where the order has a
-        // smallest step, so a rule over two decimals had no pair anything could compose.
-        // Null where the carrier's arithmetic could not put the item's levels beside the place the
-        // other position stands at. Reported as a search that composed nothing, which is what it is
-        // — read on, an item with no level in it was handed to a reader that asks where its level
-        // falls.
-        Criterion here = relativeTo(two.where(), common, two.of());
-        Place at = here == null ? null : placeMeeting(here, two.of(), bounds(within, two.on()));
-        if (at == null) {
-            return new Realization.Unknown(Realization.Unknown.Reason.NOTHING_COMPOSED_ONE);
+        return new Realization.Unknown(Realization.Unknown.Reason.NOTHING_COMPOSED_ONE);
+    }
+
+    /**
+     * How many places along a line a pair is tried at before this stops.
+     *
+     * <p>Small on purpose. What a range cannot say is that one of its values is missing, and a rule
+     * that takes a value away takes one — everything that moves an end is in the range already. So
+     * what this steps past is holes, and there are as many of those as the rules state.
+     */
+    private static final int HOW_MANY_PLACES_A_PAIR_IS_TRIED_AT = 64;
+
+    /**
+     * The places to try the pair at, from the one the ranges leave outward.
+     *
+     * <p>Every place on the line carries the pair as well as any other — where they stand is a
+     * witness and the line is the item ({@link Standing.OfTwoOnOneCarrier}) — so one that the rules
+     * refuse is one to step off rather than an answer.
+     *
+     * <p>Which is a distinction the ranges cannot make. A place is chosen from what the two ranges
+     * leave and whether it stands is the rules' to say, and a range has no word for a value taken
+     * out of the middle of it: before anything narrowed a search, nothing the ranges left was ever
+     * refused and the two never disagreed. A region draws one value out and the pair at it is the
+     * only pair on the line that cannot be written.
+     *
+     * <p>One place where the carrier's values do not count. There is no next place to step to, so
+     * the one the ranges leave is the whole of what there is to try.
+     */
+    private static List<Place> alongTheLine(NumericDomain.Bounds together, Carrier carrier) {
+        Place first = carrier.somethingInside(together.min(), together.max());
+        if (first == null) {
+            return List.of();
         }
-        Map<NumericTerm, Place> fixing = new LinkedHashMap<>();
-        fixing.put(two.on(), at);
-        fixing.put(two.against(), common);
-        return found(fixing, within);
+        if (!carrier.counts()) {
+            return List.of(first);
+        }
+        List<Place> out = new java.util.ArrayList<>();
+        out.add(first);
+        for (int step = 1; out.size() < HOW_MANY_PLACES_A_PAIR_IS_TRIED_AT; step++) {
+            Place above = carrier.onTheGrid(Count.number(first).plus(Count.of(step)));
+            Place below = carrier.onTheGrid(Count.number(first).plus(Count.of(-step)));
+            boolean took = false;
+            if (above != null && together.admits(above)) {
+                out.add(above);
+                took = true;
+            }
+            if (below != null && together.admits(below)
+                    && out.size() < HOW_MANY_PLACES_A_PAIR_IS_TRIED_AT) {
+                out.add(below);
+                took = true;
+            }
+            if (!took) {
+                break;
+            }
+        }
+        return List.copyOf(out);
     }
 
     /**
@@ -625,7 +683,8 @@ public final class LevelRealizer {
     }
 
     /**
-     * A place both positions of a line between them can hold, or null where their rules leave none.
+     * Where both positions of a line between them can stand, once the level's distance is taken off
+     * the first.
      *
      * <p>What proves a row can be written on such a line. The line is where the two positions are
      * equal, so a row on it writes one place at both — and whether one exists is the two positions'
@@ -635,14 +694,14 @@ public final class LevelRealizer {
      * fact about the rules; a range this could not read in full is a range this did not read, and the
      * caller is the one holding whether that happened.
      */
-    public static Place commonPlace(NumericDomain.Bounds on, NumericDomain.Bounds against,
-                                    Carrier carrier, Count apart) {
+    static NumericDomain.Bounds commonRange(NumericDomain.Bounds on, NumericDomain.Bounds against,
+                                            Carrier carrier, Count apart) {
         NumericDomain.Bounds moved = carrier.counts() ? shifted(on, apart.negate()) : on;
-        Endpoint min = Endpoint.lower(moved == null ? null : moved.min(),
-                against == null ? null : against.min());
-        Endpoint max = Endpoint.upper(moved == null ? null : moved.max(),
-                against == null ? null : against.max());
-        return carrier.somethingInside(min, max);
+        return new NumericDomain.Bounds(
+                Endpoint.lower(moved == null ? null : moved.min(),
+                        against == null ? null : against.min()),
+                Endpoint.upper(moved == null ? null : moved.max(),
+                        against == null ? null : against.max()));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/LevelRealizer.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LevelRealizer.java
@@ -32,39 +32,39 @@ import java.util.Optional;
  */
 public final class LevelRealizer {
 
-    private final souther.compiler.inputs.Quantities rules;
-
     /**
-     * @param rules what the declarations reaching this behavior's input leave its quantities, which
-     *              is what a row has to be written inside. Taken whole rather than as an end per
-     *              position: a rule relating two positions is not in either of their ranges, so a
-     *              search handed the ranges walks a box with a corner cut off it that it cannot see
-     *              — and offers a row in the corner
+     * Where the positions have to stand for a row to be at this item, or why this found nowhere.
+     *
+     * <p>The region is handed in per item and is no part of this. Where a row may be written depends
+     * on what the rules a row has to pass before it reaches this item leave, which is a fact about
+     * where the item's rule is written rather than about the behavior — held here, one region would
+     * answer for every item of a body and the search for a border deep in it would run over values
+     * nothing arriving there can hold.
+     *
+     * @param within where a row for this item may be written. Never wider than what the declarations
+     *               leave and never narrower than what reaches the item, which is what makes an
+     *               exhausted walk of it a proof
      */
-    public LevelRealizer(souther.compiler.inputs.Quantities rules) {
-        if (rules == null) {
+    public Realization realize(Standing standing, souther.compiler.inputs.SearchRegion within) {
+        if (within == null) {
             throw new IllegalArgumentException(
-                    "a search looks inside what the rules leave, and there is always a reading of"
-                            + " them: an input nothing was written about is one they leave"
-                            + " everything, which is an answer and not an absence");
+                    "a search looks inside a region, and there is always one: an item nothing on the"
+                            + " way to it narrows is searched for in what the declarations leave,"
+                            + " which is an answer and not an absence");
         }
-        this.rules = rules;
-    }
-
-    /** Where the positions have to stand, or why this found nowhere. */
-    public Realization realize(Standing standing) {
         return switch (standing) {
-            case Standing.OfOneCoordinate one -> ofOne(one);
-            case Standing.OfTwoOnOneCarrier two -> ofTwo(two);
-            case Standing.OfAForm over -> ofAForm(over);
+            case Standing.OfOneCoordinate one -> ofOne(one, within);
+            case Standing.OfTwoOnOneCarrier two -> ofTwo(two, within);
+            case Standing.OfAForm over -> ofAForm(over, within);
         };
     }
 
     /** One position at a place of its own carrier that the item accepts. */
-    private Realization ofOne(Standing.OfOneCoordinate one) {
-        Place at = placeMeeting(one.where(), one.of(), bounds(one.term()));
+    private Realization ofOne(Standing.OfOneCoordinate one,
+                              souther.compiler.inputs.SearchRegion within) {
+        Place at = placeMeeting(one.where(), one.of(), bounds(within, one.term()));
         return at == null ? new Realization.Unknown(Realization.Unknown.Reason.NOTHING_COMPOSED_ONE)
-                : found(Map.of(one.term(), at));
+                : found(Map.of(one.term(), at), within);
     }
 
     /**
@@ -78,8 +78,9 @@ public final class LevelRealizer {
      * that found nothing rather than as a proof, because two ranges leaving no place in common is a
      * fact about the ranges and the pair may be refused or admitted by a rule neither range holds.
      */
-    private Realization ofTwo(Standing.OfTwoOnOneCarrier two) {
-        Place common = commonPlace(bounds(two.on()), bounds(two.against()), two.of(),
+    private Realization ofTwo(Standing.OfTwoOnOneCarrier two,
+                              souther.compiler.inputs.SearchRegion within) {
+        Place common = commonPlace(bounds(within, two.on()), bounds(within, two.against()), two.of(),
                 two.where().anchor().asACount());
         if (common == null) {
             return new Realization.Unknown(Realization.Unknown.Reason.NOTHING_COMPOSED_ONE);
@@ -93,14 +94,14 @@ public final class LevelRealizer {
         // — read on, an item with no level in it was handed to a reader that asks where its level
         // falls.
         Criterion here = relativeTo(two.where(), common, two.of());
-        Place at = here == null ? null : placeMeeting(here, two.of(), bounds(two.on()));
+        Place at = here == null ? null : placeMeeting(here, two.of(), bounds(within, two.on()));
         if (at == null) {
             return new Realization.Unknown(Realization.Unknown.Reason.NOTHING_COMPOSED_ONE);
         }
         Map<NumericTerm, Place> fixing = new LinkedHashMap<>();
         fixing.put(two.on(), at);
         fixing.put(two.against(), common);
-        return found(fixing);
+        return found(fixing, within);
     }
 
     /**
@@ -138,7 +139,8 @@ public final class LevelRealizer {
      * that one's answer: whether a row can be composed at one of them is this one's, and the two are
      * apart so that how long this is willing to look does not read as a fact about the order.
      */
-    private Realization ofAForm(Standing.OfAForm over) {
+    private Realization ofAForm(Standing.OfAForm over,
+                                souther.compiler.inputs.SearchRegion within) {
         LevelSpace levels = over.levels();
         // In the form's own order and not the map's. A form is a map, so the order its coefficients
         // were recorded in is a hash order — and which position is solved last decides whether the
@@ -152,10 +154,10 @@ public final class LevelRealizer {
         boolean whole = levels.neighbour(new Level.ACount(Count.ZERO), Towards.ABOVE).isPresent();
         boolean bounded = true;
         for (Level level : LevelCandidateSource.forItem(over.where(), levels)) {
-            Search search = new Search(terms, over.of(), whole);
+            Search search = new Search(terms, over.of(), whole, within);
             Map<NumericTerm, Place> standing = search.solve(level.asACount());
             if (standing != null) {
-                Realization made = found(standing);
+                Realization made = found(standing, within);
                 if (made instanceof Realization.Found) {
                     return made;
                 }
@@ -198,6 +200,8 @@ public final class LevelRealizer {
         private final List<Map.Entry<NumericTerm, java.math.BigDecimal>> terms;
         private final Carrier carrier;
         private final boolean whole;
+        /** Where a row for the item being searched for may be written. */
+        private final souther.compiler.inputs.SearchRegion within;
         private final Place[] at;
         /**
          * Where each term runs before anything is fixed, worked out once.
@@ -214,14 +218,15 @@ public final class LevelRealizer {
         private boolean everyEndKnown = true;
 
         Search(List<Map.Entry<NumericTerm, java.math.BigDecimal>> terms, Carrier carrier,
-               boolean whole) {
+               boolean whole, souther.compiler.inputs.SearchRegion within) {
             this.terms = terms;
             this.carrier = carrier;
             this.whole = whole;
+            this.within = within;
             this.at = new Place[terms.size()];
             this.runsBetween = new NumericDomain.Bounds[terms.size()];
             for (int i = 0; i < terms.size(); i++) {
-                runsBetween[i] = bounds(terms.get(i).getKey());
+                runsBetween[i] = bounds(within, terms.get(i).getKey());
             }
         }
 
@@ -232,7 +237,7 @@ public final class LevelRealizer {
         }
 
         Map<NumericTerm, Place> solve(Count target) {
-            return walk(0, target.at(), rules) ? fixing() : null;
+            return walk(0, target.at(), within) ? fixing() : null;
         }
 
         private Map<NumericTerm, Place> fixing() {
@@ -243,7 +248,7 @@ public final class LevelRealizer {
             return out;
         }
 
-        private boolean walk(int i, java.math.BigDecimal owed, souther.compiler.inputs.Quantities here) {
+        private boolean walk(int i, java.math.BigDecimal owed, souther.compiler.inputs.SearchRegion here) {
             if (++taken > STEPS_A_SEARCH_MAY_TAKE) {
                 return false;
             }
@@ -325,7 +330,7 @@ public final class LevelRealizer {
                 if (inside == null || !(inside instanceof Count taken)) {
                     return false;
                 }
-                souther.compiler.inputs.Quantities next = narrowing(here, terms.get(i).getKey(), taken.at());
+                souther.compiler.inputs.SearchRegion next = narrowing(here, terms.get(i).getKey(), taken.at());
                 if (next == null) {
                     return false;
                 }
@@ -338,7 +343,7 @@ public final class LevelRealizer {
                 // nothing beside is skipped here rather than offered and refused where the row is
                 // built: refused there, one candidate coming back rejected is reported as every
                 // value having been tried.
-                souther.compiler.inputs.Quantities next = narrowing(here, terms.get(i).getKey(), x);
+                souther.compiler.inputs.SearchRegion next = narrowing(here, terms.get(i).getKey(), x);
                 if (next == null) {
                     continue;
                 }
@@ -372,13 +377,13 @@ public final class LevelRealizer {
          * arriving by way of a budget. So the last step is {@link #theRulesHaveNotRefused} and is
          * not budgeted.
          */
-        private souther.compiler.inputs.Quantities narrowing(souther.compiler.inputs.Quantities here, NumericTerm term,
+        private souther.compiler.inputs.SearchRegion narrowing(souther.compiler.inputs.SearchRegion here, NumericTerm term,
                                     java.math.BigDecimal at) {
             if (asked >= HOW_OFTEN_THE_RULES_ARE_ASKED_AGAIN) {
                 return here;
             }
             asked++;
-            souther.compiler.inputs.Quantities next = here.given(term, new Count(at));
+            souther.compiler.inputs.SearchRegion next = here.given(term, new Count(at));
             return next.emptiness().isPresent() ? null : next;
         }
 
@@ -402,7 +407,7 @@ public final class LevelRealizer {
             for (int j = 0; j < terms.size(); j++) {
                 all.put(terms.get(j).getKey(), at[j]);
             }
-            return LevelRealizer.this.theRulesHaveNotRefused(all);
+            return LevelRealizer.this.theRulesHaveNotRefused(all, within);
         }
 
         /**
@@ -662,10 +667,6 @@ public final class LevelRealizer {
                 : new Endpoint(count.plus(by), end.inclusive());
     }
 
-    private NumericDomain.Bounds bounds(NumericTerm term) {
-        return bounds(rules, term);
-    }
-
     /**
      * A placement handed back, or nothing composed where the rules were shown to leave none.
      *
@@ -681,8 +682,9 @@ public final class LevelRealizer {
      * the rules are already known to refuse, offered as a row and then reported as though the point
      * had nothing at it.
      */
-    private Realization found(Map<NumericTerm, Place> fixing) {
-        return theRulesHaveNotRefused(fixing)
+    private Realization found(Map<NumericTerm, Place> fixing,
+                              souther.compiler.inputs.SearchRegion within) {
+        return theRulesHaveNotRefused(fixing, within)
                 ? new Realization.Found(fixing)
                 : new Realization.Unknown(Realization.Unknown.Reason.NOTHING_COMPOSED_ONE);
     }
@@ -708,18 +710,19 @@ public final class LevelRealizer {
      * about the values in it. Anything more would be a claim about an order this reading does not
      * reach.
      */
-    private boolean theRulesHaveNotRefused(Map<NumericTerm, Place> fixing) {
+    private boolean theRulesHaveNotRefused(Map<NumericTerm, Place> fixing,
+                                           souther.compiler.inputs.SearchRegion within) {
         Map<NumericTerm, Count> counted = new LinkedHashMap<>();
         fixing.forEach((term, at) -> {
             if (at instanceof Count count) {
                 counted.put(term, count);
             }
         });
-        return counted.isEmpty() || rules.given(counted).emptiness().isEmpty();
+        return counted.isEmpty() || within.given(counted).emptiness().isEmpty();
     }
 
     /** The same, of the rules as some of the positions have been fixed. */
-    private static NumericDomain.Bounds bounds(souther.compiler.inputs.Quantities rules,
+    private static NumericDomain.Bounds bounds(souther.compiler.inputs.SearchRegion rules,
                                                NumericTerm term) {
         NumericDomain.Bounds held = rules.runsBetween(term);
         return held == null ? new NumericDomain.Bounds(null, null) : held;

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -82,7 +82,8 @@ public final class Partitions {
                                List<souther.compiler.inputs.PositionReadingBlocked> blocked,
                                List<souther.compiler.inputs.PositionValuesNotSeparated> notSeparated,
                                List<Border> between,
-                               List<GuardThresholds.Guards.AtAPosition> compared) {
+                               List<GuardThresholds.Guards.AtAPosition> compared,
+                               ReachingCuts reaching) {
         public Partitioning {
             compared = List.copyOf(compared);
             axes = List.copyOf(axes);
@@ -200,7 +201,7 @@ public final class Partitions {
         }
         return new Partitioning(kept, omitted, quantities, uncertain, undividedIn(measured),
                 List.copyOf(unread), blockedIn(measured), List.copyOf(notSeparated),
-                List.of(), List.of());
+                List.of(), List.of(), ReachingCuts.NONE);
     }
 
     /**
@@ -368,6 +369,27 @@ public final class Partitions {
                                               souther.compiler.check.PathReachability.Answers
                                                       arrives,
                                               List<GuardThresholds.Guards.AtAPosition> compared) {
+        return withThresholds(base, thresholds, symbols, policy, unread, singled, between, arrives,
+                compared, ReachingCuts.NONE);
+    }
+
+    /**
+     * The same, told what a row has already had to satisfy by the time it reaches each comparison.
+     *
+     * <p>Carried and not re-derived, which is the whole discipline {@link ReachingCuts} is written
+     * around: what a region may assume is what the walk of the body actually took in, and a reading
+     * that recovered it from where a comparison sits would be free to name a condition nothing here
+     * could read.
+     */
+    public static Partitioning withThresholds(Partitioning base, List<Threshold> thresholds,
+                                              Symbols symbols, ReadingPolicy policy,
+                                              List<UnreadRule> unread,
+                                              List<GuardThresholds.Guards.Singled> singled,
+                                              List<LineDrawn> between,
+                                              souther.compiler.check.PathReachability.Answers
+                                                      arrives,
+                                              List<GuardThresholds.Guards.AtAPosition> compared,
+                                              ReachingCuts reaching) {
         // Both producers of one kind of evidence. What a body compared and what a type's own rules
         // bound are read by different readers and answer the same question, so a position either of
         // them wrote about and neither could turn into a line is named once, whichever wrote it.
@@ -476,7 +498,8 @@ public final class Partitions {
                 // came from. A line that divides a position leaves its division on the axis and,
                 // where the position has no value beside it, its border over here — and the two
                 // sides of that border are runs of what all of them leave.
-                base.notSeparated(), Border.allOf(between, partedByQuantity(out)), compared);
+                base.notSeparated(), Border.allOf(between, partedByQuantity(out)), compared,
+                reaching);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
@@ -1,0 +1,151 @@
+package souther.compiler.partition;
+
+import souther.compiler.check.ComparisonClaim;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.coverage.ComparisonOccurrence;
+import souther.compiler.inputs.InputReads;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.SearchRegion;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.numeric.NumericDomain.LinearForm;
+import souther.compiler.numeric.NumericDomain.Rel;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * What a row has already had to satisfy by the time it arrives at one comparison.
+ *
+ * <p>The region a border a guard owes is searched in. A guard states a threshold and narrows no
+ * declaration, so what the positions are declared to hold is the same everywhere in a body while
+ * what actually arrives at a comparison deep in one is not — and a row for a border down there,
+ * looked for over the declared domains, is looked for outside the region as readily as inside it.
+ *
+ * <p><b>Collected where the condition is assumed, and never worked out afterwards from where a
+ * comparison sits.</b> A reading that walked back up the tree would be a second account of what was
+ * assumed, free to name a condition nothing here could take in — and a region narrowed on a
+ * condition nothing established is narrower than the rows that arrive, which is the one direction
+ * that takes a coverage item away. So what is here is what the walk itself put in, and a condition
+ * the arithmetic has no word for leaves nothing behind.
+ *
+ * <p><b>Its own value and not its arm.</b> Under {@code A && B} the {@code then} arm is reached with
+ * both holding, and the {@code else} arm with neither settled — a row can be in it for failing
+ * either. Under {@code A || B} it is the other way round. Which of the two a comparison is in is
+ * {@link GuardThresholds}'s reading of the condition, and taking an arm for a conjunct is how a
+ * region would come to exclude rows that reach the guard.
+ *
+ * <p>Nothing here says a row that satisfies all of this arrives. A condition of a shape the
+ * arithmetic cannot read is not on the list, so what this describes is wider than what arrives —
+ * which is what {@link SearchRegion} promises and what a proof of unreachability rests on.
+ */
+public record ReachingCuts(Map<ComparisonOccurrence, List<ReachingCuts.Cut>> byComparison) {
+
+    public static final ReachingCuts NONE = new ReachingCuts(Map.of());
+
+    public ReachingCuts {
+        byComparison = Map.copyOf(byComparison);
+    }
+
+    /** One thing a row had to satisfy to get here: {@code form rel 0} over this input's terms. */
+    public record Cut(LinearForm<NumericTerm> form, Rel rel) {}
+
+    /**
+     * {@code region}, narrowed to what reaches {@code site}.
+     *
+     * <p>{@code region} itself where nothing was collected there, which is a comparison at the top
+     * of a body as much as it is one this could read nothing on the way to. The two are not told
+     * apart because nothing downstream acts on the difference: both leave a region as wide as the
+     * declarations, and both are sound.
+     */
+    public SearchRegion narrowing(SearchRegion region, ComparisonOccurrence site) {
+        for (Cut each : byComparison.getOrDefault(site, List.of())) {
+            region = region.assuming(each.form(), each.rel());
+        }
+        return region;
+    }
+
+    /**
+     * What {@code comparison} states about this input, coming out {@code holding} — or null where
+     * the arithmetic reads nothing here.
+     *
+     * <p>Read once, off the same {@link AffineReading} every other reader of a comparison uses. A
+     * second reading of what a comparison says is a second thing to keep in step with how a border
+     * is drawn, and the two disagreeing is a region that excludes the very level the border is at.
+     */
+    static Cut of(Core.Binary comparison, boolean holding, InputReads reads, Symbols symbols) {
+        AffineReading read = AffineReading.of(comparison, reads, symbols);
+        if (read == null) {
+            return null;
+        }
+        Rel states = relOf(read.claim());
+        if (states == null) {
+            return null;
+        }
+        // The form with the threshold moved into it, since what a domain is told is `f rel 0`.
+        LinearForm<NumericTerm> against =
+                read.form().minus(LinearForm.constant(read.cut()));
+        return new Cut(against, holding ? states : negated(states));
+    }
+
+    /**
+     * Which way a comparison holds, off what it claims about the value it names.
+     *
+     * <p>Two facts and they are enough: whether the value it names is on the side the comparison is
+     * true below, and whether the comparison holds at that value. {@code x <= c} holds below and at
+     * it; {@code x < c} holds below and not at it, and {@code c} is above; {@code x >= c} holds
+     * above and at it; {@code x > c} holds above and not at it, and {@code c} is below. So the true
+     * side is the low one exactly where those two agree.
+     */
+    private static Rel relOf(ComparisonClaim claim) {
+        return switch (claim) {
+            case ComparisonClaim.Cut cut -> cut.valueBelongsBelow() == cut.holdsAtTheValue()
+                    ? (cut.holdsAtTheValue() ? Rel.LE : Rel.LT)
+                    : (cut.holdsAtTheValue() ? Rel.GE : Rel.GT);
+            case ComparisonClaim.Singled singled ->
+                    singled.holdsAtTheValue() ? Rel.EQ : Rel.NE;
+            case ComparisonClaim.Nothing _ -> null;
+        };
+    }
+
+    /** What it states when it does not hold, which is the whole of the rest of the order. */
+    private static Rel negated(Rel rel) {
+        return switch (rel) {
+            case LE -> Rel.GT;
+            case LT -> Rel.GE;
+            case GE -> Rel.LT;
+            case GT -> Rel.LE;
+            case EQ -> Rel.NE;
+            case NE -> Rel.EQ;
+        };
+    }
+
+    /** These cuts, with {@code site} reached under {@code assumed}. */
+    static final class Collected {
+
+        private final Map<ComparisonOccurrence, List<Cut>> byComparison = new LinkedHashMap<>();
+
+        void reached(ComparisonOccurrence site, List<Cut> assumed) {
+            // The first reading of a site stands. One comparison is read once per call of the helper
+            // it is written in, and each of those is a site of its own — two readings arriving under
+            // one site would be this walk and the plan disagreeing about what a site is.
+            byComparison.putIfAbsent(site, List.copyOf(assumed));
+        }
+
+        ReachingCuts made() {
+            return new ReachingCuts(byComparison);
+        }
+    }
+
+    /** How a caller adds one to what it is carrying, keeping what was already there. */
+    static List<Cut> and(List<Cut> assumed, Cut one) {
+        if (one == null) {
+            return assumed;
+        }
+        List<Cut> out = new java.util.ArrayList<>(assumed);
+        out.add(one);
+        return List.copyOf(out);
+    }
+
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
@@ -1,9 +1,11 @@
 package souther.compiler.partition;
 
 import souther.compiler.check.ComparisonClaim;
+import souther.compiler.ast.Hir;
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.ComparisonOccurrence;
+import souther.compiler.coverage.CoverageSites;
 import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.SearchRegion;
@@ -67,6 +69,77 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<ReachingCuts.Cut>> byC
     }
 
     /**
+     * Each comparison of {@code condition}, filed under what a row had already satisfied when it
+     * ran.
+     *
+     * <p><b>In the order a condition is evaluated in, which is what makes this per comparison and
+     * not per fork.</b> A condition stops as soon as it is settled: under {@code A && B} the second
+     * comparison runs only where the first held, and under {@code A || B} only where it did not. So
+     * what has been established by the time a comparison runs differs between the comparisons of one
+     * condition, and a reading that handed every comparison of a fork the same thing would be
+     * answering about the fork.
+     *
+     * <p>That is not a missing case, it is the case. Sequential guards and the same conditions run
+     * together with {@code &&} state the same model, and a coverage answer that differed between
+     * them would be a fact about how the author spelled the condition — the guard at the end of a
+     * chain would be searched for over everything its positions could ever hold, which is the
+     * defect this whole type exists to remove, arriving by way of a rewrite that changes nothing.
+     *
+     * <p>Descends through {@code &&} and {@code ||} and nothing else, which is what a condition is
+     * built out of. Anything else is where the arithmetic stops, and it contributes nothing rather
+     * than being guessed at.
+     */
+    static void collect(Core condition, List<Cut> before, CoverageSites.Plan plan,
+                        InputReads reads, Symbols symbols, Collected out) {
+        if (condition instanceof Core.Binary joined && combines(joined.op())) {
+            collect(joined.left(), before, plan, reads, symbols, out);
+            // What reaching the right operand says: under `&&` the left held, under `||` it did not.
+            collect(joined.right(),
+                    and(before, stating(joined.left(), joined.op() == Hir.BinOp.AND, reads,
+                            symbols)),
+                    plan, reads, symbols, out);
+            return;
+        }
+        if (condition instanceof Core.Binary comparison) {
+            plan.comparisonAt(comparison).ifPresent(site -> out.reached(site, before));
+        }
+    }
+
+    /**
+     * What {@code node} coming out {@code holding} says about this input, where anything can be
+     * said.
+     *
+     * <p>One rule for two questions, because they are one question. What reaching the right operand
+     * of a condition establishes and what reaching an arm of the fork establishes are both "this
+     * subtree came out this way, so what follows" — written apart, the two agreed by having been
+     * derived alike, and the day one of them learned to read a new shape of condition would be the
+     * day they stopped agreeing.
+     *
+     * <p>A conjunction coming out true is both its operands true, and a disjunction coming out false
+     * is both false. The other two ways round say a disjunction of things, which is not a list of
+     * cuts and is not approximated into one: {@code A && B} being false says one of them failed and
+     * names neither, and narrowing on either would exclude rows that arrive.
+     */
+    static List<Cut> stating(Core node, boolean holding, InputReads reads, Symbols symbols) {
+        if (node instanceof Core.Binary joined && combines(joined.op())) {
+            if ((joined.op() == Hir.BinOp.AND) != holding) {
+                return List.of();
+            }
+            return and(stating(joined.left(), holding, reads, symbols),
+                    stating(joined.right(), holding, reads, symbols));
+        }
+        if (!(node instanceof Core.Binary comparison)) {
+            return List.of();
+        }
+        Cut one = of(comparison, holding, reads, symbols);
+        return one == null ? List.of() : List.of(one);
+    }
+
+    private static boolean combines(Hir.BinOp op) {
+        return op == Hir.BinOp.AND || op == Hir.BinOp.OR;
+    }
+
+    /**
      * What {@code comparison} states about this input, coming out {@code holding} — or null where
      * the arithmetic reads nothing here.
      *
@@ -74,7 +147,8 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<ReachingCuts.Cut>> byC
      * second reading of what a comparison says is a second thing to keep in step with how a border
      * is drawn, and the two disagreeing is a region that excludes the very level the border is at.
      */
-    static Cut of(Core.Binary comparison, boolean holding, InputReads reads, Symbols symbols) {
+    private static Cut of(Core.Binary comparison, boolean holding, InputReads reads,
+                          Symbols symbols) {
         AffineReading read = AffineReading.of(comparison, reads, symbols);
         if (read == null) {
             return null;
@@ -138,13 +212,13 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<ReachingCuts.Cut>> byC
         }
     }
 
-    /** How a caller adds one to what it is carrying, keeping what was already there. */
-    static List<Cut> and(List<Cut> assumed, Cut one) {
-        if (one == null) {
+    /** What a caller is carrying, with more added, keeping what was already there. */
+    private static List<Cut> and(List<Cut> assumed, List<Cut> more) {
+        if (more.isEmpty()) {
             return assumed;
         }
         List<Cut> out = new java.util.ArrayList<>(assumed);
-        out.add(one);
+        out.addAll(more);
         return List.copyOf(out);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
@@ -1,12 +1,9 @@
 package souther.compiler.partition;
 
 import souther.compiler.check.ComparisonClaim;
-import souther.compiler.ast.Hir;
 import souther.compiler.check.Symbols;
-import souther.compiler.core.Core;
 import souther.compiler.coverage.ComparisonOccurrence;
 import souther.compiler.coverage.CoverageSites;
-import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.SearchRegion;
 import souther.compiler.numeric.NumericDomain;
@@ -89,19 +86,25 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<ReachingCuts.Cut>> byC
      * built out of. Anything else is where the arithmetic stops, and it contributes nothing rather
      * than being guessed at.
      */
-    static void collect(Core condition, List<Cut> before, CoverageSites.Plan plan,
-                        InputReads reads, Symbols symbols, Collected out) {
-        if (condition instanceof Core.Binary joined && combines(joined.op())) {
-            collect(joined.left(), before, plan, reads, symbols, out);
-            // What reaching the right operand says: under `&&` the left held, under `||` it did not.
-            collect(joined.right(),
-                    and(before, stating(joined.left(), joined.op() == Hir.BinOp.AND, reads,
-                            symbols)),
-                    plan, reads, symbols, out);
-            return;
-        }
-        if (condition instanceof Core.Binary comparison) {
-            plan.comparisonAt(comparison).ifPresent(site -> out.reached(site, before));
+    static void collect(Condition condition, List<Cut> before, CoverageSites.Plan plan,
+                        Symbols symbols, Collected out) {
+        switch (condition) {
+            case Condition.Both both -> {
+                collect(both.left(), before, plan, symbols, out);
+                collect(both.right(), and(before, stating(both.left(), true, symbols)), plan,
+                        symbols, out);
+            }
+            case Condition.Either either -> {
+                collect(either.left(), before, plan, symbols, out);
+                collect(either.right(), and(before, stating(either.left(), false, symbols)), plan,
+                        symbols, out);
+            }
+            case Condition.Compares one ->
+                    plan.comparisonAt(one.at()).ifPresent(site -> out.reached(site, before));
+            case Condition.NotRead _ -> {
+                // Nothing runs here as far as this reading is concerned, so nothing is filed and
+                // nothing is established for whatever stands beside it.
+            }
         }
     }
 
@@ -120,23 +123,23 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<ReachingCuts.Cut>> byC
      * cuts and is not approximated into one: {@code A && B} being false says one of them failed and
      * names neither, and narrowing on either would exclude rows that arrive.
      */
-    static List<Cut> stating(Core node, boolean holding, InputReads reads, Symbols symbols) {
-        if (node instanceof Core.Binary joined && combines(joined.op())) {
-            if ((joined.op() == Hir.BinOp.AND) != holding) {
-                return List.of();
+    static List<Cut> stating(Condition node, boolean holding, Symbols symbols) {
+        return switch (node) {
+            // A conjunction coming out true is both its operands true, and a disjunction coming out
+            // false is both false. The other two ways round say a disjunction of things, which is
+            // not a list of cuts and is not approximated into one: `A && B` being false says one of
+            // them failed and names neither, and narrowing on either would exclude rows that arrive.
+            case Condition.Both both when holding ->
+                    and(stating(both.left(), true, symbols), stating(both.right(), true, symbols));
+            case Condition.Either either when !holding ->
+                    and(stating(either.left(), false, symbols),
+                            stating(either.right(), false, symbols));
+            case Condition.Compares one -> {
+                Cut cut = of(one, holding, symbols);
+                yield cut == null ? List.of() : List.of(cut);
             }
-            return and(stating(joined.left(), holding, reads, symbols),
-                    stating(joined.right(), holding, reads, symbols));
-        }
-        if (!(node instanceof Core.Binary comparison)) {
-            return List.of();
-        }
-        Cut one = of(comparison, holding, reads, symbols);
-        return one == null ? List.of() : List.of(one);
-    }
-
-    private static boolean combines(Hir.BinOp op) {
-        return op == Hir.BinOp.AND || op == Hir.BinOp.OR;
+            default -> List.of();
+        };
     }
 
     /**
@@ -147,9 +150,8 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<ReachingCuts.Cut>> byC
      * second reading of what a comparison says is a second thing to keep in step with how a border
      * is drawn, and the two disagreeing is a region that excludes the very level the border is at.
      */
-    private static Cut of(Core.Binary comparison, boolean holding, InputReads reads,
-                          Symbols symbols) {
-        AffineReading read = AffineReading.of(comparison, reads, symbols);
+    private static Cut of(Condition.Compares comparison, boolean holding, Symbols symbols) {
+        AffineReading read = AffineReading.of(comparison.at(), comparison.reads(), symbols);
         if (read == null) {
             return null;
         }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -752,7 +752,7 @@ public final class Adequacy {
                 }
                 out.addAll(Coverages.assess(axis, inputs, observed, armsAsked,
                         partitioning.edgeIsKnownWritable(axis.term()), probe,
-                        partitioning.quantities(),
+                        partitioning.quantities(), partitioning.reaching(),
                         partitioning.quantities().runsBetween(axis.term())));
             }
             out.addAll(Coverages.assessBetween(partitioning, inputs, observed, armsAsked, probe));

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -452,11 +452,13 @@ final class Coverages {
      *                  well as into {@link #assessBetween} because which shape of quantity a rule
      *                  cuts says nothing about where a row for it may be written — and a region put
      *                  into one of the two paths would leave the other searching over everything its
-     *                  position could ever hold. No input is known where it changes an answer down
-     *                  this path: the points of a line at one position all sit beside the line, and
-     *                  a line the region excludes is one the reading of what arrives has already
-     *                  taken the obligation away for. That is a second route to the same answer and
-     *                  not a reason to leave a path short of what it is owed.
+     *                  position could ever hold. No model was found where it moves an answer down
+     *                  this path, and no test holds it: the points of a line at one position all sit
+     *                  beside the line, and every line tried that the region excludes turned out to
+     *                  be one {@link souther.compiler.check.PathReachability} had already taken the
+     *                  obligation away for. Whether those two always coincide is not established
+     *                  here — they are different readings — so what this says is that a path is not
+     *                  left short of what it is owed, and not that the region is idle here.
      */
     static List<BorderAssessment> assess(
             Axis axis, BehaviorInputs where, souther.compiler.query.Adequacy.Observed observed,

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -453,10 +453,11 @@ final class Coverages {
         // is read once per call of that helper, and the rows do not owe the same border twice for
         // having been offered it twice; what each reading saw is merged below.
         java.util.SequencedMap<BoundaryLine, BorderAssessment> out = new java.util.LinkedHashMap<>();
-        LevelRealizer realizer = new LevelRealizer(rules);
+        LevelRealizer realizer = new LevelRealizer();
         for (Border each : Partitions.bordersOf(axis, where.symbols(), within)) {
             out.merge(BoundaryLine.of(each),
-                    assessed(each, shapeOf(each, where, knownWritable, probe, realizer),
+                    assessed(each, shapeOf(each, where, knownWritable, probe, realizer,
+                                    rules.region()),
                             observed, armsAsked),
                     Coverages::whicheverSawMore);
         }
@@ -544,7 +545,8 @@ final class Coverages {
      */
     private static OneShapeOfBorder shapeOf(Border border, BehaviorInputs where,
                                             boolean knownWritable, Probe probe,
-                                            LevelRealizer realizer) {
+                                            LevelRealizer realizer,
+                                            souther.compiler.inputs.SearchRegion within) {
         BorderQuantity quantity = border.cut().of();
         java.util.Optional<souther.compiler.coverage.ComparisonOccurrence> site =
                 border.origin().comparisonAt();
@@ -565,7 +567,7 @@ final class Coverages {
                 // the realizer. What it composes is a candidate and no part of the item: another row
                 // in the same side is at the point as much as this one would be, so what the row is
                 // offered for goes in beside it rather than being read back off it.
-                return switch (realizer.realize(quantity.standingAt(criterion))) {
+                return switch (realizer.realize(quantity.standingAt(criterion), within)) {
                     case Realization.Found found ->
                             whatCameOfIt(probe.attempt(label, quantity.carrier(), found.fixing()));
                     // And the two ways of finding nothing are not one answer. A walk of the whole
@@ -724,10 +726,11 @@ final class Coverages {
         // line twice for having been offered it twice — nor may one reading of it take back what
         // another established.
         java.util.SequencedMap<BoundaryLine, BorderAssessment> out = new LinkedHashMap<>();
-        LevelRealizer realizer = new LevelRealizer(partitioning.quantities());
+        LevelRealizer realizer = new LevelRealizer();
         for (Border each : partitioning.between()) {
             out.merge(BoundaryLine.of(each),
-                    assessed(each, shapeOf(each, where, false, probe, realizer), observed,
+                    assessed(each, shapeOf(each, where, false, probe, realizer,
+                                    partitioning.quantities().region()), observed,
                             armsAsked),
                     Coverages::whicheverSawMore);
         }

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -448,17 +448,15 @@ final class Coverages {
      *                  differently and a measure that took one boolean for both could not say which
      *                  had happened.
      * @param probe     null where the module's classes or the runtime are not there to build against
-     */
-    /**
-     * @param reaching what a row had already satisfied when each comparison ran. Threaded here as
-     *                 well as into {@link #assessBetween} because which shape of quantity a rule
-     *                 cuts says nothing about where a row for it may be written — and a region put
-     *                 into one of the two paths would leave the other searching over everything its
-     *                 position could ever hold. No input is known where it changes an answer down
-     *                 this path: the points of a line at one position all sit beside the line, and a
-     *                 line the region excludes is one the reading of what arrives has already taken
-     *                 the obligation away for. That is a second route to the same answer and not a
-     *                 reason to leave a path short of what it is owed
+     * @param reaching  what a row had already satisfied when each comparison ran. Threaded here as
+     *                  well as into {@link #assessBetween} because which shape of quantity a rule
+     *                  cuts says nothing about where a row for it may be written — and a region put
+     *                  into one of the two paths would leave the other searching over everything its
+     *                  position could ever hold. No input is known where it changes an answer down
+     *                  this path: the points of a line at one position all sit beside the line, and
+     *                  a line the region excludes is one the reading of what arrives has already
+     *                  taken the obligation away for. That is a second route to the same answer and
+     *                  not a reason to leave a path short of what it is owed.
      */
     static List<BorderAssessment> assess(
             Axis axis, BehaviorInputs where, souther.compiler.query.Adequacy.Observed observed,

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -17,6 +17,7 @@ import souther.compiler.partition.Axis;
 import souther.compiler.partition.AxisId;
 import souther.compiler.partition.Border;
 import souther.compiler.partition.Criterion;
+import souther.compiler.partition.ReachingCuts;
 import souther.compiler.partition.Demand;
 import souther.compiler.partition.Generator;
 import souther.compiler.partition.PointRole;
@@ -93,7 +94,11 @@ final class Coverages {
                 // producers. Carried rather than derived from the lines that came back: a
                 // comparison this could not read draws no line, and that is when its questions
                 // stand.
-                both(clauses.accounting(), guards.accounting()));
+                both(clauses.accounting(), guards.accounting()),
+                // What a row had to satisfy to arrive at each comparison, from the walk that
+                // assumed it. A clause of a declaration is not written at a place in a body and has
+                // nothing on the way to it, so only the guards have any of this.
+                guards.reaching());
     }
 
     /** The two producers' lines, in one list. */
@@ -457,11 +462,32 @@ final class Coverages {
         for (Border each : Partitions.bordersOf(axis, where.symbols(), within)) {
             out.merge(BoundaryLine.of(each),
                     assessed(each, shapeOf(each, where, knownWritable, probe, realizer,
-                                    rules.region()),
+                                    regionFor(each, rules, ReachingCuts.NONE)),
                             observed, armsAsked),
                     Coverages::whicheverSawMore);
         }
         return List.copyOf(out.values());
+    }
+
+    /**
+     * Where a row for one border may be written.
+     *
+     * <p>Beside the border and not part of it. What a border is is what the rows are owed at, and it
+     * is the same border wherever a row for it is looked for — put inside, two readings of one line
+     * reached under different conditions would be two obligations, and a count of what an author
+     * owes would move with how much of a body this compiler managed to read.
+     *
+     * <p>What the declarations leave, for a line a declaration draws. An invariant is about the
+     * values and holds wherever one stands, so there is nothing on the way to it; a guard is at a
+     * place in a body, and a row that never arrives there is no row at its line whatever it holds.
+     * Read off which kind of rule it is rather than off whether anything was collected: a guard
+     * nothing narrows and a clause are then the same region for the same stated reason.
+     */
+    private static souther.compiler.inputs.SearchRegion regionFor(
+            Border border, souther.compiler.inputs.Quantities rules, ReachingCuts reaching) {
+        return border.origin().comparisonAt()
+                .map(site -> reaching.narrowing(rules.region(), site))
+                .orElseGet(rules::region);
     }
 
     /**
@@ -730,7 +756,8 @@ final class Coverages {
         for (Border each : partitioning.between()) {
             out.merge(BoundaryLine.of(each),
                     assessed(each, shapeOf(each, where, false, probe, realizer,
-                                    partitioning.quantities().region()), observed,
+                                    regionFor(each, partitioning.quantities(),
+                                            partitioning.reaching())), observed,
                             armsAsked),
                     Coverages::whicheverSawMore);
         }

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -449,10 +449,21 @@ final class Coverages {
      *                  had happened.
      * @param probe     null where the module's classes or the runtime are not there to build against
      */
+    /**
+     * @param reaching what a row had already satisfied when each comparison ran. Threaded here as
+     *                 well as into {@link #assessBetween} because which shape of quantity a rule
+     *                 cuts says nothing about where a row for it may be written — and a region put
+     *                 into one of the two paths would leave the other searching over everything its
+     *                 position could ever hold. No input is known where it changes an answer down
+     *                 this path: the points of a line at one position all sit beside the line, and a
+     *                 line the region excludes is one the reading of what arrives has already taken
+     *                 the obligation away for. That is a second route to the same answer and not a
+     *                 reason to leave a path short of what it is owed
+     */
     static List<BorderAssessment> assess(
             Axis axis, BehaviorInputs where, souther.compiler.query.Adequacy.Observed observed,
             boolean armsAsked, boolean knownWritable, Probe probe,
-            souther.compiler.inputs.Quantities rules,
+            souther.compiler.inputs.Quantities rules, ReachingCuts reaching,
             souther.compiler.numeric.NumericDomain.Bounds within) {
         // Keyed by the line rather than by the reading of it. A guard inside a non-recursive helper
         // is read once per call of that helper, and the rows do not owe the same border twice for
@@ -462,7 +473,7 @@ final class Coverages {
         for (Border each : Partitions.bordersOf(axis, where.symbols(), within)) {
             out.merge(BoundaryLine.of(each),
                     assessed(each, shapeOf(each, where, knownWritable, probe, realizer,
-                                    regionFor(each, rules, ReachingCuts.NONE)),
+                                    regionFor(each, rules, reaching)),
                             observed, armsAsked),
                     Coverages::whicheverSawMore);
         }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowForABorderIsSearchedForInTheRegionThatReachesItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowForABorderIsSearchedForInTheRegionThatReachesItTest.java
@@ -116,6 +116,47 @@ class ARowForABorderIsSearchedForInTheRegionThatReachesItTest {
             """;
 
     /**
+     * A line inside the arm a condition fails on, which is the other half of the same reading.
+     *
+     * <p>Reaching the {@code else} arm proves the condition did not hold, so the region there is
+     * where {@code y} is under seven rather than where it is past six. A reading that took the arm
+     * for the condition — or the condition for the arm — would narrow this one the wrong way round,
+     * and the row it offered would be refused for the opposite reason.
+     *
+     * <p>Written so that the answer differs. A search of the declared box solves this line by trying
+     * the positions in the order the form names them, which takes {@code y} at its largest first —
+     * so a line whose arm wants a large {@code y} is answered the same either way, and a test built
+     * on one would pass without the region being read at all.
+     */
+    private static final String INSIDE_THE_OTHER_ARM = """
+            module example.checkout
+
+            data Small = Int
+                invariant value >= 0
+                invariant value <= 20
+            data Large = Int
+                invariant value >= 0
+                invariant value <= 10
+
+            data Rejected = { reason: Int }
+            data Order = { total: Int }
+            data Result = Rejected | Order
+
+            behavior checkout : (x: Small, y: Large) -> Result
+                constructs Rejected, Order
+            let checkout (x, y) =
+                if y.value >= 7 then Order { total = x.value }
+                else {
+                    guard Int.add(x.value, Int.multiply(2, y.value)) <= 16
+                        else Rejected { reason = 5 }
+                    Order { total = 1 }
+                }
+
+            example checkout
+                | "ok" : (Small(1), Large(1)) -> Order { total = 1 }
+            """;
+
+    /**
      * A level the region has an answer at, composed.
      *
      * <p>{@code x = 1, y = 8} is at {@code x + 2y = 17} and passes every guard above the one that
@@ -162,6 +203,23 @@ class ARowForABorderIsSearchedForInTheRegionThatReachesItTest {
                     "the guard above holds y at six, and " + written(built.row())
                             + " never reaches the line at " + level);
         }
+    }
+
+    /**
+     * A row for a line in the arm a condition fails on stands where that condition fails.
+     *
+     * <p>The same rule as the arm above it, read the other way round. Nothing in this arm holds
+     * {@code y} at six or under, and a row that does never arrives at the guard.
+     */
+    @Test
+    void aRowForALineInsideTheOtherArmStandsWhereThatConditionFails() {
+        ItemAssessment.Attempt.Built built = assertInstanceOf(ItemAssessment.Attempt.Built.class,
+                owed(pointAt(INSIDE_THE_OTHER_ARM, "x + 2 * y = 16")).attempt(),
+                "a row at the level exists in the arm the condition fails on");
+
+        assertTrue(largeIn(built.row()) <= 6,
+                "nothing at seven or above reaches this arm, and " + written(built.row())
+                        + " was offered for a line inside it");
     }
 
     /** What the row puts in the second position, as a number. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowForABorderIsSearchedForInTheRegionThatReachesItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowForABorderIsSearchedForInTheRegionThatReachesItTest.java
@@ -1,0 +1,204 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ItemAssessment;
+import souther.compiler.query.PartitionEvidence;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Where a row for one of a border's points is looked for.
+ *
+ * <p>Issue #911. A border on an arithmetic form is met by solving the form for a level, and the box
+ * that search runs in was each position's declared domain — what its type and that type's
+ * invariants leave. A guard draws a threshold and narrows no domain, so a border a guard owes was
+ * searched for over the whole of what the positions could ever hold rather than over the region
+ * that reaches the guard.
+ *
+ * <p>Two things follow and they are the same fault from either side. Too wide, and a level with an
+ * answer in the region comes back as one the search did not reach. Not used at all, and the row
+ * offered for a level is one a rule above the guard refuses.
+ *
+ * <p>The first is measured as a pair rather than against a constant. The same equation over the
+ * same region is written twice — once with the bounds on the guards and once with them on the types
+ * — and what a search makes of it may not depend on which. Held against a constant instead, a test
+ * would say what this compiler manages today rather than that the two agree.
+ */
+class ARowForABorderIsSearchedForInTheRegionThatReachesItTest {
+
+    /** The bounds written as guards, so nothing narrows a declared domain. */
+    private static final String ON_GUARDS = """
+            module example.checkout
+
+            data Small = Int
+            data Large = Int
+
+            data Rejected = { reason: Int }
+            data Order = { total: Int }
+            data Result = Rejected | Order
+
+            behavior checkout : (x: Small, y: Large) -> Result
+                constructs Rejected, Order
+            let checkout (x, y) = {
+                guard x.value >= 0 else Rejected { reason = 1 }
+                guard x.value <= 20 else Rejected { reason = 2 }
+                guard y.value >= 0 else Rejected { reason = 3 }
+                guard y.value <= 10 else Rejected { reason = 4 }
+                guard Int.add(x.value, Int.multiply(2, y.value)) <= 16 else Rejected { reason = 5 }
+                Order { total = x.value }
+            }
+
+            example checkout
+                | "ok" : (Small(1), Large(1)) -> Order { total = 1 }
+            """;
+
+    /** The same region, written where the declarations carry it. */
+    private static final String ON_TYPES = """
+            module example.checkout
+
+            data Small = Int
+                invariant value >= 0
+                invariant value <= 20
+            data Large = Int
+                invariant value >= 0
+                invariant value <= 10
+
+            data Rejected = { reason: Int }
+            data Order = { total: Int }
+            data Result = Rejected | Order
+
+            behavior checkout : (x: Small, y: Large) -> Result
+                constructs Rejected, Order
+            let checkout (x, y) = {
+                guard Int.add(x.value, Int.multiply(2, y.value)) <= 16 else Rejected { reason = 5 }
+                Order { total = x.value }
+            }
+
+            example checkout
+                | "ok" : (Small(1), Large(1)) -> Order { total = 1 }
+            """;
+
+    /** A guard above the form's, which no row reaching the form's line may fail. */
+    private static final String A_GUARD_ABOVE = """
+            module example.checkout
+
+            data Small = Int
+                invariant value >= 0
+                invariant value <= 20
+            data Large = Int
+                invariant value >= 0
+                invariant value <= 10
+
+            data Rejected = { reason: Int }
+            data Order = { total: Int }
+            data Result = Rejected | Order
+
+            behavior checkout : (x: Small, y: Large) -> Result
+                constructs Rejected, Order
+            let checkout (x, y) = {
+                guard y.value <= 6 else Rejected { reason = 1 }
+                guard Int.add(x.value, Int.multiply(2, y.value)) <= 16 else Rejected { reason = 5 }
+                Order { total = x.value }
+            }
+
+            example checkout
+                | "ok" : (Small(1), Large(1)) -> Order { total = 1 }
+            """;
+
+    /**
+     * A level the region has an answer at, composed.
+     *
+     * <p>{@code x = 1, y = 8} is at {@code x + 2y = 17} and passes every guard above the one that
+     * draws the line. Searched over the declared domains, {@code x} is bounded nowhere, one value
+     * of it is tried, and the point comes back as one the search stopped short of.
+     */
+    @Test
+    void aLevelTheRegionHasAnAnswerAtIsComposed() {
+        ItemAssessment.Owed off = owed(pointAt(ON_GUARDS, "x + 2 * y = 17"));
+
+        assertInstanceOf(ItemAssessment.Attempt.Built.class, off.attempt(),
+                "a row at the level exists in the region that reaches the guard");
+    }
+
+    /**
+     * The same equation over the same region, answered the same way.
+     *
+     * <p>What moves between the two models is where the bounds are written, and that is not
+     * something a coverage answer is about.
+     */
+    @Test
+    void whereTheBoundsAreWrittenDoesNotMoveTheAnswer() {
+        for (String level : List.of("x + 2 * y = 16", "x + 2 * y = 17")) {
+            assertEquals(owed(pointAt(ON_TYPES, level)).attempt().getClass(),
+                    owed(pointAt(ON_GUARDS, level)).attempt().getClass(),
+                    "the same line over the same region, at " + level);
+        }
+    }
+
+    /**
+     * A row offered for a level is one that reaches the guard that owes it.
+     *
+     * <p>Both points of {@code x + 2y} were answered with {@code y = 8}, which the guard above
+     * refuses. The measure was right — no row is at either point — and what was wrong is the piece
+     * of work an author was handed.
+     */
+    @Test
+    void aRowOfferedForALevelReachesTheGuardThatOwesIt() {
+        for (String level : List.of("x + 2 * y = 16", "x + 2 * y = 17")) {
+            ItemAssessment.Attempt attempt = owed(pointAt(A_GUARD_ABOVE, level)).attempt();
+            ItemAssessment.Attempt.Built built = assertInstanceOf(
+                    ItemAssessment.Attempt.Built.class, attempt, "a row was composed at " + level);
+            assertTrue(largeIn(built.row()) <= 6,
+                    "the guard above holds y at six, and " + written(built.row())
+                            + " never reaches the line at " + level);
+        }
+    }
+
+    /** What the row puts in the second position, as a number. */
+    private static long largeIn(souther.compiler.partition.Generator.GeneratedRow row) {
+        String text = row.inputs().get(1).text();
+        return Long.parseLong(text.substring(text.indexOf('(') + 1, text.lastIndexOf(')')));
+    }
+
+    private static String written(souther.compiler.partition.Generator.GeneratedRow row) {
+        return row.inputs().stream().map(FixtureTemplate::text).toList().toString();
+    }
+
+    /** The one point of one border, found by the line and the level it names. */
+    private static BorderAssessment.Point pointAt(String source, String level) {
+        List<BorderAssessment.Point> found =
+                BorderAssessment.pointsOf(evidence(source).boundaries()).stream()
+                        .filter(point -> point.label() != null && point.label().endsWith(level))
+                        .toList();
+        assertEquals(1, found.size(),
+                "one point is named `" + level + "`, and these are the points: "
+                        + BorderAssessment.pointsOf(evidence(source).boundaries()).stream()
+                                .map(BorderAssessment.Point::label).toList());
+        return found.get(0);
+    }
+
+    private static ItemAssessment.Owed owed(BorderAssessment.Point point) {
+        return assertInstanceOf(ItemAssessment.Owed.class, point.item(),
+                "a row is owed at " + point.label());
+    }
+
+    private static PartitionEvidence evidence(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        Map<String, PartitionEvidence> all = compilation.db()
+                .ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
+        assertNotNull(all, "the model under test compiles");
+        return all.get("checkout");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowForABorderIsSearchedForInTheRegionThatReachesItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowForABorderIsSearchedForInTheRegionThatReachesItTest.java
@@ -235,6 +235,75 @@ class ARowForABorderIsSearchedForInTheRegionThatReachesItTest {
         }
     }
 
+    /** The same behavior with {@code helpers} beside it and {@code body} for a body. */
+    private static String checkout(String helpers, String body) {
+        return """
+                module example.checkout
+
+                data Small = Int
+                    invariant value >= 0
+                    invariant value <= 20
+                data Large = Int
+                    invariant value >= 0
+                    invariant value <= 10
+
+                data Rejected = { reason: Int }
+                data Order = { total: Int }
+                data Result = Rejected | Order
+                %s
+                behavior checkout : (x: Small, y: Large) -> Result
+                    constructs Rejected, Order
+                let checkout (x, y) = {
+                %s
+                    Order { total = x.value }
+                }
+
+                example checkout
+                    | "ok" : (Small(1), Large(1)) -> Order { total = 1 }
+                """.formatted(helpers, body);
+    }
+
+    /**
+     * Moving a comparison into a helper does not widen what stands beside it.
+     *
+     * <p>An expanded helper binds the call's argument to its own parameter, so what stands in the
+     * condition is a binding around the comparison rather than the comparison. A reading that
+     * matched on the shape in front of it stopped there — and a rewrite that changes nothing about
+     * what the model says took the region the guard beside it is searched in back out to everything
+     * the positions could ever hold.
+     *
+     * <p>What the helper's own comparison is owed is a separate question and is not asked here: the
+     * plan numbers the conditions of a body and not an expanded helper's, so no row can be shown to
+     * have reached it and no line is drawn on it
+     * ({@code AComparisonInsideAHelperRaisesNothingTest}). Establishing a fact and owing a row at
+     * one are not the same thing, and only the second wants a site.
+     */
+    @Test
+    void movingAComparisonIntoAHelperDoesNotWidenWhatStandsBesideIt() {
+        String inline = checkout("", "    guard y.value <= 6 && %s else Rejected { reason = 5 }"
+                .formatted(THE_FORM));
+        String extracted = checkout("\nlet atMostSix (y: Large): Bool = y.value <= 6\n",
+                "    guard atMostSix(y) && %s else Rejected { reason = 5 }".formatted(THE_FORM));
+
+        for (String level : List.of("x + 2 * y = 16", "x + 2 * y = 17")) {
+            assertEquals(written(built(inline, level).row()),
+                    written(built(extracted, level).row()),
+                    "the same condition, one comparison of it named, at " + level);
+            assertTrue(largeIn(built(extracted, level).row()) <= 6,
+                    "and what the helper says holds where the form's line is searched for");
+        }
+    }
+
+    /** The same, of the operand a disjunction reaches only where the first failed. */
+    @Test
+    void movingTheFirstOperandOfADisjunctionIntoAHelperKeepsWhatItFailing() {
+        String extracted = checkout("\nlet atLeastSeven (y: Large): Bool = y.value >= 7\n",
+                "    guard atLeastSeven(y) || %s else Rejected { reason = 5 }".formatted(THE_FORM));
+
+        assertTrue(largeIn(built(extracted, "x + 2 * y = 16").row()) <= 6,
+                "the second operand runs where the named comparison failed");
+    }
+
     /**
      * The second operand of a disjunction runs where the first failed.
      *

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowForABorderIsSearchedForInTheRegionThatReachesItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowForABorderIsSearchedForInTheRegionThatReachesItTest.java
@@ -156,6 +156,146 @@ class ARowForABorderIsSearchedForInTheRegionThatReachesItTest {
                 | "ok" : (Small(1), Large(1)) -> Order { total = 1 }
             """;
 
+    /** A behavior over the same two bounded positions, with {@code body} for a body. */
+    private static String checkout(String body) {
+        return """
+                module example.checkout
+
+                data Small = Int
+                    invariant value >= 0
+                    invariant value <= 20
+                data Large = Int
+                    invariant value >= 0
+                    invariant value <= 10
+
+                data Rejected = { reason: Int }
+                data Order = { total: Int }
+                data Result = Rejected | Order
+
+                behavior checkout : (x: Small, y: Large) -> Result
+                    constructs Rejected, Order
+                let checkout (x, y) = {
+                %s
+                    Order { total = x.value }
+                }
+
+                example checkout
+                    | "ok" : (Small(1), Large(1)) -> Order { total = 1 }
+                """.formatted(body);
+    }
+
+    /** The form's own line, which every model below draws. */
+    private static final String THE_FORM =
+            "Int.add(x.value, Int.multiply(2, y.value)) <= 16";
+
+    /**
+     * The bounds written as one condition rather than as four guards.
+     *
+     * <p>The same model. Running conditions together with {@code &&} and writing them one after
+     * another state the same thing, and a coverage answer that moved between them would be a fact
+     * about how the author spelled the condition.
+     */
+    @Test
+    void spellingTheConditionsAsOneChainDoesNotMoveTheAnswer() {
+        // The bounds on the guards and nowhere else, the same as `ON_GUARDS`. Declared on the types
+        // as well, the region would have nothing to add and this would pass without being read.
+        String chained = """
+                module example.checkout
+
+                data Small = Int
+                data Large = Int
+
+                data Rejected = { reason: Int }
+                data Order = { total: Int }
+                data Result = Rejected | Order
+
+                behavior checkout : (x: Small, y: Large) -> Result
+                    constructs Rejected, Order
+                let checkout (x, y) = {
+                    guard x.value >= 0
+                        && x.value <= 20
+                        && y.value >= 0
+                        && y.value <= 10
+                        && Int.add(x.value, Int.multiply(2, y.value)) <= 16
+                        else Rejected { reason = 5 }
+                    Order { total = x.value }
+                }
+
+                example checkout
+                    | "ok" : (Small(1), Large(1)) -> Order { total = 1 }
+                """;
+
+        for (String level : List.of("x + 2 * y = 16", "x + 2 * y = 17")) {
+            assertEquals(owed(pointAt(ON_GUARDS, level)).attempt().getClass(),
+                    owed(pointAt(chained, level)).attempt().getClass(),
+                    "one chain and four guards say the same thing, at " + level);
+            assertInstanceOf(ItemAssessment.Attempt.Built.class,
+                    owed(pointAt(chained, level)).attempt(),
+                    "and both of them find a row at " + level);
+        }
+    }
+
+    /**
+     * The second operand of a disjunction runs where the first failed.
+     *
+     * <p>A condition stops as soon as it is settled, so the form's line is only ever reached by rows
+     * with {@code y} at six or under — the same region the guard above it gave, arriving by the
+     * other operator.
+     */
+    @Test
+    void theSecondOperandOfADisjunctionStandsWhereTheFirstFailed() {
+        String either = checkout(
+                "    guard y.value >= 7 || %s else Rejected { reason = 5 }".formatted(THE_FORM));
+
+        assertTrue(largeIn(built(either, "x + 2 * y = 16").row()) <= 6,
+                "nothing with y at seven or above reaches the second operand");
+    }
+
+    /**
+     * And a comparison nested under both operators takes what each of them left.
+     *
+     * <p>{@code A && (B || C)} puts {@code C} where {@code A} held and {@code B} did not, which no
+     * reading of the fork's arms says: the fork's {@code else} arm holds rows that failed
+     * {@code A}, rows that failed both {@code B} and {@code C}, and rows that never reached
+     * {@code C} at all.
+     */
+    @Test
+    void aComparisonUnderBothOperatorsTakesWhatEachOfThemLeft() {
+        String nested = checkout("""
+                    guard x.value <= 20 && (y.value >= 7 || %s)
+                        else Rejected { reason = 5 }""".formatted(THE_FORM));
+
+        assertTrue(largeIn(built(nested, "x + 2 * y = 16").row()) <= 6,
+                "nothing with y at seven or above reaches the third comparison");
+    }
+
+    /**
+     * A condition the arithmetic cannot read narrows nothing.
+     *
+     * <p>The direction the whole region depends on. A product of two positions is outside what the
+     * form reading takes in, so nothing is established by passing it — and a region narrowed on it
+     * would be narrower than the rows that arrive, which is what turns a search that finds nothing
+     * into a claim that nothing is there.
+     */
+    @Test
+    void aConditionNothingCouldReadNarrowsNothing() {
+        String alone = checkout("    guard %s else Rejected { reason = 5 }".formatted(THE_FORM));
+        String under = checkout("""
+                    guard Int.multiply(x.value, y.value) <= 50 else Rejected { reason = 1 }
+                    guard %s else Rejected { reason = 5 }""".formatted(THE_FORM));
+
+        for (String level : List.of("x + 2 * y = 16", "x + 2 * y = 17")) {
+            assertEquals(written(built(alone, level).row()), written(built(under, level).row()),
+                    "an unread condition above changes nothing at " + level);
+        }
+    }
+
+    /** The row one point was answered with, where one was built at all. */
+    private static ItemAssessment.Attempt.Built built(String source, String level) {
+        return assertInstanceOf(ItemAssessment.Attempt.Built.class,
+                owed(pointAt(source, level)).attempt(), "a row was composed at " + level);
+    }
+
     /**
      * A level the region has an answer at, composed.
      *
@@ -224,8 +364,13 @@ class ARowForABorderIsSearchedForInTheRegionThatReachesItTest {
 
     /** What the row puts in the second position, as a number. */
     private static long largeIn(souther.compiler.partition.Generator.GeneratedRow row) {
-        String text = row.inputs().get(1).text();
-        return Long.parseLong(text.substring(text.indexOf('(') + 1, text.lastIndexOf(')')));
+        return numberIn(row.inputs().get(1).text());
+    }
+
+    /** The number a written newtype holds. */
+    private static long numberIn(String written) {
+        return Long.parseLong(
+                written.substring(written.indexOf('(') + 1, written.lastIndexOf(')')));
     }
 
     private static String written(souther.compiler.partition.Generator.GeneratedRow row) {


### PR DESCRIPTION
Closes #911. Sits on #927 — based on `feature/relational-quantities`, so the diff
here is this change alone. Retarget to `develop` once #927 merges.

## What was wrong

A border on an arithmetic form is met by solving the form for a level, and the
box that search ran in was each position's declared domain. A guard states a
threshold and narrows no declaration, so a border a guard owes was searched for
over the whole of what the positions could ever hold.

Both symptoms in the issue are that one box.

* Too wide: with `x` bounded nowhere, one value of it is tried, `x + 2y = 17`
  solves to eight and a half, and a level with an answer at `x = 1, y = 8` comes
  back as one the search stopped short of.
* Not used at all: the row offered for `x + 2y = 16` is `(Small(0), Large(8))`,
  which the guard above refuses at `y <= 6`.

## What this does

The walk that already reads a body's comparisons carries what it assumed on the
way, and a border read off a comparison is searched for inside that.

* `ReachingCuts` — what a row has had to satisfy by the time it reaches one
  comparison, filed where the condition was assumed.
* `GuardThresholds` — the walk descends into the arms itself and takes each
  comparison **on its own terms** rather than off the arm it is in. Under
  `A && B` the `else` arm holds rows that failed either, so taking the arm for
  the conjunct would exclude rows that reach the guard.
* `Coverages.regionFor` — the region is beside the border, never inside it. Read
  off which kind of rule drew the line: an invariant is about the values and has
  nothing on the way to it, a guard is at a place in a body.

A condition the arithmetic has no word for leaves nothing behind, so the region
stays **wider** than what arrives. That is what a walk that exhausts it rests on
when it calls a level out of reach, and it is why this does not promise the
second symptom away in general — a row found here is a row to try, and what
shows it arrives is running it (#909).

## Where the region can and cannot reach

Obligation discovery is untouched: which borders are owed still comes off the
declarations. Narrowing the search may not take an obligation away, or a
coverage denominator would move as this compiler learned more of a body. The
type split in the previous commit is what holds that — `Cutting` takes a
`Quantities`, `LevelRealizer` takes a `SearchRegion`, and there is no way from
the second back to the first.

## What was measured

`mvn -Plint clean verify`, then the full suite from clean: 6134 pass, no
checked-in answer file moved.

The four assertions in `ARowForABorderIsSearchedForInTheRegionThatReachesItTest`
were written first and were red. Each was then run again with `regionFor`
returning the declared region, and all four went red — including the `else`-arm
one, which in its first shape stayed green either way. A search of the declared
box tries the positions in the order the form names them and so takes `y` at its
largest first, which answers a line whose arm wants a large `y` the same way
with or without the region; the model was rewritten so the two differ.

The conformance corpus stays green throughout and is not evidence here, for the
reason #927 gives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)