### PR TITLE
Resolve a case against the declarations where the subject is taken apart

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/BehaviorChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BehaviorChecker.java
@@ -12,7 +12,6 @@ import souther.compiler.diag.DiagnosticRenderer;
 import souther.compiler.diag.msg.BehaviorMessage;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
-import souther.compiler.types.CaseSelector;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
@@ -206,8 +205,8 @@ public final class BehaviorChecker {
                 // the reading is abandoned instead, as a `match` arm's is.
                 throw new Unanswerable(armCase.pos());
             }
-            CaseSelector selector = answer.selector(armCase.answered().type());
-            if (selector == null) {
+            ResolvedCase selected = answer.selector(armCase.answered().type());
+            if (selected == null) {
                 throw CompileException.of(Diagnostic.at(armCase.pos())
                         .say(new BehaviorMessage.AnEnsuresArmIsNotAnOutputCase(
                                 armCase.written(), behavior.name())).build());
@@ -220,11 +219,11 @@ public final class BehaviorChecker {
             //
             // Redundant and not ambiguous, so it is collapsed rather than refused. `Found -> p |
             // Found -> q` is another matter and is two rules: the arms differ, so the ids do.
-            if (!seen.add(selector.name())) {
+            if (!seen.add(selected.name())) {
                 continue;
             }
-            rules.add(new Rule(new Guard.Case(selector), value, arm.expr(),
-                    new RuleId(named, clause, ordinal, selector.name()), arm.pos()));
+            rules.add(new Rule(new Guard.Case(selected), value, arm.expr(),
+                    new RuleId(named, clause, ordinal, selected.name()), arm.pos()));
         }
         return rules;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/BehaviorContract.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BehaviorContract.java
@@ -5,7 +5,6 @@ import souther.compiler.diag.Region;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
-import souther.compiler.types.CaseSelector;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
@@ -81,7 +80,7 @@ public record BehaviorContract(ValueName.Behavior behavior, List<ContractParam> 
         /** What {@code value} is read as here: what the case holds, or the whole answer where the
          *  rule applies to every answer. */
         public Type valueType(Type output) {
-            return guard instanceof Guard.Case c ? c.selector().bound() : output;
+            return guard instanceof Guard.Case c ? c.selected().bound() : output;
         }
 
         /**
@@ -125,8 +124,13 @@ public record BehaviorContract(ValueName.Behavior behavior, List<ContractParam> 
         /** The rule applies to every answer: the form written where the answer has no cases. */
         public record Always() implements Guard {}
 
-        /** The rule applies where the answer is this case. */
-        public record Case(CaseSelector selector) implements Guard {}
+        /** The rule applies where the answer is this case.
+         *
+         * <p>The case as this compile resolved it and not the selector alone: a reader deciding
+         * whether one rule's case is inside another's is asking about what each covers, and going
+         * back to the declarations for that is the second reading {@link CaseSpace} exists to stop.
+         */
+        public record Case(ResolvedCase selected) implements Guard {}
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/CaseSpace.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CaseSpace.java
@@ -47,7 +47,7 @@ sealed interface CaseSpace {
      * <p>It is not the order arms are tried in. Which arm of a {@code match} takes a value is
      * decided by the order the arms are written, which is the match's and not the subject's.
      */
-    List<CaseSelector> selectors();
+    List<ResolvedCase> selectors();
 
     /** A subject with no cases: nothing selects from it and nothing opens it. */
     record Plain(Type subject) implements CaseSpace {
@@ -58,7 +58,7 @@ sealed interface CaseSpace {
         }
 
         @Override
-        public List<CaseSelector> selectors() {
+        public List<ResolvedCase> selectors() {
             return List.of();
         }
     }
@@ -71,7 +71,7 @@ sealed interface CaseSpace {
      * admits a different surface is an arm here, so gaining one is a compile error at each reader
      * that decides by form rather than a silent fall into the general reading.
      */
-    record Optional(Type subject, List<CaseSelector> selectors) implements CaseSpace {
+    record Optional(Type subject, List<ResolvedCase> selectors) implements CaseSpace {
 
         public Optional {
             selectors = List.copyOf(selectors);
@@ -84,7 +84,7 @@ sealed interface CaseSpace {
     }
 
     /** A subject whose cases are named data: a union's members, or a sum's declared cases. */
-    record Cases(Type subject, String described, List<CaseSelector> selectors) implements CaseSpace {
+    record Cases(Type subject, String described, List<ResolvedCase> selectors) implements CaseSpace {
 
         public Cases {
             selectors = List.copyOf(selectors);
@@ -100,15 +100,22 @@ sealed interface CaseSpace {
      */
     static CaseSpace of(Type subject, Symbols symbols) {
         if (subject instanceof Type.OptionOf option) {
+            // An optional's carriers cover themselves. What `Some` holds is the element, and the
+            // element's own atoms are not what an arm over an optional answers for: `Some` is the
+            // case, whatever it wraps.
             return new Optional(subject, List.of(
-                    CaseSelector.optionPresent(option.element()), CaseSelector.optionAbsent()));
+                    new ResolvedCase(CaseSelector.optionPresent(option.element()),
+                            List.of(TypeSymbol.SOME)),
+                    new ResolvedCase(CaseSelector.optionAbsent(), List.of(TypeSymbol.NONE))));
         }
         if (subject instanceof Type.Union union) {
-            return new Cases(subject, "union `" + Type.show(union) + "`", direct(union.members()));
+            return new Cases(subject, "union `" + Type.show(union) + "`",
+                    direct(union.members(), symbols));
         }
         if (subject instanceof Type.Ref ref
                 && symbols.declarations().declaration(ref.name().key()) instanceof Hir.SumData sum) {
-            return new Cases(subject, "data `" + sum.name() + "`", direct(TypeOps.caseNames(sum)));
+            return new Cases(subject, "data `" + sum.name() + "`",
+                    direct(TypeOps.caseNames(sum), symbols));
         }
         return new Plain(subject);
     }
@@ -119,10 +126,10 @@ sealed interface CaseSpace {
     }
 
     /** The case {@code name} selects, or null where it selects none of these. */
-    default CaseSelector selector(TypeSymbol name) {
-        for (CaseSelector selector : selectors()) {
-            if (selector.name().equals(name)) {
-                return selector;
+    default ResolvedCase selector(TypeSymbol name) {
+        for (ResolvedCase selected : selectors()) {
+            if (selected.name().equals(name)) {
+                return selected;
             }
         }
         return null;
@@ -131,22 +138,35 @@ sealed interface CaseSpace {
     /** The names of these cases, in the order the subject states them. */
     default List<TypeSymbol> names() {
         List<TypeSymbol> out = new ArrayList<>();
-        for (CaseSelector selector : selectors()) {
-            out.add(selector.name());
+        for (ResolvedCase selected : selectors()) {
+            out.add(selected.name());
         }
         return out;
     }
 
-    /** Cases whose carrier is the value itself, de-duplicated the way the subject states them: a
-     *  member written twice is one case, and the first spelling is the one the order keeps. */
-    private static List<CaseSelector> direct(Iterable<TypeSymbol> members) {
+    /**
+     * Cases whose carrier is the value itself, de-duplicated the way the subject states them: a
+     * member written twice is one case, and the first spelling is the one the order keeps.
+     *
+     * <p>What each covers is read from what it holds and not from its name: the {@code Int} of
+     * {@code Int | DivisionByZero} holds a primitive, which {@link CaseSelector#heldBy} has already
+     * worked out, and a case that is a sum holds that sum and covers the leaves under it.
+     */
+    private static List<ResolvedCase> direct(Iterable<TypeSymbol> members, Symbols symbols) {
         Set<TypeSymbol> seen = new LinkedHashSet<>();
         for (TypeSymbol member : members) {
             seen.add(member);
         }
-        List<CaseSelector> out = new ArrayList<>();
+        List<ResolvedCase> out = new ArrayList<>();
         for (TypeSymbol member : seen) {
-            out.add(CaseSelector.direct(member));
+            CaseSelector selector = CaseSelector.direct(member);
+            // A case whose name denotes no type holds nothing to descend — `Raw`, which a stage may
+            // be unioned with and which no declaration takes apart — and covers no atom. The same
+            // answer {@link AtomSpace} gives a type that names no case, said here because the type
+            // to ask it about is the one that is missing.
+            Type held = selector.bound();
+            out.add(new ResolvedCase(selector,
+                    held == null ? List.of() : AtomSpace.subjectAtoms(held, symbols)));
         }
         return out;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/CaseSpace.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CaseSpace.java
@@ -104,9 +104,7 @@ sealed interface CaseSpace {
             // element's own atoms are not what an arm over an optional answers for: `Some` is the
             // case, whatever it wraps.
             return new Optional(subject, List.of(
-                    new ResolvedCase(CaseSelector.optionPresent(option.element()),
-                            List.of(TypeSymbol.SOME)),
-                    new ResolvedCase(CaseSelector.optionAbsent(), List.of(TypeSymbol.NONE))));
+                    ResolvedCase.optionPresent(option.element()), ResolvedCase.optionAbsent()));
         }
         if (subject instanceof Type.Union union) {
             return new Cases(subject, "union `" + Type.show(union) + "`",
@@ -148,9 +146,8 @@ sealed interface CaseSpace {
      * Cases whose carrier is the value itself, de-duplicated the way the subject states them: a
      * member written twice is one case, and the first spelling is the one the order keeps.
      *
-     * <p>What each covers is read from what it holds and not from its name: the {@code Int} of
-     * {@code Int | DivisionByZero} holds a primitive, which {@link CaseSelector#heldBy} has already
-     * worked out, and a case that is a sum holds that sum and covers the leaves under it.
+     * <p>What each covers is {@link ResolvedCase#direct}'s to work out. This says which cases there
+     * are and in what order; what one of them reaches is not restated here.
      */
     private static List<ResolvedCase> direct(Iterable<TypeSymbol> members, Symbols symbols) {
         Set<TypeSymbol> seen = new LinkedHashSet<>();
@@ -159,14 +156,7 @@ sealed interface CaseSpace {
         }
         List<ResolvedCase> out = new ArrayList<>();
         for (TypeSymbol member : seen) {
-            CaseSelector selector = CaseSelector.direct(member);
-            // A case whose name denotes no type holds nothing to descend — `Raw`, which a stage may
-            // be unioned with and which no declaration takes apart — and covers no atom. The same
-            // answer {@link AtomSpace} gives a type that names no case, said here because the type
-            // to ask it about is the one that is missing.
-            Type held = selector.bound();
-            out.add(new ResolvedCase(selector,
-                    held == null ? List.of() : AtomSpace.subjectAtoms(held, symbols)));
+            out.add(ResolvedCase.direct(member, symbols));
         }
         return out;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ContractDischarge.java
@@ -3,7 +3,6 @@ package souther.compiler.check;
 import souther.compiler.check.BehaviorContract.ContractParam;
 import souther.compiler.check.BehaviorContract.Guard;
 import souther.compiler.types.BindingId;
-import souther.compiler.types.CaseSelector;
 import souther.compiler.types.TypeSymbol;
 
 import java.util.ArrayList;
@@ -106,14 +105,14 @@ public record ContractDischarge(List<RuleDischarge> rules,
     private static List<TypeSymbol> unstatedCases(StatedContract contract, Symbols symbols) {
         Set<TypeSymbol> stated = new LinkedHashSet<>();
         for (StatedContract.StatedRule rule : contract.rules()) {
-            if (rule.guard() instanceof Guard.Case(CaseSelector selector)) {
-                stated.add(selector.name());
+            if (rule.guard() instanceof Guard.Case(ResolvedCase selected)) {
+                stated.add(selected.name());
             }
         }
         List<TypeSymbol> unstated = new ArrayList<>();
-        for (CaseSelector selector : CaseSpace.of(contract.output(), symbols).selectors()) {
-            if (!stated.contains(selector.name())) {
-                unstated.add(selector.name());
+        for (ResolvedCase selected : CaseSpace.of(contract.output(), symbols).selectors()) {
+            if (!stated.contains(selected.name())) {
+                unstated.add(selected.name());
             }
         }
         return unstated;

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -4,7 +4,6 @@ import souther.compiler.types.BinOp;
 import souther.compiler.ast.Hir;
 import souther.compiler.diag.CompileException;
 import souther.compiler.types.BindingId;
-import souther.compiler.types.CaseSelector;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
@@ -882,8 +881,8 @@ final class HelperParams {
             TypeSymbol arm = c.caseTypes().get(0).answered().type();
             // What the case refines the value to, asked of the subject's cases rather than worked
             // out from the subject's shape a second time.
-            CaseSelector selector = CaseSpace.of(scrutinee, symbols).selector(arm);
-            Type bound = selector == null ? null : selector.bound();
+            ResolvedCase selected = CaseSpace.of(scrutinee, symbols).selector(arm);
+            Type bound = selected == null ? null : selected.bound();
             return bound == null ? env : MatchElaborator.bound(env, c.binding(), bound);
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
@@ -102,8 +102,8 @@ public final class MatchElaborator {
             List<CaseSelector> selected = new ArrayList<>();
             for (Hir.Name written : c.caseTypes()) {
                 TypeSymbol caseName = names(written);
-                CaseSelector selector = space.selector(caseName);
-                if (selector == null) {
+                ResolvedCase resolved = space.selector(caseName);
+                if (resolved == null) {
                     throw notCase(written, what, c, m, cases, ctx.symbols());
                 }
                 if (!covered.add(caseName)) {
@@ -111,7 +111,10 @@ public final class MatchElaborator {
                             .say(new MatchMessage.MatchedByMoreThanOneCase(written.written()))
                             .build());
                 }
-                selected.add(selector);
+                // What goes into the arm is the selector. An arm is emitted from what it tests
+                // and reads, which is all of a case that survives into `Core`; what it covers is
+                // this pass's to hold and is not carried past it.
+                selected.add(resolved.selector());
             }
             Core.ResolvedPattern pattern = selected.size() == 1
                     ? new Core.ResolvedPattern.Single(selected.get(0))
@@ -160,10 +163,11 @@ public final class MatchElaborator {
             Hir.Name arm = c.caseTypes().get(0);
             String caseType = arm.written();
             TypeSymbol armName = names(arm);
-            CaseSelector selector = space.selector(armName);
-            if (selector == null) {
+            ResolvedCase resolved = space.selector(armName);
+            if (resolved == null) {
                 throw CompileException.of(Diagnostic.at(c.pos()).say(new MatchMessage.NotACaseOfAnOptional(caseType)).build());
             }
+            CaseSelector selector = resolved.selector();
             Type bind = selector.bound();
             if (c.unwrapAsserts() != null) {
                 // Only the carrier that holds something has something to open.

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -348,11 +348,11 @@ final class PathEngine {
         if (guard instanceof Guard.Always) {
             return true;
         }
-        if (!(guard instanceof Guard.Case(CaseSelector selector))
+        if (!(guard instanceof Guard.Case(ResolvedCase selected))
                 || !(pattern instanceof Core.ResolvedPattern.Single single)) {
             return false;
         }
-        return single.selector().name().equals(selector.name());
+        return single.selector().name().equals(selected.name());
     }
 
     /** What the arm holds of the answer: what it binds where it binds one, and the answer itself

--- a/souther-compiler/src/main/java/souther/compiler/check/ResolvedCase.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ResolvedCase.java
@@ -1,0 +1,108 @@
+package souther.compiler.check;
+
+import souther.compiler.types.CaseSelector;
+import souther.compiler.types.Refinement;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.List;
+
+/**
+ * A case as this compile resolved it: what selects it, and which atoms selecting it covers.
+ *
+ * <p>Two facts of different phases, held together because one reader needs both and neither can be
+ * worked out from the other. A {@link CaseSelector} is what a value is tested as and read as at run
+ * time, and it says that much about itself wherever it is written — {@code Some} carries the present
+ * carrier, a data-named case carries its data type — with no program around it. What it
+ * <em>covers</em> is not like that: a case that is itself a sum stands for the leaves under it
+ * (spec §sum-data), and which leaves those are is a fact about the declarations this compile read.
+ *
+ * <p>So the atoms are not a component of the selector. Putting them there would make a selector
+ * whose name and carrier agree and whose atoms do not — the half-decided state
+ * {@code CaseSelector}'s own constructor exists to refuse, and one it could not refuse, since
+ * nothing in {@code types} can ask what a name reaches. The phase boundary is the type instead:
+ * below it a case is a selector, and at this level it is a selector that has been resolved against
+ * the declarations.
+ *
+ * <p>Made in this package and read anywhere. The constructor is package-private because the atoms
+ * have one correct value and {@link CaseSpace} is where it is worked out; a caller elsewhere could
+ * only restate it, and a restatement that drifted would be a case covering leaves it does not.
+ * What is emitted downstream is the selector — {@link #selector()} — which is all
+ * {@code Core} and the backend have ever needed.
+ */
+public final class ResolvedCase {
+
+    private final CaseSelector selector;
+    private final List<TypeSymbol> atoms;
+
+    ResolvedCase(CaseSelector selector, List<TypeSymbol> atoms) {
+        if (selector == null || atoms == null) {
+            throw new IllegalArgumentException("a resolved case is a selector and what it covers");
+        }
+        this.selector = selector;
+        this.atoms = List.copyOf(atoms);
+    }
+
+    /** What tests and reads the value — what {@code Core} carries and the backend emits. */
+    public CaseSelector selector() {
+        return selector;
+    }
+
+    /**
+     * The atoms a value selected by this can be, in first-reach declaration order.
+     *
+     * <p>{@link AtomSpace#subjectAtoms} of what the case holds, which is one atom for a leaf and the
+     * leaves under it for a case that is a sum. An optional's carriers are not asked that way: what
+     * {@code Some} covers is {@code Some} and not the atoms of the element it holds, so its own name
+     * is the atom. Reading them through the element would make an optional over a sum cover that
+     * sum's leaves, and the arms of a {@code match} over an optional would be held against cases no
+     * optional has.
+     */
+    public List<TypeSymbol> atoms() {
+        return atoms;
+    }
+
+    /** The name this case is written by. */
+    public TypeSymbol name() {
+        return selector.name();
+    }
+
+    /** What the value turns out to be once this case is selected. */
+    public Refinement refinement() {
+        return selector.refinement();
+    }
+
+    /** What a value selected by this is read as, or null where nothing readable stands under it. */
+    public Type bound() {
+        return selector.bound();
+    }
+
+    /**
+     * Two resolved cases are one where they select the same case and cover the same atoms.
+     *
+     * <p>A value and not an identity. It is kept in what a behavior's declaration comes to, and two
+     * compiles of one source have to answer alike — a reader comparing what was stated before an
+     * edit with what is stated after would otherwise see every rule change because the objects are
+     * new ({@code EquivalentDatabasesAnswerTheSameTest}).
+     *
+     * <p>The atoms are compared as well as the selector. They follow from the selector and the
+     * declarations, so within one compile the two never disagree; comparing both says that plainly
+     * rather than resting on it, and two compiles of different sources that resolved one selector
+     * differently are two different things.
+     */
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof ResolvedCase that
+                && selector.equals(that.selector) && atoms.equals(that.atoms);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * selector.hashCode() + atoms.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return selector.name() + " covering " + atoms;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/ResolvedCase.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ResolvedCase.java
@@ -24,23 +24,62 @@ import java.util.List;
  * below it a case is a selector, and at this level it is a selector that has been resolved against
  * the declarations.
  *
- * <p>Made in this package and read anywhere. The constructor is package-private because the atoms
- * have one correct value and {@link CaseSpace} is where it is worked out; a caller elsewhere could
- * only restate it, and a restatement that drifted would be a case covering leaves it does not.
- * What is emitted downstream is the selector — {@link #selector()} — which is all
- * {@code Core} and the backend have ever needed.
+ * <p>Made in this package and read anywhere. There is no way to say what a case covers: the
+ * constructor is private and every way in takes the causes only — a name and the symbols to resolve
+ * it against, or the element an optional holds — so the atoms are worked out and never supplied. A
+ * constructor taking them would have moved the half-decided state rather than removed it, since a
+ * caller here could hand {@code Station}'s selector the leaves of {@code Hospital} and nothing
+ * could tell. The factories are package-private on top of that, so the backend reads one and mints
+ * none; but a tripwire over the mint sites is the lesser guard, and the value is already
+ * unrepresentable without it.
+ *
+ * <p>What is emitted downstream is the selector — {@link #selector()} — which is all {@code Core}
+ * and the backend have ever needed.
  */
 public final class ResolvedCase {
 
     private final CaseSelector selector;
     private final List<TypeSymbol> atoms;
 
-    ResolvedCase(CaseSelector selector, List<TypeSymbol> atoms) {
-        if (selector == null || atoms == null) {
-            throw new IllegalArgumentException("a resolved case is a selector and what it covers");
-        }
+    private ResolvedCase(CaseSelector selector, List<TypeSymbol> atoms) {
         this.selector = selector;
         this.atoms = List.copyOf(atoms);
+    }
+
+    /**
+     * A case whose carrier is the value: a union member, or a case of a named sum.
+     *
+     * <p>Resolved against {@code symbols} here rather than handed the answer. What it covers is read
+     * from what it holds and not from its name: the {@code Int} of {@code Int | DivisionByZero}
+     * holds a primitive, which {@link CaseSelector#heldBy} has already worked out, and a case that
+     * is a sum holds that sum and covers the leaves under it.
+     *
+     * <p>A name that denotes no type holds nothing to descend — {@code Raw}, which a stage may be
+     * unioned with and which no declaration takes apart — and covers no atom. The same answer
+     * {@link AtomSpace} gives a type that names no case, said here because the type to ask it about
+     * is the one that is missing.
+     */
+    static ResolvedCase direct(TypeSymbol name, Symbols symbols) {
+        CaseSelector selector = CaseSelector.direct(name);
+        Type held = selector.bound();
+        return new ResolvedCase(selector,
+                held == null ? List.of() : AtomSpace.subjectAtoms(held, symbols));
+    }
+
+    /**
+     * The carrier an optional holding {@code element} is.
+     *
+     * <p>No symbols, because there is nothing to resolve: what {@code Some} covers is {@code Some}.
+     * Taking the element's atoms would make an optional over a sum cover that sum's leaves, and the
+     * two arms of a {@code match} over it would be held against cases no optional has.
+     */
+    static ResolvedCase optionPresent(Type element) {
+        return new ResolvedCase(CaseSelector.optionPresent(element), List.of(TypeSymbol.SOME));
+    }
+
+    /** The carrier an optional holding nothing is, which covers itself as the present one does. */
+    static ResolvedCase optionAbsent() {
+        return new ResolvedCase(CaseSelector.optionAbsent(), List.of(TypeSymbol.NONE));
     }
 
     /** What tests and reads the value — what {@code Core} carries and the backend emits. */
@@ -51,12 +90,8 @@ public final class ResolvedCase {
     /**
      * The atoms a value selected by this can be, in first-reach declaration order.
      *
-     * <p>{@link AtomSpace#subjectAtoms} of what the case holds, which is one atom for a leaf and the
-     * leaves under it for a case that is a sum. An optional's carriers are not asked that way: what
-     * {@code Some} covers is {@code Some} and not the atoms of the element it holds, so its own name
-     * is the atom. Reading them through the element would make an optional over a sum cover that
-     * sum's leaves, and the arms of a {@code match} over an optional would be held against cases no
-     * optional has.
+     * <p>Worked out by whichever factory made this and never supplied to one. See {@link #direct}
+     * for a case whose carrier is the value and {@link #optionPresent} for an optional's.
      */
     public List<TypeSymbol> atoms() {
         return atoms;

--- a/souther-compiler/src/main/java/souther/compiler/codegen/EnsuresGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/EnsuresGen.java
@@ -6,7 +6,6 @@ import souther.compiler.check.BehaviorContract.ContractParam;
 import souther.compiler.check.BehaviorContract.Guard;
 import souther.compiler.check.BehaviorContract.Rule;
 import souther.compiler.jvm.GeneratedClass;
-import souther.compiler.types.CaseSelector;
 import souther.compiler.types.Refinement;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;

--- a/souther-compiler/src/main/java/souther/compiler/codegen/EnsuresGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/EnsuresGen.java
@@ -1,6 +1,6 @@
 package souther.compiler.codegen;
 
-import souther.compiler.check.AtomSpace;
+import souther.compiler.check.ResolvedCase;
 import souther.compiler.check.BehaviorContract;
 import souther.compiler.check.BehaviorContract.ContractParam;
 import souther.compiler.check.BehaviorContract.Guard;
@@ -153,10 +153,10 @@ final class EnsuresGen {
         // second time would be the same question answered twice. A reference slot, as above.
         int answered = gen.slot(Type.STRING);
         for (Rule rule : contract.rules()) {
-            if (!(rule.guard() instanceof Guard.Case(CaseSelector selector)) || rule.readsAnswer()) {
+            if (!(rule.guard() instanceof Guard.Case(ResolvedCase selected)) || rule.readsAnswer()) {
                 continue;
             }
-            List<TypeSymbol> answersFor = answersFor(selector);
+            List<TypeSymbol> answersFor = answersFor(selected);
             if (answersFor.isEmpty()) {
                 continue;
             }
@@ -177,7 +177,7 @@ final class EnsuresGen {
             }
             code.goto_(next);
             code.labelBinding(matched);
-            emitStatement(code, gen, contract, rule, next, selector, answered, () -> { });
+            emitStatement(code, gen, contract, rule, next, selected, answered, () -> { });
         }
         code.return_();
     }
@@ -186,9 +186,9 @@ final class EnsuresGen {
      * The cases an arm answers for, as the names they are declared under.
      *
      * <p>Its leaves, because that is what a written answer is one of: a union member may be a sum,
-     * and an arm naming that sum is about each of the cases it has. Read off the selector, which is
-     * what a selector is for — what a case means was settled where the arm was specialized, and
-     * working it back out of the name here would be a second answer to it.
+     * and an arm naming that sum is about each of the cases it has. Read off the case, which was
+     * resolved where the arm was specialized — this went back to the declarations for it until
+     * #966, which is one question with a second answer in the one stage that must not ask it.
      *
      * <p>Empty for a carrier that is not a case a written answer wears: an optional's, which is
      * made by its own factory and named by neither of the two, and a carrier standing under no
@@ -199,10 +199,11 @@ final class EnsuresGen {
      * leaves. It is what this answers rather than a rule about optionals — the question is asked of
      * the selector, and a selector that has nothing to answer with is not made into one that does.
      */
-    private List<TypeSymbol> answersFor(CaseSelector selector) {
-        return selector.refinement() instanceof Refinement.Direct(Type bound) && bound != null
-                ? AtomSpace.subjectAtoms(bound, ctx.symbols)
-                : List.of();
+    private static List<TypeSymbol> answersFor(ResolvedCase selected) {
+        // Which of them this reader takes is still this reader's. An optional's carrier covers
+        // itself — that is what an arm over an optional is held against — and `Some` is no name a
+        // written answer wears, so what it covers is not what this asks for.
+        return selected.refinement() instanceof Refinement.Direct ? selected.atoms() : List.of();
     }
 
     /**
@@ -214,19 +215,19 @@ final class EnsuresGen {
     private void emitRule(CodeBuilder code, BodyGen gen, BehaviorContract contract, Rule rule,
                           int answer, int answered) {
         Label next = code.newLabel();
-        CaseSelector selector =
-                rule.guard() instanceof Guard.Case(CaseSelector named) ? named : null;
-        if (selector != null) {
-            CaseGen.jumpUnlessMatches(code, ctx, selector, answer, next);
+        ResolvedCase selected =
+                rule.guard() instanceof Guard.Case(ResolvedCase named) ? named : null;
+        if (selected != null) {
+            CaseGen.jumpUnlessMatches(code, ctx, selected.selector(), answer, next);
         }
         Type valueType = rule.valueType(contract.output());
         Refinement refinement =
-                selector == null ? null : selector.refinement();
+                selected == null ? null : selected.refinement();
         if (refinement instanceof Refinement.OptionAbsent) {
             // The case carries nothing, so there is nothing to bind. A rule about it refers to the
             // answer through its guard, which is what having got here is.
-            emitStatement(code, gen, contract, rule, next, selector, answered,
-                    () -> readAnsweredCase(code, selector, answer, answered));
+            emitStatement(code, gen, contract, rule, next, selected, answered,
+                    () -> readAnsweredCase(code, selected, answer, answered));
             return;
         }
         if (refinement == null) {
@@ -237,8 +238,8 @@ final class EnsuresGen {
         int slot = gen.slot(valueType);
         unbox(code, valueType, slot, ctx);
         gen.bind(rule.value(), "value", slot, valueType);
-        emitStatement(code, gen, contract, rule, next, selector, answered,
-                () -> readAnsweredCase(code, selector, answer, answered));
+        emitStatement(code, gen, contract, rule, next, selected, answered,
+                () -> readAnsweredCase(code, selected, answer, answered));
     }
 
     /**
@@ -249,11 +250,11 @@ final class EnsuresGen {
      * call that was going to abort anyway.
      */
     private void emitStatement(CodeBuilder code, BodyGen gen, BehaviorContract contract, Rule rule,
-                               Label next, CaseSelector selector, int answered,
+                               Label next, ResolvedCase selected, int answered,
                                Runnable fillAnswered) {
         gen.expr(rule.statement());
         code.ifne(next);
-        emitAbort(code, contract, rule, selector, answered, fillAnswered);
+        emitAbort(code, contract, rule, selected, answered, fillAnswered);
         code.labelBinding(next);
     }
 
@@ -265,8 +266,8 @@ final class EnsuresGen {
      * keep out of the emitter — so nothing is built until there is nothing left to decide.
      */
     private void emitAbort(CodeBuilder code, BehaviorContract contract, Rule rule,
-                           CaseSelector selector, int answered, Runnable fillAnswered) {
-        if (selector != null) {
+                           ResolvedCase selected, int answered, Runnable fillAnswered) {
+        if (selected != null) {
             fillAnswered.run();
         }
         code.new_(CD_EnsuresFailure);
@@ -274,11 +275,11 @@ final class EnsuresGen {
         code.ldc(contract.behavior().module());
         code.ldc(contract.behavior().name());
         pushOrNull(code, contract.clauseOf(rule).name().orElse(null));
-        if (selector == null) {
+        if (selected == null) {
             code.aconst_null();
             code.aconst_null();
         } else {
-            pushDeclaredCase(code, selector.name());
+            pushDeclaredCase(code, selected.name());
             code.aload(answered);
         }
         code.invokespecial(CD_EnsuresFailure, ConstantDescs.INIT_NAME, MTD_ensuresFailure);
@@ -308,9 +309,9 @@ final class EnsuresGen {
      * declare does — see {@link #answersFor}. It is what this does with an answer it cannot narrow,
      * and not a claim that an optional's carrier is a case.
      */
-    private void readAnsweredCase(CodeBuilder code, CaseSelector selector, int answer, int into) {
+    private void readAnsweredCase(CodeBuilder code, ResolvedCase selected, int answer, int into) {
         Label done = code.newLabel();
-        for (TypeSymbol leaf : answersFor(selector)) {
+        for (TypeSymbol leaf : answersFor(selected)) {
             Label notThis = code.newLabel();
             code.aload(answer);
             code.instanceOf(ctx.matchCaseClass(leaf));
@@ -320,7 +321,7 @@ final class EnsuresGen {
             code.goto_(done);
             code.labelBinding(notThis);
         }
-        pushDeclaredCase(code, selector.name());
+        pushDeclaredCase(code, selected.name());
         code.astore(into);
         code.labelBinding(done);
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest.java
@@ -209,8 +209,8 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
                 souther.compiler.types.CoverageOrigin.unwritten(), Type.BOOL, POS);
         return new StatedContract(FIND, List.of(), Type.INT,
                 List.of(new StatedContract.StatedRule(new RuleId(FIND, 0, 0, AN_INT),
-                        new Guard.Case(new ResolvedCase(CaseSelector.direct(AN_INT),
-                                List.of(AN_INT))), value, Optional.empty(),
+                        new Guard.Case(ResolvedCase.direct(AN_INT, Symbols.none())), value,
+                        Optional.empty(),
                         List.of(new StatedContract.Conjunct(POS,
                                 new souther.compiler.check.TypedClause.Typed(states))))));
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest.java
@@ -209,7 +209,8 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
                 souther.compiler.types.CoverageOrigin.unwritten(), Type.BOOL, POS);
         return new StatedContract(FIND, List.of(), Type.INT,
                 List.of(new StatedContract.StatedRule(new RuleId(FIND, 0, 0, AN_INT),
-                        new Guard.Case(CaseSelector.direct(AN_INT)), value, Optional.empty(),
+                        new Guard.Case(new ResolvedCase(CaseSelector.direct(AN_INT),
+                                List.of(AN_INT))), value, Optional.empty(),
                         List.of(new StatedContract.Conjunct(POS,
                                 new souther.compiler.check.TypedClause.Typed(states))))));
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatSelectingACaseCoversIsResolvedWhereTheSubjectIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatSelectingACaseCoversIsResolvedWhereTheSubjectIsTest.java
@@ -1,0 +1,170 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Names;
+import souther.compiler.types.Refinement;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What selecting a case covers, and where that is worked out.
+ *
+ * <p>A case is two facts of different phases. What tests and reads a value is the
+ * {@link souther.compiler.types.CaseSelector}, which says all of itself wherever it is written and
+ * is held to that by {@code ACaseIsNotHalfDecidedTest}. What selecting it <em>covers</em> is not
+ * like that: a case that is a sum stands for the leaves under it, and which leaves those are is a
+ * fact about the declarations this compile read. So the atoms are not a component of the selector —
+ * they are what {@link CaseSpace} adds when it resolves one, and {@link ResolvedCase} is the pair.
+ *
+ * <p>Held here and not in {@code types} for that reason. An invariant that needs {@link Symbols} to
+ * state was never an invariant of a selector.
+ */
+class WhatSelectingACaseCoversIsResolvedWhereTheSubjectIsTest {
+
+    /** A sum two deep, a leaf two cases reach, and a case that carries a primitive. */
+    private static final String MODULE = """
+            module m
+
+            data Station
+            data Hospital
+            data Clinic
+            data Renkei
+            data OnceKind   = Station | Hospital
+            data Outpatient = Station | Clinic
+            data VisitKind  = OnceKind | Renkei
+            data Both       = OnceKind | Outpatient
+            """;
+
+    private final Hir.Module module = resolved(MODULE);
+    private final Symbols symbols = TypeChecker.symbols(module);
+
+    @Test
+    void aCaseThatIsASumCoversTheLeavesUnderIt() {
+        assertEquals(List.of("Station", "Hospital"), covered("VisitKind", "OnceKind"),
+                "an arm naming the inner sum answers for everything under it");
+    }
+
+    @Test
+    void aCaseThatIsALeafCoversItself() {
+        assertEquals(List.of("Renkei"), covered("VisitKind", "Renkei"));
+    }
+
+    /**
+     * Two cases of one sum may cover one atom, and that is representable.
+     *
+     * <p>{@code Both} reaches {@code Station} through each of its cases. Nothing here refuses it:
+     * what an overlap means to a {@code match} — which arm takes such a value, and whether writing
+     * both is a mistake — is the match's to decide (#966), and a coverage that could not say two
+     * arms overlap would have decided it by being unable to state it.
+     */
+    @Test
+    void twoCasesOfOneSumMayCoverOneAtom() {
+        assertEquals(List.of("Station", "Hospital"), covered("Both", "OnceKind"));
+        assertEquals(List.of("Station", "Clinic"), covered("Both", "Outpatient"));
+    }
+
+    /** The order is the subject's, so the atoms of one case keep the order that case declares. */
+    @Test
+    void theAtomsOfACaseComeInTheOrderItDeclaresThem() {
+        assertEquals(List.of("Station", "Hospital", "Renkei"),
+                CaseSpace.of(type("VisitKind"), symbols).selectors().stream()
+                        .flatMap(each -> each.atoms().stream()).map(TypeSymbol::name).toList());
+    }
+
+    /**
+     * An optional's carrier covers itself and not what it holds.
+     *
+     * <p>{@code Some<VisitKind>} binds a {@code VisitKind}, so what it <em>holds</em> reaches three
+     * leaves. What an arm over the optional answers for is still {@code Some}: a match over an
+     * optional has two arms, and reading the coverage through the element would hold them against
+     * cases no optional has.
+     */
+    @Test
+    void anOptionalsCarrierCoversItselfAndNotWhatItHolds() {
+        CaseSpace space = CaseSpace.of(Type.option(type("VisitKind")), symbols);
+        assertInstanceOf(CaseSpace.Optional.class, space);
+        ResolvedCase some = space.selector(TypeSymbol.SOME);
+        assertEquals(List.of(TypeSymbol.SOME), some.atoms());
+        assertEquals(List.of(TypeSymbol.NONE), space.selector(TypeSymbol.NONE).atoms());
+        assertInstanceOf(Refinement.OptionPresent.class, some.refinement(),
+                "the carrier still binds the element; only what it covers is its own name");
+        assertEquals(type("VisitKind"), some.bound());
+    }
+
+    /** A subject with no cases hands out none, so there is nothing to resolve. */
+    @Test
+    void aSubjectWithNoCasesHasNothingToCover() {
+        assertEquals(List.of(), CaseSpace.of(type("Station"), symbols).selectors());
+    }
+
+    /**
+     * What is handed downstream is the selector.
+     *
+     * <p>{@code Core} carries what tests and reads a value and nothing about the program around it.
+     * That is what keeps the atoms in this package: a reader of {@code Core} that wanted them would
+     * have to go back to the declarations, which is the second reading being removed.
+     */
+    @Test
+    void whatGoesDownstreamIsTheSelectorAlone() {
+        ResolvedCase once = resolvedCase("VisitKind", "OnceKind");
+        assertEquals(once.name(), once.selector().name());
+        assertEquals(once.refinement(), once.selector().refinement());
+        assertTrue(java.util.Arrays.stream(once.selector().getClass().getRecordComponents())
+                        .map(java.lang.reflect.RecordComponent::getName).toList()
+                        .equals(List.of("name", "refinement")),
+                "a selector is a name and a refinement; what it covers is not one of its parts");
+    }
+
+    /** Kept in what a declaration comes to, so it compares as a value and not as an object. */
+    @Test
+    void twoResolvedCasesOfOneCaseAreOneValue() {
+        assertEquals(resolvedCase("VisitKind", "OnceKind"), resolvedCase("VisitKind", "OnceKind"));
+        assertEquals(resolvedCase("VisitKind", "OnceKind").hashCode(),
+                resolvedCase("VisitKind", "OnceKind").hashCode());
+        assertNotEquals(resolvedCase("Both", "OnceKind"), resolvedCase("Both", "Outpatient"));
+    }
+
+    // --- helpers ---------------------------------------------------------------------------------
+
+    private List<String> covered(String subject, String caseName) {
+        return resolvedCase(subject, caseName).atoms().stream().map(TypeSymbol::name).toList();
+    }
+
+    private ResolvedCase resolvedCase(String subject, String caseName) {
+        return CaseSpace.of(type(subject), symbols).selector(named(caseName));
+    }
+
+    private Type type(String name) {
+        return Type.ref(named(name));
+    }
+
+    private TypeSymbol named(String type) {
+        for (Hir.Def d : module.defs()) {
+            if (d.name().equals(type)) {
+                return d.declares();
+            }
+        }
+        throw new AssertionError("the module does not declare " + type);
+    }
+
+    private static Hir.Module resolved(String source) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("m.sou", source);
+        return Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY)
+                .db().ask(new Names.Resolved("m")).value();
+    }
+}


### PR DESCRIPTION
Step 2 of #966. A case has to say what selecting it covers, so that a `match` can be decided over the leaves and the backend stops going back to the declarations for them.

## Where the coverage went, and why not on the selector

The plan said `CaseSelector.atoms`. Writing it exposed why that does not fit.

`CaseSelector` is a name and a refinement, and its constructor refuses a pair that disagrees — `ACaseIsNotHalfDecidedTest` holds it to exactly that: a case says everything about itself, and the states that would say half of it are not representable. Coverage is not that kind of fact. A case that is itself a sum stands for the leaves under it, and which leaves those are is a fact about the declarations this compile read, which nothing in `types` can ask. An `atoms` component would therefore be the one component that constructor could not check — a selector whose name and carrier agree and whose atoms are a lie.

So the phase boundary is a type instead:

```
TypeSymbol + Symbols
      |
   CaseSpace                     ← resolves once, where the subject is taken apart
      |
 ResolvedCase        check       ← selector + the atoms selecting it covers
      |
  projection
      |
 CaseSelector    types / core    ← name + refinement, unchanged
```

`ResolvedCase` lives in `check` with a package-private constructor, so `codegen` reads one but cannot mint one. `types/CaseSelector.java` is untouched by this PR.

## What that buys

`EnsuresGen.answersFor` went back to `AtomSpace.subjectAtoms(bound, ctx.symbols)` to work out the leaves an arm answers for — a closure recomputed in the one stage whose contract says nothing is worked out again. It reads `selected.atoms()` now, and `codegen` no longer names `AtomSpace` for anything about a case.

Which of those atoms that reader takes is still the reader's: an optional's carrier covers itself, and `Some` is no name a written answer wears, so the admission stays at the call.

## Two decisions worth naming

**An optional's carrier covers itself.** `Some<VisitKind>` binds a `VisitKind`, which reaches three leaves; what an arm over the optional answers for is still `Some`. Reading coverage through the element would hold a two-armed match against cases no optional has.

**No `ResolvedPattern.coverage()`.** The plan listed one. It cannot exist as written: `ResolvedPattern` is in `core`, which carries selectors and knows nothing of the program around them. The arm's coverage is available where the arms are built — `MatchElaborator` holds the `ResolvedCase`s before projecting — which is where step 3's partition check belongs. Step 3's `PathEngine.impliedBy` gets the rule side's coverage from `Guard.Case`, which now carries a `ResolvedCase`; the arm side is still compared by name and is step 3's to change.

## Tests

`check/WhatSelectingACaseCoversIsResolvedWhereTheSubjectIsTest` — a case that is a sum covers the leaves under it, a leaf covers itself, two cases of one sum may cover one atom (a diamond is representable; what an overlap means is the match's to decide), an optional's carrier covers itself, and a resolved case compares as a value. Held red under two mutations: a case covering only itself (3 red), and an optional put on the general rule (1 red).

`types/ACaseIsNotHalfDecidedTest` is unchanged — an invariant that needs `Symbols` to state was never an invariant of a selector.

`mvn -o test`: 9787 tests, 0 failures, 1 skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)