### PR TITLE
Which side of a hole a sum falls is read off everything known

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/numeric/AffineReduction.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/AffineReduction.java
@@ -97,7 +97,7 @@ public final class AffineReduction {
         Map<A, RationalCut> atMost = new LinkedHashMap<>();
         for (AffineConstraint<A> each : constraints) {
             List<AffineConstraint.HalfSpace<A>> halves = each instanceof
-                    AffineConstraint.Disequality<A> hole ? sidedBy(hole, from) : each.halfSpaces();
+                    AffineConstraint.Disequality<A> hole ? sidedBy(hole, reading) : each.halfSpaces();
             if (halves == null) {
                 return new Reduction.NothingIsLeft<>();
             }
@@ -121,19 +121,27 @@ public final class AffineReduction {
      * to go above, then it goes below. And where it is known to be exactly {@code v}, nothing is
      * left.
      *
-     * <p>Asked of the box and so of everything known, rather than of what happened to be known when
-     * the rule was read. That is the whole difference: {@code x /= 0} beside {@code x >= 0} used to
-     * leave {@code x} at nought or above depending on which of the two was written first, because
-     * the answer was decided at the moment the disequality arrived and never revisited. Here it is
-     * decided against the same box every other rule is read against, and again next round if the
-     * box has moved.
+     * <p>Asked of everything known, rather than of what happened to be known when the rule was read.
+     * {@code x /= 0} beside {@code x >= 0} used to leave {@code x} at nought or above depending on
+     * which of the two was written first, because the answer was decided at the moment the
+     * disequality arrived and never revisited. Here it is decided against the same state every other
+     * rule is read against, and again next round if that state has moved.
+     *
+     * <p>Everything known is {@link FormReach} and not the ends alone. A sum is held by things no
+     * position's own range carries — a relation between two of them, a rule naming a third — and
+     * asking the ends for it left a {@code guard} that wrote {@code /=} beside a relation stating
+     * nothing, while the same {@code /=} beside a range on the value itself was read.
+     *
+     * <p>The hole cannot side itself. A disequality states no half-space
+     * ({@link AffineConstraint#halfSpaces}), so it is not among what the reading may take as a
+     * premise, and nothing here has to arrange for that.
      *
      * @return the half-spaces it comes to, empty where the sum can still fall either side, or null
      *         where the sum is pinned at the very value it is held away from
      */
     private static <A> List<AffineConstraint.HalfSpace<A>> sidedBy(
-            AffineConstraint.Disequality<A> hole, Box<A> from) {
-        Reach reach = reachOf(hole.form(), from);
+            AffineConstraint.Disequality<A> hole, FormReach<A> reading) {
+        Reach reach = reading.of(hole.form().coefs(), Rational.ZERO);
         Rational away = hole.at();
         boolean neverBelow = reach.least() != null && reach.least().at().compareTo(away) >= 0;
         boolean neverAbove = reach.most() != null && reach.most().at().compareTo(away) <= 0;
@@ -151,12 +159,6 @@ public final class AffineReduction {
                     hole.form(), RationalCut.exclusive(away)));
         }
         return List.of();
-    }
-
-    /** What the box leaves a whole form, summed the one way this arithmetic is written. */
-    private static <A> Reach reachOf(CanonicalForm<A> form, Box<A> from) {
-        return Reach.of(form.coefs(), Rational.ZERO,
-                atom -> Reach.between(from.leastOf(atom), from.mostOf(atom)));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/AHoleIsSidedByEverythingKnownAndNotByTheEndsAloneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AHoleIsSidedByEverythingKnownAndNotByTheEndsAloneTest.java
@@ -1,0 +1,79 @@
+package souther.compiler;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.Diagnostic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A {@code /=} states no half-space of its own, and which side of the value the sum falls is read
+ * off everything known rather than off each position's own range.
+ *
+ * <p>A sum is held by things no position's range carries — a relation between two of them, a rule
+ * naming a third. Sided by the ranges alone, a {@code guard} writing {@code /=} beside a relation
+ * stated nothing, while the same {@code /=} beside a range on the value itself was read. Which of
+ * those an author wrote is not a distinction the language makes.
+ *
+ * <p>What makes each row here derivable is the whole numbers: a sum above nought and away from it
+ * is at one, so the hole is what turns a bound that does not discharge {@code value >= 1} into one
+ * that does.
+ */
+class AHoleIsSidedByEverythingKnownAndNotByTheEndsAloneTest {
+
+    private static List<String> reported(String guard) {
+        return Compiler.compileWithWarnings("""
+                module demo
+
+                data Positive = Int
+                    invariant value >= 1
+
+                behavior f : (a: Int, b: Int) -> Positive
+                    constructs Positive
+
+                let f (a, b) = {
+                    guard %s else Positive(1)
+                    Positive(a)
+                }
+                """.formatted(guard)).warnings().stream().map(Diagnostic::code).toList();
+    }
+
+    /** What the ranges answer on their own, which they did before this and still do. */
+    @Test
+    void aHoleAtTheEndOfAPositionsOwnRangeSidesIt() {
+        assertEquals(List.of(), reported("a >= 0 && a /= 0"));
+    }
+
+    /** The same argument through a difference, which is held by the closed relations and by neither
+     *  position's range. */
+    @Test
+    void aHoleOverADifferenceIsSidedByTheRelationThatHoldsIt() {
+        assertEquals(List.of(), reported("b >= 0 && b <= 5 && a - b >= 0 && a - b /= 0"));
+    }
+
+    /**
+     * And through a sum the relations cannot hold.
+     *
+     * <p>Weighed ten and minus one, so it is a rule rather than a difference and the closure holds
+     * nothing about it as a pair. It sides the hole all the same, which is the half of this that
+     * reading the relations alone does not answer.
+     */
+    @Test
+    void aHoleOverASumTheRelationsCannotHoldIsSidedByTheRuleThatDoes() {
+        assertEquals(List.of(),
+                reported("b >= 0 && b <= 5 && a * 10 - b >= 0 && a * 10 - b /= 0"));
+    }
+
+    /**
+     * The control, and the reason the rows above mean anything.
+     *
+     * <p>The same guards with the hole taken out. Nothing then puts {@code a} above nought, so the
+     * construction is owed and the report is the check working.
+     */
+    @Test
+    void withoutTheHoleThereIsNothingToSideAndItIsStillReported() {
+        assertEquals(List.of("E2011"), reported("b >= 0 && b <= 5 && a - b >= 0"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/numeric/ARuleOverSeveralPositionsNarrowsEachOfThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/ARuleOverSeveralPositionsNarrowsEachOfThemTest.java
@@ -397,16 +397,28 @@ class ARuleOverSeveralPositionsNarrowsEachOfThemTest {
                 continue;
             }
             long constant = dice.nextInt(21) - 10;
-            Rel rel = switch (dice.nextInt(5)) {
-                case 0 -> Rel.LT;
-                case 1 -> Rel.GE;
-                case 2 -> Rel.GT;
-                case 3 -> Rel.EQ;
-                default -> Rel.LE;
-            };
-            out.add(new Written(coefs, num(constant), rel));
+            out.add(new Written(coefs, num(constant), someRelation(dice)));
         }
         return out;
+    }
+
+
+    /**
+     * One of the relations a rule can be written with, taken from the enum rather than from a list.
+     *
+     * <p>Written out, this was a copy of {@link Rel} that nothing compared against it, and the
+     * {@code default} arm meant it went on compiling however far the two drifted. They did: one
+     * generator here left out {@code /=} and the one beside it left out {@code /=} and {@code >},
+     * so the properties these tests hold — sound against the points, the same whatever order the
+     * rules arrived in, never wider for a narrower box — were never asked of a rule of that shape.
+     * The reading that decides which side of a hole a sum falls went unchecked by all three.
+     *
+     * <p>Taken from the values, a relation added to the language is generated here without anyone
+     * remembering to add it.
+     */
+    private static Rel someRelation(Random dice) {
+        Rel[] all = Rel.values();
+        return all[dice.nextInt(all.length)];
     }
 
     private static List<AffineConstraint<String>> read(List<Written> written) {

--- a/souther-compiler/src/test/java/souther/compiler/numeric/OneStateAnswersForWhatTheRulesLeaveTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/OneStateAnswersForWhatTheRulesLeaveTest.java
@@ -268,15 +268,28 @@ class OneStateAnswersForWhatTheRulesLeaveTest {
             if (coefs.isEmpty()) {
                 continue;
             }
-            Rel rel = switch (dice.nextInt(4)) {
-                case 0 -> Rel.LT;
-                case 1 -> Rel.GE;
-                case 2 -> Rel.EQ;
-                default -> Rel.LE;
-            };
-            out.add(new Written(coefs, num(dice.nextInt(15) - 7), rel));
+            out.add(new Written(coefs, num(dice.nextInt(15) - 7), someRelation(dice)));
         }
         return out;
+    }
+
+
+    /**
+     * One of the relations a rule can be written with, taken from the enum rather than from a list.
+     *
+     * <p>Written out, this was a copy of {@link Rel} that nothing compared against it, and the
+     * {@code default} arm meant it went on compiling however far the two drifted. They did: one
+     * generator here left out {@code /=} and the one beside it left out {@code /=} and {@code >},
+     * so the properties these tests hold — sound against the points, the same whatever order the
+     * rules arrived in, never wider for a narrower box — were never asked of a rule of that shape.
+     * The reading that decides which side of a hole a sum falls went unchecked by all three.
+     *
+     * <p>Taken from the values, a relation added to the language is generated here without anyone
+     * remembering to add it.
+     */
+    private static Rel someRelation(Random dice) {
+        Rel[] all = Rel.values();
+        return all[dice.nextInt(all.length)];
     }
 
     private static List<AffineConstraint<String>> read(List<Written> written) {


### PR DESCRIPTION
Closes #961. Stacked on #958 — base is `feature/issue-935`, and this retargets to `develop` once that merges. The only commit of its own is `1263e906`.

## What was wrong

`f /= v` states no half-space. Which side of `v` the sum lies is something the rest of what is known says, and `sidedBy` asked the ends — each position's own range, summed. Its javadoc called that "the box and so everything known", which the existence of `FormReach` already contradicts: a sum is held by things no position's range carries.

`Positive(a)` with `invariant value >= 1`, under each guard:

| guard | before | after |
|---|---|---|
| `a >= 0 && a /= 0` | — | — |
| `b >= 0 && b <= 5 && a - b >= 0 && a - b /= 0` | E2011 | — |
| `b >= 0 && b <= 5 && a * 10 - b >= 0 && a * 10 - b /= 0` | E2011 | — |
| `b >= 0 && b <= 5 && a - b >= 0` | E2011 | E2011 |

Row one is what the ends answer on their own. Rows two and three are the same argument through a relation — `a - b` above nought and away from it is at one over the whole numbers, so `a` is at one — and neither was read. Row two's relation is difference-shaped and sits in the closed differences; row three's is weighed ten and minus one and is a rule. Both were held the whole time. Row four is the control: no hole, nothing to derive, correctly reported.

## What changed

`sidedBy` reads `FormReach`, and `reachOf` goes with it. Nothing in `AffineReduction` derives a bound on a form for itself any more.

The hole cannot side itself — a disequality states no half-space (`AffineConstraint.halfSpaces`), so it is never among what the reading may take as a premise, and nothing here arranges for that.

## Why not in #958

That change made bounds provable that were not. This one turns holes that were contributing nothing into strict half-spaces. Different observable surfaces, so they are worth bisecting apart.

## Tests

Reverting `sidedBy` alone turns exactly the two relational rows red and leaves the ends-only row and the control green:

```
AHoleIsSidedByEverythingKnown…aHoleOverADifferenceIsSidedByTheRelationThatHoldsIt      expected <[]> but was <[E2011]>
AHoleIsSidedByEverythingKnown…aHoleOverASumTheRelationsCannotHoldIsSidedByTheRuleDoes  expected <[]> but was <[E2011]>
```

Full clean suite green, +4 tests, nothing else moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)