### PR TITLE
Ask what a type is made of where the answer is worked out

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/BinaryElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BinaryElaborator.java
@@ -10,7 +10,6 @@ import souther.compiler.diag.msg.TypeMessage;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Typing a binary operator, including the rules that let a single-value newtype compare with and
@@ -162,8 +161,8 @@ public final class BinaryElaborator {
                     throw CompileException.of(Diagnostic
                                     .at(bin.pos(), 2).say(new TypeMessage.AFunctionHasNoValueToCompare(Type.show(carrier))).build());
                 }
-                Set<TypeSymbol> lCases = TypeOps.leafCases(lt, ctx.symbols());
-                Set<TypeSymbol> rCases = TypeOps.leafCases(rt, ctx.symbols());
+                List<TypeSymbol> lCases = AtomSpace.subjectAtoms(lt, ctx.symbols());
+                List<TypeSymbol> rCases = AtomSpace.subjectAtoms(rt, ctx.symbols());
                 boolean caseOfSum = !lCases.isEmpty() && !rCases.isEmpty()
                         && (lCases.containsAll(rCases) || rCases.containsAll(lCases));
                 if (!lt.equals(rt) && !eqCoercible(lt, rt, bin.left(), bin.right(), ctx.symbols())

--- a/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
@@ -197,7 +197,7 @@ public sealed interface Carrier {
         if (!(symbols.declarations().declaration(places.enumeration().key()) instanceof Hir.SumData sum)) {
             return null;
         }
-        List<TypeSymbol> cases = TypeOps.leafCases(sum, symbols);
+        List<TypeSymbol> cases = AtomSpace.subjectAtoms(Type.ref(sum.declares()), symbols);
         return cases.isEmpty() ? null : new Ordinal(places.enumeration(), cases);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -417,7 +417,7 @@ public final class DataChecker {
         sum.decoder().ifPresent(disc -> {
             // a derived codec dispatches over the leaves, so a nested sum's cases count too (§sum-data,
             // §sum-discrimination)
-            Set<TypeSymbol> dispatchable = TypeOps.leafCases(Type.ref(sum.declares()), symbols);
+            List<TypeSymbol> dispatchable = AtomSpace.subjectAtoms(Type.ref(sum.declares()), symbols);
             for (Hir.Variant v : disc.variants()) {
                 Hir.Def caseDef = symbols.declarations().declaration(names(v.caseType()).key());
                 if (!dispatchable.contains(names(v.caseType()))) {
@@ -449,7 +449,7 @@ public final class DataChecker {
                                 .hint(new DataMessage.TheTagAndTheFieldWantOneKey(enc.key())).say(new DataMessage.ACaseDeclaresTheDiscriminatorField(carrying.name(), enc.key(), sum.name())).build());
             }
             Set<TypeSymbol> covered = new HashSet<>();
-            Set<TypeSymbol> encodable = TypeOps.leafCases(Type.ref(sum.declares()), symbols);
+            List<TypeSymbol> encodable = AtomSpace.subjectAtoms(Type.ref(sum.declares()), symbols);
             for (Hir.EncVariant v : enc.variants()) {
                 if (!encodable.contains(names(v.caseType()))) {
                     throw CompileException.of(Diagnostic.at(v.pos())

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -472,8 +472,11 @@ public final class Elaborator {
                 return new Core.FieldAccess(targetCore, fa.field(), ft, fa.pos());
             }
         }
-        List<TypeSymbol> cases = TypeOps.sumCases(target, ctx.symbols());
-        if (cases != null) {
+        // Asked of a sum only. What a type is made of answers for anything — a data that is no sum
+        // is the one atom it is — and the question here is whether there are cases to read at all,
+        // which a type that is its own single leaf is not.
+        if (TypeOps.isSumType(target, ctx.symbols())) {
+            List<TypeSymbol> cases = AtomSpace.subjectAtoms(target, ctx.symbols());
             // A field every case spreads is the sum's own: the sharing is nominal, and the generated
             // sealed interface declares the accessor its cases already carry (issue #160). Only a
             // named sum, whose interface this compile emits — an anonymous union's cases are not

--- a/souther-compiler/src/main/java/souther/compiler/check/PipelineSigs.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PipelineSigs.java
@@ -230,8 +230,8 @@ public final class PipelineSigs {
             if (TypeOps.restsOnAnUnresolvedName(pipe.declaredOut())) {
                 throw new Unanswerable(pipe.declaredOut().pos());
             }
-            Set<TypeSymbol> inferred = TypeOps.leafCases(out, symbols);
-            Set<TypeSymbol> declared = TypeOps.leafCases(declaredOut, symbols);
+            Set<TypeSymbol> inferred = new LinkedHashSet<>(AtomSpace.subjectAtoms(out, symbols));
+            Set<TypeSymbol> declared = new LinkedHashSet<>(AtomSpace.subjectAtoms(declaredOut, symbols));
             if (!inferred.equals(declared)) {
                 throw CompileException.of(Diagnostic.at(pipe.pos())
 
@@ -273,7 +273,7 @@ public final class PipelineSigs {
     /** The main-line leaf cases {@code g} accepts — the ones the backend routes into it (spec §type-routing). */
     private static List<TypeSymbol> mainlineCases(Type mainline, Sig g, Symbols symbols) {
         List<TypeSymbol> accepted = new ArrayList<>();
-        for (TypeSymbol caseName : TypeOps.leafCases(mainline, symbols)) {
+        for (TypeSymbol caseName : AtomSpace.subjectAtoms(mainline, symbols)) {
             if (TypeOps.assignable(Type.ref(caseName), g.in(), symbols)) {
                 accepted.add(caseName);
             }
@@ -305,7 +305,7 @@ public final class PipelineSigs {
             Set<TypeSymbol> passed = new LinkedHashSet<>();
             // route over the leaf cases: a named sum output splits into its members, so a stage that
             // accepts one of them consumes it while the rest retire (spec §sum-data, §type-routing)
-            for (TypeSymbol caseName : TypeOps.leafCases(mainline, symbols)) {
+            for (TypeSymbol caseName : AtomSpace.subjectAtoms(mainline, symbols)) {
                 if (TypeOps.assignable(Type.ref(caseName), in, symbols)) {
                     consumed.add(caseName);
                 } else {

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -217,7 +217,7 @@ public final class SpecChecker {
                 // against, and the other compositions still have theirs.
                 continue;
             }
-            Set<TypeSymbol> inferred = TypeOps.leafCases(sig.outputType(), symbols);
+            Set<TypeSymbol> inferred = new LinkedHashSet<>(AtomSpace.subjectAtoms(sig.outputType(), symbols));
             Hir.RetType declared = module.exposedOutputs().get(pipe.name());
             if (declared == null) {
                 throw CompileException.of(Diagnostic.at(pipe.pos())
@@ -232,7 +232,7 @@ public final class SpecChecker {
             if (TypeOps.restsOnAnUnresolvedName(declared)) {
                 throw new Unanswerable(declared.pos());
             }
-            Set<TypeSymbol> declaredCases = TypeOps.leafCases(declaredOut, symbols);
+            Set<TypeSymbol> declaredCases = new LinkedHashSet<>(AtomSpace.subjectAtoms(declaredOut, symbols));
             if (!inferred.equals(declaredCases)) {
                 throw CompileException.of(Diagnostic.at(pipe.pos())
                                 

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
@@ -151,7 +151,7 @@ final class TypeGuarantees {
                 // sum of them is a type nothing is written under — which is what makes an
                 // enumeration a position this still speaks for.
                 case Hir.UnitData _ -> false;
-                case Hir.SumData sum -> TypeOps.leafCases(sum, symbols).stream()
+                case Hir.SumData sum -> AtomSpace.subjectAtoms(Type.ref(sum.declares()), symbols).stream()
                         .anyMatch(each -> anyRuleUnder(Type.ref(each), seen));
                 case Hir.Data data -> !clauses.declared(ref.name(), data).isEmpty()
                         || TypeOps.fieldTypes(data, symbols).values().stream()

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -374,15 +374,6 @@ public final class TypeOps {
                 || (t instanceof Type.Ref r && symbols.declarations().declaration(r.name().key()) instanceof Hir.SumData);
     }
 
-    /** The cases of {@code t} when it is a sum — a declared {@code data S = A | B} or the union a
-     * branch widened to — with a case that is itself a sum folded to its own cases. Null when
-     * {@code t} is not a sum at all, which is the answer this has that {@link AtomSpace} does not:
-     * a reader here is asking whether there are cases to read, and a type that is its own one leaf
-     * is not that. */
-    static List<TypeSymbol> sumCases(Type t, Symbols symbols) {
-        return isSumType(t, symbols) ? AtomSpace.subjectAtoms(t, symbols) : null;
-    }
-
     /** A sum's cases: what each name it lists denotes. A name that denotes nothing lists no case —
      * it is reported where it is written, and a reader counting the cases counts what is there. */
     public static List<TypeSymbol> caseNames(Hir.SumData sum) {
@@ -595,8 +586,8 @@ public final class TypeOps {
             }
             return true;
         }
-        Set<TypeSymbol> fa = leafCases(from, symbols);
-        Set<TypeSymbol> ta = leafCases(to, symbols);
+        List<TypeSymbol> fa = AtomSpace.subjectAtoms(from, symbols);
+        List<TypeSymbol> ta = AtomSpace.subjectAtoms(to, symbols);
         return !fa.isEmpty() && !ta.isEmpty() && ta.containsAll(fa);
     }
 
@@ -872,7 +863,7 @@ public final class TypeOps {
      */
     static TypeSymbol[] ambiguousMembers(Type out, Symbols symbols) {
         Map<String, TypeSymbol> byName = new LinkedHashMap<>();
-        for (TypeSymbol member : leafCases(out, symbols)) {
+        for (TypeSymbol member : AtomSpace.subjectAtoms(out, symbols)) {
             TypeSymbol seen = byName.put(member.name(), member);
             if (seen != null && !seen.equals(member)) {
                 return new TypeSymbol[] {seen, member};
@@ -888,7 +879,7 @@ public final class TypeOps {
      * nested sum contributes its cases rather than itself.
      */
     static TypeSymbol memberCarryingField(Type out, String key, Symbols symbols) {
-        for (TypeSymbol member : leafCases(out, symbols)) {
+        for (TypeSymbol member : AtomSpace.subjectAtoms(out, symbols)) {
             if (declaresField(member, key, symbols)) {
                 return member;
             }
@@ -904,20 +895,21 @@ public final class TypeOps {
     }
 
     /**
-     * The cases a position of this type can be, when it can be more than one thing: the leaf cases of
+     * The cases a position of this type can be, when it can be more than one thing: the atoms of
      * a union or of a named sum, and nothing otherwise.
      *
      * <p>What a row's expected arm is held against, and what an adequacy report counts as declared. The
      * two have to agree — a report that read a wider set than the rows are checked against would name a
      * case no row is allowed to write — so the rule is here rather than stated twice.
+     *
+     * <p>An admission and not a second descent: what a type is made of is {@link AtomSpace}'s, and
+     * what is left here is which types this reader will take an answer about. A primitive output
+     * names one atom like any other type, and is not a case list.
      */
     public static Set<TypeSymbol> outputCases(Type t, Symbols symbols) {
-        return t instanceof Type.Union || t instanceof Type.Ref ? leafCases(t, symbols) : Set.of();
-    }
-
-    /** The set of leaf (non-sum) case names a data-like type covers, flattening nested sums. */
-    public static Set<TypeSymbol> leafCases(Type t, Symbols symbols) {
-        return new LinkedHashSet<>(AtomSpace.subjectAtoms(t, symbols));
+        return t instanceof Type.Union || t instanceof Type.Ref
+                ? new LinkedHashSet<>(AtomSpace.subjectAtoms(t, symbols))
+                : Set.of();
     }
 
     /**
@@ -1115,7 +1107,7 @@ public final class TypeOps {
      * ADR-0012 declines. Empty when the cases share no spread, so the read stays the error it is.
      */
     public static Map<String, Type> commonSpreadFields(Hir.SumData sum, Symbols symbols) {
-        return commonSpreadFields(leafCases(sum, symbols), symbols);
+        return commonSpreadFields(AtomSpace.subjectAtoms(Type.ref(sum.declares()), symbols), symbols);
     }
 
     /** As {@link #commonSpreadFields(Hir.SumData, Symbols)}, for cases already flattened to leaves. */
@@ -1325,7 +1317,7 @@ public final class TypeOps {
     }
 
     public static boolean isUnitOnlySum(Hir.SumData sum, Symbols symbols) {
-        List<TypeSymbol> leaves = leafCases(sum, symbols);
+        List<TypeSymbol> leaves = AtomSpace.subjectAtoms(Type.ref(sum.declares()), symbols);
         if (leaves.isEmpty()) {
             return false;
         }
@@ -1335,11 +1327,6 @@ public final class TypeOps {
             }
         }
         return true;
-    }
-
-    /** A sum's leaf cases in declaration order, nested sums flattened where they are written. */
-    public static List<TypeSymbol> leafCases(Hir.SumData sum, Symbols symbols) {
-        return AtomSpace.subjectAtoms(Type.ref(sum.declares()), symbols);
     }
 
     /** The key of the first {@code Map} inside {@code t} that cannot cross the boundary, or null when
@@ -1398,7 +1385,7 @@ public final class TypeOps {
         }
         return t instanceof Type.Ref ref && (ref.name().equals(enumeration)
                 || (symbols.declarations().declaration(enumeration.key()) instanceof Hir.SumData sum
-                    && leafCases(sum, symbols).contains(ref.name())));
+                    && AtomSpace.subjectAtoms(Type.ref(sum.declares()), symbols).contains(ref.name())));
     }
 
     /**
@@ -1454,7 +1441,7 @@ public final class TypeOps {
         Set<TypeSymbol> owners = new LinkedHashSet<>();
         for (Hir.Def def : symbols.declarations().declaredIn(ref.name().module()).values()) {
             if (def instanceof Hir.SumData s && isUnitOnlySum(s, symbols)
-                    && leafCases(s, symbols).contains(ref.name())) {
+                    && AtomSpace.subjectAtoms(Type.ref(s.declares()), symbols).contains(ref.name())) {
                 owners.add(s.declares());
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -374,9 +374,17 @@ public final class TypeOps {
                 || (t instanceof Type.Ref r && symbols.declarations().declaration(r.name().key()) instanceof Hir.SumData);
     }
 
-    /** A sum's cases: what each name it lists denotes. A name that denotes nothing lists no case —
-     * it is reported where it is written, and a reader counting the cases counts what is there. */
-    public static List<TypeSymbol> caseNames(Hir.SumData sum) {
+    /**
+     * A sum's cases: what each name it lists denotes. A name that denotes nothing lists no case —
+     * it is reported where it is written, and a reader counting the cases counts what is there.
+     *
+     * <p>One layer, which is what a descent over the cases would be built out of: hold this and the
+     * declarations, and a transitive closure is a loop away. There is one such closure and it is
+     * {@link AtomSpace}. Package-private for that reason and not by accident of who happens to call
+     * it — every reader of a case list is in this package, so nothing outside it can write a second
+     * closure at all, and that much is javac's to say rather than a test's.
+     */
+    static List<TypeSymbol> caseNames(Hir.SumData sum) {
         List<TypeSymbol> names = new ArrayList<>();
         for (Hir.Name c : sum.cases()) {
             if (c.answered() instanceof Hir.Name.Denoting named) {

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueUniverse.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueUniverse.java
@@ -53,12 +53,12 @@ final class ValueUniverse {
         // have values that can be written out. Both go to `TypeOps` for what an enumeration is, so
         // this is one reading of that and not two.
         if (!(base instanceof Type.Ref ref)
-                || !(symbols.declarations().declaration(ref.name().key()) instanceof Hir.SumData sum)
+                || !(symbols.declarations().declaration(ref.name().key()) instanceof Hir.SumData _)
                 || !TypeOps.isUnitOnlySum(base, symbols)) {
             return null;
         }
         List<Value> values = new ArrayList<>();
-        TypeOps.leafCases(sum, symbols).forEach(each -> values.add(Value.of(each)));
+        AtomSpace.subjectAtoms(base, symbols).forEach(each -> values.add(Value.of(each)));
         return values.isEmpty() ? null : List.copyOf(values);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -2,6 +2,7 @@ package souther.compiler.codegen;
 
 import souther.compiler.query.Bodies;
 
+import souther.compiler.check.AtomSpace;
 import souther.compiler.check.Symbols;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
@@ -1046,7 +1047,7 @@ public final class Backend {
             if (sig == null || !(sig.outputType() instanceof Type.Union)) {
                 continue;
             }
-            List<TypeSymbol> members = new ArrayList<>(TypeOps.leafCases(sig.outputType(), symbols));
+            List<TypeSymbol> members = new ArrayList<>(AtomSpace.subjectAtoms(sig.outputType(), symbols));
             Collections.sort(members);
             results.put(new GeneratedClass.BehaviorResult(module.name(), bd.name()), members);
         }

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
@@ -1,5 +1,6 @@
 package souther.compiler.codegen;
 
+import souther.compiler.check.AtomSpace;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.ClauseHelpers;
 import souther.compiler.ast.Hir;
@@ -334,7 +335,7 @@ final class CodecGen {
      */
     byte[] generateEnumSumDecoder(Hir.SumData sum, Src src) {
         ClassDesc cdDec = cd(decoderOf(sum, src));
-        List<TypeSymbol> cases = TypeOps.leafCases(sum, symbols);
+        List<TypeSymbol> cases = AtomSpace.subjectAtoms(Type.ref(sum.declares()), symbols);
         return build(cdDec, cb -> {
             cb.withFlags(ClassFile.ACC_FINAL | ClassFile.ACC_SUPER);
             cb.withInterfaceSymbols(CD_RDecoder);

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodegenContext.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodegenContext.java
@@ -1,5 +1,6 @@
 package souther.compiler.codegen;
 
+import souther.compiler.check.AtomSpace;
 import souther.compiler.check.ReqSig;
 import souther.compiler.check.EnsuresEnforcement;
 import souther.compiler.check.Symbols;
@@ -430,7 +431,7 @@ final class CodegenContext {
             return List.of();
         }
         List<TypeSymbol> bridged = new ArrayList<>();
-        for (TypeSymbol member : TypeOps.leafCases(out, symbols)) {
+        for (TypeSymbol member : AtomSpace.subjectAtoms(out, symbols)) {
             if (member.isPrimitive() || !member.module().equals(module)) {
                 bridged.add(member);
             }

--- a/souther-compiler/src/main/java/souther/compiler/codegen/EnsuresGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/EnsuresGen.java
@@ -1,10 +1,10 @@
 package souther.compiler.codegen;
 
+import souther.compiler.check.AtomSpace;
 import souther.compiler.check.BehaviorContract;
 import souther.compiler.check.BehaviorContract.ContractParam;
 import souther.compiler.check.BehaviorContract.Guard;
 import souther.compiler.check.BehaviorContract.Rule;
-import souther.compiler.check.TypeOps;
 import souther.compiler.jvm.GeneratedClass;
 import souther.compiler.types.CaseSelector;
 import souther.compiler.types.Refinement;
@@ -19,7 +19,6 @@ import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import static souther.compiler.codegen.Descriptors.CD_ConstraintViolation;
 import static souther.compiler.codegen.Descriptors.CD_DeclaredCase;
@@ -157,7 +156,7 @@ final class EnsuresGen {
             if (!(rule.guard() instanceof Guard.Case(CaseSelector selector)) || rule.readsAnswer()) {
                 continue;
             }
-            Set<TypeSymbol> answersFor = answersFor(selector);
+            List<TypeSymbol> answersFor = answersFor(selector);
             if (answersFor.isEmpty()) {
                 continue;
             }
@@ -200,10 +199,10 @@ final class EnsuresGen {
      * leaves. It is what this answers rather than a rule about optionals — the question is asked of
      * the selector, and a selector that has nothing to answer with is not made into one that does.
      */
-    private Set<TypeSymbol> answersFor(CaseSelector selector) {
+    private List<TypeSymbol> answersFor(CaseSelector selector) {
         return selector.refinement() instanceof Refinement.Direct(Type bound) && bound != null
-                ? TypeOps.leafCases(bound, ctx.symbols)
-                : Set.of();
+                ? AtomSpace.subjectAtoms(bound, ctx.symbols)
+                : List.of();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
@@ -1,5 +1,6 @@
 package souther.compiler.codegen;
 
+import souther.compiler.check.AtomSpace;
 import souther.compiler.check.Symbols;
 import souther.compiler.ast.Hir;
 import souther.compiler.types.BindingId;
@@ -193,7 +194,7 @@ final class ValueClassGen {
             caseCds.add(cd(Backend.names(caseName)));
         }
         boolean enumeration = TypeOps.isUnitOnlySum(sum, symbols);
-        List<TypeSymbol> cases = TypeOps.leafCases(sum, symbols);
+        List<TypeSymbol> cases = AtomSpace.subjectAtoms(Type.ref(sum.declares()), symbols);
         out.put(valueOf(sum), build(cdX, cb -> {
             cb.withFlags(pub(sum.name()) | ClassFile.ACC_INTERFACE | ClassFile.ACC_ABSTRACT);
             // A sum may itself be a case of another sum (spec §sum-data), and then it carries that sum's

--- a/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
+++ b/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
@@ -1,5 +1,6 @@
 package souther.compiler.derive;
 
+import souther.compiler.check.AtomSpace;
 import souther.compiler.check.Symbols;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.ast.Hir;
@@ -260,7 +261,7 @@ public final class Deriver {
         // AtomSpace's and not written again here: an atom is one per TypeSymbol, which is what a
         // variant is about, and asking it in the written name's terms answered a leaf two of the
         // cases reach once per case (#990).
-        List<TypeSymbol> atoms = TypeOps.leafCases(s, symbols);
+        List<TypeSymbol> atoms = AtomSpace.subjectAtoms(Type.ref(s.declares()), symbols);
         Optional<Hir.Discriminate> decoder = s.decoder().isPresent()
                 ? s.decoder()
                 : Optional.of(new Hir.Discriminate("type", tagVariants(s, atoms), s.pos()));

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -2,6 +2,7 @@ package souther.compiler.examples;
 
 import souther.compiler.generated.EvaluationArtifact;
 import souther.compiler.generated.MemoryClassLoader;
+import souther.compiler.check.AtomSpace;
 import souther.compiler.check.BehaviorContract;
 import souther.compiler.check.BehaviorRequirement;
 import souther.compiler.check.Symbols;
@@ -1542,7 +1543,7 @@ public final class ExampleVerifier {
         if (result == null || !(out instanceof Type.Union)) {
             return result;
         }
-        for (TypeSymbol member : TypeOps.leafCases(out, symbols)) {
+        for (TypeSymbol member : AtomSpace.subjectAtoms(out, symbols)) {
             if (!member.isPrimitive() && member.module().equals(module.name())) {
                 continue;
             }

--- a/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
@@ -2,6 +2,7 @@ package souther.compiler.examples;
 
 import souther.compiler.generated.MemoryClassLoader;
 import souther.compiler.ast.Hir;
+import souther.compiler.check.AtomSpace;
 import souther.compiler.check.CallElaborator;
 import souther.compiler.check.FixtureEvidence;
 import souther.compiler.check.Prelude;
@@ -346,7 +347,7 @@ public final class FixtureReader {
         if (value == null) {
             return null;
         }
-        for (TypeSymbol candidate : TypeOps.leafCases(outType, symbols)) {
+        for (TypeSymbol candidate : AtomSpace.subjectAtoms(outType, symbols)) {
             if (represents(candidate, value)) {
                 return candidate;
             }
@@ -540,7 +541,7 @@ public final class FixtureReader {
                     && spells(v, r.name());
             case Type.Ref _, Type.Union _ -> {
                 TypeSymbol name = named(a);
-                yield name != null && TypeOps.leafCases(type, symbols).contains(name)
+                yield name != null && AtomSpace.subjectAtoms(type, symbols).contains(name)
                         && parts(a, name);
             }
             case Type.ListOf l -> a instanceof Asserted.Elements(Asserted.Container stated,
@@ -1238,7 +1239,7 @@ public final class FixtureReader {
     /**
      * What {@code position} takes.
      *
-     * <p>{@link TypeOps#leafCases} answers the nominal side rather than a reading of its own: it
+     * <p>{@link AtomSpace#subjectAtoms} answers the nominal side rather than a reading of its own: it
      * expands a sum to its cases and stops at everything else, so a record takes itself, a sum takes
      * the cases it lists and a newtype takes its own name, with no arm here for any of the three.
      *
@@ -1250,7 +1251,8 @@ public final class FixtureReader {
         return switch (position) {
             case Type.OptionOf o -> new Admits.OrAbsent(admits(o.element()));
             case Type.Ref r when r.name().isPrimitive() -> NO_NAME;
-            case Type.Ref r -> new Admits.OneOf(TypeOps.leafCases(Type.ref(r.name()), symbols));
+            case Type.Ref r -> new Admits.OneOf(
+                    new LinkedHashSet<>(AtomSpace.subjectAtoms(Type.ref(r.name()), symbols)));
             case Type.Prim _, Type.ListOf _, Type.SetOf _, Type.MapOf _, Type.TupleOf _ -> NO_NAME;
             case null, default -> UNSAID;
         };

--- a/souther-compiler/src/main/java/souther/compiler/examples/NeutralForm.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/NeutralForm.java
@@ -2,6 +2,7 @@ package souther.compiler.examples;
 
 import souther.compiler.jvm.SoutherJvmAbi;
 import souther.compiler.ast.Hir;
+import souther.compiler.check.AtomSpace;
 import souther.compiler.check.FixtureEvidence;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
@@ -356,7 +357,7 @@ final class NeutralForm {
             // whatever this module declares under that spelling, and the type the value stands at
             // may be one another module published — the reason the overload above takes a resolved
             // name rather than one spelled at the call.
-            for (TypeSymbol caseName : TypeOps.leafCases(from, symbols)) {
+            for (TypeSymbol caseName : AtomSpace.subjectAtoms(from, symbols)) {
                 if (!caseName.name().equals(written)
                         || symbols.declarations().declaration(caseName.key()) instanceof Hir.Data) {
                     continue;

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Distinctions.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Distinctions.java
@@ -1,6 +1,7 @@
 package souther.compiler.inputs;
 
 import souther.compiler.ast.Hir;
+import souther.compiler.check.AtomSpace;
 import souther.compiler.check.Shape;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
@@ -79,7 +80,7 @@ public final class Distinctions {
      *  which is the order a report names them in. */
     private static List<Case> casesOf(Type sum, Symbols symbols) {
         List<Case> out = new ArrayList<>();
-        for (TypeSymbol leaf : TypeOps.leafCases(sum, symbols)) {
+        for (TypeSymbol leaf : AtomSpace.subjectAtoms(sum, symbols)) {
             out.add(new Case.SumCase(leaf, oneValue(leaf, symbols)));
         }
         return List.copyOf(out);

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -10,6 +10,7 @@ import souther.compiler.diag.msg.ExampleMessage;
 import souther.compiler.diag.Citation;
 import souther.compiler.examples.FixtureReader;
 import souther.compiler.ast.Hir;
+import souther.compiler.check.AtomSpace;
 import souther.compiler.check.BehaviorRequirement;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
@@ -3221,7 +3222,9 @@ public final class Adequacy {
     /** What a sum divides into, and nothing for a type that is not one. The one thing the two
      *  measures above share; what tells them apart is which type each hands it. */
     private static Set<TypeSymbol> casesOfSum(Type t, Symbols symbols) {
-        return TypeOps.isSumType(t, symbols) ? TypeOps.leafCases(t, symbols) : Set.of();
+        return TypeOps.isSumType(t, symbols)
+                ? new LinkedHashSet<>(AtomSpace.subjectAtoms(t, symbols))
+                : Set.of();
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatATypeIsMadeOfIsAnsweredInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatATypeIsMadeOfIsAnsweredInOnePlaceTest.java
@@ -19,9 +19,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -218,38 +221,87 @@ class WhatATypeIsMadeOfIsAnsweredInOnePlaceTest {
     // --- who can build a case closure at all -----------------------------------------------------
 
     /**
-     * A sum's own case list — one layer, what a descent would be built out of — is read in four
-     * places, and a fifth is where a second closure would start.
+     * A sum's own case list is read at four call sites, all of them in the package that declares it.
      *
-     * <p>The axis the earlier tripwire could not hold. That one watched whether an optional was
-     * decided in one place, which says nothing about the descent; and {@code Hir.SumData} is named
-     * in twenty-five production files, so naming the declaration cannot be the axis either. What a
-     * second closure needs is the one thing a closure is made of, so that is what is counted.
+     * <p>What a second closure would be built out of is one layer of a sum plus the declarations:
+     * hold both and a loop away is a descent. The declarations are everywhere, so the layer is the
+     * part that can be held down, and {@code TypeOps.caseNames} is package-private for that reason.
+     * That is where most of this rule lives — no code outside {@code check} can write a second
+     * closure at all, and javac says so rather than a scan guessing at spellings.
      *
-     * <p>The three that are not the descent read one layer on purpose. A {@code match} is decided
-     * over the cases the sum declared and not over what they reach (spec
-     * §an-or-pattern-binds-the-sum-and-opens-nothing), which is #966 itself; when that changes they
+     * <p>What is left for a scan is the package itself, and it counts <em>calls</em> rather than
+     * files. A file already reading one layer is where a second reading is cheapest to add, so a
+     * check that stops at the file name would see nothing: the reader most likely to grow a descent
+     * is one of the four already listed.
+     *
+     * <p>Called out by file and not by line. A line number moves whenever anything above it is
+     * edited, and a tripwire that goes red on an unrelated edit is one that gets deleted. The name
+     * repeated is what a second call site in an existing reader shows up as.
+     *
+     * <p>Three of the four are not the descent and read one layer on purpose: a {@code match} is
+     * decided over the cases the sum declared and not over what they reach (spec
+     * §an-or-pattern-binds-the-sum-and-opens-nothing), which is #966 itself. When that changes they
      * ask {@link AtomSpace} and this list gets shorter, never longer.
      *
-     * <p>A tripwire and not a proof: a helper in between defeats it. What it does see is the line
-     * that has to be written first.
+     * <p><b>What this does not see.</b> A descent written around a call that is already here. Both
+     * halves are about who can reach the material — the visibility bounds who may, and this bounds
+     * how many do — and neither reads what a caller does with what it got.
      */
     @Test
-    void oneLayerOfASumIsReadWhereAClosureCouldNotBeBuiltFromIt() throws IOException {
-        List<Path> sources = mainSources();
-        assertTrue(sources.size() > 20,
-                () -> "the scan found only " + sources.size() + " sources, which is not the tree");
+    void aSumsOwnCaseListIsReadAtFourCallSitesInTheOnePackageThatCanReadIt() throws IOException {
+        List<Path> sources = sourcesOfTheCheckPackage();
+        assertTrue(sources.size() > 100,
+                () -> "the scan found only " + sources.size() + " sources, which is not the package");
 
-        List<String> readers = new ArrayList<>();
+        List<String> calls = new ArrayList<>();
         for (Path source : sources) {
-            if (code(source).contains("caseNames(sum)") || code(source).contains("TypeOps.caseNames(")) {
-                readers.add(source.getParent().getFileName() + "/" + source.getFileName());
+            String code = code(source);
+            assertFalse(code.contains("static souther.compiler.check.TypeOps.caseNames"),
+                    () -> source.getFileName() + " imports the case list under a bare name, "
+                            + "which is a call site this counts by the spelling it is written in");
+            int here = count(QUALIFIED, code);
+            if (source.getFileName().toString().equals(DECLARES_IT)) {
+                // Its own calls are written without the class name, and the declaration is not one.
+                here += count(UNQUALIFIED, code) - count(DECLARATION, code);
+            }
+            for (int each = 0; each < here; each++) {
+                calls.add(source.getFileName().toString());
             }
         }
-        assertEquals(List.of("check/AtomSpace.java", "check/CaseSpace.java",
-                        "check/MatchElaborator.java", "check/TypeOps.java"),
-                readers,
-                "a reader of a sum's own case list can descend it; these read it");
+        assertEquals(List.of("AtomSpace.java", "CaseSpace.java", "MatchElaborator.java", "TypeOps.java"),
+                calls,
+                "a reader holding one layer of a sum can descend it; these hold it");
+    }
+
+    /** The file that declares the case list, whose own calls to it carry no class name. */
+    private static final String DECLARES_IT = "TypeOps.java";
+
+    private static final Pattern QUALIFIED = Pattern.compile("TypeOps\\.caseNames\\s*\\(");
+
+    /** A call written without the class name — {@code caseNamesOf} is a different reader and is not
+     *  one, which is why the name is closed with its own parenthesis. */
+    private static final Pattern UNQUALIFIED = Pattern.compile("(?<![\\w.])caseNames\\s*\\(");
+
+    /** The declaration, which {@link #UNQUALIFIED} matches and which is no call. */
+    private static final Pattern DECLARATION = Pattern.compile("caseNames\\s*\\(\\s*Hir\\.SumData");
+
+    private static int count(Pattern pattern, String code) {
+        int found = 0;
+        Matcher at = pattern.matcher(code);
+        while (at.find()) {
+            found++;
+        }
+        return found;
+    }
+
+    private static List<Path> sourcesOfTheCheckPackage() throws IOException {
+        List<Path> sources = new ArrayList<>();
+        for (Path each : mainSources()) {
+            if (each.getParent().getFileName().toString().equals("check")) {
+                sources.add(each);
+            }
+        }
+        return sources;
     }
 
     private static String code(Path source) throws IOException {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatATypeIsMadeOfIsAnsweredInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatATypeIsMadeOfIsAnsweredInOnePlaceTest.java
@@ -10,24 +10,32 @@ import souther.compiler.query.Names;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * What a value of a type can be, when a case of it is itself a sum.
  *
  * <p>Four readers used to descend a sum's cases themselves — two in {@link TypeOps}, one keyed on
- * the declaration rather than the type, and one in the derivation keyed on the written name. Three
- * of them are held here against {@link AtomSpace}, which is the descent, and the fourth follows
- * (#990). What each reader is handed differs and the descent no longer does: a sum asked about
- * through its declaration is asked about as its type. What each of them answers <em>about</em> a type it was handed is its own and is held here
- * too: a reader asking {@code sumCases} is asking whether there are cases to read at all, and a
- * type that is its own one leaf is not that.
+ * the declaration rather than the type, and one in the derivation keyed on the written name. All
+ * four are gone: {@link AtomSpace} is the descent, and every reader asks it. What each of them was
+ * handed differed and the descent no longer does — a sum asked about through its declaration is
+ * asked about as its type.
+ *
+ * <p>What a reader answers <em>about</em> a type it was handed stayed with the reader, which is
+ * where it belongs: a field read asks whether there are cases to read at all, and a type that is
+ * its own one leaf is not that. Held here at what it produces rather than at the call it makes.
  */
 class WhatATypeIsMadeOfIsAnsweredInOnePlaceTest {
 
@@ -133,23 +141,37 @@ class WhatATypeIsMadeOfIsAnsweredInOnePlaceTest {
     @Test
     void aSumsOwnDeclarationAnswersWithTheSameLeaves() {
         Hir.SumData both = (Hir.SumData) declaration("Both");
-        assertEquals(shown(leavesOf("Both")), shown(TypeOps.leafCases(both, symbols)));
+        assertEquals(shown(leavesOf("Both")),
+                shown(AtomSpace.subjectAtoms(Type.ref(both.declares()), symbols)));
     }
 
     // --- what each reader answers about a type that is no sum ------------------------------------
 
+    /**
+     * A field read on a type that is no sum is not told to open its cases.
+     *
+     * <p>The one answer {@code TypeOps.sumCases} carried that the descent does not: it said null
+     * where a type is its own single leaf, and the field read turned that into which of two things
+     * the author is told. The descent answers {@code [Station]} there — a leaf is what it is — so
+     * the reader asks whether the type is a sum itself, and this is where that is held.
+     */
     @Test
-    void askingForACasesToReadIsNotAnsweredByATypeThatIsItsOwnLeaf() {
-        assertNull(TypeOps.sumCases(Type.ref(named("Station")), symbols),
+    void aFieldReadOnATypeThatIsNoSumIsNotToldToOpenIt() {
+        souther.compiler.diag.CompileException refused = org.junit.jupiter.api.Assertions
+                .assertThrows(souther.compiler.diag.CompileException.class,
+                        () -> souther.compiler.Compiler.compile(MODULE + """
+
+                                let f (s: Station) : Int = s.x
+                                """));
+        org.junit.jupiter.api.Assertions.assertInstanceOf(
+                souther.compiler.diag.msg.DeclarationMessage.CannotReadAFieldOnThisValue.class,
+                refused.diagnostic().said(),
                 "a data with no cases has none to read, which is not the same as having itself");
-        assertEquals(List.of("Station", "Hospital", "Renkei"),
-                shown(TypeOps.sumCases(Type.ref(named("VisitKind")), symbols)));
     }
 
     @Test
     void aLeafSetAnswersForATypeThatIsNoSum() {
-        assertEquals(List.of("Station"),
-                shown(List.copyOf(TypeOps.leafCases(Type.ref(named("Station")), symbols))));
+        assertEquals(List.of("Station"), shown(AtomSpace.subjectAtoms(Type.ref(named("Station")), symbols)));
     }
 
     /**
@@ -192,7 +214,117 @@ class WhatATypeIsMadeOfIsAnsweredInOnePlaceTest {
                 "a primitive output is not a case list, whatever leaf its name would be");
     }
 
+
+    // --- who can build a case closure at all -----------------------------------------------------
+
+    /**
+     * A sum's own case list — one layer, what a descent would be built out of — is read in four
+     * places, and a fifth is where a second closure would start.
+     *
+     * <p>The axis the earlier tripwire could not hold. That one watched whether an optional was
+     * decided in one place, which says nothing about the descent; and {@code Hir.SumData} is named
+     * in twenty-five production files, so naming the declaration cannot be the axis either. What a
+     * second closure needs is the one thing a closure is made of, so that is what is counted.
+     *
+     * <p>The three that are not the descent read one layer on purpose. A {@code match} is decided
+     * over the cases the sum declared and not over what they reach (spec
+     * §an-or-pattern-binds-the-sum-and-opens-nothing), which is #966 itself; when that changes they
+     * ask {@link AtomSpace} and this list gets shorter, never longer.
+     *
+     * <p>A tripwire and not a proof: a helper in between defeats it. What it does see is the line
+     * that has to be written first.
+     */
+    @Test
+    void oneLayerOfASumIsReadWhereAClosureCouldNotBeBuiltFromIt() throws IOException {
+        List<Path> sources = mainSources();
+        assertTrue(sources.size() > 20,
+                () -> "the scan found only " + sources.size() + " sources, which is not the tree");
+
+        List<String> readers = new ArrayList<>();
+        for (Path source : sources) {
+            if (code(source).contains("caseNames(sum)") || code(source).contains("TypeOps.caseNames(")) {
+                readers.add(source.getParent().getFileName() + "/" + source.getFileName());
+            }
+        }
+        assertEquals(List.of("check/AtomSpace.java", "check/CaseSpace.java",
+                        "check/MatchElaborator.java", "check/TypeOps.java"),
+                readers,
+                "a reader of a sum's own case list can descend it; these read it");
+    }
+
+    private static String code(Path source) throws IOException {
+        return withoutComments(Files.readString(source, StandardCharsets.UTF_8));
+    }
+
+    /**
+     * The source with its comments taken out.
+     *
+     * <p>So that a javadoc naming the rule does not read as a breach of it. Lexical and small: it
+     * follows string and character literals so a {@code //} inside one is not a comment, and keeps
+     * what is inside them, so the worst it can do is leave a comment standing.
+     */
+    private static String withoutComments(String source) {
+        StringBuilder out = new StringBuilder(source.length());
+        int at = 0;
+        while (at < source.length()) {
+            char here = source.charAt(at);
+            char next = at + 1 < source.length() ? source.charAt(at + 1) : '\0';
+            if (here == '/' && next == '/') {
+                while (at < source.length() && source.charAt(at) != '\n') {
+                    at++;
+                }
+            } else if (here == '/' && next == '*') {
+                at += 2;
+                while (at + 1 < source.length()
+                        && !(source.charAt(at) == '*' && source.charAt(at + 1) == '/')) {
+                    at++;
+                }
+                at = Math.min(source.length(), at + 2);
+            } else if (here == '"' || here == '\'') {
+                out.append(here);
+                at++;
+                while (at < source.length() && source.charAt(at) != here) {
+                    if (source.charAt(at) == '\\' && at + 1 < source.length()) {
+                        out.append(source.charAt(at));
+                        at++;
+                    }
+                    out.append(source.charAt(at));
+                    at++;
+                }
+                if (at < source.length()) {
+                    out.append(source.charAt(at));
+                    at++;
+                }
+            } else {
+                out.append(here);
+                at++;
+            }
+        }
+        return out.toString();
+    }
+
+    private static List<Path> mainSources() throws IOException {
+        Path module = Path.of("").toAbsolutePath();
+        Path repo = Files.isDirectory(module.resolve(Path.of("src", "main", "java")))
+                ? module.getParent() : module;
+        List<Path> sources = new ArrayList<>();
+        try (Stream<Path> modules = Files.list(repo)) {
+            for (Path candidate : modules.toList()) {
+                Path root = candidate.resolve(Path.of("src", "main", "java"));
+                if (!Files.isDirectory(root)) {
+                    continue;
+                }
+                try (Stream<Path> walk = Files.walk(root)) {
+                    walk.filter(each -> each.toString().endsWith(".java")).forEach(sources::add);
+                }
+            }
+        }
+        sources.sort(Path::compareTo);
+        return sources;
+    }
+
     // --- helpers ---------------------------------------------------------------------------------
+
 
     private List<TypeSymbol> leavesOf(String type) {
         return AtomSpace.subjectAtoms(Type.ref(named(type)), symbols);


### PR DESCRIPTION
Step 1b of #966. After #991 the descent over a sum's cases lives in `AtomSpace`, but three wrappers on `TypeOps` still stood in front of it, and every reader in the compiler went through one of them. Each wrapper carried its own collection type and its own answer for a type that is no sum, so a reader picked one by the shape it wanted rather than by the question it was asking.

## What changed

`TypeOps.leafCases(Type)`, `TypeOps.leafCases(Hir.SumData)` and `TypeOps.sumCases` are gone. Their twenty-odd callers ask `AtomSpace.subjectAtoms` directly. A reader that iterates takes the list it gets; one that tests membership or compares two answers builds its own set at the call, which is where that requirement was always coming from.

`TypeOps.sumCases` had one caller: the field read on a sum in `Elaborator`. What it carried was not the descent but the question of whether there are cases to read at all — a type that is its own single leaf is not that. The guard is written at the read now, and held by a test on what the author is told rather than on which method was called.

`TypeOps.outputCases` stays. It admits Union and Ref and answers nothing for anything else, which is a reader's rule about which types it will take an answer about, not a second descent.

## The tripwire

`WhatATypeIsMadeOfIsAnsweredInOnePlaceTest` gains the check the earlier axis could not make. Watching `Hir.SumData` is no use — twenty-five production files name it. What a second closure has to be built out of is a sum's own one-layer case list, so that is what is counted: `TypeOps.caseNames` has four readers, and only `AtomSpace` descends what it finds. The other three read one layer on purpose — a `match` is decided over the cases the sum declared and not over what they reach — and when that changes in step 3 the list gets shorter, never longer.

## What did not change

No behavior. `mvn -o test`: 9745 tests, 0 failures, 1 skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)