### PR TITLE
What a value carries belongs to the atom, and not to a reader that walked to it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/AtomKnowledge.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AtomKnowledge.java
@@ -1,0 +1,140 @@
+package souther.compiler.check;
+
+import souther.compiler.numeric.NumericDomain.LinearForm;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Everything this check knows about one atom by knowing which value it is.
+ *
+ * <p>One record and not a table per kind of thing that could be known. What was recorded about an
+ * atom used to be two maps read by name — how it was computed, and which walk it was the answer of
+ * — and a reader wanting either asked both by name. Two costs, and the second is the one that bites:
+ * a third thing worth knowing arrives as a third map, every reader that enumerates them is a reader
+ * somebody has to remember to visit, and the one that is not visited answers as though the atom
+ * carried nothing. That is what left a size inside a reduction's step unbounded (#988).
+ *
+ * <p>Two things are known, and they are different in kind rather than in where they came from.
+ *
+ * <p>{@link #computation} is how the value was reached from other values, and what it gives is
+ * conditional: what a product lies between is the answer of whatever domain its factors are read in,
+ * so it is a recipe to be put through a reading and not a fact.
+ *
+ * <p>{@link #intrinsic} is what holds of the value whatever any reading says — a size is never
+ * negative, an absolute value is not, a filtered container is no longer than what it was filtered
+ * from. No path establishes these and no path can take them away, so they are true in every domain
+ * this atom is read in and are taken in before any recipe is put through
+ * ({@link DerivedNumericFacts#readingOf}).
+ *
+ * <p>The two graphs these make are not the same graph and their cycles do not mean the same thing.
+ * A computation is written over strictly smaller expressions, so an atom reachable from itself
+ * through computations is this check having named a value it built out of itself, and
+ * {@link DerivedNumericFacts} refuses it. An intrinsic relation names whatever values it relates,
+ * with no such ordering: {@code length(filter(xs)) <= length(xs)} and a relation the other way about
+ * would be two true statements and not a contradiction. So reachability over both edges together
+ * ({@link Terms#reached}) is a closure taken with a visited set and terminates on repetition, while
+ * derivation over computation edges alone refuses repetition outright. Neither may be written in
+ * terms of the other.
+ *
+ * @param computation how the value was reached, which may be {@link Computation.None}: a size is a
+ *                   value this knows something about and computes nothing from
+ * @param intrinsic   what holds of the value whatever it was reached by, as relations. Relations and
+ *                    not ranges, because a relation is the same statement in every domain and what
+ *                    it comes to is the domain's answer — and because half of these relate this
+ *                    value to another one rather than bounding it
+ */
+record AtomKnowledge(Computation computation, List<NumericConstraint> intrinsic) {
+
+    AtomKnowledge {
+        intrinsic = List.copyOf(intrinsic);
+    }
+
+    /** An atom nothing has been recorded about yet. */
+    static AtomKnowledge nothing() {
+        return new AtomKnowledge(Computation.None.INSTANCE, List.of());
+    }
+
+    AtomKnowledge computedBy(Computation how) {
+        return new AtomKnowledge(how, intrinsic);
+    }
+
+    AtomKnowledge carrying(List<NumericConstraint> facts) {
+        return new AtomKnowledge(computation, facts);
+    }
+
+    /**
+     * The atoms reading this one reads directly, which is one edge and not the closure of them.
+     *
+     * <p>Worked out from what is here rather than recorded beside it. A recorded edge set is a second
+     * writing of what the computation and the relations already say, and the day an intrinsic rule is
+     * added the second writing is the one nobody updates — which is the same failure this record
+     * exists to stop rather than a defence against it.
+     *
+     * <p>{@code self} is left out. A relation is written over the value it is about, so every
+     * intrinsic fact names this atom, and {@code x >= 0} is not {@code x} depending on {@code x}.
+     * The closure would terminate either way; what this keeps is the model saying what is true.
+     */
+    Set<FactSubject> directlyReads(FactSubject self) {
+        Set<FactSubject> out = new LinkedHashSet<>();
+        for (LinearForm<FactSubject> form : computation.formsRead()) {
+            out.addAll(form.coefs().keySet());
+        }
+        for (NumericConstraint fact : intrinsic) {
+            out.addAll(fact.atoms());
+        }
+        out.remove(self);
+        return out;
+    }
+
+    /**
+     * How a value was reached from other values, where anything reached it.
+     *
+     * <p>A sum, so that an atom recorded as computed two ways is a state nothing can hold. Held as
+     * two tables this was a disagreement each table checked for on its own and neither checked
+     * across: a value filed as a walk's answer and as a piece of arithmetic had both recorded and
+     * was read as whichever the reader asked for first (#988).
+     */
+    sealed interface Computation {
+
+        /**
+         * The forms reading this computation reads from.
+         *
+         * <p>Abstract, so a way of reaching a value added later answers for itself. What a recipe is
+         * read from is the recipe's own answer already ({@link Derivation#formsRead}) and for the
+         * same reason: worked out from which parts happen to be forms, the first one that arrives
+         * inside something else is missed quietly.
+         */
+        List<LinearForm<FactSubject>> formsRead();
+
+        /** Nothing reached it: the value is what it is, and whatever is known of it is intrinsic. */
+        record None() implements Computation {
+
+            static final None INSTANCE = new None();
+
+            @Override
+            public List<LinearForm<FactSubject>> formsRead() {
+                return List.of();
+            }
+        }
+
+        /** Arithmetic the affine fragment does not carry, as the recipe it is. */
+        record Derived(Derivation recipe) implements Computation {
+
+            @Override
+            public List<LinearForm<FactSubject>> formsRead() {
+                return recipe.formsRead();
+            }
+        }
+
+        /** What a library operation reached by applying a closure over and over. */
+        record Reduction(InductiveBounds.Walk walk) implements Computation {
+
+            @Override
+            public List<LinearForm<FactSubject>> formsRead() {
+                return List.of(walk.seed(), walk.step());
+            }
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/DerivedNumericFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DerivedNumericFacts.java
@@ -11,6 +11,7 @@ import souther.compiler.numeric.NumericDomain.Rel;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -129,7 +130,9 @@ final class DerivedNumericFacts {
         ReadingDomain reading = readingOf(base, terms, asked);
         Memo derived = new Memo();
         if (terms.knowsAnything() && !reading.isBottom()) {
-            for (FactSubject atom : roots(terms, base.atomsSpokenOf(), asked)) {
+            Set<FactSubject> from = new LinkedHashSet<>(asked);
+            from.addAll(base.atomsSpokenOf());
+            for (FactSubject atom : toDerive(terms, from)) {
                 derive(atom, reading, terms, derived, new LinkedHashSet<>(),
                         ContextMultiplicity.ofOneReading());
             }
@@ -150,10 +153,14 @@ final class DerivedNumericFacts {
      * What a value carries is true in every domain — a size is never negative whatever a guard said —
      * so it is not something a recipe derives but something the reading starts from, and a reading
      * that started without it answered about a fold's step as though nothing were known of anything
-     * the step named (#988). Made only by {@link #readingOf}, and every operation that moves a
-     * reading along is here, so there is no way to reach {@link #derive} with a domain that skipped
-     * it. A rule written down and checked by reading the callers is a rule the next caller does not
-     * read.
+     * the step named (#988).
+     *
+     * <p>A class with a constructor of its own, and not a record. A record's canonical constructor is
+     * as accessible as the record is, and this one has to be seen by {@link InductiveBounds} — so as
+     * a record, any reader in this package could wrap a raw domain and reach {@link #derive} with a
+     * reading that had skipped the first stage, which is the thing the type is here to stop. Written
+     * this way the stage is not a rule to follow: it is the only way to hold one of these. Every
+     * operation that moves a reading along is here for the same reason.
      *
      * <p>What it reaches is not kept beside it. An arm's statements and a candidate for an
      * accumulator are relations over atoms the recipe already declared it reads from
@@ -161,7 +168,17 @@ final class DerivedNumericFacts {
      * can reach was spoken for when it was made — and a set carried through the moves would be a
      * second writing of that, read by nobody and true only for as long as nobody changed a move.
      */
-    record ReadingDomain(NumericDomain<FactSubject> domain) {
+    static final class ReadingDomain {
+
+        private final NumericDomain<FactSubject> domain;
+
+        private ReadingDomain(NumericDomain<FactSubject> domain) {
+            this.domain = domain;
+        }
+
+        private NumericDomain<FactSubject> domain() {
+            return domain;
+        }
 
         boolean isBottom() {
             return domain.isBottom();
@@ -234,25 +251,32 @@ final class DerivedNumericFacts {
     }
 
     /**
-     * The atoms this reading is to derive from: the ones the question names or the domain speaks of
-     * that were recorded as computed. Walked from the asking side rather than from the table, so
-     * what it costs is what the question is about and not how much arithmetic the behavior contains.
+     * The atoms a reading asked about {@code asked} is to derive from: everything reading those
+     * reaches that was recorded as computed.
      *
-     * <p>What a reading <em>reaches</em> is a wider set than this and is a different question. An
-     * atom under a recipe is reached — that is what says a place must be kept for it, and what says
-     * its intrinsic facts belong in the reading — and it is derived when the recipe over it is read
-     * and not before. Made roots as well, every operand of every recipe would be evaluated whether
-     * the question came near it or not, which is a cost the reaching was never about.
+     * <p>One answer, and it was two. The reading a question is asked in answered it from the domain,
+     * and reading a form answered it from the atoms the form names — so a value the reading reached
+     * but the form did not name was a recipe nobody put through. That is not a narrowing at the
+     * edges: what a value carries relates it to other values, and {@code Decimal.toInt} carries that
+     * its answer is within one of what it rounded. Read where a clause names it, the thing it
+     * rounded is in the domain and is derived; read inside a step, the step names the answer and not
+     * what it rounded, and a product there was a value nothing bounded whatever its factors were.
+     * The same divergence as #988 and along the other edge of the same graph.
+     *
+     * <p>So it is asked once, and of what the values asked about carry
+     * ({@link Terms#carriedReachFrom}) rather than of a form's own atoms. What a caller supplies is
+     * only what it asked about.
+     *
+     * <p>That reaching and not the whole of one. A value under a recipe is reached too, and it is
+     * not wanted here: putting a recipe through a reading reads its operands as part of reading it,
+     * and asking for them here as well is asking for the same work once per arm a reading is copied
+     * into — which is a cost that compounds with nesting where the recipes' own reading does not
+     * ({@link ContextMultiplicity}). What only a relation names has no such second route, which is
+     * why it is this reaching that belongs here.
      */
-    private static Set<FactSubject> roots(Terms terms, Set<FactSubject> spokenOf,
-                                          Set<FactSubject> asked) {
+    private static Set<FactSubject> toDerive(Terms terms, Collection<FactSubject> asked) {
         Set<FactSubject> out = new LinkedHashSet<>();
-        for (FactSubject atom : asked) {
-            if (recorded(terms, atom)) {
-                out.add(atom);
-            }
-        }
-        for (FactSubject atom : spokenOf) {
+        for (FactSubject atom : terms.carriedReachFrom(asked)) {
             if (recorded(terms, atom)) {
                 out.add(atom);
             }
@@ -801,8 +825,14 @@ final class DerivedNumericFacts {
     private static Bounds boundsOf(LinearForm<FactSubject> form, ReadingDomain base, Terms terms,
                                    Memo done, Set<FactSubject> deriving, ContextMultiplicity copies) {
         ReadingDomain with = base;
-        for (FactSubject atom : form.coefs().keySet()) {
-            if (recorded(terms, atom)) {
+        for (FactSubject atom : toDerive(terms, form.coefs().keySet())) {
+            // An atom this is already in the middle of deriving is one the caller is deriving now,
+            // and its facts reach this reading through the recipe that is doing so. Reached here
+            // through what a value carries, it is a relation between two values and not a value
+            // built out of itself, so it is passed over rather than refused. The refusal stays where
+            // it is a computation reaching itself: an atom the form itself names is asked for
+            // outright, and a chain of recipes that comes back to one names it there.
+            if (!deriving.contains(atom) || form.coefs().containsKey(atom)) {
                 with = with.taking(derive(atom, base, terms, done, deriving, copies), terms);
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/DerivedNumericFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DerivedNumericFacts.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.Granularity;
 import souther.compiler.numeric.Intervals;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.NumericDomain.Bounds;
@@ -125,39 +126,133 @@ final class DerivedNumericFacts {
      * which is the interval reasoning that tightens under its own answers that this declines to be.
      */
     static NumericDomain<FactSubject> refine(NumericDomain<FactSubject> base, Terms terms, Set<FactSubject> asked) {
+        ReadingDomain reading = readingOf(base, terms, asked);
         Memo derived = new Memo();
-        if ((!terms.derivations().isEmpty() || !terms.reductions().isEmpty()) && !base.isBottom()) {
-            for (FactSubject atom : roots(terms, base, asked)) {
-                derive(atom, base, terms, derived, new LinkedHashSet<>(), ContextMultiplicity.ofOneReading());
+        if (terms.knowsAnything() && !reading.isBottom()) {
+            for (FactSubject atom : roots(terms, base.atomsSpokenOf(), asked)) {
+                derive(atom, reading, terms, derived, new LinkedHashSet<>(),
+                        ContextMultiplicity.ofOneReading());
             }
         }
         derived.watched();
-        NumericDomain<FactSubject> out = base;
+        ReadingDomain out = reading;
         for (List<Fact> facts : derived.answered.values()) {
-            out = taking(out, facts, terms);
+            out = out.taking(facts, terms);
         }
-        return out;
+        return out.domain();
     }
 
-    /** Whether {@code atom} was recorded as anything this can derive from — arithmetic outside the
-     * fragment, or the answer of a walk. Two tables and one question: what a reading walks is the
-     * atoms it can reach that anything was recorded about. */
-    private static boolean recorded(Terms terms, FactSubject atom) {
-        return terms.derivations().containsKey(atom) || terms.reductions().containsKey(atom);
+    /**
+     * A domain a recipe may be read against: one with what every value it can reach carries taken as
+     * holding.
+     *
+     * <p>The first of the two stages, held as a type so that the second cannot be run without it.
+     * What a value carries is true in every domain — a size is never negative whatever a guard said —
+     * so it is not something a recipe derives but something the reading starts from, and a reading
+     * that started without it answered about a fold's step as though nothing were known of anything
+     * the step named (#988). Made only by {@link #readingOf}, and every operation that moves a
+     * reading along is here, so there is no way to reach {@link #derive} with a domain that skipped
+     * it. A rule written down and checked by reading the callers is a rule the next caller does not
+     * read.
+     *
+     * <p>What it reaches is not kept beside it. An arm's statements and a candidate for an
+     * accumulator are relations over atoms the recipe already declared it reads from
+     * ({@link AtomKnowledge.Computation#formsRead}), so every value a reading moved along this way
+     * can reach was spoken for when it was made — and a set carried through the moves would be a
+     * second writing of that, read by nobody and true only for as long as nobody changed a move.
+     */
+    record ReadingDomain(NumericDomain<FactSubject> domain) {
+
+        boolean isBottom() {
+            return domain.isBottom();
+        }
+
+        Bounds boundsOf(LinearForm<FactSubject> form) {
+            return domain.boundsOf(form);
+        }
+
+        ReadingDomain assume(LinearForm<FactSubject> form, Rel rel, Map<FactSubject, Granularity> kinds) {
+            return new ReadingDomain(domain.assume(form, rel, kinds));
+        }
+
+        ReadingDomain assuming(FactSubject atom, Bounds bounds, Map<FactSubject, Granularity> kinds) {
+            return new ReadingDomain(domain.assuming(atom, bounds, kinds));
+        }
+
+        /** This, with what a walk's step is handed taken as holding. */
+        ReadingDomain taking(StepInputFacts inputs) {
+            return new ReadingDomain(inputs.taking(domain));
+        }
+
+        /** This, with every one of {@code facts} taken as holding, each through the door it names.
+         * An end a range does not reach is asserted as the strict comparison it is, which is what
+         * the domain reads a range's ends as. */
+        ReadingDomain taking(List<Fact> facts, Terms terms) {
+            NumericDomain<FactSubject> out = domain;
+            for (Fact fact : facts) {
+                out = switch (fact) {
+                    case Fact.Between(FactSubject atom, Bounds bounds) ->
+                            out.assuming(atom, bounds, terms.kindsOf(LinearForm.atom(atom)));
+                    case NumericConstraint(LinearForm<FactSubject> form, Rel rel) ->
+                            out.assume(form, rel, terms.kindsOf(form));
+                };
+            }
+            return new ReadingDomain(out);
+        }
     }
 
-    /** The atoms this reading is to derive from: the ones it can reach that anything was recorded
-     * about. Walked from the reaching side rather than from the tables, so what it costs is what the
-     * question is about and not how much arithmetic the behavior contains. */
-    private static Set<FactSubject> roots(Terms terms, NumericDomain<FactSubject> base,
+    /**
+     * {@code base} as a reading: what every atom it can reach carries, taken as holding.
+     *
+     * <p>What it can reach is the closure over both kinds of edge ({@link Terms#reached}), because
+     * an intrinsic relation is as much a reason to reach a value as a recipe reading from one: a
+     * container's size is no greater than the size of what it was built from, and the second of
+     * those has to be in the reading for the first to say anything.
+     *
+     * <p>Not an inference and not a round. What is taken in holds of the values whatever any of it
+     * comes to, so nothing here is read back to reach anything else — the closure is over what the
+     * naming recorded, and it is walked once.
+     */
+    static ReadingDomain readingOf(NumericDomain<FactSubject> base, Terms terms,
                                    Set<FactSubject> asked) {
+        Set<FactSubject> from = new LinkedHashSet<>(asked);
+        from.addAll(base.atomsSpokenOf());
+        NumericDomain<FactSubject> out = base;
+        for (FactSubject atom : terms.reachedFrom(from)) {
+            for (NumericConstraint fact : terms.knowledgeOf(atom).intrinsic()) {
+                out = out.assume(fact.form(), fact.rel(), terms.kindsOf(fact.form()));
+            }
+        }
+        return new ReadingDomain(out);
+    }
+
+    /** Whether {@code atom} was recorded as anything this can derive from, which is a computation
+     * and not what the value carries: what it carries is already in the reading, and putting it
+     * through a derivation would make a value nothing computes count as a recipe evaluated. */
+    private static boolean recorded(Terms terms, FactSubject atom) {
+        return !(terms.knowledgeOf(atom).computation() instanceof AtomKnowledge.Computation.None);
+    }
+
+    /**
+     * The atoms this reading is to derive from: the ones the question names or the domain speaks of
+     * that were recorded as computed. Walked from the asking side rather than from the table, so
+     * what it costs is what the question is about and not how much arithmetic the behavior contains.
+     *
+     * <p>What a reading <em>reaches</em> is a wider set than this and is a different question. An
+     * atom under a recipe is reached — that is what says a place must be kept for it, and what says
+     * its intrinsic facts belong in the reading — and it is derived when the recipe over it is read
+     * and not before. Made roots as well, every operand of every recipe would be evaluated whether
+     * the question came near it or not, which is a cost the reaching was never about.
+     */
+    private static Set<FactSubject> roots(Terms terms, Set<FactSubject> spokenOf,
+                                          Set<FactSubject> asked) {
         Set<FactSubject> out = new LinkedHashSet<>();
         for (FactSubject atom : asked) {
             if (recorded(terms, atom)) {
                 out.add(atom);
             }
         }
-        for (FactSubject atom : base.atomsSpokenOf()) {
+        for (FactSubject atom : spokenOf) {
             if (recorded(terms, atom)) {
                 out.add(atom);
             }
@@ -210,7 +305,7 @@ final class DerivedNumericFacts {
      * the recipes make a graph with no way back to where it started; reaching one that is already
      * being answered would mean the naming built an atom out of itself.
      */
-    private static List<Fact> derive(FactSubject atom, NumericDomain<FactSubject> base, Terms terms,
+    private static List<Fact> derive(FactSubject atom, ReadingDomain base, Terms terms,
                                      Memo done, Set<FactSubject> deriving, ContextMultiplicity copies) {
         List<Fact> had = done.answered.get(atom);
         if (had != null) {
@@ -238,25 +333,44 @@ final class DerivedNumericFacts {
      * seed is a product reaches the product through the form its walk was recorded with, and a
      * product of two folds reaches them through its factors.
      */
-    private static List<Fact> factsFor(FactSubject atom, NumericDomain<FactSubject> base, Terms terms,
+    private static List<Fact> factsFor(FactSubject atom, ReadingDomain base, Terms terms,
                                        Memo done, Set<FactSubject> deriving, ContextMultiplicity copies) {
-        InductiveBounds.Walk walk = terms.reductions().get(atom);
-        if (walk != null) {
-            // Each reading of the walk's own forms gets a memo of its own, since each is against a
-            // different domain — the caller's, and the caller's with a candidate assumed. What is
-            // shared is `deriving`, which is what says an atom was built out of itself, and that is
-            // true of a recipe whatever domain it is read in.
-            return between(atom, InductiveBounds.provenOf(walk, base, terms, (form, domain) -> {
-                Memo memo = new Memo();
-                Bounds answer = boundsOf(form, domain, terms, memo, deriving, copies);
-                // A reading, and watched as one. What the walk reads is where a step's own recipes
-                // are evaluated, so a reading that could not be seen here was the one place the
-                // memo could stop holding without anything saying so.
-                memo.watched();
-                return answer;
-            }), terms);
-        }
-        return switch (terms.derivations().get(atom)) {
+        return switch (terms.knowledgeOf(atom).computation()) {
+            // What the value carries is not derived. It holds in every reading and is already in
+            // this one, so putting it through here would count a value nothing computes as a recipe
+            // evaluated and would say a second time what the reading was made with.
+            case AtomKnowledge.Computation.None ignored -> List.of();
+            case AtomKnowledge.Computation.Reduction(InductiveBounds.Walk walk) ->
+                    reduced(atom, walk, base, terms, deriving, copies);
+            case AtomKnowledge.Computation.Derived(Derivation recipe) ->
+                    recipeFacts(atom, recipe, base, terms, done, deriving, copies);
+        };
+    }
+
+    /** What a walk answers, proved by checking one step. */
+    private static List<Fact> reduced(FactSubject atom, InductiveBounds.Walk walk, ReadingDomain base,
+                                      Terms terms, Set<FactSubject> deriving,
+                                      ContextMultiplicity copies) {
+        // Each reading of the walk's own forms gets a memo of its own, since each is against a
+        // different domain — the caller's, and the caller's with a candidate assumed. What is
+        // shared is `deriving`, which is what says an atom was built out of itself, and that is
+        // true of a recipe whatever domain it is read in.
+        return between(atom, InductiveBounds.provenOf(walk, base, terms, (form, domain) -> {
+            Memo memo = new Memo();
+            Bounds answer = boundsOf(form, domain, terms, memo, deriving, copies);
+            // A reading, and watched as one. What the walk reads is where a step's own recipes
+            // are evaluated, so a reading that could not be seen here was the one place the
+            // memo could stop holding without anything saying so.
+            memo.watched();
+            return answer;
+        }), terms);
+    }
+
+    /** What the arithmetic a recipe records answers, under this reading. */
+    private static List<Fact> recipeFacts(FactSubject atom, Derivation of, ReadingDomain base,
+                                          Terms terms, Memo done, Set<FactSubject> deriving,
+                                          ContextMultiplicity copies) {
+        return switch (of) {
             case Derivation.Product product -> between(atom, Intervals.product(
                     boundsOf(product.left(), base, terms, done, deriving, copies),
                     boundsOf(product.right(), base, terms, done, deriving, copies)), terms);
@@ -289,7 +403,7 @@ final class DerivedNumericFacts {
      * stand over it, and the nesting costs what the recipes cost and not what a reading of every
      * path through them would.
      */
-    private static Bounds chosen(Derivation.Chosen chosen, NumericDomain<FactSubject> base,
+    private static Bounds chosen(Derivation.Chosen chosen, ReadingDomain base,
                                  Terms terms, Memo done, Set<FactSubject> deriving,
                                  ContextMultiplicity copies) {
         List<Derivation.Chosen.Arm> arms = chosen.arms();
@@ -302,7 +416,7 @@ final class DerivedNumericFacts {
                 out = spanned(out, boundsOf(arm.answer(), base, terms, done, deriving, copies));
                 continue;
             }
-            NumericDomain<FactSubject> under = stating(arm, base, terms);
+            ReadingDomain under = stating(arm, base, terms);
             // An arm whose statements cannot all hold is an arm this choice never answers, so it
             // contributes no values to the span. Spanning with what it would have answered widens
             // the range by an arm that is not there — which is how a value every arm of which is
@@ -357,9 +471,8 @@ final class DerivedNumericFacts {
     }
 
     /** {@code base} with what choosing {@code arm} states taken as holding. */
-    private static NumericDomain<FactSubject> stating(Derivation.Chosen.Arm arm,
-                                                      NumericDomain<FactSubject> base, Terms terms) {
-        NumericDomain<FactSubject> under = base;
+    private static ReadingDomain stating(Derivation.Chosen.Arm arm, ReadingDomain base, Terms terms) {
+        ReadingDomain under = base;
         for (NumericConstraint settled : arm.settles()) {
             under = under.assume(settled.form(), settled.rel(), terms.kindsOf(settled.form()));
         }
@@ -372,7 +485,7 @@ final class DerivedNumericFacts {
      * domain: an atom answered under one arm's statements is not what it comes to under another's.
      * {@code deriving} is shared, since an atom built out of itself is built out of itself whatever
      * domain it is read in. */
-    private static Bounds readingAnArm(Derivation.Chosen.Arm arm, NumericDomain<FactSubject> under,
+    private static Bounds readingAnArm(Derivation.Chosen.Arm arm, ReadingDomain under,
                                        Terms terms, Set<FactSubject> deriving,
                                        ContextMultiplicity copies) {
         Memo memo = new Memo();
@@ -458,7 +571,7 @@ final class DerivedNumericFacts {
      * one above and not one this rule needs.
      */
     private static List<Fact> quotient(FactSubject atom, Derivation.TruncatingQuotient quotient,
-                                       NumericDomain<FactSubject> base, Terms terms,
+                                       ReadingDomain base, Terms terms,
                                        Memo done, Set<FactSubject> deriving, ContextMultiplicity copies) {
         Bounds divisor = divisorOf(quotient.divisor(), quotient.divisorExtent(), base, terms, done,
                 deriving, copies);
@@ -500,7 +613,7 @@ final class DerivedNumericFacts {
      * zero means: the answer keeps the sign of what was divided, and is smaller than the divisor.
      */
     private static List<Fact> remainder(FactSubject atom, Derivation.TruncatingRemainder remainder,
-                                        NumericDomain<FactSubject> base, Terms terms,
+                                        ReadingDomain base, Terms terms,
                                         Memo done, Set<FactSubject> deriving, ContextMultiplicity copies) {
         Bounds divisor = divisorOf(remainder.divisor(), remainder.divisorExtent(), base, terms, done,
                 deriving, copies);
@@ -572,7 +685,7 @@ final class DerivedNumericFacts {
      * scale nought, since which side that answer is on is the side every other scale answers too.
      */
     private static List<Fact> rounded(FactSubject atom, Derivation.RoundedQuotient rounded,
-                                      NumericDomain<FactSubject> base, Terms terms,
+                                      ReadingDomain base, Terms terms,
                                       Memo done, Set<FactSubject> deriving, ContextMultiplicity copies) {
         Bounds divisor = divisorOf(rounded.divisor(), rounded.divisorExtent(), base, terms, done,
                 deriving, copies);
@@ -671,7 +784,7 @@ final class DerivedNumericFacts {
     /** What the operator divided by, or null where this rule has no divisor to fire on — see
      * {@link #quotient}. */
     private static Bounds divisorOf(LinearForm<FactSubject> form, Bounds extent,
-                                    NumericDomain<FactSubject> base, Terms terms,
+                                    ReadingDomain base, Terms terms,
                                     Memo done, Set<FactSubject> deriving, ContextMultiplicity copies) {
         Bounds divisor = boundsOf(form, base, terms, done, deriving, copies).meet(extent);
         return !divisor.holdsAValue() || divisor.admits(Count.ZERO) ? null : divisor;
@@ -685,32 +798,15 @@ final class DerivedNumericFacts {
      * atoms this form names are derived, so what is read is the expression's own structure and not
      * everything else the reading has recorded.
      */
-    private static Bounds boundsOf(LinearForm<FactSubject> form, NumericDomain<FactSubject> base, Terms terms,
+    private static Bounds boundsOf(LinearForm<FactSubject> form, ReadingDomain base, Terms terms,
                                    Memo done, Set<FactSubject> deriving, ContextMultiplicity copies) {
-        NumericDomain<FactSubject> with = base;
+        ReadingDomain with = base;
         for (FactSubject atom : form.coefs().keySet()) {
             if (recorded(terms, atom)) {
-                with = taking(with, derive(atom, base, terms, done, deriving, copies), terms);
+                with = with.taking(derive(atom, base, terms, done, deriving, copies), terms);
             }
         }
         return with.boundsOf(form);
-    }
-
-    /** {@code d} with every one of {@code facts} taken as holding, each through the door it names.
-     * An end a range does not reach is asserted as the strict comparison it is, which is what the
-     * domain reads a range's ends as. */
-    private static NumericDomain<FactSubject> taking(NumericDomain<FactSubject> d, List<Fact> facts,
-                                                     Terms terms) {
-        NumericDomain<FactSubject> out = d;
-        for (Fact fact : facts) {
-            out = switch (fact) {
-                case Fact.Between(FactSubject atom, Bounds bounds) ->
-                        out.assuming(atom, bounds, terms.kindsOf(LinearForm.atom(atom)));
-                case NumericConstraint(LinearForm<FactSubject> form, Rel rel) ->
-                        out.assume(form, rel, terms.kindsOf(form));
-            };
-        }
-        return out;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/DerivedNumericFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DerivedNumericFacts.java
@@ -133,7 +133,7 @@ final class DerivedNumericFacts {
             Set<FactSubject> from = new LinkedHashSet<>(asked);
             from.addAll(base.atomsSpokenOf());
             for (FactSubject atom : toDerive(terms, from)) {
-                derive(atom, reading, terms, derived, new LinkedHashSet<>(),
+                derive(atom, reading, terms, derived, Deriving.nothingYet(),
                         ContextMultiplicity.ofOneReading());
             }
         }
@@ -322,25 +322,96 @@ final class DerivedNumericFacts {
     }
 
     /**
+     * What a reading is in the middle of deriving, which is two questions and was one set.
+     *
+     * <p>An atom reached again is either this check disagreeing with itself or it is not, and which
+     * it is depends on how the reading got back to it. A recipe is recorded over the parts a value
+     * was built from and a part is a strictly smaller expression, so a computation that reaches
+     * itself is a value the naming built out of itself — the thing {@link AnAtomComputedFromItself}
+     * is for. Reading a recipe also reads the values a relation drags in
+     * ({@link Terms#carriedReachFrom}), and those carry no such ordering: {@code a} computed from
+     * {@code c}, {@code c} carrying a relation about {@code b}, and {@code b} computed from
+     * {@code a} is three true statements and no cycle among computations at all.
+     *
+     * <p>So the two are held apart. {@link #alongComputations} is the chain of recipes the reading
+     * is inside, and it begins again wherever the reading steps across to a value only a relation
+     * named; {@link #anywhere} is every atom in flight, and it is what stops the walk going round.
+     * Written as one set, "is this atom below me on the stack" answered a question about the
+     * computation graph, and a ring that closed through a relation was reported as this check
+     * having built a value out of itself (#988).
+     */
+    private static final class Deriving {
+
+        private final Set<FactSubject> alongComputations;
+        private final Set<FactSubject> anywhere;
+
+        private Deriving(Set<FactSubject> alongComputations, Set<FactSubject> anywhere) {
+            this.alongComputations = alongComputations;
+            this.anywhere = anywhere;
+        }
+
+        static Deriving nothingYet() {
+            return new Deriving(new LinkedHashSet<>(), new LinkedHashSet<>());
+        }
+
+        /** The same reading, stepping across to a value a relation named rather than down into what
+         * a recipe was computed from. What is in flight carries over — the walk still has to stop —
+         * and the chain of recipes starts again, because none of the recipes below this point was
+         * reached from the ones above it. */
+        Deriving throughWhatAValueCarries() {
+            return new Deriving(new LinkedHashSet<>(), anywhere);
+        }
+
+        /** Whether deriving {@code atom} now would be a computation reaching itself. */
+        boolean computesFromItself(FactSubject atom) {
+            return alongComputations.contains(atom);
+        }
+
+        /** Whether {@code atom} is being derived somewhere this reading is already inside. */
+        boolean isInFlight(FactSubject atom) {
+            return anywhere.contains(atom);
+        }
+
+        void entering(FactSubject atom) {
+            alongComputations.add(atom);
+            anywhere.add(atom);
+        }
+
+        void left(FactSubject atom) {
+            alongComputations.remove(atom);
+            anywhere.remove(atom);
+        }
+    }
+
+    /**
      * What is known of {@code atom}, computed once and remembered.
      *
-     * <p>{@code deriving} holds what this is in the middle of answering. An atom is recorded against
-     * arithmetic over the parts it was built from, and a part is a strictly smaller expression, so
-     * the recipes make a graph with no way back to where it started; reaching one that is already
-     * being answered would mean the naming built an atom out of itself.
+     * <p>Two ways of arriving at an atom the reading is already inside, and they are not one answer
+     * ({@link Deriving}). A computation that reaches itself is refused. A ring that closes only
+     * through what a value carries is answered with nothing — a reading that cannot see round it
+     * says less, which is what a reading should do, where refusing it would state something false
+     * about this check's own naming.
+     *
+     * <p>What is answered there is not remembered. Nothing is a shorter answer than the one this
+     * atom will have once the reading is out of the ring, and filing it would hand that shorter
+     * answer to the next reader to ask.
      */
     private static List<Fact> derive(FactSubject atom, ReadingDomain base, Terms terms,
-                                     Memo done, Set<FactSubject> deriving, ContextMultiplicity copies) {
+                                     Memo done, Deriving deriving, ContextMultiplicity copies) {
         List<Fact> had = done.answered.get(atom);
         if (had != null) {
             return had;
         }
-        if (!deriving.add(atom)) {
+        if (deriving.computesFromItself(atom)) {
             throw new AnAtomComputedFromItself(atom);
         }
+        if (deriving.isInFlight(atom)) {
+            return List.of();
+        }
+        deriving.entering(atom);
         done.evaluating(atom);
         List<Fact> facts = factsFor(atom, base, terms, done, deriving, copies);
-        deriving.remove(atom);
+        deriving.left(atom);
         done.answered.put(atom, facts);
         return facts;
     }
@@ -358,7 +429,7 @@ final class DerivedNumericFacts {
      * product of two folds reaches them through its factors.
      */
     private static List<Fact> factsFor(FactSubject atom, ReadingDomain base, Terms terms,
-                                       Memo done, Set<FactSubject> deriving, ContextMultiplicity copies) {
+                                       Memo done, Deriving deriving, ContextMultiplicity copies) {
         return switch (terms.knowledgeOf(atom).computation()) {
             // What the value carries is not derived. It holds in every reading and is already in
             // this one, so putting it through here would count a value nothing computes as a recipe
@@ -373,7 +444,7 @@ final class DerivedNumericFacts {
 
     /** What a walk answers, proved by checking one step. */
     private static List<Fact> reduced(FactSubject atom, InductiveBounds.Walk walk, ReadingDomain base,
-                                      Terms terms, Set<FactSubject> deriving,
+                                      Terms terms, Deriving deriving,
                                       ContextMultiplicity copies) {
         // Each reading of the walk's own forms gets a memo of its own, since each is against a
         // different domain — the caller's, and the caller's with a candidate assumed. What is
@@ -392,7 +463,7 @@ final class DerivedNumericFacts {
 
     /** What the arithmetic a recipe records answers, under this reading. */
     private static List<Fact> recipeFacts(FactSubject atom, Derivation of, ReadingDomain base,
-                                          Terms terms, Memo done, Set<FactSubject> deriving,
+                                          Terms terms, Memo done, Deriving deriving,
                                           ContextMultiplicity copies) {
         return switch (of) {
             case Derivation.Product product -> between(atom, Intervals.product(
@@ -428,7 +499,7 @@ final class DerivedNumericFacts {
      * path through them would.
      */
     private static Bounds chosen(Derivation.Chosen chosen, ReadingDomain base,
-                                 Terms terms, Memo done, Set<FactSubject> deriving,
+                                 Terms terms, Memo done, Deriving deriving,
                                  ContextMultiplicity copies) {
         List<Derivation.Chosen.Arm> arms = chosen.arms();
         ContextMultiplicity inAnArm = copies.opening(contextsIn(arms));
@@ -510,7 +581,7 @@ final class DerivedNumericFacts {
      * {@code deriving} is shared, since an atom built out of itself is built out of itself whatever
      * domain it is read in. */
     private static Bounds readingAnArm(Derivation.Chosen.Arm arm, ReadingDomain under,
-                                       Terms terms, Set<FactSubject> deriving,
+                                       Terms terms, Deriving deriving,
                                        ContextMultiplicity copies) {
         Memo memo = new Memo();
         Bounds answered = boundsOf(arm.answer(), under, terms, memo, deriving, copies);
@@ -596,7 +667,7 @@ final class DerivedNumericFacts {
      */
     private static List<Fact> quotient(FactSubject atom, Derivation.TruncatingQuotient quotient,
                                        ReadingDomain base, Terms terms,
-                                       Memo done, Set<FactSubject> deriving, ContextMultiplicity copies) {
+                                       Memo done, Deriving deriving, ContextMultiplicity copies) {
         Bounds divisor = divisorOf(quotient.divisor(), quotient.divisorExtent(), base, terms, done,
                 deriving, copies);
         if (divisor == null) {
@@ -638,7 +709,7 @@ final class DerivedNumericFacts {
      */
     private static List<Fact> remainder(FactSubject atom, Derivation.TruncatingRemainder remainder,
                                         ReadingDomain base, Terms terms,
-                                        Memo done, Set<FactSubject> deriving, ContextMultiplicity copies) {
+                                        Memo done, Deriving deriving, ContextMultiplicity copies) {
         Bounds divisor = divisorOf(remainder.divisor(), remainder.divisorExtent(), base, terms, done,
                 deriving, copies);
         if (divisor == null) {
@@ -710,7 +781,7 @@ final class DerivedNumericFacts {
      */
     private static List<Fact> rounded(FactSubject atom, Derivation.RoundedQuotient rounded,
                                       ReadingDomain base, Terms terms,
-                                      Memo done, Set<FactSubject> deriving, ContextMultiplicity copies) {
+                                      Memo done, Deriving deriving, ContextMultiplicity copies) {
         Bounds divisor = divisorOf(rounded.divisor(), rounded.divisorExtent(), base, terms, done,
                 deriving, copies);
         if (divisor == null) {
@@ -809,7 +880,7 @@ final class DerivedNumericFacts {
      * {@link #quotient}. */
     private static Bounds divisorOf(LinearForm<FactSubject> form, Bounds extent,
                                     ReadingDomain base, Terms terms,
-                                    Memo done, Set<FactSubject> deriving, ContextMultiplicity copies) {
+                                    Memo done, Deriving deriving, ContextMultiplicity copies) {
         Bounds divisor = boundsOf(form, base, terms, done, deriving, copies).meet(extent);
         return !divisor.holdsAValue() || divisor.admits(Count.ZERO) ? null : divisor;
     }
@@ -823,18 +894,15 @@ final class DerivedNumericFacts {
      * everything else the reading has recorded.
      */
     private static Bounds boundsOf(LinearForm<FactSubject> form, ReadingDomain base, Terms terms,
-                                   Memo done, Set<FactSubject> deriving, ContextMultiplicity copies) {
+                                   Memo done, Deriving deriving, ContextMultiplicity copies) {
         ReadingDomain with = base;
         for (FactSubject atom : toDerive(terms, form.coefs().keySet())) {
-            // An atom this is already in the middle of deriving is one the caller is deriving now,
-            // and its facts reach this reading through the recipe that is doing so. Reached here
-            // through what a value carries, it is a relation between two values and not a value
-            // built out of itself, so it is passed over rather than refused. The refusal stays where
-            // it is a computation reaching itself: an atom the form itself names is asked for
-            // outright, and a chain of recipes that comes back to one names it there.
-            if (!deriving.contains(atom) || form.coefs().containsKey(atom)) {
-                with = with.taking(derive(atom, base, terms, done, deriving, copies), terms);
-            }
+            // Which of the two edges this atom was reached by is the whole of what the refusal below
+            // turns on, and it is known here and nowhere else: an atom the form names is what this
+            // recipe was computed from, and every other one is a value some relation dragged in.
+            Deriving how = form.coefs().containsKey(atom)
+                    ? deriving : deriving.throughWhatAValueCarries();
+            with = with.taking(derive(atom, base, terms, done, how, copies), terms);
         }
         return with.boundsOf(form);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -1115,6 +1115,13 @@ final class DischargeRules {
         return e instanceof Core.PreservedCall call ? Bound.MEASURED.get(call.operation()) : null;
     }
 
+    /** Whether {@code operation} counts what two values stand apart by — the other side of the row a
+     * shift is written in, read off that row rather than listed again. A measure named in a second
+     * place is a measure the day somebody adds a shift and updates one of them. */
+    static boolean isAMeasure(ValueName operation) {
+        return Bound.MEASURES.contains(operation);
+    }
+
     /** The cases {@code e} is defined in, or null where it is not a call to an operation that
      * answers one of the values it was given. */
     static Choices chosenBy(Core e) {
@@ -1219,6 +1226,8 @@ final class DischargeRules {
                 bindBounds(BOUNDS_ON_THE_RESULT);
         private static final Map<ValueName, Choices> CHOICES = bindChoices(CHOOSES);
         private static final Map<ValueName, Shift> MEASURED = bindShifts(SHIFTS);
+        private static final Set<ValueName> MEASURES = SHIFTS.values().stream()
+                .map(Shift::measure).collect(java.util.stream.Collectors.toUnmodifiableSet());
         private static final Map<ValueName, NumericResult> ARITHMETIC =
                 bindNumericResults(NUMERIC_RESULTS);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/InductiveBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InductiveBounds.java
@@ -1,7 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.numeric.Granularity;
-import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.NumericDomain.Bounds;
 import souther.compiler.numeric.NumericDomain.LinearForm;
 

--- a/souther-compiler/src/main/java/souther/compiler/check/InductiveBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InductiveBounds.java
@@ -60,7 +60,7 @@ final class InductiveBounds {
     @FunctionalInterface
     interface Reading {
 
-        Bounds of(LinearForm<FactSubject> form, NumericDomain<FactSubject> domain);
+        Bounds of(LinearForm<FactSubject> form, DerivedNumericFacts.ReadingDomain domain);
     }
 
     /** The range with no ends, which every walk's answer is in and which proves nothing. */
@@ -74,8 +74,9 @@ final class InductiveBounds {
      * domain. So this can be asked twice with two readings and answer twice, and neither answer can
      * reach the other.
      */
-    static Bounds provenOf(Walk walk, NumericDomain<FactSubject> base, Terms terms, Reading read) {
-        NumericDomain<FactSubject> given = walk.inputs().taking(base);
+    static Bounds provenOf(Walk walk, DerivedNumericFacts.ReadingDomain base, Terms terms,
+                           Reading read) {
+        DerivedNumericFacts.ReadingDomain given = base.taking(walk.inputs());
         if (given.isBottom()) {
             return ANYTHING;   // a reading that holds nothing settles nothing about a walk under it
         }
@@ -113,12 +114,14 @@ final class InductiveBounds {
      * round that feeds its own answer back.
      */
     private static boolean inductive(Walk walk, Bounds candidate, Bounds seed,
-                                     NumericDomain<FactSubject> given, Terms terms, Reading read) {
+                                     DerivedNumericFacts.ReadingDomain given, Terms terms,
+                                     Reading read) {
         if (!seed.liesWithin(candidate)) {
             return false;
         }
         Map<FactSubject, Granularity> spacing = terms.kindsOf(LinearForm.atom(walk.accumulator()));
-        NumericDomain<FactSubject> assuming = given.assuming(walk.accumulator(), candidate, spacing);
+        DerivedNumericFacts.ReadingDomain assuming =
+                given.assuming(walk.accumulator(), candidate, spacing);
         if (assuming.isBottom()) {
             // The accumulator is an atom of its own, so a range for it cannot contradict a reading —
             // unless the reading already held nothing, which was answered before this was reached.

--- a/souther-compiler/src/main/java/souther/compiler/check/IntrinsicNumericFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/IntrinsicNumericFacts.java
@@ -1,0 +1,174 @@
+package souther.compiler.check;
+
+import souther.compiler.core.Core;
+import souther.compiler.numeric.NumericDomain.LinearForm;
+import souther.compiler.numeric.NumericDomain.Rel;
+import souther.compiler.types.ValueName;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * What a value carries by being the value it is, read off the operation that answered it.
+ *
+ * <p>The third source of what an arm or a step may be read under, beside what a condition states
+ * ({@link Conditions}) and what a declaration guarantees of a value built through its checked
+ * constructor ({@link TypeGuarantees}). Neither of those covers it. A condition did not say a length
+ * is at or above nought — {@code not List.isEmpty(xs)} says it is not nought, and the rest is the
+ * list's — and no declaration says it either: {@code List} writes no clause about its length, and
+ * what a library operation guarantees of its answer is a contract rather than a data invariant. So
+ * it is a source of its own, and until #988 it had no owner and no place to be recorded.
+ *
+ * <p><b>One node, and no traversal.</b> What is answered here is what <em>this</em> call's answer
+ * carries, and the walk to whatever else the expression names is not here. Held the other way — as
+ * {@code sizeFacts} and {@code resultFacts} were, recursing through {@link Core#forEachChild} —
+ * reading these facts meant having the tree, which meant only a reader that had one could have them:
+ * a reduction's step is forms and atoms by the time it is read, and everything it named came out
+ * unbounded whatever it was (#988). The recursion is not needed either, because {@link Terms} is
+ * already walking the expression to name it, and an atom that files what it carries where it is
+ * named leaves nothing for a second walk to collect.
+ *
+ * <p>Relations and one edge each. Where a size is no greater than the size of what it was built
+ * from, what is stated here is that one relation and not the chain behind it: naming the source's
+ * size files what <em>it</em> carries, and the chain comes back as reachability
+ * ({@link Terms#reached}) rather than as a walk this makes. So a rule added to the table states one
+ * thing, wherever in a chain it lands.
+ *
+ * <p>Functions and no state, as {@link Conditions} is. {@link Terms} is passed because a relation is
+ * written over atoms and only that reader names one; nothing here decides what an atom is called.
+ *
+ * <p>Nothing here is a rule of its own. Which operations guarantee what is {@link DischargeRules}'
+ * tables — {@code SIZES}, {@code BOUNDS_ON_THE_RESULT}, {@code LOWER_BOUNDS}, {@code BUILDINGS} —
+ * and this is the one reader of them that turns a row into a relation between atoms.
+ */
+final class IntrinsicNumericFacts {
+
+    private IntrinsicNumericFacts() {}
+
+    /**
+     * What the size {@code atom} carries: it is never negative, and it stands where the sizes of the
+     * containers this one was built from put it.
+     *
+     * <p>{@code container} is the container the atom is the size of, which is the one a construction
+     * keeping its source's size has already been peeled off of ({@link DischargeRules#sizeSource}) —
+     * the same peeling the atom's own name was made through, so that what is stated here is stated
+     * about the atom it is filed against and not about a neighbour of it.
+     */
+    static List<NumericConstraint> ofSize(ValueName size, Core container, FactSubject atom,
+                                          Denotations at, Terms terms) {
+        List<NumericConstraint> out = new ArrayList<>();
+        out.add(new NumericConstraint(LinearForm.atom(atom), Rel.GE));   // a size is never negative
+        // A construction's result is no smaller than each source the rule names for it. A rule may
+        // name more than one — `a ++ b` is as long as either half — so this is a loop where the
+        // building below is one answer.
+        for (Core added : DischargeRules.noSmallerThan(container)) {
+            standing(size, atom, added, Rel.GE, at, terms, out);
+        }
+        if (container instanceof Core.PreservedCall call) {
+            DischargeRules.Source built = DischargeRules.builtFrom(call);
+            Rel rel = built == null ? null : relationOf(built.size());
+            if (rel != null) {
+                standing(size, atom, built.container(), rel, at, terms, out);
+            }
+        }
+        return out;
+    }
+
+    /** States how {@code atom} stands to the size of {@code source}, where that size is one this can
+     * name. A container nothing names is one nothing is stated about, which leaves the size bounded
+     * by what else is known of it rather than by half a rule. */
+    private static void standing(ValueName size, FactSubject atom, Core source, Rel rel,
+                                 Denotations at, Terms terms, List<NumericConstraint> out) {
+        FactSubject there = terms.sizeAtomFor(size, source, at);
+        if (there != null && !there.equals(atom)) {
+            out.add(new NumericConstraint(LinearForm.atom(atom).minus(LinearForm.atom(there)), rel));
+        }
+    }
+
+    /** How a size is stated of the two, or null where there is nothing to state: a construction of
+     * the same size answers both with one atom ({@link DischargeRules#sizeSource}), so a relation
+     * between them would say a name stands to itself. */
+    private static Rel relationOf(DischargeRules.Cardinality size) {
+        return switch (size) {
+            case AT_MOST -> Rel.LE;
+            case SAME -> null;
+        };
+    }
+
+    /**
+     * What the answer of {@code call} carries whatever its arguments are: an absolute value is not
+     * negative, a remainder by a written divisor is below it.
+     *
+     * <p>A bound whose rule asks something of the arguments is stated only where the arguments
+     * answer, and what they are read as is the naming's answer — a name given a constant is that
+     * constant, here as everywhere.
+     */
+    static List<NumericConstraint> ofCall(Core.PreservedCall call, FactSubject atom, Denotations at,
+                                          Terms terms) {
+        List<NumericConstraint> out = new ArrayList<>();
+        for (DischargeRules.ResultBound bound
+                : DischargeRules.boundsOn(call, arg -> constantOf(arg, at, terms))) {
+            LinearForm<FactSubject> against = bound.against() == null
+                    ? LinearForm.constant(bound.offset())
+                    : addTo(terms.affineOf(bound.against().of(call), at), bound.offset());
+            if (against != null) {
+                out.add(new NumericConstraint(LinearForm.atom(atom).minus(against), bound.rel()));
+            }
+        }
+        shifted(call, atom, at, terms, out);
+        return out;
+    }
+
+    /**
+     * What a measure between two values comes to where the second of them is the first moved by an
+     * amount: exactly that amount, in the units the shift states it in.
+     *
+     * <p>Asked of the measure and not of the shift, which is where it is about the atom it is filed
+     * against. A shift's own answer is a date and no number, so a rule filed where the shift is
+     * written would be filed against a value the numeric reading has no name for — and the measure is
+     * the value the fact is about, the one a clause writing that measure names and the one this is
+     * read back through.
+     *
+     * <p>Read through the names either side was given: {@code let then = Date.addDays(d, n)} and the
+     * shift written out are one value, and a measure to either is the same measure.
+     */
+    private static void shifted(Core.PreservedCall call, FactSubject atom, Denotations at,
+                                Terms terms, List<NumericConstraint> out) {
+        if (!DischargeRules.isAMeasure(call.operation()) || call.args().size() != 2) {
+            return;
+        }
+        if (!(terms.originating(call.args().get(1), at, new java.util.HashSet<>())
+                instanceof Core.PreservedCall moved)) {
+            return;
+        }
+        DischargeRules.Shift shift = DischargeRules.shiftBy(moved);
+        if (shift == null || !shift.measure().equals(call.operation())
+                || !sameValue(shift.of().of(moved), call.args().get(0), at, terms)) {
+            return;
+        }
+        LinearForm<FactSubject> amount = terms.affineOf(shift.amount().of(moved), at);
+        if (amount != null) {
+            out.add(new NumericConstraint(
+                    LinearForm.atom(atom).minus(amount.times(shift.per())), Rel.EQ));
+        }
+    }
+
+    /** Whether the two expressions are one value, which is whether the term grammar names them
+     * alike. */
+    private static boolean sameValue(Core a, Core b, Denotations at, Terms terms) {
+        Term one = terms.bodyKey(a, at);
+        return one != null && one.equals(terms.bodyKey(b, at));
+    }
+
+    /** {@code form} with {@code offset} added, or null where the form could not be read. */
+    private static LinearForm<FactSubject> addTo(LinearForm<FactSubject> form, BigDecimal offset) {
+        return form == null ? null : form.plus(LinearForm.constant(offset));
+    }
+
+    /** The constant {@code e} reads as, or null where it reads as none. */
+    private static BigDecimal constantOf(Core e, Denotations at, Terms terms) {
+        LinearForm<FactSubject> form = terms.affineOf(e, at);
+        return form == null || !form.coefs().isEmpty() ? null : form.constant();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1943,32 +1943,25 @@ public final class InvariantChecker {
     /**
      * The domain {@code owed} is read against, built from what {@code base} holds.
      *
-     * <p>Two steps that are one operation. What each clause states of the sizes it names is taken
-     * as holding, and then what follows about the arithmetic the domain cannot carry — a product of
-     * two values, a truncating quotient — is derived from what the reading proves of the values it
-     * was computed from. The second reads the first: a size a clause bounds is one the arithmetic
-     * over it can be read against, so the derivation has to come after, and a clause added to the
-     * first step without the second being asked again is a construction judged against arithmetic
-     * nothing was derived for. Written as one step so there is no order for a caller to keep.
+     * <p>Two steps that are one operation, and both are inside {@link DerivedNumericFacts}: what
+     * every value the reading can reach carries is taken as holding, and then what follows about the
+     * arithmetic the domain cannot carry — a product of two values, a truncating quotient — is
+     * derived from what the reading proves of the values it was computed from. The second reads the
+     * first, so the order is not a caller's to keep and cannot be: a reading is made by the one
+     * function that makes one ({@link DerivedNumericFacts#readingOf}).
      *
      * <p>Each reading answers with its own. A bound derived here is derived from what this reading
      * assumed, so it belongs to the reading and not to the value — which is why the construction's
      * two readings are built by two calls rather than sharing one domain.
      */
     private NumericDomain<FactSubject> readingOf(NumericDomain<FactSubject> base, List<Owing> owed) {
-        NumericDomain<FactSubject> out = base;
-        // What the clauses are decided by, which is one half of what the derivation can reach. The
-        // other half is what the domain speaks of, and that is the domain's own to answer — asked
-        // after this loop, since assuming a clause's statements is what puts its atoms there.
+        // What the clauses are decided by, which is one half of what the reading can reach. The
+        // other half is what the domain speaks of, and that is the domain's own to answer.
         Set<FactSubject> asked = new LinkedHashSet<>();
         for (Owing owing : owed) {
-            Predicates.Clause c = owing.owed();
-            for (NumericConstraint known : c.known()) {
-                out = out.assume(known.form(), known.rel(), terms.kindsOf(known.form()));
-            }
-            asked.addAll(c.atomsItIsDecidedBy());
+            asked.addAll(owing.owed().atomsItIsDecidedBy());
         }
-        return DerivedNumericFacts.refine(out, terms, asked);
+        return DerivedNumericFacts.refine(base, terms, asked);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import souther.compiler.types.BinOp;
 import souther.compiler.check.Combinators.Handed;
-import souther.compiler.check.DischargeRules.Cardinality;
 import souther.compiler.check.DischargeRules.Carrying;
 import souther.compiler.check.DischargeRules.Projection;
 import souther.compiler.check.DischargeRules.Shape;
@@ -13,7 +12,6 @@ import souther.compiler.numeric.NumericDomain.LinearForm;
 import souther.compiler.numeric.NumericDomain.Rel;
 import souther.compiler.core.Core;
 import souther.compiler.types.BindingId;
-import souther.compiler.types.ValueName;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -677,12 +675,63 @@ final class Predicates {
         if (numeric == null && fact == null) {
             return Owed.unreadable(inv).alsoFolded(fold);
         }
-        List<NumericConstraint> known = new ArrayList<>();
-        sizeFacts(inv, at, known);
-        resultFacts(inv, at, known);
+        // What the values this clause names carry, read off the atoms rather than off the tree: an
+        // atom files what it carries where it is named, so having read the clause into forms is
+        // having read them ({@link IntrinsicNumericFacts}).
+        List<NumericConstraint> known = terms.carriedBy(namedBy(numeric, fact));
         return Owed.of(new Clause(numeric, fact, known, piecewise)).alsoFolded(fold);
     }
 
+
+    /**
+     * The atoms {@code cond} names as numbers: the two sides of a comparison where it is one, and
+     * the value it is otherwise.
+     *
+     * <p>Naming and not walking. Reading either side into a form is what names every value in it,
+     * and an atom files what it carries where it is named — so this asks for the names and takes what
+     * was filed against them, where the same question used to be answered by descending the tree a
+     * second time and reading the library's tables again.
+     *
+     * <p>What the forms name and what they reach, and nothing else. A number standing somewhere no
+     * form reads it from — an argument of an operation that answers something the domain does not
+     * carry — is named by this condition and left out here, where the walk down the tree would have
+     * stated what it carries. Nothing is lost while a value the reading cannot name in a form is a
+     * value no clause and no other guard can be written over either: a fact about it could not have
+     * been the reason a construction was discharged. That stops being true the day a clause can be
+     * decided by an atom no form of any condition reaches, and this is where to look when it is.
+     */
+    private Set<FactSubject> atomsNamedBy(Core cond, Denotations at) {
+        Set<FactSubject> out = new LinkedHashSet<>();
+        if (cond instanceof Core.Binary b && Conditions.relOf(b.op()) != null) {
+            LinearForm<FactSubject> left = terms.affineOf(b.left(), at);
+            LinearForm<FactSubject> right = terms.affineOf(b.right(), at);
+            if (left != null) {
+                out.addAll(left.coefs().keySet());
+            }
+            if (right != null) {
+                out.addAll(right.coefs().keySet());
+            }
+            return out;
+        }
+        FactSubject atom = terms.atomOf(cond, at);
+        if (atom != null) {
+            out.add(atom);
+        }
+        return out;
+    }
+
+    /** The atoms a clause read this far names: the ones its relation is written over, and the one a
+     * predicate it states is keyed on. */
+    private static Set<FactSubject> namedBy(NumericConstraint numeric, Fact fact) {
+        Set<FactSubject> out = new LinkedHashSet<>();
+        if (numeric != null) {
+            out.addAll(numeric.atoms());
+        }
+        if (fact != null) {
+            out.addAll(fact.keys());
+        }
+        return out;
+    }
 
     /** Whether {@code inv} is decided outright: the clause, with the construction's own values
      * already standing where it read a field, folded. {@code null} where it does not fold — which is
@@ -752,11 +801,12 @@ final class Predicates {
             return assumeCond(under, k, at, !positive).alsoRead(taken, shapeRead);
         }
         Known out = k;
-        // What holds of the sizes the condition names, and of what the operations in it answer,
-        // whichever way the condition itself is read.
-        List<NumericConstraint> known = new ArrayList<>();
-        sizeFacts(cond, at, known);
-        resultFacts(cond, at, known);
+        // What the values this condition names carry, whichever way the condition itself is read.
+        // Read off the atoms the condition was named into and not by walking it again: naming an
+        // expression is what files what its values carry, so the reading that named it has them
+        // ({@link IntrinsicNumericFacts}). Taken before the condition is read at all, for the reason
+        // the reachability question below is asked with them.
+        List<NumericConstraint> known = terms.carriedBy(atomsNamedBy(cond, at));
         for (NumericConstraint c : known) {
             // A size is never negative whether or not the condition holds, so this holds of the value
             // and not of the path — the condition is only where the container got named.
@@ -941,72 +991,6 @@ final class Predicates {
 
     // --- affine forms --------------------------------------------------------------------------
 
-    /** What is known of the size of every container an expression names: never negative, and no
-     * greater than the size of what it was built from wherever the building can only drop elements. */
-    void sizeFacts(Core e, Denotations at, List<NumericConstraint> out) {
-        // A name is what it was given, here as everywhere: what is known of a size does not depend on
-        // whether the size was written where it is read or bound first.
-        if (e instanceof Core.Read r && at.valueOf(r.binding()) != null) {
-            sizeFacts(at.valueOf(r.binding()), at, out);
-            return;
-        }
-        if (!(e instanceof Core.PreservedCall call)) {
-            Core.forEachChild(e, child -> sizeFacts(child, at, out));
-            return;
-        }
-        Core container = DischargeRules.sizeArgOf(call);
-        if (container != null) {
-            // The subject and not the symbolic key: a size is never negative whatever it is taken
-            // of, and a count over something the term grammar cannot read is still a count.
-            FactSubject atom = terms.subjectOf(call, at);
-            if (atom != null) {
-                out.add(new NumericConstraint(LinearForm.atom(atom), Rel.GE));   // a size is never negative
-                bounds(call.operation(), DischargeRules.sizeSource(container), at, out);
-            }
-        }
-        for (Core arg : call.args()) {
-            sizeFacts(arg, at, out);
-        }
-    }
-
-    /**
-     * What is known of the result of every operation an expression names, whatever its arguments are:
-     * an absolute value is not negative, a remainder by a written divisor is below it.
-     *
-     * <p>The sibling of {@link #sizeFacts}, and read in both the places that one is: what an
-     * operation guarantees holds where a clause is read against the call and where a condition names
-     * it alike. A bound whose rule asks something of the arguments is stated only where the arguments
-     * answer, and what they are read as is this reading's answer — a name given a constant is that
-     * constant, here as everywhere.
-     */
-    void resultFacts(Core e, Denotations at, List<NumericConstraint> out) {
-        // A name is what it was given, as in `sizeFacts`: an operation's guarantee does not depend on
-        // whether its call was written where it is read or bound first.
-        if (e instanceof Core.Read r && at.valueOf(r.binding()) != null) {
-            resultFacts(at.valueOf(r.binding()), at, out);
-            return;
-        }
-        if (!(e instanceof Core.PreservedCall call)) {
-            Core.forEachChild(e, child -> resultFacts(child, at, out));
-            return;
-        }
-        FactSubject result = terms.atomOf(call, at);
-        if (result != null) {
-            for (DischargeRules.ResultBound bound
-                    : DischargeRules.boundsOn(call, arg -> constantOf(arg, at))) {
-                LinearForm<FactSubject> against = bound.against() == null
-                        ? LinearForm.constant(bound.offset())
-                        : addTo(terms.affineOf(bound.against().of(call), at), bound.offset());
-                if (against != null) {
-                    out.add(new NumericConstraint(LinearForm.atom(result).minus(against), bound.rel()));
-                }
-            }
-        }
-        shiftFact(call, at, out);
-        for (Core arg : call.args()) {
-            resultFacts(arg, at, out);
-        }
-    }
 
     /**
      * Whether {@code cond}, asserted with polarity {@code positive}, fails in every case an
@@ -1102,89 +1086,6 @@ final class Predicates {
         Core.forEachChild(e, child -> chosenCalls(child, at, out));
     }
 
-    /**
-     * What {@code call} states through the measure that counts what it shifted and what it answered
-     * apart, where it is a shift this has a rule about.
-     *
-     * <p>The measure over the two values is the atom a clause written in that measure builds, so the
-     * fact and the clause meet at one term. Where either value is named by nothing there is no such
-     * atom, and nothing is stated.
-     */
-    private void shiftFact(Core.PreservedCall call, Denotations at, List<NumericConstraint> out) {
-        DischargeRules.Shift shift = DischargeRules.shiftBy(call);
-        if (shift == null) {
-            return;
-        }
-        Term from = terms.bodyKey(shift.of().of(call), at);
-        Term to = terms.bodyKey(call, at);
-        LinearForm<FactSubject> amount = terms.affineOf(shift.amount().of(call), at);
-        if (from == null || to == null || amount == null) {
-            return;
-        }
-        out.add(new NumericConstraint(
-                LinearForm.atom(terms.measureKeyOf(shift.measure(), from, to))
-                        .minus(amount.times(shift.per())),
-                Rel.EQ));
-    }
-
-    /** {@code form} with {@code offset} added, or null where the form could not be read. */
-    private static LinearForm<FactSubject> addTo(LinearForm<FactSubject> form, BigDecimal offset) {
-        return form == null ? null : form.plus(LinearForm.constant(offset));
-    }
-
-    /** The constant {@code e} reads as, or null where it reads as none. */
-    private BigDecimal constantOf(Core e, Denotations at) {
-        LinearForm<FactSubject> form = terms.affineOf(e, at);
-        return form == null || !form.coefs().isEmpty() ? null : form.constant();
-    }
-
-    /** How the size of a container relates to the size of what it was built from, down the chain.
-     * Which way it is stated is what the construction's {@link Cardinality} says. */
-    void bounds(ValueName sizeCall, Core container, Denotations at, List<NumericConstraint> out) {
-        // A construction's result is never smaller than each source named for it. A rule may name
-        // more than one, so this is a loop where the building below is a single answer — and it is
-        // asked of the expression rather than of a call, since `a ++ b` is one of these and is
-        // written as an operator.
-        for (Core added : DischargeRules.noSmallerThan(container)) {
-            stated(sizeCall, container, DischargeRules.sizeSource(added), Rel.GE, at, out);
-        }
-        if (!(container instanceof Core.PreservedCall call)) {
-            return;
-        }
-        Source built = DischargeRules.builtFrom(call);
-        Rel rel = built == null ? null : relationOf(built.size());
-        if (rel == null) {
-            return;
-        }
-        stated(sizeCall, container, DischargeRules.sizeSource(built.container()), rel, at, out);
-    }
-
-    /** States how the size of {@code container} relates to the size of {@code source}, and goes on
-     * down whatever that one was built from. A container neither of them has a key for is one
-     * nothing can be said of, and stops the walk. */
-    private void stated(ValueName sizeCall, Core container, Core source, Rel rel, Denotations at,
-                        List<NumericConstraint> out) {
-        Term here = terms.bodyKey(container, at);
-        Term there = terms.bodyKey(source, at);
-        if (here == null || there == null) {
-            return;
-        }
-        out.add(new NumericConstraint(
-                LinearForm.atom(terms.sizeKeyOf(sizeCall, here))
-                        .minus(LinearForm.atom(terms.sizeKeyOf(sizeCall, there))),
-                rel));
-        bounds(sizeCall, source, at, out);
-    }
-
-    /** How {@code size} is stated of the two sizes, or null where there is nothing to state: a
-     * construction of the same size answers both with one atom ({@code DischargeRules.sizeSource}),
-     * so a constraint between them would say a name is itself. */
-    private static Rel relationOf(Cardinality size) {
-        return switch (size) {
-            case AT_MOST -> Rel.LE;
-            case SAME -> null;
-        };
-    }
 
     /** The keys a guard could have settled to establish this clause: the predicate as written, and
      * the same predicate of each container the written one was built from by a construction that

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -103,25 +103,23 @@ final class Terms {
      * terms equal ({@link Term}).
      */
     private final Term.Interner interned = new Term.Interner();
-    /** How each atom outside the affine fragment was computed. */
-    private final Map<FactSubject, Derivation> derivations = new HashMap<>();
-
     /**
-     * The walk each atom that is a reduction's answer was reached by.
+     * What this reading knows about each atom it has named by knowing which value it is: how the
+     * value was reached, and what it carries whatever reached it ({@link AtomKnowledge}).
      *
-     * <p>Beside {@link #derivations} and not among them. A derivation is what one expression is made
-     * of — a product of two values, a quotient by a written number — and it is read off the operands
-     * where they stand. A walk is what a library operation does with a closure it applies over and
-     * over, which no arrangement of an expression's parts says. Held as two tables because they are
-     * two facts: an operation the library gains is a row here and never a new shape of arithmetic,
-     * and a shape of arithmetic the language gains is the other way about.
+     * <p>One table and not one per kind of thing worth knowing. Held as a table of recipes beside a
+     * table of walks, the two were enumerated by name wherever an atom was read, and what a reader
+     * did not enumerate an atom silently did not have — which is how a size named inside a
+     * reduction's step came out with nothing known of it whatever the step did with it (#988). It
+     * also let one atom stand in both tables at once, which is two answers to what one value is, and
+     * neither table could see it.
      *
-     * <p>What is held is what was read of the walk here, as numbers. Nothing in it is a tree to be
-     * read again and nothing in it holds what the names around the call denoted — a walk whose parts
-     * could not be read at naming time is not recorded at all, rather than recorded as somewhere to
-     * go back to.
+     * <p>What is held is what was read at naming time, as numbers. Nothing in it is a tree to be
+     * read again and nothing in it holds what the names around a call denoted — a walk whose parts
+     * could not be read then is not recorded at all, rather than recorded as somewhere to go back
+     * to.
      */
-    private final Map<FactSubject, InductiveBounds.Walk> reductions = new HashMap<>();
+    private final Map<FactSubject, AtomKnowledge> knowledge = new HashMap<>();
 
     /** The subject each evaluation this could not name is, made once per occurrence. Identity-keyed:
      * an occurrence is a node, and two nodes are two evaluations however alike they are written. */
@@ -131,14 +129,71 @@ final class Terms {
     /** What each node a rewrite built stands for, so an occurrence keeps its identity through one. */
     private final java.util.IdentityHashMap<Core, Core> builtFrom = new java.util.IdentityHashMap<>();
 
-    /** What each atom this named outside the affine fragment was computed from. */
-    Map<FactSubject, Derivation> derivations() {
-        return derivations;
+    /**
+     * What this knows about {@code atom}, which is never null: an atom nothing was recorded about is
+     * one known to be reached no way and to carry nothing.
+     *
+     * <p>One lookup and three questions. What a reader wants of an atom is not one thing — which
+     * atoms it reads, whether a recipe has to be put through a reading, what holds of it in every
+     * reading — and answering them from one record is what keeps a reader from having to know how
+     * many tables there are ({@link AtomKnowledge}).
+     */
+    AtomKnowledge knowledgeOf(FactSubject atom) {
+        AtomKnowledge had = knowledge.get(atom);
+        return had == null ? AtomKnowledge.nothing() : had;
     }
 
-    /** The walk each atom this named as a reduction's answer was reached by. */
-    Map<FactSubject, InductiveBounds.Walk> reductions() {
-        return reductions;
+    /** Whether anything at all has been recorded about any atom, which is what says a reading has
+     * nothing to derive rather than nothing to derive it from. */
+    boolean knowsAnything() {
+        return !knowledge.isEmpty();
+    }
+
+    /**
+     * Records that {@code atom} was reached by {@code how}.
+     *
+     * <p>One value is reached one way. An atom recorded as reached two ways is the naming and the
+     * reading disagreeing about which value the atom is, and every bound derived under that name is
+     * about neither of them — which is as true of a walk recorded beside a piece of arithmetic as of
+     * two pieces of arithmetic, and was checked only within each table until they were one.
+     */
+    void computedBy(FactSubject atom, AtomKnowledge.Computation how) {
+        AtomKnowledge had = knowledgeOf(atom);
+        if (!(had.computation() instanceof AtomKnowledge.Computation.None)
+                && !sameComputation(had.computation(), how)) {
+            throw new OneTermTwoDerivations("atom `" + atom.rendered() + "` was reached as "
+                    + had.computation() + " and as " + how);
+        }
+        knowledge.put(atom, had.computedBy(how));
+    }
+
+    /**
+     * Records that {@code atom} carries {@code facts} whatever reached it.
+     *
+     * <p>One answer whoever named it. What a value carries is a function of which value it is, so
+     * two namings of one atom that came to different answers is one of them having read a rule the
+     * other did not — and merging the two would make what an atom carries depend on how many readers
+     * had got to it, with the reader that asked first answered from half of it.
+     *
+     * <p>Saying nothing is not one of the two answers. An expression may be named while the reading
+     * cannot make out the operation behind it — a library operation applied bare reaches the naming
+     * as an application and reaches {@link #asOperator} as nothing — and what comes back then is not
+     * "this value carries nothing" but "this reader had nothing to read". Both writings are one
+     * value and one atom, so the reading that did make out the operation answers for it, and nothing
+     * about the order they were named in shows through: an absence never replaces an answer and
+     * never disagrees with one. Two answers that are both answers still disagree, which is the case
+     * this is here for.
+     */
+    void carrying(FactSubject atom, List<NumericConstraint> facts) {
+        AtomKnowledge had = knowledgeOf(atom);
+        if (facts.isEmpty()) {
+            return;
+        }
+        if (!had.intrinsic().isEmpty() && !sameFacts(had.intrinsic(), facts)) {
+            throw new OneTermTwoIntrinsicAnswers("atom `" + atom.rendered() + "` carries "
+                    + had.intrinsic() + " and carries " + facts);
+        }
+        knowledge.put(atom, had.carrying(facts));
     }
 
     /**
@@ -158,24 +213,46 @@ final class Terms {
      * answering a semantic question by a naming convention, and this is the reader that would go
      * wrong quietly — a form it does not reach leaves the places under it unbounded and nothing else
      * says so ({@link StepInputFacts}).
+     *
+     * <p>Both kinds of edge, and a closure taken with a visited set. What an atom carries relates it
+     * to other values as surely as a recipe reads from them — a size no greater than the size of
+     * what it was built from is a statement about two atoms, and reaching one of them without the
+     * other leaves the relation saying nothing. Repetition is where this stops and is not an error:
+     * intrinsic relations carry no ordering, so an atom reachable from itself through them is two
+     * true statements rather than a value built out of itself. That is the opposite of what
+     * repetition means over computation edges alone, which is why the two walks are separate and
+     * neither is written in terms of the other ({@link DerivedNumericFacts}).
      */
     Set<FactSubject> reached(LinearForm<FactSubject> form) {
+        return reachedFrom(form.coefs().keySet());
+    }
+
+    /** Every atom reading {@code from} reaches, the ones named among them. */
+    Set<FactSubject> reachedFrom(java.util.Collection<FactSubject> from) {
         Set<FactSubject> out = new java.util.LinkedHashSet<>();
-        java.util.Deque<FactSubject> todo = new java.util.ArrayDeque<>(form.coefs().keySet());
+        java.util.Deque<FactSubject> todo = new java.util.ArrayDeque<>(from);
         while (!todo.isEmpty()) {
             FactSubject atom = todo.poll();
             if (!out.add(atom)) {
                 continue;
             }
-            Derivation recipe = derivations.get(atom);
-            if (recipe != null) {
-                recipe.formsRead().forEach(f -> todo.addAll(f.coefs().keySet()));
-            }
-            InductiveBounds.Walk under = reductions.get(atom);
-            if (under != null) {
-                todo.addAll(under.seed().coefs().keySet());
-                todo.addAll(under.step().coefs().keySet());
-            }
+            todo.addAll(knowledgeOf(atom).directlyReads(atom));
+        }
+        return out;
+    }
+
+    /**
+     * What every value reachable from {@code from} carries, as relations.
+     *
+     * <p>The closure and not the atoms themselves. What a size carries relates it to the size of
+     * what it was built from, and that one carries its own being at or above nought — so a reader
+     * taking in only what the atoms it named carry would take in the relation and leave the value at
+     * the other end of it unspoken for.
+     */
+    List<NumericConstraint> carriedBy(java.util.Collection<FactSubject> from) {
+        List<NumericConstraint> out = new ArrayList<>();
+        for (FactSubject atom : reachedFrom(from)) {
+            out.addAll(knowledgeOf(atom).intrinsic());
         }
         return out;
     }
@@ -546,7 +623,7 @@ final class Terms {
      * could not be read, since it was read to decide whether that value had a name at all.
      */
     FactSubject atomOf(Core e, Denotations at) {
-        FactSubject size = sizeAtomOf(e, arg -> bodyKey(arg, at));
+        FactSubject size = sizeAtomOf(e, at);
         if (size != null) {
             return size;
         }
@@ -569,7 +646,7 @@ final class Terms {
      * domain carries nothing of — an enumeration, a string — is called something and is no number.
      */
     Position positionOf(Core e, Denotations at) {
-        FactSubject size = sizeAtomOf(e, arg -> bodyKey(arg, at));
+        FactSubject size = sizeAtomOf(e, at);
         FactSubject key = subjectOf(e, at);
         if (size != null) {
             return new Position(key, size);
@@ -594,6 +671,12 @@ final class Terms {
         if (atom != null) {
             atomExtents.putIfAbsent(atom, extentOf(affineScalarBase(e.type())));
             recording(atom, e, at);
+            // What the value carries is filed where the value is named, so that a reader holding the
+            // atom and no tree has it. Asked of the operation the value came from, whichever surface
+            // it was written on — the same normalisation the recipe is read through.
+            if (asOperator(e) instanceof Core.PreservedCall call) {
+                carrying(atom, IntrinsicNumericFacts.ofCall(call, atom, at, this));
+            }
         }
         return atom;
     }
@@ -654,11 +737,7 @@ final class Terms {
         if (made == null) {
             return;
         }
-        Derivation had = derivations.putIfAbsent(atom, made);
-        if (had != null && !sameDerivation(had, made)) {
-            throw new OneTermTwoDerivations("atom `" + atom.rendered() + "` was computed as "
-                    + had + " and as " + made);
-        }
+        computedBy(atom, new AtomKnowledge.Computation.Derived(made));
     }
 
     /**
@@ -711,13 +790,13 @@ final class Terms {
         // The accumulator is a number of the kind the walk answers, whether or not the step read it:
         // a step that ignores it names it nowhere, and a range is still asserted about it here.
         named(accumulator, granularityOf(e.type()));
+        // What the step reaches is asked after the step has been read, which is what names the atoms
+        // inside it and files what each of them carries. A place a relation of theirs names is one
+        // this has to keep, so the reaching is taken over both kinds of edge and not over the
+        // recipes alone ({@link #reached}).
         InductiveBounds.Walk made = new InductiveBounds.Walk(seed, accumulator, step,
                 StepInputFacts.of(walk, inside, this, symbols, policy, reached(step)));
-        InductiveBounds.Walk had = reductions.putIfAbsent(atom, made);
-        if (had != null && !had.equals(made)) {
-            throw new OneTermTwoDerivations("atom `" + atom.rendered() + "` is the answer of two"
-                    + " different walks");
-        }
+        computedBy(atom, new AtomKnowledge.Computation.Reduction(made));
     }
 
     /**
@@ -1111,6 +1190,36 @@ final class Terms {
         return a.sameAs(b, SAME_NUMBERS);
     }
 
+    /** Whether two readings reached a value the same way. A walk is compared by the numbers it was
+     * read as, which is what it is here. */
+    private static boolean sameComputation(AtomKnowledge.Computation a, AtomKnowledge.Computation b) {
+        return switch (a) {
+            case AtomKnowledge.Computation.None ignored ->
+                    b instanceof AtomKnowledge.Computation.None;
+            case AtomKnowledge.Computation.Derived(Derivation recipe) ->
+                    b instanceof AtomKnowledge.Computation.Derived it
+                            && sameDerivation(recipe, it.recipe());
+            case AtomKnowledge.Computation.Reduction(InductiveBounds.Walk walk) ->
+                    b instanceof AtomKnowledge.Computation.Reduction it && walk.equals(it.walk());
+        };
+    }
+
+    /** Whether two readings came to the same answer about what a value carries. Compared on the
+     * numbers and not on the records' own equality, for the reason a recipe is: {@code 0.10} and
+     * {@code 0.1} are one number, and two readings differing in nothing but a scale are not this
+     * check disagreeing with itself. */
+    private static boolean sameFacts(List<NumericConstraint> a, List<NumericConstraint> b) {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        for (int i = 0; i < a.size(); i++) {
+            if (a.get(i).rel() != b.get(i).rel() || !sameForm(a.get(i).form(), b.get(i).form())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /** How the numbers in a recipe are compared, which is this reading's answer and not the
      * recipe's: what is being caught is the check naming two values alike, and a difference in
      * scale is not that. */
@@ -1165,15 +1274,58 @@ final class Terms {
         }
     }
 
-    /** The atom of the size {@code e} takes of a container {@code key} can name, or null where it
-     * takes none or names none. */
-    FactSubject sizeAtomOf(Core e, java.util.function.Function<Core, Term> key) {
+    /**
+     * One atom this said carries two different things.
+     *
+     * <p>Beside {@link OneTermTwoDerivations} and for its reason. What a value carries is a function
+     * of which value it is, so two namings answering differently is one of them having read a rule
+     * the other did not — and the reader that asked between them was answered from half of it.
+     */
+    static final class OneTermTwoIntrinsicAnswers extends TheCheckDisagreesWithItself {
+        private static final long serialVersionUID = 1L;
+
+        OneTermTwoIntrinsicAnswers(String message) {
+            super(message);
+        }
+    }
+
+    /** The atom of the size {@code e} takes of a container this can name, or null where it takes
+     * none or names none. */
+    FactSubject sizeAtomOf(Core e, Denotations at) {
         Core container = DischargeRules.sizeArgOf(e);
-        if (container == null) {
+        return container == null ? null
+                : sizeAtomFor(((Core.PreservedCall) e).operation(), container, at);
+    }
+
+    /**
+     * The atom the size {@code size} of {@code container} is, named and with what it carries filed.
+     *
+     * <p>The one route to a size's atom, so that a size named while reading a clause and a size named
+     * while relating one container to another are one value that carries one thing. Reached from
+     * {@link IntrinsicNumericFacts} as well, which states one edge of a chain and leaves the rest to
+     * the naming of the atom at the other end of it — so the chain is walked by this, once per atom,
+     * rather than by a reader that had to remember to walk it.
+     *
+     * <p>Two readings of the container and they are not one. What the atom is <em>called</em> is read
+     * off the container as written, which is how it has always been named and is what makes a size
+     * over a name and a size over the expression it was given one atom ({@link #bodyKey} is what
+     * resolves the name). What the atom <em>carries</em> is read off the value that name was given,
+     * because the rules are about how the container was built and a name is not a way of building
+     * one. Resolving before naming makes naming fail where the value has no key of its own though
+     * the name has; asking the rules of the name instead states nothing where the expression states
+     * something, and one atom then has two answers.
+     */
+    FactSubject sizeAtomFor(ValueName size, Core container, Denotations at) {
+        Term counted = bodyKey(DischargeRules.sizeSource(container), at);
+        if (counted == null) {
             return null;
         }
-        Term arg = key.apply(DischargeRules.sizeSource(container));
-        return arg == null ? null : sizeKeyOf(((Core.PreservedCall) e).operation(), arg);
+        FactSubject atom = sizeKeyOf(size, counted);
+        if (atom != null) {
+            carrying(atom, IntrinsicNumericFacts.ofSize(size,
+                    DischargeRules.sizeSource(listedOut(container, at)), atom, at, this));
+        }
+        return atom;
     }
 
     /** The size {@code size} takes of {@code container}, named as the whole number it is. A size
@@ -1181,7 +1333,7 @@ final class Terms {
      * that takes it and nothing besides, which is the term a clause reading one builds and the term a
      * guard stating one builds — so the two are one value rather than two writings that have to keep
      * spelling each other alike. */
-    FactSubject sizeKeyOf(ValueName size, Term container) {
+    private FactSubject sizeKeyOf(ValueName size, Term container) {
         return named(interned.called(size, List.of(container)), Granularity.DISCRETE);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -227,6 +227,31 @@ final class Terms {
         return reachedFrom(form.coefs().keySet());
     }
 
+    /**
+     * Every atom reading {@code from} reaches by what those values carry, and no further.
+     *
+     * <p>The narrower of the two reachings and a different question from {@link #reachedFrom}. What
+     * is wanted where a recipe is put through a reading is the values a relation drags in —
+     * {@code Decimal.toInt} carries that its answer is within one of what it rounded, and what it
+     * rounded may be arithmetic nothing else names. The values under a recipe are not wanted there:
+     * reading a recipe reads its operands itself, and asking for them again multiplies with every
+     * arm a reading is copied into ({@link ContextMultiplicity}).
+     */
+    Set<FactSubject> carriedReachFrom(java.util.Collection<FactSubject> from) {
+        Set<FactSubject> out = new java.util.LinkedHashSet<>();
+        java.util.Deque<FactSubject> todo = new java.util.ArrayDeque<>(from);
+        while (!todo.isEmpty()) {
+            FactSubject atom = todo.poll();
+            if (!out.add(atom)) {
+                continue;
+            }
+            for (NumericConstraint fact : knowledgeOf(atom).intrinsic()) {
+                todo.addAll(fact.atoms());
+            }
+        }
+        return out;
+    }
+
     /** Every atom reading {@code from} reaches, the ones named among them. */
     Set<FactSubject> reachedFrom(java.util.Collection<FactSubject> from) {
         Set<FactSubject> out = new java.util.LinkedHashSet<>();
@@ -1337,19 +1362,6 @@ final class Terms {
         return named(interned.called(size, List.of(container)), Granularity.DISCRETE);
     }
 
-    /**
-     * The number {@code measure} answers of {@code from} and {@code to}, named as the call it is.
-     *
-     * <p>The same shape a clause writing that measure builds, so a rule stated in it and an invariant
-     * written in it name one value. How its values are spaced is read off what the library declares
-     * the measure to answer, which is what a clause reading the call is named with too — a count of
-     * whole days is one thing wherever it is written.
-     */
-    FactSubject measureKeyOf(ValueName.Stdlib measure, Term from, Term to) {
-        Prelude.PreludeEntry counts = Prelude.entry(measure.qualified());
-        return named(interned.called(measure, List.of(from, to)),
-                granularityOf(counts.signature().result()));
-    }
 
     /**
      * The atom a rule counting {@code e} would have bounded, or null where there is no such atom.

--- a/souther-compiler/src/test/java/souther/compiler/WhatAValueCarriesReachesAStepAsItReachesAPathTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatAValueCarriesReachesAStepAsItReachesAPathTest.java
@@ -33,6 +33,9 @@ class WhatAValueCarriesReachesAStepAsItReachesAPathTest {
             data AtLeastTwo = Int
                 invariant twoUp = value >= 2
 
+            data NonNegD = Decimal
+                invariant nn = value >= 0.0m
+
             data Counted =
                 { items: List<Int>
                 }
@@ -110,6 +113,34 @@ class WhatAValueCarriesReachesAStepAsItReachesAPathTest {
 
                 let total (xs) = Positive(List.fold((a, c) -> a + List.length(c.items) * 2, 1, xs))
                 """), "twice something at or above nought is at or above nought");
+    }
+
+    /**
+     * And the other way about: what a value carries reaching the arithmetic under it.
+     *
+     * <p>The two kinds of edge are one graph and a reading has to walk both ways along it.
+     * {@code Decimal.toInt} carries that its answer is within one of what it rounded, and what it
+     * rounded is a product here — so the answer is at or above nought only once the product is, and
+     * the product is a recipe somebody has to put through this reading. Read where a clause names
+     * it, the product is in the domain and is derived. Read inside a step, the step names the answer
+     * and never the product, and a reading that derived only what the step named left it unbounded
+     * — the same divergence as the rows above, along the edge they do not use.
+     */
+    @Test
+    void whatAValueCarriesReachesTheArithmeticUnderIt() {
+        assertFalse(owed("""
+                behavior one : (d: NonNegD) -> Positive
+                    constructs Positive
+
+                let one (d) = Positive(Decimal.toInt(HALF_UP, d.value * d.value) + 1)
+                """), "on a path");
+        assertFalse(owed("""
+                behavior total : (xs: List<NonNegD>) -> Positive
+                    constructs Positive
+
+                let total (xs) = Positive(List.fold(
+                    (a, d) -> a + Decimal.toInt(HALF_UP, d.value * d.value), 1, xs))
+                """), "and inside a step, where the step names the answer and not what it rounded");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/WhatAValueCarriesReachesAStepAsItReachesAPathTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatAValueCarriesReachesAStepAsItReachesAPathTest.java
@@ -1,0 +1,172 @@
+package souther.compiler;
+
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a value carries by being what it is, read where a step is read as well as where a path is
+ * (#988).
+ *
+ * <p>A size is never negative and an absolute value is not, whatever any condition said and whatever
+ * declaration was written. Those hold of the value, so they hold on every arm of every choice and
+ * before any guard — and they were collected by walking the expression a reading had, which meant a
+ * reduction's step, read out of forms and atoms, had none of them. What that came to is the pair
+ * below: one fold discharged and its neighbour did not, differing in nothing but which of two
+ * spellings of one guard the author wrote.
+ *
+ * <p>Both sides of the boundary are here. Everything written on a path was already silent and stays
+ * silent, which is what says the change was not to the rules; and every row that a fact is not
+ * enough for stays reported, which is what says the facts are being used rather than assumed past.
+ */
+class WhatAValueCarriesReachesAStepAsItReachesAPathTest {
+
+    private static final String TYPES = """
+            module demo
+
+            data Positive = Int
+                invariant atLeastOne = value >= 1
+
+            data AtLeastTwo = Int
+                invariant twoUp = value >= 2
+
+            data Counted =
+                { items: List<Int>
+                }
+            """;
+
+    private static boolean owed(String body) {
+        return Compiler.compileWithWarnings(TYPES + "\n" + body).warnings().stream()
+                .anyMatch(d -> d.severity() == Severity.WARNING && "E2011".equals(d.code()));
+    }
+
+    /**
+     * The pair the issue was written from: one guard, two spellings, one value, one bound needed.
+     *
+     * <p>The comparison states {@code length > 0} on its own, which is a relation a condition wrote
+     * and stands beside the arm. The emptiness check normalises to {@code length /= 0}, and "not
+     * nought" bounds nothing without "never below nought" — which no condition said and no
+     * declaration writes, being what a length is.
+     */
+    @Test
+    void twoSpellingsOfOneGuardAnswerAlikeInsideAFold() {
+        assertFalse(owed("""
+                behavior total : (xs: List<Counted>) -> Positive
+                    constructs Positive
+
+                let total (xs) = Positive(List.fold(
+                    (a, c) -> if List.length(c.items) > 0 then a + List.length(c.items) else a,
+                    1, xs))
+                """), "the guard states the bound itself");
+        assertFalse(owed("""
+                behavior total : (xs: List<Counted>) -> Positive
+                    constructs Positive
+
+                let total (xs) = Positive(List.fold(
+                    (a, c) -> if Bool.not(List.isEmpty(c.items)) then a + List.length(c.items) else a,
+                    1, xs))
+                """), "and the emptiness check leaves the bound to what a length is");
+    }
+
+    /**
+     * And with no guard at all, which is what says this is not about conditions.
+     *
+     * <p>The row that rules out recording these beside the arm a choice was decided by: there is no
+     * choice here to record them beside.
+     */
+    @Test
+    void aStepThatNamesASizeUnderNoGuardIsBoundedByWhatASizeIs() {
+        assertFalse(owed("""
+                behavior total : (xs: List<Counted>) -> Positive
+                    constructs Positive
+
+                let total (xs) = Positive(List.fold((a, c) -> a + List.length(c.items), 1, xs))
+                """), "one plus something at or above nought is at or above one");
+    }
+
+    /** What an operation guarantees of its answer reaches a step the same way a size does. Two
+     * sources in one family, and a reading that had one without the other would be answering by
+     * which table a fact happened to be written in. */
+    @Test
+    void aStepThatNamesAnOperationsOwnGuaranteeIsBoundedByIt() {
+        assertFalse(owed("""
+                behavior total : (xs: List<Int>) -> Positive
+                    constructs Positive
+
+                let total (xs) = Positive(List.fold((a, x) -> a + Int.abs(x), 1, xs))
+                """), "an absolute value is not negative, whatever the element is");
+    }
+
+    /** And through a recipe standing over it, since what a product is read from is where its
+     * factors' own facts have to arrive. */
+    @Test
+    void aFactReachesAStepThroughTheArithmeticOverIt() {
+        assertFalse(owed("""
+                behavior total : (xs: List<Counted>) -> Positive
+                    constructs Positive
+
+                let total (xs) = Positive(List.fold((a, c) -> a + List.length(c.items) * 2, 1, xs))
+                """), "twice something at or above nought is at or above nought");
+    }
+
+    /**
+     * The same facts where they were already read, which is every writing on a path.
+     *
+     * <p>Silent before this and silent after. A change that made a step read what a path reads could
+     * as easily have been a change to what either reads, and these are what say it was not.
+     */
+    @Test
+    void whatIsWrittenOnAPathAnswersAsItDid() {
+        assertFalse(owed("""
+                behavior one : (c: Counted) -> Positive
+                    constructs Positive
+
+                let one (c) = Positive(List.length(c.items) + 1)
+                """), "a size on the path");
+        assertFalse(owed("""
+                behavior one : (x: Int) -> Positive
+                    constructs Positive
+
+                let one (x) = Positive(Int.abs(x) + 1)
+                """), "an operation's own guarantee on the path");
+        assertFalse(owed("""
+                behavior one : (c: Counted) -> Positive
+                    constructs Positive
+
+                let one (c) =
+                    Positive(if Bool.not(List.isEmpty(c.items)) then List.length(c.items) else 1)
+                """), "and a choice read on the path, under the spelling that states the least");
+    }
+
+    /**
+     * A fact is what it is and no more.
+     *
+     * <p>Every silent row above has a neighbour here differing in one thing, so what discharged them
+     * was the fact and not a reading that stopped asking. A size at or above nought does not put a
+     * total above one; and it says nothing at all about what is left when it is taken away.
+     */
+    @Test
+    void whatTheFactDoesNotReachStaysReported() {
+        assertTrue(owed("""
+                behavior total : (xs: List<Int>) -> AtLeastTwo
+                    constructs AtLeastTwo
+
+                let total (xs) = AtLeastTwo(List.fold((a, x) -> a + Int.abs(x), 1, xs))
+                """), "at or above nought carries a seed of one to one, and not to two");
+        assertTrue(owed("""
+                behavior total : (xs: List<Counted>) -> Positive
+                    constructs Positive
+
+                let total (xs) = Positive(List.fold((a, c) -> a - List.length(c.items), 1, xs))
+                """), "how far below one it goes is what a size has no upper end for");
+        assertTrue(owed("""
+                behavior total : (xs: List<Int>) -> Positive
+                    constructs Positive
+
+                let total (xs) = Positive(List.fold((a, x) -> a + x, 1, xs))
+                """), "and an element nothing bounds is bounded by nothing here");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AProductIsHeldToWhatThePathKnowsOfItsFactorsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AProductIsHeldToWhatThePathKnowsOfItsFactorsTest.java
@@ -195,7 +195,8 @@ class AProductIsHeldToWhatThePathKnowsOfItsFactorsTest {
         FactSubject second = terms.affineOf(arithmetic(BinOp.MUL, read("a", a), read("b", b)), at).coefs().keySet().iterator().next();
 
         assertEquals(first, second);
-        assertEquals(1, terms.derivations().size());
+        assertTrue(terms.knowledgeOf(first).computation()
+                instanceof AtomKnowledge.Computation.Derived, "the one atom holds the one recipe");
     }
 
     /** A product of two whole numbers is a whole number, which is what the domain records it as. */

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARecipeIsReadFromIsWhatAReadingReachesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARecipeIsReadFromIsWhatAReadingReachesTest.java
@@ -67,11 +67,11 @@ class WhatARecipeIsReadFromIsWhatAReadingReachesTest {
         FactSubject product = marker();
         FactSubject other = marker();
         FactSubject choice = marker();
-        terms.derivations().put(product,
-                new Derivation.Product(LinearForm.atom(left), LinearForm.atom(right)));
-        terms.derivations().put(choice, new Derivation.Chosen(List.of(
+        terms.computedBy(product, new AtomKnowledge.Computation.Derived(
+                new Derivation.Product(LinearForm.atom(left), LinearForm.atom(right))));
+        terms.computedBy(choice, new AtomKnowledge.Computation.Derived(new Derivation.Chosen(List.of(
                 new Derivation.Chosen.Arm(LinearForm.atom(product), List.of()),
-                new Derivation.Chosen.Arm(LinearForm.atom(other), List.of()))));
+                new Derivation.Chosen.Arm(LinearForm.atom(other), List.of())))));
 
         assertEquals(Set.of(choice, product, other, left, right),
                 terms.reached(LinearForm.atom(choice)),
@@ -96,10 +96,10 @@ class WhatARecipeIsReadFromIsWhatAReadingReachesTest {
         FactSubject answered = marker();
         FactSubject askedAbout = marker();
         FactSubject choice = marker();
-        terms.derivations().put(choice, new Derivation.Chosen(List.of(
+        terms.computedBy(choice, new AtomKnowledge.Computation.Derived(new Derivation.Chosen(List.of(
                 new Derivation.Chosen.Arm(LinearForm.atom(answered),
                         List.of(new NumericConstraint(LinearForm.atom(askedAbout), Rel.GE))),
-                new Derivation.Chosen.Arm(LinearForm.atom(answered), List.of()))));
+                new Derivation.Chosen.Arm(LinearForm.atom(answered), List.of())))));
 
         assertTrue(terms.reached(LinearForm.atom(choice)).contains(askedAbout),
                 "no arm answers it and deciding between them reads it, which is what the arm's"

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAValueCarriesBelongsToTheAtomTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAValueCarriesBelongsToTheAtomTest.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -52,6 +53,10 @@ class WhatAValueCarriesBelongsToTheAtomTest {
 
     private static Core.Read list(BindingId of) {
         return new Core.Read("xs", of, new Type.ListOf(Type.INT), POS);
+    }
+
+    private static Core.Read number(BindingId of) {
+        return new Core.Read("n", of, Type.INT, POS);
     }
 
     private static Core length(Core of) {
@@ -227,6 +232,55 @@ class WhatAValueCarriesBelongsToTheAtomTest {
         assertThrows(DerivedNumericFacts.AnAtomComputedFromItself.class,
                 () -> DerivedNumericFacts.refine(nothingKnown(), computed, Set.of(one)),
                 "and an atom computed from itself is refused where it is derived");
+    }
+
+    /**
+     * A cycle that only closes through what a value carries is not a value built out of itself.
+     *
+     * <p>The two graphs again, and this time on the stack rather than in the tables. Reading a
+     * recipe reads the values a relation drags in, and reading one of those reads its own operands —
+     * so a derivation can arrive back at an atom it is in the middle of without any computation
+     * having reached itself. Here {@code a} is computed from {@code c}, {@code c} carries a relation
+     * naming {@code b}, and {@code b} is computed from {@code a}: over computations alone that is
+     * {@code a → c} and {@code b → a} and no cycle at all.
+     *
+     * <p>What is fixed is only that this is not called a disagreement. Deriving nothing for such an
+     * atom is a reading that says less, which is what a reading that cannot see round a cycle should
+     * say; refusing it says the naming built a value out of itself, which is a claim about this
+     * check and is false here.
+     */
+    @Test
+    void aCycleThatCrossesWhatAValueCarriesIsNotOneAtomComputedFromItself() {
+        Terms terms = terms();
+        Denotations at = holding(binding(0), binding(1), binding(2));
+        FactSubject a = terms.atomOf(number(binding(0)), at);
+        FactSubject b = terms.atomOf(number(binding(1)), at);
+        FactSubject c = terms.atomOf(number(binding(2)), at);
+        terms.computedBy(a, new AtomKnowledge.Computation.Derived(
+                new Derivation.Product(LinearForm.atom(c), LinearForm.atom(c))));
+        terms.computedBy(b, new AtomKnowledge.Computation.Derived(
+                new Derivation.Product(LinearForm.atom(a), LinearForm.atom(a))));
+        terms.carrying(c, List.of(new NumericConstraint(
+                LinearForm.atom(c).minus(LinearForm.atom(b)), Rel.LE)));
+
+        assertDoesNotThrow(() -> DerivedNumericFacts.refine(nothingKnown(), terms, Set.of(a)),
+                "no computation reaches itself here, and only the relation closes the ring");
+
+        // And the chain of recipes still answers for itself. Starting it again where the reading
+        // steps across a relation must not stop it noticing a ring made of recipes alone, which
+        // this one is: two of them and neither names itself.
+        Terms round = terms();
+        Denotations places = holding(binding(0), binding(1));
+        FactSubject one = round.atomOf(number(binding(0)), places);
+        FactSubject two = round.atomOf(number(binding(1)), places);
+        round.computedBy(one, new AtomKnowledge.Computation.Derived(
+                new Derivation.Product(LinearForm.atom(two), LinearForm.atom(two))));
+        round.computedBy(two, new AtomKnowledge.Computation.Derived(
+                new Derivation.Product(LinearForm.atom(one), LinearForm.atom(one))));
+
+        assertThrows(DerivedNumericFacts.AnAtomComputedFromItself.class,
+                () -> DerivedNumericFacts.refine(nothingKnown(), round, Set.of(one)),
+                "a ring of recipes is a value built out of itself however many recipes long it is");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAValueCarriesBelongsToTheAtomTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAValueCarriesBelongsToTheAtomTest.java
@@ -1,0 +1,286 @@
+package souther.compiler.check;
+
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.numeric.NumericDomain.LinearForm;
+import souther.compiler.numeric.NumericDomain.Rel;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a value carries by being what it is, held against the atom rather than against a reader.
+ *
+ * <p>The rules themselves have tests of their own — that a size is never negative, that an absolute
+ * value is not, that a shift states what it moved by. Those pass while a reader that cannot reach
+ * them exists, which is what #988 was: the facts were collected by walking an expression, so a
+ * reading that had forms and atoms and no expression answered as though nothing were known of
+ * anything it named. What is fixed here is therefore not the rules but where their answer lives and
+ * who can reach it.
+ *
+ * <p>So these are tests about structure. Each one names a way the arrangement could come apart again
+ * without any rule being wrong and without any diagnostic changing.
+ */
+class WhatAValueCarriesBelongsToTheAtomTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    private static final ValueName LENGTH = new ValueName.Stdlib("List", "length");
+
+    private static BindingId binding(int index) {
+        return new BindingId(new BindingOwner.OfValue("demo", "f"), index);
+    }
+
+    private static Terms terms() {
+        return new Terms(Symbols.none(), souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+    }
+
+    private static Core.Read list(BindingId of) {
+        return new Core.Read("xs", of, new Type.ListOf(Type.INT), POS);
+    }
+
+    private static Core length(Core of) {
+        return new Core.PreservedCall(LENGTH, List.of(of), Type.INT, POS);
+    }
+
+    private static Core distinct(Core of) {
+        return new Core.PreservedCall(new ValueName.Stdlib("List", "distinct"), List.of(of),
+                of.type(), POS);
+    }
+
+    private static Denotations holding(BindingId... bindings) {
+        Denotations at = Denotations.none();
+        for (BindingId one : bindings) {
+            at = at.location(one, AsPlaces.of(one), AsPlaces.term(one));
+        }
+        return at;
+    }
+
+    /** A size names an atom, and what that atom carries is filed where it was named. Nothing asks an
+     * expression for it, which is the whole of what #988 turned on. */
+    @Test
+    void namingASizeFilesWhatItCarries() {
+        Terms terms = terms();
+        BindingId xs = binding(0);
+        FactSubject atom = terms.atomOf(length(list(xs)), holding(xs));
+
+        assertNotNull(atom, "a size over a nameable container is an atom");
+        assertTrue(terms.knowledgeOf(atom).intrinsic().stream()
+                        .anyMatch(one -> one.rel() == Rel.GE
+                                && one.form().equals(LinearForm.atom(atom))),
+                "and it carries that it is at or above nought, filed against itself");
+    }
+
+    /**
+     * A size that stands to another size carries that relation, and the value at the other end of it
+     * is reached.
+     *
+     * <p>The case a reader working reachability out from the recipes alone would drop. Nothing
+     * computes {@code List.length(List.distinct(xs))} from {@code List.length(xs)} — one is no
+     * recipe over the other — and a reading that did not reach the second would take the relation in
+     * against a value it had left unspoken for.
+     */
+    @Test
+    void whatARelationNamesIsReached() {
+        Terms terms = terms();
+        BindingId xs = binding(0);
+        Denotations at = holding(xs);
+        FactSubject narrowed = terms.atomOf(length(distinct(list(xs))), at);
+        FactSubject whole = terms.atomOf(length(list(xs)), at);
+
+        assertNotNull(narrowed);
+        assertNotNull(whole);
+        assertTrue(terms.knowledgeOf(narrowed).directlyReads(narrowed).contains(whole),
+                "reading what a filtered container's size carries reads the size it came from");
+        assertTrue(terms.reached(LinearForm.atom(narrowed)).contains(whole),
+                "so the closure reaches it, and a place is kept for it (#988)");
+    }
+
+    /**
+     * One value carries one thing, however many readings name it.
+     *
+     * <p>A container written out and the same container reached through a name are one value, so the
+     * size of either is one atom. Answered differently by the two routes, what an atom carried would
+     * depend on which reader got to it first, and the reader that asked between them would be
+     * answered out of half of it.
+     */
+    @Test
+    void oneAtomCarriesOneAnswerWhicheverRouteNamedIt() {
+        Terms terms = terms();
+        BindingId xs = binding(0);
+        BindingId ys = binding(1);
+        Terms naming = terms;
+        Denotations outer = holding(xs);
+        Core built = distinct(list(xs));
+        // Entered as a `let` does it: a name for a value, and no location — a binding with one is a
+        // place, and a place is named by where it is rather than by what it was given.
+        Denotations at = outer.binding(ys, built, naming.subjectOf(built, outer),
+                null, naming.bodyKey(built, outer), null);
+
+        FactSubject written = terms.atomOf(length(distinct(list(xs))), at);
+        FactSubject named = terms.atomOf(
+                length(new Core.Read("ys", ys, new Type.ListOf(Type.INT), POS)), at);
+
+        assertEquals(written, named, "one value, so one atom");
+        assertEquals(terms.knowledgeOf(written).intrinsic(), terms.knowledgeOf(named).intrinsic(),
+                "and one answer about what it carries");
+    }
+
+    /** And two answers about one atom are refused rather than merged: merging leaves the reading
+     * that asked in between answered out of half of one. */
+    @Test
+    void twoAnswersAboutWhatOneAtomCarriesAreRefused() {
+        Terms terms = terms();
+        BindingId xs = binding(0);
+        FactSubject atom = terms.atomOf(length(list(xs)), holding(xs));
+
+        assertThrows(Terms.OneTermTwoIntrinsicAnswers.class, () -> terms.carrying(atom,
+                List.of(new NumericConstraint(LinearForm.atom(atom), Rel.LE))));
+    }
+
+    /**
+     * And saying nothing is not one of the two answers.
+     *
+     * <p>One value is named by more than one writing of it, and a writing the reading cannot make
+     * out the operation behind — a library operation applied bare — comes back with nothing. That is
+     * this reader having nothing to read and not the value carrying nothing, so it leaves what was
+     * answered standing. Treated as an answer, what an atom carried would turn on which writing of
+     * it the naming reached first.
+     */
+    @Test
+    void sayingNothingLeavesTheAnswerStanding() {
+        Terms terms = terms();
+        BindingId xs = binding(0);
+        FactSubject atom = terms.atomOf(length(list(xs)), holding(xs));
+        List<NumericConstraint> answered = terms.knowledgeOf(atom).intrinsic();
+
+        terms.carrying(atom, List.of());
+
+        assertFalse(answered.isEmpty(), "the reading that could read it answered");
+        assertEquals(answered, terms.knowledgeOf(atom).intrinsic(),
+                "and the one that could not left that answer where it was");
+    }
+
+    /**
+     * One value is reached one way, and the two ways of reaching one are one sum.
+     *
+     * <p>Held as a table of recipes beside a table of walks, each checked itself for a second entry
+     * and neither checked the other, so an atom could stand in both — and the reader that asked was
+     * answered by whichever table it looked in first.
+     */
+    @Test
+    void anAtomIsNotReachedTwoWays() {
+        Terms terms = terms();
+        FactSubject atom = AsPlaces.of(binding(0));
+        FactSubject other = AsPlaces.of(binding(1));
+        terms.computedBy(atom, new AtomKnowledge.Computation.Derived(
+                new Derivation.Product(LinearForm.atom(other), LinearForm.atom(other))));
+
+        assertThrows(Terms.OneTermTwoDerivations.class, () -> terms.computedBy(atom,
+                new AtomKnowledge.Computation.Reduction(new InductiveBounds.Walk(
+                        LinearForm.constant(java.math.BigDecimal.ZERO), other,
+                        LinearForm.atom(other), StepInputFacts.none()))));
+    }
+
+    /**
+     * The two graphs an atom stands in have different cycles, and only one of them is an error.
+     *
+     * <p>A computation is written over strictly smaller expressions, so an atom reached from itself
+     * that way is this check having named a value built out of itself. What a value carries relates
+     * it to whatever it relates it to, with no such ordering: two values each no greater than the
+     * other are two true statements. Written as one walk, one of the two answers would be wrong —
+     * either a legitimate pair of relations reported as an internal disagreement, or a value built
+     * out of itself walked until it ran out of stack.
+     */
+    @Test
+    void aCycleThroughWhatValuesCarryIsNotACycleThroughHowTheyAreComputed() {
+        Terms terms = terms();
+        FactSubject one = AsPlaces.of(binding(0));
+        FactSubject two = AsPlaces.of(binding(1));
+        terms.carrying(one, List.of(new NumericConstraint(
+                LinearForm.atom(one).minus(LinearForm.atom(two)), Rel.LE)));
+        terms.carrying(two, List.of(new NumericConstraint(
+                LinearForm.atom(two).minus(LinearForm.atom(one)), Rel.LE)));
+
+        assertEquals(Set.of(one, two), terms.reached(LinearForm.atom(one)),
+                "the closure stops on repetition, which is what a visited set is for");
+
+        Terms computed = terms();
+        computed.computedBy(one, new AtomKnowledge.Computation.Derived(
+                new Derivation.Product(LinearForm.atom(one), LinearForm.atom(two))));
+
+        assertThrows(DerivedNumericFacts.AnAtomComputedFromItself.class,
+                () -> DerivedNumericFacts.refine(nothingKnown(), computed, Set.of(one)),
+                "and an atom computed from itself is refused where it is derived");
+    }
+
+    /**
+     * A value that carries something and computes nothing is not a recipe evaluated.
+     *
+     * <p>What the accounting states is that a reading does no work the question cannot reach, and it
+     * counts recipes put through a reading. A size has no recipe and never had one; counted as work
+     * done, the measure would start answering about how much the reading was handed rather than
+     * about how much of it was evaluated twice.
+     */
+    @Test
+    void whatAValueCarriesIsNoRecipeEvaluated() {
+        Terms terms = terms();
+        BindingId xs = binding(0);
+        FactSubject atom = terms.atomOf(length(list(xs)), holding(xs));
+        List<List<FactSubject>> watching = new ArrayList<>();
+        DerivedNumericFacts.WATCHING = watching;
+        try {
+            DerivedNumericFacts.refine(nothingKnown(), terms, Set.of(atom));
+        } finally {
+            DerivedNumericFacts.WATCHING = null;
+        }
+
+        assertFalse(watching.stream().anyMatch(one -> one.contains(atom)),
+                "it was taken into the reading, which is not a recipe being put through one");
+    }
+
+    /**
+     * Nothing evaluates a recipe against a domain that has not been made a reading.
+     *
+     * <p>The one rule here that a reader could otherwise break by writing four correct lines. Both
+     * stages have to happen and in that order, and a rule of that shape written down is a rule the
+     * next caller does not read — so the second stage takes a type only the first stage makes, and
+     * this fixes that it stays that way. Checked over the parameters and not over the callers: what
+     * would go wrong is a new caller, and a test naming today's callers is a test that says nothing
+     * about it.
+     */
+    @Test
+    void aRecipeIsOnlyEvaluatedAgainstAReading() {
+        List<String> takingARawDomain = new ArrayList<>();
+        for (Method method : DerivedNumericFacts.class.getDeclaredMethods()) {
+            for (Class<?> parameter : method.getParameterTypes()) {
+                if (parameter.equals(NumericDomain.class) && !method.getName().equals("refine")
+                        && !method.getName().equals("readingOf")) {
+                    takingARawDomain.add(method.getName());
+                }
+            }
+        }
+
+        assertEquals(List.of(), takingARawDomain,
+                "a domain reaches a recipe through `readingOf` or it does not reach one");
+    }
+
+    private static NumericDomain<FactSubject> nothingKnown() {
+        return Known.top().numbers();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAValueCarriesBelongsToTheAtomTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAValueCarriesBelongsToTheAtomTest.java
@@ -278,6 +278,15 @@ class WhatAValueCarriesBelongsToTheAtomTest {
 
         assertEquals(List.of(), takingARawDomain,
                 "a domain reaches a recipe through `readingOf` or it does not reach one");
+
+        // And the other way in, which the parameters say nothing about: a reading anybody can make
+        // is a first stage anybody can skip. As a record this was open to the whole package, since a
+        // record's canonical constructor is as accessible as the record and this one has to be seen
+        // from `InductiveBounds`.
+        for (var made : DerivedNumericFacts.ReadingDomain.class.getDeclaredConstructors()) {
+            assertTrue(java.lang.reflect.Modifier.isPrivate(made.getModifiers()),
+                    "a reading is made where the first stage is run, and nowhere else");
+        }
     }
 
     private static NumericDomain<FactSubject> nothingKnown() {


### PR DESCRIPTION
Closes #988.

## What was measured

The issue reads the divergence off two spellings of one guard. Measured on the branch point, that is one row of a wider boundary. Same value, same bound needed, only the writing differs:

| the step, under a fold | before |
|---|---|
| `if List.length(c.items) > 0 then a + List.length(c.items) else a` | — |
| `if Bool.not(List.isEmpty(c.items)) then a + List.length(c.items) else a` | E2011 |
| `a + List.length(c.items)`, no guard at all | E2011 |
| `a + Int.abs(x)` | E2011 |
| `a + List.length(c.items) * 2` | E2011 |

And every one of the same writings on a path — including a choice read on the path — was silent before and is silent now.

So the first row is not silent because the emptiness check says less. It is silent because that guard states its bound as a relation, which stands beside the arm already. Everything inside a reduction's step was unbounded whatever the step did, guard or no guard, choice or no choice.

## Why

What a value carries entered a domain by descending the expression a reader had (`Predicates.sizeFacts`, `Predicates.resultFacts`). A step is forms and atoms by the time it is read, so no reader of one could have them. The facts had no owner and no place to be recorded against the atom.

## What is in here

`Terms` holds one record per atom, `AtomKnowledge`: how the value was reached, and what it carries whatever reached it. The two ways of reaching one are a sum, which removes a state the two tables it replaces could hold at once and neither could see — an atom filed as a walk's answer and as arithmetic was read as whichever table a reader asked first. What an atom reads directly is derived from those two rather than recorded beside them.

`IntrinsicNumericFacts` is the one reader of the library's tables (`SIZES`, `BOUNDS_ON_THE_RESULT`, `LOWER_BOUNDS`, `BUILDINGS`, `SHIFTS`) that turns a row into a relation between atoms. It reads one node and has no traversal: the naming already walks the expression, and a size states one edge of a chain with the rest coming back as reachability.

A reading is made in two stages and the second cannot be run without the first. `DerivedNumericFacts.readingOf` takes what every reachable value carries into the domain and is the only maker of `ReadingDomain`, which is the only thing the recipe evaluators accept.

The shift equality moved to the measure atom it is about, since the value a shift answers is a date and no number.

Cycles mean different things in the two graphs an atom stands in, and this is now written down: a computation reaching itself is a value built out of itself and is refused; an intrinsic relation carries no ordering, so reachability is a closure with a visited set.

## Tests

One symptom matrix (`WhatAValueCarriesReachesAStepAsItReachesAPathTest`), fold and path, with a neighbour for every silent row that stays reported.

Eight structural contracts (`WhatAValueCarriesBelongsToTheAtomTest`): every naming route files, one atom carries one answer, saying nothing is not an answer, two answers disagree, an atom is not reached two ways, the two cycle semantics, an intrinsic-only atom is no recipe evaluated, and no recipe evaluator takes a raw domain.

Two of them were confirmed red by breaking the mechanism: dropping the intrinsic edges reddens the reachability and cycle contracts — **and leaves the symptom matrix green**, which is what says the structural tests are not the symptoms restated. Making intrinsic-only atoms count as recorded reddens the accounting contract and leaves the existing accounting test green.

## Cost

Full build green, 9,721 tests. Wall clock is inside the run-to-run spread either way.

What the first stage costs, measured across the suite with a temporary counter: 4,088 readings, 11,411 atoms asked about, 12,285 reached — 1.08x — at most 17 atoms in one reading, and 1.15 intrinsic relations assumed per reading.

Derivation work is **not** identical, and deliberately so: a reading now puts through the recipes that a relation names, which is what the `Decimal.toInt` row above needs. What that costs depends on which reaching it is asked of, and the difference is large. Over what the values carry, nesting costs 12, 34, 70, 122, 192, 272 — the same numbers as before, and the plateau the accounting test requires. Over the whole reaching, recipe operands included, it costs 12, 42, 122, 322, 802, 1862 and stops being a plateau, because reading a recipe reads its operands already and asking again repeats that once per arm a reading is copied into. So the narrower reaching is the one in here, and the wider one is measured rather than argued against.

## Left standing

`Predicates.Clause.known` still carries the facts on the clause. It is a projection of the registry answer taken where the clause is read, not a second derivation, but whether a clause needs to carry them is its own question.

A ring of atoms that closes only through what values carry is answered with nothing rather than derived to a fixed point. That is a reading that says less, which is what a reading that cannot see round a ring should say.

A guard names a number that no form of it reads — an argument of an operation answering something the domain does not carry — and what that value carries is no longer stated. It could not have discharged anything, since no clause can be decided by an atom no form reaches; the condition for that to stop being true is written at the reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

