### PR TITLE
Write the rows of a table at one column

### DIFF
--- a/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
+++ b/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
@@ -332,6 +332,10 @@ column, and the two answers are columns:
 - the rows of a table of fakes write their -> at one column — a `fake` has the one column, since its
   rows have no description.
 
+The column a row is said to be at is where the padding it wrote carries it, with the rest of the
+line as the canonical form has it. So a table lined up correctly and indented one column too deep is
+told about its indentation and nothing else, rather than about every row.
+
 What separates one thing from another, and what ends:
 
 - a blank line stands where the author wrote one, and under a header — how many, as lines.

--- a/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
+++ b/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
@@ -244,6 +244,22 @@ departure to break off: the `else` ends the guard's own line and the clauses go 
         | unique -> DuplicateProduct
 ```
 
+An `example` and a `fake` are decision tables, and their rows are read against each other: which
+input differs between two rows is what writing them one under the other is for. So the connectors of
+a table's rows are written at one column — the `:` and the `->` of an `example`, the `->` of a
+`fake` — with the shorter rows padded out to the widest. Adding a row rewrites the table where the
+new one is the widest, which is the diff a table asks for. Whatever the author lined up by hand is
+derived again like everything else, and a row too long for one line is written down the page and
+takes no part in the columns. The padding is measured in columns on the screen, so a table whose
+descriptions are Japanese lines up on a screen rather than on a character count.
+
+```
+example priceOfTheFirstGlass
+    | "off peak, no coupon" : (OffPeak, NoCoupon)     -> Price(490)
+    | "happy hour"          : (HappyHour, NoCoupon)   -> Price(290)
+    | "with a coupon"       : (OffPeak, WithCoupon)   -> Price(100)
+```
+
 A comment keeps what it was written about. On the line of the code it follows it stays there; on a
 line of its own it goes above what follows it, unless a blank line separates it from that and none
 separates it from the code above, in which case it stays under that code. A comment with nothing
@@ -301,6 +317,15 @@ How far in a line begins. The two answers are columns:
 - one level deeper is one indent further in — a step, and not a column the rule never states.
 - a line the file holds begins at column zero — the outermost level, which has no level outside it
   to be measured from.
+
+Where a table's rows line up. An `example` and a `fake` write the connectors of every row at one
+column, and the two answers are columns:
+
+- the rows of a table of examples write their : at one column — the description was padded out to
+  the widest one in the table, or was not.
+- the rows of a table of examples write their -> at one column — the same, for the input.
+- the rows of a table of fakes write their -> at one column — a `fake` has the one column, since its
+  rows have no description.
 
 What separates one thing from another, and what ends:
 

--- a/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
+++ b/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
@@ -289,7 +289,8 @@ What stands between two tokens the same line holds:
 - what goes between two tokens on a line — one space, or none. The two answers quote the characters,
   so a source that wrote a line break where neither text ends a line reads it back as `\n`. At a
   table's column this answers about the separator and the column rule about the padding after it,
-  which is why a tab written there is quoted here rather than counted as a column.
+  so what is written there is this rule's until the separator is what the canonical form has —
+  a tab, or no space at all, is quoted here rather than reported as a column the row missed.
 
 Whether a construct is written down the page at all. The two answers are `on one line` and `down the
 page`, and which rule is named is which one decided the form:

--- a/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
+++ b/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
@@ -251,7 +251,9 @@ a table's rows are written at one column — the `:` and the `->` of an `example
 new one is the widest, which is the diff a table asks for. Whatever the author lined up by hand is
 derived again like everything else, and a row too long for one line is written down the page and
 takes no part in the columns. The padding is measured in columns on the screen, so a table whose
-descriptions are Japanese lines up on a screen rather than on a character count.
+descriptions are Japanese lines up on a screen rather than on a character count, and it is written
+as spaces — a tab reaches a column too, and what a source wrote there is the rule about what goes
+between two tokens' to say rather than the column's.
 
 ```
 example priceOfTheFirstGlass
@@ -285,7 +287,9 @@ rest of the rules are about:
 What stands between two tokens the same line holds:
 
 - what goes between two tokens on a line — one space, or none. The two answers quote the characters,
-  so a source that wrote a line break where neither text ends a line reads it back as `\n`.
+  so a source that wrote a line break where neither text ends a line reads it back as `\n`. At a
+  table's column this answers about the separator and the column rule about the padding after it,
+  which is why a tab written there is quoted here rather than counted as a column.
 
 Whether a construct is written down the page at all. The two answers are `on one line` and `down the
 page`, and which rule is named is which one decided the form:

--- a/souther-compiler/src/test/java/souther/compiler/WhatIsWrittenInAnEnsuresIsQuotedOverTheRowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatIsWrittenInAnEnsuresIsQuotedOverTheRowsTest.java
@@ -76,8 +76,8 @@ class WhatIsWrittenInAnEnsuresIsQuotedOverTheRowsTest {
                 //
                 // example findTodo
                 //     | "id=0 <= x <= 0" : (TodoId(0)) -> <?>
-                //     | "id=0 < x" : (TodoId(1)) -> <?>
-                //     | (TodoId(2)) -> <?>
+                //     | "id=0 < x"       : (TodoId(1)) -> <?>
+                //     | (TodoId(2))                    -> <?>
                 //
                 // example echo
                 //     | (TodoId(0)) -> <?>

--- a/souther-fmt/src/main/java/souther/compiler/fmt/ColumnDecision.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/ColumnDecision.java
@@ -1,0 +1,15 @@
+package souther.compiler.fmt;
+
+/**
+ * Where one column of one table is, on the screen.
+ *
+ * <p>Taken once for the whole column, as a group's is taken once for the whole group. Which column
+ * a table's {@code ->} stands at is one answer that every row of it is written to, so a decision per
+ * row would be counting the rows and calling the count decisions.
+ *
+ * <p>A display column and not an index into the text. What lines up is what a reader sees, and the
+ * rows of a table whose descriptions are Japanese line up where the columns agree and not where the
+ * characters do.
+ */
+record ColumnDecision(Columns.Unit unit, int column) {
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/ColumnOccurrence.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/ColumnOccurrence.java
@@ -1,0 +1,20 @@
+package souther.compiler.fmt;
+
+/**
+ * One row written to a column: where that row would have reached on its own, and where in the text
+ * the padding that carries it to the column stands.
+ *
+ * <p>The occurrences are to a {@link ColumnDecision} what the opportunities are to a group's: the
+ * decision is one and the places it is realized at are many. What makes the pair worth keeping is
+ * that the decision cannot be read back off the text — every row of a table is at the column, so a
+ * text says where the column is and never which row put it there.
+ *
+ * <p>{@code naturalColumn} is where the connector stands with every column before it on this line
+ * already written and this one not — so the column is the greatest of them, and a row whose natural
+ * column is the column is one the rule writes nothing for.
+ *
+ * <p>Only for a row the canonical form writes on one line. A row it breaks has its connector at the
+ * start of a line, where a column is not a thing that could be asked about.
+ */
+record ColumnOccurrence(Columns.Unit unit, int at, int naturalColumn) {
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Columns.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Columns.java
@@ -1,0 +1,130 @@
+package souther.compiler.fmt;
+
+import souther.compiler.cst.SyntaxKind;
+
+/**
+ * The rule that the rows of a table write each of their connectors at one column, and the vocabulary
+ * it is stated in.
+ *
+ * <p>A table is a construct whose rows are read against each other: which input differs between two
+ * of them is what writing them one under the other is for. That is what an {@code example} and a
+ * {@code fake} are and it is not what a {@code match} is — the arms of a match are read from the top
+ * down, and a rule that lined their arrows up would move every arm to the width of the longest one
+ * for no question anyone asks of them.
+ *
+ * <p><b>Not a second answer about a boundary.</b> {@link Spacing} decides what stands between two
+ * tokens and still has no third answer. A stop is written <em>after</em> that answer, so what a
+ * column says is where the connector after it begins and never what separates it from what came
+ * before. A source whose table is already aligned and one that is not both hold one space there;
+ * they differ in the padding, which is this rule's and nobody else's.
+ *
+ * <p><b>The stops are in the order a row writes them.</b> Where a column is depends on the ones
+ * before it on the same line — a row's {@code ->} stands after however far its {@code :} pushed it —
+ * so {@link Stop} is declared in that order and the layout settles them in it.
+ */
+final class Columns {
+
+    private Columns() {
+    }
+
+    /**
+     * Which table a column belongs to. An identity and nothing else, as {@link Doc.GroupRef} and
+     * {@link Doc.NestRef} are: two {@code example}s written the same way are two tables, and a rule
+     * keyed by what they are called would run the widths of one into the other.
+     */
+    static final class TableRef {
+    }
+
+    /** One column of one table. */
+    record Unit(TableRef table, Stop stop) {
+
+        Unit {
+            if (table == null || stop == null) {
+                throw new IllegalArgumentException("a column is one stop of one table");
+            }
+        }
+    }
+
+    /**
+     * A place a table's rows line up at: the construct the row is, and the connector that stands at
+     * the column.
+     *
+     * <p>Named by the connector rather than by how many stops come before it. A row with no
+     * description has no {@code :} and its {@code ->} is still the same column as everybody else's;
+     * counted by position it would be the first stop of that row and the second of the rest, and the
+     * table would have two columns where it has one.
+     */
+    enum Stop {
+
+        /** Where an example row's input begins. */
+        THE_INPUT_OF_AN_EXAMPLE(SyntaxKind.EXAMPLE_ROW, SyntaxKind.COLON),
+
+        /** Where an example row's expected value begins. */
+        THE_RESULT_OF_AN_EXAMPLE(SyntaxKind.EXAMPLE_ROW, SyntaxKind.ARROW),
+
+        /** Where a fake row's output begins. */
+        THE_RESULT_OF_A_FAKE(SyntaxKind.FAKE_ROW, SyntaxKind.ARROW);
+
+        private final SyntaxKind row;
+        private final SyntaxKind connector;
+
+        Stop(SyntaxKind row, SyntaxKind connector) {
+            this.row = row;
+            this.connector = connector;
+        }
+
+        /** The row this is a stop of. */
+        SyntaxKind row() {
+            return row;
+        }
+
+        /** The token written at the column. */
+        SyntaxKind connector() {
+            return connector;
+        }
+
+        /** What the rule says, for a reader who is being told their source does not. */
+        String said() {
+            return "the rows of a " + switch (row) {
+                case EXAMPLE_ROW -> "table of examples";
+                case FAKE_ROW -> "table of fakes";
+                default -> throw new IllegalStateException("no such table: " + row);
+            } + " write their " + connector.fixedSpelling().orElseThrow()
+                    + " at one column";
+        }
+    }
+
+    /**
+     * Whether a construct's rows are read against each other. What holds a table's rows is what a
+     * column's widths are closed over.
+     */
+    static boolean isTable(SyntaxKind kind) {
+        return kind == SyntaxKind.EXAMPLE_DEF || kind == SyntaxKind.FAKE_DEF;
+    }
+
+    /**
+     * The stop written at a boundary, or null where the boundary is not one.
+     *
+     * <p>Read from the construct joining the two tokens and the one on the right, which is the same
+     * pair {@link Spacing} is asked about. The token on the left is not read: what a row writes
+     * before its {@code ->} is its input, and an input is whatever the author put there.
+     *
+     * <p>{@code joining} is the deepest construct holding both tokens, so an arrow written inside
+     * the row — a lambda's — is joined by that lambda and is not a stop of the table.
+     */
+    static Stop at(SyntaxKind joining, SyntaxKind right) {
+        for (Stop stop : Stop.values()) {
+            if (stop.row() == joining && stop.connector() == right) {
+                return stop;
+            }
+        }
+        return null;
+    }
+
+    /** How many times the layout has to be laid out before every column has settled. Each stop is
+     *  settled by the pass after the one that settled the stop before it on its line, and one more
+     *  pass sees that nothing moved. */
+    static int passes() {
+        return Stop.values().length + 1;
+    }
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Columns.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Columns.java
@@ -120,11 +120,4 @@ final class Columns {
         }
         return null;
     }
-
-    /** How many times the layout has to be laid out before every column has settled. Each stop is
-     *  settled by the pass after the one that settled the stop before it on its line, and one more
-     *  pass sees that nothing moved. */
-    static int passes() {
-        return Stop.values().length + 1;
-    }
 }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Deviations.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Deviations.java
@@ -147,7 +147,8 @@ public final class Deviations {
         List<Family> families = List.of(Witnesses::tokens, Witnesses::spacing,
                 Witnesses::separation,
                 Witnesses::indentation, Witnesses::forced, Witnesses::settled,
-                Witnesses::conditional, Witnesses::comments, Witnesses::lineEnds);
+                Witnesses::conditional, Witnesses::comments, Witnesses::lineEnds,
+                Witnesses::columns);
         for (Family family : families) {
             try {
                 out.addAll(family.of(source, canonical, pairing));
@@ -202,6 +203,9 @@ public final class Deviations {
         for (Rewrites.Kind k : Rewrites.Kind.values()) {
             out.add(k.said());
         }
+        for (Columns.Stop stop : Columns.Stop.values()) {
+            out.add(stop.said());
+        }
         return out;
     }
 
@@ -231,6 +235,9 @@ public final class Deviations {
             case Witness.TrailingComment _ -> A_TRAILING_COMMENT;
             case Witness.CommentAbove _ -> A_COMMENT_ABOVE;
             case Witness.CommentCarrier _ -> A_COMMENT_IS_CARRIED;
+            // One statement per stop rather than one for the rule. A reader is being told which
+            // column their row missed, and the tables have different ones.
+            case Witness.AtAColumn c -> c.unit().stop().said();
         };
     }
 
@@ -248,6 +255,7 @@ public final class Deviations {
             case Witness.TrailingComment t -> quoted(t.canonical());
             case Witness.CommentAbove a -> lineBreaks(a.canonical());
             case Witness.CommentCarrier _ -> "somewhere else";
+            case Witness.AtAColumn c -> "column " + c.canonical();
         };
     }
 
@@ -266,6 +274,8 @@ public final class Deviations {
             case Witness.TrailingComment t -> quoted(t.source());
             case Witness.CommentAbove a -> lineBreaks(a.source());
             case Witness.CommentCarrier _ -> "here";
+            case Witness.AtAColumn c -> c.source().size() == 1
+                    ? "column " + c.source().get(0) : "columns " + c.source();
         };
     }
 

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
@@ -18,6 +18,16 @@ sealed interface Doc {
 
     Doc NIL = new Nil();
 
+    /**
+     * How many times a document is laid out before every column has settled.
+     *
+     * <p>A stop is settled by the pass after the one that settled the stop before it on its line,
+     * and one more pass sees that nothing moved. So it is one more than the stops there are — read
+     * from {@link Columns.Stop} because that is where they are listed, and held here because how
+     * many times this lays a document out is this file's and not the rule's.
+     */
+    int PASSES = Columns.Stop.values().length + 1;
+
     /** Writes nothing, and the group holding it is never laid out flat. A comment cannot share the
      * line after it, so a construct holding one breaks even where its own content would have fitted
      * — and where the break itself is the enclosing construct's to write, as the brackets of a list
@@ -225,7 +235,7 @@ sealed interface Doc {
      *
      * <p>It settles because a column depends only on the columns before it on its line: the first
      * stop is settled by the first pass, the one after it by the second, and one more pass sees that
-     * nothing moved. {@link Columns#passes()} is that count and this refuses to run past it.
+     * nothing moved. {@link #PASSES} is that count and this refuses to run past it.
      *
      * <p>A document with no table is laid out once. The first pass writes no stop, so there is
      * nothing to settle and the layout it produced is the answer — which is what keeps this off the
@@ -239,9 +249,9 @@ sealed interface Doc {
             if (settled.equals(columns)) {
                 return laid;
             }
-            if (pass >= Columns.passes()) {
+            if (pass >= PASSES) {
                 throw new IllegalStateException(
-                        "the columns of a table did not settle in " + Columns.passes()
+                        "the columns of a table did not settle in " + PASSES
                                 + " layouts; a column reads the ones before it on its line and"
                                 + " nothing else, so this is a cycle that should not exist");
             }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
@@ -276,18 +276,25 @@ sealed interface Doc {
         StringBuilder sb = new StringBuilder();
         Deque<Item> todo = new ArrayDeque<>();
         todo.push(new Item(0, Mode.BREAK, this));   // the outermost context breaks
-        // Two counts run side by side here and they are not interchangeable. `displayCol` is where
-        // the line has reached on the screen, which is what the width is about and what a
-        // full-width character advances by two. Everything taken from `sb.length()` — an extent, an
-        // opportunity, a newline's offset — is an index into the text, which is what the readers of
-        // a layout use to cut and search the same Java string, and stays in UTF-16 units.
-        int displayCol = 0;
-        // And a third, which is neither. `padded` is how many columns of a table's padding have been
-        // written on this line. It is not in `displayCol` because the width rule does not read
-        // padding — a group whose flatness depended on it would be decided by a column that is
-        // decided by which rows came out flat — and it is not out of the reckoning either, because
-        // where a row's second connector lands is where its first one pushed it to.
-        int padded = 0;
+        // Three counts run side by side here and no two of them are interchangeable. Everything
+        // taken from `sb.length()` — an extent, an opportunity, a newline's offset — is an index
+        // into the text, which is what the readers of a layout use to cut and search the same Java
+        // string, and stays in UTF-16 units. The other two are columns on the screen, which is what
+        // a full-width character advances by two and what a tab advances to the next multiple of
+        // eight of.
+        //
+        // `measuredCol` is what the width reads, and a table's padding is not in it: a group whose
+        // flatness depended on padding would be decided by a column that is decided by which rows
+        // came out flat. `writtenCol` is where the line has actually reached, padding and all, and
+        // it is what a column is settled in — a row's second connector stands where its first one
+        // pushed it to.
+        //
+        // Two counts and not one with a correction added to it. How far a token advances a column
+        // depends on the column it starts at, which is the whole of what a tab is; a written column
+        // reconstructed as `measuredCol` plus the padding so far is right for every token but that
+        // one, and wrong for the rows of a table that holds it.
+        int measuredCol = 0;
+        int writtenCol = 0;
         while (!todo.isEmpty()) {
             Item it = todo.pop();
             if (it.closes != null) {
@@ -298,7 +305,8 @@ sealed interface Doc {
                 case Nil _ -> { }
                 case Text t -> {
                     sb.append(t.s());
-                    displayCol = DisplayColumns.advance(t.s(), displayCol);
+                    measuredCol = DisplayColumns.advance(t.s(), measuredCol);
+                    writtenCol = DisplayColumns.advance(t.s(), writtenCol);
                 }
                 case Concat c -> {
                     List<Doc> parts = c.parts();
@@ -319,9 +327,9 @@ sealed interface Doc {
                     todo.push(it.within(a.doc()));
                 }
                 case Group g -> {
-                    Outcome outcome = flatnessOf(displayCol, width,
+                    Outcome outcome = flatnessOf(measuredCol, width,
                             new Item(it.indent, Mode.FLAT, g.doc()), todo);
-                    decisions.add(new GroupDecision(g.ref(), displayCol, outcome));
+                    decisions.add(new GroupDecision(g.ref(), measuredCol, outcome));
                     todo.push(new Item(it.indent,
                             outcome instanceof Outcome.Flat ? Mode.FLAT : Mode.BREAK, g.doc(),
                             null, it.under, g.ref()));
@@ -337,39 +345,41 @@ sealed interface Doc {
                     }
                     if (it.mode == Mode.FLAT) {
                         sb.append(l.flat());
-                        displayCol = DisplayColumns.advance(l.flat(), displayCol);
+                        measuredCol = DisplayColumns.advance(l.flat(), measuredCol);
+                        writtenCol = DisplayColumns.advance(l.flat(), writtenCol);
                     } else {
                         breaks.add(newline(sb, it, it.indent,
                                 new Newline.Cause.Settled(l.ref()), true));
-                        displayCol = it.indent;
-                        padded = 0;
+                        measuredCol = it.indent;
+                        writtenCol = it.indent;
                     }
                 }
                 case Hard h -> {
                     int indent = h.indents() ? it.indent : 0;
                     breaks.add(newline(sb, it, indent,
                             new Newline.Cause.Forced(h.ref().obligation()), h.indents()));
-                    displayCol = indent;
-                    padded = 0;
+                    measuredCol = indent;
+                    writtenCol = indent;
                 }
                 case Trailing t -> {
                     sb.append(' ').append(t.s());
-                    displayCol = DisplayColumns.advance(t.s(), displayCol + 1);
+                    measuredCol = DisplayColumns.advance(t.s(), measuredCol + 1);
+                    writtenCol = DisplayColumns.advance(t.s(), writtenCol + 1);
                 }
                 case MustBreak _ -> { }
                 case ColumnStop cs -> {
                     // A row written down the page has its connector opening a line, and there is no
                     // column to be at there. It neither reaches for one nor says how wide it is.
                     if (it.mode == Mode.FLAT) {
-                        int natural = displayCol + padded;
                         Integer column = columns.get(cs.unit());
                         // Nothing to write on the pass that is finding out where the column is, and
                         // nothing on a pass whose column is one an earlier pass measured short. The
                         // pass after it has the room this one asked for.
-                        int pad = column == null ? 0 : Math.max(0, column - natural);
-                        stops.add(new ColumnOccurrence(cs.unit(), sb.length(), natural));
+                        int pad = column == null ? 0 : Math.max(0, column - writtenCol);
+                        stops.add(new ColumnOccurrence(cs.unit(), sb.length(), writtenCol));
                         sb.append(" ".repeat(pad));
-                        padded += pad;
+                        // What the width reads is untouched, which is the whole of the rule.
+                        writtenCol += pad;
                     }
                 }
             }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
@@ -112,6 +112,18 @@ sealed interface Doc {
 
     record MustBreak(Ref ref) implements Doc, Refuses {}
 
+    /**
+     * A column of a table, at the place one row is written to it. Writes the spaces that carry the
+     * connector after it out to the column, and nothing where the row is written down the page.
+     *
+     * <p>It stands after the boundary rather than in place of it: what separates two tokens is
+     * {@link Spacing}'s answer and this never touches it. So a row already at the column has this
+     * write nothing, and the text either way holds the separator the rule wrote.
+     *
+     * <p>What it writes is not measured. See {@link #layout}.
+     */
+    record ColumnStop(Columns.Unit unit) implements Doc {}
+
     static Doc text(String s) {
         return new Text(s);
     }
@@ -161,6 +173,11 @@ sealed interface Doc {
         return new Nest(new NestRef(), indent, doc);
     }
 
+    /** The place one row of a table is written out to one of its columns. */
+    static Doc columnStop(Columns.Unit unit) {
+        return new ColumnStop(unit);
+    }
+
     static Doc at(Place place, Doc doc) {
         return new At(place, doc);
     }
@@ -198,11 +215,58 @@ sealed interface Doc {
      * <p>A decision is taken once, where the outer walk reaches the group. {@link #fits} walks ahead
      * over groups it is only measuring and takes none, so what comes back is what was laid out
      * rather than what was considered.
+     *
+     * <p>A column cannot be decided that way. Where a row's connector goes depends on every other
+     * row of its table, and the walk that reaches the first row has not read the last one — so the
+     * document is laid out, the columns are read off what that wrote, and it is laid out again to
+     * write them. The alternative is to look ahead over the table at the row that opens it, which
+     * would be a second walk deciding what the real one has to decide again; the same machine run
+     * twice cannot disagree with itself.
+     *
+     * <p>It settles because a column depends only on the columns before it on its line: the first
+     * stop is settled by the first pass, the one after it by the second, and one more pass sees that
+     * nothing moved. {@link Columns#passes()} is that count and this refuses to run past it.
+     *
+     * <p>A document with no table is laid out once. The first pass writes no stop, so there is
+     * nothing to settle and the layout it produced is the answer — which is what keeps this off the
+     * files that have no columns in them.
      */
     default Layout layout(int width) {
+        java.util.Map<Columns.Unit, Integer> columns = java.util.Map.of();
+        for (int pass = 0; ; pass++) {
+            Layout laid = laidOut(width, columns);
+            java.util.Map<Columns.Unit, Integer> settled = settle(laid.stops());
+            if (settled.equals(columns)) {
+                return laid;
+            }
+            if (pass >= Columns.passes()) {
+                throw new IllegalStateException(
+                        "the columns of a table did not settle in " + Columns.passes()
+                                + " layouts; a column reads the ones before it on its line and"
+                                + " nothing else, so this is a cycle that should not exist");
+            }
+            columns = settled;
+        }
+    }
+
+    /**
+     * Where each column is, from what the rows reached without it. The greatest natural column, so
+     * that the row that needed the most room is the one the rule writes nothing for.
+     */
+    private static java.util.Map<Columns.Unit, Integer> settle(List<ColumnOccurrence> stops) {
+        java.util.Map<Columns.Unit, Integer> out = new java.util.LinkedHashMap<>();
+        for (ColumnOccurrence stop : stops) {
+            out.merge(stop.unit(), stop.naturalColumn(), Math::max);
+        }
+        return out;
+    }
+
+    /** One layout, writing the columns it is given. */
+    private Layout laidOut(int width, java.util.Map<Columns.Unit, Integer> columns) {
         List<GroupDecision> decisions = new ArrayList<>();
         List<Newline> breaks = new ArrayList<>();
         List<Opportunity> opportunities = new ArrayList<>();
+        List<ColumnOccurrence> stops = new ArrayList<>();
         java.util.Map<Place, Extent> extents = new java.util.LinkedHashMap<>();
         // A place that writes a region and also carries a comment has both an `At` and a
         // point; the region is where it is, so the points are kept apart and read only
@@ -218,6 +282,12 @@ sealed interface Doc {
         // opportunity, a newline's offset — is an index into the text, which is what the readers of
         // a layout use to cut and search the same Java string, and stays in UTF-16 units.
         int displayCol = 0;
+        // And a third, which is neither. `padded` is how many columns of a table's padding have been
+        // written on this line. It is not in `displayCol` because the width rule does not read
+        // padding — a group whose flatness depended on it would be decided by a column that is
+        // decided by which rows came out flat — and it is not out of the reckoning either, because
+        // where a row's second connector lands is where its first one pushed it to.
+        int padded = 0;
         while (!todo.isEmpty()) {
             Item it = todo.pop();
             if (it.closes != null) {
@@ -272,6 +342,7 @@ sealed interface Doc {
                         breaks.add(newline(sb, it, it.indent,
                                 new Newline.Cause.Settled(l.ref()), true));
                         displayCol = it.indent;
+                        padded = 0;
                     }
                 }
                 case Hard h -> {
@@ -279,16 +350,34 @@ sealed interface Doc {
                     breaks.add(newline(sb, it, indent,
                             new Newline.Cause.Forced(h.ref().obligation()), h.indents()));
                     displayCol = indent;
+                    padded = 0;
                 }
                 case Trailing t -> {
                     sb.append(' ').append(t.s());
                     displayCol = DisplayColumns.advance(t.s(), displayCol + 1);
                 }
                 case MustBreak _ -> { }
+                case ColumnStop cs -> {
+                    // A row written down the page has its connector opening a line, and there is no
+                    // column to be at there. It neither reaches for one nor says how wide it is.
+                    if (it.mode == Mode.FLAT) {
+                        int natural = displayCol + padded;
+                        Integer column = columns.get(cs.unit());
+                        // Nothing to write on the pass that is finding out where the column is, and
+                        // nothing on a pass whose column is one an earlier pass measured short. The
+                        // pass after it has the room this one asked for.
+                        int pad = column == null ? 0 : Math.max(0, column - natural);
+                        stops.add(new ColumnOccurrence(cs.unit(), sb.length(), natural));
+                        sb.append(" ".repeat(pad));
+                        padded += pad;
+                    }
+                }
             }
         }
         points.forEach(extents::putIfAbsent);
-        return new Layout(sb.toString(), decisions, extents, breaks, opportunities);
+        List<ColumnDecision> settled = new ArrayList<>();
+        columns.forEach((unit, column) -> settled.add(new ColumnDecision(unit, column)));
+        return new Layout(sb.toString(), decisions, extents, breaks, opportunities, settled, stops);
     }
 
     /** Writes a break and says what it wrote, and what wrote it. {@code indent} is the item's,
@@ -377,6 +466,10 @@ sealed interface Doc {
                     }
                     return over ? new Outcome.BrokenByWidth() : new Outcome.Flat();
                 }
+                // Padding is not content the width has to make room for, the same as a trailing
+                // comment is not. What it writes is read off a column, and a column that a group's
+                // flatness read would be decided by the rows that came out flat.
+                case ColumnStop _ -> { }
             }
         }
     }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Gaps.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Gaps.java
@@ -28,13 +28,33 @@ final class Gaps {
         List<Slot> slots = new ArrayList<>();
         collect(doc, null, slots);
         List<String> answers = new ArrayList<>();
+        List<Columns.Stop> stops = new ArrayList<>();
         for (int i = 0; i < slots.size(); i++) {
             if (slots.get(i) instanceof GapSlot gap) {
                 answers.add(gap.policy() == TokenDoc.Break.ALWAYS
                         ? null : spell(slots, i, gap.policy()));
+                stops.add(gap.policy() == TokenDoc.Break.ALWAYS ? null : stopAt(slots, i));
             }
         }
-        return lower(doc, answers, new int[1]);
+        return lower(doc, answers, stops, new int[1], null);
+    }
+
+    /**
+     * The column a boundary is a stop of, or null where it is not one.
+     *
+     * <p>Read from the same pair the spacing rule is: the construct joining the two tokens, and the
+     * one on the right. Asked here rather than where the document is built so that a construct
+     * cannot make itself a table by writing one, which is the arrangement {@link TokenDoc} takes
+     * away for the separator and would leave standing for the column.
+     */
+    private static Columns.Stop stopAt(List<Slot> slots, int i) {
+        TokenSlot left = nearestToken(slots, i, -1);
+        TokenSlot right = nearestToken(slots, i, 1);
+        if (left == null || right == null || crossesAComment(slots, i)) {
+            return null;
+        }
+        Within joining = deepestHolding(left.within(), right.within());
+        return joining == null ? null : Columns.at(joining.kind(), right.kind());
     }
 
     /** The construct a token is under, and the ones above that. One of these is built per node
@@ -253,7 +273,14 @@ final class Gaps {
         return a == b ? a : null;
     }
 
-    private static Doc lower(TokenDoc doc, List<String> answers, int[] next) {
+    /**
+     * The document the renderer lays out. {@code table} is the table the part being lowered is
+     * written inside, or null where it is written inside none — an identity made where a table's
+     * construct is entered, so that two {@code example}s written the same way close their widths
+     * over themselves without anyone comparing what they are called.
+     */
+    private static Doc lower(TokenDoc doc, List<String> answers, List<Columns.Stop> stops,
+            int[] next, Columns.TableRef table) {
         return switch (doc) {
             case TokenDoc.Nil _ -> Doc.NIL;
             case TokenDoc.MustBreak _ -> Doc.mustBreak();
@@ -262,28 +289,44 @@ final class Gaps {
             case TokenDoc.Token t -> Doc.text(t.lexeme());
             case TokenDoc.Comment c -> Doc.text(c.text());
             case TokenDoc.Trailing t -> Doc.trailing(t.text());
-            case TokenDoc.Node n -> lower(n.doc(), answers, next);
-            case TokenDoc.At a -> Doc.at(a.place(), lower(a.doc(), answers, next));
+            case TokenDoc.Node n -> lower(n.doc(), answers, stops, next,
+                    Columns.isTable(n.kind()) ? new Columns.TableRef() : table);
+            case TokenDoc.At a -> Doc.at(a.place(), lower(a.doc(), answers, stops, next, table));
             case TokenDoc.PointOf p -> Doc.pointOf(p.place());
             case TokenDoc.Carries _, TokenDoc.Vacant _ -> throw new IllegalStateException(
                     "a carrier reached the layout unresolved");
-            case TokenDoc.Nest n -> Doc.nest(n.indent(), lower(n.doc(), answers, next));
-            case TokenDoc.Group g -> Doc.group(lower(g.doc(), answers, next));
+            case TokenDoc.Nest n -> Doc.nest(n.indent(),
+                    lower(n.doc(), answers, stops, next, table));
+            case TokenDoc.Group g -> Doc.group(lower(g.doc(), answers, stops, next, table));
             case TokenDoc.Concat c -> {
                 List<Doc> parts = new ArrayList<>();
                 for (TokenDoc part : c.parts()) {
-                    parts.add(lower(part, answers, next));
+                    parts.add(lower(part, answers, stops, next, table));
                 }
                 yield Doc.concat(parts);
             }
             case TokenDoc.Gap g -> {
-                String flat = answers.get(next[0]++);
-                yield switch (g.policy()) {
+                String flat = answers.get(next[0]);
+                Columns.Stop stop = stops.get(next[0]);
+                next[0]++;
+                Doc separator = switch (g.policy()) {
                     case ALWAYS -> g.indents() ? Doc.hardline(g.forced())
                             : Doc.blankLine(g.forced());
                     case MAY -> flat.isEmpty() ? Doc.softline() : Doc.line();
                     case NEVER -> flat.isEmpty() ? Doc.NIL : Doc.text(flat);
                 };
+                if (stop == null) {
+                    yield separator;
+                }
+                if (table == null) {
+                    throw new IllegalStateException(
+                            "a stop of " + stop + " outside any table; a column is one stop of one"
+                                    + " table and the rows of that table are what it is closed"
+                                    + " over");
+                }
+                // After the separator, never instead of it. What stands between two tokens is the
+                // spacing rule's answer and the column says only where the one on the right begins.
+                yield Doc.concat(separator, Doc.columnStop(new Columns.Unit(table, stop)));
             }
         };
     }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/GroupDecision.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/GroupDecision.java
@@ -1,9 +1,13 @@
 package souther.compiler.fmt;
 
 /**
- * What the layout did with one group, and the display column it was measured from — the column on
- * the screen, not an index into the text, since the width it was measured against is a screen
- * width.
+ * What the layout did with one group, and the display column it was measured from.
+ *
+ * <p>A column and not an index into the text, since the width it was measured against is a screen
+ * width. The column the width read, which past a table's column is not the column the group stands
+ * at on the screen: padding is not content the width has to make room for, so it is not in this
+ * number, and a reader looking for where the group was written finds that in the layout's text
+ * rather than here.
  *
  * <p>The group is named by its own identity rather than by its shape. Two groups written the same
  * way are two decisions, and the conditional-layout rule answers about a group rather than about a

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Layout.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Layout.java
@@ -17,19 +17,22 @@ import java.util.List;
  */
 record Layout(String text, List<GroupDecision> decisions,
         java.util.Map<Place, Extent> extents, List<Newline> breaks,
-        List<Opportunity> opportunities) {
+        List<Opportunity> opportunities, List<ColumnDecision> columns,
+        List<ColumnOccurrence> stops) {
 
     Layout {
         decisions = List.copyOf(decisions);
         extents = java.util.Map.copyOf(extents);
         breaks = List.copyOf(breaks);
         opportunities = List.copyOf(opportunities);
+        columns = List.copyOf(columns);
+        stops = List.copyOf(stops);
     }
 
     /** This layout with one more place located. */
     Layout and(Place place, Extent extent) {
         java.util.Map<Place, Extent> out = new java.util.LinkedHashMap<>(extents);
         out.put(place, extent);
-        return new Layout(text, decisions, out, breaks, opportunities);
+        return new Layout(text, decisions, out, breaks, opportunities, columns, stops);
     }
 }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Repair.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Repair.java
@@ -312,10 +312,10 @@ final class Repair {
             if (between.indexOf('\n') >= 0 || between.contains("//")) {
                 continue;   // the source broke the row, or wrote a comment there
             }
-            if (!Witnesses.padsWithSpaces(source, had.get(i), had.get(i + 1))) {
+            String separator = stop.separator();
+            if (!Witnesses.padsAfterTheSeparator(source, had.get(i), had.get(i + 1), separator)) {
                 continue;   // the spacing rule is writing this run, and two of us must not
             }
-            String separator = stop.separator();
             if (separator.chars().anyMatch(c -> c != ' ')) {
                 throw new IllegalStateException(
                         "a column stop whose separator is not spaces ([" + separator + "]); what is"

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Repair.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Repair.java
@@ -301,9 +301,7 @@ final class Repair {
      */
     private static List<Edit> columns(Round round, Witness.AtAColumn witness) {
         String source = round.source();
-        String text = round.canonical().layout().text();
         List<SyntaxToken> had = round.pairing().hadCode();
-        List<SyntaxToken> writes = round.pairing().writesCode();
         List<Edit> out = new ArrayList<>();
         for (Witnesses.CanonicalStop stop
                 : round.atAColumn().getOrDefault(witness.unit(), List.of())) {
@@ -314,7 +312,10 @@ final class Repair {
             if (between.indexOf('\n') >= 0 || between.contains("//")) {
                 continue;   // the source broke the row, or wrote a comment there
             }
-            String separator = text.substring(writes.get(i).end(), stop.occurrence().at());
+            if (!Witnesses.padsWithSpaces(source, had.get(i), had.get(i + 1))) {
+                continue;   // the spacing rule is writing this run, and two of us must not
+            }
+            String separator = stop.separator();
             if (separator.chars().anyMatch(c -> c != ' ')) {
                 throw new IllegalStateException(
                         "a column stop whose separator is not spaces ([" + separator + "]); what is"

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Repair.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Repair.java
@@ -5,6 +5,7 @@ import souther.compiler.cst.SyntaxToken;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -55,11 +56,30 @@ final class Repair {
      */
     record Round(String source, Formatter.CanonicalForm canonical, Witnesses.Pairing pairing,
             Map<Doc.GroupRef, List<Opportunity>> settling,
-            Map<Doc.NestRef, List<Witnesses.CanonicalLine>> under) {
+            Map<Doc.NestRef, List<Witnesses.CanonicalLine>> under,
+            Map<Columns.Unit, List<Witnesses.CanonicalStop>> atAColumn) {
 
         Round(String source, Formatter.CanonicalForm canonical, Witnesses.Pairing pairing) {
             this(source, canonical, pairing, settling(canonical.layout()),
-                    under(Witnesses.lines(source, canonical, pairing)));
+                    under(Witnesses.lines(source, canonical, pairing)),
+                    atAColumn(canonical, pairing));
+        }
+
+        /**
+         * The canonical form's stops, gathered under the column each is written to.
+         *
+         * <p>The third of these, and the same reason as the other two: what a column's repair is
+         * about is the rows written to that column, and asked per witness it would read the whole
+         * file once for each column the file has.
+         */
+        private static Map<Columns.Unit, List<Witnesses.CanonicalStop>> atAColumn(
+                Formatter.CanonicalForm canonical, Witnesses.Pairing pairing) {
+            Map<Columns.Unit, List<Witnesses.CanonicalStop>> out = new LinkedHashMap<>();
+            for (Witnesses.CanonicalStop stop
+                    : Witnesses.stops(canonical, pairing.writesCode())) {
+                out.computeIfAbsent(stop.occurrence().unit(), _ -> new ArrayList<>()).add(stop);
+            }
+            return out;
         }
 
         /**
@@ -262,7 +282,50 @@ final class Repair {
                     t.unit().at() - t.source().length(), t.unit().at(), t.canonical()));
             case Witness.CommentAbove a -> List.of(under(source, a));
             case Witness.CommentCarrier c -> moved(source, canonical, pairing, c);
+            case Witness.AtAColumn c -> columns(round, c);
         };
+    }
+
+    /**
+     * The rows of one column, each carried out to it.
+     *
+     * <p>One edit per row and one decision behind them. What is written is the whole run before the
+     * connector, which is this rule's: the spacing rule is not asked at a stop, so nothing else
+     * answers about these characters.
+     *
+     * <p>The number of spaces is worked out from where the row has got to in the text being
+     * repaired rather than from what the source had there, so a row whose own content is also being
+     * repaired does not have to be written in any order. Where the row has got further than the
+     * column, the run is the separator alone and the round after this one asks again — the width in
+     * front of the connector is another rule's and it has not been written yet.
+     */
+    private static List<Edit> columns(Round round, Witness.AtAColumn witness) {
+        String source = round.source();
+        String text = round.canonical().layout().text();
+        List<SyntaxToken> had = round.pairing().hadCode();
+        List<SyntaxToken> writes = round.pairing().writesCode();
+        List<Edit> out = new ArrayList<>();
+        for (Witnesses.CanonicalStop stop
+                : round.atAColumn().getOrDefault(witness.unit(), List.of())) {
+            int i = stop.adjacency();
+            int from = had.get(i).end();
+            int to = had.get(i + 1).start();
+            String between = source.substring(from, to);
+            if (between.indexOf('\n') >= 0 || between.contains("//")) {
+                continue;   // the source broke the row, or wrote a comment there
+            }
+            String separator = text.substring(writes.get(i).end(), stop.occurrence().at());
+            if (separator.chars().anyMatch(c -> c != ' ')) {
+                throw new IllegalStateException(
+                        "a column stop whose separator is not spaces ([" + separator + "]); what is"
+                                + " written before a connector is counted in columns here, and a"
+                                + " tab is not one of them");
+            }
+            int reached = Witnesses.columnAt(source, from);
+            int wide = Math.max(witness.canonical() - reached, separator.length());
+            out.add(new Edit(from, to, " ".repeat(wide)));
+        }
+        return out;
     }
 
     /**

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Repair.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Repair.java
@@ -290,14 +290,15 @@ final class Repair {
      * The rows of one column, each carried out to it.
      *
      * <p>One edit per row and one decision behind them. What is written is the whole run before the
-     * connector, which is this rule's: the spacing rule is not asked at a stop, so nothing else
-     * answers about these characters.
+     * connector, which is this rule's wherever it is asked at all: a run that does not come apart
+     * into the separator and padding is the spacing rule's that round and is skipped here, so the
+     * two never write over each other.
      *
-     * <p>The number of spaces is worked out from where the row has got to in the text being
-     * repaired rather than from what the source had there, so a row whose own content is also being
-     * repaired does not have to be written in any order. Where the row has got further than the
-     * column, the run is the separator alone and the round after this one asks again — the width in
-     * front of the connector is another rule's and it has not been written yet.
+     * <p>What is written is what the canonical form writes there: the separator, and the spaces that
+     * carry this row from where the canonical form has it reaching to the column. Not spaces counted
+     * from where the source's own line has got to — that count is the indent and every separator
+     * before it as much as it is this rule's padding, so a row whose line is also being repaired
+     * elsewhere would be written to a column that the other repair then moves.
      */
     private static List<Edit> columns(Round round, Witness.AtAColumn witness) {
         String source = round.source();
@@ -322,9 +323,14 @@ final class Repair {
                                 + " written before a connector is counted in columns here, and a"
                                 + " tab is not one of them");
             }
-            int reached = Witnesses.columnAt(source, from);
-            int wide = Math.max(witness.canonical() - reached, separator.length());
-            out.add(new Edit(from, to, " ".repeat(wide)));
+            int padding = witness.canonical() - stop.occurrence().naturalColumn();
+            if (padding < 0) {
+                throw new IllegalStateException(
+                        "a row reaching column " + stop.occurrence().naturalColumn() + " is written"
+                                + " to column " + witness.canonical() + "; a column is the greatest"
+                                + " of what its rows reach and no row is written back from one");
+            }
+            out.add(new Edit(from, to, separator + " ".repeat(padding)));
         }
         return out;
     }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Witness.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Witness.java
@@ -100,10 +100,13 @@ sealed interface Witness {
      *
      * <p>Display columns, because what lines up is what a reader sees.
      *
-     * <p>This rule owns the whole run of spaces before the connector, so {@link BetweenTwoTokens}
-     * is not asked there. Both would be answering about the same characters, and what a reader
-     * wants to be told at a table is which column the row missed rather than that one space is
-     * eight.
+     * <p>What this rule owns at a stop is the padding, and {@link BetweenTwoTokens} owns the
+     * separator in front of it. So that one is not asked at a stop whose separator the source
+     * already writes, and it is the only one asked where the source wrote a tab there or no space
+     * at all — a run that does not come apart into a separator and padding holds nothing this rule
+     * could be the answer about. The two never answer about the same characters, which the
+     * composition of a repair refuses, and never both stay silent, which would leave a difference
+     * no rule accounts for.
      */
     record AtAColumn(Columns.Unit unit, int canonical, java.util.List<Integer> source)
             implements Witness {

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Witness.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Witness.java
@@ -90,6 +90,30 @@ sealed interface Witness {
     record BetweenTwoTokens(Boundary unit, String canonical, String source) implements Witness {}
 
     /**
+     * The column rule at one column of one table: which display column the canonical form writes
+     * the rows' connector at, and which ones the source wrote it at.
+     *
+     * <p>The unit is {@link Columns.Unit}, the column itself, and not a row. The rule is evaluated
+     * once for the whole column — the widest row is what it reads — and a table whose five rows are
+     * all at different columns has departed from one decision five times, not from five decisions.
+     * The same shape as {@link Indentation}, and for the same reason.
+     *
+     * <p>Display columns, because what lines up is what a reader sees.
+     *
+     * <p>This rule owns the whole run of spaces before the connector, so {@link BetweenTwoTokens}
+     * is not asked there. Both would be answering about the same characters, and what a reader
+     * wants to be told at a table is which column the row missed rather than that one space is
+     * eight.
+     */
+    record AtAColumn(Columns.Unit unit, int canonical, java.util.List<Integer> source)
+            implements Witness {
+
+        public AtAColumn {
+            source = java.util.List.copyOf(source);
+        }
+    }
+
+    /**
      * The separation rule's unit: two top-level items, one written after the other.
      *
      * <p>A pair, because what the rule says is what stands between them. A blank line is two breaks

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Witnesses.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Witnesses.java
@@ -521,8 +521,8 @@ final class Witnesses {
         Set<Integer> padded = new LinkedHashSet<>();
         for (CanonicalStop stop : stops(canonical, writes)) {
             atAColumn.put(stop.adjacency(), stop.separator());
-            if (padsWithSpaces(source, had.get(stop.adjacency()),
-                    had.get(stop.adjacency() + 1))) {
+            if (padsAfterTheSeparator(source, had.get(stop.adjacency()),
+                    had.get(stop.adjacency() + 1), stop.separator())) {
                 padded.add(stop.adjacency());
             }
         }
@@ -566,20 +566,31 @@ final class Witnesses {
     }
 
     /**
-     * Whether what the source writes at a stop is padding this rule can answer for.
+     * Whether what the source writes at a stop reads as the separator and then this rule's padding.
      *
-     * <p>Spaces, and nothing else. A column says where a connector begins and the padding that
-     * carries it there is spaces; a source that wrote a tab has written something a column cannot
-     * be the answer about, and it is the spacing rule that quotes characters. So this is what
-     * divides the two families at a stop, and it is asked in one place because the two must not
-     * both answer and must not both stay silent — the first is a conflict the repair refuses, and
-     * the second leaves a difference no rule accounts for.
+     * <p>The canonical form writes a separator and then the spaces that carry the connector out to
+     * the column, and this asks whether the source's run comes apart the same way: the separator
+     * itself, and after it spaces and nothing else. That is the whole of what divides the two
+     * families at a stop, and it is asked in one place because they must neither both answer about
+     * the same characters — a conflict the repair refuses — nor both stay silent, which leaves a
+     * difference no rule accounts for.
      *
-     * <p>A tab reaches a column as well as spaces do, so a rule reading only the column the source
-     * arrived at would find nothing wrong with a text that is not the canonical form.
+     * <p>Both halves are the question. Asked only whether what stands there is spaces, a run that
+     * is <em>empty</em> answers yes — a source that wrote no separator at all would be this rule's,
+     * and a one-row table with no space before its arrow would be told that its rows do not line up
+     * with each other. And a tab reaches a column as well as spaces do, so a run this admitted on
+     * the strength of the column it arrived at would leave a text that is not the canonical form
+     * with nothing said against it.
+     *
+     * <p>Written against {@code separator} rather than against one space, so a stop whose separator
+     * is nothing needs no second reading of this: the prefix is there vacuously and all of the run
+     * is padding.
      */
-    static boolean padsWithSpaces(String source, SyntaxToken before, SyntaxToken after) {
-        return source.substring(before.end(), after.start()).chars().allMatch(c -> c == ' ');
+    static boolean padsAfterTheSeparator(String source, SyntaxToken before, SyntaxToken after,
+            String separator) {
+        String run = source.substring(before.end(), after.start());
+        return run.startsWith(separator)
+                && run.substring(separator.length()).chars().allMatch(c -> c == ' ');
     }
 
     /**
@@ -643,7 +654,7 @@ final class Witnesses {
             if (between.indexOf('\n') >= 0 || between.contains("//")) {
                 continue;
             }
-            if (!padsWithSpaces(source, had.get(i), had.get(i + 1))) {
+            if (!padsAfterTheSeparator(source, had.get(i), had.get(i + 1), stop.separator())) {
                 continue;   // the spacing rule is answering this run; asked again once it has
             }
             hadAt.computeIfAbsent(stop.occurrence().unit(), _ -> new LinkedHashSet<>())

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Witnesses.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Witnesses.java
@@ -5,7 +5,6 @@ import souther.compiler.cst.SyntaxElement;
 import souther.compiler.cst.SyntaxKind;
 import souther.compiler.cst.SyntaxNode;
 import souther.compiler.cst.SyntaxToken;
-import souther.compiler.text.DisplayColumns;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -621,7 +620,20 @@ final class Witnesses {
 
     /**
      * What the column rule has against {@code source}: for each column of each table, the display
-     * column the canonical form writes the connector at, and the ones the source wrote it at.
+     * column the canonical form writes the connector at, and the ones the source's rows come to.
+     *
+     * <p>What a row comes to is where its connector stands with the padding the source wrote and
+     * everything before it on the line as the canonical form has it — not the column the connector
+     * physically occupies in the source. An absolute column is the sum of everything to its left:
+     * the indent, every separator, and every column before it on the line. Read that way, a table
+     * an author lined up correctly and indented one column too deep departs from this rule at every
+     * row, and repairing the indentation is what makes those departures go away — which is a rule
+     * reporting somebody else's difference as its own. {@link Witness.Indentation} met the same
+     * thing and answers with a step rather than with a column for the same reason.
+     *
+     * <p>So what is read from the source is the padding, which is this rule's own, and it is said
+     * as the column that padding comes to. Where the rest of the line is already canonical the two
+     * are the same number, which is every source that has nothing else wrong with it.
      *
      * <p>A row the canonical form writes down the page has no stop, so it is not asked about here.
      * Neither is a row the source broke: its connector opens a line there, and a column is not
@@ -657,8 +669,11 @@ final class Witnesses {
             if (!padsAfterTheSeparator(source, had.get(i), had.get(i + 1), stop.separator())) {
                 continue;   // the spacing rule is answering this run; asked again once it has
             }
+            // The run comes apart, so what is left of it after the separator is spaces and each of
+            // them is one column.
+            int padding = between.length() - stop.separator().length();
             hadAt.computeIfAbsent(stop.occurrence().unit(), _ -> new LinkedHashSet<>())
-                    .add(columnAt(source, had.get(i + 1).start()));
+                    .add(stop.occurrence().naturalColumn() + padding);
         }
         List<Witness> out = new ArrayList<>();
         hadAt.forEach((unit, columns) -> {
@@ -674,12 +689,6 @@ final class Witnesses {
             }
         });
         return out;
-    }
-
-    /** The display column {@code at} stands at in {@code text}. */
-    static int columnAt(String text, int at) {
-        int start = text.lastIndexOf('\n', at - 1) + 1;
-        return DisplayColumns.advance(text.substring(start, at), 0);
     }
 
     /**

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Witnesses.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Witnesses.java
@@ -512,18 +512,27 @@ final class Witnesses {
                             + " asks what the source has between the same two");
         }
         List<Gaps.Boundary> boundaries = between(canonical.construction().doc(), writes.size());
-        // A stop is the column rule's whole run, so this is not asked there. Both rules would be
-        // answering about the same characters, and the composition of a repair refuses that.
-        Set<Integer> atAColumn = new LinkedHashSet<>();
+        // At a stop the run holds this rule's answer and then the column's padding, and this is
+        // asked about the first of them. Where the source wrote spaces there, all of it is the
+        // column's and this says nothing; where it wrote anything else, what it wrote is not
+        // padding and the column rule has no answer about it, so this one does — and the round
+        // after it, with the separator written, is where the column is asked.
+        Map<Integer, String> atAColumn = new LinkedHashMap<>();
+        Set<Integer> padded = new LinkedHashSet<>();
         for (CanonicalStop stop : stops(canonical, writes)) {
-            atAColumn.add(stop.adjacency());
+            atAColumn.put(stop.adjacency(), stop.separator());
+            if (padsWithSpaces(source, had.get(stop.adjacency()),
+                    had.get(stop.adjacency() + 1))) {
+                padded.add(stop.adjacency());
+            }
         }
         List<Witness> out = new ArrayList<>();
         for (int i = 0; i + 1 < writes.size(); i++) {
-            if (atAColumn.contains(i)) {
+            if (padded.contains(i)) {
                 continue;
             }
-            String wrote = text.substring(writes.get(i).end(), writes.get(i + 1).start());
+            String wrote = atAColumn.containsKey(i) ? atAColumn.get(i)
+                    : text.substring(writes.get(i).end(), writes.get(i + 1).start());
             if (wrote.indexOf('\n') >= 0) {
                 continue;   // the canonical form breaks here, so it writes no spacing
             }
@@ -553,7 +562,24 @@ final class Witnesses {
      * one thing the two share — so the offset is read once, here, and everything downstream is
      * about the adjacency.
      */
-    record CanonicalStop(ColumnOccurrence occurrence, int adjacency) {
+    record CanonicalStop(ColumnOccurrence occurrence, int adjacency, String separator) {
+    }
+
+    /**
+     * Whether what the source writes at a stop is padding this rule can answer for.
+     *
+     * <p>Spaces, and nothing else. A column says where a connector begins and the padding that
+     * carries it there is spaces; a source that wrote a tab has written something a column cannot
+     * be the answer about, and it is the spacing rule that quotes characters. So this is what
+     * divides the two families at a stop, and it is asked in one place because the two must not
+     * both answer and must not both stay silent — the first is a conflict the repair refuses, and
+     * the second leaves a difference no rule accounts for.
+     *
+     * <p>A tab reaches a column as well as spaces do, so a rule reading only the column the source
+     * arrived at would find nothing wrong with a text that is not the canonical form.
+     */
+    static boolean padsWithSpaces(String source, SyntaxToken before, SyntaxToken after) {
+        return source.substring(before.end(), after.start()).chars().allMatch(c -> c == ' ');
     }
 
     /**
@@ -576,7 +602,8 @@ final class Witnesses {
                                 + " canonical form's tokens; a stop is written between the"
                                 + " separator and the connector after it");
             }
-            out.add(new CanonicalStop(stop, i));
+            out.add(new CanonicalStop(stop, i,
+                    canonical.layout().text().substring(writes.get(i).end(), stop.at())));
         }
         return out;
     }
@@ -615,6 +642,9 @@ final class Witnesses {
             String between = source.substring(had.get(i).end(), had.get(i + 1).start());
             if (between.indexOf('\n') >= 0 || between.contains("//")) {
                 continue;
+            }
+            if (!padsWithSpaces(source, had.get(i), had.get(i + 1))) {
+                continue;   // the spacing rule is answering this run; asked again once it has
             }
             hadAt.computeIfAbsent(stop.occurrence().unit(), _ -> new LinkedHashSet<>())
                     .add(columnAt(source, had.get(i + 1).start()));

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Witnesses.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Witnesses.java
@@ -5,6 +5,7 @@ import souther.compiler.cst.SyntaxElement;
 import souther.compiler.cst.SyntaxKind;
 import souther.compiler.cst.SyntaxNode;
 import souther.compiler.cst.SyntaxToken;
+import souther.compiler.text.DisplayColumns;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,7 +27,7 @@ import java.util.Set;
  * <p>One family per rule, and each of them answers about its own unit: a boundary for spacing, a pair
  * of items for separation, a pair of levels for indentation, a group for conditional layout, a
  * comment for the rules about comments, a site of the source for the rules about which code tokens
- * are written.
+ * are written, a column of a table for the rule that lines its rows up.
  *
  * <p>A family reads the results of the rules it depends on rather than competing with them, and
  * where what it depends on is not settled yet it says nothing: the rules are asked again once it is.
@@ -511,8 +512,17 @@ final class Witnesses {
                             + " asks what the source has between the same two");
         }
         List<Gaps.Boundary> boundaries = between(canonical.construction().doc(), writes.size());
+        // A stop is the column rule's whole run, so this is not asked there. Both rules would be
+        // answering about the same characters, and the composition of a repair refuses that.
+        Set<Integer> atAColumn = new LinkedHashSet<>();
+        for (CanonicalStop stop : stops(canonical, writes)) {
+            atAColumn.add(stop.adjacency());
+        }
         List<Witness> out = new ArrayList<>();
         for (int i = 0; i + 1 < writes.size(); i++) {
+            if (atAColumn.contains(i)) {
+                continue;
+            }
             String wrote = text.substring(writes.get(i).end(), writes.get(i + 1).start());
             if (wrote.indexOf('\n') >= 0) {
                 continue;   // the canonical form breaks here, so it writes no spacing
@@ -533,6 +543,102 @@ final class Witnesses {
                     wrote, has));
         }
         return out;
+    }
+
+    /**
+     * One stop of the canonical form, and which adjacency of its code tokens it stands at.
+     *
+     * <p>The layout says where a stop is as an offset into the text it wrote. What a rule holding
+     * two texts side by side can use is which pair of tokens it stands between, since that is the
+     * one thing the two share — so the offset is read once, here, and everything downstream is
+     * about the adjacency.
+     */
+    record CanonicalStop(ColumnOccurrence occurrence, int adjacency) {
+    }
+
+    /**
+     * Every stop the canonical form wrote, with the adjacency it stands at.
+     *
+     * <p>Read by the two rules that have to know about a stop: the column rule, whose units these
+     * are, and the spacing rule, which is not asked at one. Two readers of one value, so that a
+     * boundary cannot be a stop for the first and an ordinary boundary for the second.
+     */
+    static List<CanonicalStop> stops(Formatter.CanonicalForm canonical, List<SyntaxToken> writes) {
+        List<CanonicalStop> out = new ArrayList<>();
+        int i = 0;
+        for (ColumnOccurrence stop : canonical.layout().stops()) {
+            while (i + 1 < writes.size() && writes.get(i + 1).start() < stop.at()) {
+                i++;
+            }
+            if (i + 1 >= writes.size() || writes.get(i).end() > stop.at()) {
+                throw new IllegalStateException(
+                        "a column stop at offset " + stop.at() + " stands at no adjacency of the"
+                                + " canonical form's tokens; a stop is written between the"
+                                + " separator and the connector after it");
+            }
+            out.add(new CanonicalStop(stop, i));
+        }
+        return out;
+    }
+
+    /**
+     * What the column rule has against {@code source}: for each column of each table, the display
+     * column the canonical form writes the connector at, and the ones the source wrote it at.
+     *
+     * <p>A row the canonical form writes down the page has no stop, so it is not asked about here.
+     * Neither is a row the source broke: its connector opens a line there, and a column is not
+     * something a line's first token can be at. What the source did instead is the conditional
+     * layout rule's to report, and once that is repaired this is asked again.
+     */
+    static List<Witness> columns(String source, Formatter.CanonicalForm canonical) {
+        return columns(source, canonical, new Pairing(source, canonical));
+    }
+
+    /** The same, for a caller that has already read the two texts' tokens. */
+    static List<Witness> columns(String source, Formatter.CanonicalForm canonical,
+            Pairing pairing) {
+        List<SyntaxToken> had = pairing.hadCode();
+        List<SyntaxToken> writes = pairing.writesCode();
+        if (had.size() != writes.size()) {
+            throw new NoCorrespondence(
+                    "the source has " + had.size() + " tokens and its canonical form "
+                            + writes.size() + "; the two cannot be held side by side and this rule"
+                            + " asks where the source wrote the same connector");
+        }
+        Map<Columns.Unit, Integer> written = new LinkedHashMap<>();
+        for (ColumnDecision decision : canonical.layout().columns()) {
+            written.put(decision.unit(), decision.column());
+        }
+        Map<Columns.Unit, Set<Integer>> hadAt = new LinkedHashMap<>();
+        for (CanonicalStop stop : stops(canonical, writes)) {
+            int i = stop.adjacency();
+            String between = source.substring(had.get(i).end(), had.get(i + 1).start());
+            if (between.indexOf('\n') >= 0 || between.contains("//")) {
+                continue;
+            }
+            hadAt.computeIfAbsent(stop.occurrence().unit(), _ -> new LinkedHashSet<>())
+                    .add(columnAt(source, had.get(i + 1).start()));
+        }
+        List<Witness> out = new ArrayList<>();
+        hadAt.forEach((unit, columns) -> {
+            Integer column = written.get(unit);
+            if (column == null) {
+                throw new IllegalStateException(
+                        "a row was written to " + unit.stop() + " and the layout says no column is"
+                                + " there; a stop and the decision it is written to are made by one"
+                                + " run");
+            }
+            if (!columns.equals(Set.of(column))) {
+                out.add(new Witness.AtAColumn(unit, column, List.copyOf(columns)));
+            }
+        });
+        return out;
+    }
+
+    /** The display column {@code at} stands at in {@code text}. */
+    static int columnAt(String text, int at) {
+        int start = text.lastIndexOf('\n', at - 1) + 1;
+        return DisplayColumns.advance(text.substring(start, at), 0);
     }
 
     /**

--- a/souther-fmt/src/test/java/souther/compiler/fmt/ARowOfATableIsWrittenAtItsTablesColumnTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/ARowOfATableIsWrittenAtItsTablesColumnTest.java
@@ -58,6 +58,14 @@ class ARowOfATableIsWrittenAtItsTablesColumnTest {
                     + "    | \"long description\" : (\"abc\") -> X\n"
                     + "    | \"short\" : (\"\t\") -> Y\n";
 
+    /**
+     * A table of one row that wrote no separator at all. There is no question about lining rows up
+     * here — a table of one row is at its own width — so what is wrong with it is that a space is
+     * missing, and nothing else.
+     */
+    private static final String NO_SEPARATOR =
+            "examples for demo\n\nfake f\n    | (A)-> X\n";
+
     /** The canonical form of a source, with both texts' tokens read back. */
     private record Written(Formatter.CanonicalForm form, Witnesses.Pairing pairing) {
 
@@ -330,6 +338,29 @@ class ARowOfATableIsWrittenAtItsTablesColumnTest {
                 "and repairing what the rules say writes it");
     }
 
+    /**
+     * A row that wrote no separator is told that, and not that its rows do not line up.
+     *
+     * <p>What the canonical form writes at a stop is the separator and then the padding, and which
+     * of the two rules answers is settled by whether the source's run comes apart the same way. A
+     * run of spaces and no separator comes apart that way only if the separator is nothing — so a
+     * source that wrote no space at all is the spacing rule's, and the table is not brought into
+     * it. Asked instead whether what stands there is spaces, an empty run answers yes, and this
+     * one-row table is told its rows disagree with each other.
+     */
+    @Test
+    void aRowThatWroteNoSeparatorIsToldThatAndNotAboutItsColumn() {
+        Deviations.Report report = Deviations.of(NO_SEPARATOR);
+
+        Set<String> rules = new LinkedHashSet<>();
+        report.deviations().forEach(d -> rules.add(d.rule()));
+        assertEquals(Set.of("what goes between two tokens on a line"), rules);
+        assertTrue(report.whole(), "and repairing what the rules say writes the canonical form");
+        assertEquals(List.of(), Witnesses.columns(NO_SEPARATOR,
+                Formatter.canonicalize(CstParser.parse(NO_SEPARATOR).root())),
+                "the column rule has nothing to say about this run");
+    }
+
     /** Every stop the rule lists is one some source in the repository writes. */
     @Test
     void everyStopIsReached() {
@@ -353,7 +384,8 @@ class ARowOfATableIsWrittenAtItsTablesColumnTest {
      */
     private static List<String> sources() {
         List<String> out = new ArrayList<>(
-                List.of(TWO_TABLES, A_TAB_REACHING_THE_COLUMN, A_TAB_AFTER_A_COLUMN));
+                List.of(TWO_TABLES, A_TAB_REACHING_THE_COLUMN, A_TAB_AFTER_A_COLUMN,
+                        NO_SEPARATOR));
         out.addAll(WhatGoesBetweenTwoTokensOnALineTest.corpus());
         out.addAll(inTheRepository());
         return out;

--- a/souther-fmt/src/test/java/souther/compiler/fmt/ARowOfATableIsWrittenAtItsTablesColumnTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/ARowOfATableIsWrittenAtItsTablesColumnTest.java
@@ -41,22 +41,43 @@ class ARowOfATableIsWrittenAtItsTablesColumnTest {
                 | "yy" : (F) -> Q(2)
             """;
 
-    /** The canonical form of a source, with its tokens read back. */
-    private record Written(Formatter.CanonicalForm form, List<SyntaxToken> code) {
+    /**
+     * A source that reaches the column with a tab where the canonical form writes spaces. Its rows
+     * line up on a screen and its text is not the canonical form, which is the pair of facts a rule
+     * reading only the column the source arrived at cannot tell apart.
+     */
+    private static final String A_TAB_REACHING_THE_COLUMN =
+            "examples for demo\n\nexample f\n"
+                    + "    | \"1234567\" : (A) -> X\n"
+                    + "    | \"a\"\t: (B) -> Y\n";
+
+    /** A source with a tab inside a token written after a column, where how far the tab advances
+     *  depends on the padding in front of it. */
+    private static final String A_TAB_AFTER_A_COLUMN =
+            "examples for demo\n\nexample f\n"
+                    + "    | \"long description\" : (\"abc\") -> X\n"
+                    + "    | \"short\" : (\"\t\") -> Y\n";
+
+    /** The canonical form of a source, with both texts' tokens read back. */
+    private record Written(Formatter.CanonicalForm form, Witnesses.Pairing pairing) {
 
         static Written of(String source) {
             Formatter.CanonicalForm form =
                     Formatter.canonicalize(CstParser.parse(source).root());
-            return new Written(form, new Witnesses.Pairing(source, form).writesCode());
+            return new Written(form, new Witnesses.Pairing(source, form));
+        }
+
+        List<SyntaxToken> code() {
+            return pairing.writesCode();
         }
 
         List<Witnesses.CanonicalStop> stops() {
-            return Witnesses.stops(form, code);
+            return Witnesses.stops(form, code());
         }
 
         /** The display column the connector of one stop was written at. */
         int columnOf(Witnesses.CanonicalStop stop) {
-            return Witnesses.columnAt(form.text(), code.get(stop.adjacency() + 1).start());
+            return Witnesses.columnAt(form.text(), code().get(stop.adjacency() + 1).start());
         }
 
         /** Where each column of each table was settled, in the order the tables are written. */
@@ -169,7 +190,11 @@ class ARowOfATableIsWrittenAtItsTablesColumnTest {
         assertEquals(without.columns(), with.columns(), "the columns the other rows settle");
         assertEquals(without.stops().size(), with.stops().size(),
                 "the long row is written to no column");
-        assertTrue(with.form().text().contains("d".repeat(60)), "and it is still written");
+        // And the row is still written. Said as the tokens the two texts share rather than as a
+        // stretch of the output: what could go wrong here is a row dropped, and a row dropped is
+        // tokens the canonical form does not have.
+        assertEquals(with.pairing().hadCode().size(), with.code().size(),
+                "the canonical form writes every code token the source had");
     }
 
     /**
@@ -258,6 +283,53 @@ class ARowOfATableIsWrittenAtItsTablesColumnTest {
                 "the spacing rule is not asked at a stop");
     }
 
+    /**
+     * A source that reaches the column by other characters is told so all the same.
+     *
+     * <p>The column rule answers about a column and a tab reaches one as well as spaces do, so what
+     * the two texts differ by there is not something a column can be the answer about. The spacing
+     * rule says it — the run before a connector is its answer and then the column's padding, and
+     * that split is made on the source's side as well as on the canonical form's.
+     *
+     * <p>What this is really about is {@link Deviations.Report#whole}. Left to the column rule
+     * alone, this source has nothing at all reported against it and is still not the canonical
+     * form.
+     */
+    @Test
+    void aSourceThatReachesTheColumnByOtherCharactersIsToldWhatItWrote() {
+        Deviations.Report report = Deviations.of(A_TAB_REACHING_THE_COLUMN);
+
+        Set<String> rules = new LinkedHashSet<>();
+        report.deviations().forEach(d -> rules.add(d.rule()));
+        assertTrue(rules.contains("what goes between two tokens on a line"),
+                "the rule that quotes characters says what was written: " + rules);
+        assertTrue(report.whole(), "every difference from the canonical form was named");
+    }
+
+    /**
+     * A tab written after a column advances from where it stands, not from where it would have
+     * stood unpadded.
+     *
+     * <p>How far a token carries a line depends on the column it starts at, which is the whole of
+     * what a tab is. So the column a row reaches is counted on its own and not as what the width
+     * measured plus the padding so far — the second is right for every token but that one, and
+     * wrong for the rows of a table that holds it.
+     */
+    @Test
+    void aTabWrittenAfterAColumnIsMeasuredFromWhereItStands() {
+        Written written = Written.of(A_TAB_AFTER_A_COLUMN);
+
+        Set<Integer> arrows = new LinkedHashSet<>();
+        for (Witnesses.CanonicalStop stop : written.stops()) {
+            if (stop.occurrence().unit().stop() == Columns.Stop.THE_RESULT_OF_AN_EXAMPLE) {
+                arrows.add(written.columnOf(stop));
+            }
+        }
+        assertEquals(1, arrows.size(), "the two rows write their arrow at " + arrows);
+        assertTrue(Deviations.of(A_TAB_AFTER_A_COLUMN).whole(),
+                "and repairing what the rules say writes it");
+    }
+
     /** Every stop the rule lists is one some source in the repository writes. */
     @Test
     void everyStopIsReached() {
@@ -270,10 +342,35 @@ class ARowOfATableIsWrittenAtItsTablesColumnTest {
         assertEquals(Set.of(Columns.Stop.values()), reached);
     }
 
-    /** The fixtures here and every source the repository holds. */
+    /**
+     * What these properties are held over: the fixtures above, the corpus the formatter's rules are
+     * measured against — chosen to reach every kind of node the grammar has — and every {@code .sou}
+     * file the repository holds.
+     *
+     * <p>The third of those is the one that makes this about the formatter rather than about a
+     * fixture. The first two are what makes it about the cases a repository of well-written sources
+     * does not contain: a corpus written by hand reaches no tab and no row too long for a line.
+     */
     private static List<String> sources() {
-        List<String> out = new ArrayList<>(List.of(TWO_TABLES));
+        List<String> out = new ArrayList<>(
+                List.of(TWO_TABLES, A_TAB_REACHING_THE_COLUMN, A_TAB_AFTER_A_COLUMN));
         out.addAll(WhatGoesBetweenTwoTokensOnALineTest.corpus());
+        out.addAll(inTheRepository());
         return out;
+    }
+
+    /** Every {@code .sou} the repository holds, a build's copies of them left out. */
+    private static List<String> inTheRepository() {
+        try (java.util.stream.Stream<java.nio.file.Path> walk =
+                java.nio.file.Files.walk(java.nio.file.Path.of(".."))) {
+            List<String> out = new ArrayList<>();
+            for (java.nio.file.Path p : walk.filter(q -> q.toString().endsWith(".sou"))
+                    .filter(q -> !q.toString().contains("target")).sorted().toList()) {
+                out.add(java.nio.file.Files.readString(p));
+            }
+            return out;
+        } catch (java.io.IOException e) {
+            throw new java.io.UncheckedIOException(e);
+        }
     }
 }

--- a/souther-fmt/src/test/java/souther/compiler/fmt/ARowOfATableIsWrittenAtItsTablesColumnTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/ARowOfATableIsWrittenAtItsTablesColumnTest.java
@@ -66,6 +66,39 @@ class ARowOfATableIsWrittenAtItsTablesColumnTest {
     private static final String NO_SEPARATOR =
             "examples for demo\n\nfake f\n    | (A)-> X\n";
 
+    /**
+     * A table whose rows are lined up with each other and whose whole block is written one column
+     * too deep. Nothing about the columns is wrong with it; one thing about its indentation is.
+     */
+    private static final String INDENTED_ONE_DEEPER = """
+            examples for demo
+
+            example f
+                 | "aaaa" : (A) -> X
+                 | "b"    : (B) -> Y
+            """;
+
+    /** The same, with one row missing the separator its first column stands after. The row's second
+     *  connector is then a column to the left of where the canonical form has it, and nothing about
+     *  the padding in front of it is what put it there. */
+    private static final String ONE_SEPARATOR_MISSING = """
+            examples for demo
+
+            example f
+                | "a": (A) -> X
+            """;
+
+    /** A table written in Japanese, where a name is twice the width its characters suggest. What
+     *  #938 was reported against. */
+    private static final String FULL_WIDTH = """
+            examples for demo
+
+            example 一杯目の価格を求める
+                | "通常時間・クーポンなし" : (通常時間, クーポンなし) -> 価格(490)
+                | "ハッピーアワー・クーポンなし" : (ハッピーアワー, クーポンなし) -> 価格(290)
+                | (通常時間, クーポンあり) -> 価格(100)
+            """;
+
     /** The canonical form of a source, with both texts' tokens read back. */
     private record Written(Formatter.CanonicalForm form, Witnesses.Pairing pairing) {
 
@@ -85,7 +118,7 @@ class ARowOfATableIsWrittenAtItsTablesColumnTest {
 
         /** The display column the connector of one stop was written at. */
         int columnOf(Witnesses.CanonicalStop stop) {
-            return Witnesses.columnAt(form.text(), code().get(stop.adjacency() + 1).start());
+            return columnAt(form.text(), code().get(stop.adjacency() + 1).start());
         }
 
         /** Where each column of each table was settled, in the order the tables are written. */
@@ -226,7 +259,7 @@ class ARowOfATableIsWrittenAtItsTablesColumnTest {
 
         int longest = 0;
         for (String line : written.form().text().split("\n", -1)) {
-            longest = Math.max(longest, Witnesses.columnAt(line + "\n", line.length()));
+            longest = Math.max(longest, columnAt(line + "\n", line.length()));
         }
         assertTrue(longest > 100, "the fixture writes a line over the width; it reaches " + longest);
         for (GroupDecision decision : written.form().layout().decisions()) {
@@ -350,15 +383,43 @@ class ARowOfATableIsWrittenAtItsTablesColumnTest {
      */
     @Test
     void aRowThatWroteNoSeparatorIsToldThatAndNotAboutItsColumn() {
-        Deviations.Report report = Deviations.of(NO_SEPARATOR);
-
-        Set<String> rules = new LinkedHashSet<>();
-        report.deviations().forEach(d -> rules.add(d.rule()));
-        assertEquals(Set.of("what goes between two tokens on a line"), rules);
-        assertTrue(report.whole(), "and repairing what the rules say writes the canonical form");
+        assertEquals(Set.of("what goes between two tokens on a line"), rulesAgainst(NO_SEPARATOR));
         assertEquals(List.of(), Witnesses.columns(NO_SEPARATOR,
                 Formatter.canonicalize(CstParser.parse(NO_SEPARATOR).root())),
                 "the column rule has nothing to say about this run");
+    }
+
+    /**
+     * A rule says what its own unit has against a source, and a column's unit is the padding it
+     * writes rather than the column its connector physically occupies.
+     *
+     * <p>An absolute column is the sum of everything to the left of it on the line: the indent,
+     * every separator, and every column already written. Read that way this rule reports whatever
+     * those rules got wrong as its own, and a reader repairing what it was told to repair finds the
+     * report was about something else.
+     *
+     * <p>Two sources say it. One is lined up correctly and indented a column too deep — nothing
+     * about its columns is wrong. The other has one separator missing before its first column, and
+     * what that moved is the connector after it. Each has exactly one thing wrong with it and is
+     * told exactly that.
+     */
+    @Test
+    void aColumnDoesNotReportWhatSomebodyElseMoved() {
+        assertEquals(Set.of("one level deeper is one indent further in"),
+                rulesAgainst(INDENTED_ONE_DEEPER),
+                "a table lined up correctly and indented one deeper");
+        assertEquals(Set.of("what goes between two tokens on a line"),
+                rulesAgainst(ONE_SEPARATOR_MISSING),
+                "a row that wrote no separator before its first column");
+    }
+
+    /** What the report names against a source, and that repairing it writes the canonical form. */
+    private static Set<String> rulesAgainst(String source) {
+        Deviations.Report report = Deviations.of(source);
+        assertTrue(report.whole(), "everything this source departs from was named");
+        Set<String> rules = new LinkedHashSet<>();
+        report.deviations().forEach(d -> rules.add(d.rule()));
+        return rules;
     }
 
     /** Every stop the rule lists is one some source in the repository writes. */
@@ -373,6 +434,12 @@ class ARowOfATableIsWrittenAtItsTablesColumnTest {
         assertEquals(Set.of(Columns.Stop.values()), reached);
     }
 
+    /** The display column {@code at} stands at in {@code text}. */
+    private static int columnAt(String text, int at) {
+        int start = text.lastIndexOf('\n', at - 1) + 1;
+        return souther.compiler.text.DisplayColumns.advance(text.substring(start, at), 0);
+    }
+
     /**
      * What these properties are held over: the fixtures above, the corpus the formatter's rules are
      * measured against — chosen to reach every kind of node the grammar has — and every {@code .sou}
@@ -385,7 +452,7 @@ class ARowOfATableIsWrittenAtItsTablesColumnTest {
     private static List<String> sources() {
         List<String> out = new ArrayList<>(
                 List.of(TWO_TABLES, A_TAB_REACHING_THE_COLUMN, A_TAB_AFTER_A_COLUMN,
-                        NO_SEPARATOR));
+                        NO_SEPARATOR, INDENTED_ONE_DEEPER, ONE_SEPARATOR_MISSING, FULL_WIDTH));
         out.addAll(WhatGoesBetweenTwoTokensOnALineTest.corpus());
         out.addAll(inTheRepository());
         return out;

--- a/souther-fmt/src/test/java/souther/compiler/fmt/ARowOfATableIsWrittenAtItsTablesColumnTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/ARowOfATableIsWrittenAtItsTablesColumnTest.java
@@ -1,0 +1,279 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.cst.CstParser;
+import souther.compiler.cst.SyntaxToken;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The rows of a table write each of their connectors at one column.
+ *
+ * <p>What is measured is the layout's own answers and the display column each connector was written
+ * at, never a stretch of the output quoted whole. A table is the one construct where quoting the
+ * text would be self-defeating: adding a row to it moves every other row, so an expectation written
+ * as the text would have to be rewritten for a change it is not about — which is the complaint
+ * issue #938 makes about the formatter itself.
+ */
+class ARowOfATableIsWrittenAtItsTablesColumnTest {
+
+    /** Two tables, each with rows of unequal width, and a row with no description. */
+    private static final String TWO_TABLES = """
+            examples for demo
+
+            example price
+                | "a description of some length" : (Off, None) -> P(1)
+                | "short" : (On, Some) -> P(2)
+                | (Off, Some) -> P(3)
+
+            example other
+                | "x" : (E) -> Q(1)
+                | "yy" : (F) -> Q(2)
+            """;
+
+    /** The canonical form of a source, with its tokens read back. */
+    private record Written(Formatter.CanonicalForm form, List<SyntaxToken> code) {
+
+        static Written of(String source) {
+            Formatter.CanonicalForm form =
+                    Formatter.canonicalize(CstParser.parse(source).root());
+            return new Written(form, new Witnesses.Pairing(source, form).writesCode());
+        }
+
+        List<Witnesses.CanonicalStop> stops() {
+            return Witnesses.stops(form, code);
+        }
+
+        /** The display column the connector of one stop was written at. */
+        int columnOf(Witnesses.CanonicalStop stop) {
+            return Witnesses.columnAt(form.text(), code.get(stop.adjacency() + 1).start());
+        }
+
+        /** Where each column of each table was settled, in the order the tables are written. */
+        List<Integer> columns() {
+            return form.layout().columns().stream().map(ColumnDecision::column).toList();
+        }
+    }
+
+    /**
+     * Every row written to a column has its connector at that column, on the screen.
+     *
+     * <p>The decision and the text are two things: the layout says where the column is and the
+     * output is where the row ended up, and it is the second a reader sees. Held over every source
+     * in the repository as well as the fixtures here, so the statement is about the formatter rather
+     * than about these tables.
+     */
+    @Test
+    void everyRowWrittenToAColumnIsAtIt() {
+        List<String> wrong = new ArrayList<>();
+        int held = 0;
+        for (String source : sources()) {
+            Written written = Written.of(source);
+            Map<Columns.Unit, Integer> settled = new LinkedHashMap<>();
+            for (ColumnDecision decision : written.form().layout().columns()) {
+                settled.put(decision.unit(), decision.column());
+            }
+            Map<Columns.Unit, Integer> howMany = new LinkedHashMap<>();
+            for (ColumnOccurrence stop : written.form().layout().stops()) {
+                howMany.merge(stop.unit(), 1, Integer::sum);
+            }
+            held += howMany.values().stream().filter(n -> n > 1).toList().size();
+            for (Witnesses.CanonicalStop stop : written.stops()) {
+                int at = written.columnOf(stop);
+                int column = settled.get(stop.occurrence().unit());
+                if (at != column) {
+                    wrong.add(stop.occurrence().unit().stop() + ": written at column " + at
+                            + " and the column is " + column);
+                }
+            }
+        }
+        assertEquals(List.of(), wrong);
+        // And it is a statement about tables rather than about rows. A column one row is written to
+        // is at that row's own width whatever the rule does, so what says the rule was asked is the
+        // columns two or more rows share.
+        assertTrue(held >= 2, "only " + held + " columns anywhere hold more than one row");
+    }
+
+    /**
+     * The column is the greatest the rows need, and not merely one they all fit inside.
+     *
+     * <p>Both halves. That every row reaches the column would be true of a formatter that wrote
+     * every table at column 200; what rules that out is that some row of the table is at the column
+     * with nothing written for it.
+     */
+    @Test
+    void theColumnIsTheGreatestTheRowsNeed() {
+        for (String source : sources()) {
+            Written written = Written.of(source);
+            Map<Columns.Unit, List<Integer>> natural = new LinkedHashMap<>();
+            for (ColumnOccurrence stop : written.form().layout().stops()) {
+                natural.computeIfAbsent(stop.unit(), _ -> new ArrayList<>())
+                        .add(stop.naturalColumn());
+            }
+            for (ColumnDecision decision : written.form().layout().columns()) {
+                List<Integer> reached = natural.get(decision.unit());
+                assertEquals(reached.stream().max(Integer::compare).orElseThrow(),
+                        decision.column(),
+                        "the column of " + decision.unit().stop() + " against what its rows reach");
+                assertTrue(reached.contains(decision.column()),
+                        "no row of this table needed column " + decision.column());
+            }
+        }
+    }
+
+    /**
+     * A table's widths are its own. Widening a row of one table moves that table's columns and
+     * leaves every other table where it was.
+     *
+     * <p>A pair rather than a constant. What this is about is that two tables do not share a width,
+     * and a fixed set of numbers would say that only for the day the fixture was written.
+     */
+    @Test
+    void aTableSettlesItsOwnColumnsAndNobodyElses() {
+        List<Integer> before = Written.of(TWO_TABLES).columns();
+        List<Integer> after = Written.of(
+                TWO_TABLES.replace("\"a description of some length\"",
+                        "\"a description of considerably more length than that\"")).columns();
+
+        assertEquals(4, before.size(), "two tables with two columns each");
+        assertNotEquals(before.subList(0, 2), after.subList(0, 2), "the table that was widened");
+        assertEquals(before.subList(2, 4), after.subList(2, 4), "the table that was not");
+    }
+
+    /**
+     * A row the canonical form writes down the page takes no part. Its connector opens a line, where
+     * a column is not something a token can be at, so it neither reaches for one nor says how wide
+     * the table is.
+     *
+     * <p>Measured as a pair: the table with the long row and the table without it settle the same
+     * columns. A formatter that let the broken row set the width would move every other row out to
+     * a column none of them can be written at.
+     */
+    @Test
+    void aRowWrittenDownThePageTakesNoPartInTheColumns() {
+        String longRow = "    | \"" + "d".repeat(60) + "\" : (" + "a".repeat(60) + ") -> P(9)\n";
+        Written with = Written.of(TWO_TABLES.replace("    | (Off, Some) -> P(3)\n",
+                "    | (Off, Some) -> P(3)\n" + longRow));
+        Written without = Written.of(TWO_TABLES);
+
+        assertEquals(without.columns(), with.columns(), "the columns the other rows settle");
+        assertEquals(without.stops().size(), with.stops().size(),
+                "the long row is written to no column");
+        assertTrue(with.form().text().contains("d".repeat(60)), "and it is still written");
+    }
+
+    /**
+     * Padding is not content the width has to make room for. A row carried past the width by its
+     * table's column is not broken for it — the alternative is a column decided by which rows came
+     * out flat, and which rows came out flat decided by the column.
+     *
+     * <p>The fixture writes lines over the width to say so: if the padding were measured, the rows
+     * being padded are the ones that would break.
+     */
+    @Test
+    void paddingIsNotMeasuredAgainstTheWidth() {
+        String wide = """
+                examples for demo
+
+                example price
+                    | "%s" : (A) -> P(1)
+                    | "b" : (%s) -> P(2)
+                """.formatted("d".repeat(60), "c".repeat(60));
+        Written written = Written.of(wide);
+
+        int longest = 0;
+        for (String line : written.form().text().split("\n", -1)) {
+            longest = Math.max(longest, Witnesses.columnAt(line + "\n", line.length()));
+        }
+        assertTrue(longest > 100, "the fixture writes a line over the width; it reaches " + longest);
+        for (GroupDecision decision : written.form().layout().decisions()) {
+            assertEquals(Outcome.Flat.class, decision.outcome().getClass(),
+                    "a group broken although nothing but padding took it past the width");
+        }
+    }
+
+    /**
+     * A match forms no column. Its arms are read from the top down rather than against each other,
+     * and lining their arrows up would move every arm out to the width of the longest.
+     *
+     * <p>Said as what the layout wrote rather than as what {@link Columns} lists: a table listed and
+     * never reached and a construct that is not a table are the same list and different outputs.
+     */
+    @Test
+    void theArmsOfAMatchFormNoColumn() {
+        Written written = Written.of("""
+                module demo
+
+                let f (x) =
+                    match x with
+                        | Aaaaaaaaaaaaaaaa -> 1
+                        | B -> 2
+                """);
+
+        assertEquals(List.of(), written.form().layout().stops());
+        assertEquals(List.of(), written.form().layout().columns());
+    }
+
+    /**
+     * Both halves of the report. A source whose table is not aligned is told which rule it departed
+     * from, and repairing what the rules say writes the canonical form — so nothing about the table
+     * is left for {@link Deviations.Report#whole} to be false about.
+     *
+     * <p>And the spacing rule says nothing there. The run before a connector is one rule's, and two
+     * of them answering about the same characters is a conflict the model says is not there.
+     */
+    @Test
+    void aTableThatIsNotAlignedIsReportedAsThisRule() {
+        String misaligned = """
+                examples for demo
+
+                example price
+                    | "a description of some length" : (Off, None) -> P(1)
+                    | "short" : (On, Some) -> P(2)
+                """;
+        Deviations.Report report = Deviations.of(misaligned);
+
+        Set<String> rules = new LinkedHashSet<>();
+        report.deviations().forEach(d -> rules.add(d.rule()));
+        assertEquals(Set.of(Columns.Stop.THE_INPUT_OF_AN_EXAMPLE.said(),
+                        Columns.Stop.THE_RESULT_OF_AN_EXAMPLE.said()), rules);
+        assertTrue(report.whole(), "every difference from the canonical form was named");
+
+        Formatter.CanonicalForm form =
+                Formatter.canonicalize(CstParser.parse(misaligned).root());
+        for (Witness w : Witnesses.spacing(misaligned, form)) {
+            assertEquals(Witness.BetweenTwoTokens.class, w.getClass());
+        }
+        assertEquals(0, Witnesses.spacing(misaligned, form).size(),
+                "the spacing rule is not asked at a stop");
+    }
+
+    /** Every stop the rule lists is one some source in the repository writes. */
+    @Test
+    void everyStopIsReached() {
+        Set<Columns.Stop> reached = new LinkedHashSet<>();
+        for (String source : sources()) {
+            for (ColumnOccurrence stop : Written.of(source).form().layout().stops()) {
+                reached.add(stop.unit().stop());
+            }
+        }
+        assertEquals(Set.of(Columns.Stop.values()), reached);
+    }
+
+    /** The fixtures here and every source the repository holds. */
+    private static List<String> sources() {
+        List<String> out = new ArrayList<>(List.of(TWO_TABLES));
+        out.addAll(WhatGoesBetweenTwoTokensOnALineTest.corpus());
+        return out;
+    }
+}

--- a/souther-fmt/src/test/java/souther/compiler/fmt/AWidthIsMeasuredInColumnsNotCharactersTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/AWidthIsMeasuredInColumnsNotCharactersTest.java
@@ -51,6 +51,33 @@ class AWidthIsMeasuredInColumnsNotCharactersTest {
     }
 
     /**
+     * And a third number, which is neither of the two. Past a table's column the line has reached
+     * further on the screen than the width has counted, because padding is not content the width has
+     * to make room for. What a group decision carries is the column the width read.
+     *
+     * <p>Held as a pair. The group after the padded stop is written at column 5 and measured from
+     * column 2, and a layout that kept the screen column here would have measured this group against
+     * a width three columns further along than the one it was decided by.
+     */
+    @Test
+    void a_group_is_measured_from_the_column_the_width_read_and_not_the_one_it_stands_at() {
+        Columns.Unit column = new Columns.Unit(new Columns.TableRef(),
+                Columns.Stop.THE_RESULT_OF_A_FAKE);
+        Doc wide = Doc.group(Doc.concat(Doc.text("xxxx"), Doc.columnStop(column), Doc.text("|"),
+                Doc.group(Doc.text("ab"))));
+        Doc narrow = Doc.group(Doc.concat(Doc.text("x"), Doc.columnStop(column), Doc.text("|"),
+                Doc.group(Doc.text("ab"))));
+        Layout laid = Doc.concat(wide,
+                Doc.hardline(Obligation.MEMBERS_TAKE_LINES_OF_THEIR_OWN), narrow).layout(100);
+
+        assertEquals("xxxx|ab\nx   |ab", laid.text());
+        assertEquals(5, laid.text().indexOf("ab", 8) - laid.text().indexOf('\n') - 1,
+                "the second row's group stands at column 5 on the screen");
+        assertEquals(2, laid.decisions().get(3).startColumn(),
+                "and the width read column 2, which is where it stands with no padding counted");
+    }
+
+    /**
      * The other half of the contract. Everything a layout says about where something is in its text
      * — a break's offset, a break opportunity's — indexes the text it wrote, and the readers of a
      * layout cut and search that string with it. Moving those to columns alongside the width would

--- a/souther-fmt/src/test/java/souther/compiler/fmt/AWitnessIsProjectedThroughItsOwnUnitAndNotTheWholeFileTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/AWitnessIsProjectedThroughItsOwnUnitAndNotTheWholeFileTest.java
@@ -154,6 +154,30 @@ class AWitnessIsProjectedThroughItsOwnUnitAndNotTheWholeFileTest {
         return out;
     }
 
+    /** Which stops are written to a column, by sweeping the canonical form's stops. */
+    private static List<Witnesses.CanonicalStop> sweptAt(List<Witnesses.CanonicalStop> stops,
+            Columns.Unit unit) {
+        List<Witnesses.CanonicalStop> out = new ArrayList<>();
+        for (Witnesses.CanonicalStop stop : stops) {
+            if (stop.occurrence().unit().equals(unit)) {
+                out.add(stop);
+            }
+        }
+        return out;
+    }
+
+    /** Every column any stop of a canonical form is written to, in the order they are met. */
+    private static List<Columns.Unit> columnsOf(List<Witnesses.CanonicalStop> stops) {
+        Set<Columns.Unit> seen = new java.util.LinkedHashSet<>();
+        List<Columns.Unit> out = new ArrayList<>();
+        for (Witnesses.CanonicalStop stop : stops) {
+            if (seen.add(stop.occurrence().unit())) {
+                out.add(stop.occurrence().unit());
+            }
+        }
+        return out;
+    }
+
     /** Every group any opportunity of a layout names, in the order they are met. */
     private static List<Doc.GroupRef> groupsOf(Layout layout) {
         Set<Doc.GroupRef> seen = java.util.Collections.newSetFromMap(new IdentityHashMap<>());
@@ -297,7 +321,15 @@ class AWitnessIsProjectedThroughItsOwnUnitAndNotTheWholeFileTest {
             for (Doc.NestRef level : levelsOf(lines)) {
                 under.put(level, sweptUnder(lines, level));
             }
-            Repair.Round swept = new Repair.Round(source, canonical, pairing, settling, under);
+            List<Witnesses.CanonicalStop> stops =
+                    Witnesses.stops(canonical, pairing.writesCode());
+            Map<Columns.Unit, List<Witnesses.CanonicalStop>> atAColumn =
+                    new java.util.LinkedHashMap<>();
+            for (Columns.Unit unit : columnsOf(stops)) {
+                atAColumn.put(unit, sweptAt(stops, unit));
+            }
+            Repair.Round swept =
+                    new Repair.Round(source, canonical, pairing, settling, under, atAColumn);
             Repair.Round gathered = new Repair.Round(source, canonical, pairing);
 
             for (Witness w : witnesses(source, canonical, pairing)) {

--- a/souther-fmt/src/test/java/souther/compiler/fmt/FormatterTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/FormatterTest.java
@@ -529,7 +529,7 @@ class FormatterTest {
                 let f (r, clock) = r
                 fake lookup
                     | (R { x = 1 }) -> R { x = 2 }
-                    | _ -> R { x = 0 }
+                    | _             -> R { x = 0 }
                 example f
                     | (R { x = 1 }) with clock = "t" -> R { x = 1 }
                 """;

--- a/souther-fmt/src/test/java/souther/compiler/fmt/WhatGoesBetweenTwoTokensOnALineTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/WhatGoesBetweenTwoTokensOnALineTest.java
@@ -338,8 +338,9 @@ class WhatGoesBetweenTwoTokensOnALineTest {
         throw new AssertionError("two tokens of one file with no node holding both");
     }
 
-    /** One adjacency in a canonical form: what joins the two tokens, their kinds, and what is
-     * written between them. */
+    /** One adjacency in a canonical form: what joins the two tokens, their kinds, and the
+     * separator written between them — which is what the spacing rule answers and not the whole run,
+     * where a table's column has padded it out. */
     record Adjacency(SyntaxKind joins, SyntaxKind left, SyntaxKind right, String separator) {
         String pair() {
             return left + " " + right;
@@ -349,20 +350,31 @@ class WhatGoesBetweenTwoTokensOnALineTest {
     /** Every adjacency in the canonical form of every source, excluding the pairs a break separated,
      * which are the other rules' business. Read by
      * {@link TheSpacingRuleAgreesWithTheCanonicalFormTest} as well: what is measured — the rendered
-     * text — is the same, and what each of the two holds it against is not. */
+     * text — is the same, and what each of the two holds it against is not.
+     *
+     * <p>Where a table's column stands at an adjacency, the run before the connector is the
+     * separator and then the padding that carries the row out to the column. The two are different
+     * rules' and the split between them is the layout's own answer, read from where it wrote the
+     * stop rather than guessed at from the spaces. */
     static List<Adjacency> adjacencies() {
         List<Adjacency> out = new ArrayList<>();
         for (String source : corpus()) {
-            String canonical = Formatter.format(source);
+            Formatter.CanonicalForm form = Formatter.canonicalize(CstParser.parse(source).root());
+            String canonical = form.text();
             CstParser.Result parsed = CstParser.parse(canonical);
             assertTrue(parsed.errors().isEmpty(), "a canonical form did not reparse:\n" + canonical);
             List<SyntaxToken> code = tokens(parsed.root()).stream().filter(t -> !t.isTrivia()).toList();
+            Map<Integer, Integer> padsFrom = new LinkedHashMap<>();
+            for (Witnesses.CanonicalStop stop : Witnesses.stops(form, code)) {
+                padsFrom.put(stop.adjacency(), stop.occurrence().at());
+            }
             for (int i = 0; i + 1 < code.size(); i++) {
                 SyntaxToken a = code.get(i);
                 SyntaxToken b = code.get(i + 1);
                 String gap = canonical.substring(a.end(), b.start());
                 if (!gap.contains("\n")) {
-                    out.add(new Adjacency(joining(a, b).kind(), a.kind(), b.kind(), gap));
+                    out.add(new Adjacency(joining(a, b).kind(), a.kind(), b.kind(),
+                            canonical.substring(a.end(), padsFrom.getOrDefault(i, b.start()))));
                 }
             }
         }
@@ -371,8 +383,9 @@ class WhatGoesBetweenTwoTokensOnALineTest {
 
     // --- the range ---
 
-    /** Nothing, or one space. Alignment is what this rules out: a column of `=` signs lined up under
-     * each other needs a run of spaces between two tokens, and no such run survives. */
+    /** Nothing, or one space. What this rules out is a construct spacing its own tokens by however
+     * many columns it likes: the one place a run of spaces is written is a table's column, and there
+     * it is written after this answer rather than instead of it. */
     @Test
     void whatIsWrittenBetweenThemIsNothingOrOneSpace() {
         Set<String> seen = new LinkedHashSet<>();

--- a/specification.adoc
+++ b/specification.adoc
@@ -3143,7 +3143,7 @@ A *function dependency* — one whose result varies with its input — is given 
 ----
 fake findManager
     | (EmployeeId("e-1")) -> EmployeeId("boss-1")
-    | _ -> EmployeeId("unknown")
+    | _                   -> EmployeeId("unknown")
 ----
 
 Each dependency of the target must have a fake — a `+with+` on the row or a `+fake+` table — or it is a compile error (<<e1908>>). A fake, like an example, is written inline or in an attached `+examples for+` file, and is local to its module. `+fake+` is a contextual keyword.
@@ -3197,7 +3197,7 @@ behavior findMember : (id: MemberId) -> Found | Missing
 
 example findMember
     | "a member that is registered" : (MemberId("m-1")) -> Found { id = MemberId("m-1") }
-    | "a member that is not" : (MemberId("m-9")) -> Missing { reason = "no such member" }
+    | "a member that is not"        : (MemberId("m-9")) -> Missing { reason = "no such member" }
 ----
 
 How many rows are waiting is what `+souther examples+` reports; it is not a compile warning, because waiting is the normal state of a model being written and a warning on every one of them says nothing.


### PR DESCRIPTION
Closes #938 — the formatter took the columns out of an `example` table, so a decision table could not be formatted at all.

## What was wrong

Not what the issue says. The `text(" ")` calls it describes are gone; #476 moved every separator into `Spacing.between`, and the fix is not to undo that.

`Spacing.between` reads two token kinds and the construct joining them and answers with nothing or one space. A column is a fact about the sibling rows of a block, and neither the domain nor the range of that function can hold one. Underneath it, `Doc.layout` walks the text once from left to right, and there is no point of that walk at which a width across lines is known. Losing the author's padding was the boundary rule being total and local, which is the right design.

## The rule

**The rows of a table write each of their connectors at one column.** A table is an `example` or a `fake`; a `match` is not, since its arms are read from the top down rather than against each other.

`Columns` holds the vocabulary and nothing else — which constructs are tables, and which boundaries are stops — read from the same pair `Spacing` is asked about, so no construct can make itself a table by writing one. A stop is keyed by its connector rather than by how many stops precede it, so a row with no description still writes its `->` at everybody else's column. A table is a `TableRef`, an identity like `GroupRef` and `NestRef`, so two `example`s cannot run their widths into each other.

A stop is written **after** the separator and never instead of it. `Spacing` is unchanged and still has no third answer; what a column says is where the connector begins.

## How the column is decided once

`Doc.layout` lays the document out, reads the columns off what it wrote, and lays it out again to write them, until nothing moves. Looking ahead over the table at the row that opens it would be a second walk taking the decisions the real one has to take again — the thing `flatnessOf` is careful about — and the same machine run twice cannot disagree with itself. It settles because a column depends only on the columns before it on its line. A document with no table is laid out once.

Two consequences are stated rather than left to the mechanism:

- **Padding is not measured against the width.** A group whose flatness read it would be decided by a column that is decided by which rows came out flat. `Trailing` is already handled the same way.
- **A row written down the page takes no part in the columns.** Its connector opens a line, where a column is not something a token can be at.

## `fmt --check`

`Witness.AtAColumn` has the shape of `Witness.Indentation`: the unit is the column, the canonical answer is one number, and what the source wrote is a list. The rule is evaluated once for the whole column, so a table whose five rows all miss it has departed from one decision five times.

```
4:20: the rows of a table of examples write their : at one column — column 37, and this is columns [31, 37]
4:37: the rows of a table of examples write their -> at one column — column 70, and this is columns [58, 70]
```

What the canonical form writes at a stop is the separator and then the padding, and which of the two rules answers is settled by whether the source's run comes apart the same way: that separator, and after it spaces and nothing else. So the spacing rule is not asked at a stop whose separator the source already has, and it is the only one asked at a stop where the source wrote a tab, or no space at all. One predicate, read by both families and by the repair, so they can neither both answer about the same characters — a conflict `Repair.composed` refuses — nor both stay silent, which would leave a difference no rule accounts for.

## What the tests measure

`ARowOfATableIsWrittenAtItsTablesColumnTest`, eight of them, all against the layout's own answers and display columns. None quotes a stretch of the output: a table is the one construct where adding a row moves every other row, so an expectation written as text would have to be rewritten for a change it is not about — which is the complaint this issue makes about the formatter itself.

- every row written to a column is at it, over every source in the repository
- the column is the greatest the rows need, and some row is at it unpadded
- a table settles its own columns and nobody else's — measured as a pair, not as fixed numbers
- a row written down the page changes no column — the same table with and without it
- padding is not measured against the width — lines over 100 columns and no group broken for it
- the arms of a `match` form no column
- a table that is not aligned is reported as this rule, repairs to the canonical form, and the spacing rule says nothing there
- every stop the rule lists is one some source writes

`WhatGoesBetweenTwoTokensOnALineTest` used to state that no run of spaces survives between two tokens. It now splits the run at the stop, so the separator is still nothing-or-one-space and the padding is the other rule's.

## Measured

- All nine modules green.
- The repair path is live rather than green on canonical sources: five `.sou` files in the repository hold twelve columns that are not aligned, and every one reaches `whole == true`.
- Whole test run: 1:07 on `develop`, 1:05 here.

## Left out

The five `.sou` files above are not in canonical form and `souther fmt` would now reflow their tables. Aligning only their columns is not well defined — the column rule reads the break rules' results, and those files break rows the canonical form keeps whole, so a column-only repair pads a continuation line out to a column nothing reaches. Running the whole formatter on them brings 122–358 departures that have nothing to do with this issue. Both are separable from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
