### PR TITLE
A measure answers for itself whether it was made, and how much of it

### DIFF
--- a/souther-cli/src/main/java/souther/cli/init/Templates.java
+++ b/souther-cli/src/main/java/souther/cli/init/Templates.java
@@ -70,14 +70,14 @@ final class Templates {
                         invariant String.length(value) >= 1
                     """.formatted(project.moduleName());
             case FULL -> """
-                    // A library desk takes a book back. What is left to decide is whether it is late,
-                    // and by how much.
+                    // A library desk takes a book back. What is left to decide is whether what the
+                    // desk was handed is a loan at all.
                     //
                     // Every rule the desk works by is written once, where the value is built: a title
                     // is not empty, a loan runs between one and twenty-eight days, and a book cannot
                     // come back before it went out. Nothing downstream checks any of them again.
                     module %s exposing
-                        ( Title, LoanDays, DaysLate, Returned
+                        ( Title, LoanDays, Returned
                         , NoTitle, NotALoanPeriod, ReturnedBeforeItWentOut
                         , returnBook
                         )
@@ -88,12 +88,9 @@ final class Templates {
                     data LoanDays = Int
                         invariant value >= 1 && value <= 28
 
-                    data DaysLate = Int
-                        invariant value >= 0
-
                     data Returned =
                         { title: Title
-                        , daysLate: DaysLate
+                        , lentFor: LoanDays
                         }
 
                     // The three ways the desk's own input is not a loan. They are cases of the answer
@@ -108,23 +105,14 @@ final class Templates {
                     // of the cases it answers with.
                     behavior %s : (title: String, borrowedOn: Date, days: Int, returnedOn: Date)
                         -> Returned | NoTitle | NotALoanPeriod | ReturnedBeforeItWentOut
-                        constructs Returned, Title, LoanDays, DaysLate
-
-                    let daysOut (borrowedOn: Date, returnedOn: Date): Int =
-                        Date.daysBetween(borrowedOn, returnedOn)
-
-                    let lateBy (out: Int, lent: LoanDays): Int =
-                        if out > lent.value then out - lent.value else 0
+                        constructs Returned, Title, LoanDays
 
                     let %s (title, borrowedOn, days, returnedOn) = {
                         guard Title(title) as name else NoTitle
                         guard LoanDays(days) as lent else NotALoanPeriod
                         guard borrowedOn <= returnedOn else ReturnedBeforeItWentOut
 
-                        Returned
-                            { title = name
-                            , daysLate = DaysLate(lateBy(daysOut(borrowedOn, returnedOn), lent))
-                            }
+                        Returned { title = name, lentFor = lent }
                     }
                     """.formatted(project.moduleName(), BEHAVIOR, BEHAVIOR);
         };
@@ -147,24 +135,30 @@ final class Templates {
                 examples for %s
 
                 example %s
-                    | "a book back inside its loan is not late" :
+                    | "a loan the desk can take back" :
                         ("Souther in Action", Date("2026-04-01"), 14, Date("2026-04-10"))
-                            -> Returned { title = Title("Souther in Action"), daysLate = DaysLate(0) }
-                    | "the day after it was due is one day late" :
-                        ("Souther in Action", Date("2026-04-01"), 14, Date("2026-04-16"))
-                            -> Returned { title = Title("Souther in Action"), daysLate = DaysLate(1) }
-                    | "the day it was due is not late" :
-                        ("Souther in Action", Date("2026-04-01"), 14, Date("2026-04-15"))
-                            -> Returned { title = Title("Souther in Action"), daysLate = DaysLate(0) }
-                    | "a book back the day it went out is not late" :
+                            -> Returned { title = Title("Souther in Action"), lentFor = LoanDays(14) }
+                    | "a book back the day it went out" :
                         ("Souther in Action", Date("2026-04-01"), 14, Date("2026-04-01"))
-                            -> Returned { title = Title("Souther in Action"), daysLate = DaysLate(0) }
+                            -> Returned { title = Title("Souther in Action"), lentFor = LoanDays(14) }
+                    | "the shortest loan there is" :
+                        ("Souther in Action", Date("2026-04-01"), 1, Date("2026-04-10"))
+                            -> Returned { title = Title("Souther in Action"), lentFor = LoanDays(1) }
+                    | "and the longest" :
+                        ("Souther in Action", Date("2026-04-01"), 28, Date("2026-04-10"))
+                            -> Returned { title = Title("Souther in Action"), lentFor = LoanDays(28) }
+                    | "a day under the shortest is not a loan period" :
+                        ("Souther in Action", Date("2026-04-01"), 0, Date("2026-04-10"))
+                            -> NotALoanPeriod
+                    | "nor a day over the longest" :
+                        ("Souther in Action", Date("2026-04-01"), 29, Date("2026-04-10"))
+                            -> NotALoanPeriod
                     | "an empty title is not a title" :
                         ("", Date("2026-04-01"), 14, Date("2026-04-10"))
                             -> NoTitle
-                    | "twenty-nine days is not a loan period" :
-                        ("Souther in Action", Date("2026-04-01"), 29, Date("2026-04-10"))
-                            -> NotALoanPeriod
+                    | "one character is a title" :
+                        ("S", Date("2026-04-01"), 14, Date("2026-04-10"))
+                            -> Returned { title = Title("S"), lentFor = LoanDays(14) }
                     | "a book cannot come back the day before it went out" :
                         ("Souther in Action", Date("2026-04-02"), 14, Date("2026-04-01"))
                             -> ReturnedBeforeItWentOut
@@ -203,13 +197,13 @@ final class Templates {
                 class %s {
 
                     @Test
-                    void aBookHandedBackLateSaysHowLate() {
+                    void aLoanTheDeskTakesBackComesBackAsAValue() {
                         %s answer = %s.of().apply(
                                 "Souther in Action", LocalDate.of(2026, 4, 1), 14L,
                                 LocalDate.of(2026, 4, 16));
 
                         Returned returned = assertInstanceOf(Returned.class, answer);
-                        assertEquals(1L, returned.daysLate().value());
+                        assertEquals(14L, returned.lentFor().value());
                     }
 
                     @Test

--- a/souther-cli/src/test/java/souther/cli/ABuildCanBeHeldToReliableDomainCoverageTest.java
+++ b/souther-cli/src/test/java/souther/cli/ABuildCanBeHeldToReliableDomainCoverageTest.java
@@ -97,10 +97,11 @@ class ABuildCanBeHeldToReliableDomainCoverageTest {
     @Test
     void aVerdictRestsOnTheEvidenceItsCriterionAsksFor() {
         PartitionEvidence measured = AReportOfOneBorder.partition(
-                AReportOfOneBorder.assessed(AReportOfOneBorder.aBoundedBorder(),
-                        role -> role.againstTheLine()
-                                ? new ItemAssessment.Coverage.Hit()
-                                : new ItemAssessment.Coverage.Undecided()));
+                AReportOfOneBorder.measured(
+                        AReportOfOneBorder.assessed(AReportOfOneBorder.aBoundedBorder(),
+                                role -> role.againstTheLine()
+                                        ? new ItemAssessment.Coverage.Hit()
+                                        : new ItemAssessment.Coverage.Undecided())));
 
         assertEquals(AdequacyReport.AdequacyStatus.SATISFIED,
                 AReportOfOneBorder.verdictOf(measured, Adequacy.Criterion.SIMPLIFIED_DOMAIN),

--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -21,6 +21,8 @@ import souther.compiler.partition.PointRole;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.BorderAssessment;
 import souther.compiler.query.ItemAssessment;
+import souther.compiler.query.BoundaryDerivation;
+import souther.compiler.query.PartitionDerivation;
 import souther.compiler.query.PartitionEvidence;
 import souther.compiler.report.AdequacyReport;
 import souther.compiler.source.SourceId;
@@ -107,12 +109,32 @@ final class AReportOfOneBorder {
         return new ItemAssessment.Coverage.Hit();
     }
 
-    static PartitionEvidence partition(BorderAssessment boundary,
+    /**
+     * One behavior's measures, as a verdict reads them.
+     *
+     * <p>The measures' own answers and not the entries beside them. What a dropped axis costs is
+     * settled where the reading is, and reaches a verdict as the measure saying it was not made in
+     * full — so a fixture here says which answer it is putting in front of the verdict, and the
+     * step that decides that answer is tested where it happens
+     * (souther-compiler, {@code AMeasureIsShortOfWhateverItsReadingDidNotReachTest}).
+     */
+    static PartitionEvidence partition(BoundaryDerivation border,
                                        Partitions.OmittedAxis... omitted) {
-        return new PartitionEvidence(PartitionEvidence.Partitioned.of(List.of()),
-                PartitionEvidence.Bounded.of(List.of(boundary)), PartitionEvidence.PairSpace.NONE,
+        return new PartitionEvidence(new PartitionDerivation.Unresolved(), border,
+                PartitionEvidence.PairSpace.NONE,
                 List.of(), List.of(), List.of(), List.of(), List.of(), List.of(omitted),
                 List.of());
+    }
+
+    /** The border measure made in full, over the one border. */
+    static BoundaryDerivation measured(BorderAssessment boundary) {
+        return new BoundaryDerivation.Complete(List.of(boundary));
+    }
+
+    /** And the same border, from a reading that was short of something — which is what a dropped
+     *  axis carrying a line leaves behind. */
+    static BoundaryDerivation shortOfSomething(BorderAssessment boundary) {
+        return new BoundaryDerivation.Partial(List.of(boundary));
     }
 
     /** What one behavior's partition makes of the whole report, held to {@code criterion}. */

--- a/souther-cli/src/test/java/souther/cli/WhatStrictRefusesIsWhatTheRowsDoNotCoverTest.java
+++ b/souther-cli/src/test/java/souther/cli/WhatStrictRefusesIsWhatTheRowsDoNotCoverTest.java
@@ -291,22 +291,33 @@ class WhatStrictRefusesIsWhatTheRowsDoNotCoverTest {
      * measure no build refuses over, and holding the verdict open for it would report a doubt nobody
      * can act on.
      *
-     * <p>Written from the evidence rather than from a source: reaching the limit takes thirteen axes
-     * on one behavior, and a fixture that size says less than this does about which of the two it is.
+     * <p>What a verdict does with the answer, and not what a dropped axis does to the answer. The
+     * second is settled where the reading is and reaches a verdict only as the measure's own status
+     * — so this hands the verdict each status in turn, and that a dropped axis carrying a line
+     * produces the second of them is held against a source in souther-compiler
+     * ({@code AMeasureIsShortOfWhateverItsReadingDidNotReachTest}). Written the other way round,
+     * this fixture would name a status of its own choosing and call the naming a test.
      */
     @Test
     void anAxisDroppedPastTheLimitHoldsTheVerdictOpenOnlyWhereItCarriedAnObligation() {
         BorderAssessment met = AReportOfOneBorder.assessed(
                 AReportOfOneBorder.aBorderAtTheEdgeOfItsDomain(), AReportOfOneBorder::hit);
 
-        assertEquals(AdequacyReport.AdequacyStatus.SATISFIED, verdictOf(partition(met)),
-                "nothing dropped");
         assertEquals(AdequacyReport.AdequacyStatus.SATISFIED,
-                verdictOf(partition(met, dropped("weigh", "w.flag", false))),
-                "a dropped axis that was only classifying");
+                verdictOf(partition(AReportOfOneBorder.measured(met))),
+                "a border measure made in full");
+        // The same border, from a reading that was short of something. Which is what a dropped axis
+        // carrying a line leaves the measure with, and the verdict reads the measure's answer and
+        // never the list of what was dropped: a report working out for itself what an omission cost
+        // is a second reading of a question the measure has already answered.
         assertEquals(AdequacyReport.AdequacyStatus.UNDETERMINED,
-                verdictOf(partition(met, dropped("weigh", "w.m", true))),
-                "a dropped axis that was carrying a boundary");
+                verdictOf(partition(AReportOfOneBorder.shortOfSomething(met),
+                        dropped("weigh", "w.m", true))),
+                "a border measure that was not made in full");
+        assertEquals(AdequacyReport.AdequacyStatus.SATISFIED,
+                verdictOf(partition(AReportOfOneBorder.measured(met),
+                        dropped("weigh", "w.flag", false))),
+                "a dropped axis the border measure was not measuring");
     }
 
     private static Partitions.OmittedAxis dropped(String behavior, String path,
@@ -316,9 +327,9 @@ class WhatStrictRefusesIsWhatTheRowsDoNotCoverTest {
 
     /** This one asks nothing about the criterion, so it is held to the one a build asks for by
      *  default; {@link AReportOfOneBorder} is where the report itself is built. */
-    private static PartitionEvidence partition(BorderAssessment boundary,
+    private static PartitionEvidence partition(souther.compiler.query.BoundaryDerivation border,
                                                Partitions.OmittedAxis... omitted) {
-        return AReportOfOneBorder.partition(boundary, omitted);
+        return AReportOfOneBorder.partition(border, omitted);
     }
 
     private static AdequacyReport.AdequacyStatus verdictOf(PartitionEvidence partition) {

--- a/souther-compiler/src/main/java/souther/compiler/check/CoverageObligation.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CoverageObligation.java
@@ -76,5 +76,43 @@ public enum CoverageObligation {
      * are owed in the classes it makes. Both shapes raise this, and a measure counting one for the
      * other reports a model divided where nothing said so.
      */
-    PARTITION
+    PARTITION;
+
+    /**
+     * Which measure of coverage answers this question.
+     *
+     * <p>Settled here, where the question is, and read by everything that has to know. A report
+     * chooses which section to print a standing question under, and a measure has to know which
+     * questions it is short of before it may say it read the model — two readings of one table, and
+     * the table was a renderer's private method while the second reader did not exist. Written
+     * twice, the day a question is added is the day one of them files it somewhere and the other
+     * silently answers for it.
+     *
+     * <p>A singling belongs to the partition measure. It makes the two classes {@code {c}} and
+     * everything else, and that is what counts a row for it; a border has an order across it and a
+     * role for each side, which a singled value has no sides for.
+     */
+    public Measure answeredBy() {
+        return switch (this) {
+            case ADMITTED_VALUES, PARTITION, SINGLETON -> Measure.PARTITION;
+            case BOUNDARY -> Measure.BOUNDARY;
+        };
+    }
+
+    /**
+     * A measure of coverage, as the questions are filed under it.
+     *
+     * <p>Two, and each answers for itself. What one of them is short of says nothing about the
+     * other: a rule whose line nothing could read leaves the border measure short while the classes
+     * either side of it were read in full, and a completeness shared between the two would report
+     * both on the strength of whichever failed.
+     */
+    public enum Measure {
+
+        /** Which values may stand where, which classes hold them, and which value is singled out. */
+        PARTITION,
+
+        /** Where a line falls, and the rows either side of it. */
+        BOUNDARY
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/BlockReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/BlockReason.java
@@ -29,7 +29,36 @@ public sealed interface BlockReason {
      * fact about that rule and this compiler. So a finding built on one of these owes an identity
      * for the rule, and the type is what makes owing it unavoidable.
      */
-    sealed interface AboutARule extends BlockReason {}
+    sealed interface AboutARule extends BlockReason {
+
+        /**
+         * Whether a measure that would have had this rule's evidence is thereby short of something.
+         *
+         * <p>Not every rule a reading set aside was one it fell short of. A comparison relating two
+         * positions divides neither of them however well it is read, so a measure without it is a
+         * measure that read the model and found no class there — while a comparison in a form no
+         * reader takes apart may have divided the position or bounded it, and nothing knows which.
+         * The first is the model, the second is this compiler, and a measure told they were one
+         * thing reports whichever it happens to meet.
+         *
+         * <p>A switch and no {@code default}, so a reason added answers this on the day it is added
+         * rather than falling into whichever arm stands nearest.
+         *
+         * <p>Which measure is short is not asked, and there is nothing here to ask it of. A rule
+         * this could not read is one whose line and whose classes are both unknown: what it would
+         * have said is exactly what nobody has.
+         */
+        default boolean leavesAMeasureShort() {
+            return switch (this) {
+                case UnreadComparisonForm _, UnreadComparisonDomain _, RuleAboutADerivedValue _,
+                     UnreadValueRule _, CompetingCoordinates _ -> true;
+                // Nothing is missing. The rule is read and settled beside the partition rather than
+                // in it, and a measure counting it short would hold a verdict open over a model
+                // whose every rule this compiler understood.
+                case ComparisonBetweenPositions _ -> false;
+            };
+        }
+    }
 
     /**
      * The reading did not get to the rules of the position, so there is no rule to name.

--- a/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
@@ -1,0 +1,144 @@
+package souther.compiler.partition;
+
+import souther.compiler.check.CoverageObligation;
+import souther.compiler.check.RuleAccounting;
+import souther.compiler.inputs.StructuralInspection;
+
+import java.util.List;
+
+/**
+ * Whether the reading one measure of coverage depends on came to an end.
+ *
+ * <p>Two types and not one value shared between them, because the two measures are short of
+ * different things. A rule whose line nothing could read leaves the border measure short while the
+ * classes either side of it were read in full; a walk that never reached a position's rules leaves
+ * both short. Written as one answer about the behavior, the first case reports the partition
+ * measure on the strength of what stopped the other one — and the day a third measure arrives it
+ * inherits whatever the two of them happened to share.
+ *
+ * <p><b>Closed is a conclusion, and only this package draws it.</b> Each {@code Closed} has a
+ * package-private constructor and is reached through {@link #of}, which is handed the whole of what
+ * a behavior's reading came to. Outside this package there is no way to make one, so a caller
+ * holding one is holding the proof that the reading ran out — the arrangement
+ * {@link UndividedPosition.Why.Absent} is under, at the measure rather than at a position.
+ *
+ * <p><b>The questions first.</b> What a measure is mostly short of is a question the model raised
+ * that nothing answered, filed under the measure that answers it
+ * ({@link CoverageObligation#answeredBy}). Counted as "every reader ran to the end" instead, a
+ * completeness says the model was read in full for exactly as long as nobody adds a reader.
+ *
+ * <p><b>And three facts no question carries.</b> A position whose rules were never enumerated
+ * raises none, and a set of raised questions all answered is what a reading that never looked also
+ * produces ({@link Axis#rulesNotReached}). A position past the axis limit was dropped with whatever
+ * it was carrying. And a rule the model wrote that this could not use is one whose question a
+ * reading may well have answered before the position refused the answer — two clauses placing ends
+ * on a {@code String}'s two coordinates are read, accounted for, and then both dropped, and the
+ * accounting is right to say they were read. What an accounting cannot say is that the measure was
+ * then left with nothing, and that is what this reads the refusals for.
+ *
+ * <p>All three leave every measure short, because what is not known about them is not known for
+ * either. A refusal names the rule and not which measure loses by it: which line would have been
+ * drawn, and which classes would have stood either side of it, are both unknown once the rule is
+ * out.
+ */
+public final class MeasureClosure {
+
+    private MeasureClosure() {}
+
+    /** Whether the partition measure's reading ran out. */
+    public sealed interface OfThePartition {
+
+        /** It did: every question this measure answers was accounted for, everywhere. */
+        final class Closed implements OfThePartition {
+
+            private Closed() {}
+
+            @Override
+            public String toString() {
+                return "PartitionClosed";
+            }
+        }
+
+        /** It did not, so what this measure did not find is not known not to be there. */
+        record Open() implements OfThePartition {}
+    }
+
+    /** Whether the border measure's reading ran out. The same question of the other measure, and a
+     *  separate type so that neither can be answered with the other's answer. */
+    public sealed interface OfTheBorder {
+
+        /** It did: every question this measure answers was accounted for, everywhere. */
+        final class Closed implements OfTheBorder {
+
+            private Closed() {}
+
+            @Override
+            public String toString() {
+                return "BorderClosed";
+            }
+        }
+
+        /** It did not. */
+        record Open() implements OfTheBorder {}
+    }
+
+    /** What the two closures come to, together, so that neither is built from half a reading. */
+    record Both(OfThePartition partition, OfTheBorder border) {}
+
+    /**
+     * What each measure's reading came to over one behavior.
+     *
+     * <p>Everything the reading could be short of arrives here at once. Asked measure by measure
+     * afterwards, the two would be built from whatever their caller had in hand at the time, which
+     * is the second bookkeeping this type exists to prevent.
+     *
+     * @param axes    every position the reading kept, measured or not
+     * @param compared what the body's comparisons raised and what answered each
+     * @param omitted positions dropped past the axis limit, which leave both measures short: what
+     *                they were carrying went with them and no question stands for it
+     * @param refused the rules of the model this reading set aside, each from the reader that did.
+     *                Asked whether it is short of them rather than counted: a comparison relating
+     *                two positions is set aside by what it says and not by anything missing here
+     *                ({@link souther.compiler.inputs.BlockReason.AboutARule#leavesAMeasureShort})
+     */
+    static Both of(List<Axis> axes, List<GuardThresholds.Guards.AtAPosition> compared,
+                   List<Partitions.OmittedAxis> omitted,
+                   List<souther.compiler.inputs.UnreadRule> refused) {
+        boolean short_ = refused.stream()
+                .anyMatch(each -> each.why().leavesAMeasureShort());
+        // A dropped axis, asked which measure lost by it. What it was carrying is recorded where it
+        // was dropped, because it cannot be read back afterwards: one that was carrying a line took
+        // the border's evidence with it, and one that was only classifying took the partition's.
+        // Counted as one fact, a model dropping an axis that divides nothing anybody bounds was
+        // held open over a measure it never had.
+        boolean partition = !short_ && omitted.isEmpty();
+        boolean border = !short_
+                && omitted.stream().noneMatch(Partitions.OmittedAxis::carriedAnObligation);
+        for (Axis axis : axes) {
+            // A position whose rules nothing enumerated, and one the walk could not reach into.
+            // Neither raises a question, so neither can be short of one — which is why they are
+            // asked here and not among the questions (issue #791).
+            if (axis.rulesNotReached() || axis.pending() instanceof StructuralInspection.Blocked) {
+                partition = false;
+                border = false;
+                continue;
+            }
+            for (RuleAccounting.Unanswered each : axis.unanswered()) {
+                switch (each.owed().obligation().answeredBy()) {
+                    case PARTITION -> partition = false;
+                    case BOUNDARY -> border = false;
+                }
+            }
+        }
+        for (GuardThresholds.Guards.AtAPosition each : compared) {
+            for (RuleAccounting.Unanswered open : each.accounting().unansweredQuestions()) {
+                switch (open.owed().obligation().answeredBy()) {
+                    case PARTITION -> partition = false;
+                    case BOUNDARY -> border = false;
+                }
+            }
+        }
+        return new Both(partition ? new OfThePartition.Closed() : new OfThePartition.Open(),
+                border ? new OfTheBorder.Closed() : new OfTheBorder.Open());
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -83,7 +83,9 @@ public final class Partitions {
                                List<souther.compiler.inputs.PositionValuesNotSeparated> notSeparated,
                                List<Border> between,
                                List<GuardThresholds.Guards.AtAPosition> compared,
-                               ReachingCuts reaching) {
+                               ReachingCuts reaching,
+                               MeasureClosure.OfThePartition partitionClosure,
+                               MeasureClosure.OfTheBorder borderClosure) {
         public Partitioning {
             compared = List.copyOf(compared);
             axes = List.copyOf(axes);
@@ -94,6 +96,13 @@ public final class Partitions {
             blocked = List.copyOf(blocked);
             notSeparated = List.copyOf(notSeparated);
             between = List.copyOf(between);
+            // Made where the reading is, never here. A closure this constructor could compute would
+            // be one a caller assembling a `Partitioning` by hand could also have written, and
+            // `Closed` is a conclusion about a reading rather than a shape of the lists beside it.
+            if (partitionClosure == null || borderClosure == null) {
+                throw new IllegalArgumentException(
+                        "a partitioning with no account of what each measure's reading came to");
+            }
         }
 
         /** Whether an edge of this term is a value some row could carry.
@@ -197,11 +206,12 @@ public final class Partitions {
         // of them was left unread — settled beside each axis, as it is once a body has spoken.
         List<Measured> measured = new ArrayList<>();
         for (Axis axis : kept) {
-            keep(new ArrayList<>(), measured, axis, null, unread);
+            keep(new ArrayList<>(), measured, axis, unread);
         }
+        MeasureClosure.Both closed = MeasureClosure.of(kept, List.of(), omitted, unread);
         return new Partitioning(kept, omitted, quantities, uncertain, undividedIn(measured),
                 List.copyOf(unread), blockedIn(measured), List.copyOf(notSeparated),
-                List.of(), List.of(), ReachingCuts.NONE);
+                List.of(), List.of(), ReachingCuts.NONE, closed.partition(), closed.border());
     }
 
     /**
@@ -226,10 +236,13 @@ public final class Partitions {
      *  went unread. Kept beside the axis rather than looked up afterwards by how its path is
      *  spelled. */
     private static void keep(List<Axis> out, List<Measured> measured, Axis axis,
-                             BodyCutInspection drew, List<UnreadRule> rules) {
+                             List<UnreadRule> rules) {
         out.add(axis);
-        if (drew != null) {
-            measured.add(new Measured(axis, drew));
+        // Asked of the axis rather than taken from the caller. What the body drew and what the
+        // position is left with are the same fact read twice, and a caller passing the first was
+        // the second's only account of itself.
+        if (axis.measurable()) {
+            measured.add(new Measured(axis, new BodyCutInspection.Evidence()));
             return;
         }
         // Whether this phase left anything at the position unread, and not which limit it was.
@@ -419,7 +432,7 @@ public final class Partitions {
                         () -> singledClasses(points, at, here2.type(), only, symbols),
                         mergedPoints(axis.cuts(), points, at.carrierAt(axis.type(), symbols)),
                         axis.parted()),
-                        new BodyCutInspection.Evidence(), rules);
+                        rules);
                 continue;
             }
             if (here.isEmpty()) {
@@ -429,7 +442,7 @@ public final class Partitions {
                 // for it to be about, and dropping the threshold would lose a line the body draws.
                 NumericTerm drawn = axis.measurable() ? null : soleTermAt(thresholds, axis.path());
                 if (drawn == null) {
-                    keep(out, measured, axis, null, rules);
+                    keep(out, measured, axis, rules);
                     continue;
                 }
                 term = drawn;
@@ -484,8 +497,9 @@ public final class Partitions {
                             within == null ? null : within.max()),
                     merged(axis.cuts(), reachable, carrier),
                     reachable.stream().map(Threshold::parts).toList()),
-                    reachable.isEmpty() ? null : new BodyCutInspection.Evidence(), rules);
+                    rules);
         }
+        MeasureClosure.Both closed = MeasureClosure.of(out, compared, base.omitted(), rules);
         return new Partitioning(out, base.omitted(), base.quantities(), base.uncertain(),
                 undividedIn(measured), List.copyOf(rules), blockedIn(measured),
                 // Carried across: what a reading could not hold together is a fact about the
@@ -499,7 +513,7 @@ public final class Partitions {
                 // where the position has no value beside it, its border over here — and the two
                 // sides of that border are runs of what all of them leave.
                 base.notSeparated(), Border.allOf(between, partedByQuantity(out)), compared,
-                reaching);
+                reaching, closed.partition(), closed.border());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/BoundaryDerivation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BoundaryDerivation.java
@@ -1,0 +1,195 @@
+package souther.compiler.query;
+
+import souther.compiler.observe.MeasurementStatus;
+import souther.compiler.partition.MeasureClosure;
+
+import java.util.List;
+
+/**
+ * What the border measure came to over one behavior: the lines its rules drew, or — where there are
+ * none — which nothing there is.
+ *
+ * <p>The same five answers as {@link PartitionDerivation}, and a separate type. The two measures are
+ * short of different things and reach empty for different reasons — an enumeration divides and has
+ * no line, an invariant's bound has a line and divides nothing — so a behavior is routinely one
+ * answer at one and another at the other. Shared, each would be reported on the strength of whatever
+ * stopped its neighbour.
+ *
+ * <p><b>{@link Absent} costs a proof.</b> #521 is what that protects. A boundary measure that
+ * derived nothing may have been reading a model whose bounds sit where this could not get to, and
+ * calling it measured says the rows carrying a model's whole risk earned nothing. That case cannot
+ * reach an absence here because a reading that stopped produces no {@code Closed} — the protection
+ * is the shape of the type and not a condition anybody has to remember to write.
+ *
+ * <p>And {@link Partial} is #521's other half, which was missing while the question was only about
+ * empty answers. A behavior one of whose rules drew a line and another of whose lines nothing could
+ * read has borders to show and a measure that was not made in full; reported complete, a build was
+ * held to what this compiler managed rather than to what the model states.
+ */
+public sealed interface BoundaryDerivation {
+
+    /** How much of the measure was made. */
+    MeasurementStatus status();
+
+    /** Why there is no number, or null where there is one. */
+    Reason reason();
+
+    /** The lines this behavior is measured at, empty where the measure has none to show. */
+    List<BorderAssessment> at();
+
+    /** Why the border measure has no number. */
+    enum Reason implements souther.compiler.observe.MeasureReason {
+
+        /**
+         * The reading of what this measure answers did not run out. A rule that places an end and
+         * could not be turned into a line, a position whose rules were never reached, a position
+         * dropped past the axis limit.
+         *
+         * <p>What {@code NO_LINES_DERIVED} said of every empty answer. #521 made it
+         * {@code NOT_MEASURED} because nothing could tell a model whose bounds sit one type away
+         * from a model with no bound at all; the closure tells them apart, and this is what is left
+         * of the first.
+         */
+        THE_READING_DID_NOT_RUN_OUT(MeasurementStatus.NOT_MEASURED),
+
+        /**
+         * Every question this measure answers was answered, and no rule of the model draws a line
+         * anywhere on this behavior's positions.
+         *
+         * <p>A row cannot make a line. What draws one is a rule — an invariant's bound, a
+         * {@code guard}'s comparison — so a behavior over an enumeration nothing bounds has no line
+         * for a row to be at and no row that could put one there. That is nothing for the measure to
+         * be about, and counting it held the module's verdict open for as long as the behavior
+         * existed.
+         */
+        NO_RULE_DRAWS_A_LINE(MeasurementStatus.NOT_APPLICABLE),
+
+        /** This behavior has no positions for a line to be drawn on — a {@code >->} composition,
+         *  which is measured at its stages. */
+        NO_SUBJECT(MeasurementStatus.NOT_APPLICABLE);
+
+        private final MeasurementStatus status;
+
+        Reason(MeasurementStatus status) {
+            this.status = status;
+        }
+
+        @Override
+        public MeasurementStatus status() {
+            return status;
+        }
+    }
+
+    /** Every question this measure answers was answered, and these are the lines it found. */
+    record Complete(List<BorderAssessment> at) implements BoundaryDerivation {
+
+        public Complete {
+            at = List.copyOf(at);
+            if (at.isEmpty()) {
+                throw new IllegalStateException(
+                        "a complete border measure with no line is a measure disagreeing with itself");
+            }
+        }
+
+        @Override
+        public MeasurementStatus status() {
+            return MeasurementStatus.COMPLETE;
+        }
+
+        @Override
+        public Reason reason() {
+            return null;
+        }
+    }
+
+    /** Lines were drawn, and something this measure answers for went unanswered. */
+    record Partial(List<BorderAssessment> at) implements BoundaryDerivation {
+
+        public Partial {
+            at = List.copyOf(at);
+            if (at.isEmpty()) {
+                throw new IllegalStateException(
+                        "a partial border measure with no line is `Unresolved`, which says so");
+            }
+        }
+
+        @Override
+        public MeasurementStatus status() {
+            return MeasurementStatus.PARTIAL;
+        }
+
+        @Override
+        public Reason reason() {
+            return null;
+        }
+    }
+
+    /** The reading ran out and no rule draws a line. The argument is the proof. */
+    record Absent(MeasureClosure.OfTheBorder.Closed proven) implements BoundaryDerivation {
+
+        public Absent {
+            java.util.Objects.requireNonNull(proven, "an absence is what a closed reading came to");
+        }
+
+        @Override
+        public MeasurementStatus status() {
+            return Reason.NO_RULE_DRAWS_A_LINE.status();
+        }
+
+        @Override
+        public Reason reason() {
+            return Reason.NO_RULE_DRAWS_A_LINE;
+        }
+
+        @Override
+        public List<BorderAssessment> at() {
+            return List.of();
+        }
+    }
+
+    /** No line came back and the reading did not run out. */
+    record Unresolved() implements BoundaryDerivation {
+
+        @Override
+        public MeasurementStatus status() {
+            return Reason.THE_READING_DID_NOT_RUN_OUT.status();
+        }
+
+        @Override
+        public Reason reason() {
+            return Reason.THE_READING_DID_NOT_RUN_OUT;
+        }
+
+        @Override
+        public List<BorderAssessment> at() {
+            return List.of();
+        }
+    }
+
+    /** This behavior has no positions of its own for a line to be drawn on. */
+    record NoSubject() implements BoundaryDerivation {
+
+        @Override
+        public MeasurementStatus status() {
+            return Reason.NO_SUBJECT.status();
+        }
+
+        @Override
+        public Reason reason() {
+            return Reason.NO_SUBJECT;
+        }
+
+        @Override
+        public List<BorderAssessment> at() {
+            return List.of();
+        }
+    }
+
+    /** What the measure came to, from what it found and whether its reading ran out. */
+    static BoundaryDerivation of(List<BorderAssessment> at, MeasureClosure.OfTheBorder closure) {
+        if (closure instanceof MeasureClosure.OfTheBorder.Closed closed) {
+            return at.isEmpty() ? new Absent(closed) : new Complete(at);
+        }
+        return at.isEmpty() ? new Unresolved() : new Partial(at);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -182,8 +182,14 @@ final class Coverages {
                         measureSaid(open.owed().subject(), each)));
             }
         }
-        return new PartitionEvidence(PartitionEvidence.Partitioned.of(axes),
-                PartitionEvidence.Bounded.of(boundaries), pairsOf(divided, readings),
+        // Each measure asked its own closure, and neither told from the length of what came back.
+        // What one of them is short of says nothing about the other: a rule whose line nothing
+        // could read leaves the border measure short while the classes either side of it were read
+        // in full, and the enumeration above is the same case the other way round.
+        return new PartitionEvidence(
+                PartitionDerivation.of(axes, partitioning.partitionClosure()),
+                BoundaryDerivation.of(boundaries, partitioning.borderClosure()),
+                pairsOf(divided, readings),
                 partitioning.undivided(), partitioning.unread(), partitioning.blocked(),
                 partitioning.notSeparated(), List.copyOf(standing),
                 partitioning.omitted(),

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionDerivation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionDerivation.java
@@ -1,0 +1,232 @@
+package souther.compiler.query;
+
+import souther.compiler.observe.MeasurementStatus;
+import souther.compiler.partition.MeasureClosure;
+
+import java.util.List;
+
+/**
+ * What the partition measure came to over one behavior: the positions it is measured at, or — where
+ * there are none — which nothing there is.
+ *
+ * <p>One value and not a list beside a status. The list used to answer both questions and could
+ * answer neither: an empty one is what a behavior whose model divides nothing has, what a behavior
+ * whose positions could not be read has, and what a {@code >->} composition has, and a reader
+ * counting entries called all three measured. Split into a list and a status held next to it, the
+ * two could still be built out of step — {@code axes} full beside an answer saying nothing was
+ * found — and the invariant would be a constructor check over a state the type still let anybody
+ * write.
+ *
+ * <p>So the evidence lives inside the arm that has any, and the arms that have none carry no list to
+ * read. {@code []} never leaves this type.
+ *
+ * <p><b>{@link Absent} is a conclusion and costs a proof to say.</b> It takes the closure of this
+ * measure's own reading, which only {@code souther.compiler.partition} can produce — the same
+ * arrangement {@code UndividedPosition.Why.Absent} is under. The sentence "the model divides
+ * nothing anywhere and no row would change that" is the one that must not be cheap to write, since
+ * it is what takes a behavior out of the verdict.
+ *
+ * <p><b>Which reading is asked is this measure's own.</b> Not "every reader ran to the end": which
+ * readers there are is a fact about this compiler, and a completeness written off them moves when
+ * one is added. The closure is over the questions the model raised that this measure answers
+ * ({@code CoverageObligation.answeredBy}), so a rule whose line nothing could read leaves the border
+ * measure short and this one whole.
+ */
+public sealed interface PartitionDerivation {
+
+    /** How much of the measure was made, which is what every reader of a measure asks first. */
+    MeasurementStatus status();
+
+    /** Why there is no number, or null where there is one. */
+    Reason reason();
+
+    /** The positions this behavior is measured at, empty where the measure has none to show. */
+    List<PartitionEvidence.AxisCoverage> at();
+
+    /**
+     * Why the partition measure has no number.
+     *
+     * <p>One constant per arm that has none, and never one shared between two. Which kind of
+     * no-number each is, is the reason's own answer.
+     */
+    enum Reason implements souther.compiler.observe.MeasureReason {
+
+        /**
+         * The reading of what this measure answers did not run out, so what it did not find is not
+         * known not to be there. A rule about a position's values that nothing took in, a position
+         * whose rules were never enumerated, a position dropped past the axis limit.
+         *
+         * <p>What {@code NO_AXIS_DERIVED} said of every empty answer, now said only where it is
+         * true. Its own javadoc stated the problem it had: whether the model draws no line anywhere
+         * or the reading stopped short of one was not something it could tell.
+         */
+        THE_READING_DID_NOT_RUN_OUT(MeasurementStatus.NOT_MEASURED),
+
+        /**
+         * Every question this measure answers was answered, and the model divides no position of
+         * this behavior into classes.
+         *
+         * <p>Nothing here for the measure to be about. A plain {@code String}, an {@code Int} no
+         * rule cuts, a {@code List} whose elements were reached and have no rule about them: no row
+         * an author writes puts a class there, and only editing the model would. Counted in the
+         * verdict, one such behavior held every model it appears in open for a measurement that was
+         * never anybody's to make.
+         */
+        NOTHING_IS_DIVIDED(MeasurementStatus.NOT_APPLICABLE),
+
+        /** This behavior has no positions for the measure to be about — a {@code >->} composition,
+         *  which is measured at its stages. */
+        NO_SUBJECT(MeasurementStatus.NOT_APPLICABLE);
+
+        private final MeasurementStatus status;
+
+        Reason(MeasurementStatus status) {
+            this.status = status;
+        }
+
+        @Override
+        public MeasurementStatus status() {
+            return status;
+        }
+    }
+
+    /** The measure was made in full: every question it answers was answered, and these are the
+     *  positions it found. */
+    record Complete(List<PartitionEvidence.AxisCoverage> at) implements PartitionDerivation {
+
+        public Complete {
+            at = List.copyOf(at);
+            if (at.isEmpty()) {
+                // Not recovered to an absence. A measure that says it found positions and shows
+                // none is two accounts of one reading disagreeing, and answering either way would
+                // report one of them as the model.
+                throw new IllegalStateException(
+                        "a complete partition with no position is a measure disagreeing with itself");
+            }
+        }
+
+        @Override
+        public MeasurementStatus status() {
+            return MeasurementStatus.COMPLETE;
+        }
+
+        @Override
+        public Reason reason() {
+            return null;
+        }
+    }
+
+    /**
+     * Positions were found, and the reading this measure depends on did not run out.
+     *
+     * <p>The other half of what {@link Absent} and {@link Unresolved} are about. An empty answer
+     * from a reading that stopped is not a measurement, and neither is a full one: a rule nothing
+     * took in may divide a position that came back with two classes, so the classes are what was
+     * read and not what the model states. Reported as complete, a build was told a model was
+     * covered on the strength of the rules this compiler happened to manage.
+     */
+    record Partial(List<PartitionEvidence.AxisCoverage> at) implements PartitionDerivation {
+
+        public Partial {
+            at = List.copyOf(at);
+            if (at.isEmpty()) {
+                throw new IllegalStateException(
+                        "a partial partition with no position is `Unresolved`, which says so");
+            }
+        }
+
+        @Override
+        public MeasurementStatus status() {
+            return MeasurementStatus.PARTIAL;
+        }
+
+        @Override
+        public Reason reason() {
+            return null;
+        }
+    }
+
+    /**
+     * The reading ran out and the model divides nothing.
+     *
+     * <p>The argument is the proof, as it is for a position. A caller able to write this without
+     * one could say the model divides no position anywhere without having asked, and that sentence
+     * is what takes a behavior out of the verdict.
+     */
+    record Absent(MeasureClosure.OfThePartition.Closed proven) implements PartitionDerivation {
+
+        public Absent {
+            java.util.Objects.requireNonNull(proven, "an absence is what a closed reading came to");
+        }
+
+        @Override
+        public MeasurementStatus status() {
+            return Reason.NOTHING_IS_DIVIDED.status();
+        }
+
+        @Override
+        public Reason reason() {
+            return Reason.NOTHING_IS_DIVIDED;
+        }
+
+        @Override
+        public List<PartitionEvidence.AxisCoverage> at() {
+            return List.of();
+        }
+    }
+
+    /** No position came back and the reading did not run out, so nothing is established either
+     *  way. */
+    record Unresolved() implements PartitionDerivation {
+
+        @Override
+        public MeasurementStatus status() {
+            return Reason.THE_READING_DID_NOT_RUN_OUT.status();
+        }
+
+        @Override
+        public Reason reason() {
+            return Reason.THE_READING_DID_NOT_RUN_OUT;
+        }
+
+        @Override
+        public List<PartitionEvidence.AxisCoverage> at() {
+            return List.of();
+        }
+    }
+
+    /** This behavior has no positions of its own for the measure to be about. */
+    record NoSubject() implements PartitionDerivation {
+
+        @Override
+        public MeasurementStatus status() {
+            return Reason.NO_SUBJECT.status();
+        }
+
+        @Override
+        public Reason reason() {
+            return Reason.NO_SUBJECT;
+        }
+
+        @Override
+        public List<PartitionEvidence.AxisCoverage> at() {
+            return List.of();
+        }
+    }
+
+    /**
+     * What the measure came to, from what it found and whether its reading ran out.
+     *
+     * <p>The one place the four are chosen between, so that no caller pairs an answer with evidence
+     * it does not go with. Nothing is decided from the shape of {@code at} alone: an empty answer is
+     * an absence or an unresolved reading depending on the closure, and a full one is complete or
+     * partial by the same fact.
+     */
+    static PartitionDerivation of(List<PartitionEvidence.AxisCoverage> at,
+                                  MeasureClosure.OfThePartition closure) {
+        if (closure instanceof MeasureClosure.OfThePartition.Closed closed) {
+            return at.isEmpty() ? new Absent(closed) : new Complete(at);
+        }
+        return at.isEmpty() ? new Unresolved() : new Partial(at);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -30,7 +30,7 @@ import java.util.Set;
  *                     reasons: these are what classification observed, and joining them to
  *                     everything else a module could not read happens where that list is built
  */
-public record PartitionEvidence(Partitioned partitioned, Bounded bounded,
+public record PartitionEvidence(PartitionDerivation partitioned, BoundaryDerivation bounded,
                                 PairSpace pairs,
                                 List<souther.compiler.partition.UndividedPosition> notDerivable,
                                 List<souther.compiler.inputs.UnreadRule> unread,
@@ -49,8 +49,9 @@ public record PartitionEvidence(Partitioned partitioned, Bounded bounded,
      * answer inapplicable, and a verdict that counted them would hold every model with a composition
      * in it open for a measurement that was never anybody's to make.
      */
-    public static final PartitionEvidence NONE = new PartitionEvidence(Partitioned.absent(),
-            Bounded.absent(), PairSpace.NONE, List.of(), List.of(), List.of(), List.of(),
+    public static final PartitionEvidence NONE = new PartitionEvidence(
+            new PartitionDerivation.NoSubject(), new BoundaryDerivation.NoSubject(),
+            PairSpace.NONE, List.of(), List.of(), List.of(), List.of(),
             List.of(), List.of(), List.of());
 
     public PartitionEvidence {
@@ -217,100 +218,6 @@ public record PartitionEvidence(Partitioned partitioned, Bounded bounded,
     /** The lines, likewise. */
     public List<BorderAssessment> boundaries() {
         return bounded.at();
-    }
-
-    /**
-     * The positions this behavior is measured at, and — where there are none — why not.
-     *
-     * <p>The list alone cannot say. An empty one is what a behavior whose model divides nothing has
-     * and what a behavior whose positions could not be read has, and a reader counting entries calls
-     * both of them measured and finds no gaps. So the measure answers for itself, and the entries are
-     * what it answered with.
-     */
-    public record Partitioned(List<AxisCoverage> at, MeasurementStatus status, Reason reason) {
-
-        /** Why no position was measured. */
-        public enum Reason implements souther.compiler.observe.MeasureReason {
-            /** Nothing came back divided. Whether the model draws no line anywhere or the reading
-             *  stopped short of one is not something this can tell, and only a proof excludes: the
-             *  positions it could not derive are named beside it and may be carrying rules. */
-            NO_AXIS_DERIVED(MeasurementStatus.NOT_MEASURED),
-            /** This behavior has no positions for the measure to be about — a {@code >->}
-             *  composition, which is measured at its stages. */
-            NO_SUBJECT(MeasurementStatus.NOT_APPLICABLE);
-
-            private final MeasurementStatus status;
-
-            Reason(MeasurementStatus status) {
-                this.status = status;
-            }
-
-            @Override
-            public MeasurementStatus status() {
-                return status;
-            }
-        }
-
-        public static Partitioned of(List<AxisCoverage> at) {
-            return at.isEmpty()
-                    ? new Partitioned(List.of(), Reason.NO_AXIS_DERIVED.status(),
-                            Reason.NO_AXIS_DERIVED)
-                    : new Partitioned(at, MeasurementStatus.COMPLETE, null);
-        }
-
-        static Partitioned absent() {
-            return new Partitioned(List.of(), Reason.NO_SUBJECT.status(), Reason.NO_SUBJECT);
-        }
-
-        public Partitioned {
-            at = List.copyOf(at);
-            Unavailable.check(status, reason);
-        }
-    }
-
-    /** The lines some rule drew that this behavior is measured at, and — where there are none — why
-     * not. The same argument as {@link Partitioned}: an empty list of obligations reads exactly like
-     * a measure that was made and found everything met. */
-    public record Bounded(List<BorderAssessment> at, MeasurementStatus status, Reason reason) {
-
-        /** Why no line was measured. */
-        public enum Reason implements souther.compiler.observe.MeasureReason {
-            /** No obligation was derived. A model whose bounds sit one type away from the position
-             *  the behavior takes has this, and so has one with no bound anywhere; nothing here can
-             *  tell them apart, and calling it measured said the rows carrying a model's whole risk
-             *  had earned nothing. */
-            NO_LINES_DERIVED(MeasurementStatus.NOT_MEASURED),
-            /** This behavior has no positions for a line to be drawn on — a {@code >->} composition,
-             *  which is measured at its stages. */
-            NO_SUBJECT(MeasurementStatus.NOT_APPLICABLE);
-
-            private final MeasurementStatus status;
-
-            Reason(MeasurementStatus status) {
-                this.status = status;
-            }
-
-            @Override
-            public MeasurementStatus status() {
-                return status;
-            }
-        }
-
-        public static Bounded of(List<BorderAssessment> at) {
-            return at.isEmpty()
-                    ? new Bounded(List.of(), Reason.NO_LINES_DERIVED.status(),
-                            Reason.NO_LINES_DERIVED)
-                    : new Bounded(at, MeasurementStatus.COMPLETE, null);
-        }
-
-        static Bounded absent() {
-            return new Bounded(List.of(), Reason.NO_SUBJECT.status(), Reason.NO_SUBJECT);
-        }
-
-        public Bounded {
-            at = List.copyOf(at);
-            Unavailable.check(status, reason);
-        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -389,14 +389,10 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 BorderAssessment.pointsOf(behavior.partition().boundaries()).stream()
                         .filter(p -> asked.criterion().requires(p.role()))
                         .forEach(p -> add(measures, p.item().status()));
-                // A dropped axis that was carrying a line some rule drew took boundaries with it, and
-                // nothing can ask about them now. One that was only classifying took a measure no
-                // build refuses over, so it costs a line in the report and not the verdict. The pair
-                // space is neither: a combination is not where a boundary comes from.
-                if (behavior.partition().omitted().stream()
-                        .anyMatch(Partitions.OmittedAxis::carriedAnObligation)) {
-                    measures.add(MeasurementStatus.PARTIAL);
-                }
+                // A dropped axis is not asked after here. What it was carrying went with it and no
+                // question stands for it, which is a fact about the measure's reading — so it
+                // leaves the measure's own answer short of complete, and reading it back off the
+                // list of what was dropped would be this report deciding a measure's status again.
             }
         }
         return measures;
@@ -1072,16 +1068,22 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         };
     }
 
-    private static String whyNoPartition(PartitionEvidence.Partitioned.Reason reason) {
+    private static String whyNoPartition(souther.compiler.query.PartitionDerivation.Reason reason) {
         return switch (reason) {
-            case NO_AXIS_DERIVED -> "not measured (no partition axis was derived at any position)";
+            case THE_READING_DID_NOT_RUN_OUT ->
+                    "not measured (no partition axis was derived at any position)";
+            case NOTHING_IS_DIVIDED ->
+                    "not applicable (the model divides no position of this behavior)";
             case NO_SUBJECT -> "not applicable (this behavior is measured at its stages)";
         };
     }
 
-    private static String whyNoBoundary(PartitionEvidence.Bounded.Reason reason) {
+    private static String whyNoBoundary(souther.compiler.query.BoundaryDerivation.Reason reason) {
         return switch (reason) {
-            case NO_LINES_DERIVED -> "not measured (no line was derived at any position)";
+            case THE_READING_DID_NOT_RUN_OUT ->
+                    "not measured (no line was derived at any position)";
+            case NO_RULE_DRAWS_A_LINE ->
+                    "not applicable (no rule of the model draws a line on this behavior)";
             case NO_SUBJECT -> "not applicable (this behavior is measured at its stages)";
         };
     }
@@ -1149,21 +1151,14 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     /**
      * Whether the partition measure is the one that answers this question.
      *
-     * <p>Which values may stand somewhere, which classes hold them, and which value a rule tells
-     * from every other: a singling makes the two classes {@code {c}} and everything else, so that
-     * measure is what counts a row for it. A border is the other one's, and is the only one.
-     * Filed by what the question asks and not by which producer raised it.
+     * <p>Asked of the question and not decided here. Which measure answers a question is the
+     * question's own answer ({@link souther.compiler.check.CoverageObligation#answeredBy}), and the
+     * measures read the same table to know what they are short of. Filed by what the question asks
+     * and not by which producer raised it.
      */
     private static boolean aboutTheClasses(souther.compiler.check.CoverageObligation question) {
-        return switch (question) {
-            // A value singled out is one class of the position and everything else is the other,
-            // which is what this measure counts. Printed under the borders it would say a border is
-            // what the rule placed, in a section whose words are about an order across one and a
-            // role for each side — the order the rule never drew, arriving in the report after
-            // being kept out of the question.
-            case ADMITTED_VALUES, PARTITION, SINGLETON -> true;
-            case BOUNDARY -> false;
-        };
+        return question.answeredBy()
+                == souther.compiler.check.CoverageObligation.Measure.PARTITION;
     }
 
     /**

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-4.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-4.json
@@ -217,8 +217,8 @@
           "properties": {
             "status": { "$ref": "#/$defs/status" },
             "reason": {
-              "description": "Why there is no measure, present exactly where `status` is `unavailable`. `no_axis_derived` is a reading that produced no position — which is not itself evidence that the model divides none; `no_subject` is a behavior with no positions of its own, a `>->` composition, which is measured at its stages.",
-              "enum": ["no_axis_derived", "no_subject"]
+              "description": "Why there is no measure, present exactly where `status` is `unavailable`. `the_reading_did_not_run_out` is a reading that produced no position and was short of something it answers for, so the model is not thereby known to divide none; `nothing_is_divided` is a reading that answered everything it answers for and found no position the model divides, which no row would change; `no_subject` is a behavior with no positions of its own, a `>->` composition, which is measured at its stages. `no_axis_derived` is what the first was called while it also stood for the second, and is retired rather than gone.",
+              "enum": ["the_reading_did_not_run_out", "nothing_is_divided", "no_subject", "no_axis_derived"]
             }
           }
         },
@@ -230,8 +230,8 @@
           "properties": {
             "status": { "$ref": "#/$defs/status" },
             "reason": {
-              "description": "Why there is no measure, present exactly where `status` is `unavailable`. `no_lines_derived` is a reading that produced no obligation — which is not itself evidence that the model draws no line; `no_subject` is a behavior with no positions of its own.",
-              "enum": ["no_lines_derived", "no_subject"]
+              "description": "Why there is no measure, present exactly where `status` is `unavailable`. `the_reading_did_not_run_out` is a reading that produced no line and was short of something it answers for, so the model is not thereby known to draw none; `no_rule_draws_a_line` is a reading that answered everything it answers for and found no rule drawing a line, which no row would change since a row cannot make a line; `no_subject` is a behavior with no positions of its own. `no_lines_derived` is what the first was called while it also stood for the second, and is retired rather than gone.",
+              "enum": ["the_reading_did_not_run_out", "no_rule_draws_a_line", "no_subject", "no_lines_derived"]
             }
           }
         },

--- a/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
@@ -156,22 +156,22 @@ class AMeasureWithNoNumberSaysWhyTest {
                 example.repro                                            measurement: complete
                   widen                    implemented   rows 0    pending 0
                     signature   not applicable (this behavior's output is not a sum)
-                    partition   not measured (no partition axis was derived at any position)
+                    partition   not applicable (the model divides no position of this behavior)
                       · not derivable: w.v
-                    border      not measured (no line was derived at any position)
+                    border      not applicable (no rule of the model draws a line on this behavior)
                     branch      not measured (no row names this behavior)
                   narrow                   implemented   rows 0    pending 0
                     signature   not applicable (this behavior's output is not a sum)
-                    partition   not measured (no partition axis was derived at any position)
+                    partition   not applicable (the model divides no position of this behavior)
                       · not derivable: m.v
-                    border      not measured (no line was derived at any position)
+                    border      not applicable (no rule of the model draws a line on this behavior)
                     branch      not measured (no row names this behavior)
                   both                     implemented   rows 1    pending 0
                     signature   not applicable (this behavior's output is not a sum)
                     branch      not applicable (this behavior has no body)
                   baseRate                 injected      rows 0    pending 0
                     signature   not applicable (this behavior's output is not a sum)
-                    partition   not measured (no partition axis was derived at any position)
+                    partition   not applicable (the model divides no position of this behavior)
                     border      borders 2   coverage items 0/0   excluded 4   (4 not measured: no row names this behavior)
                       · no OFF point is owed at r.cost = 0 (invariant Amount #1): excluded — the rules leave no value there
                       · no OUT point is owed at r.cost = 0 (invariant Amount #1): excluded — the rules leave no value there
@@ -180,7 +180,7 @@ class AMeasureWithNoNumberSaysWhyTest {
                     branch      not applicable (this behavior has no body)
                   rated                    implemented   rows 0    pending 0
                     signature   not applicable (this behavior's output is not a sum)
-                    partition   not measured (no partition axis was derived at any position)
+                    partition   not applicable (the model divides no position of this behavior)
                     border      borders 2   coverage items 0/0   excluded 4   (4 not measured: no row names this behavior)
                       · no OFF point is owed at r.cost = 0 (invariant Amount #1): excluded — the rules leave no value there
                       · no OUT point is owed at r.cost = 0 (invariant Amount #1): excluded — the rules leave no value there
@@ -191,12 +191,12 @@ class AMeasureWithNoNumberSaysWhyTest {
                     signature   not applicable (this behavior's output is not a sum)
                     partition   axes 1   equivalence partitions 1/2
                       · no row is in `No` at q.flag
-                    border      not measured (no line was derived at any position)
+                    border      not applicable (no rule of the model draws a line on this behavior)
                     branch      0/0
                   sift                     implemented   rows 0    pending 0
                     signature   not applicable (this behavior's output is not a sum)
                     partition   axes 2   equivalence partitions 0/0   (2 not measured: no row names this behavior)
-                    border      not measured (no line was derived at any position)
+                    border      not applicable (no rule of the model draws a line on this behavior)
                     branch      not measured (no row names this behavior)
 
                 7 behaviors: 6 implemented, 0 unimplemented, 1 injected; 0 rows waiting for a `let`.
@@ -493,14 +493,31 @@ class AMeasureWithNoNumberSaysWhyTest {
         return measures;
     }
 
-    /** Held where the value is built, so that no measure can be assembled without it. */
+    /**
+     * Held where the value is built, so that no measure can be assembled without it.
+     *
+     * <p>The two measures whose evidence is a list keep it by shape now rather than by check: an
+     * answer that has entries is an arm that carries them and an answer that has none is an arm
+     * with nowhere to put any, so a status paired with the wrong list is not a value anybody can
+     * write. What is left to assert of them is the one pairing the arms could still get wrong —
+     * an arm that promises entries and holds none.
+     */
     @Test
     void aMeasureCannotBeBuiltWithoutKeepingThatContract() {
-        assertThrows(IllegalArgumentException.class, () -> new PartitionEvidence.Partitioned(
-                List.of(), MeasurementStatus.NOT_MEASURED, null));
-        assertThrows(IllegalArgumentException.class, () -> new PartitionEvidence.Bounded(
-                List.of(), MeasurementStatus.COMPLETE,
-                PartitionEvidence.Bounded.Reason.NO_LINES_DERIVED));
+        assertThrows(IllegalStateException.class,
+                () -> new souther.compiler.query.PartitionDerivation.Complete(List.of()));
+        assertThrows(IllegalStateException.class,
+                () -> new souther.compiler.query.PartitionDerivation.Partial(List.of()));
+        assertThrows(IllegalStateException.class,
+                () -> new souther.compiler.query.BoundaryDerivation.Complete(List.of()));
+        assertThrows(IllegalStateException.class,
+                () -> new souther.compiler.query.BoundaryDerivation.Partial(List.of()));
+        // And an absence that nothing proved. The proof is the argument, so this is the whole of
+        // what "the model divides nothing anywhere" costs to say.
+        assertThrows(NullPointerException.class,
+                () -> new souther.compiler.query.PartitionDerivation.Absent(null));
+        assertThrows(NullPointerException.class,
+                () -> new souther.compiler.query.BoundaryDerivation.Absent(null));
         assertThrows(IllegalArgumentException.class, () -> new Adequacy.BranchEvidence(
                 List.of(), java.util.Set.of(), java.util.Set.of(),
                 MeasurementStatus.NOT_MEASURED, MeasurementStatus.NOT_MEASURED, null));
@@ -522,12 +539,6 @@ class AMeasureWithNoNumberSaysWhyTest {
         // reason of the other kind is the confusion the two words were split to prevent: it says its
         // arms do not apply and asks somebody to go and measure them, and a report reading either
         // half of it is right about one and wrong about the other.
-        assertThrows(IllegalArgumentException.class, () -> new PartitionEvidence.Bounded(
-                List.of(), MeasurementStatus.NOT_APPLICABLE,
-                PartitionEvidence.Bounded.Reason.NO_LINES_DERIVED));
-        assertThrows(IllegalArgumentException.class, () -> new PartitionEvidence.Partitioned(
-                List.of(), MeasurementStatus.NOT_MEASURED,
-                PartitionEvidence.Partitioned.Reason.NO_SUBJECT));
         assertThrows(IllegalArgumentException.class, () -> new Adequacy.BranchEvidence(
                 List.of(), java.util.Set.of(), java.util.Set.of(),
                 MeasurementStatus.NOT_MEASURED, MeasurementStatus.NOT_MEASURED,

--- a/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
@@ -178,20 +178,26 @@ class EverySchemaWordIsAccountedForTest {
             // schema move together or the compile stops.
             new Vocabulary("coverageQuestion", List.of("$defs", "coverageQuestion"),
                     souther.compiler.check.CoverageObligation.class),
+            // `no_axis_derived` is what `the_reading_did_not_run_out` was called while it also
+            // stood for a reading that ran out and found nothing to divide. Retired rather than
+            // gone: reports of this version were written carrying it.
             new Vocabulary("partition.axesMeasure.reason",
                     List.of("$defs", "partition", "properties", "axesMeasure", "properties",
                             "reason"),
-                    PartitionEvidence.Partitioned.Reason.class),
+                    souther.compiler.query.PartitionDerivation.Reason.class,
+                    Set.of("no_axis_derived")),
             // Written once and referred to twice: a position's reading and a rule left unread are
             // the same question asked of two things, and two copies of the words would be two
             // places for one of them to gain a word the other does not have.
             new Vocabulary("notReadReason",
                     List.of("$defs", "notReadReason"),
                     souther.compiler.partition.UndividedPosition.Reason.class),
+            // And `no_lines_derived` likewise.
             new Vocabulary("partition.boundariesMeasure.reason",
                     List.of("$defs", "partition", "properties", "boundariesMeasure", "properties",
                             "reason"),
-                    PartitionEvidence.Bounded.Reason.class),
+                    souther.compiler.query.BoundaryDerivation.Reason.class,
+                    Set.of("no_lines_derived")),
             new Vocabulary("partition.axes[].reason",
                     List.of("$defs", "partition", "properties", "axes", "items", "properties",
                             "reason"),

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClauseReachingOneCoordinatePlacesAnEdgeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClauseReachingOneCoordinatePlacesAnEdgeTest.java
@@ -313,10 +313,10 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
         assertTrue(report.contains("""
                   onSpan                   implemented   rows 1    pending 0
                     signature   not applicable (this behavior's output is not a sum)
-                    partition   not measured (no partition axis was derived at any position)
+                    partition   not applicable (the model divides no position of this behavior)
                       · not read: invariant Span #1 — it relates two positions rather than dividing one, about `v.startsAt`
                       · not read: invariant Span #1 — it relates two positions rather than dividing one, about `v.endsAt`
-                    border      not measured (no line was derived at any position)
+                    border      not applicable (no rule of the model draws a line on this behavior)
                 """), report);
     }
 
@@ -329,10 +329,10 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
         assertTrue(report.contains("""
                   onFloor                  implemented   rows 1    pending 0
                     signature   not applicable (this behavior's output is not a sum)
-                    partition   not measured (no partition axis was derived at any position)
+                    partition   not applicable (the model divides no position of this behavior)
                       · not read: invariant Floor #1 — it relates two positions rather than dividing one, about `v.n`
                       · not read: invariant Floor #1 — it relates two positions rather than dividing one, about `v.min`
-                    border      not measured (no line was derived at any position)
+                    border      not applicable (no rule of the model draws a line on this behavior)
                 """), report);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AMeasureIsShortOfWhateverItsReadingDidNotReachTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AMeasureIsShortOfWhateverItsReadingDidNotReachTest.java
@@ -1,0 +1,125 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BoundaryDerivation;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.PartitionDerivation;
+import souther.compiler.query.PartitionEvidence;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * A measure says it was made in full only where the reading it depends on ran out.
+ *
+ * <p>Held against sources, because every fact this is about is one a reading produces. A fixture
+ * naming an answer and a test reading the name back is two spellings of one decision, and the step
+ * being checked here is the one in between: what the reading came to, and what the measure makes of
+ * it.
+ *
+ * <p>Both measures, and separately. What one of them is short of says nothing about the other, so a
+ * model is written for each way of being short and the other measure's answer is asserted beside it.
+ */
+class AMeasureIsShortOfWhateverItsReadingDidNotReachTest {
+
+    /**
+     * Thirteen positions, one past {@link Partitions#MAX_AXES}, with a bound either side of the
+     * limit.
+     *
+     * <p>The fields are in declaration order and the axes are drawn in it, so the thirteenth is the
+     * one dropped. Two of them are {@code Amount}s on purpose: the twelfth's line survives and the
+     * thirteenth's goes with the axis, which is what leaves the measure with a line to show and
+     * short of one it cannot ask about. With only the dropped one bounded, the measure has nothing
+     * to show and answers that it found no line rather than that it found some — a different
+     * sentence, and one this model would not be about.
+     */
+    private static final String PAST_THE_LIMIT = """
+            module example.limit
+
+            data A
+            data B
+            data Flag = A | B
+            data Amount = Int
+                invariant value >= 0 && value <= 100
+            data Wide = { f1: Flag, f2: Flag, f3: Flag, f4: Flag, f5: Flag, f6: Flag,
+                          f7: Flag, f8: Flag, f9: Flag, f10: Flag, f11: Flag,
+                          cost: Amount, extra: Amount }
+            data Res = { n: Int }
+
+            behavior wide : (w: Wide) -> Res
+                constructs Res
+            let wide (w) = Res { n = 1 }
+
+            example wide
+                | "one" : (Wide { f1 = A, f2 = A, f3 = A, f4 = A, f5 = A, f6 = A, f7 = A, f8 = A,
+                                  f9 = A, f10 = A, f11 = A, cost = 1, extra = 1 })
+                        -> Res { n = 1 }
+            """;
+
+    /**
+     * The same twelve positions and no thirteenth, so nothing is dropped.
+     *
+     * <p>The control the model above needs. Without it, a border measure short of something would
+     * be as good an account of a model this cannot read at all, and neither the limit nor the axis
+     * past it would be what the first model shows.
+     */
+    private static final String WITHIN_THE_LIMIT = """
+            module example.within
+
+            data A
+            data B
+            data Flag = A | B
+            data Amount = Int
+                invariant value >= 0 && value <= 100
+            data Narrow = { f1: Flag, f2: Flag, f3: Flag, f4: Flag, f5: Flag,
+                            f6: Flag, f7: Flag, f8: Flag, f9: Flag, f10: Flag, f11: Flag,
+                            cost: Amount }
+            data Res = { n: Int }
+
+            behavior narrow : (w: Narrow) -> Res
+                constructs Res
+            let narrow (w) = Res { n = 1 }
+
+            example narrow
+                | "one" : (Narrow { f1 = A, f2 = A, f3 = A, f4 = A, f5 = A, f6 = A, f7 = A, f8 = A,
+                                    f9 = A, f10 = A, f11 = A, cost = 1 }) -> Res { n = 1 }
+            """;
+
+    /**
+     * An axis dropped past the limit leaves both measures short of what it was carrying.
+     *
+     * <p>Not a report working out afterwards what the omission cost. What was carried is known where
+     * the axis is dropped and nowhere else — neither a dropped classifier nor a dropped bound leaves
+     * anything behind, so a reader counting entries afterwards sees a measure that was made and
+     * found what there was.
+     */
+    @Test
+    void anAxisDroppedPastTheLimitLeavesBothMeasuresShort() {
+        PartitionEvidence wide = evidenceFor(PAST_THE_LIMIT, "wide");
+
+        assertInstanceOf(BoundaryDerivation.Partial.class, wide.bounded());
+        assertInstanceOf(PartitionDerivation.Partial.class, wide.partitioned());
+    }
+
+    /** And within the limit both are made in full, which is what says the answers above are the
+     *  limit's and not the model's. */
+    @Test
+    void andWithinTheLimitBothAreMadeInFull() {
+        PartitionEvidence narrow = evidenceFor(WITHIN_THE_LIMIT, "narrow");
+
+        assertInstanceOf(BoundaryDerivation.Complete.class, narrow.bounded());
+        assertInstanceOf(PartitionDerivation.Complete.class, narrow.partitioned());
+    }
+
+    private static PartitionEvidence evidenceFor(String source, String behavior) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        Map<String, PartitionEvidence> partitions = compilation.db()
+                .ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
+        return partitions.get(behavior);
+    }
+}

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
@@ -40,10 +40,10 @@
       },
       "partition" : {
         "axesMeasure" : {
-          "status" : "complete"
+          "status" : "partial"
         },
         "boundariesMeasure" : {
-          "status" : "complete"
+          "status" : "partial"
         },
         "axes" : [ {
           "axis" : "discount/item.note",
@@ -236,10 +236,10 @@
       },
       "partition" : {
         "axesMeasure" : {
-          "status" : "complete"
+          "status" : "partial"
         },
         "boundariesMeasure" : {
-          "status" : "complete"
+          "status" : "partial"
         },
         "axes" : [ {
           "axis" : "台帳へ書く/指示.区分",
@@ -411,10 +411,10 @@
       },
       "partition" : {
         "axesMeasure" : {
-          "status" : "complete"
+          "status" : "partial"
         },
         "boundariesMeasure" : {
-          "status" : "complete"
+          "status" : "partial"
         },
         "axes" : [ {
           "axis" : "出荷する/指示.重量",


### PR DESCRIPTION
`Partitioned.of(axes)` and `Bounded.of(boundaries)` decided their status from the length of their
own output. An empty list is what a behavior whose model divides nothing has, what a behavior
whose positions could not be read has, and what a `>->` composition has — and only the second is a
measurement anybody owes. A behavior over an enumeration, every measure of it met, answered `not
measured` for as long as it existed and held its module's verdict at `undetermined` with nothing an
author could do about it.

The empty case has a non-empty twin, and that is the one the corpus is about: a measure with one
line to show and a rule it could not read was `complete`, which held a build to what this compiler
managed rather than to what the model states. #521's argument, on the other side of the same fold.

## What is in

Each measure is one value now, not a list beside a status:

```
PartitionDerivation / BoundaryDerivation
  NoSubject     no positions of its own            NOT_APPLICABLE
  Absent        the reading ran out, nothing there NOT_APPLICABLE
  Unresolved    nothing found, reading did not run out  NOT_MEASURED
  Partial       entries found, reading did not run out  PARTIAL
  Complete      entries found, reading ran out          COMPLETE
```

`[]` never leaves the type. An arm promising entries and holding none is refused rather than
recovered to whichever status looks safer.

`Absent` takes the closure of its own measure's reading, which only `souther.compiler.partition`
can produce — the arrangement `UndividedPosition.Why.Absent` is under, at the measure rather than
at a position. #521 is kept by that shape and not by a condition anybody has to remember: a reading
that stopped produces no `Closed`.

`MeasureClosure` holds one closure per measure, in two separate types so neither can be answered
with the other's answer. What a measure is short of is a question the model raised that nothing
answered, filed by `CoverageObligation.answeredBy` — the one table, moved out of the report that
had it as a private method. Beside the questions, three facts no question carries: a position whose
rules were never enumerated, a position dropped past the axis limit (per measure, from what it was
carrying), and a rule this could not use — asked of `BlockReason.AboutARule.leavesAMeasureShort`,
since a comparison relating two positions divides neither of them however well it is read.

The verdict reads the measure's answer and no longer the list of what was dropped.

## What moved

Over the conformance corpus three behaviors go `complete` to `partial`, each with a comparison this
could not read or a position the walk did not reach. Nothing else in the corpus moves.

`souther init --model full` shipped a model with a comparison over a derived operand, which is now
correctly `partial` and left the starter reporting `undetermined` on the first build. The template
drops the derived arithmetic rather than the compiler relaxing: what is promised is not that every
Souther program is measurable, but that the model we chose as the starting point stays inside the
subset this compiler fully reads. `AGeneratedModelIsCompiledRatherThanMatchedTest` is a contract on
the template now rather than a fact about it. What it takes to close such a comparison is #949.

The schema keeps version 4. Three words are added and `no_axis_derived` / `no_lines_derived` are
retired rather than dropped, since reports of this version were written carrying them.

## Verification

`mvn -o test` from the reactor root, rebased onto `1b23e239`: all modules green.

Closes #934

🤖 Generated with [Claude Code](https://claude.com/claude-code)