### PR TITLE
Ask the atoms what a derived sum codec dispatches over

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
+++ b/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
@@ -6,6 +6,7 @@ import souther.compiler.ast.Hir;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.LeafScalar;
 import souther.compiler.types.Type;
+import souther.compiler.types.TypeSymbol;
 import souther.compiler.check.TypeChecker;
 import souther.compiler.check.TypeOps;
 
@@ -253,67 +254,41 @@ public final class Deriver {
     // --- sum derivation ---
 
     private static Hir.SumData deriveSum(Hir.SumData s, Symbols symbols) {
-        List<Hir.Name> leaves = leafCases(s, symbols);
+        // What a value of the sum can be, with nested sums descended to their leaves —
+        // `費用負担区分 = 自社負担 | 先方負担` where `自社負担 = 立替 | 仮払い | 会社カード` dispatches over
+        // 立替 / 仮払い / 会社カード / 先方負担 (spec §sum-data, §sum-discrimination). The descent is
+        // AtomSpace's and not written again here: an atom is one per TypeSymbol, which is what a
+        // variant is about, and asking it in the written name's terms answered a leaf two of the
+        // cases reach once per case (#990).
+        List<TypeSymbol> atoms = TypeOps.leafCases(s, symbols);
         Optional<Hir.Discriminate> decoder = s.decoder().isPresent()
                 ? s.decoder()
-                : Optional.of(new Hir.Discriminate("type", tagVariants(s, leaves), s.pos()));
+                : Optional.of(new Hir.Discriminate("type", tagVariants(s, atoms), s.pos()));
         Optional<Hir.SumEncoder> encoder = s.encoder().isPresent()
                 ? s.encoder()
-                : Optional.of(new Hir.SumEncoder("type", encVariants(s, leaves), s.pos()));
+                : Optional.of(new Hir.SumEncoder("type", encVariants(s, atoms), s.pos()));
         return new Hir.SumData(s.written(), s.declares(), s.cases(), decoder, encoder, s.pos());
     }
 
     /**
-     * The cases a derived codec dispatches over, with nested sums folded to their leaves —
-     * `費用負担区分 = 自社負担 | 先方負担` where `自社負担 = 立替 | 仮払い | 会社カード` dispatches over
-     * 立替 / 仮払い / 会社カード / 先方負担 (spec §sum-data, §sum-discrimination).
+     * The variant an atom is dispatched to, on either side.
      *
-     * <p>Folding is what makes a nested sum round-trip. Tagging the direct case instead would put
-     * two levels on one `"type"` key: the outer encoder wrote {@code {type: 自社負担}}, losing
-     * which leaf it was, and the inner decoder then rejected that same tag.
+     * <p>The tag and the case are read off the one atom, so the two cannot name different types.
+     * The name is written here rather than carried from the declaration: a leaf two of the sum's
+     * cases reach is written twice, and neither occurrence is the one a variant is about.
      */
-    private static List<Hir.Name> leafCases(Hir.SumData s, Symbols symbols) {
-        List<Hir.Name> leaves = new ArrayList<>();
-        collectLeafCases(s, symbols, leaves);
-        return leaves;
-    }
-
-    private static void collectLeafCases(Hir.SumData s, Symbols symbols, List<Hir.Name> out) {
-        collectLeafCases(s, symbols, out, new java.util.HashSet<>());
-    }
-
-    private static void collectLeafCases(Hir.SumData s, Symbols symbols, List<Hir.Name> out,
-                                         java.util.Set<String> visiting) {
-        if (!visiting.add(s.name())) {
-            return;   // a sum that reaches itself; DataChecker reports it, this only has to terminate
-        }
-        for (Hir.Name caseName : s.cases()) {
-            // A case naming nothing is no sum to descend into and no leaf to derive a codec for; it
-            // is reported where it is written.
-            if (caseName.answered() == null) {
-                continue;
-            }
-            if (symbols.declarations().declaration(caseName.answered().type().key())
-                    instanceof Hir.SumData nested) {
-                collectLeafCases(nested, symbols, out, visiting);
-            } else if (!out.contains(caseName)) {
-                out.add(caseName);
-            }
-        }
-    }
-
-    private static List<Hir.Variant> tagVariants(Hir.SumData s, List<Hir.Name> cases) {
+    private static List<Hir.Variant> tagVariants(Hir.SumData s, List<TypeSymbol> atoms) {
         List<Hir.Variant> variants = new ArrayList<>();
-        for (Hir.Name caseName : cases) {
-            variants.add(new Hir.Variant(caseName.answered().type().name(), caseName, s.pos()));
+        for (TypeSymbol atom : atoms) {
+            variants.add(new Hir.Variant(atom.name(), Hir.Name.resolved(atom, s.pos()), s.pos()));
         }
         return variants;
     }
 
-    private static List<Hir.EncVariant> encVariants(Hir.SumData s, List<Hir.Name> cases) {
+    private static List<Hir.EncVariant> encVariants(Hir.SumData s, List<TypeSymbol> atoms) {
         List<Hir.EncVariant> variants = new ArrayList<>();
-        for (Hir.Name caseName : cases) {
-            variants.add(new Hir.EncVariant(caseName, caseName.answered().type().name(), s.pos()));
+        for (TypeSymbol atom : atoms) {
+            variants.add(new Hir.EncVariant(Hir.Name.resolved(atom, s.pos()), atom.name(), s.pos()));
         }
         return variants;
     }

--- a/souther-compiler/src/test/java/souther/compiler/derive/ADerivedSumCodecHasOneVariantPerAtomTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/derive/ADerivedSumCodecHasOneVariantPerAtomTest.java
@@ -1,0 +1,126 @@
+package souther.compiler.derive;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.AtomSpace;
+import souther.compiler.check.TypeChecker;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Names;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What a derived sum codec dispatches over: the atoms of the sum, one variant each, in their order.
+ *
+ * <p>The derivation used to descend the cases itself and ask {@code List.contains} of an
+ * {@link Hir.Name}, which is a written occurrence and what it denotes. A leaf two of the sum's
+ * cases reach is written twice and is one type, so it got a variant from each of them and the codec
+ * carried one case twice (#990). Nothing said so: both readers take the first variant whose tag or
+ * case answers, so the second was never reached.
+ *
+ * <p>Held against {@link AtomSpace} rather than against a written-out list, so what a variant is
+ * about and what an atom is stay one answer. The decoder and the encoder are held against it
+ * separately and against each other: they are two lists today, and two lists agree by coincidence
+ * unless something says they do not.
+ */
+class ADerivedSumCodecHasOneVariantPerAtomTest {
+
+    /** A leaf `Both` reaches through `OnceKind` and again through `Outpatient`. */
+    private static final String MODULE = """
+            module m
+
+            data Station
+            data Hospital
+            data Clinic
+            data OnceKind   = Station | Hospital
+            data Outpatient = Station | Clinic
+            data Both       = OnceKind | Outpatient
+            """;
+
+    private final Hir.Module derived = derive(MODULE);
+
+    @Test
+    void aLeafReachedThroughTwoCasesIsOneVariant() {
+        assertEquals(List.of("Station", "Hospital", "Clinic"), tagsOf("Both"));
+    }
+
+    @Test
+    void theVariantsAreTheAtomsInTheirOrder() {
+        assertEquals(atomsOf("Both"), decoderCases("Both"));
+        assertEquals(atomsOf("Both"), encoderCases("Both"));
+    }
+
+    /** The tag names the case it dispatches to, on both sides. */
+    @Test
+    void theTagAndTheCaseNameOneType() {
+        assertEquals(names(atomsOf("Both")), tagsOf("Both"));
+        assertEquals(names(atomsOf("Both")), encoderTagsOf("Both"));
+    }
+
+    @Test
+    void theDecoderAndTheEncoderDispatchOverTheSameCases() {
+        assertEquals(decoderCases("Both"), encoderCases("Both"));
+        assertEquals(tagsOf("Both"), encoderTagsOf("Both"));
+    }
+
+    /** A sum no case of which is reached twice is unchanged by any of this. */
+    @Test
+    void aSumWithNoSharedLeafIsTheLeavesUnderIt() {
+        assertEquals(List.of("Station", "Hospital"), tagsOf("OnceKind"));
+    }
+
+    // --- helpers ---------------------------------------------------------------------------------
+
+    private List<String> tagsOf(String sum) {
+        return sumData(sum).decoder().orElseThrow().variants().stream().map(Hir.Variant::tag).toList();
+    }
+
+    private List<String> encoderTagsOf(String sum) {
+        return sumData(sum).encoder().orElseThrow().variants().stream()
+                .map(Hir.EncVariant::tag).toList();
+    }
+
+    private List<TypeSymbol> decoderCases(String sum) {
+        return sumData(sum).decoder().orElseThrow().variants().stream()
+                .map(v -> v.caseType().answered().type()).toList();
+    }
+
+    private List<TypeSymbol> encoderCases(String sum) {
+        return sumData(sum).encoder().orElseThrow().variants().stream()
+                .map(v -> v.caseType().answered().type()).toList();
+    }
+
+    private List<TypeSymbol> atomsOf(String sum) {
+        return AtomSpace.subjectAtoms(Type.ref(sumData(sum).declares()), TypeChecker.symbols(derived));
+    }
+
+    private static List<String> names(List<TypeSymbol> atoms) {
+        return atoms.stream().map(TypeSymbol::name).toList();
+    }
+
+    private Hir.SumData sumData(String name) {
+        for (Hir.Def d : derived.defs()) {
+            if (d.name().equals(name)) {
+                return (Hir.SumData) d;
+            }
+        }
+        throw new AssertionError("the module does not declare " + name);
+    }
+
+    private static Hir.Module derive(String source) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("m.sou", source);
+        Hir.Module resolved = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY)
+                .db().ask(new Names.Resolved("m")).value();
+        return Deriver.derive(resolved);
+    }
+}


### PR DESCRIPTION
Closes #990.

A sum's derived codecs dispatch over the leaves of its nested sums. `Deriver` descended the cases itself and asked `List.contains` of an `Hir.Name` — a written occurrence and what it denotes — so a leaf two of the cases reach got a variant from each occurrence:

```souther
data Station
data Hospital
data Clinic
data OnceKind   = Station | Hospital
data Outpatient = Station | Clinic
data Both       = OnceKind | Outpatient
```

```
Variant[tag=Station,  caseType=Station]
Variant[tag=Hospital, caseType=Hospital]
Variant[tag=Station,  caseType=Station]      // again
Variant[tag=Clinic,   caseType=Clinic]
```

The identity the collection was keyed by is not the identity the result is about. The tag is `caseName.answered().type().name()`, and codegen resolves the case back to a `TypeSymbol` before dispatching on it. Both readers take the first variant whose tag or case answers, so the second was never reached and nothing reported it.

## What changed

`Deriver.leafCases` / `collectLeafCases` are gone. `deriveSum` asks `TypeOps.leafCases(s, symbols)`, which is `AtomSpace` — the fourth reader #991 left standing. `tagVariants` / `encVariants` take `List<TypeSymbol>`; the tag is `atom.name()` and the case is `Hir.Name.resolved(atom, s.pos())`, so the two come off one atom and cannot name different types.

The recursion also no longer terminates on `s.name()`, a `String`. Nothing reaches that today — a case is declared with its sum — but it was the same key.

## What it does not change

No run reached the second variant, so the external representation is as it was: the wire fixtures stand and the boundary version does not move.

## Tests

`ADerivedSumCodecHasOneVariantPerAtomTest` holds the derived variants against `AtomSpace` — the decoder and the encoder each against the atoms, and then against each other. The last of those passed before the change too, because both sides carried the same duplicate; two lists agreeing is not evidence when one answer produced both.

Reverting `Deriver` alone fails three of the five with `[Station, Hospital, Station, Clinic]`. Full reactor: 9722 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)