### PR TITLE
A report says what region a row was looked for in

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadQuantities.java
@@ -157,8 +157,8 @@ final class ReadQuantities implements Quantities {
      * <p>This value back where the arithmetic cannot take the assertion in — a form over a position
      * whose values it has no spacing for. Kept anyway, it would sit in the state as a rule about a
      * number nothing knows how to space, which {@link souther.compiler.numeric.NumericDomain#assume}
-     * refuses outright; declined here, the region stays wider than what reaches the border, which is
-     * the direction every reader of it depends on.
+     * refuses outright; declined here, the region still holds everything that reaches the border,
+     * which is the direction every reader of it depends on.
      */
     ReadQuantities assuming(NumericDomain.LinearForm<NumericTerm> form, NumericDomain.Rel rel) {
         if (form == null || form.coefs().isEmpty()) {

--- a/souther-compiler/src/main/java/souther/compiler/inputs/SearchRegion.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/SearchRegion.java
@@ -33,8 +33,10 @@ import java.util.Optional;
  * proves nothing. Neither survives a reading that narrowed on a condition it had not established.
  *
  * <p>Which also says what this is not: it is not the set of rows that reach the border. A condition
- * of a shape the arithmetic has no word for leaves this wider than that set, so a row found here is
- * a row to try and not a row shown to arrive — what shows that is running it.
+ * of a shape the arithmetic has no word for narrows nothing, so this may hold rows that never
+ * arrive and a row found here is a row to try and not a row shown to arrive — what shows that is
+ * running it. Only the inclusion is promised, never that it is strict: a condition nothing took in
+ * may be implied by the ones that were.
  */
 public interface SearchRegion {
 
@@ -48,7 +50,7 @@ public interface SearchRegion {
      * <p>Where the arithmetic has nothing to say about a condition — a form over a position whose
      * values it cannot count, a subject it has no spacing for — what comes back is this region
      * unchanged. Which is the direction that keeps the inclusions above: a condition nothing took in
-     * leaves the region wider than the rows that arrive, and a region narrowed on a condition
+     * leaves a region that still holds every row that arrives, and a region narrowed on a condition
      * nothing established would leave it narrower than they are.
      */
     SearchRegion assuming(NumericDomain.LinearForm<NumericTerm> form, NumericDomain.Rel rel);

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonReadings.java
@@ -44,11 +44,12 @@ final class ComparisonReadings {
      * comparison inside an expanded helper is about the argument the call handed it, and read
      * against the names outside the binding it is about nothing at all.
      *
-     * @param assumed what a row had already satisfied by the time it got here. Empty is an ordinary
-     *                answer — a comparison at the top of a body has satisfied nothing yet, and so
-     *                has one reached past a condition this reading has no arithmetic for
+     * @param assumed every condition on the way here, each with what became of it. Empty says
+     *                nothing stood on the way, which a comparison at the top of a body is; one this
+     *                reading has no arithmetic for is on the list as a decline, so the two are not
+     *                one answer
      */
-    record Reading(Core.Binary comparison, InputReads reads, List<ReachingCuts.Cut> assumed,
+    record Reading(Core.Binary comparison, InputReads reads, List<OnTheWay> assumed,
                    BoundaryPolicy.Standing standing) {}
 
     private final List<Reading> readings;
@@ -98,7 +99,7 @@ final class ComparisonReadings {
      *                nothing says the applications of settles it for everything under it
      */
     private static void walk(Core e, CoverageSites.Plan plan, InputReads reads, Symbols symbols,
-                             LiveFlow flow, List<ReachingCuts.Cut> assumed, boolean live,
+                             LiveFlow flow, List<OnTheWay> assumed, boolean live,
                              boolean each, List<Reading> out) {
         if (e instanceof Core.Binary comparison && plan.comparisons().at(comparison).isPresent()) {
             out.add(new Reading(comparison, reads, assumed,
@@ -179,15 +180,10 @@ final class ComparisonReadings {
      * written apart they would agree by having been derived alike — until one of them learned to
      * read a shape of condition the other did not.
      */
-    private static List<ReachingCuts.Cut> taking(Core node, boolean holding, InputReads reads,
-                                                 List<ReachingCuts.Cut> assumed, Symbols symbols) {
-        List<ReachingCuts.Cut> more =
-                ReachingCuts.stating(Condition.of(node, reads), holding, symbols);
-        if (more.isEmpty()) {
-            return assumed;
-        }
-        List<ReachingCuts.Cut> out = new ArrayList<>(assumed);
-        out.addAll(more);
+    private static List<OnTheWay> taking(Core node, boolean holding, InputReads reads,
+                                         List<OnTheWay> assumed, Symbols symbols) {
+        List<OnTheWay> out = new ArrayList<>(assumed);
+        out.addAll(ReachingCuts.stating(Condition.of(node, reads), holding, symbols));
         return List.copyOf(out);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Condition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Condition.java
@@ -48,11 +48,22 @@ import souther.compiler.inputs.InputReads;
  */
 sealed interface Condition {
 
+    /**
+     * The node this is a reading of.
+     *
+     * <p>Kept by every shape, because a reader that could not take one in owes the place it is
+     * written. Recovered afterwards from what is under a node, the place would be a child's — a
+     * conjunction nothing could turn into a region would be reported at whichever operand happened
+     * to be first, which is a second account of where a condition stands and is the kind of thing
+     * this vocabulary exists to have one of.
+     */
+    Core at();
+
     /** Both, and the right one runs only where the left held. */
-    record Both(Condition left, Condition right) implements Condition {}
+    record Both(Core.Binary at, Condition left, Condition right) implements Condition {}
 
     /** Either, and the right one runs only where the left did not hold. */
-    record Either(Condition left, Condition right) implements Condition {}
+    record Either(Core.Binary at, Condition left, Condition right) implements Condition {}
 
     /**
      * One comparison, and where the names in it point.
@@ -93,7 +104,8 @@ sealed interface Condition {
         if (e instanceof Core.Binary binary && combines(binary.op())) {
             Condition left = of(binary.left(), reads);
             Condition right = of(binary.right(), reads);
-            return binary.op() == Hir.BinOp.AND ? new Both(left, right) : new Either(left, right);
+            return binary.op() == Hir.BinOp.AND
+                    ? new Both(binary, left, right) : new Either(binary, left, right);
         }
         if (e instanceof Core.Binary comparison && comparison.op().compares()) {
             return new Compares(comparison, reads);

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -225,7 +225,30 @@ public final class Generator {
              * seemed likely when the branch was added, and a reason read off an empty result outlives
              * whatever made it plausible.
              */
-            NO_REASON_RECORDED
+            NO_REASON_RECORDED;
+
+            /**
+             * Whether this reason proves there is nothing to find, which one of them does.
+             *
+             * <p>Asked rather than matched on. Every reader of one of these has the same question —
+             * may I say the model settles this, or am I saying what this compiler did not manage —
+             * and each that answered it by naming the one word carried a copy of the decision
+             * ADR-0091 took. A reason added is then a case here rather than a word that quietly
+             * joins whichever side a reader's condition happened to leave it on.
+             *
+             * <p>Named as {@link souther.compiler.query.PartitionEvidence.PairSpace#provenInfeasible}
+             * names it, since it is the same question about the same thing.
+             */
+            public boolean provesInfeasible() {
+                return switch (this) {
+                    case THE_RULES_LEAVE_NOTHING_THERE -> true;
+                    // Every one of these is this compiler falling short, and none of them is the
+                    // model saying anything: another value of the same classes may well build.
+                    case NOTHING_COMPOSES_ONE, ALL_CANDIDATES_REJECTED, SEARCH_LIMIT,
+                         NOTHING_TO_BUILD_AGAINST, LINKAGE_FAILED, NO_CERTIFIED_WITNESS,
+                         NO_REASON_RECORDED -> false;
+                };
+            }
         }
 
         public UnresolvedCombination {

--- a/souther-compiler/src/main/java/souther/compiler/partition/OnTheWay.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/OnTheWay.java
@@ -1,0 +1,65 @@
+package souther.compiler.partition;
+
+import souther.compiler.diag.Citation;
+
+/**
+ * One condition on the way to a comparison, and what became of it.
+ *
+ * <p>Both halves, because a region says nothing about how it was arrived at. What the walk took in
+ * is what narrowed the search; what it could not take in is why the search may be looking over rows
+ * that never arrive. Kept as one sequence in the order the walk met them, so that a reader asking
+ * either question asks the same list — split into two at the seam, "nothing stood on the way" and
+ * "everything on the way was taken in" come out as the same empty answer, which is the reading a
+ * report cannot make and the one an author needs.
+ *
+ * <p>Collected where the condition is met and never worked out afterwards from where a comparison
+ * sits, which is the rule {@link souther.compiler.reach.PathDecision} is written to as well.
+ */
+public sealed interface OnTheWay {
+
+    /**
+     * Where the condition is, as a report is entitled to say it.
+     *
+     * <p>A {@link Citation} and not a {@link souther.compiler.diag.SourcePos}, because what this is
+     * for is being said. Whether a reader can be sent to the text and whether the condition is
+     * written at the place are the two questions that type answers, and a helper's condition
+     * reached from a call is exactly where a raw position sends a reader somewhere the code is not.
+     */
+    Citation at();
+
+    /** A condition the arithmetic took in, and the cut it came to. */
+    record TakenIn(Citation at, ReachingCuts.Cut cut) implements OnTheWay {}
+
+    /** A condition nothing here could turn into a cut, and what stopped it. */
+    record Declined(Citation at, Why why) implements OnTheWay {}
+
+    /**
+     * What stopped a condition from becoming a cut.
+     *
+     * <p>Every one of these is a limit of this compiler and none of them is a fact about the model:
+     * a condition an author wrote plainly is on this list wherever the arithmetic here has no way
+     * of carrying it. Which is why nothing read off one of these says a row cannot be written, and
+     * why a word here going away is a capability gained rather than a model changed.
+     *
+     * <p>Its own set, and not {@link souther.compiler.inputs.BlockReason.AboutARule}. That one is
+     * about one rule this read and could not use, and it answers for whether a measure is thereby
+     * short of something. An arm of a fork stating one of two things is neither: there is no single
+     * rule to name, and the measures are not short — the line is still owed and still measured, and
+     * what is affected is where a row for it was looked for.
+     */
+    enum Why {
+
+        /** A condition of a shape this reading has no words for, so nothing was read of it. */
+        CONDITION_NOT_READ,
+
+        /** Read as far as it goes, and it states nothing about any position of the input. */
+        NO_CONSTRAINT_REPRESENTED,
+
+        /**
+         * What the condition coming out this way says is one of two things, and a region is what
+         * has been accumulated onto it. {@code A && B} coming out false says one of them failed and
+         * names neither, and taking either would exclude rows that arrive.
+         */
+        NON_CONJUNCTIVE_OUTCOME
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/OnTheWay.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/OnTheWay.java
@@ -1,7 +1,6 @@
 package souther.compiler.partition;
 
 import souther.compiler.diag.Citation;
-import souther.compiler.inputs.BlockReason;
 
 /**
  * One condition on the way to a comparison, and what became of it.
@@ -37,44 +36,37 @@ public sealed interface OnTheWay {
     /**
      * What stopped a condition from becoming a cut.
      *
-     * <p>Three shapes, and only one of them has a rule to name. A condition this reading has no
-     * words for is not one thing an author wrote; an arm of a fork stating one of two things is
-     * about the arm and not about either operand; and a comparison read and not used is a rule,
-     * which is why that one carries the account of it rather than a word of its own.
+     * <p>Three shapes, and each says what this reading did rather than what the model says. A
+     * condition an author wrote plainly is here wherever the arithmetic has no way of carrying it,
+     * so nothing read off one of these says a row cannot be written, and a word going away is a
+     * capability gained rather than a model changed.
      *
-     * <p><b>The comparison's reason is the one this compiler already gives.</b>
-     * {@link souther.compiler.inputs.BlockReason.AboutARule} is what a reading of a rule it could
-     * not use comes to, and {@link UnreadComparison} is where a comparison is turned into one — the
-     * same answer the line beside this one is filed under. A word invented here would be a second
-     * classification of one question: it merged a form outside the arithmetic, a carrier no line is
-     * drawn on and a comparison relating two positions into one sentence, and called all three a
-     * limit of this compiler when the last is what the rule says.
+     * <p><b>Not the reason the same comparison gets for drawing no line.</b>
+     * {@link UnreadComparison} answers why a comparison did not become a boundary, which is a
+     * different question with different answers: {@code 1 < 2} comes back there as a form nothing
+     * reads, when what happened is that it constrains no position; and a comparison this
+     * arithmetic cannot carry comes back as one relating two positions, when a relation between two
+     * positions is exactly what a cut over a {@code LinearForm} does carry. Borrowed here, either
+     * would send an author after the wrong thing.
      *
-     * <p>Which of these leaves a region wider than the rows that arrive is not answered here and is
-     * not the same question as {@link souther.compiler.inputs.BlockReason.AboutARule#leavesShort},
-     * which is about a measure. A condition that did not narrow the region may still be implied by
-     * one that did.
+     * <p>So what is said about a comparison is what is known about it here, and no more. The finer
+     * answer belongs to whatever decided — {@link AffineReading}, which returns nothing and says
+     * nothing about why — and it is not invented at this end from the shape of what it was given.
      */
     sealed interface Why {
 
-        /** A condition of a shape this reading has no words for, so nothing was read of it. */
+        /** A condition that is neither a comparison nor a combination of them, so nothing was read
+         *  of it. */
         record NoWordsForTheShape() implements Why {}
 
         /**
-         * One comparison it read and could not use, in the words that already answer that.
+         * A comparison this reading did not turn into a cut.
          *
-         * @param why what {@link UnreadComparison} makes of it, which is what the same comparison
-         *            is filed under wherever else this compiler says it could not use one
+         * <p>One word, because one word is what this end knows. A comparison naming no position, a
+         * form outside the arithmetic and a subject with no spacing for its values arrive here as
+         * one absence, and {@link AffineReading} is where they would be told apart.
          */
-        record ARuleItCouldNotUse(BlockReason.AboutARule why) implements Why {
-
-            public ARuleItCouldNotUse {
-                if (why == null) {
-                    throw new IllegalArgumentException(
-                            "a rule this could not use is one a reader can be told about");
-                }
-            }
-        }
+        record ComparisonNotRepresentedAsACut() implements Why {}
 
         /**
          * What the condition coming out this way says is one of two things, and a region is what

--- a/souther-compiler/src/main/java/souther/compiler/partition/OnTheWay.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/OnTheWay.java
@@ -1,6 +1,7 @@
 package souther.compiler.partition;
 
 import souther.compiler.diag.Citation;
+import souther.compiler.inputs.BlockReason;
 
 /**
  * One condition on the way to a comparison, and what became of it.
@@ -36,30 +37,50 @@ public sealed interface OnTheWay {
     /**
      * What stopped a condition from becoming a cut.
      *
-     * <p>Every one of these is a limit of this compiler and none of them is a fact about the model:
-     * a condition an author wrote plainly is on this list wherever the arithmetic here has no way
-     * of carrying it. Which is why nothing read off one of these says a row cannot be written, and
-     * why a word here going away is a capability gained rather than a model changed.
+     * <p>Three shapes, and only one of them has a rule to name. A condition this reading has no
+     * words for is not one thing an author wrote; an arm of a fork stating one of two things is
+     * about the arm and not about either operand; and a comparison read and not used is a rule,
+     * which is why that one carries the account of it rather than a word of its own.
      *
-     * <p>Its own set, and not {@link souther.compiler.inputs.BlockReason.AboutARule}. That one is
-     * about one rule this read and could not use, and it answers for whether a measure is thereby
-     * short of something. An arm of a fork stating one of two things is neither: there is no single
-     * rule to name, and the measures are not short — the line is still owed and still measured, and
-     * what is affected is where a row for it was looked for.
+     * <p><b>The comparison's reason is the one this compiler already gives.</b>
+     * {@link souther.compiler.inputs.BlockReason.AboutARule} is what a reading of a rule it could
+     * not use comes to, and {@link UnreadComparison} is where a comparison is turned into one — the
+     * same answer the line beside this one is filed under. A word invented here would be a second
+     * classification of one question: it merged a form outside the arithmetic, a carrier no line is
+     * drawn on and a comparison relating two positions into one sentence, and called all three a
+     * limit of this compiler when the last is what the rule says.
+     *
+     * <p>Which of these leaves a region wider than the rows that arrive is not answered here and is
+     * not the same question as {@link souther.compiler.inputs.BlockReason.AboutARule#leavesShort},
+     * which is about a measure. A condition that did not narrow the region may still be implied by
+     * one that did.
      */
-    enum Why {
+    sealed interface Why {
 
         /** A condition of a shape this reading has no words for, so nothing was read of it. */
-        CONDITION_NOT_READ,
+        record NoWordsForTheShape() implements Why {}
 
-        /** Read as far as it goes, and it states nothing about any position of the input. */
-        NO_CONSTRAINT_REPRESENTED,
+        /**
+         * One comparison it read and could not use, in the words that already answer that.
+         *
+         * @param why what {@link UnreadComparison} makes of it, which is what the same comparison
+         *            is filed under wherever else this compiler says it could not use one
+         */
+        record ARuleItCouldNotUse(BlockReason.AboutARule why) implements Why {
+
+            public ARuleItCouldNotUse {
+                if (why == null) {
+                    throw new IllegalArgumentException(
+                            "a rule this could not use is one a reader can be told about");
+                }
+            }
+        }
 
         /**
          * What the condition coming out this way says is one of two things, and a region is what
          * has been accumulated onto it. {@code A && B} coming out false says one of them failed and
          * names neither, and taking either would exclude rows that arrive.
          */
-        NON_CONJUNCTIVE_OUTCOME
+        record OneOfTwoThings() implements Why {}
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
@@ -43,10 +43,12 @@ import java.util.Map;
  * region would come to exclude rows that reach the guard.
  *
  * <p>Nothing here says a row that satisfies all of this arrives. A condition of a shape the
- * arithmetic cannot read is on the list without narrowing anything, so what a region built from
- * this describes is wider than what arrives — which is what {@link SearchRegion} promises and what
- * a proof of unreachability rests on. Being on the list is what lets a report say so; it is not
- * what the region is built from.
+ * arithmetic cannot read is on the list without narrowing anything, so a region built from this
+ * holds every row that arrives and may hold rows that do not — which is what {@link SearchRegion}
+ * promises and what a proof of unreachability rests on. It is the inclusion and not a strict one:
+ * a condition nothing took in may be implied by the ones that were, or hold of every row. Being on
+ * the list is what lets a report say a condition is unaccounted for; it is not what the region is
+ * built from.
  */
 public record ReachingCuts(Map<ComparisonOccurrence, List<OnTheWay>> byComparison) {
 
@@ -104,15 +106,15 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<OnTheWay>> byCompariso
             case Condition.Both both -> holding
                     ? and(stating(both.left(), true, symbols), stating(both.right(), true, symbols))
                     : List.of(new OnTheWay.Declined(Citation.of(both.at().pos()),
-                            OnTheWay.Why.NON_CONJUNCTIVE_OUTCOME));
+                            new OnTheWay.Why.OneOfTwoThings()));
             case Condition.Either either -> holding
                     ? List.of(new OnTheWay.Declined(Citation.of(either.at().pos()),
-                            OnTheWay.Why.NON_CONJUNCTIVE_OUTCOME))
+                            new OnTheWay.Why.OneOfTwoThings()))
                     : and(stating(either.left(), false, symbols),
                             stating(either.right(), false, symbols));
             case Condition.Compares one -> List.of(of(one, holding, symbols));
-            case Condition.NotRead not -> List.of(new OnTheWay.Declined(Citation.of(not.at().pos()),
-                    OnTheWay.Why.CONDITION_NOT_READ));
+            case Condition.NotRead not -> List.of(new OnTheWay.Declined(
+                    Citation.of(not.at().pos()), new OnTheWay.Why.NoWordsForTheShape()));
         };
     }
 
@@ -124,17 +126,19 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<OnTheWay>> byCompariso
      * second reading of what a comparison says is a second thing to keep in step with how a border
      * is drawn, and the two disagreeing is a region that excludes the very level the border is at.
      *
-     * <p>One word for both ways the reading comes back empty. A comparison whose operands are
-     * outside the affine fragment and one whose operator places nothing leave the same thing
-     * missing here — a statement about a position — and what would lift either is the same piece of
-     * work.
+     * <p>And where it comes back with nothing, the reason is asked of {@link GuardThresholds#why},
+     * which is what this compiler already answers about a comparison it could not use. Read off
+     * where the reading returned nothing instead, the answer would be one word for a form outside
+     * the arithmetic, a carrier no line is drawn on and a comparison of two positions — three
+     * things that reading tells apart, and a reader would be sent after the wrong one.
      */
     private static OnTheWay of(Condition.Compares comparison, boolean holding, Symbols symbols) {
         Citation at = Citation.of(comparison.at().pos());
         AffineReading read = AffineReading.of(comparison.at(), comparison.reads(), symbols);
         Rel states = read == null ? null : relOf(read.claim());
         if (states == null) {
-            return new OnTheWay.Declined(at, OnTheWay.Why.NO_CONSTRAINT_REPRESENTED);
+            return new OnTheWay.Declined(at, new OnTheWay.Why.ARuleItCouldNotUse(
+                    GuardThresholds.why(comparison.at(), comparison.reads(), symbols)));
         }
         // The form with the threshold moved into it, since what a domain is told is `f rel 0`.
         LinearForm<NumericTerm> against =

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
@@ -126,19 +126,20 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<OnTheWay>> byCompariso
      * second reading of what a comparison says is a second thing to keep in step with how a border
      * is drawn, and the two disagreeing is a region that excludes the very level the border is at.
      *
-     * <p>And where it comes back with nothing, the reason is asked of {@link GuardThresholds#why},
-     * which is what this compiler already answers about a comparison it could not use. Read off
-     * where the reading returned nothing instead, the answer would be one word for a form outside
-     * the arithmetic, a carrier no line is drawn on and a comparison of two positions — three
-     * things that reading tells apart, and a reader would be sent after the wrong one.
+     * <p>And where it comes back with nothing, that is the whole of what is said. The reason the
+     * same comparison gets for drawing no line is {@link UnreadComparison}'s and answers another
+     * question: {@code 1 < 2} is a form nothing reads over there and constrains no position here,
+     * and a form this arithmetic cannot carry is a comparison between two positions over there
+     * while a relation between two positions is exactly what a cut carries here. What would tell
+     * this end's cases apart is {@link AffineReading} saying why it read nothing, which it does
+     * not.
      */
     private static OnTheWay of(Condition.Compares comparison, boolean holding, Symbols symbols) {
         Citation at = Citation.of(comparison.at().pos());
         AffineReading read = AffineReading.of(comparison.at(), comparison.reads(), symbols);
         Rel states = read == null ? null : relOf(read.claim());
         if (states == null) {
-            return new OnTheWay.Declined(at, new OnTheWay.Why.ARuleItCouldNotUse(
-                    GuardThresholds.why(comparison.at(), comparison.reads(), symbols)));
+            return new OnTheWay.Declined(at, new OnTheWay.Why.ComparisonNotRepresentedAsACut());
         }
         // The form with the threshold moved into it, since what a domain is told is `f rel 0`.
         LinearForm<NumericTerm> against =

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReachingCuts.java
@@ -4,6 +4,7 @@ import souther.compiler.check.ComparisonClaim;
 import souther.compiler.check.Symbols;
 import souther.compiler.coverage.ComparisonOccurrence;
 import souther.compiler.coverage.CoverageSites;
+import souther.compiler.diag.Citation;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.SearchRegion;
 import souther.compiler.numeric.NumericDomain;
@@ -26,8 +27,14 @@ import java.util.Map;
  * comparison sits.</b> A reading that walked back up the tree would be a second account of what was
  * assumed, free to name a condition nothing here could take in — and a region narrowed on a
  * condition nothing established is narrower than the rows that arrive, which is the one direction
- * that takes a coverage item away. So what is here is what the walk itself put in, and a condition
- * the arithmetic has no word for leaves nothing behind.
+ * that takes a coverage item away. So what is here is what the walk itself put in.
+ *
+ * <p><b>Including what it could not put in.</b> A condition the arithmetic has no word for narrows
+ * nothing, and it is written down all the same: what a region is is one question and how it came to
+ * be that region is another, and only the second can tell a search that ran over what the
+ * declarations leave because nothing stood in the way from one that ran over the same box because a
+ * guard above could not be read. Held as {@link OnTheWay}, so the two are one sequence in the order
+ * the walk met them rather than a list and a silence.
  *
  * <p><b>Its own value and not its arm.</b> Under {@code A && B} the {@code then} arm is reached with
  * both holding, and the {@code else} arm with neither settled — a row can be in it for failing
@@ -36,10 +43,12 @@ import java.util.Map;
  * region would come to exclude rows that reach the guard.
  *
  * <p>Nothing here says a row that satisfies all of this arrives. A condition of a shape the
- * arithmetic cannot read is not on the list, so what this describes is wider than what arrives —
- * which is what {@link SearchRegion} promises and what a proof of unreachability rests on.
+ * arithmetic cannot read is on the list without narrowing anything, so what a region built from
+ * this describes is wider than what arrives — which is what {@link SearchRegion} promises and what
+ * a proof of unreachability rests on. Being on the list is what lets a report say so; it is not
+ * what the region is built from.
  */
-public record ReachingCuts(Map<ComparisonOccurrence, List<ReachingCuts.Cut>> byComparison) {
+public record ReachingCuts(Map<ComparisonOccurrence, List<OnTheWay>> byComparison) {
 
     public static final ReachingCuts NONE = new ReachingCuts(Map.of());
 
@@ -51,23 +60,26 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<ReachingCuts.Cut>> byC
     public record Cut(LinearForm<NumericTerm> form, Rel rel) {}
 
     /**
-     * {@code region}, narrowed to what reaches {@code site}.
+     * Where a row for a border at {@code site} is looked for: {@code region} narrowed by what the
+     * walk to it took in, beside the whole account of that walk.
      *
-     * <p>{@code region} itself where nothing was collected there, which is a comparison at the top
-     * of a body as much as it is one this could read nothing on the way to. The two are not told
-     * apart because nothing downstream acts on the difference: both leave a region as wide as the
-     * declarations, and both are sound.
+     * <p>{@code region} itself where nothing was collected there — and the answer says so, rather
+     * than leaving a reader to tell a comparison at the top of a body from one this could read
+     * nothing on the way to. Both leave a region as wide as the declarations and both are sound;
+     * only one of them is a limit of this compiler, and an author who is told nothing has no way to
+     * find out which they are looking at.
      */
-    public SearchRegion narrowing(SearchRegion region, ComparisonOccurrence site) {
-        for (Cut each : byComparison.getOrDefault(site, List.of())) {
-            region = region.assuming(each.form(), each.rel());
-        }
-        return region;
+    public RegionForARow narrowing(SearchRegion region, ComparisonOccurrence site) {
+        return RegionForARow.narrowed(region, byComparison.getOrDefault(site, List.of()));
     }
 
     /**
-     * What {@code node} coming out {@code holding} says about this input, where anything can be
-     * said.
+     * What {@code node} coming out {@code holding} says about this input, and where it says
+     * nothing, that.
+     *
+     * <p>Never empty. Every shape has an answer — a cut where one could be made and a decline
+     * where none could — because an empty answer is what made a comparison reached under nothing
+     * and one reached past something unreadable into the same reading.
      *
      * <p>One rule for two questions, because they are one question. What reaching the right operand
      * of a condition establishes and what reaching an arm of the fork establishes are both "this
@@ -78,48 +90,56 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<ReachingCuts.Cut>> byC
      * <p>A conjunction coming out true is both its operands true, and a disjunction coming out false
      * is both false. The other two ways round say a disjunction of things, which is not a list of
      * cuts and is not approximated into one: {@code A && B} being false says one of them failed and
-     * names neither, and narrowing on either would exclude rows that arrive.
+     * names neither, and narrowing on either would exclude rows that arrive. So those two are
+     * declined whole, at the condition rather than at an operand — neither operand is what could
+     * not be carried.
      */
-    static List<Cut> stating(Condition node, boolean holding, Symbols symbols) {
+    static List<OnTheWay> stating(Condition node, boolean holding, Symbols symbols) {
         return switch (node) {
             // A conjunction coming out true is both its operands true, and a disjunction coming out
             // false is both false. The other two ways round say a disjunction of things, which is
             // not a list of cuts and is not approximated into one: `A && B` being false says one of
             // them failed and names neither, and narrowing on either would exclude rows that arrive.
-            case Condition.Both both when holding ->
-                    and(stating(both.left(), true, symbols), stating(both.right(), true, symbols));
-            case Condition.Either either when !holding ->
-                    and(stating(either.left(), false, symbols),
+            // So the whole node is declined, at the whole node's place.
+            case Condition.Both both -> holding
+                    ? and(stating(both.left(), true, symbols), stating(both.right(), true, symbols))
+                    : List.of(new OnTheWay.Declined(Citation.of(both.at().pos()),
+                            OnTheWay.Why.NON_CONJUNCTIVE_OUTCOME));
+            case Condition.Either either -> holding
+                    ? List.of(new OnTheWay.Declined(Citation.of(either.at().pos()),
+                            OnTheWay.Why.NON_CONJUNCTIVE_OUTCOME))
+                    : and(stating(either.left(), false, symbols),
                             stating(either.right(), false, symbols));
-            case Condition.Compares one -> {
-                Cut cut = of(one, holding, symbols);
-                yield cut == null ? List.of() : List.of(cut);
-            }
-            default -> List.of();
+            case Condition.Compares one -> List.of(of(one, holding, symbols));
+            case Condition.NotRead not -> List.of(new OnTheWay.Declined(Citation.of(not.at().pos()),
+                    OnTheWay.Why.CONDITION_NOT_READ));
         };
     }
 
     /**
-     * What {@code comparison} states about this input, coming out {@code holding} — or null where
-     * the arithmetic reads nothing here.
+     * What {@code comparison} states about this input, coming out {@code holding} — or a decline
+     * where the arithmetic reads nothing here.
      *
      * <p>Read once, off the same {@link AffineReading} every other reader of a comparison uses. A
      * second reading of what a comparison says is a second thing to keep in step with how a border
      * is drawn, and the two disagreeing is a region that excludes the very level the border is at.
+     *
+     * <p>One word for both ways the reading comes back empty. A comparison whose operands are
+     * outside the affine fragment and one whose operator places nothing leave the same thing
+     * missing here — a statement about a position — and what would lift either is the same piece of
+     * work.
      */
-    private static Cut of(Condition.Compares comparison, boolean holding, Symbols symbols) {
+    private static OnTheWay of(Condition.Compares comparison, boolean holding, Symbols symbols) {
+        Citation at = Citation.of(comparison.at().pos());
         AffineReading read = AffineReading.of(comparison.at(), comparison.reads(), symbols);
-        if (read == null) {
-            return null;
-        }
-        Rel states = relOf(read.claim());
+        Rel states = read == null ? null : relOf(read.claim());
         if (states == null) {
-            return null;
+            return new OnTheWay.Declined(at, OnTheWay.Why.NO_CONSTRAINT_REPRESENTED);
         }
         // The form with the threshold moved into it, since what a domain is told is `f rel 0`.
         LinearForm<NumericTerm> against =
                 read.form().minus(LinearForm.constant(read.cut()));
-        return new Cut(against, holding ? states : negated(states));
+        return new OnTheWay.TakenIn(at, new Cut(against, holding ? states : negated(states)));
     }
 
     /**
@@ -154,12 +174,12 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<ReachingCuts.Cut>> byC
         };
     }
 
-    /** These cuts, with {@code site} reached under {@code assumed}. */
+    /** These conditions, with {@code site} reached under {@code assumed}. */
     static final class Collected {
 
-        private final Map<ComparisonOccurrence, List<Cut>> byComparison = new LinkedHashMap<>();
+        private final Map<ComparisonOccurrence, List<OnTheWay>> byComparison = new LinkedHashMap<>();
 
-        void reached(ComparisonOccurrence site, List<Cut> assumed) {
+        void reached(ComparisonOccurrence site, List<OnTheWay> assumed) {
             // The first reading of a site stands. One comparison is read once per call of the helper
             // it is written in, and each of those is a site of its own — two readings arriving under
             // one site would be this walk and the plan disagreeing about what a site is.
@@ -172,11 +192,8 @@ public record ReachingCuts(Map<ComparisonOccurrence, List<ReachingCuts.Cut>> byC
     }
 
     /** What a caller is carrying, with more added, keeping what was already there. */
-    private static List<Cut> and(List<Cut> assumed, List<Cut> more) {
-        if (more.isEmpty()) {
-            return assumed;
-        }
-        List<Cut> out = new java.util.ArrayList<>(assumed);
+    private static List<OnTheWay> and(List<OnTheWay> assumed, List<OnTheWay> more) {
+        List<OnTheWay> out = new java.util.ArrayList<>(assumed);
         out.addAll(more);
         return List.copyOf(out);
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/RegionForARow.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/RegionForARow.java
@@ -1,0 +1,94 @@
+package souther.compiler.partition;
+
+import souther.compiler.inputs.SearchRegion;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Where a row for one border is looked for, and how that came to be the place.
+ *
+ * <p>Three things hold of every one of these, and the first two are {@link SearchRegion}'s own:
+ *
+ * <pre>what reaches the border ⊆ where ⊆ what the declarations leave</pre>
+ *
+ * <p>and {@code where} is {@code base} with exactly the {@link OnTheWay.TakenIn} entries of
+ * {@code provenance} taken in, in the order they are written. A {@link OnTheWay.Declined} entry
+ * never narrows {@code where} — it is the record that something on the way is not represented in
+ * it.
+ *
+ * <p><b>Made here and nowhere else.</b> A region and an account of it are two values that have to
+ * say the same thing, and nothing can check that they do: {@link SearchRegion} answers questions
+ * about values and does not say which conditions it was built from, on purpose, so a pair handed in
+ * from outside could disagree with no reader able to tell. So the pair is not constructible — only
+ * narrowed, which builds one from the other.
+ *
+ * <p>What a report may say from this is what the entries say and no more. That some condition was
+ * declined does not make {@code where} wider than the rows that reach the border: a condition the
+ * arithmetic could not take in may have been implied by the ones it did, or may hold everywhere.
+ * What is known is that not everything on the way is represented here.
+ */
+public final class RegionForARow {
+
+    private final SearchRegion where;
+    private final List<OnTheWay> provenance;
+
+    private RegionForARow(SearchRegion where, List<OnTheWay> provenance) {
+        this.where = where;
+        this.provenance = provenance;
+    }
+
+    /** {@code base} with the cuts of {@code provenance} taken in, carrying the whole of it. */
+    public static RegionForARow narrowed(SearchRegion base, List<OnTheWay> provenance) {
+        SearchRegion region = base;
+        for (OnTheWay each : provenance) {
+            if (each instanceof OnTheWay.TakenIn taken) {
+                region = region.assuming(taken.cut().form(), taken.cut().rel());
+            }
+        }
+        return new RegionForARow(region, List.copyOf(provenance));
+    }
+
+    /**
+     * {@code base} with nothing on the way to take in.
+     *
+     * <p>Which is a border of a rule that is about the values rather than about a place in a body:
+     * an invariant holds wherever a value stands, so there is nowhere for a row to have come from.
+     * Said by the empty account rather than by the absence of one.
+     */
+    public static RegionForARow untouched(SearchRegion base) {
+        return narrowed(base, List.of());
+    }
+
+    /** Where a row is looked for. */
+    public SearchRegion where() {
+        return where;
+    }
+
+    /** Every condition on the way to the border, in the order the walk met them. */
+    public List<OnTheWay> provenance() {
+        return provenance;
+    }
+
+    /** The ones that narrowed {@link #where()}. */
+    public List<OnTheWay.TakenIn> takenIn() {
+        List<OnTheWay.TakenIn> out = new ArrayList<>();
+        for (OnTheWay each : provenance) {
+            if (each instanceof OnTheWay.TakenIn taken) {
+                out.add(taken);
+            }
+        }
+        return List.copyOf(out);
+    }
+
+    /** The ones that did not, which is what is not represented in {@link #where()}. */
+    public List<OnTheWay.Declined> declined() {
+        List<OnTheWay.Declined> out = new ArrayList<>();
+        for (OnTheWay each : provenance) {
+            if (each instanceof OnTheWay.Declined left) {
+                out.add(left);
+            }
+        }
+        return List.copyOf(out);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1680,9 +1680,11 @@ public final class Adequacy {
                         new GenerationOutcome.Generated(List.of(built.row()));
                 case ItemAssessment.Attempt.Unresolved why ->
                         new GenerationOutcome.CannotGenerate(why.why());
-                // Carried apart, because the assessment kept them apart. Classes that were not
-                // there and classes that would not link are two things this saw, and choosing
-                // one of them to print is this compiler deciding what it observed.
+                // Classes that were not there is a thing this saw, said in the words the
+                // generator says it in. Classes that would not link used to be beside it and is
+                // not: it is found by running a candidate the region search had already produced,
+                // so it arrives above as a search that came to nothing, in the same words this
+                // was rebuilding here.
                 //
                 // The other two reasons do not reach an unmet edge: a row is already at the
                 // value, or the line was never measured against the rows, and neither is a gap.
@@ -1693,9 +1695,6 @@ public final class Adequacy {
                             new Generator.UnresolvedCombination(List.of(subject),
                                     Generator.UnresolvedCombination.Reason
                                             .NOTHING_TO_BUILD_AGAINST));
-                    case LINKAGE_FAILED -> new GenerationOutcome.CannotGenerate(
-                            new Generator.UnresolvedCombination(List.of(subject),
-                                    Generator.UnresolvedCombination.Reason.LINKAGE_FAILED));
                     case A_ROW_IS_ALREADY_THERE, NOT_MEASURED ->
                             throw new IllegalStateException("the assessment at " + subject
                                     + " says " + absent.reason() + ", which is not a gap: "
@@ -1790,10 +1789,23 @@ public final class Adequacy {
                 }
                 switch (each.attempt()) {
                     case ItemAssessment.Attempt.Built built -> rows.add(built.row());
-                    case ItemAssessment.Attempt.Unresolved why -> unresolved.add(why.why());
-                    // Nothing was tried. One of the reasons is news — the decoders could not be
-                    // reached, so this block is short of rows it would otherwise have offered — and
-                    // two are boundaries nobody is owed a row at, where saying so would be noise.
+                    case ItemAssessment.Attempt.Unresolved why -> {
+                        unresolved.add(why.why());
+                        // And where the decoders were out of reach, the block is short of rows it
+                        // would otherwise have offered, which is a thing about this run rather than
+                        // about the point. Read off the reason because that is where the search
+                        // records it: a boundary search keeps no reasons list of its own, which is
+                        // what the pairs half above takes its copy of this from.
+                        if (why.why().reason()
+                                == Generator.UnresolvedCombination.Reason.LINKAGE_FAILED) {
+                            stopped.add(new souther.compiler.partition.GenerationReason
+                                    .LinkageFailed(behavior));
+                        }
+                    }
+                    // Nothing was tried. Two of the reasons are boundaries nobody is owed a row
+                    // at, where saying so would be noise; the news is the one above them, and the
+                    // decoders being out of reach is no longer here to be it — that is found by
+                    // running a candidate, which takes a search having already produced one.
                     //
                     // NO_CLASSES is here for completeness and does not arrive: the evaluation is
                     // asked only of a module that checked, so a module with no classes has no rows
@@ -1807,9 +1819,6 @@ public final class Adequacy {
                             case NO_CLASSES -> stopped.add(
                                     new souther.compiler.partition.GenerationReason
                                             .NothingToBuildAgainst(behavior));
-                            case LINKAGE_FAILED -> stopped.add(
-                                    new souther.compiler.partition.GenerationReason
-                                            .LinkageFailed(behavior));
                             case A_ROW_IS_ALREADY_THERE, NOT_MEASURED -> { }
                         }
                     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -642,7 +642,7 @@ final class Coverages {
                 // offered for goes in beside it rather than being read back off it.
                 return switch (realizer.realize(quantity.standingAt(criterion), within.where())) {
                     case Realization.Found found -> whatCameOfIt(
-                            probe.attempt(label, quantity.carrier(), found.fixing()), within);
+                            probe.attempt(label, quantity.carrier(), found.fixing()), label, within);
                     // And the two ways of finding nothing are not one answer. A walk of the whole
                     // of what the rules leave that reaches no value settles the point; a search
                     // that stopped, or one that composed no candidate at all, settles nothing
@@ -927,13 +927,23 @@ final class Coverages {
      * and a run that composed a row and never saw it arrive is the answer that most needs it — the
      * candidate came out of this box, and a condition on the way that nothing represented in the
      * box is a thing an author would want to know at exactly that point.
+     *
+     * <p>Including where the decoders could not be reached. This is asked only of a placement the
+     * realizer found, so the region was walked and a candidate came out of it before anything was
+     * run — which makes it a search that came to nothing rather than a search nobody made, and it
+     * carries what it was looking over like the rest. Filed as one nobody made, it was the one
+     * outcome of a search that dropped its region, and the reader that wanted it back built the
+     * same value by hand a moment later.
      */
-    private static ItemAssessment.Attempt whatCameOfIt(
-            souther.compiler.partition.Generator.BoundaryAttempt made,
+    private static ItemAssessment.Attempt.Searched whatCameOfIt(
+            souther.compiler.partition.Generator.BoundaryAttempt made, String subject,
             souther.compiler.partition.RegionForARow within) {
         return switch (made) {
-            case null -> new ItemAssessment.Attempt.NotAttempted(
-                    ItemAssessment.Attempt.Reason.LINKAGE_FAILED);
+            case null -> new ItemAssessment.Attempt.Unresolved(
+                    new souther.compiler.partition.Generator.UnresolvedCombination(
+                            List.of(subject),
+                            souther.compiler.partition.Generator.UnresolvedCombination.Reason
+                                    .LINKAGE_FAILED), within);
             case souther.compiler.partition.Generator.BoundaryAttempt.Built built ->
                     new ItemAssessment.Attempt.Built(built.row(), within);
             case souther.compiler.partition.Generator.BoundaryAttempt.Unresolved left ->

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -527,13 +527,14 @@ final class Coverages {
      * values and holds wherever one stands, so there is nothing on the way to it; a guard is at a
      * place in a body, and a row that never arrives there is no row at its line whatever it holds.
      * Read off which kind of rule it is rather than off whether anything was collected: a guard
-     * nothing narrows and a clause are then the same region for the same stated reason.
+     * nothing narrows and a clause are then the same region for the same stated reason, and each
+     * says so in its own account rather than by coming back with nothing.
      */
-    private static souther.compiler.inputs.SearchRegion regionFor(
+    private static souther.compiler.partition.RegionForARow regionFor(
             Border border, souther.compiler.inputs.Quantities rules, ReachingCuts reaching) {
         return border.origin().comparisonAt()
                 .map(site -> reaching.narrowing(rules.region(), site))
-                .orElseGet(rules::region);
+                .orElseGet(() -> souther.compiler.partition.RegionForARow.untouched(rules.region()));
     }
 
     /**
@@ -618,7 +619,7 @@ final class Coverages {
     private static OneShapeOfBorder shapeOf(Border border, BehaviorInputs where,
                                             boolean knownWritable, Probe probe,
                                             LevelRealizer realizer,
-                                            souther.compiler.inputs.SearchRegion within) {
+                                            souther.compiler.partition.RegionForARow within) {
         BorderQuantity quantity = border.cut().of();
         java.util.Optional<souther.compiler.coverage.ComparisonOccurrence> site =
                 border.origin().comparisonAt();
@@ -639,9 +640,9 @@ final class Coverages {
                 // the realizer. What it composes is a candidate and no part of the item: another row
                 // in the same side is at the point as much as this one would be, so what the row is
                 // offered for goes in beside it rather than being read back off it.
-                return switch (realizer.realize(quantity.standingAt(criterion), within)) {
-                    case Realization.Found found ->
-                            whatCameOfIt(probe.attempt(label, quantity.carrier(), found.fixing()));
+                return switch (realizer.realize(quantity.standingAt(criterion), within.where())) {
+                    case Realization.Found found -> whatCameOfIt(
+                            probe.attempt(label, quantity.carrier(), found.fixing()), within);
                     // And the two ways of finding nothing are not one answer. A walk of the whole
                     // of what the rules leave that reaches no value settles the point; a search
                     // that stopped, or one that composed no candidate at all, settles nothing
@@ -650,14 +651,14 @@ final class Coverages {
                             new souther.compiler.partition.Generator.UnresolvedCombination(
                                     java.util.List.of(label),
                                     souther.compiler.partition.Generator.UnresolvedCombination
-                                            .Reason.THE_RULES_LEAVE_NOTHING_THERE));
+                                            .Reason.THE_RULES_LEAVE_NOTHING_THERE), within);
                     case Realization.Unknown unknown -> switch (unknown.why()) {
-                        case NOTHING_COMPOSED_ONE -> nothingComposedOne(label);
+                        case NOTHING_COMPOSED_ONE -> nothingComposedOne(label, within);
                         case THE_SEARCH_RAN_OUT -> new ItemAssessment.Attempt.Unresolved(
                                 new souther.compiler.partition.Generator.UnresolvedCombination(
                                         java.util.List.of(label),
                                         souther.compiler.partition.Generator.UnresolvedCombination
-                                                .Reason.SEARCH_LIMIT));
+                                                .Reason.SEARCH_LIMIT), within);
                     };
                 };
             }
@@ -911,23 +912,32 @@ final class Coverages {
     }
 
     /** A search that came to nothing at {@code subject}, which is what a point is written as. */
-    private static ItemAssessment.Attempt nothingComposedOne(String subject) {
+    private static ItemAssessment.Attempt nothingComposedOne(
+            String subject, souther.compiler.partition.RegionForARow within) {
         return new ItemAssessment.Attempt.Unresolved(
                 new souther.compiler.partition.Generator.UnresolvedCombination(List.of(subject),
                         souther.compiler.partition.Generator.UnresolvedCombination.Reason
-                                .NOTHING_COMPOSES_ONE));
+                                .NOTHING_COMPOSES_ONE), within);
     }
 
-    /** What a search of the module's own decoders came to, in this measure's words. */
+    /**
+     * What a search of the module's own decoders came to, in this measure's words.
+     *
+     * <p>{@code within} travels as far as the answer does. The region is what the search ran in,
+     * and a run that composed a row and never saw it arrive is the answer that most needs it — the
+     * candidate came out of this box, and a condition on the way that nothing represented in the
+     * box is a thing an author would want to know at exactly that point.
+     */
     private static ItemAssessment.Attempt whatCameOfIt(
-            souther.compiler.partition.Generator.BoundaryAttempt made) {
+            souther.compiler.partition.Generator.BoundaryAttempt made,
+            souther.compiler.partition.RegionForARow within) {
         return switch (made) {
             case null -> new ItemAssessment.Attempt.NotAttempted(
                     ItemAssessment.Attempt.Reason.LINKAGE_FAILED);
             case souther.compiler.partition.Generator.BoundaryAttempt.Built built ->
-                    new ItemAssessment.Attempt.Built(built.row());
+                    new ItemAssessment.Attempt.Built(built.row(), within);
             case souther.compiler.partition.Generator.BoundaryAttempt.Unresolved left ->
-                    new ItemAssessment.Attempt.Unresolved(left.why());
+                    new ItemAssessment.Attempt.Unresolved(left.why(), within);
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
@@ -5,6 +5,8 @@ import souther.compiler.partition.Criterion;
 import souther.compiler.partition.Generator;
 import souther.compiler.partition.NotOwedReason;
 
+import java.util.List;
+
 /**
  * Everything known about one of the four coverage items of a border.
  *
@@ -137,14 +139,24 @@ public sealed interface ItemAssessment {
     sealed interface Attempt {
 
         /**
-         * A value at the point, built and accepted by the module's own decoders.
+         * What a search of the region came to, whichever way it came out.
          *
-         * @param region where it was looked for, and what the walk to the point took in and could
-         *               not. Carried by the two states a search ran in and by neither of the ones
-         *               it did not: a region nothing searched is not a fact about this run
+         * <p>The boundary is which side of the search an outcome is on, and it is a type because it
+         * was a sentence. A candidate is composed by walking the region, so everything found out
+         * afterwards — a row that was accepted, a row that was refused, decoders that could not be
+         * reached — is an outcome of a search that ran and carries what it ran over. What was
+         * written instead was a comment saying so, and the one outcome that arrived by a different
+         * route was filed as a search nobody made and dropped its region on the way.
          */
+        sealed interface Searched extends Attempt {
+
+            /** Where the row was looked for, and what the way to the point took in and could not. */
+            souther.compiler.partition.RegionForARow region();
+        }
+
+        /** A value at the point, built and accepted by the module's own decoders. */
         record Built(Generator.GeneratedRow row,
-                     souther.compiler.partition.RegionForARow region) implements Attempt {}
+                     souther.compiler.partition.RegionForARow region) implements Searched {}
 
         /**
          * The search ran and no row came of it.
@@ -155,12 +167,12 @@ public sealed interface ItemAssessment {
          * name that said "refused" would invite a reader to take the other two for a decision the
          * decoder made — which is the mistake this type exists to prevent, one size down.
          *
-         * @param region where the search ran, as {@link Built#region()} carries it. What a search
-         *               that settled nothing was looking over is the half of the answer that says
-         *               how much the other half is worth
+         * <p>What a search that settled nothing was looking over is the half of the answer that
+         * says how much the other half is worth, so it carries the region like every other outcome
+         * of a search.
          */
         record Unresolved(Generator.UnresolvedCombination why,
-                          souther.compiler.partition.RegionForARow region) implements Attempt {}
+                          souther.compiler.partition.RegionForARow region) implements Searched {}
 
         /** Nothing was tried, and why not. Separate from a refusal because they license different
          * sentences: one is a fact about values, the other is a fact about this run. */
@@ -172,11 +184,33 @@ public sealed interface ItemAssessment {
             /** The point was not measured against the rows, so no row here is owed to anybody yet. */
             NOT_MEASURED,
             /** The module's classes were not there to build against. */
-            NO_CLASSES,
-            /** The generated classes would not link, so the decoders could not be reached. What
-             * the JVM raised is a {@code LinkageError}, and which of its causes it was is not
-             * something this can tell. */
-            LINKAGE_FAILED
+            NO_CLASSES
+            // The decoders being out of reach was one of these and is not. It is found by running a
+            // candidate, and a candidate is something a search of the region already produced — so
+            // it is a search that came to nothing, which is `Unresolved`, and it says so in the
+            // generator's own words. Left here, it was the one search whose region went unrecorded.
+        }
+
+        /**
+         * What the search ran over that the way to the point does not account for.
+         *
+         * <p>Asked of the attempt because the attempt is what holds both halves: which conditions
+         * were left out of the region, and whether this outcome is one they bear on. Answered at a
+         * renderer instead, the two halves were a pair of conditions written into a sentence, and
+         * the only way to ask what they came to was to compile a model that produced the sentence.
+         *
+         * <p>Empty where nothing was left out, and empty where the outcome settles the point on its
+         * own: a walk of the whole of what the rules leave that reaches no value proves there is
+         * nothing to find whether or not the box it walked held rows that never arrive, since an
+         * empty box leaves what it contains empty too. Empty for a row that was built, which is a
+         * point answered rather than a search to account for, and for a search nobody made.
+         */
+        default List<souther.compiler.partition.OnTheWay.Declined> unaccountedFor() {
+            return switch (this) {
+                case Built _, NotAttempted _ -> List.of();
+                case Unresolved left -> left.why().reason().provesInfeasible()
+                        ? List.of() : left.region().declined();
+            };
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
@@ -136,8 +136,15 @@ public sealed interface ItemAssessment {
      */
     sealed interface Attempt {
 
-        /** A value at the point, built and accepted by the module's own decoders. */
-        record Built(Generator.GeneratedRow row) implements Attempt {}
+        /**
+         * A value at the point, built and accepted by the module's own decoders.
+         *
+         * @param region where it was looked for, and what the walk to the point took in and could
+         *               not. Carried by the two states a search ran in and by neither of the ones
+         *               it did not: a region nothing searched is not a fact about this run
+         */
+        record Built(Generator.GeneratedRow row,
+                     souther.compiler.partition.RegionForARow region) implements Attempt {}
 
         /**
          * The search ran and no row came of it.
@@ -147,8 +154,13 @@ public sealed interface ItemAssessment {
          * before it got here, are the others, and only the first is the decoder saying anything. A
          * name that said "refused" would invite a reader to take the other two for a decision the
          * decoder made — which is the mistake this type exists to prevent, one size down.
+         *
+         * @param region where the search ran, as {@link Built#region()} carries it. What a search
+         *               that settled nothing was looking over is the half of the answer that says
+         *               how much the other half is worth
          */
-        record Unresolved(Generator.UnresolvedCombination why) implements Attempt {}
+        record Unresolved(Generator.UnresolvedCombination why,
+                          souther.compiler.partition.RegionForARow region) implements Attempt {}
 
         /** Nothing was tried, and why not. Separate from a refusal because they license different
          * sentences: one is a fact about values, the other is a fact about this run. */

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1158,8 +1158,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      * What the search ran over that the way to the border does not account for, where anything did.
      *
      * <p>Said only where the search settled nothing. A walk of the whole of what the rules leave
-     * that reaches no value settles the point whether or not the box it walked was wider than the
-     * rows that arrive — a wider box that is empty leaves the narrower one empty too. Everywhere
+     * that reaches no value settles the point whether or not the box it walked held rows that never
+     * arrive — an empty box leaves what it contains empty too. Everywhere
      * else the search came back without an answer, and which box it looked in is half of what that
      * answer is worth.
      *
@@ -1179,8 +1179,10 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         for (int i = 0; i < left.size(); i++) {
             out.append(i == 0 ? "" : ", ")
                     .append(whyDeclined(left.get(i).why()))
-                    .append(" at ")
-                    .append(left.get(i).at().said(names, declaredIn));
+                    // The place last and in brackets, as every other line of this report writes
+                    // one. Written into the sentence, it lands after a verb and reads as part of
+                    // what the sentence says rather than as where to look.
+                    .append(" (").append(left.get(i).at().said(names, declaredIn)).append(")");
         }
         return out.toString();
     }
@@ -1189,18 +1191,28 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      * What stopped one condition on the way from narrowing the search, in the words a reader acts
      * on.
      *
-     * <p>One sentence per case rather than one for all three. What an author does about a condition
-     * this reading has no words for is not what they do about one it read and could place no
-     * constraint from, and neither is what they do about an arm that states one of two things — and
-     * a single "was not read" for all of them is the vocabulary being kept apart in the compiler
-     * and put back together on the way out.
+     * <p>One sentence per shape rather than one for all three, and the one that has a rule to name
+     * takes that rule's own words. What an author does about a condition this reading has no words
+     * for is not what they do about a comparison it read and could not use, and neither is what
+     * they do about an arm that states one of two things — a single "was not read" for all of them
+     * is the vocabulary being kept apart in the compiler and put back together on the way out.
      */
     private static String whyDeclined(souther.compiler.partition.OnTheWay.Why why) {
         return switch (why) {
-            case CONDITION_NOT_READ -> "the condition was not read";
-            case NO_CONSTRAINT_REPRESENTED ->
-                    "the comparison places no constraint this could take in";
-            case NON_CONJUNCTIVE_OUTCOME ->
+            // What this reading takes apart is a comparison and the two ways of joining them, so
+            // what it stops at is a condition that is neither. Said as "written in a form this
+            // compiler does not read", it would be the sentence a comparison whose form was
+            // unreadable gets, and the two are lifted by different work — a reader for a shape, and
+            // arithmetic for a form.
+            case souther.compiler.partition.OnTheWay.Why.NoWordsForTheShape _ ->
+                    "the condition is neither a comparison nor a combination of them";
+            // The rule's own reason, in the words this document already writes for one. A sentence
+            // of this line's own would be a second wording of one answer, and the two would part on
+            // the day either was made more precise.
+            case souther.compiler.partition.OnTheWay.Why.ARuleItCouldNotUse(var reason) ->
+                    "the comparison is "
+                            + whyUnread(souther.compiler.partition.ReportedReason.of(reason));
+            case souther.compiler.partition.OnTheWay.Why.OneOfTwoThings _ ->
                     "the outcome of the condition states one of two things";
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -826,7 +826,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // without this line the difference reads as the tool being arbitrary.
             out.append(String.format("      · not known to be writable: the %s point %s %s (%s)%s%n",
                     p.role(), p.border().axis(), p.asked(),
-                    p.border().origin(names, declaredIn), whatWasTried(owed(p).attempt())));
+                    p.border().origin(names, declaredIn),
+                    whatWasTried(owed(p).attempt(), names, declaredIn)));
         }
         // And what the model itself answered, which is not a row anybody is behind on. Named by the
         // reason rather than left blank: a point the rules refuse and a point this language cannot
@@ -1138,19 +1139,70 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     }
 
     /** What the search for a value at an edge came to, where it ran and found none. */
-    private static String whatWasTried(ItemAssessment.Attempt attempt) {
+    private static String whatWasTried(ItemAssessment.Attempt attempt, SourceNameResolver names,
+                                       SourceId declaredIn) {
         if (!(attempt instanceof ItemAssessment.Attempt.Unresolved left)) {
             return "";   // nothing ran, and what a run would have said is not this line's to guess
         }
         // A proof is not a failure, and the sentence in front of the reason may not say it is.
         // Every other word here is this compiler saying what it did not manage; one of them is the
         // model settling the point, and reading them under one opening sends an author looking for
-        // a row nothing can write.
-        String opening = left.why().reason()
-                == souther.compiler.partition.Generator.UnresolvedCombination.Reason
-                        .THE_RULES_LEAVE_NOTHING_THERE
-                ? " — " : " — nothing composed one: ";
-        return opening + left.why().said().orElseGet(() -> whyUnresolved(left.why()));
+        // a row nothing can write. Asked of the reason, which is where that decision is written.
+        boolean settled = left.why().reason().provesInfeasible();
+        String opening = settled ? " — " : " — nothing composed one: ";
+        return opening + left.why().said().orElseGet(() -> whyUnresolved(left.why()))
+                + (settled ? "" : whatTheRegionLeftOut(left.region(), names, declaredIn));
+    }
+
+    /**
+     * What the search ran over that the way to the border does not account for, where anything did.
+     *
+     * <p>Said only where the search settled nothing. A walk of the whole of what the rules leave
+     * that reaches no value settles the point whether or not the box it walked was wider than the
+     * rows that arrive — a wider box that is empty leaves the narrower one empty too. Everywhere
+     * else the search came back without an answer, and which box it looked in is half of what that
+     * answer is worth.
+     *
+     * <p>What is said is what is known: these conditions are not represented in the region. Not
+     * that the region is wider than the rows that reach the line — a condition nothing could take
+     * in may be implied by the ones that were, or may hold of every row — and a sentence claiming
+     * the wider box would be this report deciding something it has not been shown.
+     */
+    private static String whatTheRegionLeftOut(souther.compiler.partition.RegionForARow region,
+                                               SourceNameResolver names, SourceId declaredIn) {
+        List<souther.compiler.partition.OnTheWay.Declined> left = region.declined();
+        if (left.isEmpty()) {
+            return "";
+        }
+        StringBuilder out = new StringBuilder("; not every condition on the way to the line is"
+                + " represented in the region searched: ");
+        for (int i = 0; i < left.size(); i++) {
+            out.append(i == 0 ? "" : ", ")
+                    .append(whyDeclined(left.get(i).why()))
+                    .append(" at ")
+                    .append(left.get(i).at().said(names, declaredIn));
+        }
+        return out.toString();
+    }
+
+    /**
+     * What stopped one condition on the way from narrowing the search, in the words a reader acts
+     * on.
+     *
+     * <p>One sentence per case rather than one for all three. What an author does about a condition
+     * this reading has no words for is not what they do about one it read and could place no
+     * constraint from, and neither is what they do about an arm that states one of two things — and
+     * a single "was not read" for all of them is the vocabulary being kept apart in the compiler
+     * and put back together on the way out.
+     */
+    private static String whyDeclined(souther.compiler.partition.OnTheWay.Why why) {
+        return switch (why) {
+            case CONDITION_NOT_READ -> "the condition was not read";
+            case NO_CONSTRAINT_REPRESENTED ->
+                    "the comparison places no constraint this could take in";
+            case NON_CONJUNCTIVE_OUTCOME ->
+                    "the outcome of the condition states one of two things";
+        };
     }
 
     /** The category a search came back with, where the class it was about said nothing itself. */

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1148,29 +1148,28 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // Every other word here is this compiler saying what it did not manage; one of them is the
         // model settling the point, and reading them under one opening sends an author looking for
         // a row nothing can write. Asked of the reason, which is where that decision is written.
-        boolean settled = left.why().reason().provesInfeasible();
-        String opening = settled ? " — " : " — nothing composed one: ";
+        String opening = left.why().reason().provesInfeasible()
+                ? " — " : " — nothing composed one: ";
         return opening + left.why().said().orElseGet(() -> whyUnresolved(left.why()))
-                + (settled ? "" : whatTheRegionLeftOut(left.region(), names, declaredIn));
+                + whatTheRegionLeftOut(left.unaccountedFor(), names, declaredIn);
     }
 
     /**
      * What the search ran over that the way to the border does not account for, where anything did.
      *
-     * <p>Said only where the search settled nothing. A walk of the whole of what the rules leave
-     * that reaches no value settles the point whether or not the box it walked held rows that never
-     * arrive — an empty box leaves what it contains empty too. Everywhere
-     * else the search came back without an answer, and which box it looked in is half of what that
-     * answer is worth.
+     * <p>Which conditions those are, and whether this outcome is one they bear on, is
+     * {@link ItemAssessment.Attempt#unaccountedFor()}'s — so what is left here is the wording. A
+     * report deciding it would be a second reader of the same two facts, and the only way to ask
+     * what it decided would be to compile a model that produces this sentence.
      *
      * <p>What is said is what is known: these conditions are not represented in the region. Not
      * that the region is wider than the rows that reach the line — a condition nothing could take
      * in may be implied by the ones that were, or may hold of every row — and a sentence claiming
      * the wider box would be this report deciding something it has not been shown.
      */
-    private static String whatTheRegionLeftOut(souther.compiler.partition.RegionForARow region,
-                                               SourceNameResolver names, SourceId declaredIn) {
-        List<souther.compiler.partition.OnTheWay.Declined> left = region.declined();
+    private static String whatTheRegionLeftOut(
+            List<souther.compiler.partition.OnTheWay.Declined> left,
+            SourceNameResolver names, SourceId declaredIn) {
         if (left.isEmpty()) {
             return "";
         }
@@ -1191,29 +1190,28 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      * What stopped one condition on the way from narrowing the search, in the words a reader acts
      * on.
      *
-     * <p>One sentence per shape rather than one for all three, and the one that has a rule to name
-     * takes that rule's own words. What an author does about a condition this reading has no words
-     * for is not what they do about a comparison it read and could not use, and neither is what
-     * they do about an arm that states one of two things — a single "was not read" for all of them
-     * is the vocabulary being kept apart in the compiler and put back together on the way out.
+     * <p>One phrase per shape rather than one for all three. What an author does about a condition
+     * this reading has no words for is not what they do about a comparison it could not turn into a
+     * cut, and neither is what they do about an arm that states one of two things — a single "was
+     * not read" for all of them is the vocabulary being kept apart in the compiler and put back
+     * together on the way out.
      */
     private static String whyDeclined(souther.compiler.partition.OnTheWay.Why why) {
+        // Noun phrases, because what the line above them says is "not every condition ... is
+        // represented", and each of these names one of those conditions. Written as sentences, the
+        // place in brackets after them lands after a verb and reads as part of what is being said
+        // rather than as where to look.
         return switch (why) {
-            // What this reading takes apart is a comparison and the two ways of joining them, so
-            // what it stops at is a condition that is neither. Said as "written in a form this
-            // compiler does not read", it would be the sentence a comparison whose form was
-            // unreadable gets, and the two are lifted by different work — a reader for a shape, and
-            // arithmetic for a form.
             case souther.compiler.partition.OnTheWay.Why.NoWordsForTheShape _ ->
-                    "the condition is neither a comparison nor a combination of them";
-            // The rule's own reason, in the words this document already writes for one. A sentence
-            // of this line's own would be a second wording of one answer, and the two would part on
-            // the day either was made more precise.
-            case souther.compiler.partition.OnTheWay.Why.ARuleItCouldNotUse(var reason) ->
-                    "the comparison is "
-                            + whyUnread(souther.compiler.partition.ReportedReason.of(reason));
+                    "a condition that is neither a comparison nor a combination of them";
+            // Not the words a comparison gets for drawing no line: that answers why there is no
+            // boundary, and its answers are wrong about this — a comparison of two constants is a
+            // form nothing reads there, and a form this arithmetic cannot carry is a relation
+            // between positions there, which is something a cut carries perfectly well.
+            case souther.compiler.partition.OnTheWay.Why.ComparisonNotRepresentedAsACut _ ->
+                    "a comparison this reading could not turn into a cut";
             case souther.compiler.partition.OnTheWay.Why.OneOfTwoThings _ ->
-                    "the outcome of the condition states one of two things";
+                    "an outcome that states one of two things";
         };
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/AReportSaysWhatRegionARowWasLookedForInTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AReportSaysWhatRegionARowWasLookedForInTest.java
@@ -85,8 +85,10 @@ class AReportSaysWhatRegionARowWasLookedForInTest {
 
         assertTrue(line.contains("not every condition on the way to the line is represented in the"
                 + " region searched"), line);
-        assertTrue(line.contains("the condition was not read at 17:8"),
-                "and where it is written, so the author has somewhere to look: " + line);
+        assertTrue(line.contains(
+                        "the condition is neither a comparison nor a combination of them (17:8)"),
+                "in the words for the shape this reading stopped at — not the ones a comparison it"
+                        + " could not use gets — and where it is written: " + line);
         // Beside what the search came to and not instead of it. The two answer different questions
         // — what happened, and what the search was looking over — and a reader acts on both.
         assertTrue(line.contains("nothing composed one: every value tried at p.low = 11 was"

--- a/souther-compiler/src/test/java/souther/compiler/AReportSaysWhatRegionARowWasLookedForInTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AReportSaysWhatRegionARowWasLookedForInTest.java
@@ -1,0 +1,123 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A report says what the search for a row was looked over, where the way to the line is not all in
+ * it.
+ *
+ * <p>A row for a border a guard owes is looked for in the region that reaches the guard, and the
+ * same sentence came out whether that region was the declarations because nothing stood on the way,
+ * or the declarations because a condition above could not be read. The second is a limit of this
+ * compiler and the first is not, and an author told only that a search composed nothing had no way
+ * to find out that a guard above the one they are looking at is why.
+ *
+ * <p>Two models whose conditions above the line differ in whether this reading has words for one.
+ * Not a controlled pair beyond that: a readable condition draws a line of its own and narrows the
+ * region below it, so which points a search settles is not the same on both sides — which is the
+ * mechanism working rather than a difference to hold against. What is held here is the sentence: it
+ * is there where something on the way was not accounted for, it is absent where everything was, and
+ * it is added to what the search already said rather than replacing it.
+ */
+class AReportSaysWhatRegionARowWasLookedForInTest {
+
+    /** {@code above} written as the condition over the line, in a model nothing can build a row of. */
+    private static String model(String above) {
+        return """
+                module example.region
+
+                data Ok
+
+                data Amount = Int
+                    invariant range = value >= 0 && value <= 100
+
+                data Tag = String
+                    invariant shape = String.matches("(a+)\\\\1", value)
+
+                data Pair = { low: Amount, high: Amount, tag: Tag }
+                    invariant together = low.value /= high.value
+
+                behavior check : (p: Pair) -> Ok
+
+                let check (p) =
+                    if %s then
+                        if p.low.value > 10 then Ok else Ok
+                    else Ok
+
+                example check
+                    | "one" : (Pair { low = Amount(5), high = Amount(7), tag = Tag("aa") }) -> Ok
+                """.formatted(above);
+    }
+
+    /** A comparison over a string, which draws no line and is on the way to one. */
+    private static final String NOTHING_READS_IT = "String.startsWith(p.tag.value, \"a\")";
+
+    /** The same shape of condition, over a number, which this reading has words for. */
+    private static final String READ = "p.high.value > 3";
+
+    private static String report(String above) {
+        Compilation compilation = Compilation.ofSource(model(above), "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).human(SourceNameResolver.identity());
+    }
+
+    /** The line about one point, which is where what a search came to is written. */
+    private static String about(String point, String above) {
+        String human = report(above);
+        return human.lines()
+                .filter(each -> each.contains("not known to be writable: the " + point))
+                .findFirst().orElseThrow(() -> new AssertionError(human));
+    }
+
+    /** A condition on the way that nothing could take in is said, beside what the search came to. */
+    @Test
+    void aConditionTheRegionDoesNotAccountForIsSaid() {
+        String line = about("ON point check/p.low = 11", NOTHING_READS_IT);
+
+        assertTrue(line.contains("not every condition on the way to the line is represented in the"
+                + " region searched"), line);
+        assertTrue(line.contains("the condition was not read at 17:8"),
+                "and where it is written, so the author has somewhere to look: " + line);
+        // Beside what the search came to and not instead of it. The two answer different questions
+        // — what happened, and what the search was looking over — and a reader acts on both.
+        assertTrue(line.contains("nothing composed one: every value tried at p.low = 11 was"
+                + " refused"), line);
+    }
+
+    /**
+     * And a search that accounted for everything on the way says nothing extra.
+     *
+     * <p>Which is the half that makes the other half worth reading. Said of every search, the
+     * sentence would be a decoration rather than a difference between two models.
+     */
+    @Test
+    void aRegionThatAccountsForTheWholeWayIsNotRemarkedOn() {
+        String line = about("ON point check/p.low = 11", READ);
+
+        assertFalse(line.contains("not every condition on the way"), line);
+    }
+
+    /**
+     * A border with nothing on the way to it says nothing either.
+     *
+     * <p>An invariant is about the values and holds wherever one stands, so there is nowhere for a
+     * row to have come from and nothing that could have gone unaccounted for.
+     */
+    @Test
+    void aLineNothingStandsOnTheWayToIsNotRemarkedOn() {
+        String line = about("ON point check/p.low = 0", NOTHING_READS_IT);
+
+        assertTrue(line.contains("invariant Amount (range)"), line);
+        assertFalse(line.contains("not every condition on the way"), line);
+    }
+
+}

--- a/souther-compiler/src/test/java/souther/compiler/AReportSaysWhatRegionARowWasLookedForInTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AReportSaysWhatRegionARowWasLookedForInTest.java
@@ -86,9 +86,8 @@ class AReportSaysWhatRegionARowWasLookedForInTest {
         assertTrue(line.contains("not every condition on the way to the line is represented in the"
                 + " region searched"), line);
         assertTrue(line.contains(
-                        "the condition is neither a comparison nor a combination of them (17:8)"),
-                "in the words for the shape this reading stopped at — not the ones a comparison it"
-                        + " could not use gets — and where it is written: " + line);
+                        "a condition that is neither a comparison nor a combination of them (17:8)"),
+                "named for the shape this reading stopped at, and where it is written: " + line);
         // Beside what the search came to and not instead of it. The two answer different questions
         // — what happened, and what the search was looking over — and a reader acts on both.
         assertTrue(line.contains("nothing composed one: every value tried at p.low = 11 was"

--- a/souther-compiler/src/test/java/souther/compiler/partition/TheCutsAWalkTookInAreTheOnesARegionIsNarrowedByTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/TheCutsAWalkTookInAreTheOnesARegionIsNarrowedByTest.java
@@ -110,9 +110,9 @@ class TheCutsAWalkTookInAreTheOnesARegionIsNarrowedByTest {
         Recording region = new Recording();
 
         RegionForARow narrowed = RegionForARow.narrowed(region, List.of(
-                new OnTheWay.Declined(somewhere(1), OnTheWay.Why.CONDITION_NOT_READ),
+                new OnTheWay.Declined(somewhere(1), new OnTheWay.Why.NoWordsForTheShape()),
                 new OnTheWay.TakenIn(somewhere(2), only),
-                new OnTheWay.Declined(somewhere(3), OnTheWay.Why.NON_CONJUNCTIVE_OUTCOME)));
+                new OnTheWay.Declined(somewhere(3), new OnTheWay.Why.OneOfTwoThings())));
 
         assertEquals(List.of(only), region.told, "a decline is a record and not a cut");
         assertEquals(2, narrowed.declined().size(), "and it is still on the account");

--- a/souther-compiler/src/test/java/souther/compiler/partition/TheCutsAWalkTookInAreTheOnesARegionIsNarrowedByTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/TheCutsAWalkTookInAreTheOnesARegionIsNarrowedByTest.java
@@ -1,0 +1,148 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.Citation;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.inputs.EmptyInput;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.SearchRegion;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.numeric.NumericDomain.LinearForm;
+import souther.compiler.numeric.NumericDomain.Rel;
+import souther.compiler.source.SourceId;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * A region is narrowed by exactly the conditions its account says were taken in.
+ *
+ * <p>The other half of what {@link RegionForARow} promises. That the cuts a walk took in hold of
+ * every row that arrives is about the walk and is held elsewhere; this is about the pair — that the
+ * region beside an account is the one that account describes, in the order it describes, and that a
+ * condition written down as declined reaches the domains not at all.
+ *
+ * <p>Measured against a region that records what it is told rather than against what the numbers
+ * come to. What a domain does with a cut is the domain's business and two different cuts can leave
+ * one region unchanged, so an answer read off the values would hold just as well if half the
+ * account were fiction.
+ */
+class TheCutsAWalkTookInAreTheOnesARegionIsNarrowedByTest {
+
+    /**
+     * A region that remembers what it was told and refuses everything else.
+     *
+     * <p>Refuses rather than answers. What is under test is which conditions reach the domains, and
+     * a stand-in that answered questions about values would be inventing a region — the day
+     * narrowing starts asking one of them, this says so instead of being read as though the answer
+     * had come from somewhere.
+     */
+    private static final class Recording implements SearchRegion {
+
+        private final List<ReachingCuts.Cut> told = new ArrayList<>();
+
+        @Override
+        public SearchRegion assuming(LinearForm<NumericTerm> form, Rel rel) {
+            told.add(new ReachingCuts.Cut(form, rel));
+            return this;
+        }
+
+        @Override
+        public SearchRegion given(Map<NumericTerm, Count> fixed) {
+            throw new UnsupportedOperationException("narrowing fixes no position");
+        }
+
+        @Override
+        public NumericDomain.Bounds runsBetween(LinearForm<NumericTerm> form) {
+            throw new UnsupportedOperationException("narrowing reads no value");
+        }
+
+        @Override
+        public Optional<EmptyInput> emptiness() {
+            throw new UnsupportedOperationException("narrowing asks nothing about what is left");
+        }
+    }
+
+    private static ReachingCuts.Cut cut(String position, Rel rel) {
+        return new ReachingCuts.Cut(
+                LinearForm.atom(new NumericTerm.ValueOf(TermPath.of(position))), rel);
+    }
+
+    private static Citation somewhere(int line) {
+        return Citation.of(new SourcePos(line, 1, new SourceId("m.sou")));
+    }
+
+    /** Every cut the account carries, in the order it carries them, and nothing else. */
+    @Test
+    void theRegionIsToldTheCutsTheAccountCarries() {
+        ReachingCuts.Cut first = cut("x", Rel.GE);
+        ReachingCuts.Cut second = cut("y", Rel.LT);
+        Recording region = new Recording();
+
+        RegionForARow narrowed = RegionForARow.narrowed(region, List.of(
+                new OnTheWay.TakenIn(somewhere(1), first),
+                new OnTheWay.TakenIn(somewhere(2), second)));
+
+        assertEquals(List.of(first, second), region.told,
+                "the region is narrowed by the cuts the account says it was narrowed by");
+        assertSame(region, narrowed.where(), "and by nothing after them");
+    }
+
+    /**
+     * A condition nothing could take in narrows nothing.
+     *
+     * <p>Which is the direction that keeps a region wide enough to hold the rows that arrive. A
+     * decline that reached the domains would be this compiler narrowing on a condition it could not
+     * read, and the region would then be narrower than the rows it is searched for.
+     */
+    @Test
+    void aDeclinedConditionIsNotToldToTheRegion() {
+        ReachingCuts.Cut only = cut("x", Rel.GE);
+        Recording region = new Recording();
+
+        RegionForARow narrowed = RegionForARow.narrowed(region, List.of(
+                new OnTheWay.Declined(somewhere(1), OnTheWay.Why.CONDITION_NOT_READ),
+                new OnTheWay.TakenIn(somewhere(2), only),
+                new OnTheWay.Declined(somewhere(3), OnTheWay.Why.NON_CONJUNCTIVE_OUTCOME)));
+
+        assertEquals(List.of(only), region.told, "a decline is a record and not a cut");
+        assertEquals(2, narrowed.declined().size(), "and it is still on the account");
+        assertEquals(3, narrowed.provenance().size(),
+                "which holds every condition on the way, in the order the walk met them");
+    }
+
+    /** A border with nothing on the way to it is the region it started as, and says so. */
+    @Test
+    void aRegionWithNothingOnTheWayIsToldNothing() {
+        Recording region = new Recording();
+
+        RegionForARow untouched = RegionForARow.untouched(region);
+
+        assertEquals(List.of(), region.told, "nothing stood on the way, so nothing was taken in");
+        assertEquals(List.of(), untouched.provenance(),
+                "and the account says that rather than being absent");
+        assertSame(region, untouched.where());
+    }
+
+    /** A cut with a constant in it is handed over as written, since a domain is told `f rel 0`. */
+    @Test
+    void aCutIsHandedOverAsTheAccountHoldsIt() {
+        ReachingCuts.Cut shifted = new ReachingCuts.Cut(
+                LinearForm.<NumericTerm>atom(new NumericTerm.ValueOf(TermPath.of("x")))
+                        .minus(LinearForm.constant(new BigDecimal("17"))), Rel.LE);
+        Recording region = new Recording();
+
+        RegionForARow.narrowed(region, List.of(new OnTheWay.TakenIn(somewhere(1), shifted)));
+
+        assertEquals(List.of(shifted), region.told);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatARowSatisfiedOnTheWayDoesNotTurnOnTheSpellingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatARowSatisfiedOnTheWayDoesNotTurnOnTheSpellingTest.java
@@ -79,12 +79,28 @@ class WhatARowSatisfiedOnTheWayDoesNotTurnOnTheSpellingTest {
                 compilation.db().ask(new Adequacy.Inputs(module)).value();
         GuardThresholds.Guards guards =
                 GuardThresholds.of(behavior, body, plan, inputs.get(behavior), symbols);
-        // By what the cuts say and not by which site they are filed under. Two spellings number
-        // their comparisons differently and state the same thing.
+        // By what the walk came to and not by which site it is filed under, nor by where the
+        // conditions are written. Two spellings number their comparisons differently and write
+        // them in different places, and what they state is the same.
         return guards.reaching().byComparison().values().stream()
-                .map(Object::toString)
+                .map(WhatARowSatisfiedOnTheWayDoesNotTurnOnTheSpellingTest::said)
                 .sorted()
                 .toList();
+    }
+
+    /**
+     * What one comparison stands under, with the places left out.
+     *
+     * <p>The cuts and the reasons nothing could be cut from, which is the whole of what two
+     * spellings of one model have to agree about. A place is not: the same condition written two
+     * ways is at two positions, and holding this against the position would be holding it against
+     * the spelling.
+     */
+    private static String said(List<OnTheWay> assumed) {
+        return assumed.stream().map(each -> switch (each) {
+            case OnTheWay.TakenIn taken -> taken.cut().toString();
+            case OnTheWay.Declined left -> left.why().toString();
+        }).toList().toString();
     }
 
     /** The second comparison of a conjunction runs under the first, however the two are joined. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAWalkTakesInHoldsOfEveryRowItLetsThroughTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAWalkTakesInHoldsOfEveryRowItLetsThroughTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
-import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.numeric.NumericDomain.LinearForm;
@@ -190,22 +189,22 @@ class WhatAWalkTakesInHoldsOfEveryRowItLetsThroughTest {
     }
 
     /**
-     * A comparison this could not use carries the reason this compiler already gives for one.
+     * A comparison this reading could not turn into a cut says that, and says no more.
      *
-     * <p>The rule's own account and not a word made up here. Which reason a comparison comes back
-     * with is {@link souther.compiler.check.UnreadComparison}'s, and what it makes of each shape is
-     * held where that lives — a form outside the arithmetic, a carrier no line is drawn on and a
-     * comparison relating two positions are three answers there, and one word here would have been
-     * one answer for all three.
+     * <p>Not the answer the same comparison gets for drawing no line. That question is
+     * {@link souther.compiler.check.UnreadComparison}'s and its answers are about boundaries: a
+     * relation between two positions stops a line there and is carried here without trouble, and a
+     * comparison of two constants comes back there as a form nothing reads when what is true of it
+     * is that it constrains no position.
      */
     @Test
-    void aComparisonItCouldNotUseCarriesTheReasonThisCompilerGivesForOne() {
-        assertEquals(List.of(new OnTheWay.Why.ARuleItCouldNotUse(
-                new BlockReason.UnreadComparisonForm())), whys("product", true));
+    void aComparisonItCouldNotTurnIntoACutSaysThatAndNoMore() {
+        assertEquals(List.of(new OnTheWay.Why.ComparisonNotRepresentedAsACut()),
+                whys("product", true));
         // The affine operand is taken in beside it: a conjunction coming out true says both, and
         // one of them being unreadable is no reason to lose the other.
-        assertEquals(List.of(new OnTheWay.Why.ARuleItCouldNotUse(
-                new BlockReason.UnreadComparisonForm())), whys("withACall", true));
+        assertEquals(List.of(new OnTheWay.Why.ComparisonNotRepresentedAsACut()),
+                whys("withACall", true));
         assertEquals(1, stating("withACall", true).stream()
                 .filter(each -> each instanceof OnTheWay.TakenIn).count());
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAWalkTakesInHoldsOfEveryRowItLetsThroughTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAWalkTakesInHoldsOfEveryRowItLetsThroughTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
+import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.numeric.NumericDomain.LinearForm;
@@ -182,25 +183,29 @@ class WhatAWalkTakesInHoldsOfEveryRowItLetsThroughTest {
      */
     @Test
     void anArmThatStatesOneOfTwoThingsIsDeclinedWhole() {
-        assertEquals(List.of(OnTheWay.Why.NON_CONJUNCTIVE_OUTCOME), whys("both", false));
-        assertEquals(List.of(OnTheWay.Why.NON_CONJUNCTIVE_OUTCOME), whys("either", true));
+        assertEquals(List.of(new OnTheWay.Why.OneOfTwoThings()), whys("both", false));
+        assertEquals(List.of(new OnTheWay.Why.OneOfTwoThings()), whys("either", true));
         assertEquals(List.of(), whys("both", true), "and both operands are taken in the other way");
         assertEquals(List.of(), whys("either", false));
     }
 
     /**
-     * A comparison read as far as it goes that places no constraint is its own answer.
+     * A comparison this could not use carries the reason this compiler already gives for one.
      *
-     * <p>Apart from a condition of a shape nothing reads: what would lift this one is arithmetic
-     * this compiler does not have, and what would lift that one is a reader for a shape. An author
-     * told one word for both is told what neither of them says.
+     * <p>The rule's own account and not a word made up here. Which reason a comparison comes back
+     * with is {@link souther.compiler.check.UnreadComparison}'s, and what it makes of each shape is
+     * held where that lives — a form outside the arithmetic, a carrier no line is drawn on and a
+     * comparison relating two positions are three answers there, and one word here would have been
+     * one answer for all three.
      */
     @Test
-    void aComparisonThatConstrainsNothingIsSaidApartFromAShapeNothingReads() {
-        assertEquals(List.of(OnTheWay.Why.NO_CONSTRAINT_REPRESENTED), whys("product", true));
+    void aComparisonItCouldNotUseCarriesTheReasonThisCompilerGivesForOne() {
+        assertEquals(List.of(new OnTheWay.Why.ARuleItCouldNotUse(
+                new BlockReason.UnreadComparisonForm())), whys("product", true));
         // The affine operand is taken in beside it: a conjunction coming out true says both, and
         // one of them being unreadable is no reason to lose the other.
-        assertEquals(List.of(OnTheWay.Why.NO_CONSTRAINT_REPRESENTED), whys("withACall", true));
+        assertEquals(List.of(new OnTheWay.Why.ARuleItCouldNotUse(
+                new BlockReason.UnreadComparisonForm())), whys("withACall", true));
         assertEquals(1, stating("withACall", true).stream()
                 .filter(each -> each instanceof OnTheWay.TakenIn).count());
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAWalkTakesInHoldsOfEveryRowItLetsThroughTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAWalkTakesInHoldsOfEveryRowItLetsThroughTest.java
@@ -1,0 +1,215 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.inputs.InputReads;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.numeric.NumericDomain.LinearForm;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiPredicate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a walk took in on the way to a comparison holds of every row that gets there.
+ *
+ * <p>The inclusion {@link souther.compiler.inputs.SearchRegion} rests on, at the place it is
+ * established. A region is narrowed by exactly these cuts, so a cut that does not hold of a row
+ * that arrives is a region that excludes it — and a row for a border is then looked for outside the
+ * set of rows that could ever meet it, which is the one direction a coverage measure may not move
+ * in.
+ *
+ * <p>Held against the condition itself rather than against a region. What a domain does with a cut
+ * is the domain's, and two accounts of one condition can leave one region identical; an answer read
+ * off the region would hold as well for a walk that took in something the condition never said.
+ *
+ * <p>And every shape is answered for. A condition this reading has no words for and one it read and
+ * could place no constraint from are both on the list as declines, so a comparison reached under
+ * nothing at all is told from one reached past something nothing could carry — which reading a
+ * report gets is the whole of what an author has to go on.
+ */
+class WhatAWalkTakesInHoldsOfEveryRowItLetsThroughTest {
+
+    private static final String MODEL = """
+            module example.walk
+
+            data Pair = { x: Int, y: Int }
+
+            behavior simple : (p: Pair) -> Bool
+            let simple (p) = p.x > 0
+
+            behavior both : (p: Pair) -> Bool
+            let both (p) = p.x > 0 && p.y > 10
+
+            behavior either : (p: Pair) -> Bool
+            let either (p) = p.x > 0 || p.y > 10
+
+            behavior affineSum : (p: Pair) -> Bool
+            let affineSum (p) = p.x + 2 * p.y <= 7
+
+            behavior withACall : (p: Pair) -> Bool
+            let withACall (p) = p.x > 0 && Int.max(p.y, 3) > 10
+
+            behavior product : (p: Pair) -> Bool
+            let product (p) = p.x * p.y > 4
+
+            behavior nested : (p: Pair) -> Bool
+            let nested (p) = (p.x > 0 || p.y > 1) && p.y < 5
+            """;
+
+    /** The same conditions, as Java reads them. */
+    private static final Map<String, BiPredicate<Integer, Integer>> MEANS = Map.of(
+            "simple", (x, y) -> x > 0,
+            "both", (x, y) -> x > 0 && y > 10,
+            "either", (x, y) -> x > 0 || y > 10,
+            "affineSum", (x, y) -> x + 2 * y <= 7,
+            "withACall", (x, y) -> x > 0 && Math.max(y, 3) > 10,
+            "product", (x, y) -> x * y > 4,
+            "nested", (x, y) -> (x > 0 || y > 1) && y < 5);
+
+    /**
+     * What {@code behavior}'s body states, coming out {@code holding}.
+     *
+     * <p>A body that is one condition, so that what is asked here is the rule itself and not a walk
+     * of a body that happens to reach it.
+     */
+    private static List<OnTheWay> stating(String behavior, boolean holding) {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
+        assertNotNull(checked, "the model under test compiles");
+        Core body = checked.behaviorBodies().get(behavior);
+        assertNotNull(body, () -> "the model under test writes " + behavior);
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        InputReads reads = InputReads.of(
+                compilation.db().ask(new Adequacy.Inputs(module)).value().get(behavior),
+                checked.elementBindings().get(behavior));
+        return ReachingCuts.stating(Condition.of(body, reads), holding, symbols);
+    }
+
+    /** Whether {@code cut} holds where {@code x} and {@code y} stand at these values. */
+    private static boolean holdsAt(ReachingCuts.Cut cut, int x, int y) {
+        LinearForm<NumericTerm> form = cut.form();
+        BigDecimal value = form.constant();
+        for (Map.Entry<NumericTerm, BigDecimal> each : form.coefs().entrySet()) {
+            String term = each.getKey().toString();
+            assertTrue(term.endsWith("x") || term.endsWith("y"),
+                    () -> "the cuts of this model are over its two positions: " + term);
+            value = value.add(each.getValue()
+                    .multiply(BigDecimal.valueOf(term.endsWith("x") ? x : y)));
+        }
+        int against = value.compareTo(BigDecimal.ZERO);
+        return switch (cut.rel()) {
+            case GE -> against >= 0;
+            case GT -> against > 0;
+            case LE -> against <= 0;
+            case LT -> against < 0;
+            case EQ -> against == 0;
+            case NE -> against != 0;
+        };
+    }
+
+    /**
+     * Every cut taken in holds of every row that comes out that way.
+     *
+     * <p>Walked over the whole grid rather than sampled, so that a cut wrong by one is caught at the
+     * value it is wrong at: the thresholds these conditions name are all inside it.
+     */
+    @Test
+    void whatWasTakenInHoldsWhereverTheConditionComesOutThatWay() {
+        for (String behavior : MEANS.keySet()) {
+            for (boolean holding : List.of(true, false)) {
+                List<ReachingCuts.Cut> cuts = stating(behavior, holding).stream()
+                        .filter(each -> each instanceof OnTheWay.TakenIn)
+                        .map(each -> ((OnTheWay.TakenIn) each).cut())
+                        .toList();
+                for (int x = -4; x <= 13; x++) {
+                    for (int y = -4; y <= 13; y++) {
+                        if (MEANS.get(behavior).test(x, y) != holding) {
+                            continue;   // this row does not come here, so nothing is claimed of it
+                        }
+                        for (ReachingCuts.Cut cut : cuts) {
+                            int atX = x;
+                            int atY = y;
+                            assertTrue(holdsAt(cut, x, y),
+                                    () -> behavior + " coming out " + holding + " does not state "
+                                            + cut + ", which fails at x=" + atX + " y=" + atY);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * And every shape of condition is answered for.
+     *
+     * <p>An empty answer is the one thing this may not come back with. A comparison at the top of a
+     * body has nothing on the way to it and a comparison past a condition nothing could read has
+     * something on the way that is not represented — said with an empty list, the two are one
+     * answer, and the second is the one that costs an author a search they cannot account for.
+     */
+    @Test
+    void everyShapeOfConditionIsAnsweredFor() {
+        for (String behavior : MEANS.keySet()) {
+            for (boolean holding : List.of(true, false)) {
+                assertFalse(stating(behavior, holding).isEmpty(),
+                        () -> behavior + " coming out " + holding + " says nothing at all");
+            }
+        }
+    }
+
+    /**
+     * The two ways round a fork's operators say one of two things, and neither is approximated.
+     *
+     * <p>{@code A && B} coming out false says one of them failed and names neither. Taking either
+     * would narrow a region on something no row here satisfies, which is what the answer being a
+     * decline rather than a cut is for — and it is filed at the whole condition, since neither
+     * operand is what could not be carried.
+     */
+    @Test
+    void anArmThatStatesOneOfTwoThingsIsDeclinedWhole() {
+        assertEquals(List.of(OnTheWay.Why.NON_CONJUNCTIVE_OUTCOME), whys("both", false));
+        assertEquals(List.of(OnTheWay.Why.NON_CONJUNCTIVE_OUTCOME), whys("either", true));
+        assertEquals(List.of(), whys("both", true), "and both operands are taken in the other way");
+        assertEquals(List.of(), whys("either", false));
+    }
+
+    /**
+     * A comparison read as far as it goes that places no constraint is its own answer.
+     *
+     * <p>Apart from a condition of a shape nothing reads: what would lift this one is arithmetic
+     * this compiler does not have, and what would lift that one is a reader for a shape. An author
+     * told one word for both is told what neither of them says.
+     */
+    @Test
+    void aComparisonThatConstrainsNothingIsSaidApartFromAShapeNothingReads() {
+        assertEquals(List.of(OnTheWay.Why.NO_CONSTRAINT_REPRESENTED), whys("product", true));
+        // The affine operand is taken in beside it: a conjunction coming out true says both, and
+        // one of them being unreadable is no reason to lose the other.
+        assertEquals(List.of(OnTheWay.Why.NO_CONSTRAINT_REPRESENTED), whys("withACall", true));
+        assertEquals(1, stating("withACall", true).stream()
+                .filter(each -> each instanceof OnTheWay.TakenIn).count());
+    }
+
+    /** What the walk declined, and why, in the order it met them. */
+    private static List<OnTheWay.Why> whys(String behavior, boolean holding) {
+        return stating(behavior, holding).stream()
+                .filter(each -> each instanceof OnTheWay.Declined)
+                .map(each -> ((OnTheWay.Declined) each).why())
+                .toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ASearchThatSettlesThePointOwesNoAccountOfItsRegionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ASearchThatSettlesThePointOwesNoAccountOfItsRegionTest.java
@@ -1,0 +1,116 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.Citation;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.inputs.EmptyInput;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.SearchRegion;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.partition.Generator;
+import souther.compiler.partition.OnTheWay;
+import souther.compiler.partition.RegionForARow;
+import souther.compiler.source.SourceId;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What a search left unaccounted for is asked of the search, and a search that settled the point
+ * left nothing.
+ *
+ * <p>A walk of the whole of what the rules leave that reaches no value proves there is nothing to
+ * find, and it proves it whether or not the box it walked held rows that never arrive:
+ *
+ * <pre>what reaches the point ⊆ the region searched, and the region searched is empty</pre>
+ *
+ * <p>so what reaches the point is empty as well. A condition on the way that nothing represented in
+ * that region takes nothing away from the proof, and telling an author about it there would send
+ * them looking for a row the model has already been shown not to hold.
+ *
+ * <p>Held here rather than against a report. Two outcomes of one search differ only in what the
+ * search came to, and no pair of models produces that pair: a condition a reading takes in narrows
+ * the region and draws a line of its own, so the two sides of a model-level comparison differ in
+ * more than the thing under test. At this end the region is held still and the outcome varied,
+ * which is the comparison the rule is about.
+ */
+class ASearchThatSettlesThePointOwesNoAccountOfItsRegionTest {
+
+    /** A region that answers nothing, which is all a decline needs: nothing narrows it. */
+    private static final class Inert implements SearchRegion {
+
+        @Override
+        public SearchRegion assuming(NumericDomain.LinearForm<NumericTerm> form,
+                                     NumericDomain.Rel rel) {
+            throw new UnsupportedOperationException("nothing here was taken in");
+        }
+
+        @Override
+        public SearchRegion given(Map<NumericTerm, Count> fixed) {
+            throw new UnsupportedOperationException("nothing here fixes a position");
+        }
+
+        @Override
+        public NumericDomain.Bounds runsBetween(NumericDomain.LinearForm<NumericTerm> form) {
+            throw new UnsupportedOperationException("nothing here reads a value");
+        }
+
+        @Override
+        public Optional<EmptyInput> emptiness() {
+            throw new UnsupportedOperationException("nothing here asks what is left");
+        }
+    }
+
+    private static final OnTheWay.Declined LEFT_OUT = new OnTheWay.Declined(
+            Citation.of(new SourcePos(4, 3, new SourceId("m.sou"))),
+            new OnTheWay.Why.NoWordsForTheShape());
+
+    /** One region, with one condition on the way to it that nothing took in. */
+    private static RegionForARow region() {
+        return RegionForARow.narrowed(new Inert(), List.of(LEFT_OUT));
+    }
+
+    private static ItemAssessment.Attempt came(Generator.UnresolvedCombination.Reason to) {
+        return new ItemAssessment.Attempt.Unresolved(
+                new Generator.UnresolvedCombination(List.of("p.x = 11"), to), region());
+    }
+
+    /** A search that settled nothing owes the account: the box it looked in is half the answer. */
+    @Test
+    void aSearchThatSettledNothingOwesWhatItsRegionLeftOut() {
+        assertEquals(List.of(LEFT_OUT),
+                came(Generator.UnresolvedCombination.Reason.SEARCH_LIMIT).unaccountedFor());
+        assertEquals(List.of(LEFT_OUT),
+                came(Generator.UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS).unaccountedFor());
+        assertEquals(List.of(LEFT_OUT),
+                came(Generator.UnresolvedCombination.Reason.LINKAGE_FAILED).unaccountedFor());
+    }
+
+    /** And one that proved there is nothing there owes none of it, over the same region. */
+    @Test
+    void aSearchThatProvedThereIsNothingThereOwesNothing() {
+        assertEquals(List.of(), came(
+                Generator.UnresolvedCombination.Reason.THE_RULES_LEAVE_NOTHING_THERE)
+                .unaccountedFor());
+    }
+
+    /**
+     * A search nobody made owes none of it either, and neither does one that produced a row.
+     *
+     * <p>A row at the point answers the question the search was asked; what it was looked for over
+     * is then a fact about how it was found rather than a caveat on an answer nobody got.
+     */
+    @Test
+    void anAnsweredPointAndAnUnmadeSearchOweNothing() {
+        assertEquals(List.of(), new ItemAssessment.Attempt.Built(
+                new Generator.GeneratedRow(List.of("p.x = 11"), List.of()), region())
+                .unaccountedFor());
+        assertEquals(List.of(), new ItemAssessment.Attempt.NotAttempted(
+                ItemAssessment.Attempt.Reason.NO_CLASSES).unaccountedFor());
+    }
+}


### PR DESCRIPTION
Closes #929.

The region a row for a border is searched in is what the declarations leave, narrowed by the conditions on the way to the guard that owes the line. A condition this compiler has no word for narrows nothing — the direction that keeps the region holding every row that arrives — and it left nothing behind. So a comparison at the top of a body and one reached past a condition nothing could read came back as the same empty list, and the same sentence was printed for both.

`ReachingCuts.narrowing` said so itself: the two are not told apart because nothing downstream acts on the difference. Both are sound, and only one of them is a limit of this compiler.

## What changed

A walk answers for every condition it meets. `OnTheWay` is one condition with what became of it — a cut, or a decline saying what stopped it: a condition that is neither a comparison nor a combination of them, a comparison this reading could not turn into a cut, or an arm that states one of two things. The last is declined whole rather than at an operand. `stating`'s switch has no `default`.

Each word says what this reading did and no more. The reason the same comparison gets for drawing no line is a different question with different answers — `1 < 2` is a form nothing reads there while what is true of it is that it constrains no position — so it is not borrowed here. Telling this end's cases apart belongs to `AffineReading`, which returns nothing and says nothing about why.

`Condition` keeps the node each shape is a reading of, so a decline is filed where the condition stands rather than at whichever operand happened to be first.

`RegionForARow` is the region and the account together, constructible only by narrowing one from the other — `SearchRegion` does not say which conditions it was built from, so nothing could check a pair handed in from outside.

`Attempt.Searched` is the boundary: `Built` and `Unresolved` are what a search of the region came to and carry it; `NotAttempted` is a search nobody made and carries nothing. It is a type because it was a comment, and the one outcome that arrived by another route — decoders that would not link, found by running a candidate the region search had already produced — was filed on the wrong side and dropped its region.

`unaccountedFor()` is the attempt's answer to what the search left unexplained: empty where nothing was left out, and empty where the outcome proves there is nothing to find, since an empty region leaves what it contains empty too. The report words it and decides nothing.

```
· not known to be writable: the ON point check/p.low = 11 (comparison@18:24)
  — nothing composed one: every value tried at p.low = 11 was refused;
    not every condition on the way to the line is represented in the region searched:
    a condition that is neither a comparison nor a combination of them (17:8)
```

What is said is what is known. A decline does not make the region wider than the rows that reach the line: a condition nothing could take in may be implied by the ones that were.

Whether a reason settles the point is `UnresolvedCombination.Reason.provesInfeasible()`, where ADR-0091's decision is read rather than copied into a renderer's condition.

## What did not change

The coverage numbers and `MeasurementStatus`. A condition nothing read on the way does not take a border away and does not make a measure partial: the line is still owed and still measured, and what is affected is where a row for it was looked for.

The JSON form. A boundary item does not carry the attempt, so a `declined` beside it would be provenance of a search the document does not describe. What belongs on the wire is the search itself — `search { result, scope }` — which is a schema version rather than a field.

## Checks

`WhatAWalkTakesInHoldsOfEveryRowItLetsThroughTest` holds the two properties at the walk: every cut taken in holds wherever the condition comes out that way, over the whole grid the thresholds sit in, and no shape of condition comes back with an empty answer. `TheCutsAWalkTookInAreTheOnesARegionIsNarrowedByTest` holds the pair — a recording region is told exactly the cuts the account carries, in order, and a decline reaches it not at all. `ASearchThatSettlesThePointOwesNoAccountOfItsRegionTest` holds one region against several outcomes, which is the comparison no pair of models can make: a readable condition narrows the region and draws a line of its own, so two models differ in more than the thing under test. `AReportSaysWhatRegionARowWasLookedForInTest` holds the sentence.

Each was taken by writing the detour and seeing it red: an arm returning nothing, an arm narrowing on one side of a disjunction, `narrowed` applying a decline, and a settled outcome owing an account. Putting a search's outcome back on the unsearched side no longer compiles.

No ADR. ADR-0091 already decided which reasons a reader may act on; what is added here is that the approximation a search ran over is not lost on the way to the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)