### PR TITLE
A type guarantee has one reading, and choice settlement is a second consumer of it

### DIFF
--- a/souther-bench/src/test/java/souther/bench/AReaderOfHowAnArmWasDecidedNamesEveryWayThereIsTest.java
+++ b/souther-bench/src/test/java/souther/bench/AReaderOfHowAnArmWasDecidedNamesEveryWayThereIsTest.java
@@ -54,7 +54,10 @@ class AReaderOfHowAnArmWasDecidedNamesEveryWayThereIsTest {
      * keep to one.
      */
     private static final Map<String, String> READERS = new LinkedHashMap<>(Map.of(
-            "souther.compiler.check.Terms#choosing", "what choosing the arm binds",
+            "souther.compiler.check.Terms#chose", "what choosing the arm binds, and the value it"
+                    + " opened. Both from one reader: a recipe wanting to say what that value's type"
+                    + " guarantees needs the second half, and working it out for itself would be a"
+                    + " second account of this node",
             "souther.compiler.check.Conditions#settledBy", "what choosing the arm states, as"
                     + " relations",
             "souther.compiler.check.InvariantChecker#opening", "what a walk over paths reads of it:"

--- a/souther-compiler/src/main/java/souther/compiler/check/Conditions.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Conditions.java
@@ -45,8 +45,9 @@ final class Conditions {
      * ({@link Derivation.Chosen.Arm}), and worth keeping straight.
      *
      * <p>A case and an attempt state nothing here. What choosing them settles is what the value's
-     * type guarantees of what the arm binds, which is a guarantee about a place rather than a
-     * relation a condition wrote, and it is read where places are seeded.
+     * type guarantees of what the arm binds, which is a declaration's answer and not a relation a
+     * condition wrote, so it is read through the one reading of a declaration there is
+     * ({@link TypeGuarantees}) and composed with this beside the arm ({@link Terms#chosen}).
      *
      * <p>An operation the library defines by cases states the relations its case is reached under,
      * which arrive already lowered to the values the call was given ({@link Choice}). Nothing about
@@ -65,8 +66,9 @@ final class Conditions {
      * and not statements the condition makes. An arm read here is read without them, so
      * {@code List.size(xs)} under {@code not List.isEmpty(xs)} comes to "not nought" here where the
      * walk has "above nought". Not two readings of one question — it is one question this reader
-     * does not ask — but the same family as the type guarantees a case and an attempt rest on, and
-     * it is answered where those are (#982).
+     * does not ask. What a case and an attempt rest on is the same family and is now asked, of the
+     * value the arm opens; this is the value a condition <em>names</em>, which no arm opened and
+     * nothing here has been given a place to read from.
      */
     static List<NumericConstraint> settledBy(Terms terms, Choice.Decides decidedBy, Denotations at) {
         List<NumericConstraint> out = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/Conditions.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Conditions.java
@@ -66,9 +66,10 @@ final class Conditions {
      * and not statements the condition makes. An arm read here is read without them, so
      * {@code List.size(xs)} under {@code not List.isEmpty(xs)} comes to "not nought" here where the
      * walk has "above nought". Not two readings of one question — it is one question this reader
-     * does not ask. What a case and an attempt rest on is the same family and is now asked, of the
-     * value the arm opens; this is the value a condition <em>names</em>, which no arm opened and
-     * nothing here has been given a place to read from.
+     * does not ask. It was written down as the same family as what a case and an attempt rest on,
+     * and it is not: a value built through a checked constructor carries what its declaration
+     * states ({@link TypeGuarantees}), and a list carries a length that is never negative because of
+     * what a length is, with no declaration saying so. A third source, and #988.
      */
     static List<NumericConstraint> settledBy(Terms terms, Choice.Decides decidedBy, Denotations at) {
         List<NumericConstraint> out = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
@@ -9,6 +9,7 @@ import souther.compiler.types.TypeSymbol;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -77,7 +78,10 @@ public record ContractDischarge(List<RuleDischarge> rules,
             named.add(param.binding());
         }
         named.add(rule.value());
-        Terms naming = new Terms(symbols, policy);
+        // Its own reading, over the clauses every declaration writes: a type another module
+        // declares is read off its declaration either way, and nothing here reads one at all.
+        Terms naming = new Terms(symbols, Terms.Of.THE_DISCHARGE_TREE, policy,
+                new Clauses(symbols, Map.of()));
         Denotations locations =
                 Denotations.none().locations(named, naming::placeSubject, naming::placeTerm);
 

--- a/souther-compiler/src/main/java/souther/compiler/check/GuaranteeWalk.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/GuaranteeWalk.java
@@ -32,6 +32,19 @@ final class GuaranteeWalk {
     }
 
     /**
+     * How far into a value's fields a walk over a body can afford to read.
+     *
+     * <p>A type's own invariant is what its fields guarantee, and a field's type carries its own;
+     * past a couple of levels what a clause could be read against is a value the body would have had
+     * to name, and it names it by reading it.
+     *
+     * <p>A cost bound and not a rule of the model: a rule four records down refuses the outermost
+     * construction exactly as one on its own fields does. What a construction has to satisfy has no
+     * depth at all, and a reader answering for that asks for one that has none.
+     */
+    static final int FIELDS_SEEDED = 2;
+
+    /**
      * How far a reader is asking this walk to go.
      *
      * <p>Not one number for everybody. What a walk over a body can afford to read of a parameter is

--- a/souther-compiler/src/main/java/souther/compiler/check/GuaranteeWalk.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/GuaranteeWalk.java
@@ -1,0 +1,164 @@
+package souther.compiler.check;
+
+import souther.compiler.core.Core;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * A reader taken over the positions under a value, told what each one guarantees.
+ *
+ * <p>Mechanism and not meaning. What a declaration says is {@link TypeGuarantees}' answer and this
+ * asks for it a position at a time; what this owns is getting to the positions — how deep to go,
+ * which names were to be left out, and stopping where a record holds another of its own kind. Two
+ * readers may walk to different depths and still be reading one model, which is the whole point of
+ * keeping the two apart: a scope changes which positions were visited, never what a declaration
+ * states at one.
+ *
+ * <p>Nothing here decides what a stop costs. A reader is told where the walk stopped and answers
+ * that for itself, because the same stop means different things to different readers: a measurement
+ * that has to account for every rule owes a line for what it did not read, and a reading that only
+ * wants the relations it can state is short of nothing.
+ */
+final class GuaranteeWalk {
+
+    private final TypeGuarantees guarantees;
+
+    GuaranteeWalk(TypeGuarantees guarantees) {
+        this.guarantees = guarantees;
+    }
+
+    /**
+     * How far a reader is asking this walk to go.
+     *
+     * <p>Not one number for everybody. What a walk over a body can afford to read of a parameter is
+     * a cost bound; what a construction has to satisfy has no depth at all, since a rule four
+     * records down refuses the outermost value exactly as one on the top does.
+     *
+     * @param depth           how many positions down to read
+     * @param stopAt          names this reader is supposing hold values whatever is written under
+     *                        them, so nothing under one of them is read
+     * @param withoutClauses  names whose own clauses this reader asked to leave out, what is under
+     *                        them still being read
+     */
+    record Scope(int depth, Predicate<TypeSymbol> stopAt, Predicate<TypeSymbol> withoutClauses) {
+
+        /** Every rule down to {@code depth} positions, wherever it is written. */
+        static Scope asFarAs(int depth) {
+            return new Scope(depth, _ -> false, _ -> false);
+        }
+    }
+
+    /** Told what was read, and where the reading stopped. */
+    interface Reader {
+
+        /** What the declaration at {@code path} guarantees of the value there. */
+        void guaranteed(String path, TypeGuarantee guarantee);
+
+        /** Where the walk went no further, and what stood there. */
+        default void stopped(String path, Type type, Stop why) {}
+
+        /** That a declaration at {@code path} writes clauses this reading could not state, so what
+         * they were about is not among what was handed over. */
+        default void lostAClause(String path) {}
+    }
+
+    /** Why a walk went no further. */
+    enum Stop {
+
+        /** As far down as the reader asked to be taken. Not a limit on the model: a rule four
+         * records down refuses the outermost construction exactly as one on its own fields does. */
+        PAST_THE_DEPTH,
+
+        /** Nothing is declared here that could hold a rule about every value standing at it: a
+         * container or an optional, a type nothing is written under, or a choice between
+         * declarations, whose rules are about values of one case and not about every value here. */
+        NOTHING_DECLARED,
+
+        /** A name the reader is supposing holds values, so what is under it says nothing here. */
+        ASKED_TO_STOP,
+
+        /** Met already on the way down, and read where it was met. A record holding one of its own
+         * kind stops here and nothing is short of anything for it. */
+        ALREADY_ENTERED,
+
+        /** A declaration names a position the walk could find no value for. */
+        NO_VALUE_THERE
+    }
+
+    /**
+     * Take {@code reader} over {@code root} and the positions beneath it.
+     *
+     * <p>{@code path} names where {@code root} itself stands, and every position is named relative
+     * to it.
+     */
+    void from(Core root, String path, Denotations at, Scope scope, Reader reader) {
+        walk(root, path, at, 0, scope, new HashSet<>(), reader);
+    }
+
+    private void walk(Core root, String path, Denotations at, int depth, Scope scope,
+                      Set<TypeSymbol> entered, Reader reader) {
+        // Asked one at a time, because a stop says two things and only one of them is the same for
+        // all of these: whether the rules under it were read, and whether a construction could have
+        // got out of making the value they are about.
+        if (depth > scope.depth()) {
+            reader.stopped(path, root.type(), Stop.PAST_THE_DEPTH);
+            return;
+        }
+        if (!(root.type() instanceof Type.Ref ref)) {
+            // Nothing here is named, so there is nothing this walk could have been told to stop at
+            // and nothing to record as entered.
+            reader.stopped(path, root.type(), Stop.NOTHING_DECLARED);
+            return;
+        }
+        // Asked of the name and before the reading, because being told to stop at a name is this
+        // walk's business and says nothing about what the declaration states.
+        if (scope.stopAt().test(ref.name())) {
+            reader.stopped(path, root.type(), Stop.ASKED_TO_STOP);
+            return;
+        }
+        if (!(guarantees.at(root, at) instanceof TypeGuarantees.At.Declared here)) {
+            reader.stopped(path, root.type(), Stop.NOTHING_DECLARED);
+            return;
+        }
+        // Entered before anything under it is walked, so that the one name and the other stay
+        // paired: a stop taken after entering would leave the name on the path with nothing to take
+        // it off, and the next field of the same type would be passed over as one already read.
+        if (!entered.add(here.name())) {
+            reader.stopped(path, root.type(), Stop.ALREADY_ENTERED);
+            return;
+        }
+        // What the declaration states is read whatever this walk was asked for; whether this reader
+        // hears it is the scope's answer. A reader told to leave a declaration's clauses out was not
+        // asked to lose any, so nothing is reported lost for them either.
+        if (!scope.withoutClauses().test(here.name())) {
+            if (!here.everyClauseStated()) {
+                reader.lostAClause(path);
+            }
+            for (TypeGuarantee guarantee : here.guarantees()) {
+                reader.guaranteed(path, guarantee);
+            }
+        }
+        for (TypeGuarantees.At.Beneath under : here.beneath()) {
+            // A position wearing a name is at a path of its own; a newtype's value is the same
+            // position and keeps this one's, which is the rule a path walks by: wearing a name is
+            // not being somewhere else.
+            String there = under.field().isEmpty() ? path : under(path, under.field());
+            if (under.value() == null) {
+                reader.stopped(there, under.type(), Stop.NO_VALUE_THERE);
+            } else {
+                walk(under.value(), there, at, depth + 1, scope, entered, reader);
+            }
+        }
+        entered.remove(here.name());
+    }
+
+    /** A field of the value at {@code path}. The root of a newtype's own reading is the value it
+     * wraps, which is at no path of its own, so its fields are the first step there is. */
+    static String under(String path, String field) {
+        return path.isEmpty() ? field : path + "." + field;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/GuaranteeWalk.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/GuaranteeWalk.java
@@ -133,6 +133,14 @@ final class GuaranteeWalk {
             reader.stopped(path, root.type(), Stop.ASKED_TO_STOP);
             return;
         }
+        // Asked before the declaration is read, and of the type's own name, which is the name a
+        // reading here would answer with. A name already entered was read where it was met, so
+        // reading it again would be the same reading done twice — which costs, and which a reader
+        // that remembers what it was asked would see twice.
+        if (entered.contains(ref.name())) {
+            reader.stopped(path, root.type(), Stop.ALREADY_ENTERED);
+            return;
+        }
         if (!(guarantees.at(root, at) instanceof TypeGuarantees.At.Declared here)) {
             reader.stopped(path, root.type(), Stop.NOTHING_DECLARED);
             return;
@@ -140,10 +148,7 @@ final class GuaranteeWalk {
         // Entered before anything under it is walked, so that the one name and the other stay
         // paired: a stop taken after entering would leave the name on the path with nothing to take
         // it off, and the next field of the same type would be passed over as one already read.
-        if (!entered.add(here.name())) {
-            reader.stopped(path, root.type(), Stop.ALREADY_ENTERED);
-            return;
-        }
+        entered.add(here.name());
         // What the declaration states is read whatever this walk was asked for; whether this reader
         // hears it is the scope's answer. A reader told to leave a declaration's clauses out was not
         // asked to lose any, so nothing is reported lost for them either.

--- a/souther-compiler/src/main/java/souther/compiler/check/GuaranteeWalk.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/GuaranteeWalk.java
@@ -47,21 +47,68 @@ final class GuaranteeWalk {
     /**
      * How far a reader is asking this walk to go.
      *
-     * <p>Not one number for everybody. What a walk over a body can afford to read of a parameter is
-     * a cost bound; what a construction has to satisfy has no depth at all, since a rule four
-     * records down refuses the outermost value exactly as one on the top does.
-     *
-     * @param depth           how many positions down to read
+     * @param extent          how far down to read
      * @param stopAt          names this reader is supposing hold values whatever is written under
      *                        them, so nothing under one of them is read
      * @param withoutClauses  names whose own clauses this reader asked to leave out, what is under
      *                        them still being read
      */
-    record Scope(int depth, Predicate<TypeSymbol> stopAt, Predicate<TypeSymbol> withoutClauses) {
+    record Scope(Extent extent, Predicate<TypeSymbol> stopAt, Predicate<TypeSymbol> withoutClauses) {
 
-        /** Every rule down to {@code depth} positions, wherever it is written. */
-        static Scope asFarAs(int depth) {
-            return new Scope(depth, _ -> false, _ -> false);
+        /** Every rule down to {@code positions} positions, wherever it is written. */
+        static Scope asFarAs(int positions) {
+            return new Scope(new Extent.AsFarAs(positions), _ -> false, _ -> false);
+        }
+
+        /** Every rule the model writes under this value. */
+        static Scope everyPosition() {
+            return new Scope(new Extent.EveryPosition(), _ -> false, _ -> false);
+        }
+    }
+
+    /**
+     * How far down a reader reads.
+     *
+     * <p>Two answers and not one number. A reader that cannot afford the whole value states what it
+     * can afford; a reader whose question has no depth in it says so. Held as a number for both,
+     * the second has to invent one — and the numbers that get invented are a bound belonging to some
+     * other question, or a sentinel standing for "not applicable" inside a type that cannot say it.
+     * Either way the depth a reader could afford becomes part of what a declaration is taken to say.
+     */
+    sealed interface Extent {
+
+        /** Whether a position {@code down} steps from the root is one this reader reads. */
+        boolean reaches(int down);
+
+        /**
+         * As far as the model goes.
+         *
+         * <p>What a value guarantees has no depth in it: a rule four records down refuses the
+         * outermost value exactly as one on the top does, and a reading that stopped short would
+         * make what a declaration says depend on how deeply an author nested a field. Terminating
+         * because a name met on the way down is not entered again, which is a fact about the type
+         * graph and not a budget.
+         */
+        record EveryPosition() implements Extent {
+
+            @Override
+            public boolean reaches(int down) {
+                return true;
+            }
+        }
+
+        /**
+         * As far as {@code positions} steps down, and no further.
+         *
+         * <p>A cost bound, and only ever that. A reader states one where reading further is work it
+         * cannot afford — never where the question it is asking runs deeper than it wants to go.
+         */
+        record AsFarAs(int positions) implements Extent {
+
+            @Override
+            public boolean reaches(int down) {
+                return down <= positions;
+            }
         }
     }
 
@@ -117,7 +164,7 @@ final class GuaranteeWalk {
         // Asked one at a time, because a stop says two things and only one of them is the same for
         // all of these: whether the rules under it were read, and whether a construction could have
         // got out of making the value they are about.
-        if (depth > scope.depth()) {
+        if (!scope.extent().reaches(depth)) {
             reader.stopped(path, root.type(), Stop.PAST_THE_DEPTH);
             return;
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -342,7 +342,7 @@ public final class InvariantChecker {
         }
         try {
             return CapabilityResult.of(
-                    predicates.obligations(it.value(), Known.top(), locations, false));
+                    predicates.assumed(it.value(), locations, false));
         } catch (RuntimeException why) {
             // Fail-open, as the walk is — and said as a stop rather than as a conclusion, because
             // what the clause is outside of is what this did not find out.
@@ -564,7 +564,7 @@ public final class InvariantChecker {
                 // decide for itself which of the rules that draw a line it was looking at.
                 RuleRef.Invariant origin = new RuleRef.Invariant(Clause.Ref.of(declared));
                 written.add(new Written(origin, stated));
-                Predicates.Owed owed = c.predicates.obligations(stated, k, at, false,
+                Predicates.Owed owed = c.predicates.assumed(stated, at, false,
                         (part, said) -> gathering.constrained(origin, part, partRead(said)));
                 // And the reading that builds the numeric constraints, said by what it produced.
                 // `value * 2 >= 4` is beyond the two readings below and is taken in here about the

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -764,7 +764,7 @@ public final class InvariantChecker {
         }
         for (Map.Entry<String, Type> field : clauses.fieldsOf(data).entrySet()) {
             name(new Core.FieldAccess(inner, field.getKey(), field.getValue(), NOWHERE),
-                    PathEngine.under(path, field.getKey()), field.getValue(), at, symbols, depth + 1,
+                    GuaranteeWalk.under(path, field.getKey()), field.getValue(), at, symbols, depth + 1,
                     atoms, typeAt, held, keys);
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -758,7 +758,7 @@ public final class InvariantChecker {
             inner = new Core.FieldAccess(inner, "value", under, NOWHERE);
             worn = under;
         }
-        if (depth > PathEngine.FIELDS_SEEDED || !(worn instanceof Type.Ref ref)
+        if (depth > GuaranteeWalk.FIELDS_SEEDED || !(worn instanceof Type.Ref ref)
                 || !(symbols.declarations().declaration(ref.name().key()) instanceof Hir.Data data) || data.newtype()) {
             return;
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -584,7 +584,7 @@ public final class InvariantChecker {
                     // rule the construction must satisfy is a rule wherever in the value it sits.
                     k = c.engine.seedAt(new Core.Read(field.getKey(), field.getValue(), type, NOWHERE),
                             data.newtype() ? FieldDomains.THE_VALUE : field.getKey(),
-                            k, at, 1, Integer.MAX_VALUE, new HashSet<>(), gathering, reach);
+                            k, at, 1, Integer.MAX_VALUE, gathering, reach);
                 }
             }
             Map<String, FactSubject> atoms = new LinkedHashMap<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -580,11 +579,11 @@ public final class InvariantChecker {
             for (Map.Entry<String, BindingId> field : bindings.entrySet()) {
                 Type type = fields.get(field.getKey());
                 if (type != null) {
-                    // No depth limit here: this is the reading a boundary is derived from, and a
-                    // rule the construction must satisfy is a rule wherever in the value it sits.
+                    // Every position: this is the reading a boundary is derived from, and a rule
+                    // the construction must satisfy is a rule wherever in the value it sits.
                     k = c.engine.seedAt(new Core.Read(field.getKey(), field.getValue(), type, NOWHERE),
                             data.newtype() ? FieldDomains.THE_VALUE : field.getKey(),
-                            k, at, 1, Integer.MAX_VALUE, gathering, reach);
+                            k, at, new GuaranteeWalk.Extent.EveryPosition(), gathering, reach);
                 }
             }
             Map<String, FactSubject> atoms = new LinkedHashMap<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -50,10 +50,6 @@ final class PathEngine {
      */
     static List<Core> SEEDED;
 
-    /** How far into a value's fields the seeding reads. A type's own invariant is what its fields
-     * guarantee, and a field's type carries its own; past a couple of levels what a clause could be
-     * read against is a value the body would have had to name, and it names it by reading it. */
-    static final int FIELDS_SEEDED = 2;
 
     private final Symbols symbols;
     /** The declarations' invariants, typed where they are declared and read where a value is built. */
@@ -99,7 +95,7 @@ final class PathEngine {
                ReadingPolicy policy) {
         this.symbols = symbols;
         this.clauses = new Clauses(symbols, dischargeInvariants);
-        this.terms = new Terms(symbols, reading, policy);
+        this.terms = new Terms(symbols, reading, policy, clauses);
         this.predicates = new Predicates(terms);
         this.guarantees = new TypeGuarantees(symbols, clauses, predicates);
         this.walk = new GuaranteeWalk(guarantees);
@@ -568,7 +564,7 @@ final class PathEngine {
      * only in direction.
      */
     Known seedAt(Core root, Known k, Denotations at, int depth) {
-        return seedAt(root, FieldDomains.THE_VALUE, k, at, depth, FIELDS_SEEDED, new HashSet<>(),
+        return seedAt(root, FieldDomains.THE_VALUE, k, at, depth, GuaranteeWalk.FIELDS_SEEDED, new HashSet<>(),
                 null, InvariantChecker.Reach.EVERYTHING);
     }
 
@@ -576,7 +572,7 @@ final class PathEngine {
      * The same, as far as {@code limit} levels down, with the types on the way recorded.
      *
      * <p>How far to seed is not one number. What a walk over a body can afford to read of a
-     * parameter is a cost bound and stops at {@code FIELDS_SEEDED}; what a construction has to
+     * parameter is a cost bound and stops at {@link GuaranteeWalk#FIELDS_SEEDED}; what a construction has to
      * satisfy has no depth at all, since a rule four records down refuses the outermost value
      * exactly as one on the top does. A projection that stopped at two and was then classified by a
      * walk that did not would call a bound complete that a rule below it moves.

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -62,6 +62,9 @@ final class PathEngine {
     private final Terms terms;
     /** What a clause owes and what a guard settles. */
     private final Predicates predicates;
+
+    /** The one reading of what a declaration guarantees. This walk is one of its consumers. */
+    private final TypeGuarantees guarantees;
     /** What each behavior a body may call states about its answer, by the name it is called under. */
     private final Map<ValueName.Behavior, StatedContract> contracts;
 
@@ -95,6 +98,7 @@ final class PathEngine {
         this.clauses = new Clauses(symbols, dischargeInvariants);
         this.terms = new Terms(symbols, reading, policy);
         this.predicates = new Predicates(terms);
+        this.guarantees = new TypeGuarantees(symbols, clauses, predicates);
         this.contracts = Map.copyOf(contracts);
     }
 
@@ -587,11 +591,6 @@ final class PathEngine {
     Known seedAt(Core root, String path, Known k, Denotations at, int depth, int limit,
                  Set<TypeSymbol> onPath, InvariantChecker.Gathering gathering,
                  InvariantChecker.Reach reach) {
-        // Read before the path is entered, so that the one name and the other stay paired: a stop
-        // taken after entering would leave the name on the path with nothing to take it off, and the
-        // next field of the same type would be passed over as one already read. Supposed to hold
-        // values, so nothing written under it is read: what is under it is what would say it holds
-        // none, and reading it here is the supposing undone one step in.
         // Asked one at a time, because a stop says two things and only one of them is the same for
         // all of these: whether the rules under it were read, and whether a construction could have
         // got out of making the value they are about.
@@ -603,91 +602,67 @@ final class PathEngine {
                     InvariantChecker.Borne.BY_EVERY_VALUE);
         }
         if (!(root.type() instanceof Type.Ref ref)) {
-            // Not a declaration of its own: a container or an optional, whose element is a value
-            // that need not be there, or a type nothing is written under at all.
+            // Nothing here is named, so there is nothing this walk could have been told to stop at
+            // and nothing to record as entered. What may be declared is the reading's question and
+            // is asked below.
             return declining(root.type(), path, gathering, k,
                     InvariantChecker.Borne.BY_SOME_VALUES);
         }
+        // Asked of the name and before the reading, because being told to stop at a name is this
+        // walk's business and says nothing about what the declaration states. Supposed to hold
+        // values, so nothing written under it is read: what is under it is what would say it holds
+        // none, and reading it here is the supposing undone one step in.
         if (reach.stopAt().test(ref.name())) {
             // Left out because this reading was asked to leave it out, which is still a rule of a
             // value every construction has to make.
             return declining(root.type(), path, gathering, k,
                     InvariantChecker.Borne.BY_EVERY_VALUE);
         }
-        if (!(symbols.declarations().declaration(ref.name().key()) instanceof Hir.Data data)) {
-            // A choice between declarations, which is the only kind that reaches here holding a rule
-            // at all: a unit holds none and a name standing for nothing declares none. A
-            // construction picks one of the cases, so a rule written on one of them refuses values
-            // of that case and not every value of this.
+        if (!(guarantees.at(root, at) instanceof TypeGuarantees.At.Declared here)) {
+            // No declaration of its own to read: a container or an optional, whose element is a
+            // value that need not be there, a type nothing is written under at all, or a choice
+            // between declarations. A construction picks one of a choice's cases, so a rule written
+            // on one of them refuses values of that case and not every value of this.
             return declining(root.type(), path, gathering, k,
                     InvariantChecker.Borne.BY_SOME_VALUES);
         }
-        if (!onPath.add(ref.name())) {
+        // Entered before anything under it is walked, so that the one name and the other stay
+        // paired: a stop taken after entering would leave the name on the path with nothing to take
+        // it off, and the next field of the same type would be passed over as one already read.
+        if (!onPath.add(here.name())) {
             // Already met on the way down, so entering it again reads the rules that were read where
             // it was met. A record holding one of its own kind stops here and nothing is short of
             // anything for it.
             return declining(root.type(), path, gathering, k,
                     InvariantChecker.Borne.BY_SOME_VALUES);
         }
-        Map<String, Type> fields = clauses.fieldsOf(data);
-        Map<String, BindingId> bindings = clauses.bindingsOf(ref.name(), data);
-        Map<BindingId, Core> given = new HashMap<>();
-        fields.forEach((name, type) -> {
-            BindingId field = bindings.get(name);
-            if (field != null) {
-                given.put(field, new Core.FieldAccess(root, name, type, root.pos()));
-            }
-        });
-        Clauses.StatedClauses stated = reach.withoutClauses().test(ref.name())
-                ? Clauses.StatedClauses.NONE_ASKED_FOR : clauses.statedAt(ref.name(), data, given);
-        // A clause of a declaration under here that states nothing this can read is gone before any
-        // reading sees it, and which position it was about goes with it. Said as it happens: a
-        // reader collecting the clauses would otherwise take the ones it was handed for every
-        // clause there is, and answer for a rule it never saw.
-        if (gathering != null && !stated.everyClauseStated()) {
-            gathering.missed(path, InvariantChecker.Borne.BY_EVERY_VALUE);
-        }
-        List<TypeGuarantee> guarantees = new ArrayList<>();
-        for (Clauses.Stated one : stated.clauses()) {
-            // Where this clause becomes a rule of the model something can be attributed to. What is
-            // read off it below belongs to this rule, and the identity is settled here so that no
-            // reader of the reading has to decide which of the rules of the model it is holding.
-            RuleRef.Invariant rule = new RuleRef.Invariant(one.clause().ref());
-            // Read before it is handed over, so that what is recorded is this reading's own answer
-            // about this clause rather than a guess made from its shape somewhere else.
-            Predicates.Owed owed = gathering == null
-                    ? predicates.assumed(one.expr(), at, false)
-                    : predicates.assumed(one.expr(), at, false,
-                            (part, said) -> gathering.constrained(rule, part,
-                                    InvariantChecker.partRead(said)));
-            List<Quantified> quantified = new ArrayList<>();
-            predicates.quantifiedBy(one.expr(), at, true, quantified);
-            guarantees.add(new TypeGuarantee(rule, one.expr(), owed, quantified));
-        }
         Known out = k;
-        for (TypeGuarantee guarantee : guarantees) {
-            out = taking(guarantee, out, gathering);
-        }
-        if (data.newtype()) {
-            // A newtype's `.value` is the same location as the newtype, so what its base guarantees is
-            // guaranteed of this very atom: `data Outer = Inner` carries Inner's invariant.
-            // A newtype's `.value` is at no path of its own, which is the rule `name` walks by:
-            // wearing a name is not being somewhere else.
-            Core value = given.get(bindings.get("value"));
-            out = value == null
-                    ? declining(fields.get("value"), path, gathering, out,
-                            InvariantChecker.Borne.BY_EVERY_VALUE)
-                    : seedAt(value, path, out, at, depth + 1, limit, onPath, gathering, reach);
-        } else {
-            for (Map.Entry<String, BindingId> field : bindings.entrySet()) {
-                Core value = given.get(field.getValue());
-                if (value != null) {
-                    out = seedAt(value, under(path, field.getKey()), out, at, depth + 1, limit,
-                            onPath, gathering, reach);
-                }
+        // What the declaration states is read whatever this walk was asked for; whether this walk
+        // takes it in is the walk's own answer. A reading told to leave a declaration's clauses out
+        // was not asked to lose any, so nothing is reported missing for them either.
+        if (!reach.withoutClauses().test(here.name())) {
+            // A clause of a declaration under here that states nothing the reading can use is gone
+            // before any reader sees it, and which position it was about goes with it. Said here
+            // because a reader answering for the clauses it was handed would otherwise answer for a
+            // rule it never saw.
+            if (gathering != null && !here.everyClauseStated()) {
+                gathering.missed(path, InvariantChecker.Borne.BY_EVERY_VALUE);
+            }
+            for (TypeGuarantee guarantee : here.guarantees()) {
+                out = taking(guarantee, out, gathering);
             }
         }
-        onPath.remove(ref.name());
+        for (TypeGuarantees.At.Beneath under : here.beneath()) {
+            // A position wearing a name is at a path of its own; a newtype's value is the same
+            // position and keeps this one's.
+            String there = under.field().isEmpty() ? path : under(path, under.field());
+            out = under.value() == null
+                    ? declining(under.type(), there, gathering, out,
+                            InvariantChecker.Borne.BY_EVERY_VALUE)
+                    : seedAt(under.value(), there, out, at, depth + 1, limit, onPath, gathering,
+                            reach);
+        }
+        onPath.remove(here.name());
         return out;
     }
 
@@ -704,6 +679,10 @@ final class PathEngine {
      */
     private Known taking(TypeGuarantee guarantee, Known k, InvariantChecker.Gathering gathering) {
         if (gathering != null) {
+            for (TypeGuarantee.Part part : guarantee.parts()) {
+                gathering.constrained(guarantee.rule(), part.part(),
+                        InvariantChecker.partRead(part.owed()));
+            }
             gathering.gathered(guarantee.rule(), guarantee.clause(),
                     Predicates.subjectsIn(guarantee.owed()));
         }
@@ -723,43 +702,10 @@ final class PathEngine {
      */
     private Known declining(Type type, String path, InvariantChecker.Gathering gathering, Known k,
                             InvariantChecker.Borne borne) {
-        if (gathering != null && type != null && anyRuleUnder(type, new HashSet<>())) {
+        if (gathering != null && type != null && guarantees.anyRuleUnder(type)) {
             gathering.missed(path, borne);
         }
         return k;
-    }
-
-    /**
-     * Whether any rule is written anywhere under {@code type}.
-     *
-     * <p>A question about the model and not about the walk, which is what makes it the right one to
-     * ask at a stop: the walk's own reach is what is being decided, so reading it would answer that
-     * whatever was not read had nothing in it.
-     *
-     * <p>{@code seen} stops a type that holds its own kind. A name met on the way here was read
-     * where it was met, so what it holds is accounted for and reaching it again adds nothing.
-     */
-    private boolean anyRuleUnder(Type type, Set<TypeSymbol> seen) {
-        if (type instanceof Type.Ref ref) {
-            if (!seen.add(ref.name())) {
-                return false;
-            }
-            return switch (symbols.declarations().declaration(ref.name().key())) {
-                // A unit data holds nothing and may write no rule about it (spec §unit-data), so a
-                // sum of them is a type nothing is written under — which is what makes an
-                // enumeration a position this still speaks for.
-                case Hir.UnitData _ -> false;
-                case Hir.SumData sum -> TypeOps.leafCases(sum, symbols).stream()
-                        .anyMatch(each -> anyRuleUnder(Type.ref(each), seen));
-                case Hir.Data data -> !clauses.declared(ref.name(), data).isEmpty()
-                        || TypeOps.fieldTypes(data, symbols).values().stream()
-                                .anyMatch(each -> anyRuleUnder(each, seen));
-                case null, default -> false;
-            };
-        }
-        boolean[] found = {false};
-        Type.forEachChild(type, child -> found[0] |= anyRuleUnder(child, seen));
-        return found[0];
     }
 
     /** A field of the value at {@code path}. The root of a newtype's own reading is the value it

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -9,7 +9,6 @@ import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -59,7 +58,8 @@ final class PathEngine {
     /** What a clause owes and what a guard settles. */
     private final Predicates predicates;
 
-    /** The one reading of what a declaration guarantees. This walk is one of its consumers. */
+    /** The one reading of what a declaration guarantees, which this reading owns and this walk is
+     * one consumer of. */
     private final TypeGuarantees guarantees;
 
     /** Getting to the positions that reading is asked about, which is nobody's semantics. */
@@ -97,8 +97,8 @@ final class PathEngine {
         this.clauses = new Clauses(symbols, dischargeInvariants);
         this.terms = new Terms(symbols, reading, policy, clauses);
         this.predicates = terms.predicates();
-        this.guarantees = new TypeGuarantees(symbols, clauses, predicates);
-        this.walk = new GuaranteeWalk(guarantees);
+        this.guarantees = terms.guarantees();
+        this.walk = terms.walk();
         this.contracts = Map.copyOf(contracts);
     }
 
@@ -154,7 +154,7 @@ final class PathEngine {
     Entered enter(Core.Read root, Known known, Denotations at) {
         Denotations next = at.location(root.binding(), terms.placeSubject(root.binding()),
                 terms.placeTerm(root.binding()));
-        return new Entered(seedAt(root, known, next, 0), next);
+        return new Entered(seedAt(root, known, next), next);
     }
 
     /**
@@ -304,7 +304,7 @@ final class PathEngine {
     private Entered opening(Core.Case arm, Core scrutinee, Known k, Denotations at) {
         Core.Read root = Terms.read(arm.binder(), arm.bindType(), arm.pos());
         Denotations next = terms.choosing(new Choice.Decides.ACase(arm, scrutinee), at);
-        return new Entered(seedAt(root, k, next, 0), next);
+        return new Entered(seedAt(root, k, next), next);
     }
 
 
@@ -451,7 +451,7 @@ final class PathEngine {
     Entered enteringBuilt(Core.IfConstructed ic, Known k, Denotations at) {
         Core.Read root = Terms.read(ic.binder(), ic.construct().type(), ic.pos());
         Denotations next = terms.choosing(new Choice.Decides.ItWasBuilt(ic), at);
-        return new Entered(seedAt(root, k, next, 0), next);
+        return new Entered(seedAt(root, k, next), next);
     }
 
     // --- seeding -------------------------------------------------------------------------------
@@ -510,7 +510,7 @@ final class PathEngine {
         Known out = k;
         if (isACheckedProducer(e)) {
             seeded(e);
-            out = seedAt(e, out, at, 0);
+            out = seedAt(e, out, at);
         }
         out = assuming(answeredBy(e, at), e, guard -> guard instanceof Guard.Always,
                 new Entered(out, at)).known();
@@ -569,9 +569,10 @@ final class PathEngine {
      * clause is the declaration's either way, and where it is established and where it is owed differ
      * only in direction.
      */
-    Known seedAt(Core root, Known k, Denotations at, int depth) {
-        return seedAt(root, FieldDomains.THE_VALUE, k, at, depth, GuaranteeWalk.FIELDS_SEEDED,
-                null, InvariantChecker.Reach.EVERYTHING);
+    Known seedAt(Core root, Known k, Denotations at) {
+        return seedAt(root, FieldDomains.THE_VALUE, k, at,
+                new GuaranteeWalk.Extent.AsFarAs(GuaranteeWalk.FIELDS_SEEDED), null,
+                InvariantChecker.Reach.EVERYTHING);
     }
 
     /**
@@ -590,12 +591,11 @@ final class PathEngine {
      *                  that list has to be told here or walk the same descent again and rebase it a
      *                  second way.
      */
-    Known seedAt(Core root, String path, Known k, Denotations at, int depth, int limit,
+    Known seedAt(Core root, String path, Known k, Denotations at, GuaranteeWalk.Extent extent,
                  InvariantChecker.Gathering gathering, InvariantChecker.Reach reach) {
         Seeding seeding = new Seeding(k, gathering);
         walk.from(root, path, at,
-                new GuaranteeWalk.Scope(limit - depth, reach.stopAt(), reach.withoutClauses()),
-                seeding);
+                new GuaranteeWalk.Scope(extent, reach.stopAt(), reach.withoutClauses()), seeding);
         return seeding.known;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -638,8 +638,6 @@ final class PathEngine {
                 given.put(field, new Core.FieldAccess(root, name, type, root.pos()));
             }
         });
-        Known out = k;
-        List<Quantified> quantified = new ArrayList<>();
         Clauses.StatedClauses stated = reach.withoutClauses().test(ref.name())
                 ? Clauses.StatedClauses.NONE_ASKED_FOR : clauses.statedAt(ref.name(), data, given);
         // A clause of a declaration under here that states nothing this can read is gone before any
@@ -649,25 +647,27 @@ final class PathEngine {
         if (gathering != null && !stated.everyClauseStated()) {
             gathering.missed(path, InvariantChecker.Borne.BY_EVERY_VALUE);
         }
+        List<TypeGuarantee> guarantees = new ArrayList<>();
         for (Clauses.Stated one : stated.clauses()) {
             // Where this clause becomes a rule of the model something can be attributed to. What is
             // read off it below belongs to this rule, and the identity is settled here so that no
             // reader of the reading has to decide which of the rules of the model it is holding.
-            RuleRef.Invariant origin = new RuleRef.Invariant(one.clause().ref());
+            RuleRef.Invariant rule = new RuleRef.Invariant(one.clause().ref());
             // Read before it is handed over, so that what is recorded is this reading's own answer
             // about this clause rather than a guess made from its shape somewhere else.
             Predicates.Owed owed = gathering == null
                     ? predicates.assumed(one.expr(), at, false)
                     : predicates.assumed(one.expr(), at, false,
-                            (part, said) -> gathering.constrained(origin, part,
+                            (part, said) -> gathering.constrained(rule, part,
                                     InvariantChecker.partRead(said)));
-            if (gathering != null) {
-                gathering.gathered(origin, one.expr(), Predicates.subjectsIn(owed));
-            }
+            List<Quantified> quantified = new ArrayList<>();
             predicates.quantifiedBy(one.expr(), at, true, quantified);
-            out = predicates.assume(owed, out, Known.Held.OF_THE_VALUE);
+            guarantees.add(new TypeGuarantee(rule, one.expr(), owed, quantified));
         }
-        out = out.and(quantified);
+        Known out = k;
+        for (TypeGuarantee guarantee : guarantees) {
+            out = taking(guarantee, out, gathering);
+        }
         if (data.newtype()) {
             // A newtype's `.value` is the same location as the newtype, so what its base guarantees is
             // guaranteed of this very atom: `data Outer = Inner` carries Inner's invariant.
@@ -689,6 +689,26 @@ final class PathEngine {
         }
         onPath.remove(ref.name());
         return out;
+    }
+
+    /**
+     * {@code k} with what {@code guarantee} says taken as holding of the value it was read at.
+     *
+     * <p>The one step that turns an answer about a declaration into knowledge on this path, kept
+     * apart from the reading that produced it. What a type guarantees is the same wherever it is
+     * read; that it is held {@link Known.Held#OF_THE_VALUE} rather than of the path is this reader's
+     * account of it, and the reader settling a choice has no use for it.
+     *
+     * <p>{@code gathering} is told here for the same reason: what was gathered is a fact about this
+     * measurement and not about the model.
+     */
+    private Known taking(TypeGuarantee guarantee, Known k, InvariantChecker.Gathering gathering) {
+        if (gathering != null) {
+            gathering.gathered(guarantee.rule(), guarantee.clause(),
+                    Predicates.subjectsIn(guarantee.owed()));
+        }
+        return predicates.assume(guarantee.owed(), k, Known.Held.OF_THE_VALUE)
+                .and(guarantee.quantified());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -96,7 +96,7 @@ final class PathEngine {
         this.symbols = symbols;
         this.clauses = new Clauses(symbols, dischargeInvariants);
         this.terms = new Terms(symbols, reading, policy, clauses);
-        this.predicates = new Predicates(terms);
+        this.predicates = terms.predicates();
         this.guarantees = new TypeGuarantees(symbols, clauses, predicates);
         this.walk = new GuaranteeWalk(guarantees);
         this.contracts = Map.copyOf(contracts);
@@ -570,7 +570,7 @@ final class PathEngine {
      * only in direction.
      */
     Known seedAt(Core root, Known k, Denotations at, int depth) {
-        return seedAt(root, FieldDomains.THE_VALUE, k, at, depth, GuaranteeWalk.FIELDS_SEEDED, new HashSet<>(),
+        return seedAt(root, FieldDomains.THE_VALUE, k, at, depth, GuaranteeWalk.FIELDS_SEEDED,
                 null, InvariantChecker.Reach.EVERYTHING);
     }
 
@@ -583,10 +583,6 @@ final class PathEngine {
      * exactly as one on the top does. A projection that stopped at two and was then classified by a
      * walk that did not would call a bound complete that a rule below it moves.
      *
-     * <p>{@code onPath} is the types entered on the way here, so a record that holds another of its
-     * own kind stops rather than descending for ever. Kept per path and not for the whole walk: two
-     * fields of one type are two positions and both are seeded.
-     *
      * @param gathering told what this walk gathers, or null where nobody is collecting. A clause
      *                  governs a position from wherever it is written — the record the position is a
      *                  field of, and the declarations under that record it sits inside — and this
@@ -595,8 +591,7 @@ final class PathEngine {
      *                  second way.
      */
     Known seedAt(Core root, String path, Known k, Denotations at, int depth, int limit,
-                 Set<TypeSymbol> onPath, InvariantChecker.Gathering gathering,
-                 InvariantChecker.Reach reach) {
+                 InvariantChecker.Gathering gathering, InvariantChecker.Reach reach) {
         Seeding seeding = new Seeding(k, gathering);
         walk.from(root, path, at,
                 new GuaranteeWalk.Scope(limit - depth, reach.stopAt(), reach.withoutClauses()),

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -65,6 +65,9 @@ final class PathEngine {
 
     /** The one reading of what a declaration guarantees. This walk is one of its consumers. */
     private final TypeGuarantees guarantees;
+
+    /** Getting to the positions that reading is asked about, which is nobody's semantics. */
+    private final GuaranteeWalk walk;
     /** What each behavior a body may call states about its answer, by the name it is called under. */
     private final Map<ValueName.Behavior, StatedContract> contracts;
 
@@ -99,6 +102,7 @@ final class PathEngine {
         this.terms = new Terms(symbols, reading, policy);
         this.predicates = new Predicates(terms);
         this.guarantees = new TypeGuarantees(symbols, clauses, predicates);
+        this.walk = new GuaranteeWalk(guarantees);
         this.contracts = Map.copyOf(contracts);
     }
 
@@ -591,79 +595,63 @@ final class PathEngine {
     Known seedAt(Core root, String path, Known k, Denotations at, int depth, int limit,
                  Set<TypeSymbol> onPath, InvariantChecker.Gathering gathering,
                  InvariantChecker.Reach reach) {
-        // Asked one at a time, because a stop says two things and only one of them is the same for
-        // all of these: whether the rules under it were read, and whether a construction could have
-        // got out of making the value they are about.
-        if (depth > limit) {
-            // A limit on how far a measurement is worth carrying, which is not a limit on the model:
-            // a rule four records down refuses the outermost construction exactly as one on its own
-            // fields does.
-            return declining(root.type(), path, gathering, k,
-                    InvariantChecker.Borne.BY_EVERY_VALUE);
+        Seeding seeding = new Seeding(k, gathering);
+        walk.from(root, path, at,
+                new GuaranteeWalk.Scope(limit - depth, reach.stopAt(), reach.withoutClauses()),
+                seeding);
+        return seeding.known;
+    }
+
+    /**
+     * The reading a seeding is: every guarantee taken as holding of the value it was read at, and
+     * every stop accounted for.
+     *
+     * <p>What a stop costs is this reader's question and not the walk's. Most of them stop where
+     * there was nothing to read, so what is asked is whether any rule stands under what is being
+     * left, and only then is anything said. A walk that reported every stop would have a record with
+     * one plain string field speaking for none of its positions.
+     */
+    private final class Seeding implements GuaranteeWalk.Reader {
+
+        private Known known;
+
+        private final InvariantChecker.Gathering gathering;
+
+        private Seeding(Known known, InvariantChecker.Gathering gathering) {
+            this.known = known;
+            this.gathering = gathering;
         }
-        if (!(root.type() instanceof Type.Ref ref)) {
-            // Nothing here is named, so there is nothing this walk could have been told to stop at
-            // and nothing to record as entered. What may be declared is the reading's question and
-            // is asked below.
-            return declining(root.type(), path, gathering, k,
-                    InvariantChecker.Borne.BY_SOME_VALUES);
+
+        @Override
+        public void guaranteed(String path, TypeGuarantee guarantee) {
+            known = taking(guarantee, known, gathering);
         }
-        // Asked of the name and before the reading, because being told to stop at a name is this
-        // walk's business and says nothing about what the declaration states. Supposed to hold
-        // values, so nothing written under it is read: what is under it is what would say it holds
-        // none, and reading it here is the supposing undone one step in.
-        if (reach.stopAt().test(ref.name())) {
-            // Left out because this reading was asked to leave it out, which is still a rule of a
-            // value every construction has to make.
-            return declining(root.type(), path, gathering, k,
-                    InvariantChecker.Borne.BY_EVERY_VALUE);
+
+        @Override
+        public void stopped(String path, Type type, GuaranteeWalk.Stop why) {
+            declining(type, path, gathering, borne(why));
         }
-        if (!(guarantees.at(root, at) instanceof TypeGuarantees.At.Declared here)) {
-            // No declaration of its own to read: a container or an optional, whose element is a
-            // value that need not be there, a type nothing is written under at all, or a choice
-            // between declarations. A construction picks one of a choice's cases, so a rule written
-            // on one of them refuses values of that case and not every value of this.
-            return declining(root.type(), path, gathering, k,
-                    InvariantChecker.Borne.BY_SOME_VALUES);
-        }
-        // Entered before anything under it is walked, so that the one name and the other stay
-        // paired: a stop taken after entering would leave the name on the path with nothing to take
-        // it off, and the next field of the same type would be passed over as one already read.
-        if (!onPath.add(here.name())) {
-            // Already met on the way down, so entering it again reads the rules that were read where
-            // it was met. A record holding one of its own kind stops here and nothing is short of
-            // anything for it.
-            return declining(root.type(), path, gathering, k,
-                    InvariantChecker.Borne.BY_SOME_VALUES);
-        }
-        Known out = k;
-        // What the declaration states is read whatever this walk was asked for; whether this walk
-        // takes it in is the walk's own answer. A reading told to leave a declaration's clauses out
-        // was not asked to lose any, so nothing is reported missing for them either.
-        if (!reach.withoutClauses().test(here.name())) {
-            // A clause of a declaration under here that states nothing the reading can use is gone
-            // before any reader sees it, and which position it was about goes with it. Said here
-            // because a reader answering for the clauses it was handed would otherwise answer for a
-            // rule it never saw.
-            if (gathering != null && !here.everyClauseStated()) {
+
+        @Override
+        public void lostAClause(String path) {
+            // Said whatever stands under the position, because the clause was read and lost rather
+            // than never reached: a reader answering for the clauses it was handed would otherwise
+            // answer for a rule it never saw.
+            if (gathering != null) {
                 gathering.missed(path, InvariantChecker.Borne.BY_EVERY_VALUE);
             }
-            for (TypeGuarantee guarantee : here.guarantees()) {
-                out = taking(guarantee, out, gathering);
-            }
         }
-        for (TypeGuarantees.At.Beneath under : here.beneath()) {
-            // A position wearing a name is at a path of its own; a newtype's value is the same
-            // position and keeps this one's.
-            String there = under.field().isEmpty() ? path : under(path, under.field());
-            out = under.value() == null
-                    ? declining(under.type(), there, gathering, out,
-                            InvariantChecker.Borne.BY_EVERY_VALUE)
-                    : seedAt(under.value(), there, out, at, depth + 1, limit, onPath, gathering,
-                            reach);
+
+        /** What a stop leaves unread: a rule of every value that stands there, or one of only some.
+         * A stop the reader asked for and a depth it could not afford both leave rules every
+         * construction has to make; the rest stop where no rule holds of every value anyway. */
+        private InvariantChecker.Borne borne(GuaranteeWalk.Stop why) {
+            return switch (why) {
+                case PAST_THE_DEPTH, ASKED_TO_STOP, NO_VALUE_THERE ->
+                        InvariantChecker.Borne.BY_EVERY_VALUE;
+                case NOTHING_DECLARED, ALREADY_ENTERED -> InvariantChecker.Borne.BY_SOME_VALUES;
+            };
         }
-        onPath.remove(here.name());
-        return out;
     }
 
     /**
@@ -691,26 +679,17 @@ final class PathEngine {
     }
 
     /**
-     * {@code k} as it stands, with the reading told where it is leaving rules unread.
+     * Tells the reading where it is leaving rules unread.
      *
-     * <p>Every way this walk stops short comes here: past the depth it reads to, at a value the
-     * caller supposed holds values, at a type it has no declaration for, and at a name already on
-     * the path. What a stop costs is not the same at each of them — most of them stop where there
-     * was nothing to read — so what is asked is whether any rule stands under what is being left,
-     * and only then is anything said. A walk that reported every stop would have a record with one
-     * plain string field speaking for none of its positions.
+     * <p>Every way the walk stops short comes here. Whether a stop costs anything is a question
+     * about the model — is any rule written under what is being left — and asking it of the walk's
+     * own reach would answer that whatever was not read had nothing in it.
      */
-    private Known declining(Type type, String path, InvariantChecker.Gathering gathering, Known k,
-                            InvariantChecker.Borne borne) {
+    private void declining(Type type, String path, InvariantChecker.Gathering gathering,
+                           InvariantChecker.Borne borne) {
         if (gathering != null && type != null && guarantees.anyRuleUnder(type)) {
             gathering.missed(path, borne);
         }
-        return k;
     }
 
-    /** A field of the value at {@code path}. The root of a newtype's own reading is the value it
-     * wraps, which is at no path of its own, so its fields are the first step there is. */
-    static String under(String path, String field) {
-        return path.isEmpty() ? field : path + "." + field;
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -106,6 +106,12 @@ final class PathEngine {
         return symbols;
     }
 
+    /** The one reading of what a declaration guarantees, for a reader that wants the answer without
+     * the walk. */
+    TypeGuarantees guarantees() {
+        return guarantees;
+    }
+
     Clauses clauses() {
         return clauses;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -392,7 +392,7 @@ final class PathEngine {
                     continue;
                 }
                 Core here = Clauses.substituted(conjunct.stated().orNull(), given);
-                out = predicates.assume(predicates.obligations(here, out, in.at(), false), out,
+                out = predicates.assume(predicates.assumed(here, in.at(), false), out,
                         Known.Held.OF_THE_VALUE);
             }
         }
@@ -657,8 +657,8 @@ final class PathEngine {
             // Read before it is handed over, so that what is recorded is this reading's own answer
             // about this clause rather than a guess made from its shape somewhere else.
             Predicates.Owed owed = gathering == null
-                    ? predicates.obligations(one.expr(), out, at, false)
-                    : predicates.obligations(one.expr(), out, at, false,
+                    ? predicates.assumed(one.expr(), at, false)
+                    : predicates.assumed(one.expr(), at, false,
                             (part, said) -> gathering.constrained(origin, part,
                                     InvariantChecker.partRead(said)));
             if (gathering != null) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -397,6 +397,32 @@ final class Predicates {
             both.addAll(other.parts);
             return new Owed(List.copyOf(both), folded.and(other.folded));
         }
+
+        /**
+         * What this states, as relations.
+         *
+         * <p>Here beside {@link Predicates#assume} because both read what a clause came to, and a
+         * second place that knew the shape of a {@link Clause} would answer differently the day one
+         * gains a part.
+         *
+         * <p>What is known of a size holds of the value whatever established the clause it was read
+         * out of, which is why it stands beside what the clause itself states. A clause this reading
+         * could not state as a relation is not here, and neither is one it read as a fact:
+         * under-answering costs precision, and answering with something else would not be sound.
+         */
+        List<NumericConstraint> relations() {
+            List<NumericConstraint> out = new ArrayList<>();
+            for (Part each : parts) {
+                if (!(each instanceof Part.Carried carried)) {
+                    continue;
+                }
+                out.addAll(carried.clause().known());
+                if (carried.clause().numeric() != null) {
+                    out.add(carried.clause().numeric());
+                }
+            }
+            return List.copyOf(out);
+        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -89,7 +89,7 @@ final class Predicates {
         // of which recorded it, so what it gives an element is taken as the path's. That is the
         // weaker of the two readings: a violation it decides is reported as one the values alone did
         // not decide, which holds either way. It is why nothing downstream says a guard decided it.
-        return assume(obligations(stated, k, at, false), k, Known.Held.ON_THE_PATH).and(nested);
+        return assume(assumed(stated, at, false), k, Known.Held.ON_THE_PATH).and(nested);
     }
 
     /** What {@code e}, asserted with polarity {@code positive}, says of every element of a container.
@@ -466,24 +466,29 @@ final class Predicates {
         }
     }
 
-    /** What {@code inv} owes, where {@code decidesFalse} says a clause folding to the other answer
-     * than it is read with is this check's to report. A newtype's constant construction is checked
-     * elsewhere, and that check names the clause that failed rather than only saying one did, so it
-     * is left to say it. */
-    Owed obligations(Core inv, Known k, Denotations at, boolean decidesFalse) {
-        return obligations(inv, k, at, Set.of(), true, decidesFalse, Read.AN_ASSUMPTION, null);
+    /** What {@code inv} states where it is already established, with {@code decidesFalse} saying a
+     * clause folding to the other answer than it is read with is this check's to report. A newtype's
+     * constant construction is checked elsewhere, and that check names the clause that failed rather
+     * than only saying one did, so it is left to say it.
+     *
+     * <p>No {@link Known}, and not because none is at hand. An assumption reads nothing off what was
+     * already known ({@link Discharge}), so a reading that took one would let the knowledge a caller
+     * happened to be holding decide what a declaration says. The parameter is gone rather than
+     * ignored: what is not there cannot come to be read. */
+    Owed assumed(Core inv, Denotations at, boolean decidesFalse) {
+        return obligations(inv, at, Set.of(), true, decidesFalse, Discharge.AN_ASSUMPTION, null);
     }
 
     /**
-     * The same, telling {@code per} what each part of the clause owed as it is read.
+     * The same, telling {@code per} what each part of the clause stated as it is read.
      *
      * <p>A conjunction is read a conjunct at a time, and what each conjunct came to is this
      * reading's own answer about that conjunct. Handed over here rather than asked again afterwards:
      * a second reading of a part is a second reader, and the two agree only for as long as nobody
      * changes one of them.
      */
-    Owed obligations(Core inv, Known k, Denotations at, boolean decidesFalse, PerPart per) {
-        return obligations(inv, k, at, Set.of(), true, decidesFalse, Read.AN_ASSUMPTION, per);
+    Owed assumed(Core inv, Denotations at, boolean decidesFalse, PerPart per) {
+        return obligations(inv, at, Set.of(), true, decidesFalse, Discharge.AN_ASSUMPTION, per);
     }
 
     /** Told what one part of a clause owed, keyed by the part it was read from. */
@@ -492,36 +497,70 @@ final class Predicates {
     }
 
     /**
-     * Whether a clause is being read as something that makes knowledge or as something that spends
-     * it. Not a direction of travel: the two read one expression through one reader, which is what
-     * keeps them from drifting, and this is the single thing they cannot share.
+     * Whether a relation this reading found may be taken in, asked of the atoms it rests on.
      *
-     * <p>An assumption produces. A guard holds because the branch was taken, an {@code ensures}
-     * holds because the callee established it, and an invariant holds because the value was built
-     * through a checked constructor — none of them needs anything to have been said about the value
-     * beforehand, and each is how something first comes to be said about it.
+     * <p>The one thing a clause read as something that makes knowledge and a clause read as
+     * something that spends it cannot share. The two read one expression through one reader, which
+     * is what keeps them from drifting, and this is where they part.
      *
-     * <p>An obligation spends. It asks the author to account for a value, and asking that about a
-     * value nothing has ever said anything of is asking for something no guard they could write
-     * would settle; the run-time check stands for such a clause instead.
-     *
-     * <p>Requiring an assumption to spend what it produces is the circle it looks like: to be spoken
-     * of, a value would have to already be spoken of. It is not a theoretical worry — written that
-     * way, a declaration that refutes a construction stopped refusing it, because the declaration was
-     * turned away for want of the knowledge it was carrying.
+     * <p>Carried as this answer and not as a flag beside the knowledge to answer it from. Held the
+     * other way, every reading took a {@link Known} whether or not it could read one, and the reader
+     * that may not read one was told so by a comment.
      */
-    enum Read {
-        /** Knowledge being made: a guard, an invariant, a declared guarantee. */
-        AN_ASSUMPTION,
-        /** Knowledge being spent: a clause this construction has to account for. */
-        AN_OBLIGATION
+    interface Discharge {
+
+        /** Whether a relation over {@code form} is one this reading may take in. */
+        boolean takesIn(LinearForm<FactSubject> form);
+
+        /**
+         * Knowledge being made: a guard, an invariant, a declared guarantee. Every relation is taken
+         * in.
+         *
+         * <p>An assumption produces. A guard holds because the branch was taken, an {@code ensures}
+         * holds because the callee established it, and an invariant holds because the value was
+         * built through a checked constructor — none of them needs anything to have been said about
+         * the value beforehand, and each is how something first comes to be said about it.
+         *
+         * <p>Requiring an assumption to spend what it produces is the circle it looks like: to be
+         * spoken of, a value would have to already be spoken of. It is not a theoretical worry —
+         * written that way, a declaration that refutes a construction stopped refusing it, because
+         * the declaration was turned away for want of the knowledge it was carrying.
+         */
+        Discharge AN_ASSUMPTION = form -> true;
+
+        /**
+         * Knowledge being spent: a clause this construction has to account for, read against what
+         * {@code k} speaks of.
+         *
+         * <p>An obligation spends. It asks the author to account for a value, and asking that about
+         * a value nothing has ever said anything of is asking for something no guard they could
+         * write would settle; the run-time check stands for such a clause instead.
+         *
+         * <p>The same question {@link Terms#reportableSite} asks of a value, asked here of the atoms
+         * a clause is written over — and it has to be asked here as well, because a clause reaches
+         * atoms the site's own value never mentions. An atom is either one the check writes about of
+         * its own accord, which is what a place is, or one something on this path has spoken of.
+         * There is no third kind, and for an atom the first reduces to a single test: only an atom
+         * standing on one evaluation is outside what the seeding writes about.
+         *
+         * <p>Asked at all only because identity closed. A form being built used to be evidence that
+         * something was known, because a value nothing could be said of could not be composed into a
+         * form either; now every value has an identity and arithmetic composes over any of them, so
+         * the coincidence is gone and the rule it stood for has to be stated. Left unstated, a
+         * clause over a value nothing has ever mentioned would be owed here, and owing it would mean
+         * reporting a construction no guard an author could write would ever settle.
+         */
+        static Discharge spending(Known k) {
+            return form -> form.coefs().keySet().stream()
+                    .allMatch(atom -> !atom.identity().standsOnAnEvaluation() || k.speaksOf(atom));
+        }
     }
 
-    /** The same, where {@code unnamed} holds the values the site hands over that no clause may be
-     * read against. */
+    /** What {@code inv} owes, where {@code unnamed} holds the values the site hands over that no
+     * clause may be read against. */
     Owed obligations(Core inv, Known k, Denotations at, Set<Core> unnamed,
                      boolean decidesFalse) {
-        return obligations(inv, k, at, unnamed, true, decidesFalse, Read.AN_OBLIGATION, null);
+        return obligations(inv, at, unnamed, true, decidesFalse, Discharge.spending(k), null);
     }
 
     /**
@@ -531,13 +570,14 @@ final class Predicates {
      * name is one thing, and the date a day after it is another — so the one that answers is the one
      * taken. Reading a predicate never takes a reading away.
      */
-    private Owed obligations(Core rawInv, Known k, Denotations at, Set<Core> unnamed,
-                             boolean positive, boolean decidesFalse, Read way, PerPart per) {
+    private Owed obligations(Core rawInv, Denotations at, Set<Core> unnamed,
+                             boolean positive, boolean decidesFalse, Discharge discharge,
+                             PerPart per) {
         Core sized = Conditions.asSizeComparison(rawInv);
         Core ordered = Conditions.asOrderComparison(terms, sized, at);
-        Owed read = read(ordered, k, at, unnamed, positive, decidesFalse, way, per);
+        Owed read = read(ordered, at, unnamed, positive, decidesFalse, discharge, per);
         Owed out = ordered != sized && read.unreadable()
-                ? read(sized, k, at, unnamed, positive, decidesFalse, way, per) : read;
+                ? read(sized, at, unnamed, positive, decidesFalse, discharge, per) : read;
         if (per != null) {
             // Keyed by the part as it was handed in, which is the node a reader of this walk holds.
             // What it was rewritten to on the way is this reading's business.
@@ -548,19 +588,20 @@ final class Predicates {
 
     /** What {@code inv} owes, read as it stands. Its parts are read through {@link #obligations},
      * which is where each of them is taken as the comparison it states. */
-    private Owed read(Core inv, Known k, Denotations at, Set<Core> unnamed,
-                      boolean positive, boolean decidesFalse, Read way, PerPart per) {
+    private Owed read(Core inv, Denotations at, Set<Core> unnamed,
+                      boolean positive, boolean decidesFalse, Discharge discharge,
+                      PerPart per) {
         if (inv instanceof Core.Binary b && b.op() == BinOp.AND && positive) {
             // Each conjunct on its own: an invariant is a set of things that hold, and one the check
             // cannot read leaves its own run-time check standing without costing the others theirs.
             // That it stands is carried rather than dropped — the other conjunct being discharged is
             // not the invariant proven.
-            return obligations(b.left(), k, at, unnamed, true, decidesFalse, way, per)
-                    .and(obligations(b.right(), k, at, unnamed, true, decidesFalse, way, per));
+            return obligations(b.left(), at, unnamed, true, decidesFalse, discharge, per)
+                    .and(obligations(b.right(), at, unnamed, true, decidesFalse, discharge, per));
         }
         Core under = Conditions.negated(inv);
         if (under != null) {
-            return obligations(under, k, at, unnamed, !positive, decidesFalse, way, per);
+            return obligations(under, at, unnamed, !positive, decidesFalse, discharge, per);
         }
         Boolean folded = decidedAt(inv);
         if (folded != null) {
@@ -591,7 +632,7 @@ final class Predicates {
             // away for a value it does not actually rest on would report nothing about a value the
             // author was never asked about.
             LinearForm<FactSubject> between = la == null || ra == null ? null : la.minus(ra);
-            if (between != null && canBeDischargedFrom(between, k, way)) {
+            if (between != null && discharge.takesIn(between)) {
                 numeric = new NumericConstraint(between, eff);
                 // The same clause read as the cases of whatever chooses inside it. Both readings are
                 // kept: a guard may name the call itself, which the clause as it stands is what
@@ -616,27 +657,6 @@ final class Predicates {
         return Owed.of(new Clause(numeric, fact, known, piecewise)).alsoFolded(fold);
     }
 
-    /**
-     * Whether there is anything for a clause written over {@code form} to be discharged from.
-     *
-     * <p>The same question {@link Terms#reportableSite} asks of a value, asked here of the atoms a
-     * clause is written over — and it has to be asked here as well, because a clause reaches atoms
-     * the site's own value never mentions. An atom is either one the check writes about of its own
-     * accord, which is what a place is, or one something on this path has spoken of. There is no
-     * third kind, and for an atom the first reduces to a single test: only an atom standing on one
-     * evaluation is outside what the seeding writes about.
-     *
-     * <p>Asked at all only because identity closed. A form being built used to be evidence that
-     * something was known, because a value nothing could be said of could not be composed into a form
-     * either; now every value has an identity and arithmetic composes over any of them, so the
-     * coincidence is gone and the rule it stood for has to be stated. Left unstated, a clause over a
-     * value nothing has ever mentioned would be owed here, and owing it would mean reporting a
-     * construction no guard an author could write would ever settle.
-     */
-    private static boolean canBeDischargedFrom(LinearForm<FactSubject> form, Known k, Read way) {
-        return way == Read.AN_ASSUMPTION || form.coefs().keySet().stream()
-                .allMatch(atom -> !atom.identity().standsOnAnEvaluation() || k.speaksOf(atom));
-    }
 
     /** Whether {@code inv} is decided outright: the clause, with the construction's own values
      * already standing where it read a field, folded. {@code null} where it does not fold — which is

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -55,6 +55,18 @@ final class Terms {
     private final ReadingPolicy policy;
 
     private final Symbols symbols;
+    /**
+     * What a clause states, read through this very reading.
+     *
+     * <p>Here and not built by each caller, so that there is one of it. {@link Predicates} holds
+     * nothing but the reading it was given, so two of them would answer alike today — and the day
+     * one of them remembers something, two of them are two readers.
+     */
+    private final Predicates predicates;
+
+    /** What a type guarantees of a value, over the positions under it. */
+    private final GuaranteeWalk guarantees;
+
     private final Map<TypeSymbol, java.util.Optional<Type>> affineScalarBases = new HashMap<>();
     /** How the values of each atom this has named are spaced. Kept here because this is where an
      * atom's name is made: the key and the kind of number behind it are decided in one step, and
@@ -164,31 +176,40 @@ final class Terms {
         return policy;
     }
 
-    /** What a type guarantees of a value, or null where this reading was given no declarations to
-     * read. A recipe built from such a reading says what a condition states and no more. */
-    private final GuaranteeWalk guarantees;
+    /** What a clause states, read through this reading. */
+    Predicates predicates() {
+        return predicates;
+    }
 
-    /** A reading that names places and reads no declaration. What a type guarantees is not asked
-     * here, so nothing that needs it may be built from this one. */
+    /**
+     * A reading over the discharge tree, reading every declaration's clauses off the declaration.
+     *
+     * <p>Which is what a type another module declares is read by either way (spec
+     * §invariant-discharge-representation). A reading of the module being checked has its clauses in
+     * the representation the discharge rules are written at and passes them.
+     */
     Terms(Symbols symbols, ReadingPolicy policy) {
-        this(symbols, Of.THE_DISCHARGE_TREE, policy, null);
+        this(symbols, Of.THE_DISCHARGE_TREE, policy);
+    }
+
+    /** The same, over {@code reading}'s tree. */
+    Terms(Symbols symbols, Of reading, ReadingPolicy policy) {
+        this(symbols, reading, policy, new Clauses(symbols, Map.of()));
     }
 
     /**
      * A reading over {@code reading}'s tree, told where the declarations' invariants are.
      *
      * <p>{@code clauses} is what lets a recipe say what choosing an arm settles where the arm binds
-     * a value: the answer is what that value's type guarantees, and it is read through the one
-     * reading of a declaration there is ({@link TypeGuarantees}). Its own {@link Predicates} over
-     * this very reading, which is the same reader a seeding asks — {@link Predicates} holds nothing
-     * but the reading it was given, so two of them answer alike.
+     * a value: the answer is what that value's type guarantees, read through the one reading of a
+     * declaration there is ({@link TypeGuarantees}).
      */
     Terms(Symbols symbols, Of reading, ReadingPolicy policy, Clauses clauses) {
         this.symbols = symbols;
         this.reading = reading;
         this.policy = policy;
-        this.guarantees = clauses == null
-                ? null : new GuaranteeWalk(new TypeGuarantees(symbols, clauses, new Predicates(this)));
+        this.predicates = new Predicates(this);
+        this.guarantees = new GuaranteeWalk(new TypeGuarantees(symbols, clauses, predicates));
     }
 
     /**
@@ -897,15 +918,25 @@ final class Terms {
             if (form == null) {
                 return null;
             }
-            // Two sources and one question. What a condition states is read where the condition is
-            // written, which is outside the arm; what a type guarantees of what the arm bound is
-            // read where that name stands, which is inside it.
-            List<NumericConstraint> settles =
-                    new ArrayList<>(Conditions.settledBy(this, arm.decidedBy(), at));
-            settles.addAll(guaranteedBy(arm.decidedBy(), inside));
-            arms.add(new Derivation.Chosen.Arm(form, settles));
+            arms.add(new Derivation.Chosen.Arm(form, settledBy(arm.decidedBy(), at, inside)));
         }
         return new Derivation.Chosen(arms);
+    }
+
+    /**
+     * Everything choosing {@code decidedBy} settles, as relations.
+     *
+     * <p>Two sources and one question. What a condition states is read where the condition is
+     * written, which is {@code outside} the arm; what a type guarantees of what the arm bound is
+     * read where that name stands, which is {@code inside} it. Both are relations, and a relation
+     * is the same statement wherever it was read, so they stand together beside the arm.
+     */
+    private List<NumericConstraint> settledBy(Choice.Decides decidedBy, Denotations outside,
+                                              Denotations inside) {
+        List<NumericConstraint> out =
+                new ArrayList<>(Conditions.settledBy(this, decidedBy, outside));
+        out.addAll(guaranteedBy(decidedBy, inside));
+        return out;
     }
 
     /**
@@ -936,13 +967,13 @@ final class Terms {
                     it.attempt().construct().type(), it.attempt().pos());
             case Choice.Decides.ACondition _, Choice.Decides.ItDeparted _ -> null;
         };
-        if (guarantees == null || root == null) {
+        if (root == null) {
             return List.of();
         }
         List<NumericConstraint> out = new ArrayList<>();
         guarantees.from(root, FieldDomains.THE_VALUE, inside,
                 GuaranteeWalk.Scope.asFarAs(GuaranteeWalk.FIELDS_SEEDED),
-                (path, guarantee) -> out.addAll(guarantee.relations()));
+                (path, guarantee) -> out.addAll(guarantee.owed().relations()));
         return out;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -164,14 +164,31 @@ final class Terms {
         return policy;
     }
 
+    /** What a type guarantees of a value, or null where this reading was given no declarations to
+     * read. A recipe built from such a reading says what a condition states and no more. */
+    private final GuaranteeWalk guarantees;
+
+    /** A reading that names places and reads no declaration. What a type guarantees is not asked
+     * here, so nothing that needs it may be built from this one. */
     Terms(Symbols symbols, ReadingPolicy policy) {
-        this(symbols, Of.THE_DISCHARGE_TREE, policy);
+        this(symbols, Of.THE_DISCHARGE_TREE, policy, null);
     }
 
-    Terms(Symbols symbols, Of reading, ReadingPolicy policy) {
+    /**
+     * A reading over {@code reading}'s tree, told where the declarations' invariants are.
+     *
+     * <p>{@code clauses} is what lets a recipe say what choosing an arm settles where the arm binds
+     * a value: the answer is what that value's type guarantees, and it is read through the one
+     * reading of a declaration there is ({@link TypeGuarantees}). Its own {@link Predicates} over
+     * this very reading, which is the same reader a seeding asks — {@link Predicates} holds nothing
+     * but the reading it was given, so two of them answer alike.
+     */
+    Terms(Symbols symbols, Of reading, ReadingPolicy policy, Clauses clauses) {
         this.symbols = symbols;
         this.reading = reading;
         this.policy = policy;
+        this.guarantees = clauses == null
+                ? null : new GuaranteeWalk(new TypeGuarantees(symbols, clauses, new Predicates(this)));
     }
 
     /**
@@ -875,14 +892,58 @@ final class Terms {
         }
         List<Derivation.Chosen.Arm> arms = new ArrayList<>();
         for (Choice.Arm arm : choice.arms()) {
-            LinearForm<FactSubject> form = affineOf(arm.answers(), choosing(arm.decidedBy(), at));
+            Denotations inside = choosing(arm.decidedBy(), at);
+            LinearForm<FactSubject> form = affineOf(arm.answers(), inside);
             if (form == null) {
                 return null;
             }
-            arms.add(new Derivation.Chosen.Arm(form,
-                    Conditions.settledBy(this, arm.decidedBy(), at)));
+            // Two sources and one question. What a condition states is read where the condition is
+            // written, which is outside the arm; what a type guarantees of what the arm bound is
+            // read where that name stands, which is inside it.
+            List<NumericConstraint> settles =
+                    new ArrayList<>(Conditions.settledBy(this, arm.decidedBy(), at));
+            settles.addAll(guaranteedBy(arm.decidedBy(), inside));
+            arms.add(new Derivation.Chosen.Arm(form, settles));
         }
         return new Derivation.Chosen(arms);
+    }
+
+    /**
+     * What the type of the value choosing {@code decidedBy} opens guarantees of it, as relations.
+     *
+     * <p>The other half of what choosing an arm settles. A {@code match} arm binds the scrutinee
+     * refined to the case it names, and an attempt binds what it built; either way the value was
+     * built through its type's checked constructor, so what that type states holds of it. That is
+     * the same argument a seeding rests on for a parameter, and it is the same reading — asked here
+     * of a value a recipe names rather than of a place a walk stands at.
+     *
+     * <p>Under the arm and not beside it. The value only exists because that arm was chosen, so what
+     * it guarantees is stated of that arm and of no other.
+     *
+     * <p>A condition settles nothing here, and a departure settles nothing at all: nothing was
+     * built, so there is no value for a type to guarantee anything of.
+     *
+     * <p>Only the relations. A clause states what it states, and what a recipe can record beside an
+     * arm is a relation ({@link NumericConstraint}); a fact about a value is settled where facts
+     * are, and leaving it out costs precision where taking it in as something else would not be
+     * sound.
+     */
+    private List<NumericConstraint> guaranteedBy(Choice.Decides decidedBy, Denotations inside) {
+        Core.Read root = switch (decidedBy) {
+            case Choice.Decides.ACase it -> read(it.arm().binder(), it.arm().bindType(),
+                    it.arm().pos());
+            case Choice.Decides.ItWasBuilt it -> read(it.attempt().binder(),
+                    it.attempt().construct().type(), it.attempt().pos());
+            case Choice.Decides.ACondition _, Choice.Decides.ItDeparted _ -> null;
+        };
+        if (guarantees == null || root == null) {
+            return List.of();
+        }
+        List<NumericConstraint> out = new ArrayList<>();
+        guarantees.from(root, FieldDomains.THE_VALUE, inside,
+                GuaranteeWalk.Scope.asFarAs(GuaranteeWalk.FIELDS_SEEDED),
+                (path, guarantee) -> out.addAll(guarantee.relations()));
+        return out;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -771,18 +771,49 @@ final class Terms {
      * here would be this reader answering it a second way.
      */
     Denotations choosing(Choice.Decides decidedBy, Denotations at) {
+        return chose(decidedBy, at).at();
+    }
+
+    /**
+     * Where a reading stands once an arm is chosen, and the value that arm opened.
+     *
+     * <p>Both halves from one reader. Which value an arm opens and where the reading then stands are
+     * one answer about one node, and a second method working the first out for itself would be a
+     * second account of a node that has an owner — the thing the sum
+     * ({@link Choice.Decides}) is a sum for. So this is the only reader here that names the ways of
+     * deciding, and what wants either half asks it.
+     *
+     * @param opened the value the arm brought into being, or null where it brought none: a
+     *               condition names values that stand whatever arm is chosen, a departure was taken
+     *               where nothing was built, and an operation whose arms are chosen by how its
+     *               arguments stand relates arguments that were already there
+     */
+    record Chose(Denotations at, Core.Read opened) {}
+
+    /** The same question {@link #choosing} answers, with what it opened said beside it. */
+    Chose chose(Choice.Decides decidedBy, Denotations at) {
         return switch (decidedBy) {
             // A condition binds nothing. What it settles is read where the arm is read.
-            case Choice.Decides.ACondition ignored -> at;
+            case Choice.Decides.ACondition ignored -> new Chose(at, null);
             // A departure is taken where nothing was built, so it has nothing to enter.
-            case Choice.Decides.ItDeparted ignored -> at;
-            case Choice.Decides.ACase(Core.Case arm, Core scrutinee) -> opening(arm, scrutinee, at);
-            case Choice.Decides.ItWasBuilt(Core.IfConstructed ic) ->
-                    entering(read(ic.binder(), ic.construct().type(), ic.pos()), at);
+            case Choice.Decides.ItDeparted ignored -> new Chose(at, null);
+            case Choice.Decides.ACase(Core.Case arm, Core scrutinee) ->
+                    new Chose(opening(arm, scrutinee, at), openedByArm(arm));
+            case Choice.Decides.ItWasBuilt(Core.IfConstructed ic) -> {
+                Core.Read root = read(ic.binder(), ic.construct().type(), ic.pos());
+                yield new Chose(entering(root, at), root);
+            }
             // An operation defined by cases answers a value the call was already given, written
             // where the call is. It introduces no name, so there is nothing to enter.
-            case Choice.Decides.ByArgumentRelations ignored -> at;
+            case Choice.Decides.ByArgumentRelations ignored -> new Chose(at, null);
         };
+    }
+
+    /** What a {@code match} arm binds, or null where it binds nothing — which is the same condition
+     * {@link #opening} leaves the reading where it found it under. */
+    private static Core.Read openedByArm(Core.Case arm) {
+        return arm.binder() == null || arm.bindType() == null
+                ? null : read(arm.binder(), arm.bindType(), arm.pos());
     }
 
     /**
@@ -933,12 +964,12 @@ final class Terms {
         }
         List<Derivation.Chosen.Arm> arms = new ArrayList<>();
         for (Choice.Arm arm : choice.arms()) {
-            Denotations inside = choosing(arm.decidedBy(), at);
-            LinearForm<FactSubject> form = affineOf(arm.answers(), inside);
+            Terms.Chose chose = chose(arm.decidedBy(), at);
+            LinearForm<FactSubject> form = affineOf(arm.answers(), chose.at());
             if (form == null) {
                 return null;
             }
-            arms.add(new Derivation.Chosen.Arm(form, settledBy(arm.decidedBy(), at, inside)));
+            arms.add(new Derivation.Chosen.Arm(form, settledBy(arm.decidedBy(), at, chose)));
         }
         return new Derivation.Chosen(arms);
     }
@@ -952,10 +983,10 @@ final class Terms {
      * is the same statement wherever it was read, so they stand together beside the arm.
      */
     private List<NumericConstraint> settledBy(Choice.Decides decidedBy, Denotations outside,
-                                              Denotations inside) {
+                                              Chose chose) {
         List<NumericConstraint> out =
                 new ArrayList<>(Conditions.settledBy(this, decidedBy, outside));
-        out.addAll(guaranteedBy(decidedBy, inside));
+        out.addAll(guaranteedBy(chose.opened(), chose.at()));
         return out;
     }
 
@@ -971,22 +1002,15 @@ final class Terms {
      * <p>Under the arm and not beside it. The value only exists because that arm was chosen, so what
      * it guarantees is stated of that arm and of no other.
      *
-     * <p>A condition settles nothing here, and a departure settles nothing at all: nothing was
-     * built, so there is no value for a type to guarantee anything of.
+     * <p>Nothing for an arm that opened no value, which is {@link #chose}'s answer and not this
+     * method's: asking the node a second time here would be a second account of it.
      *
      * <p>Only the relations. A clause states what it states, and what a recipe can record beside an
      * arm is a relation ({@link NumericConstraint}); a fact about a value is settled where facts
      * are, and leaving it out costs precision where taking it in as something else would not be
      * sound.
      */
-    private List<NumericConstraint> guaranteedBy(Choice.Decides decidedBy, Denotations inside) {
-        Core.Read root = switch (decidedBy) {
-            case Choice.Decides.ACase it -> read(it.arm().binder(), it.arm().bindType(),
-                    it.arm().pos());
-            case Choice.Decides.ItWasBuilt it -> read(it.attempt().binder(),
-                    it.attempt().construct().type(), it.attempt().pos());
-            case Choice.Decides.ACondition _, Choice.Decides.ItDeparted _ -> null;
-        };
+    private List<NumericConstraint> guaranteedBy(Core.Read root, Denotations inside) {
         if (root == null) {
             return List.of();
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -64,8 +64,17 @@ final class Terms {
      */
     private final Predicates predicates;
 
-    /** What a type guarantees of a value, over the positions under it. */
-    private final GuaranteeWalk guarantees;
+    /**
+     * What a type guarantees of a value.
+     *
+     * <p>The one there is. A reader that built its own would be a second owner of an answer this
+     * whole reading exists to have one of, and the day it remembers anything the two are two
+     * readers — the argument {@link #predicates} is held here for, and the same one.
+     */
+    private final TypeGuarantees guarantees;
+
+    /** Getting to the positions that reading is asked about, which is nobody's semantics. */
+    private final GuaranteeWalk walk;
 
     private final Map<TypeSymbol, java.util.Optional<Type>> affineScalarBases = new HashMap<>();
     /** How the values of each atom this has named are spaced. Kept here because this is where an
@@ -181,6 +190,16 @@ final class Terms {
         return predicates;
     }
 
+    /** What a type guarantees of a value, read through this reading. */
+    TypeGuarantees guarantees() {
+        return guarantees;
+    }
+
+    /** The positions under a value, walked for a reader of this reading. */
+    GuaranteeWalk walk() {
+        return walk;
+    }
+
     /**
      * A reading over the discharge tree, reading every declaration's clauses off the declaration.
      *
@@ -209,7 +228,8 @@ final class Terms {
         this.reading = reading;
         this.policy = policy;
         this.predicates = new Predicates(this);
-        this.guarantees = new GuaranteeWalk(new TypeGuarantees(symbols, clauses, predicates));
+        this.guarantees = new TypeGuarantees(symbols, clauses, predicates);
+        this.walk = new GuaranteeWalk(guarantees);
     }
 
     /**
@@ -971,8 +991,10 @@ final class Terms {
             return List.of();
         }
         List<NumericConstraint> out = new ArrayList<>();
-        guarantees.from(root, FieldDomains.THE_VALUE, inside,
-                GuaranteeWalk.Scope.asFarAs(GuaranteeWalk.FIELDS_SEEDED),
+        // Every position, because this question has no depth in it. What the value guarantees is
+        // what its type states wherever the rule is written, and a bound here would make a
+        // derivation depend on how deeply an author nested a field rather than on what was declared.
+        walk.from(root, FieldDomains.THE_VALUE, inside, GuaranteeWalk.Scope.everyPosition(),
                 (path, guarantee) -> out.addAll(guarantee.owed().relations()));
         return out;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantee.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantee.java
@@ -1,0 +1,39 @@
+package souther.compiler.check;
+
+import souther.compiler.core.Core;
+
+import java.util.List;
+
+/**
+ * What one clause of a declaration guarantees of the value at one position, read as an assumption.
+ *
+ * <p>The answer a type gives about a value, and nothing about who asked. A walk seeding a path and a
+ * recipe settling a choice want the same thing of a declaration, and what they do with it differs;
+ * this is the thing, and what is done with it is the consumer's. So nothing here mentions a
+ * {@link Known}, a path, or what is being measured.
+ *
+ * <p>{@code owed} and {@code quantified} are one answer and not two lists to be read side by side.
+ * A quantified relation is one this very clause states of the elements of a container it names, so
+ * pairing them by index somewhere downstream is an account of the pairing that can come apart from
+ * the reading that made it.
+ *
+ * @param rule      which rule of the model this is — the clause of the declaration's invariant, and
+ *                  not where this reading met it ({@link RuleRef}). Beside the answer rather than
+ *                  inside it: what a type guarantees is the same whether or not anybody is filing
+ *                  questions under rules, and only a consumer that does ({@link
+ *                  InvariantChecker.Gathering}) reads this
+ * @param clause    the clause as it stands at this position, with the declaration's fields rebased
+ *                  onto the value they are about
+ * @param owed      what reading that clause came to: a relation, a fact, both, or that it could not
+ *                  be read at all. Not narrowed to a numeric constraint — a clause states what it
+ *                  states, and a reader wanting only the numbers can ask {@link Predicates.Owed}
+ *                  for them
+ * @param quantified what the clause states of every element of a container it names
+ */
+record TypeGuarantee(RuleRef.Invariant rule, Core clause, Predicates.Owed owed,
+                     List<Quantified> quantified) {
+
+    TypeGuarantee {
+        quantified = List.copyOf(quantified);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantee.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantee.java
@@ -29,11 +29,19 @@ import java.util.List;
  *                  states, and a reader wanting only the numbers can ask {@link Predicates.Owed}
  *                  for them
  * @param quantified what the clause states of every element of a container it names
+ * @param parts      what each part of the clause came to as it was read. A conjunction is read a
+ *                   conjunct at a time, and what each conjunct came to is the reading's own answer
+ *                   about that conjunct — kept here because asking it again afterwards is a second
+ *                   reader, and the two agree only until somebody changes one of them
  */
 record TypeGuarantee(RuleRef.Invariant rule, Core clause, Predicates.Owed owed,
-                     List<Quantified> quantified) {
+                     List<Quantified> quantified, List<Part> parts) {
 
     TypeGuarantee {
         quantified = List.copyOf(quantified);
+        parts = List.copyOf(parts);
     }
+
+    /** What one part of a clause came to, beside the part it was read from. */
+    record Part(Core part, Predicates.Owed owed) {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantee.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantee.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import souther.compiler.core.Core;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -40,6 +41,32 @@ record TypeGuarantee(RuleRef.Invariant rule, Core clause, Predicates.Owed owed,
     TypeGuarantee {
         quantified = List.copyOf(quantified);
         parts = List.copyOf(parts);
+    }
+
+    /**
+     * What this guarantee comes to as relations.
+     *
+     * <p>What a clause states of the value, and what is known of the size of any container it names.
+     * Both hold of the value itself, which is what makes them recordable where a range could not be
+     * ({@link NumericConstraint}).
+     *
+     * <p>A clause this reading could not state as a relation is not here, and neither is one it
+     * read as a fact. Under-answering costs precision; answering with something else would not be
+     * sound.
+     */
+    List<NumericConstraint> relations() {
+        List<NumericConstraint> out = new ArrayList<>();
+        for (Predicates.Part each : owed.parts()) {
+            if (!(each instanceof Predicates.Part.Carried carried)) {
+                continue;
+            }
+            Predicates.Clause clause = carried.clause();
+            out.addAll(clause.known());
+            if (clause.numeric() != null) {
+                out.add(clause.numeric());
+            }
+        }
+        return List.copyOf(out);
     }
 
     /** What one part of a clause came to, beside the part it was read from. */

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantee.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantee.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import souther.compiler.core.Core;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -41,32 +40,6 @@ record TypeGuarantee(RuleRef.Invariant rule, Core clause, Predicates.Owed owed,
     TypeGuarantee {
         quantified = List.copyOf(quantified);
         parts = List.copyOf(parts);
-    }
-
-    /**
-     * What this guarantee comes to as relations.
-     *
-     * <p>What a clause states of the value, and what is known of the size of any container it names.
-     * Both hold of the value itself, which is what makes them recordable where a range could not be
-     * ({@link NumericConstraint}).
-     *
-     * <p>A clause this reading could not state as a relation is not here, and neither is one it
-     * read as a fact. Under-answering costs precision; answering with something else would not be
-     * sound.
-     */
-    List<NumericConstraint> relations() {
-        List<NumericConstraint> out = new ArrayList<>();
-        for (Predicates.Part each : owed.parts()) {
-            if (!(each instanceof Predicates.Part.Carried carried)) {
-                continue;
-            }
-            Predicates.Clause clause = carried.clause();
-            out.addAll(clause.known());
-            if (clause.numeric() != null) {
-                out.add(clause.numeric());
-            }
-        }
-        return List.copyOf(out);
     }
 
     /** What one part of a clause came to, beside the part it was read from. */

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
@@ -1,0 +1,209 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.core.Core;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What a type guarantees of a value, asked one position at a time.
+ *
+ * <p>The one reading of a declaration. A value of type {@code T} was built through {@code T}'s
+ * checked constructor, so what {@code T} states holds of it; that argument is the same for a
+ * behavior's parameter, for what a {@code match} arm binds, for what an attempt built, and for what
+ * a combinator hands a closure. Each of those has a reader, and none of them may come to a different
+ * answer about what the declaration says — so the answer is here and the readers ask.
+ *
+ * <p><b>A question about a position, not a walk over positions.</b> Everything a walk would carry —
+ * how deep to go, which names to leave out, what a stop costs, what is being measured — is missing
+ * on purpose. A caller that wants the positions beneath one asks {@link At.Declared#beneath} and
+ * decides for itself whether to go there. Held the other way, the depth a walk could afford would be
+ * part of what a declaration means, and two callers that could afford different depths would be two
+ * readings of the model.
+ *
+ * <p>Nothing here mentions {@link Known}, a path, or a {@link InvariantChecker.Gathering}. Reading a
+ * clause as an assumption cannot consult what was already known ({@link Predicates.Discharge}), so
+ * there is nothing for a caller's knowledge to change about the answer.
+ */
+final class TypeGuarantees {
+
+    private final Symbols symbols;
+
+    private final Clauses clauses;
+
+    private final Predicates predicates;
+
+    TypeGuarantees(Symbols symbols, Clauses clauses, Predicates predicates) {
+        this.symbols = symbols;
+        this.clauses = clauses;
+        this.predicates = predicates;
+    }
+
+    /**
+     * What the type of the value at {@code root} guarantees of it, and what positions are beneath it.
+     *
+     * <p>The clauses are the declaration's, rebased onto this very value: a rule written about a
+     * field is a rule about that field of this value, and where it is established and where it is
+     * owed differ only in direction.
+     */
+    At at(Core root, Denotations denotations) {
+        if (!(root.type() instanceof Type.Ref ref)
+                || !(symbols.declarations().declaration(ref.name().key()) instanceof Hir.Data data)) {
+            // Either not a declaration of its own — a container or an optional, whose element is a
+            // value that need not be there, or a type nothing is written under at all — or a choice
+            // between declarations, which is the only kind that reaches here holding a rule at all.
+            // A construction picks one of the cases, so a rule written on one of them refuses values
+            // of that case and not every value of this.
+            return new At.Undeclared();
+        }
+        Map<String, Type> fields = clauses.fieldsOf(data);
+        Map<String, BindingId> bindings = clauses.bindingsOf(ref.name(), data);
+        Map<BindingId, Core> given = new HashMap<>();
+        fields.forEach((name, type) -> {
+            BindingId field = bindings.get(name);
+            if (field != null) {
+                given.put(field, new Core.FieldAccess(root, name, type, root.pos()));
+            }
+        });
+        Clauses.StatedClauses stated = clauses.statedAt(ref.name(), data, given);
+        List<TypeGuarantee> guarantees = new ArrayList<>();
+        for (Clauses.Stated one : stated.clauses()) {
+            guarantees.add(read(one, denotations));
+        }
+        return new At.Declared(ref.name(), List.copyOf(guarantees), stated.everyClauseStated(),
+                beneath(data, fields, bindings, given));
+    }
+
+    /**
+     * One clause, read as something that holds of this value.
+     *
+     * <p>What each part of it came to is read here and kept, rather than handed to a caller as it
+     * happens. A reader told mid-reading is a reader the reading has to know about; a reader given
+     * the parts afterwards is one this does not.
+     */
+    private TypeGuarantee read(Clauses.Stated one, Denotations denotations) {
+        // Where this clause becomes a rule of the model something can be attributed to. Settled here
+        // so that no reader of the reading has to decide which of the rules of the model it holds.
+        RuleRef.Invariant rule = new RuleRef.Invariant(one.clause().ref());
+        List<TypeGuarantee.Part> parts = new ArrayList<>();
+        Predicates.Owed owed = predicates.assumed(one.expr(), denotations, false,
+                (part, said) -> parts.add(new TypeGuarantee.Part(part, said)));
+        List<Quantified> quantified = new ArrayList<>();
+        predicates.quantifiedBy(one.expr(), denotations, true, quantified);
+        return new TypeGuarantee(rule, one.expr(), owed, quantified, parts);
+    }
+
+    /**
+     * The positions under a declaration.
+     *
+     * <p>A newtype's {@code .value} is the same location as the newtype, so what its base guarantees
+     * is guaranteed of this very atom: {@code data Outer = Inner} carries Inner's invariant. It is at
+     * no path of its own — wearing a name is not being somewhere else — which is what an empty
+     * {@link At.Beneath#field} says.
+     */
+    private List<At.Beneath> beneath(Hir.Data data, Map<String, Type> fields,
+                                     Map<String, BindingId> bindings, Map<BindingId, Core> given) {
+        List<At.Beneath> out = new ArrayList<>();
+        if (data.newtype()) {
+            BindingId held = bindings.get("value");
+            Core value = held == null ? null : given.get(held);
+            out.add(value == null ? new At.Beneath("", null, fields.get("value"))
+                    : new At.Beneath("", value, value.type()));
+            return out;
+        }
+        for (Map.Entry<String, BindingId> field : bindings.entrySet()) {
+            Core value = given.get(field.getValue());
+            if (value != null) {
+                out.add(new At.Beneath(field.getKey(), value, value.type()));
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Whether any rule is written anywhere under {@code type}.
+     *
+     * <p>A question about the model and not about any walk, which is what makes it the right one to
+     * ask where a reader stops: the reader's own reach is what is being decided, so reading that
+     * would answer that whatever was not read had nothing in it.
+     */
+    boolean anyRuleUnder(Type type) {
+        return anyRuleUnder(type, new HashSet<>());
+    }
+
+    /** {@code seen} stops a type that holds its own kind. A name met on the way here was read where
+     * it was met, so what it holds is accounted for and reaching it again adds nothing. */
+    private boolean anyRuleUnder(Type type, Set<TypeSymbol> seen) {
+        if (type instanceof Type.Ref ref) {
+            if (!seen.add(ref.name())) {
+                return false;
+            }
+            return switch (symbols.declarations().declaration(ref.name().key())) {
+                // A unit data holds nothing and may write no rule about it (spec §unit-data), so a
+                // sum of them is a type nothing is written under — which is what makes an
+                // enumeration a position this still speaks for.
+                case Hir.UnitData _ -> false;
+                case Hir.SumData sum -> TypeOps.leafCases(sum, symbols).stream()
+                        .anyMatch(each -> anyRuleUnder(Type.ref(each), seen));
+                case Hir.Data data -> !clauses.declared(ref.name(), data).isEmpty()
+                        || TypeOps.fieldTypes(data, symbols).values().stream()
+                                .anyMatch(each -> anyRuleUnder(each, seen));
+                case null, default -> false;
+            };
+        }
+        boolean[] found = {false};
+        Type.forEachChild(type, child -> found[0] |= anyRuleUnder(child, seen));
+        return found[0];
+    }
+
+    /** What stands at one position. */
+    sealed interface At {
+
+        /**
+         * A position whose type declares rules of its own, with what they guarantee here.
+         *
+         * @param name             the declaration, which is what a caller keeping track of the ones
+         *                         it has entered files under
+         * @param guarantees       what each of its clauses states of this value
+         * @param everyClauseStated whether every clause of the declaration could be read at all. A
+         *                          clause stating nothing a reader can use is gone before any
+         *                          reading sees it, and which position it was about goes with it, so
+         *                          a caller answering for the rules it was handed would answer for a
+         *                          rule it never saw
+         * @param beneath          the positions under this one
+         */
+        record Declared(TypeSymbol name, List<TypeGuarantee> guarantees, boolean everyClauseStated,
+                        List<Beneath> beneath) implements At {
+
+            public Declared {
+                guarantees = List.copyOf(guarantees);
+                beneath = List.copyOf(beneath);
+            }
+        }
+
+        /** A position with no declaration of its own to read, so nothing is stated here of every
+         * value that stands at it. What is written under its type may still be worth asking about
+         * ({@link TypeGuarantees#anyRuleUnder}). */
+        record Undeclared() implements At {}
+
+        /**
+         * A position under another.
+         *
+         * @param field the name it is reached by, or empty where it is this same position wearing a
+         *              name
+         * @param value what stands there, or null where the declaration names a field this could not
+         *              read a value for
+         * @param type  what stands there is of this type, which is answerable even where the value
+         *              is not
+         */
+        record Beneath(String field, Core value, Type type) {}
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/AWalkFromASeedIsBoundedByCheckingOneStepTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AWalkFromASeedIsBoundedByCheckingOneStepTest.java
@@ -65,6 +65,24 @@ class AWalkFromASeedIsBoundedByCheckingOneStepTest {
                 { held: Holding
                 }
 
+            data Inner =
+                { amount: NonNegInt
+                }
+
+            data Middle =
+                { inner: Inner
+                }
+
+            data Deeper =
+                { mid: Middle
+                }
+
+            data DeepHolding = Deeper | Missing
+
+            data DeepBoxed =
+                { held: DeepHolding
+                }
+
             data Classed =
                 { kind: Kind
                 , amount: NonNegInt
@@ -748,6 +766,32 @@ class AWalkFromASeedIsBoundedByCheckingOneStepTest {
                     | Held as h -> sum + h.amount.value
                     | Empty -> sum, 0, xs))
                 """)), "and this one reads what a `match` arm bound, which is the same thing again");
+    }
+
+    /**
+     * What an arm bound guarantees is read wherever the rule is written under it.
+     *
+     * <p>The neighbour above reads a rule one position under what the arm bound, and a reading that
+     * stopped where a seeding stops would still have found it. This one is three under it, which is
+     * past what a walk over a body can afford — and the model says the same thing about both: a rule
+     * four records down refuses a value exactly as one on the top does.
+     *
+     * <p>Written down because the reading did borrow that number, and the borrowing was invisible
+     * from either side. The walk's own tests pass with a bound in place, since they say what a bound
+     * does; the recipe's tests pass, since a rule a position or two down is inside any of them. This
+     * is the case that fails the moment
+     * {@link souther.compiler.check.GuaranteeWalk.Scope#everyPosition} here becomes a number.
+     */
+    @Test
+    void whatAnArmBoundGuaranteesIsReadHoweverDeepTheRuleIsWritten() {
+        assertFalse(owed(compiled("""
+                behavior total : (xs: List<DeepBoxed>) -> Money
+                    constructs Money
+
+                let total (xs) = Money(List.fold((sum, x) -> match x.held with
+                    | Deeper as d -> sum + d.mid.inner.amount.value
+                    | Missing -> sum, 0, xs))
+                """)), "the rule is three positions under what the arm bound, and it is read");
     }
 
 }

--- a/souther-compiler/src/test/java/souther/compiler/AWalkFromASeedIsBoundedByCheckingOneStepTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AWalkFromASeedIsBoundedByCheckingOneStepTest.java
@@ -703,24 +703,22 @@ class AWalkFromASeedIsBoundedByCheckingOneStepTest {
     }
 
     /**
-     * What choosing an arm settles is not read, so an arm whose body reads what the arm itself bound
-     * gets no range.
+     * An arm whose body reads what the arm itself bound is read against what that value's type
+     * guarantees.
      *
-     * <p>The boundary as it stands, and narrower than it was. What the arm binds is entered before
-     * the arm is named ({@link souther.compiler.check.Terms#choosing}), so the body below reads the
-     * place it meant rather than a value nothing named. What is still not read is what choosing the
-     * arm <em>settles</em>: that {@code held} is the case that carries an amount, and that the
-     * attempt's construction held. Both are true only where that arm is the answer, so neither is
-     * among the facts that hold of every element a step is handed, and the step gets no range from
-     * them (#973).
+     * <p>What choosing an arm settles has two sources. What a condition states is the condition's
+     * ({@link souther.compiler.check.Conditions}); what being a value of a type guarantees is the
+     * declaration's, and is the same answer a seeding reads of a parameter
+     * ({@link souther.compiler.check.TypeGuarantees}). A {@code match} arm binds the scrutinee
+     * refined to the case it names and an attempt binds what it built, so both were built through
+     * their type's checked constructor and both carry what that type states.
      *
-     * <p>One gap and not three: a {@code match} arm's binding, an attempt's built value and an
-     * {@code if}'s condition are all what choosing an arm settles. Written down beside a neighbour
-     * that differs only in reading the element instead, so what is owed is the binding and not the
-     * branch.
+     * <p>Stated under the arm and not beside it: the value only exists because that arm was chosen.
+     * Written down beside a neighbour that reads the element instead, so what is read is the
+     * binding and not the branch.
      */
     @Test
-    void anArmReadingWhatItBoundGetsNoRange() {
+    void anArmReadingWhatItBoundIsReadByWhatItsTypeGuarantees() {
         assertFalse(owed(compiled("""
                 behavior total : (xs: List<Flagged>) -> Money
                     constructs Money, NonNegInt
@@ -728,14 +726,14 @@ class AWalkFromASeedIsBoundedByCheckingOneStepTest {
                 let total (xs) = Money(List.fold((sum, x) ->
                     if NonNegInt(x.amount.value) as n then sum + x.amount.value else sum, 0, xs))
                 """)), "this arm reads the element, which the walk entered, so the step is read");
-        assertTrue(owed(compiled("""
+        assertFalse(owed(compiled("""
                 behavior total : (xs: List<Flagged>) -> Money
                     constructs Money, NonNegInt
 
                 let total (xs) = Money(List.fold((sum, x) ->
                     if NonNegInt(x.amount.value) as n then sum + n.value else sum, 0, xs))
-                """)), "and this one reads what the attempt built, which nothing here has entered");
-        assertTrue(owed(compiled("""
+                """)), "and this one reads what the attempt built, which its own type speaks for");
+        assertFalse(owed(compiled("""
                 behavior total : (xs: List<Boxed>) -> Money
                     constructs Money
 

--- a/souther-compiler/src/test/java/souther/compiler/AWalkFromASeedIsBoundedByCheckingOneStepTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AWalkFromASeedIsBoundedByCheckingOneStepTest.java
@@ -703,22 +703,21 @@ class AWalkFromASeedIsBoundedByCheckingOneStepTest {
     }
 
     /**
-     * An arm whose body reads what the arm itself bound is read against what that value's type
-     * guarantees.
+     * What choosing an arm settles has two sources.
      *
-     * <p>What choosing an arm settles has two sources. What a condition states is the condition's
-     * ({@link souther.compiler.check.Conditions}); what being a value of a type guarantees is the
-     * declaration's, and is the same answer a seeding reads of a parameter
-     * ({@link souther.compiler.check.TypeGuarantees}). A {@code match} arm binds the scrutinee
-     * refined to the case it names and an attempt binds what it built, so both were built through
-     * their type's checked constructor and both carry what that type states.
+     * <p>What a condition states is the condition's ({@link souther.compiler.check.Conditions});
+     * what being a value of a type guarantees is the declaration's, and is the same answer a seeding
+     * reads of a parameter ({@link souther.compiler.check.TypeGuarantees}). A {@code match} arm
+     * binds the scrutinee refined to the case it names and an attempt binds what it built, so both
+     * were built through their type's checked constructor and both carry what that type states.
+     * Stated under the arm and not beside it: the value only exists because that arm was chosen.
      *
-     * <p>Stated under the arm and not beside it: the value only exists because that arm was chosen.
-     * Written down beside a neighbour that reads the element instead, so what is read is the
-     * binding and not the branch.
+     * <p>One fact per test below. Written as one method, the first that failed hid the rest — which
+     * it did, and a reading of what the other two were doing was made from assertions that never
+     * ran.
      */
     @Test
-    void anArmReadingWhatItBoundIsReadByWhatItsTypeGuarantees() {
+    void anArmReadingTheElementIsTheNeighbourThatWasAlwaysRead() {
         assertFalse(owed(compiled("""
                 behavior total : (xs: List<Flagged>) -> Money
                     constructs Money, NonNegInt
@@ -726,13 +725,21 @@ class AWalkFromASeedIsBoundedByCheckingOneStepTest {
                 let total (xs) = Money(List.fold((sum, x) ->
                     if NonNegInt(x.amount.value) as n then sum + x.amount.value else sum, 0, xs))
                 """)), "this arm reads the element, which the walk entered, so the step is read");
+    }
+
+    @Test
+    void anArmReadingWhatAnAttemptBuiltIsReadByWhatItsTypeGuarantees() {
         assertFalse(owed(compiled("""
                 behavior total : (xs: List<Flagged>) -> Money
                     constructs Money, NonNegInt
 
                 let total (xs) = Money(List.fold((sum, x) ->
                     if NonNegInt(x.amount.value) as n then sum + n.value else sum, 0, xs))
-                """)), "and this one reads what the attempt built, which its own type speaks for");
+                """)), "this one reads what the attempt built, which its own type speaks for");
+    }
+
+    @Test
+    void anArmReadingWhatAMatchBoundIsReadByWhatItsTypeGuarantees() {
         assertFalse(owed(compiled("""
                 behavior total : (xs: List<Boxed>) -> Money
                     constructs Money
@@ -742,4 +749,5 @@ class AWalkFromASeedIsBoundedByCheckingOneStepTest {
                     | Empty -> sum, 0, xs))
                 """)), "and this one reads what a `match` arm bound, which is the same thing again");
     }
+
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest.java
@@ -41,7 +41,7 @@ class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
     private static final SourcePos POS = new SourcePos(1, 1);
 
     private static final String SOURCE = """
-            module demo exposing ( Money, Wrapped, Chain, Bounded, Plain, keep )
+            module demo exposing ( Money, Wrapped, Chain, Bounded, Deeper, Plain, keep )
 
             data NonNegInt = Int
                 invariant value >= 0
@@ -54,6 +54,10 @@ class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
 
             data Bounded = { cap: NonNegInt }
                 invariant cap.value <= 100
+
+            data Middle = { inner: Money }
+
+            data Deeper = { mid: Middle }
 
             data Plain = { label: String }
 
@@ -182,7 +186,7 @@ class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
     @Test
     void aNameTheReaderStopsAtIsNotDescendedInto() {
         GuaranteeWalk.Scope stopping =
-                new GuaranteeWalk.Scope(4, named("NonNegInt")::equals, _ -> false);
+                new GuaranteeWalk.Scope(new GuaranteeWalk.Extent.AsFarAs(4), named("NonNegInt")::equals, _ -> false);
 
         assertTrue(guaranteedUnder("Money", stopping).isEmpty(),
                 "the only clause under Money is NonNegInt's, and this reader stops there");
@@ -203,11 +207,32 @@ class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
                 "both rules stand: Bounded's own, and NonNegInt's about the field");
 
         GuaranteeWalk.Scope without =
-                new GuaranteeWalk.Scope(2, _ -> false, named("Bounded")::equals);
+                new GuaranteeWalk.Scope(new GuaranteeWalk.Extent.AsFarAs(2), _ -> false, named("Bounded")::equals);
 
         assertEquals(List.of("cap"),
                 List.copyOf(guaranteedUnder("Bounded", without).keySet()),
                 "the one left out is Bounded's own, and the field's is read as it was");
+    }
+
+    /**
+     * A rule is where it is written, and a reader asking for every position gets it there.
+     *
+     * <p>The failure this is written against: a reader whose question has no depth in it borrowing
+     * the number a reader with a cost bound uses. Held as one {@code int}, "as far as I can afford"
+     * and "as far as the model goes" are the same kind of answer and the first gets copied into the
+     * second — which makes what a declaration is taken to say depend on how deeply an author nested
+     * a field. {@code Deeper} writes nothing, and the rule is three positions under it.
+     */
+    @Test
+    void aReaderAskingForEveryPositionIsNotBoundedByWhatAnotherCanAfford() {
+        assertEquals(List.of("mid.inner.amount"),
+                List.copyOf(guaranteedUnder("Deeper", GuaranteeWalk.Scope.everyPosition()).keySet()),
+                "the rule three positions down is read, and read at the position it governs");
+        assertTrue(guaranteedUnder("Deeper",
+                        new GuaranteeWalk.Scope(new GuaranteeWalk.Extent.AsFarAs(2), _ -> false,
+                                _ -> false)).isEmpty(),
+                "a reader that can afford two positions does not reach it — which is what makes"
+                        + " borrowing its number a change to what the model says");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest.java
@@ -201,6 +201,52 @@ class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
     }
 
     /**
+     * Nothing a consumer holds may be handed to the reading.
+     *
+     * <p>The wall the rest of this rests on. Every test above says what the answer is; this one says
+     * the answer cannot come to depend on who asked. A {@link Known} the reading could read would
+     * let one caller's knowledge decide what a declaration says, a {@link InvariantChecker.Gathering}
+     * would put what is being measured inside what is meant, and a {@link PathEngine} would make the
+     * walk that seeds a path the owner of a question the recipe reader asks too.
+     *
+     * <p>Read off the signatures rather than promised in prose, because a parameter added in a hurry
+     * is added to a signature and not to a comment.
+     */
+    @Test
+    void theReadingIsHandedNothingAConsumerHolds() {
+        List<String> theirs =
+                List.of("Known", "Gathering", "PathEngine", "GuaranteeWalk", "Reach", "Borne");
+        List<String> found = new ArrayList<>();
+        for (Class<?> each : List.of(TypeGuarantees.class, TypeGuarantees.At.class,
+                TypeGuarantees.At.Declared.class, TypeGuarantees.At.Beneath.class,
+                TypeGuarantee.class, TypeGuarantee.Part.class)) {
+            for (java.lang.reflect.Field field : each.getDeclaredFields()) {
+                mentioning(theirs, each.getSimpleName() + "." + field.getName(),
+                        field.getType(), found);
+            }
+            for (java.lang.reflect.Method method : each.getDeclaredMethods()) {
+                String where = each.getSimpleName() + "." + method.getName();
+                mentioning(theirs, where, method.getReturnType(), found);
+                for (Class<?> taken : method.getParameterTypes()) {
+                    mentioning(theirs, where, taken, found);
+                }
+            }
+        }
+        assertEquals(List.of(), found,
+                "what a type guarantees is read from the declaration and the value, and from nothing"
+                        + " a consumer of the answer happens to be holding");
+    }
+
+    private static void mentioning(List<String> theirs, String where, Class<?> type,
+                                   List<String> found) {
+        for (String name : theirs) {
+            if (type.getSimpleName().equals(name)) {
+                found.add(where + " takes or answers a " + name);
+            }
+        }
+    }
+
+    /**
      * One reading and many readers.
      *
      * <p>The contract itself: two scopes are two walks, and where both of them looked they were told

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest.java
@@ -41,7 +41,7 @@ class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
     private static final SourcePos POS = new SourcePos(1, 1);
 
     private static final String SOURCE = """
-            module demo exposing ( Money, Wrapped, Chain, Plain, keep )
+            module demo exposing ( Money, Wrapped, Chain, Bounded, Plain, keep )
 
             data NonNegInt = Int
                 invariant value >= 0
@@ -51,6 +51,9 @@ class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
             data Wrapped = Money
 
             data Chain = { here: NonNegInt, next: List<Chain> }
+
+            data Bounded = { cap: NonNegInt }
+                invariant cap.value <= 100
 
             data Plain = { label: String }
 
@@ -186,18 +189,25 @@ class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
         assertEquals(GuaranteeWalk.Stop.ASKED_TO_STOP, stoppedIn("Money", stopping).get("amount"));
     }
 
-    /** A declaration's own clauses may be left out while what is under it is still read. */
+    /**
+     * A declaration's own clauses may be left out while what is under it is still read.
+     *
+     * <p>Which is the whole difference between this and a name the reader stops at. {@code Bounded}
+     * writes a rule of its own and holds a field whose type writes another; leaving the first out
+     * leaves the second standing.
+     */
     @Test
     void aDeclarationsOwnClausesCanBeLeftOutWithoutLeavingWhatIsUnderIt() {
-        GuaranteeWalk.Scope without =
-                new GuaranteeWalk.Scope(4, _ -> false, named("NonNegInt")::equals);
+        assertEquals(List.of(FieldDomains.THE_VALUE, "cap"),
+                List.copyOf(guaranteedUnder("Bounded", GuaranteeWalk.Scope.asFarAs(2)).keySet()),
+                "both rules stand: Bounded's own, and NonNegInt's about the field");
 
-        assertTrue(guaranteedUnder("Money", without).isEmpty(),
-                "NonNegInt's clause is the one left out");
-        assertEquals(GuaranteeWalk.Stop.NOTHING_DECLARED, stoppedIn("Money", without).get("amount"),
-                "and the position was still entered and walked through — the stop under it is the"
-                        + " whole number a newtype wraps, which declares nothing, and not this"
-                        + " reader being told to go no further");
+        GuaranteeWalk.Scope without =
+                new GuaranteeWalk.Scope(2, _ -> false, named("Bounded")::equals);
+
+        assertEquals(List.of("cap"),
+                List.copyOf(guaranteedUnder("Bounded", without).keySet()),
+                "the one left out is Bounded's own, and the field's is read as it was");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest.java
@@ -1,0 +1,220 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.ast.Hir;
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a declaration guarantees, asked of the reading itself.
+ *
+ * <p>{@link TypeGuarantees} answers one question for every reader there is: a walk seeding a path,
+ * and a recipe settling a choice. Each of those has tests of its own about what it does with the
+ * answer, and those are the tests that pass while the answer is wrong — a walk can agree with itself
+ * about a declaration it reads two levels too shallowly. So the answer is held here, on its own.
+ *
+ * <p>What is fixed is what a position guarantees and where the positions are. How far a reader goes
+ * is not fixed and may not be: two readers walking to different depths are still reading one model,
+ * and requiring one depth would put a reader's affordance inside what a declaration means. What is
+ * required instead is the last test here — where two scopes both looked, they were told the same
+ * thing.
+ */
+class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    private static final String SOURCE = """
+            module demo exposing ( Money, Wrapped, Chain, Plain, keep )
+
+            data NonNegInt = Int
+                invariant value >= 0
+
+            data Money = { amount: NonNegInt }
+
+            data Wrapped = Money
+
+            data Chain = { here: NonNegInt, next: List<Chain> }
+
+            data Plain = { label: String }
+
+            behavior keep : (m: Money) -> Money
+
+            let keep (m) = m
+            """;
+
+    private final Symbols symbols = symbols();
+
+    private final PathEngine engine = new PathEngine(symbols, Map.of(),
+            Terms.Of.THE_DISCHARGE_TREE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+
+    private final GuaranteeWalk walk = new GuaranteeWalk(engine.guarantees());
+
+    private static Symbols symbols() {
+        Compilation compilation = Compilation.ofSource(SOURCE, "Main");
+        compilation.answerEverything();
+        return Scopes.derived(compilation.db(), compilation.modules().get(0)).value();
+    }
+
+    private static TypeSymbol named(String name) {
+        return TypeSymbols.declared(new TypeKey("demo", name));
+    }
+
+    /** A place of type {@code name}, and the reading that has it named. */
+    private Read place(String name) {
+        BindingId binding = CoreBinders
+                .of(new Hir.Binders(new BindingOwner.OfValue("demo", "keep")).binder("v", POS))
+                .binding();
+        Core.Read root = new Core.Read("v", binding, Type.ref(named(name)), POS);
+        Denotations at = Denotations.none().location(binding, engine.terms().placeSubject(binding),
+                engine.terms().placeTerm(binding));
+        return new Read(root, at);
+    }
+
+    private record Read(Core.Read root, Denotations at) {}
+
+    /** Every clause the walk was told about, by the position it was told at. */
+    private Map<String, List<String>> guaranteedUnder(String name, GuaranteeWalk.Scope scope) {
+        Map<String, List<String>> out = new LinkedHashMap<>();
+        Read read = place(name);
+        walk.from(read.root(), FieldDomains.THE_VALUE, read.at(), scope,
+                (path, guarantee) -> out.computeIfAbsent(path, _ -> new ArrayList<>())
+                        .add(guarantee.rule().clause().toString()));
+        return out;
+    }
+
+    /** Every position the walk stopped at, and why. */
+    private Map<String, GuaranteeWalk.Stop> stoppedIn(String name, GuaranteeWalk.Scope scope) {
+        Map<String, GuaranteeWalk.Stop> out = new LinkedHashMap<>();
+        Read read = place(name);
+        walk.from(read.root(), FieldDomains.THE_VALUE, read.at(), scope,
+                new GuaranteeWalk.Reader() {
+                    @Override
+                    public void guaranteed(String path, TypeGuarantee guarantee) {}
+
+                    @Override
+                    public void stopped(String path, Type type, GuaranteeWalk.Stop why) {
+                        out.put(path, why);
+                    }
+                });
+        return out;
+    }
+
+    /**
+     * A clause written on a field's type is a rule about that field of this value, at that field's
+     * position.
+     */
+    @Test
+    void aFieldIsAPositionOfItsOwn() {
+        assertEquals(List.of("amount"),
+                List.copyOf(guaranteedUnder("Money", GuaranteeWalk.Scope.asFarAs(2)).keySet()),
+                "Money writes no clause of its own; NonNegInt's is about the amount");
+    }
+
+    /**
+     * A newtype's value is the same location as the newtype, so what its base guarantees is
+     * guaranteed of this very atom. Wearing a name is not being somewhere else.
+     */
+    @Test
+    void aNewtypeCarriesWhatItsBaseGuaranteesAtItsOwnPosition() {
+        assertEquals(List.of("amount"),
+                List.copyOf(guaranteedUnder("Wrapped", GuaranteeWalk.Scope.asFarAs(2)).keySet()),
+                "Wrapped is Money, which is at no path of its own, so its field is the first step");
+    }
+
+    /** A declaration writing nothing, and nothing written under it, guarantees nothing. */
+    @Test
+    void aDeclarationWithNoRuleUnderItGuaranteesNothing() {
+        assertTrue(guaranteedUnder("Plain", GuaranteeWalk.Scope.asFarAs(2)).isEmpty(),
+                "a record of a String writes no rule and holds nothing that does");
+    }
+
+    /**
+     * A record holding another of its own kind stops rather than descending for ever, and stopping
+     * there is not being short of anything: the name was read where it was met.
+     */
+    @Test
+    void aRecordHoldingItsOwnKindIsReadWhereItWasMet() {
+        Map<String, List<String>> guaranteed =
+                guaranteedUnder("Chain", GuaranteeWalk.Scope.asFarAs(6));
+
+        assertEquals(List.of("here"), List.copyOf(guaranteed.keySet()),
+                "the chain's own field is read once, and the list under it reaches no further");
+        assertFalse(stoppedIn("Chain", GuaranteeWalk.Scope.asFarAs(6)).isEmpty(),
+                "and the walk says where it stopped rather than going round again");
+    }
+
+    /**
+     * A depth a reader could not afford is a stop and not an answer.
+     *
+     * <p>Which is why the depth may not live in the reading: a position left unread is one this
+     * reader did not reach, and saying nothing about it would be saying no rule stands there.
+     */
+    @Test
+    void aDepthTheReaderCouldNotAffordIsAStop() {
+        assertTrue(guaranteedUnder("Money", GuaranteeWalk.Scope.asFarAs(0)).isEmpty(),
+                "the amount is one position down, and this reader asked for none");
+        assertEquals(GuaranteeWalk.Stop.PAST_THE_DEPTH,
+                stoppedIn("Money", GuaranteeWalk.Scope.asFarAs(0)).get("amount"),
+                "and it is told that it stopped there rather than that nothing was written");
+    }
+
+    /** A name a reader supposes holds values is not descended into, and nothing under it is read. */
+    @Test
+    void aNameTheReaderStopsAtIsNotDescendedInto() {
+        GuaranteeWalk.Scope stopping =
+                new GuaranteeWalk.Scope(4, named("NonNegInt")::equals, _ -> false);
+
+        assertTrue(guaranteedUnder("Money", stopping).isEmpty(),
+                "the only clause under Money is NonNegInt's, and this reader stops there");
+        assertEquals(GuaranteeWalk.Stop.ASKED_TO_STOP, stoppedIn("Money", stopping).get("amount"));
+    }
+
+    /** A declaration's own clauses may be left out while what is under it is still read. */
+    @Test
+    void aDeclarationsOwnClausesCanBeLeftOutWithoutLeavingWhatIsUnderIt() {
+        GuaranteeWalk.Scope without =
+                new GuaranteeWalk.Scope(4, _ -> false, named("NonNegInt")::equals);
+
+        assertTrue(guaranteedUnder("Money", without).isEmpty(),
+                "NonNegInt's clause is the one left out");
+        assertEquals(GuaranteeWalk.Stop.NOTHING_DECLARED, stoppedIn("Money", without).get("amount"),
+                "and the position was still entered and walked through — the stop under it is the"
+                        + " whole number a newtype wraps, which declares nothing, and not this"
+                        + " reader being told to go no further");
+    }
+
+    /**
+     * One reading and many readers.
+     *
+     * <p>The contract itself: two scopes are two walks, and where both of them looked they were told
+     * the same thing. A reader that could afford less is short of positions, never of a different
+     * answer about one.
+     */
+    @Test
+    void twoScopesAreToldTheSameThingWhereBothLooked() {
+        Map<String, List<String>> shallow =
+                guaranteedUnder("Chain", GuaranteeWalk.Scope.asFarAs(1));
+        Map<String, List<String>> deep = guaranteedUnder("Chain", GuaranteeWalk.Scope.asFarAs(6));
+
+        assertFalse(shallow.isEmpty(), "a reading saying nothing would agree with anything");
+        shallow.forEach((path, clauses) -> assertEquals(clauses, deep.get(path),
+                "what stands at " + path + " is what stands there, however far the reader went"));
+    }
+}


### PR DESCRIPTION
Closes #982. Takes in the half of #973 that was left standing.

## What was measured first

`PathEngine.seedAt` threaded the `Known` it was building into every clause it read. It never read it: within `Predicates`, `k` and the read mode met at one place, `canBeDischargedFrom`, which returned true for an assumption before looking at anything. Replacing both arguments with `Known.top()` left the whole suite green, so the dependency was already vacuous.

The issue said no line of `seedAt` held a path-independent answer. That is half wrong, and the terminology needed fixing with it: what can be lifted out is not path-independent — field rebasing and field descent depend on structural position — it is independent of the *ambient* `Known`. That distinction is what the rest rests on.

`RuleRef.Invariant` was chased on the same grounds. It is the model's rule identity by its own contract, but inside `seedAt` it reached only the `Gathering`; nothing that becomes knowledge reads it, and `Derivation.Chosen.Arm` has no rule key at all. So it sits beside the answer rather than inside it.

## The shape

    model
      │
      ▼
    TypeGuarantees        at(position) → what the declaration guarantees there,
      │                                  and the positions beneath it
      ▼
    GuaranteeWalk         depth, names left out, the stop where a record holds
      │                   its own kind — and no opinion on what a stop costs
      ├──────────────► Terms.chosen → Derivation.Chosen.Arm.settles
      ▼
    PathEngine.Seeding    Gathering, assume, Held.OF_THE_VALUE, Known

`TypeGuarantees` takes a `Core` and a `Denotations` and nothing else. A scope changes which positions a reader visited, never what a declaration states at one — which is why two readers may walk to different depths and still be reading one model.

## What it fixes

The two rows the issue tabulated. An arm reading what a `match` bound, and a body reading what an attempt built, are now read against what those values' types guarantee — the same argument a seeding rests on for a parameter, since both were built through a checked constructor. Stated under the arm and not beside it: the value only exists because that arm was chosen. A departure settles nothing, having built nothing.

`AWalkFromASeedIsBoundedByCheckingOneStepTest.anArmReadingWhatItBoundGetsNoRange` held the boundary where it stood and now holds where it stands.

## Tests

`WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest` asks the reading directly rather than through a consumer: what a position guarantees, a newtype at no path of its own, a record holding its own kind, a depth that is a stop and not an answer, and the two ways a scope leaves something out. Two of them were checked by mutation — breaking the newtype position rule fails two, adding a `Known` parameter fails the signature guard.

Two tests carry the contract itself. Two scopes are two walks, and where both looked they were told the same thing. And the reading's signatures mention no `Known`, `Gathering`, `PathEngine`, `Reach` or `Borne`, read off reflection rather than promised in prose.

Full reactor green: 9688 tests, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)