### PR TITLE
Take Error Prone out of the build an edit runs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,21 @@
         <build.test.classes>${project.basedir}/target/test-classes</build.test.classes>
         <errorprone.version>2.50.0</errorprone.version>
         <nullaway.version>0.13.8</nullaway.version>
+        <!-- What NullAway is asked for, written once. The gate below and the `lint` profile both
+             ask, and a gate configured differently in each is a gate whose answer depends on which
+             build asked. -->
+        <nullaway.args>-Xep:NullAway:ERROR -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:JSpecifyMode=true</nullaway.args>
+        <!-- The nullness gate an ordinary build runs, carried by the modules that declare
+             `@NullMarked` — souther-runtime, today. Nothing else in Error Prone: this is the one
+             rule those modules state about themselves, and the other five hundred checks are the
+             `lint` profile's.
+
+             It is a property because the profile empties it. javac takes one `-Xplugin:ErrorProne`
+             per compilation and reports the second as a plugin it cannot find, so under `lint`,
+             which puts the plugin on every module, a module carrying its own would be handing javac
+             two. Emptying this leaves the profile's the only one, and NullAway is in both spellings,
+             so the gate does not lift when the profile takes over. -->
+        <errorprone.gate>-Xplugin:ErrorProne -XepDisableAllChecks ${nullaway.args}</errorprone.gate>
         <!-- The build protocol souther-build-driver implements. Not this project's version and not
              tracked to it: it moves when the interface between a build plugin and a driver moves,
              which is why it is released from souther-lang/souther-build-api and named here like any
@@ -267,6 +282,11 @@
                     <name>env.CI</name>
                 </property>
             </activation>
+            <properties>
+                <!-- The gate a module carries, emptied: this profile's plugin argument below is the
+                     only one javac may be given. -->
+                <errorprone.gate/>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -280,7 +300,7 @@
                                      as a thing that confuses a reader, and this compiler's tests
                                      call methods the language named in Japanese: the check would be
                                      asking the tests to stop covering what Souther supports. -->
-                                <arg>-Xplugin:ErrorProne -Xep:UnicodeInCode:OFF -Xep:NullAway:ERROR -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:JSpecifyMode=true</arg>
+                                <arg>-Xplugin:ErrorProne -Xep:UnicodeInCode:OFF ${nullaway.args}</arg>
                             </compilerArgs>
                             <annotationProcessorPaths>
                                 <path>

--- a/pom.xml
+++ b/pom.xml
@@ -58,13 +58,6 @@
         <build.test.classes>${project.basedir}/target/test-classes</build.test.classes>
         <errorprone.version>2.50.0</errorprone.version>
         <nullaway.version>0.13.8</nullaway.version>
-        <!-- Which Error Prone checks a build runs. Measured on `clean test-compile`, whole
-             reactor, one run each: 8.7s with no Error Prone at all, 12.0s with NullAway alone,
-             38.0s with the default checks as well. The nullness gate is the rule this repository
-             holds itself to, and it costs three seconds; the other five hundred checks cost
-             twenty-six, which is too much to spend on every compile while writing code. So a
-             development build runs the gate, and the `lint` profile below runs the rest. -->
-        <errorprone.checks>-XepDisableAllChecks</errorprone.checks>
         <!-- The build protocol souther-build-driver implements. Not this project's version and not
              tracked to it: it moves when the interface between a build plugin and a driver moves,
              which is why it is released from souther-lang/souther-build-api and named here like any
@@ -197,19 +190,8 @@
             </plugins>
         </pluginManagement>
         <plugins>
-            <!-- The null analysis runs here, in javac, rather than in an editor: a rule only some
-                 checkouts enforce is not a rule. NullAway reads the JSpecify annotations
-                 souther-runtime already carries, and `OnlyNullMarked` is what decides where it
-                 looks — the packages that declare `@NullMarked`, and no others. Adopting a package
-                 is then one line in its `package-info.java`, and the packages that have not adopted
-                 it compile as they did. Declaring the whole of souther-compiler annotated instead
-                 reports 1024 findings at once, which is a migration and not a check.
-
-                 The `compilePolicy` and `should-stop` arguments below are Error Prone's, not ours:
-                 its checks read the flow graph, and javac builds one per class only under that
-                 policy. The exports the plugin needs to reach javac's internals are in
-                 `.mvn/jvm.config`, because the compiler runs in the Maven JVM; without them the
-                 build stops at `IllegalAccessError` before any source is read. -->
+            <!-- Nothing but javac here. Error Prone and the nullness gate are in the `lint`
+                 profile below, which CI runs. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -225,26 +207,7 @@
                         <arg>100000</arg>
                         <arg>-Xmaxerrs</arg>
                         <arg>100000</arg>
-                        <arg>-XDcompilePolicy=simple</arg>
-                        <arg>--should-stop=ifError=FLOW</arg>
-                        <!-- UnicodeInCode is off for good. It reads a non-ASCII identifier as a
-                             thing that confuses a reader, and this compiler's tests call methods
-                             the language named in Japanese: the check would be asking the tests to
-                             stop covering what Souther supports. -->
-                        <arg>-Xplugin:ErrorProne ${errorprone.checks} -Xep:UnicodeInCode:OFF -Xep:NullAway:ERROR -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:JSpecifyMode=true</arg>
                     </compilerArgs>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>com.google.errorprone</groupId>
-                            <artifactId>error_prone_core</artifactId>
-                            <version>${errorprone.version}</version>
-                        </path>
-                        <path>
-                            <groupId>com.uber.nullaway</groupId>
-                            <artifactId>nullaway</artifactId>
-                            <version>${nullaway.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <!-- Implementation-Version in every jar's manifest. A compiled Souther module records
@@ -267,14 +230,36 @@
     </build>
 
     <profiles>
-        <!-- Error Prone's own checks, on top of the nullness gate every build runs. On in CI,
-             which sets `CI` in the environment, and available anywhere as `mvn -Plint verify`.
-             What this buys is the checks that are errors by default — the first run of it found a
-             `String` handed to a `Map<NumericTerm, ...>`, which had left two tests asserting
-             something about a domain they were never given. What it costs is three times the
-             compile, which is why it is not what a build runs while code is being written. A
-             finding can therefore reach CI without having been seen locally; `mvn -Plint` on the
-             module in hand is the way to answer it. -->
+        <!-- Error Prone, the JSpecify nullness gate included. On in CI, which sets `CI` in the
+             environment, and available anywhere as `mvn -Plint clean verify`.
+
+             Not in a development build. Measured on `clean test-compile`, whole reactor, one run
+             each: 8.7s with none of this, 12.0s with NullAway alone, 38.0s with the default checks
+             as well; and on the incremental build one edited source costs, 10.7s without it
+             against 13.5s with. A finding therefore reaches CI without having been seen locally,
+             and `mvn -Plint clean verify` is how to answer one. What it buys is the checks that
+             are errors by default — the first run of it found a `String` handed to a
+             `Map<NumericTerm, ...>`, which had left two tests asserting something about a domain
+             they were never given.
+
+             `clean` is not optional. The checks are javac's plugin, so a compilation Maven skips
+             as up to date runs none of them and reports nothing.
+
+             NullAway reads the JSpecify annotations souther-runtime carries, and `OnlyNullMarked`
+             is what decides where it looks — the packages that declare `@NullMarked`, and no
+             others. Adopting a package is one line in its `package-info.java`. Declaring the whole
+             of souther-compiler annotated instead reports 1024 findings at once, which is a
+             migration and not a check.
+
+             `compilePolicy` and `should-stop` are Error Prone's arguments, not ours: its checks
+             read the flow graph, and javac builds one per class only under that policy. The
+             exports the plugin needs to reach javac's internals are in `.mvn/jvm.config`, because
+             the compiler runs in the Maven JVM; without them the build stops at
+             `IllegalAccessError` before any source is read.
+
+             `combine.children` is what keeps the error and warning limits the build above sets:
+             without it a profile's list of arguments replaces that list rather than adding to
+             it, and a lint run would stop counting at a hundred. -->
         <profile>
             <id>lint</id>
             <activation>
@@ -282,9 +267,37 @@
                     <name>env.CI</name>
                 </property>
             </activation>
-            <properties>
-                <errorprone.checks/>
-            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <compilerArgs combine.children="append">
+                                <arg>-XDcompilePolicy=simple</arg>
+                                <arg>--should-stop=ifError=FLOW</arg>
+                                <!-- UnicodeInCode is off for good. It reads a non-ASCII identifier
+                                     as a thing that confuses a reader, and this compiler's tests
+                                     call methods the language named in Japanese: the check would be
+                                     asking the tests to stop covering what Souther supports. -->
+                                <arg>-Xplugin:ErrorProne -Xep:UnicodeInCode:OFF -Xep:NullAway:ERROR -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:JSpecifyMode=true</arg>
+                            </compilerArgs>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>com.google.errorprone</groupId>
+                                    <artifactId>error_prone_core</artifactId>
+                                    <version>${errorprone.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>com.uber.nullaway</groupId>
+                                    <artifactId>nullaway</artifactId>
+                                    <version>${nullaway.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <!-- An editor's Java support builds these modules through m2e, and m2e points an Eclipse
              project's output at whatever the pom names: ECJ then writes into target/classes, which

--- a/souther-bench/src/test/java/souther/bench/TheNullnessGateRunsWhereItIsDeclaredTest.java
+++ b/souther-bench/src/test/java/souther/bench/TheNullnessGateRunsWhereItIsDeclaredTest.java
@@ -1,0 +1,247 @@
+package souther.bench;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.attribute.RuntimeInvisibleAnnotationsAttribute;
+import java.lang.classfile.attribute.RuntimeVisibleAnnotationsAttribute;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The modules an ordinary build runs NullAway over are the modules that declare {@code @NullMarked}.
+ *
+ * <p>#711 put the null analysis in the build so that a rule only some checkouts enforce would not be
+ * the rule, and asked that adopting a package be one line in its {@code package-info.java}. Two
+ * things have to agree for that to hold: which packages are annotated, and which modules configure
+ * the gate. Both are written by hand, in different files, and nothing else compares them. They agree
+ * today because there is one of each. This is what refuses the day they stop.
+ *
+ * <p>Equality rather than containment, and in both directions. A module that declares the annotation
+ * and does not run the gate has a rule nobody checks; a module that runs the gate and declares
+ * nothing pays Error Prone's startup on every compile to check nothing at all. Either way the two
+ * statements have come apart, and the fix is named by which side is short.
+ *
+ * <p>The annotated side is read off class files rather than sources, because souther-compiler's
+ * javadoc discusses {@code @NullMarked} and its code generator writes the annotation into the classes
+ * it emits — both put the word in a source file that declares nothing. An annotation on a class is
+ * only an annotation in the class file.
+ *
+ * <p>The configured side is read off {@code /project/build}, never a profile: the question is what an
+ * ordinary {@code mvn test} runs, and the {@code lint} profile deliberately runs the gate over
+ * everything. A gate declared in the root's build would cover every module, so that is read too.
+ *
+ * <p>The root's properties are substituted into an argument before it is read. The gate's
+ * options are named in one property so that the module and the profile cannot ask for
+ * different ones, and a reader that stopped at the placeholder would see neither of them
+ * mention NullAway.
+ *
+ * <p>It lives in the last module the reactor builds, because it reads every module's classes and they
+ * have to be there.
+ */
+class TheNullnessGateRunsWhereItIsDeclaredTest {
+
+    /** JSpecify's package-level annotation, as a class file spells it. */
+    private static final String NULL_MARKED = "Lorg/jspecify/annotations/NullMarked;";
+
+    @Test
+    void theGateIsConfiguredForEveryModuleThatDeclaresItAndNoOther() {
+        List<String> modules = modules();
+        Set<String> declared = new LinkedHashSet<>();
+        Set<String> configured = new LinkedHashSet<>();
+        boolean rootGates = gateIsInTheBuildOf(repoRoot().resolve("pom.xml"));
+        for (String module : modules) {
+            if (declaresNullMarked(module)) {
+                declared.add(module);
+            }
+            if (rootGates || gateIsInTheBuildOf(repoRoot().resolve(module).resolve("pom.xml"))) {
+                configured.add(module);
+            }
+        }
+
+        // Neither set may be empty. An empty declared set would make this pass by having nothing to
+        // say, and an empty configured set is the gate being gone.
+        assertFalse(declared.isEmpty(),
+                "no module declares @NullMarked, so either the annotation was dropped or this is"
+                        + " reading the wrong thing");
+        assertFalse(configured.isEmpty(),
+                "no module runs the nullness gate in an ordinary build, which is what #711 was for");
+
+        assertEquals(declared, configured,
+                "the gate and the annotation have come apart.\n"
+                        + "  declares @NullMarked: " + declared + "\n"
+                        + "  runs the gate:        " + configured + "\n"
+                        + "A module in the first and not the second states a rule its own build does"
+                        + " not check: give it the maven-compiler-plugin block souther-runtime"
+                        + " carries. A module in the second and not the first runs Error Prone on"
+                        + " every compile to check nothing: take that block out.");
+    }
+
+    /** Whether any class the module built carries the annotation. */
+    private static boolean declaresNullMarked(String module) {
+        Path classes = repoRoot().resolve(module).resolve("target/classes");
+        assertTrue(Files.isDirectory(classes),
+                module + " has no built classes: this reads what has been built, so a module that has"
+                        + " not been is a hole rather than a pass");
+        try (Stream<Path> walk = Files.walk(classes)) {
+            return walk.filter(p -> p.toString().endsWith(".class")).anyMatch(TheNullnessGateRunsWhereItIsDeclaredTest::carriesNullMarked);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static boolean carriesNullMarked(Path classFile) {
+        ClassModel model;
+        try {
+            model = ClassFile.of().parse(Files.readAllBytes(classFile));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        // Both retentions, because which one JSpecify uses is JSpecify's to change.
+        Stream<java.lang.classfile.Annotation> annotations = Stream.concat(
+                model.findAttribute(java.lang.classfile.Attributes.runtimeVisibleAnnotations())
+                        .map(RuntimeVisibleAnnotationsAttribute::annotations).orElse(List.of()).stream(),
+                model.findAttribute(java.lang.classfile.Attributes.runtimeInvisibleAnnotations())
+                        .map(RuntimeInvisibleAnnotationsAttribute::annotations).orElse(List.of()).stream());
+        return annotations.anyMatch(a -> a.className().stringValue().equals(NULL_MARKED));
+    }
+
+    /**
+     * Whether this pom's own build — not one of its profiles — hands javac the Error Prone plugin
+     * with NullAway turned on.
+     */
+    private static boolean gateIsInTheBuildOf(Path pom) {
+        if (!Files.isRegularFile(pom)) {
+            return false;
+        }
+        Element project = parse(pom);
+        Map<String, String> properties = rootProperties();
+        for (Element build : childrenNamed(project, "build")) {
+            for (Element plugins : childrenNamed(build, "plugins")) {
+                for (Element plugin : childrenNamed(plugins, "plugin")) {
+                    if (!textOfFirst(plugin, "artifactId").equals("maven-compiler-plugin")) {
+                        continue;
+                    }
+                    for (Element configuration : childrenNamed(plugin, "configuration")) {
+                        for (Element args : childrenNamed(configuration, "compilerArgs")) {
+                            for (Element arg : childrenNamed(args, "arg")) {
+                                String text = substitute(arg.getTextContent(), properties);
+                                if (text.contains("-Xplugin:ErrorProne") && text.contains("NullAway")) {
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /** The root pom's {@code <properties>}, which is where the gate's options are named. */
+    private static Map<String, String> rootProperties() {
+        Map<String, String> properties = new LinkedHashMap<>();
+        for (Element block : childrenNamed(parse(repoRoot().resolve("pom.xml")), "properties")) {
+            NodeList children = block.getChildNodes();
+            for (int i = 0; i < children.getLength(); i++) {
+                if (children.item(i) instanceof Element element) {
+                    properties.put(element.getTagName(), element.getTextContent().trim());
+                }
+            }
+        }
+        assertFalse(properties.isEmpty(), "the root pom names no properties, which cannot be right");
+        return properties;
+    }
+
+    /**
+     * To a fixed point, because a property here names another: the gate is written as the plugin
+     * plus {@code ${nullaway.args}}. One pass over the properties in document order would resolve
+     * that only when the inner one happens to be declared first, which is a reading that depends on
+     * the order of a file nobody is holding to an order.
+     */
+    private static String substitute(String text, Map<String, String> properties) {
+        String substituted = text;
+        for (int pass = 0; pass < properties.size() + 1; pass++) {
+            String next = substituted;
+            for (Map.Entry<String, String> property : properties.entrySet()) {
+                next = next.replace("${" + property.getKey() + "}", property.getValue());
+            }
+            if (next.equals(substituted)) {
+                return substituted;
+            }
+            substituted = next;
+        }
+        throw new IllegalStateException("a property in the root pom refers to itself: " + text);
+    }
+
+    private static Element parse(Path pom) {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(false);
+            return factory.newDocumentBuilder().parse(pom.toFile()).getDocumentElement();
+        } catch (Exception e) {
+            throw new IllegalStateException("cannot read " + pom, e);
+        }
+    }
+
+    private static List<Element> childrenNamed(Element parent, String name) {
+        List<Element> found = new ArrayList<>();
+        NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node child = children.item(i);
+            if (child instanceof Element element && element.getTagName().equals(name)) {
+                found.add(element);
+            }
+        }
+        return found;
+    }
+
+    private static String textOfFirst(Element parent, String name) {
+        List<Element> found = childrenNamed(parent, name);
+        return found.isEmpty() ? "" : found.get(0).getTextContent().trim();
+    }
+
+    /**
+     * Everything this covers, read off the reactor rather than listed here, for the reason the ABI
+     * check gives: a list of its own would say what was true when it was written.
+     */
+    private static List<String> modules() {
+        String pom;
+        try {
+            pom = Files.readString(repoRoot().resolve("pom.xml"));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        List<String> modules = new ArrayList<>();
+        Matcher m = Pattern.compile("<module>([^<]+)</module>").matcher(pom);
+        while (m.find()) {
+            modules.add(m.group(1));
+        }
+        assertFalse(modules.isEmpty(), "the reactor names no modules");
+        return modules;
+    }
+
+    private static Path repoRoot() {
+        return Path.of("").toAbsolutePath().getParent();
+    }
+}

--- a/souther-runtime/pom.xml
+++ b/souther-runtime/pom.xml
@@ -53,4 +53,41 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <!-- The nullness gate runs here in every build, `mvn test` included, because this is the module
+         whose packages declare `@NullMarked`. What the gate asks for is `errorprone.gate` in the
+         root pom, including why that is a property rather than written out here.
+
+         Which modules carry this block is not a thing to remember. A `@NullMarked` package in a
+         module that does not run the gate, and a module that runs the gate and declares no such
+         package, are both refused by a check in souther-bench that reads the two sets off the
+         tree. -->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs combine.children="append">
+                        <arg>-XDcompilePolicy=simple</arg>
+                        <arg>--should-stop=ifError=FLOW</arg>
+                        <arg>${errorprone.gate}</arg>
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>${errorprone.version}</version>
+                        </path>
+                        <path>
+                            <groupId>com.uber.nullaway</groupId>
+                            <artifactId>nullaway</artifactId>
+                            <version>${nullaway.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
Error Prone was on the compiler plugin itself, so every compile of every module ran it,
including the one an edit runs. The `lint` profile only widened which checks were enabled — it
never turned the plugin on. This moves `-Xplugin:ErrorProne`, `-XDcompilePolicy=simple`,
`--should-stop` and the annotation processor paths into that profile. A development build is
javac and nothing else.

On the build one edited source in souther-compiler costs, from the reactor root, three runs
each: 13.39 / 13.76 / 13.48 seconds with the plugin, 11.11 / 10.39 / 11.17 without.

## The nullness gate was already looking at nothing here

`OnlyNullMarked` decides where NullAway looks, and `@NullMarked` is written in two files in
this repository, both `package-info.java` under souther-runtime. Across souther-compiler's 516
sources it was analysing none of them. Moving it does not weaken a rule this module was being
held to.

## Held both ways

A `@NullMarked` package returning null from a non-null return type, and a `String.trim()` whose
value is dropped:

| | default build | `CI=1 mvn -o -Plint clean test-compile` |
|---|---|---|
| the null return | BUILD SUCCESS | `[NullAway] returning @Nullable expression from method with @NonNull return type` |
| the dropped value | BUILD SUCCESS | `[ReturnValueIgnored] Return value of 'trim' must be used` |

`combine.children` on the profile's `compilerArgs` is load-bearing: a profile's list of
arguments replaces the list the build declares rather than adding to it, so without it a lint
run loses `-Xmaxerrs` and `-Xmaxwarns` and stops counting at a hundred. Both effective poms
were read.

`mvn -o test` from the root is green, and `CI=1 mvn -o -Plint clean verify` is green on this
branch with sixteen compilations actually run.

## The other half of #944

The issue also asked whether splitting souther-compiler's 905 test sources into modules of
their own would cut the loop. Measured and dropped. Every downstream module already recompiles
in full when a souther-compiler main source changes, so a carved-out test module would too and
the main-edit path would not move. Counting 21336 builds in the local transcripts by what was
edited since the previous build: 59.3% had no source edit at all, 19.3% main only, 17.5% test
only, 3.8% both — which, weighted by what each costs, is about a quarter of the time spent
building. So the reason to leave it is not that the effect is small. It is that the effect is
confined to test-only edits and the change is a restructuring, while what this PR does reaches
every build and is a pom.

Closes #944.

