### PR TITLE
A total written with List.sum is read where the same total written as a fold is

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Accumulations.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Accumulations.java
@@ -1,0 +1,130 @@
+package souther.compiler.check;
+
+import souther.compiler.types.ValueName;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Which library operations answer what their container holds accumulated: started from an identity
+ * and carried through one binary combine over the accumulator and an element, both of the type the
+ * operation answers.
+ *
+ * <p>The sibling of {@link Reductions}, and separate for the reason that is separate from
+ * {@link Combinators}. A reduction is handed the step it repeats and this is not: {@code List.sum}
+ * takes a container and nothing else, so what it starts from and what it repeats are not arguments
+ * anything can read off the call — they are what the operation means, and are written down here.
+ * {@link Question#ACCUMULATION} states the range and this answers it.
+ *
+ * <p>What is written down is a recipe and not a value. {@code List.concat} starts from the empty
+ * list of a type its declaration does not name — {@code (List<List<'a>>) -> List<'a>} leaves
+ * {@code 'a} to the call — and {@code List.sum} starts from a nought that is an {@code Int} at one
+ * call and a {@code Decimal} at the next (ADR-0082). So the identity is named as the value it is and
+ * instantiated at the type the call answers, where a reader needs one; a table holding a
+ * {@link souther.compiler.core.Core} literal would have to have decided that already.
+ *
+ * <p>Nothing here knows what any check can do with an answer. The domain that reads bounds carries
+ * numbers and no strings, and that is a fact about the reader, not about {@code String.concat},
+ * which accumulates exactly as {@code List.concat} does. A registry that left it out because nothing
+ * downstream could use it would be answering a different question than the one it is named for —
+ * and would say, to the next reader, that the library's own definition of {@code concat} as
+ * {@code join("", xs)} is not what it says. What may be read as a number is asked after this, by
+ * whoever needs it to be one.
+ */
+final class Accumulations {
+
+    /** What an accumulation starts from, as the value it is rather than as a term of some type. */
+    enum Identity {
+        ZERO,
+        ONE,
+        EMPTY
+    }
+
+    /** The step it repeats over the accumulator and an element. */
+    enum Combine {
+        ADD,
+        MULTIPLY,
+        APPEND
+    }
+
+    /** An accumulation: what it starts from, and the step it repeats. */
+    record Accumulation(Identity identity, Combine combine) {}
+
+    /**
+     * The operations that accumulate, and what each is.
+     *
+     * <p>{@code List.concat} and {@code String.concat} are here beside the two numeric ones because
+     * they are the same shape said of other values: a list of lists joined from the empty list, a
+     * list of strings joined from the empty string. The library states the second as
+     * {@code join("", xs)} itself.
+     */
+    private static final Map<ValueName, Accumulation> ACCUMULATES = accumulates();
+
+    private static Map<ValueName, Accumulation> accumulates() {
+        Map<ValueName, Accumulation> stated = new LinkedHashMap<>();
+        stated.put(op("List", "sum"), new Accumulation(Identity.ZERO, Combine.ADD));
+        stated.put(op("List", "product"), new Accumulation(Identity.ONE, Combine.MULTIPLY));
+        stated.put(op("List", "concat"), new Accumulation(Identity.EMPTY, Combine.APPEND));
+        stated.put(op("String", "concat"), new Accumulation(Identity.EMPTY, Combine.APPEND));
+        return stated;
+    }
+
+    /**
+     * The operations in range that accumulate from no identity through no single step.
+     *
+     * <p>{@code String.join} is one, and not because it answers a string. A separator stands between
+     * elements and not before the first, so what the walk does at each element depends on whether
+     * anything came before it — and an identity with a combine over two values of one type has
+     * nowhere to keep that. Written as {@code join(sep, xs)} it is a walk carrying more than the
+     * answer so far, which is a different question from this one and is not asked of it here.
+     */
+    static final Set<ValueName> NO_SIMPLE_ACCUMULATION = Set.of(op("String", "join"));
+
+    /** What {@code operation} accumulates, or null where it accumulates nothing — including where
+     * the name is not a library operation. */
+    static Accumulation of(ValueName operation) {
+        return operation == null ? null : Derived.RULES.get(operation);
+    }
+
+    /** The operations there is a rule about, for the check that a rule answers a question its
+     * operation is asked. */
+    static Set<ValueName> answered() {
+        return Derived.RULES.keySet();
+    }
+
+    /** Read once, and held to the library while it is read. The library is the same library for
+     * every module compiled. */
+    private static final class Derived {
+        private static final Map<ValueName, Accumulation> RULES = read();
+    }
+
+    /**
+     * The rules, checked against the declarations they are about.
+     *
+     * <p>A rule under a name the library does not declare is a rule nothing reaches, and is the
+     * defect {@link Question} exists to catch seen from the other end — so it is raised here, where
+     * the name is read, rather than left to a test.
+     */
+    private static Map<ValueName, Accumulation> read() {
+        Map<ValueName, Accumulation> rules = new LinkedHashMap<>();
+        ACCUMULATES.forEach((operation, accumulation) -> {
+            if (Prelude.entry(operation.toString()) == null) {
+                throw new IllegalStateException(operation + " is named an accumulation and the"
+                        + " library declares no such operation");
+            }
+            rules.put(operation, accumulation);
+        });
+        return Collections.unmodifiableMap(rules);
+    }
+
+    /** The operation {@code name} of the library module published as {@code alias}, written as the
+     * two values a library name is made of — the spelling {@link Reductions} states its own rows
+     * in. */
+    private static ValueName op(String alias, String name) {
+        return new ValueName.Stdlib(alias, name);
+    }
+
+    private Accumulations() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Accumulations.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Accumulations.java
@@ -1,5 +1,7 @@
 package souther.compiler.check;
 
+import souther.compiler.core.Core;
+import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
 import java.util.Collections;
@@ -52,6 +54,9 @@ final class Accumulations {
     /** An accumulation: what it starts from, and the step it repeats. */
     record Accumulation(Identity identity, Combine combine) {}
 
+    /** What a call accumulates, and the container it accumulates over. */
+    record Accumulating(Accumulation what, Core container) {}
+
     /**
      * The operations that accumulate, and what each is.
      *
@@ -88,6 +93,22 @@ final class Accumulations {
         return operation == null ? null : Derived.RULES.get(operation);
     }
 
+    /**
+     * What {@code call} accumulates and over what, or null where it accumulates nothing.
+     *
+     * <p>Which argument holds the elements is not written down. An accumulation answers a value of
+     * the type its container holds, so the argument that holds them is the one whose elements are of
+     * the type the operation answers — which the declaration already says, in the same way it says
+     * where a {@link Reductions reduction}'s seed is. A signature admitting two readings of it is
+     * refused where the rules are read rather than answered by half.
+     */
+    static Accumulating accumulating(Core.PreservedCall call) {
+        Accumulation what = of(call.operation());
+        Integer container = Derived.CONTAINERS.get(call.operation());
+        return what == null || container == null || container >= call.args().size() ? null
+                : new Accumulating(what, call.args().get(container));
+    }
+
     /** The operations there is a rule about, for the check that a rule answers a question its
      * operation is asked. */
     static Set<ValueName> answered() {
@@ -98,6 +119,7 @@ final class Accumulations {
      * every module compiled. */
     private static final class Derived {
         private static final Map<ValueName, Accumulation> RULES = read();
+        private static final Map<ValueName, Integer> CONTAINERS = containers();
     }
 
     /**
@@ -117,6 +139,42 @@ final class Accumulations {
             rules.put(operation, accumulation);
         });
         return Collections.unmodifiableMap(rules);
+    }
+
+    /**
+     * Which argument each accumulation holds its elements in, read off the declarations.
+     *
+     * <p>The half a signature answers, kept apart from the half it does not, as {@link Reductions}
+     * keeps them apart. An operation answering a value of the type one of its containers holds is
+     * the range {@link Question#ACCUMULATION} is drawn on, so a rule here has such an argument by
+     * construction; two of them would be a declaration that does not say which it walks, and is
+     * refused rather than guessed at.
+     */
+    private static Map<ValueName, Integer> containers() {
+        Map<ValueName, Integer> where = new LinkedHashMap<>();
+        Derived.RULES.keySet().forEach(operation -> {
+            Prelude.Signature signature = Prelude.entry(operation.toString()).signature();
+            int found = -1;
+            for (int i = 0; i < signature.params().size(); i++) {
+                Type param = signature.params().get(i);
+                if (!Question.holdsElements(param)
+                        || !signature.result().equals(Terms.elementType(param))) {
+                    continue;
+                }
+                if (found >= 0) {
+                    throw new IllegalStateException(operation + " is named an accumulation and takes"
+                            + " two containers of what it answers, so which one it walks is not read"
+                            + " off its signature");
+                }
+                found = i;
+            }
+            if (found < 0) {
+                throw new IllegalStateException(operation + " is named an accumulation and takes no"
+                        + " container of the type it answers");
+            }
+            where.put(operation, found);
+        });
+        return Collections.unmodifiableMap(where);
     }
 
     /** The operation {@code name} of the library module published as {@code alias}, written as the

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -1475,6 +1475,27 @@ final class DischargeRules {
                 ? same.source().argument() : null;
     }
 
+    /**
+     * The container {@code call} built its result from, and where each element of what it answers
+     * came from — the lineage itself, for a reader that has an answer per alternative.
+     *
+     * <p>Beside {@link #builtFrom} and not instead of it. The four words are what a reader asking
+     * "does what I know survive this" wants, and they are a projection; a reader that can say
+     * something different about each of the things an element may be wants what the projection was
+     * read off. Null where the elements came from more than one place, as the projection is refused
+     * there: without one container there is nothing to ask the question of.
+     */
+    static Kept keptFrom(Core.PreservedCall call) {
+        Built built = Bound.BUILDINGS.get(call.operation());
+        if (built == null || built.outputs().size() != 1 || built.lineage().source() == null) {
+            return null;
+        }
+        return new Kept(built.from().of(call), built.lineage());
+    }
+
+    /** A construction's source container and the lineage of the elements it answers. */
+    record Kept(Core container, ElementLineage lineage) {}
+
     /** The container {@code call} built its result from, or null where the check has no rule about
      * what the operation keeps. */
     static Source builtFrom(Core.PreservedCall call) {

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -163,17 +163,40 @@ final class DischargeRules {
          * a fifth thing to keep in step with it.
          */
         Shape shape() {
-            boolean asMany = size == Cardinality.SAME;
-            return switch (lineage()) {
+            return wordFor(lineage(), size == Cardinality.SAME);
+        }
+
+        /**
+         * The word for one lineage, given whether the result has as many elements as its source.
+         *
+         * <p>Elements that are each one of several things are each of them read, and the word is the
+         * one they all read where they read one — otherwise the word for elements nothing was kept
+         * of, which licenses nothing and so is true of a run holding some of each.
+         * {@code Map.updateIfPresent} is that: every value is the argument's own or what the closure
+         * made of it, so neither {@code PERMUTES} nor {@code MAPS} is true of the run, and what a
+         * reader of the four words may assume of it is nothing.
+         */
+        private Shape wordFor(ElementLineage lineage, boolean asMany) {
+            return switch (lineage) {
                 case ElementLineage.SameAs _ -> asMany ? Shape.PERMUTES : Shape.SUBSET;
                 case ElementLineage.ClosureResult _ -> asMany ? Shape.MAPS : Shape.COLLAPSES;
                 // What the closure answered holds it, so what was stated of the source says nothing
                 // of it, and there may be any number of them. No word of the four is about that,
                 // and the nearest is the one for elements nothing was kept of.
                 case ElementLineage.InsideClosureResult _ -> Shape.COLLAPSES;
-                case ElementLineage.OneOf _ -> throw new IllegalStateException(
-                        "a construction whose elements come from more than one place has no single"
-                                + " source for a shape to be about: " + outputs);
+                case ElementLineage.OneOf one -> {
+                    if (one.source() == null) {
+                        throw new IllegalStateException(
+                                "a construction whose elements come from more than one place has no"
+                                        + " single source for a shape to be about: " + outputs);
+                    }
+                    Shape word = null;
+                    for (ElementLineage alternative : one.alternatives()) {
+                        Shape read = wordFor(alternative, asMany);
+                        word = word == null || word == read ? read : Shape.COLLAPSES;
+                    }
+                    yield word;
+                }
             };
         }
     }
@@ -221,8 +244,13 @@ final class DischargeRules {
                     new ElementLineage.Source(at(0), 1)), Cardinality.AT_MOST)),
             Map.entry(op("Set", "difference"), new Built(new ElementLineage.SameAs(
                     new ElementLineage.Source(at(0), 1)), Cardinality.AT_MOST)),
-            Map.entry(op("Map", "updateIfPresent"), new Built(new ElementLineage.ClosureResult(
-                    new ElementLineage.Source(CONTAINER, 1)), Cardinality.SAME)),
+            // Every value in the answer came from the map it was given: the one under the key is
+            // what the closure made of it, and every other is the value that was there. Read as a
+            // closure result alone, what is true of one value would be said of all of them.
+            Map.entry(op("Map", "updateIfPresent"), new Built(new ElementLineage.OneOf(List.of(
+                    new ElementLineage.SameAs(new ElementLineage.Source(CONTAINER, 1)),
+                    new ElementLineage.ClosureResult(new ElementLineage.Source(CONTAINER, 1)))),
+                    Cardinality.SAME)),
             // Inside what the closure answered, which is an optional here and a list in a
             // `flatMap`. One lineage for the two, told apart by what the closure's own signature
             // says it answers with.

--- a/souther-compiler/src/main/java/souther/compiler/check/ElementLineage.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ElementLineage.java
@@ -205,9 +205,14 @@ public sealed interface ElementLineage {
      * The element came from any one of these, and nothing here says which.
      *
      * <p>{@code List.append} and a union: every element of the answer was an element of one of the
-     * arguments, and the answer holds neither argument's elements alone. A single source is what
-     * {@link DischargeRules.Shape} needs and has no word for the absence of, which is why these sit
-     * outside its table with only their count recorded.
+     * arguments, and the answer holds neither argument's elements alone.
+     *
+     * <p>Two things can be unsettled and they are not the same thing. Which argument an element came
+     * from is one — that is {@code append}, whose alternatives name two arguments. What happened to
+     * it on the way is the other: {@code Map.updateIfPresent} answers the map it was given with the
+     * value under one key replaced, so every value in its answer came from the argument, and each is
+     * either that argument's own value or what the closure made of it. Read as one alternative, it
+     * would say of every value what is true of one of them.
      */
     record OneOf(List<ElementLineage> alternatives) implements ElementLineage {
 
@@ -219,10 +224,23 @@ public sealed interface ElementLineage {
             }
         }
 
-        /** Null: which of them is not settled, so there is no one argument the elements come from. */
+        /**
+         * The place they all came from, where they came from one, and null where they did not.
+         *
+         * <p>Where the alternatives differ in what happened rather than in where it came from, there
+         * is one argument to answer with and a reader asking where the elements are from is owed it.
+         * Where they name different arguments there is none, and saying so is what keeps a rule
+         * about {@code List.append} from being read as a rule about its first argument.
+         */
         @Override
         public Source source() {
-            return null;
+            Source common = alternatives.get(0).source();
+            for (ElementLineage alternative : alternatives) {
+                if (common == null || !common.equals(alternative.source())) {
+                    return null;
+                }
+            }
+            return common;
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/InductiveBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InductiveBounds.java
@@ -86,7 +86,8 @@ final class InductiveBounds {
         // Taking it is what keeps the answer from depending on the order they were proposed in: a
         // generator lengthened later makes the answer sharper or leaves it alone.
         Bounds proved = null;
-        for (Bounds candidate : InvariantCandidates.from(seed, read.of(walk.step(), given))) {
+        for (Bounds candidate : InvariantCandidates.from(
+                seed, read.of(walk.step(), given), walk.inputs().at().values())) {
             if (!inductive(walk, candidate, seed, given, terms, read)) {
                 continue;
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantCandidates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantCandidates.java
@@ -3,6 +3,7 @@ package souther.compiler.check;
 import souther.compiler.numeric.NumericDomain.Bounds;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -27,8 +28,8 @@ final class InvariantCandidates {
     private InvariantCandidates() {}
 
     /**
-     * The ranges to try, given what the seed lies between and what the step answers with nothing
-     * assumed about the accumulator.
+     * The ranges to try, given what the seed lies between, what the step answers with nothing
+     * assumed about the accumulator, and what holds of everything the step is handed besides it.
      *
      * <p>Four, and each is a different thing a fold does. The seed itself is what a step preserving
      * its accumulator answers. Open above the seed and open below it are the two directions an
@@ -42,8 +43,20 @@ final class InvariantCandidates {
      * is an atom the domain holds nothing about — so the join is unbounded too and proves nothing. A
      * test of the step's shape would answer the same and would be a second place that decides what a
      * step does with what it was handed.
+     *
+     * <p>Then the seed joined with each of the inputs, which is the symmetry the proof already has.
+     * {@link InductiveBounds} reads what holds of everything the step is handed while checking that
+     * the step stays inside a range, and nothing was reading it while deciding which ranges to put
+     * through that — so a product of elements at or above nought, started at one, was proved by no
+     * candidate anybody proposed. A walk carries its accumulator through what it was handed, so
+     * where the answer runs is where the two together run.
+     *
+     * <p>Each input separately, and no reading of which of them the step uses. {@code Map.fold} is
+     * handed a key and a value bounded by different declarations, and which of the two an answer
+     * follows is what the proof settles; a guess that follows neither is one check and is discarded.
      */
-    static List<Bounds> from(Bounds seed, Bounds stepWithNothingAssumed) {
+    static List<Bounds> from(Bounds seed, Bounds stepWithNothingAssumed,
+                             Collection<Bounds> whatTheStepIsHanded) {
         List<Bounds> out = new ArrayList<>();
         add(out, seed);
         if (seed.min() != null) {
@@ -53,6 +66,9 @@ final class InvariantCandidates {
             add(out, new Bounds(null, seed.max()));
         }
         add(out, Bounds.spanning(seed, stepWithNothingAssumed));
+        for (Bounds handed : whatTheStepIsHanded) {
+            add(out, Bounds.spanning(seed, handed));
+        }
         return out;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Question.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Question.java
@@ -102,6 +102,48 @@ enum Question {
         }
     },
 
+    /**
+     * Whether it accumulates what its container holds ({@link Accumulations}). Asked of an operation
+     * answering a value of the type one of its container arguments holds: the question is whether
+     * that answer is the elements started from an identity and carried through one binary combine
+     * over the accumulator and an element, both of the type it answers.
+     *
+     * <p>The range is read off the shape of the declaration and not off what the answer could be
+     * used for. {@code (List<'a>) -> 'a} says of {@code List.sum} exactly what it says of
+     * {@code String.concat}: an operation that answers one of the thing it was given many of. Which
+     * of those a check can carry as a number is asked after the answer, by the check that needs one
+     * — a range drawn where the numeric domain stops would put the library's own reading of
+     * {@code concat} out of reach of the question it is an answer to.
+     *
+     * <p>Beside {@link #REDUCTION} and not folded into it. A reduction is handed its step and its
+     * seed as arguments, so what it walks is read off the call; an accumulation is handed neither,
+     * and a range that took the one for the other would ask nothing of an operation whose whole
+     * meaning is what it does not take.
+     */
+    ACCUMULATION("whether it accumulates what its container holds, and from what through what") {
+        @Override
+        boolean asksOf(Prelude.Signature signature) {
+            Type result = signature.result();
+            return result != null && signature.params().stream().anyMatch(
+                    t -> holdsElements(t) && result.equals(Terms.elementType(t)));
+        }
+
+        @Override
+        boolean answeredFor(ValueName operation) {
+            return Accumulations.of(operation) != null;
+        }
+
+        @Override
+        Set<ValueName> answeredOperations() {
+            return Accumulations.answered();
+        }
+
+        @Override
+        Set<ValueName> nothingSaidOf() {
+            return Accumulations.NO_SIMPLE_ACCUMULATION;
+        }
+    },
+
     /** What it keeps of the container it was built from ({@link DischargeRules#builtFrom}). Asked of
      * an operation that answers a container and is given one. A string is not in range: a shape says
      * what became of a container's elements, and of a string this names only its length. */

--- a/souther-compiler/src/main/java/souther/compiler/check/StepInputFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StepInputFacts.java
@@ -1,16 +1,11 @@
 package souther.compiler.check;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.core.Core;
-import souther.compiler.numeric.Count;
-import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.Granularity;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.NumericDomain.Bounds;
 import souther.compiler.types.Type;
-import souther.compiler.types.TypeSymbol;
 
-import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,10 +21,19 @@ import java.util.Set;
  * it arrives on, rather than a range for "the element" — and every parameter but the accumulator is
  * read, so a key is read the day a step is written over one.
  *
- * <p>What a value of a type guarantees is not decided here. {@link InvariantChecker#seedFields} is
- * what decides it, and this projects that answer onto the places the walk names — the same
- * projection {@link FieldDomains} makes of the same reading. Read here instead, only a numeric
- * newtype's own rules would have been found: a record's own invariant bounds its fields, and
+ * <p>What holds of an element is not decided here either. {@link UniversalElementFacts} answers that
+ * of the container the walk is over, by the path under an element each bound is about, and this
+ * instantiates those paths at the place the element arrives — so a fold over a list and an
+ * accumulation over the same list are bounded by one reading, and a fold reads what a
+ * {@code List.map} upstream of it kept without having met the closure that built it. What a
+ * parameter that is not an element guarantees is the same reading asked of that parameter's own
+ * type: a key a {@code Map.fold} hands its step is bounded by its declaration and by nothing about
+ * what the container holds.
+ *
+ * <p>Neither is what a value of a type guarantees. {@link InvariantChecker#seedFields} is what
+ * decides it, and both readings above project that one answer — the same projection
+ * {@link FieldDomains} makes of the same reading. Decided here instead, only a numeric newtype's own
+ * rules would have been found: a record's own invariant bounds its fields, and
  * {@code data Line = { amount: Int } invariant amount >= 0} says nothing about any type
  * {@code DeclaredBounds} would have been asked about. That fact is one the walk into a combinator's
  * closure already has ({@link InvariantChecker#walkCall} enters the element and seeds it), so
@@ -61,23 +65,30 @@ record StepInputFacts(Map<FactSubject, Bounds> at, Map<FactSubject, Granularity>
      * What holds of everything {@code r}'s step is handed besides its accumulator, where each of
      * those parameters is entered in {@code inside} as the place it is.
      *
-     * <p>Two sources, and they are two different kinds of fact. What a value's type guarantees holds
-     * of every value of that type, so it holds of whichever one the walk is at. What a container
-     * written out holds is read off the line it is written on: three elements written there are the
-     * only three there are, and every one of them lies between the least and the greatest.
+     * <p>The element is asked of the container and every other parameter of its own type. Which
+     * parameter is which is what the reduction already says, and reading the element's bounds off
+     * its type here as well would be the second answer this class exists not to have: what the
+     * container's elements are is a question about the container, and the type of what it holds is
+     * one of the things {@link UniversalElementFacts} reads to answer it.
      */
     static StepInputFacts of(Reductions.Reducing r, Denotations inside, Terms terms,
                              Symbols symbols, ReadingPolicy policy,
                              Set<FactSubject> namedByTheStep) {
         Gathering gathering = new Gathering(terms, namedByTheStep);
         List<Core.Binder> params = r.step().params();
+        UniversalElementFacts elements =
+                UniversalElementFacts.of(r.container(), inside, terms, symbols, policy);
         for (int i = 0; i < params.size(); i++) {
-            if (params.get(i) == r.accumulator()) {
+            Core.Binder param = params.get(i);
+            if (param == r.accumulator()) {
                 continue;
             }
-            guaranteed(params.get(i), handedAt(r, i), inside, terms, symbols, policy, gathering);
+            if (param == r.element()) {
+                elements.at(inside.subject(param.binding()), terms).forEach(gathering::holds);
+                continue;
+            }
+            guaranteed(param, handedAt(r, i), inside, terms, symbols, policy, gathering);
         }
-        writtenOut(r, inside, terms, gathering);
         return gathering.gathered();
     }
 
@@ -100,67 +111,19 @@ record StepInputFacts(Map<FactSubject, Bounds> at, Map<FactSubject, Granularity>
     /**
      * What a value of {@code param}'s type guarantees, projected onto the places under the parameter.
      *
-     * <p>{@link InvariantChecker#seedFields} answers by path — {@code ""} for the value itself,
-     * {@code "amount"} for a field, {@code "a.b"} for a field of one — and the walk names those same
-     * places under whatever subject the parameter was entered as. So the projection is the path read
-     * off one and put back on the other, and nothing here reads a declaration.
+     * <p>The reading answers by path — {@code ""} for the value itself, {@code "amount"} for a
+     * field, {@code "a.b"} for a field of one — and the walk names those same places under whatever
+     * subject the parameter was entered as. So the projection is the path read off one and put back
+     * on the other, and nothing here reads a declaration.
      */
     private static void guaranteed(Core.Binder param, Type handed, Denotations inside, Terms terms,
                                    Symbols symbols, ReadingPolicy policy, Gathering gathering) {
         FactSubject root = inside.subject(param.binding());
-        if (root == null || !(handed instanceof Type.Ref ref)
-                || !(symbols.declarations().declaration(ref.name().key()) instanceof Hir.Data data)) {
+        if (root == null) {
             return;
         }
-        InvariantChecker.Seeded seeded = seededOf(ref.name(), data, symbols, policy);
-        if (seeded == null) {
-            return;
-        }
-        seeded.atoms().forEach((path, atom) ->
-                gathering.holds(terms.under(root, path), seeded.numbers().boundsOf(atom)));
-    }
-
-    /** The reading of {@code named}, or null where it fell over. A reading that fell over is one
-     * this says nothing from, which leaves the walk unbounded rather than bounded by half of what a
-     * declaration says. */
-    private static InvariantChecker.Seeded seededOf(TypeSymbol named, Hir.Data data,
-                                                    Symbols symbols, ReadingPolicy policy) {
-        InvariantChecker.Seeded seeded = InvariantChecker.seedFields(named, data, symbols, policy);
-        return seeded.everyClauseRead() && !seeded.constraints().isBottom() ? seeded : null;
-    }
-
-    /**
-     * The element of a container written out, bounded by the elements written there.
-     *
-     * <p>Only where every one of them is a number this folds. A container written with a computed
-     * element says nothing here — the least of what is written is not the least of what is held once
-     * one of them is decided at run time — and saying nothing is what leaves the walk unbounded
-     * rather than wrongly bounded.
-     *
-     * <p>A container written out with nothing in it says nothing either, and that is a narrowing
-     * this does not reach past: what it would establish is that the step never runs, which is a fact
-     * about how many elements there are and not about what any of them is.
-     */
-    private static void writtenOut(Reductions.Reducing r, Denotations inside, Terms terms,
-                                   Gathering gathering) {
-        Type element = Terms.elementType(r.container().type());
-        if (element == null || !(terms.listedOut(r.container(), inside) instanceof Core.ListLit list)
-                || list.elements().isEmpty()) {
-            return;
-        }
-        BigDecimal low = null;
-        BigDecimal high = null;
-        for (Core each : list.elements()) {
-            BigDecimal written = Terms.constantNumber(each);
-            if (written == null) {
-                return;
-            }
-            low = low == null || written.compareTo(low) < 0 ? written : low;
-            high = high == null || written.compareTo(high) > 0 ? written : high;
-        }
-        gathering.holds(
-                terms.positionOf(Terms.read(r.element(), element, r.step().pos()), inside).atom(),
-                new Bounds(Endpoint.inclusive(Count.of(low)), Endpoint.inclusive(Count.of(high))));
+        UniversalElementFacts.guaranteed(handed, symbols, policy).forEach(
+                (path, bounds) -> gathering.holds(terms.under(root, path), bounds));
     }
 
     /** {@code domain} with all of this taken as holding. Handed a domain rather than answering with

--- a/souther-compiler/src/main/java/souther/compiler/check/StepInputFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StepInputFacts.java
@@ -93,6 +93,23 @@ record StepInputFacts(Map<FactSubject, Bounds> at, Map<FactSubject, Granularity>
     }
 
     /**
+     * The same for an accumulation, whose step is no block and whose element arrives at a place of
+     * the walk rather than at a parameter something was written with.
+     *
+     * <p>What holds of the element is the same question and the same answer — {@code elements} was
+     * read of the container either way — so the two consumers differ in where they instantiate it
+     * and in nothing else. There is no other parameter to read: an accumulation applies one step to
+     * the accumulator and an element, so a key or an index a reduction might be handed has nowhere
+     * to arrive.
+     */
+    static StepInputFacts ofTheElement(UniversalElementFacts elements, FactSubject element,
+                                       Terms terms, Set<FactSubject> namedByTheStep) {
+        Gathering gathering = new Gathering(terms, namedByTheStep);
+        elements.at(element, terms).forEach(gathering::holds);
+        return gathering.gathered();
+    }
+
+    /**
      * What the step's parameter at {@code i} is handed, as a type.
      *
      * <p>The same two answers {@link InvariantChecker#walkCall} enters a closure's parameters at:

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -610,17 +610,38 @@ final class Terms {
         if (container == null) {
             return null;
         }
-        return listedOut(container, at) instanceof Core.ListLit list
+        return given(container, at).value() instanceof Core.ListLit list
                 ? BigDecimal.valueOf(list.elements().size()) : null;
     }
 
-    /** The list {@code e} is, written where it is or written where the name it is was given one. */
-    Core listedOut(Core e, Denotations at) {
-        if (!(e instanceof Core.Read r)) {
-            return e;
+    /** An expression a value is written at, and the environment that expression is read in — which
+     * travel together, since following a name into a binding is what makes them differ. */
+    record Given(Core value, Denotations at) {}
+
+    /**
+     * The expression {@code e}'s value is written at, and where it is read.
+     *
+     * <p>A name is not a way of building a value, and neither is a binding. {@code xs} given
+     * {@code List.map(f, ys)} is that call, and a helper the discharge tree expanded is
+     * {@code let $0 = ys in List.map(f, $0)} and is that call too — so a reader asking what a value
+     * is asks here, and what comes back is the expression that built it beside the environment its
+     * names mean something in.
+     *
+     * <p>One peeler and not one per reader. Every reader of a value meets the same two ways of
+     * re-naming one, and each that answered for itself answered for the shapes its author had met:
+     * a container read through its name and not through a binding, a closure's answer read through
+     * neither. What is left to the reader is what is genuinely about the value — the fields a
+     * construction is built from, the arithmetic a number is — and never how it was written down.
+     */
+    Given given(Core e, Denotations at) {
+        if (e instanceof Core.Read r) {
+            Core given = at.valueOf(r.binding());
+            return given == null || given == e ? new Given(e, at) : given(given, at);
         }
-        Core given = at.valueOf(r.binding());
-        return given == null || given == e ? e : listedOut(given, at);
+        if (e instanceof Core.LetIn li) {
+            return given(li.body(), inside(li, at));
+        }
+        return new Given(e, at);
     }
 
     static <A> LinearForm<A> negate(LinearForm<A> f) {
@@ -1449,8 +1470,12 @@ final class Terms {
         }
         FactSubject atom = sizeKeyOf(size, counted);
         if (atom != null) {
+            // The rules are about how the container was built, so they are read of the expression
+            // that built it — and in the environment that expression's own names mean something in,
+            // which is not the one the name was read in where a binding stands between them.
+            Given built = given(container, at);
             carrying(atom, IntrinsicNumericFacts.ofSize(size,
-                    DischargeRules.sizeSource(listedOut(container, at)), atom, at, this));
+                    DischargeRules.sizeSource(built.value()), atom, built.at(), this));
         }
         return atom;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -768,6 +768,11 @@ final class Terms {
                 && Reductions.reducing(call, at) instanceof Reductions.Reducing walk) {
             recordingWalk(atom, walk, e, at);
             return;
+        } else if (asOperator(e) instanceof Core.PreservedCall accumulation
+                && Accumulations.accumulating(accumulation)
+                        instanceof Accumulations.Accumulating accumulating) {
+            recordingAccumulation(atom, accumulating, e, at);
+            return;
         } else {
             // What is left is a value that is one of several. Asked last because being one of
             // several is what a value is where nothing else says what it was computed from — a
@@ -844,6 +849,81 @@ final class Terms {
         InductiveBounds.Walk made = new InductiveBounds.Walk(seed, accumulator, step,
                 StepInputFacts.of(walk, inside, this, symbols, policy, reached(step)));
         computedBy(atom, new AtomKnowledge.Computation.Reduction(made));
+    }
+
+    /**
+     * Records the walk {@code atom} is the answer of, where the operation is handed no step and no
+     * seed and what it repeats is what it means ({@link Accumulations}).
+     *
+     * <p>The same walk, made of the same numbers. {@link InductiveBounds} is written against a seed,
+     * an accumulator, a step and what holds of what the step is handed, and asks for no tree and no
+     * operation's name — so an accumulation is one of its walks as soon as those four are made, and
+     * a total written {@code List.sum(ns)} is proved by what proves the fold that spells it out.
+     *
+     * <p>Nothing is expanded to get them. The accumulator and the element are places of this walk,
+     * as a reduction's parameters are, and the seed is the identity the operation starts from read
+     * at the type the call answers — not a literal written into a tree for the types to be inferred
+     * off again, which is the reading ADR-0082 has going the other way.
+     *
+     * <p>Both places are named with how their values are spaced, for the reason
+     * {@link #recordingWalk} names its accumulator: {@link InductiveBounds} asks the domain to
+     * assume a range for the accumulator, and a range asserted about an atom whose spacing was never
+     * recorded is one the domain refuses — which would be a walk of the right shape that settles
+     * nothing.
+     */
+    private void recordingAccumulation(FactSubject atom, Accumulations.Accumulating accumulating,
+                                       Core e, Denotations at) {
+        Granularity spacing = granularityOf(e.type());
+        FactSubject accumulator =
+                named(FactSubject.of(interned.handed(atom.identity(), 0)), spacing);
+        FactSubject element = named(FactSubject.of(interned.handed(atom.identity(), 1)), spacing);
+        LinearForm<FactSubject> seed = startedFrom(accumulating.what().identity());
+        LinearForm<FactSubject> step =
+                repeating(accumulating.what().combine(), accumulator, element, spacing);
+        if (seed == null || step == null) {
+            return;
+        }
+        UniversalElementFacts elements =
+                UniversalElementFacts.of(accumulating.container(), at, this, symbols, policy);
+        computedBy(atom, new AtomKnowledge.Computation.Reduction(new InductiveBounds.Walk(
+                seed, accumulator, step,
+                StepInputFacts.ofTheElement(elements, element, this, reached(step)))));
+    }
+
+    /** The value an accumulation starts from, as a number — or null where the domain carries no such
+     * value. The empty list a {@code List.concat} starts from is a value the library states and this
+     * reading has no number for, which is a fact about this reading. */
+    private LinearForm<FactSubject> startedFrom(Accumulations.Identity identity) {
+        return switch (identity) {
+            case ZERO -> LinearForm.constant(java.math.BigDecimal.ZERO);
+            case ONE -> LinearForm.constant(java.math.BigDecimal.ONE);
+            case EMPTY -> null;
+        };
+    }
+
+    /**
+     * The step an accumulation repeats, as a form over the two places it is applied to — or null
+     * where the domain carries no such arithmetic.
+     *
+     * <p>A product is not a form, so it is an atom that stands for one, recorded against the recipe
+     * that says what it is — the same recipe the naming makes of a product written in a fold's step,
+     * so what proves one proves the other. Under the induction hypothesis the two operands are both
+     * bounded and the recipe answers a range; read with nothing assumed of the accumulator it
+     * answers none, which is what leaves the unprovable candidates unproved.
+     */
+    private LinearForm<FactSubject> repeating(Accumulations.Combine combine, FactSubject accumulator,
+                                              FactSubject element, Granularity spacing) {
+        return switch (combine) {
+            case ADD -> LinearForm.atom(accumulator).plus(LinearForm.atom(element));
+            case MULTIPLY -> {
+                FactSubject product = named(FactSubject.of(interned.operator(
+                        BinOp.MUL, accumulator.identity(), element.identity())), spacing);
+                computedBy(product, new AtomKnowledge.Computation.Derived(new Derivation.Product(
+                        LinearForm.atom(accumulator), LinearForm.atom(element))));
+                yield LinearForm.atom(product);
+            }
+            case APPEND -> null;
+        };
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/UniversalElementFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UniversalElementFacts.java
@@ -246,13 +246,19 @@ record UniversalElementFacts(Map<String, Bounds> byPath) {
      * source states are assumed of it: what the reading proves of the form holds of every element of
      * the list answered, since it was proved of an element nothing but those facts is true of.
      *
-     * <p>The reading is the one that owns the question ({@link NumericDomain}) and is asked on a
-     * domain of its own. Nothing of where the call stands is assumed into it: a closure is applied
-     * to every element, so what is true where the call was written is not true of what it answers,
-     * and a reader that assumed the surrounding facts would prove of every element what is true
-     * where one of them was named. What that leaves outside is arithmetic the affine fragment does
-     * not carry — a product of two places is an atom this domain holds nothing of — and outside is
-     * where it stays until a reader that carries recipes asks the question.
+     * <p>The reading is the one that reads recipes and what values carry
+     * ({@link DerivedNumericFacts#refine}), and not one assembled here. What a form is worth is two
+     * stages — everything the atoms it reaches carry, and then what follows about the arithmetic the
+     * affine fragment cannot hold — and a caller that asked a raw domain instead would get a second
+     * reader that knows neither: {@code x -> x.value * x.value} names an atom whose recipe says it
+     * is a product, and {@code x -> Int.abs(x)} names one the library says is never negative. Both
+     * are read where a fold's step is read, and a walk over what the closure built would have lost
+     * them — the same value readable or not by where the tree put it, which is what this class is
+     * for.
+     *
+     * <p>What is assumed into that reading is what every element satisfies and nothing else. Nothing
+     * of where the call stands goes in: a closure is applied to every element, so what is true where
+     * one of them was named is not true of what it answers.
      */
     private static Map<String, Bounds> throughTheClosure(Core.PreservedCall call, Core source,
                                                          Denotations at, Terms terms,
@@ -279,7 +285,9 @@ record UniversalElementFacts(Map<String, Bounds> byPath) {
                 given = given.assuming(one.getKey(), one.getValue(), spacing);
             }
         }
-        Bounds bounds = given.isBottom() ? null : given.boundsOf(answered);
+        NumericDomain<FactSubject> read =
+                DerivedNumericFacts.refine(given, terms, answered.coefs().keySet());
+        Bounds bounds = read.isBottom() ? null : read.boundsOf(answered);
         return bounds == null || bounds.saysNothing() ? Map.of()
                 : Map.of(FieldDomains.THE_VALUE, bounds);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/UniversalElementFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UniversalElementFacts.java
@@ -59,16 +59,24 @@ record UniversalElementFacts(Map<String, Bounds> byPath) {
      * the elements written there and nothing else, so every one of them lies between the least and
      * the greatest. Beside those, what a construction was built from says what it kept
      * ({@link #transferred}).
+     *
+     * <p>The name a container was given is followed once, here, and every reading below is of what
+     * it was given. A name is not a third kind of container: {@code List.sum(ys)} where {@code ys}
+     * was bound to {@code List.map(f, xs)} is the same question as the one written in a line, and a
+     * reading that followed the name for the elements written out and not for what the construction
+     * kept would answer the two differently — which is the shape of what this class was written to
+     * stop, seen inside it.
      */
-    static UniversalElementFacts of(Core container, Denotations at, Terms terms, Symbols symbols,
+    static UniversalElementFacts of(Core written, Denotations at, Terms terms, Symbols symbols,
                                     ReadingPolicy policy) {
-        if (container == null) {
+        if (written == null) {
             return NONE;
         }
+        Core container = terms.listedOut(written, at);
         Map<String, Bounds> held = new LinkedHashMap<>();
         Type element = Terms.elementType(container.type());
         guaranteed(element, symbols, policy).forEach((path, bounds) -> holds(held, path, bounds));
-        writtenOut(container, element, at, terms, held);
+        writtenOut(container, element, held);
         transferred(container, at, terms, symbols, policy, held);
         return held.isEmpty() ? NONE : new UniversalElementFacts(held);
     }
@@ -136,10 +144,8 @@ record UniversalElementFacts(Map<String, Bounds> byPath) {
      * one of them is decided at run time — and saying nothing is what leaves a reader unbounded
      * rather than wrongly bounded.
      */
-    private static void writtenOut(Core container, Type element, Denotations at, Terms terms,
-                                   Map<String, Bounds> held) {
-        if (element == null
-                || !(terms.listedOut(container, at) instanceof Core.ListLit list)
+    private static void writtenOut(Core container, Type element, Map<String, Bounds> held) {
+        if (element == null || !(container instanceof Core.ListLit list)
                 || list.elements().isEmpty()) {
             return;
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/UniversalElementFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UniversalElementFacts.java
@@ -1,0 +1,246 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.core.Core;
+import souther.compiler.types.BindingId;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.NumericDomain.Bounds;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeSymbol;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * What holds of every element a container expression holds, wherever the container came from.
+ *
+ * <p>Read off the tree the discharge check is given, which is one where the library's own operations
+ * are still calls ({@code InliningPolicy#DISCHARGE}). So this is not a record of what some earlier
+ * pass observed: it is the same question asked again of the expression a container is written as —
+ * what its own type and its own written-out elements say, and what a construction keeps of the
+ * container it was built from.
+ *
+ * <p>Keyed by the path under an element and not by a subject. What holds of an element is a fact
+ * about {@code amount} of every element, or about the element itself ({@code ""}); which value the
+ * reader is standing at, and what that value is called there, is the reader's own question. That is
+ * what lets a producer and a consumer that share no binder share a fact: {@code List.map(x -> x.value,
+ * xs)} says of the list it answers that every element of it is at or above nought, and the fold or
+ * the accumulation that walks that list never met {@code x}.
+ *
+ * <p>Everything here holds of <em>every</em> element, so a reader may assume it of the one element
+ * it is standing at. Nothing that holds of some elements belongs here, and nothing about how many
+ * elements there are: that a container written out with nothing in it makes a walk answer its seed
+ * is true and is not this — it is a fact about the count, and stating it here would make a reader
+ * that assumes these of an element assume something no element satisfies.
+ */
+record UniversalElementFacts(Map<String, Bounds> byPath) {
+
+    UniversalElementFacts {
+        byPath = Map.copyOf(byPath);
+    }
+
+    private static final UniversalElementFacts NONE = new UniversalElementFacts(Map.of());
+
+    static UniversalElementFacts none() {
+        return NONE;
+    }
+
+    boolean saysNothing() {
+        return byPath.isEmpty();
+    }
+
+    /**
+     * What holds of every element of {@code container}.
+     *
+     * <p>Two sources and one transfer. A value's type guarantees what it guarantees of every value
+     * of it, so the container's element type says it of every element; a container written out holds
+     * the elements written there and nothing else, so every one of them lies between the least and
+     * the greatest. Beside those, what a construction was built from says what it kept
+     * ({@link #transferred}).
+     */
+    static UniversalElementFacts of(Core container, Denotations at, Terms terms, Symbols symbols,
+                                    ReadingPolicy policy) {
+        if (container == null) {
+            return NONE;
+        }
+        Map<String, Bounds> held = new LinkedHashMap<>();
+        Type element = Terms.elementType(container.type());
+        guaranteed(element, symbols, policy).forEach((path, bounds) -> holds(held, path, bounds));
+        writtenOut(container, element, at, terms, held);
+        transferred(container, at, terms, symbols, policy, held);
+        return held.isEmpty() ? NONE : new UniversalElementFacts(held);
+    }
+
+    /**
+     * These of the value at {@code root}, as the subjects a reader files facts under.
+     *
+     * <p>The instantiation, and the only place a path becomes a subject. A reader hands the place it
+     * is standing at and gets back what holds there — which is what keeps the facts themselves free
+     * of whatever binder either side happened to be written with.
+     */
+    Map<FactSubject, Bounds> at(FactSubject root, Terms terms) {
+        Map<FactSubject, Bounds> instantiated = new LinkedHashMap<>();
+        byPath.forEach((path, bounds) -> {
+            FactSubject subject = terms.under(root, path);
+            if (subject != null) {
+                instantiated.put(subject, bounds);
+            }
+        });
+        return instantiated;
+    }
+
+    /**
+     * What a value of {@code type} guarantees, by the path under it each bound is about.
+     *
+     * <p>{@link InvariantChecker#seedFields} is what decides it and this reads that answer: a
+     * record's own invariant bounds its fields, and a reading of the declarations is what has that.
+     * Shared with {@link StepInputFacts}, which asks it of a parameter that is not an element — a
+     * key a {@code Map.fold} hands its step is bounded by its own declaration and by nothing about
+     * the container's elements.
+     */
+    static Map<String, Bounds> guaranteed(Type type, Symbols symbols, ReadingPolicy policy) {
+        if (!(type instanceof Type.Ref ref)
+                || !(symbols.declarations().declaration(ref.name().key()) instanceof Hir.Data data)) {
+            return Map.of();
+        }
+        InvariantChecker.Seeded seeded = seededOf(ref.name(), data, symbols, policy);
+        if (seeded == null) {
+            return Map.of();
+        }
+        Map<String, Bounds> guaranteed = new LinkedHashMap<>();
+        seeded.atoms().forEach((path, atom) -> {
+            Bounds bounds = seeded.numbers().boundsOf(atom);
+            if (bounds != null && !bounds.saysNothing()) {
+                guaranteed.put(path, bounds);
+            }
+        });
+        return guaranteed;
+    }
+
+    /** The reading of {@code named}, or null where it fell over. A reading that fell over is one
+     * this says nothing from, which leaves an element unbounded rather than bounded by half of what
+     * a declaration says. */
+    private static InvariantChecker.Seeded seededOf(TypeSymbol named, Hir.Data data,
+                                                    Symbols symbols, ReadingPolicy policy) {
+        InvariantChecker.Seeded seeded = InvariantChecker.seedFields(named, data, symbols, policy);
+        return seeded.everyClauseRead() && !seeded.constraints().isBottom() ? seeded : null;
+    }
+
+    /**
+     * The elements of a container written out, bounded by the elements written there.
+     *
+     * <p>Only where every one of them is a number this folds. A container written with a computed
+     * element says nothing here — the least of what is written is not the least of what is held once
+     * one of them is decided at run time — and saying nothing is what leaves a reader unbounded
+     * rather than wrongly bounded.
+     */
+    private static void writtenOut(Core container, Type element, Denotations at, Terms terms,
+                                   Map<String, Bounds> held) {
+        if (element == null
+                || !(terms.listedOut(container, at) instanceof Core.ListLit list)
+                || list.elements().isEmpty()) {
+            return;
+        }
+        BigDecimal low = null;
+        BigDecimal high = null;
+        for (Core each : list.elements()) {
+            BigDecimal written = Terms.constantNumber(each);
+            if (written == null) {
+                return;
+            }
+            low = low == null || written.compareTo(low) < 0 ? written : low;
+            high = high == null || written.compareTo(high) > 0 ? written : high;
+        }
+        holds(held, FieldDomains.THE_VALUE,
+                new Bounds(Endpoint.inclusive(Count.of(low)), Endpoint.inclusive(Count.of(high))));
+    }
+
+    /**
+     * What a construction kept of the container it was built from.
+     *
+     * <p>Four words and an answer for each of them ({@link DischargeRules.Shape}), because a word
+     * that fell through to the answer beside it is how a reading comes to say of an element
+     * something no element satisfies. The same elements in another order, or some of them, are
+     * elements a property of every element was already true of. A new element for each is the
+     * closure's answer, so what holds of it is read through the closure and not from the source.
+     *
+     * <p>{@code COLLAPSES} says nothing, and that is written down rather than left out. At most one
+     * new element for each is what {@code List.filterMap} answers, where an element is what a
+     * closure's answer held rather than the answer itself — so the projection the mapped case makes
+     * is not the one to make here, and until a reading of that is written the honest answer is that
+     * this keeps nothing.
+     */
+    private static void transferred(Core container, Denotations at, Terms terms, Symbols symbols,
+                                    ReadingPolicy policy, Map<String, Bounds> held) {
+        if (!(container instanceof Core.PreservedCall call)) {
+            return;
+        }
+        DischargeRules.Source built = DischargeRules.builtFrom(call);
+        if (built == null || built.container() == null) {
+            return;
+        }
+        switch (built.shape()) {
+            case PERMUTES, SUBSET ->
+                    of(built.container(), at, terms, symbols, policy).byPath()
+                            .forEach((path, bounds) -> holds(held, path, bounds));
+            case MAPS -> throughTheClosure(call, built.container(), at, terms, symbols, policy, held);
+            case COLLAPSES -> { }
+        }
+    }
+
+    /**
+     * What holds of what the closure answered, where what it answers is a place of the element it
+     * was handed.
+     *
+     * <p>A closure that answers a place of its element — {@code x -> x.value}, {@code x -> x.amount}
+     * — hands on what was true there: what held of that place of every element of the source holds
+     * of every element of the list answered. A closure that computes anything else says nothing
+     * here. What it computes is arithmetic, and reading it would be this deciding what an expression
+     * is worth, which is a question with an owner ({@link DerivedNumericFacts}) and one that cannot
+     * be asked of a closure standing where no accumulator has been assumed.
+     *
+     * <p>Which place it answered is asked of the subjects and not of the fields written. The two are
+     * not the same question: a newtype's carrier is read as {@code x.value} and is the value itself,
+     * so the path that names it is the empty one, and a reader that counted the fields it saw would
+     * have gone looking for what holds of a place under a number. So the element is entered
+     * somewhere nothing else names, the closure's answer is asked which subject it is, and the paths
+     * the source states are put under that same root until one of them is that subject — the algebra
+     * deciding which two spellings are one place, as it does everywhere else.
+     */
+    private static void throughTheClosure(Core.PreservedCall call, Core source, Denotations at,
+                                          Terms terms, Symbols symbols, ReadingPolicy policy,
+                                          Map<String, Bounds> held) {
+        Combinators.Handed handed = Combinators.handedTo(call, at);
+        if (handed == null) {
+            return;
+        }
+        UniversalElementFacts kept = of(source, at, terms, symbols, policy);
+        if (kept.saysNothing()) {
+            return;
+        }
+        BindingId element = handed.element().binding();
+        FactSubject root = terms.placeSubject(element);
+        Denotations reading = at.location(element, root, terms.placeTerm(element));
+        FactSubject answered = terms.subjectOf(handed.step().body(), reading);
+        if (answered == null) {
+            return;
+        }
+        kept.byPath().forEach((path, bounds) -> {
+            if (answered.equals(terms.under(root, path))) {
+                holds(held, FieldDomains.THE_VALUE, bounds);
+            }
+        });
+    }
+
+    /** Records that everything at {@code path} lies between {@code bounds}. Two sources reaching one
+     * place are both true of it, so the tighter end of each side is kept. */
+    private static void holds(Map<String, Bounds> held, String path, Bounds bounds) {
+        if (bounds == null || bounds.saysNothing()) {
+            return;
+        }
+        Bounds had = held.get(path);
+        held.put(path, had == null ? bounds : had.meet(bounds));
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/UniversalElementFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UniversalElementFacts.java
@@ -14,6 +14,7 @@ import souther.compiler.types.TypeSymbol;
 
 import java.math.BigDecimal;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -239,26 +240,13 @@ record UniversalElementFacts(Map<String, Bounds> byPath) {
     /**
      * What holds of what the closure answered, given what holds of every element it is applied to.
      *
-     * <p>Not a projection of the paths. A closure answers a value it computed — {@code x -> 0},
-     * {@code x -> x.value + 1}, {@code x -> x.value} — and what holds of that value is what the
-     * arithmetic makes of what holds of the element. So the element is entered somewhere nothing
-     * else names, what the closure answers is read as a form over that place, and the facts the
-     * source states are assumed of it: what the reading proves of the form holds of every element of
-     * the list answered, since it was proved of an element nothing but those facts is true of.
-     *
-     * <p>The reading is the one that reads recipes and what values carry
-     * ({@link DerivedNumericFacts#refine}), and not one assembled here. What a form is worth is two
-     * stages — everything the atoms it reaches carry, and then what follows about the arithmetic the
-     * affine fragment cannot hold — and a caller that asked a raw domain instead would get a second
-     * reader that knows neither: {@code x -> x.value * x.value} names an atom whose recipe says it
-     * is a product, and {@code x -> Int.abs(x)} names one the library says is never negative. Both
-     * are read where a fold's step is read, and a walk over what the closure built would have lost
-     * them — the same value readable or not by where the tree put it, which is what this class is
-     * for.
-     *
-     * <p>What is assumed into that reading is what every element satisfies and nothing else. Nothing
-     * of where the call stands goes in: a closure is applied to every element, so what is true where
-     * one of them was named is not true of what it answers.
+     * <p>By the path under what it answered, because that is what these facts are. A closure answers
+     * a value, and a value is not always a number: {@code x -> x.inner} answers a record, and what
+     * is known of it is what was known of that place of the element; {@code x -> Row { amount = ... }}
+     * answers one made here, and what is known of each field is what the field was made from. A
+     * reading that could only answer about a whole numeric value would keep the facts a mapping
+     * kept only where the mapping ended at a number — the same value provable or not by where the
+     * map was written, which is what this class is for.
      */
     private static Map<String, Bounds> throughTheClosure(Core.PreservedCall call, Core source,
                                                          Denotations at, Terms terms,
@@ -271,25 +259,89 @@ record UniversalElementFacts(Map<String, Bounds> byPath) {
         BindingId element = handed.element().binding();
         FactSubject root = terms.placeSubject(element);
         Denotations reading = at.location(element, root, terms.placeTerm(element));
-        // Read before anything is assumed: reading the closure is what names the places inside it,
-        // and a place with no name is one no range can be asserted about.
-        LinearForm<FactSubject> answered = terms.affineOf(handed.step().body(), reading);
-        if (answered == null) {
-            return Map.of();
+        return answeredBy(handed.step().body(), reading, terms, root, kept);
+    }
+
+    /**
+     * What holds of the value {@code e} answers, by the path under it, given {@code kept} of the
+     * element it was written over and {@code root} the place that element was entered at.
+     *
+     * <p>Three readings of one value and each may answer where the others do not. A value that is a
+     * place of the element carries what was said of that place — and of everything under it, with
+     * the place's own steps dropped, since {@code inner.amount} of the element is {@code amount} of
+     * what {@code x -> x.inner} answers. A value built here carries, at each field, whatever that
+     * field was built from, which is this question again. And a value that is a number is read by
+     * the reading that reads recipes and what values carry, at the path {@code ""} that a value
+     * itself is.
+     *
+     * <p>Recursive rather than a case list, because a field of a construction is a value like any
+     * other: {@code Row { inner = x.inner }} is a projection under a field, and nothing here has to
+     * know that combination for it to be read.
+     */
+    private static Map<String, Bounds> answeredBy(Core e, Denotations reading, Terms terms,
+                                                  FactSubject root, UniversalElementFacts kept) {
+        Map<String, Bounds> answered = new LinkedHashMap<>();
+        FactSubject subject = terms.subjectOf(e, reading);
+        kept.byPath().forEach((path, bounds) -> {
+            String under = beneath(subject, path, root, terms);
+            if (under != null) {
+                holds(answered, under, bounds);
+            }
+        });
+        if (e instanceof Core.Construct construct) {
+            for (Core.FieldValue field : construct.values()) {
+                answeredBy(field.value(), reading, terms, root, kept).forEach((path, bounds) ->
+                        holds(answered, path.isEmpty() ? field.field() : field.field() + "." + path,
+                                bounds));
+            }
         }
+        // Read after the places inside it are named, which reading it as a form is what does: a
+        // range asserted about an atom whose spacing was never recorded is one the domain refuses.
+        LinearForm<FactSubject> form = terms.affineOf(e, reading);
+        if (form != null) {
+            NumericDomain<FactSubject> given = DerivedNumericFacts.refine(
+                    assuming(kept.at(root, terms), terms), terms, form.coefs().keySet());
+            holds(answered, FieldDomains.THE_VALUE, given.isBottom() ? null : given.boundsOf(form));
+        }
+        return answered;
+    }
+
+    /**
+     * The path {@code path} names under the value at {@code subject}, or null where it names no
+     * place of it.
+     *
+     * <p>Asked of the subjects and not of the fields written. A newtype's carrier is read as
+     * {@code x.value} and is the value itself, so the path that names it is the empty one, and a
+     * reader counting the fields it saw would have gone looking for what holds of a place under a
+     * number. So the element's own paths are put back under the place it was entered at, one step
+     * at a time, and the algebra says which of them the closure answered — as it does everywhere
+     * else.
+     */
+    private static String beneath(FactSubject subject, String path, FactSubject root, Terms terms) {
+        if (subject == null) {
+            return null;
+        }
+        List<String> steps = StepInputFacts.stepsOf(path);
+        for (int taken = 0; taken <= steps.size(); taken++) {
+            if (subject.equals(terms.under(root, String.join(".", steps.subList(0, taken))))) {
+                return String.join(".", steps.subList(taken, steps.size()));
+            }
+        }
+        return null;
+    }
+
+    /** A domain with every one of {@code facts} taken as holding, for the reading to start from.
+     * A place whose spacing was never recorded is one no range can be asserted about, and is left
+     * out rather than asserted into a domain that would refuse it. */
+    private static NumericDomain<FactSubject> assuming(Map<FactSubject, Bounds> facts, Terms terms) {
         NumericDomain<FactSubject> given = NumericDomain.top();
-        for (Map.Entry<FactSubject, Bounds> one : kept.at(root, terms).entrySet()) {
-            Map<FactSubject, Granularity> spacing =
-                    terms.kindsOf(NumericDomain.LinearForm.atom(one.getKey()));
+        for (Map.Entry<FactSubject, Bounds> one : facts.entrySet()) {
+            Map<FactSubject, Granularity> spacing = terms.kindsOf(LinearForm.atom(one.getKey()));
             if (!spacing.isEmpty()) {
                 given = given.assuming(one.getKey(), one.getValue(), spacing);
             }
         }
-        NumericDomain<FactSubject> read =
-                DerivedNumericFacts.refine(given, terms, answered.coefs().keySet());
-        Bounds bounds = read.isBottom() ? null : read.boundsOf(answered);
-        return bounds == null || bounds.saysNothing() ? Map.of()
-                : Map.of(FieldDomains.THE_VALUE, bounds);
+        return given;
     }
 
     /** Records that everything at {@code path} lies between {@code bounds}. Two sources reaching one

--- a/souther-compiler/src/main/java/souther/compiler/check/UniversalElementFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UniversalElementFacts.java
@@ -64,11 +64,12 @@ record UniversalElementFacts(Map<String, Bounds> byPath) {
      * the greatest. Beside those, what a construction was built from says what it kept
      * ({@link #transferred}).
      *
-     * <p>The name a container was given is followed once, here, and every reading below is of what
-     * it was given. A name is not a third kind of container: {@code List.sum(ys)} where {@code ys}
-     * was bound to {@code List.map(f, xs)} is the same question as the one written in a line, and a
-     * reading that followed the name for the elements written out and not for what the construction
-     * kept would answer the two differently — which is the shape of what this class was written to
+     * <p>Where the container's value is written is asked of {@link Terms#given}, and every reading
+     * below is of what comes back — the expression and the environment together. A name is not a
+     * third kind of container and neither is a binding: {@code List.sum(ys)} where {@code ys} was
+     * bound to {@code List.map(f, xs)}, and the same call with a helper the discharge tree expanded
+     * into a binding, are the question written in one line. A reader that followed one of those and
+     * not the other would answer them differently, which is the shape this class was written to
      * stop, seen inside it.
      */
     static UniversalElementFacts of(Core written, Denotations at, Terms terms, Symbols symbols,
@@ -76,12 +77,13 @@ record UniversalElementFacts(Map<String, Bounds> byPath) {
         if (written == null) {
             return NONE;
         }
-        Core container = terms.listedOut(written, at);
+        Terms.Given given = terms.given(written, at);
+        Core container = given.value();
         Map<String, Bounds> held = new LinkedHashMap<>();
         Type element = Terms.elementType(container.type());
         guaranteed(element, symbols, policy).forEach((path, bounds) -> holds(held, path, bounds));
         writtenOut(container, element, held);
-        transferred(container, at, terms, symbols, policy, held);
+        transferred(container, given.at(), terms, symbols, policy, held);
         return held.isEmpty() ? NONE : new UniversalElementFacts(held);
     }
 
@@ -277,9 +279,18 @@ record UniversalElementFacts(Map<String, Bounds> byPath) {
      * <p>Recursive rather than a case list, because a field of a construction is a value like any
      * other: {@code Row { inner = x.inner }} is a projection under a field, and nothing here has to
      * know that combination for it to be read.
+     *
+     * <p>Where the value is written is asked of {@link Terms#given} first, so none of the three is
+     * about how it was named. A closure calling a helper is a binding once the discharge tree has
+     * expanded it, and a reader that dispatched on the shapes it had thought of would answer that
+     * one with nothing — which is how this class had already answered a container given a name, and
+     * a closure answering a record.
      */
-    private static Map<String, Bounds> answeredBy(Core e, Denotations reading, Terms terms,
+    private static Map<String, Bounds> answeredBy(Core written, Denotations at, Terms terms,
                                                   FactSubject root, UniversalElementFacts kept) {
+        Terms.Given given = terms.given(written, at);
+        Core e = given.value();
+        Denotations reading = given.at();
         Map<String, Bounds> answered = new LinkedHashMap<>();
         FactSubject subject = terms.subjectOf(e, reading);
         kept.byPath().forEach((path, bounds) -> {
@@ -299,9 +310,9 @@ record UniversalElementFacts(Map<String, Bounds> byPath) {
         // range asserted about an atom whose spacing was never recorded is one the domain refuses.
         LinearForm<FactSubject> form = terms.affineOf(e, reading);
         if (form != null) {
-            NumericDomain<FactSubject> given = DerivedNumericFacts.refine(
+            NumericDomain<FactSubject> read = DerivedNumericFacts.refine(
                     assuming(kept.at(root, terms), terms), terms, form.coefs().keySet());
-            holds(answered, FieldDomains.THE_VALUE, given.isBottom() ? null : given.boundsOf(form));
+            holds(answered, FieldDomains.THE_VALUE, read.isBottom() ? null : read.boundsOf(form));
         }
         return answered;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/UniversalElementFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UniversalElementFacts.java
@@ -5,7 +5,10 @@ import souther.compiler.core.Core;
 import souther.compiler.types.BindingId;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.Granularity;
+import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.NumericDomain.Bounds;
+import souther.compiler.numeric.NumericDomain.LinearForm;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 
@@ -166,78 +169,119 @@ record UniversalElementFacts(Map<String, Bounds> byPath) {
     /**
      * What a construction kept of the container it was built from.
      *
-     * <p>Four words and an answer for each of them ({@link DischargeRules.Shape}), because a word
-     * that fell through to the answer beside it is how a reading comes to say of an element
-     * something no element satisfies. The same elements in another order, or some of them, are
-     * elements a property of every element was already true of. A new element for each is the
-     * closure's answer, so what holds of it is read through the closure and not from the source.
+     * <p>Read off the lineage and not off the four words it projects to. The words answer whether
+     * what was known survives, which is one bit where this has an answer per alternative: what
+     * {@code Map.updateIfPresent} answers holds values the closure made and values that were already
+     * there, and a reader with one word for the run can only say the true thing about neither.
      *
-     * <p>{@code COLLAPSES} says nothing, and that is written down rather than left out. At most one
-     * new element for each is what {@code List.filterMap} answers, where an element is what a
-     * closure's answer held rather than the answer itself — so the projection the mapped case makes
-     * is not the one to make here, and until a reading of that is written the honest answer is that
-     * this keeps nothing.
+     * <p>An answer for each of the four lineages, because a case that fell through to the one beside
+     * it is how a reading comes to say of an element something no element satisfies. The same
+     * elements keep what was true of every one of them, however many of them there are — how many is
+     * {@link DischargeRules.Cardinality} and is a different algebra, so {@code Set.map} carries what
+     * its closure answered exactly as {@code List.map} does. An element inside what a closure
+     * answered is not what the closure answered, and nothing here reads into a list or an optional,
+     * so that one keeps nothing. One of several is what holds of every one of them, which is the
+     * span of what each keeps.
      */
     private static void transferred(Core container, Denotations at, Terms terms, Symbols symbols,
                                     ReadingPolicy policy, Map<String, Bounds> held) {
         if (!(container instanceof Core.PreservedCall call)) {
             return;
         }
-        DischargeRules.Source built = DischargeRules.builtFrom(call);
-        if (built == null || built.container() == null) {
+        DischargeRules.Kept kept = DischargeRules.keptFrom(call);
+        if (kept == null || kept.container() == null) {
             return;
         }
-        switch (built.shape()) {
-            case PERMUTES, SUBSET ->
-                    of(built.container(), at, terms, symbols, policy).byPath()
-                            .forEach((path, bounds) -> holds(held, path, bounds));
-            case MAPS -> throughTheClosure(call, built.container(), at, terms, symbols, policy, held);
-            case COLLAPSES -> { }
-        }
+        keptBy(kept.lineage(), call, kept.container(), at, terms, symbols, policy)
+                .forEach((path, bounds) -> holds(held, path, bounds));
+    }
+
+    /** What one lineage keeps of {@code source}, by the path under an element. */
+    private static Map<String, Bounds> keptBy(ElementLineage lineage, Core.PreservedCall call,
+                                              Core source, Denotations at, Terms terms,
+                                              Symbols symbols, ReadingPolicy policy) {
+        return switch (lineage) {
+            case ElementLineage.SameAs _ -> of(source, at, terms, symbols, policy).byPath();
+            case ElementLineage.ClosureResult _ ->
+                    throughTheClosure(call, source, at, terms, symbols, policy);
+            case ElementLineage.InsideClosureResult _ -> Map.of();
+            case ElementLineage.OneOf one -> {
+                Map<String, Bounds> both = null;
+                for (ElementLineage alternative : one.alternatives()) {
+                    Map<String, Bounds> keeps =
+                            keptBy(alternative, call, source, at, terms, symbols, policy);
+                    both = both == null ? keeps : spanning(both, keeps);
+                }
+                yield both == null ? Map.of() : both;
+            }
+        };
     }
 
     /**
-     * What holds of what the closure answered, where what it answers is a place of the element it
-     * was handed.
+     * What holds of an element that is one of two things: what holds of both.
      *
-     * <p>A closure that answers a place of its element — {@code x -> x.value}, {@code x -> x.amount}
-     * — hands on what was true there: what held of that place of every element of the source holds
-     * of every element of the list answered. A closure that computes anything else says nothing
-     * here. What it computes is arithmetic, and reading it would be this deciding what an expression
-     * is worth, which is a question with an owner ({@link DerivedNumericFacts}) and one that cannot
-     * be asked of a closure standing where no accumulator has been assumed.
-     *
-     * <p>Which place it answered is asked of the subjects and not of the fields written. The two are
-     * not the same question: a newtype's carrier is read as {@code x.value} and is the value itself,
-     * so the path that names it is the empty one, and a reader that counted the fields it saw would
-     * have gone looking for what holds of a place under a number. So the element is entered
-     * somewhere nothing else names, the closure's answer is asked which subject it is, and the paths
-     * the source states are put under that same root until one of them is that subject — the algebra
-     * deciding which two spellings are one place, as it does everywhere else.
+     * <p>A place either of them says nothing about is a place nothing is said about, and the ends
+     * are the outer ones of the two — an element the closure never saw is bounded by what the source
+     * guarantees, and one it made is bounded by what it answered, and every element is one of the
+     * two.
      */
-    private static void throughTheClosure(Core.PreservedCall call, Core source, Denotations at,
-                                          Terms terms, Symbols symbols, ReadingPolicy policy,
-                                          Map<String, Bounds> held) {
+    private static Map<String, Bounds> spanning(Map<String, Bounds> one, Map<String, Bounds> other) {
+        Map<String, Bounds> both = new LinkedHashMap<>();
+        one.forEach((path, bounds) -> {
+            Bounds there = other.get(path);
+            if (there != null) {
+                both.put(path, Bounds.spanning(bounds, there));
+            }
+        });
+        return both;
+    }
+
+    /**
+     * What holds of what the closure answered, given what holds of every element it is applied to.
+     *
+     * <p>Not a projection of the paths. A closure answers a value it computed — {@code x -> 0},
+     * {@code x -> x.value + 1}, {@code x -> x.value} — and what holds of that value is what the
+     * arithmetic makes of what holds of the element. So the element is entered somewhere nothing
+     * else names, what the closure answers is read as a form over that place, and the facts the
+     * source states are assumed of it: what the reading proves of the form holds of every element of
+     * the list answered, since it was proved of an element nothing but those facts is true of.
+     *
+     * <p>The reading is the one that owns the question ({@link NumericDomain}) and is asked on a
+     * domain of its own. Nothing of where the call stands is assumed into it: a closure is applied
+     * to every element, so what is true where the call was written is not true of what it answers,
+     * and a reader that assumed the surrounding facts would prove of every element what is true
+     * where one of them was named. What that leaves outside is arithmetic the affine fragment does
+     * not carry — a product of two places is an atom this domain holds nothing of — and outside is
+     * where it stays until a reader that carries recipes asks the question.
+     */
+    private static Map<String, Bounds> throughTheClosure(Core.PreservedCall call, Core source,
+                                                         Denotations at, Terms terms,
+                                                         Symbols symbols, ReadingPolicy policy) {
         Combinators.Handed handed = Combinators.handedTo(call, at);
         if (handed == null) {
-            return;
+            return Map.of();
         }
         UniversalElementFacts kept = of(source, at, terms, symbols, policy);
-        if (kept.saysNothing()) {
-            return;
-        }
         BindingId element = handed.element().binding();
         FactSubject root = terms.placeSubject(element);
         Denotations reading = at.location(element, root, terms.placeTerm(element));
-        FactSubject answered = terms.subjectOf(handed.step().body(), reading);
+        // Read before anything is assumed: reading the closure is what names the places inside it,
+        // and a place with no name is one no range can be asserted about.
+        LinearForm<FactSubject> answered = terms.affineOf(handed.step().body(), reading);
         if (answered == null) {
-            return;
+            return Map.of();
         }
-        kept.byPath().forEach((path, bounds) -> {
-            if (answered.equals(terms.under(root, path))) {
-                holds(held, FieldDomains.THE_VALUE, bounds);
+        NumericDomain<FactSubject> given = NumericDomain.top();
+        for (Map.Entry<FactSubject, Bounds> one : kept.at(root, terms).entrySet()) {
+            Map<FactSubject, Granularity> spacing =
+                    terms.kindsOf(NumericDomain.LinearForm.atom(one.getKey()));
+            if (!spacing.isEmpty()) {
+                given = given.assuming(one.getKey(), one.getValue(), spacing);
             }
-        });
+        }
+        Bounds bounds = given.isBottom() ? null : given.boundsOf(answered);
+        return bounds == null || bounds.saysNothing() ? Map.of()
+                : Map.of(FieldDomains.THE_VALUE, bounds);
     }
 
     /** Records that everything at {@code path} lies between {@code bounds}. Two sources reaching one

--- a/souther-compiler/src/test/java/souther/compiler/ARangeWorthTryingIsMadeFromWhatTheStepIsHandedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARangeWorthTryingIsMadeFromWhatTheStepIsHandedTest.java
@@ -1,0 +1,90 @@
+package souther.compiler;
+
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The ranges a walk is checked against are made from what the step is handed as well as from the
+ * seed (spec §invariant-discharge-reduction).
+ *
+ * <p>The proof reads what holds of everything the step is handed while checking that the step stays
+ * inside a range, and nothing read it while deciding which ranges to check. So a product of elements
+ * at or above nought, started at one, was owed: the range it stays in is {@code [0, +∞)}, which is
+ * neither the seed, nor either direction opened from it, nor the seed joined with what the step
+ * answers with nothing assumed. Nobody proposed it, so nothing could prove it.
+ *
+ * <p>What is added is a symmetry and not a rule about products. A walk carries its accumulator
+ * through what it was handed, so where the answer runs is where the two together run — and the
+ * candidates are guesses either way, each costing one check and proving nothing it cannot survive
+ * ({@code InductiveBounds}).
+ *
+ * <p>The three ways a product is proved are three different layers of the reading, which is what
+ * makes them worth writing down together.
+ */
+class ARangeWorthTryingIsMadeFromWhatTheStepIsHandedTest {
+
+    private static final String TYPES = """
+            module demo
+
+            data U = Int
+                invariant nonNeg = value >= 0
+
+            data AtLeastOne = Int
+                invariant one = value >= 1
+
+            data Money = Int
+                invariant nonNeg = value >= 0
+            """;
+
+    private static boolean owed(String expression) {
+        Compiler.Compiled compiled = Compiler.compileWithWarnings(TYPES + "\n" + """
+                behavior total : (xs: List<U>, ns: List<Int>, ones: List<AtLeastOne>) -> Money
+                    constructs Money
+
+                let total (xs, ns, ones) = Money(%s)
+                """.formatted(expression));
+        return compiled.warnings().stream()
+                .anyMatch(d -> d.severity() == Severity.WARNING && "E2011".equals(d.code()));
+    }
+
+    /** Elements at or above one: the seed opened upward already held this, and it held it before
+     * anything was read of what the step is handed. */
+    @Test
+    void aProductOfElementsAtOrAboveOneIsProvedFromTheSeed() {
+        assertFalse(owed("List.fold((acc, x) -> acc * x.value, 1, ones)"));
+        assertFalse(owed("List.product(List.map(x -> x.value, ones))"));
+    }
+
+    /** Elements written on the line: what bounds them is what is written there, and the range it
+     * proposes is the one the seed and those numbers make together. */
+    @Test
+    void aProductOfElementsWrittenOutIsProvedFromWhatIsWritten() {
+        assertFalse(owed("List.fold((acc, x) -> acc * x, 1, [2, 3])"));
+        assertFalse(owed("List.product([2, 3])"));
+    }
+
+    /** Elements at or above nought: the case this commit is for. A product of them started at one
+     * never leaves {@code [0, +∞)}, and that range is the seed joined with what the elements
+     * guarantee. */
+    @Test
+    void aProductOfElementsAtOrAboveNoughtIsProvedFromWhatTheStepIsHanded() {
+        assertFalse(owed("List.fold((acc, x) -> acc * x.value, 1, xs)"));
+        assertFalse(owed("List.product(List.map(x -> x.value, xs))"));
+    }
+
+    /** And a longer list of guesses proves nothing more than it should: a product over elements
+     * nothing bounds is owed, and so is a step that leaves every range the seed and the elements
+     * make. */
+    @Test
+    void aRangeNothingHoldsIsStillNotProved() {
+        assertTrue(owed("List.fold((acc, x) -> acc * x, 1, ns)"));
+        assertTrue(owed("List.product(ns)"));
+        assertTrue(owed("List.fold((acc, x) -> acc - x.value, 0, xs)"),
+                "a total that takes away from itself leaves every range made from a seed of nought"
+                        + " and elements at or above it");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/AnAccumulationIsProvedByWhatProvesTheFoldThatSpellsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnAccumulationIsProvedByWhatProvesTheFoldThatSpellsItTest.java
@@ -36,6 +36,11 @@ class AnAccumulationIsProvedByWhatProvesTheFoldThatSpellsItTest {
                 invariant nonNeg = value >= 0
             """;
 
+    private static boolean owedIn(String source) {
+        return Compiler.compileWithWarnings(source).warnings().stream()
+                .anyMatch(d -> d.severity() == Severity.WARNING && "E2011".equals(d.code()));
+    }
+
     private static boolean owed(String expression) {
         Compiler.Compiled compiled = Compiler.compileWithWarnings(TYPES + "\n" + """
                 behavior total : (xs: List<U>, ns: List<Int>, ones: List<AtLeastOne>) -> Money
@@ -88,6 +93,39 @@ class AnAccumulationIsProvedByWhatProvesTheFoldThatSpellsItTest {
         assertFalse(owed("List.fold((acc, x) -> acc * x.value, 1, ones)"),
                 "which is what the fold saying the same thing answers");
         assertFalse(owed("List.product([2, 3])"));
+    }
+
+    /**
+     * And the same over the other kind of number the domain carries.
+     *
+     * <p>What an accumulation starts from is a recipe read at the type the call answers (ADR-0082),
+     * so {@code List.sum} of decimals starts from a nought that is a {@code Decimal} — not from a
+     * literal written into a tree for its type to be inferred off again. The two places of the walk
+     * are named with that type's spacing for the same reason, so a range asserted about the
+     * accumulator is one the domain takes.
+     */
+    @Test
+    void anAccumulationOfDecimalsIsTheWalkItMeansAsAnAccumulationOfWholeNumbersIs() {
+        String decimals = """
+                module demo
+
+                data Rate = Decimal
+                    invariant nonNeg = value >= 0.0m
+
+                data Summed = Decimal
+                    invariant nonNeg = value >= 0.0m
+
+                behavior walkIt : (ds: List<Rate>) -> Summed
+                    constructs Summed
+                let walkIt (ds) = Summed(%s)
+                """;
+        assertFalse(owedIn(decimals.formatted("List.sum(List.map(x -> x.value, ds))")),
+                "a sum of decimals at or above nought is at or above nought");
+        assertFalse(owedIn(decimals.formatted(
+                        "List.fold((acc, x) -> acc + x.value, 0.0m, ds)")),
+                "which is what the fold saying the same thing answers");
+        assertFalse(owedIn(decimals.formatted("List.product(List.map(x -> x.value, ds))")),
+                "and a product of them, started at one, never leaves them");
     }
 
     /** And a product over elements nothing bounds is reported, as its fold is. */

--- a/souther-compiler/src/test/java/souther/compiler/AnAccumulationIsProvedByWhatProvesTheFoldThatSpellsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnAccumulationIsProvedByWhatProvesTheFoldThatSpellsItTest.java
@@ -1,0 +1,99 @@
+package souther.compiler;
+
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A total written {@code List.sum} answers what the fold that spells it out answers, and is proved
+ * by what proves that fold (spec §invariant-discharge-reduction).
+ *
+ * <p>{@code List.sum} and {@code List.product} are primitives over a numeric element (ADR-0082), and
+ * the only walk the discharge check read was one it was handed a step and a seed for. So a total
+ * written as a fold was read and the same total written with the library's own function was a value
+ * nothing was known about — the library being the expensive way to write something (#963).
+ *
+ * <p>Every case here is one total written both ways. What proves it is the same procedure either
+ * way: the accumulation is made into the walk it means — an identity, an accumulator, an element,
+ * and one step over the two — and {@code InductiveBounds} is asked, which knows no operation's name.
+ * The neighbours that stay reported say the walk is being proved rather than credited.
+ */
+class AnAccumulationIsProvedByWhatProvesTheFoldThatSpellsItTest {
+
+    private static final String TYPES = """
+            module demo
+
+            data U = Int
+                invariant nonNeg = value >= 0
+
+            data AtLeastOne = Int
+                invariant one = value >= 1
+
+            data Money = Int
+                invariant nonNeg = value >= 0
+            """;
+
+    private static boolean owed(String expression) {
+        Compiler.Compiled compiled = Compiler.compileWithWarnings(TYPES + "\n" + """
+                behavior total : (xs: List<U>, ns: List<Int>, ones: List<AtLeastOne>) -> Money
+                    constructs Money
+
+                let total (xs, ns, ones) = Money(%s)
+                """.formatted(expression));
+        return compiled.warnings().stream()
+                .anyMatch(d -> d.severity() == Severity.WARNING && "E2011".equals(d.code()));
+    }
+
+    /** The two lines the issue is about: a total of the same amounts, written with the library's
+     * function and written out as the walk it is. */
+    @Test
+    void aSumOfWhatAMapBuiltIsTheFoldThatSpellsItOut() {
+        assertFalse(owed("List.sum(List.map(x -> x.value, xs))"),
+                "a sum of numbers at or above nought is at or above nought");
+        assertFalse(owed("List.fold((acc, x) -> acc + x, 0, List.map(x -> x.value, xs))"),
+                "which is what the fold saying the same thing answers");
+    }
+
+    /** The elements written on the line bound the accumulation as they bound the fold: the seed is
+     * the identity the operation starts from, and nothing was expanded to find it. */
+    @Test
+    void aSumOfElementsWrittenOutIsBoundedByThem() {
+        assertFalse(owed("List.sum([1, 2, 3])"));
+        assertFalse(owed("List.fold((acc, x) -> acc + x, 0, [1, 2, 3])"));
+    }
+
+    /** And a sum over elements nothing bounds is reported, both ways round — a walk over numbers
+     * that may be below nought answers something that may be below nought. */
+    @Test
+    void aSumOverElementsNothingBoundsIsOwed() {
+        assertTrue(owed("List.sum(ns)"));
+        assertTrue(owed("List.fold((acc, x) -> acc + x, 0, ns)"));
+    }
+
+    /**
+     * The other primitive, whose step is a product.
+     *
+     * <p>A product is not a form, so what the step answers is an atom standing for one, recorded
+     * against the recipe that says what it is — the same recipe the naming makes of a product
+     * written into a fold's step. Under the induction hypothesis both operands are bounded and the
+     * recipe answers a range, which is how one line proves the other.
+     */
+    @Test
+    void aProductIsProvedWhereTheFoldThatSpellsItOutIs() {
+        assertFalse(owed("List.product(List.map(x -> x.value, ones))"),
+                "a product of numbers at or above one, started at one, stays at or above one");
+        assertFalse(owed("List.fold((acc, x) -> acc * x.value, 1, ones)"),
+                "which is what the fold saying the same thing answers");
+        assertFalse(owed("List.product([2, 3])"));
+    }
+
+    /** And a product over elements nothing bounds is reported, as its fold is. */
+    @Test
+    void aProductOverElementsNothingBoundsIsOwed() {
+        assertTrue(owed("List.product(ns)"));
+        assertTrue(owed("List.fold((acc, x) -> acc * x, 1, ns)"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/TheSameTotalIsReadWhicheverWayItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/TheSameTotalIsReadWhicheverWayItIsWrittenTest.java
@@ -1,0 +1,50 @@
+package souther.compiler;
+
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The two behaviors #963 was reported with, compiled together.
+ *
+ * <p>They say the same thing about the same list: a total of the amounts, constructed as a value
+ * whose invariant is that it is at or above nought. One was written as a fold and read; the other
+ * was written with the library's own {@code List.sum} and was a value nothing was known about. The
+ * report this came from rewrote eleven such totals into folds and fifteen warnings went away, with
+ * no change of meaning anywhere — the library being the expensive way to write something.
+ *
+ * <p>Three separate readings had to arrive for the second line to be read, and this is where they
+ * meet: the primitive is made into the walk it means, what a {@code List.map} kept of the elements
+ * it was built from travels to the walk that consumes them, and the range such a walk stays in is
+ * proposed from what the step is handed. Each of those is held on its own elsewhere; what is held
+ * here is that the model an author writes compiles clean.
+ */
+class TheSameTotalIsReadWhicheverWayItIsWrittenTest {
+
+    @Test
+    void aTotalWrittenAsAFoldAndOneWrittenWithTheLibraryAreBothRead() {
+        Compiler.Compiled compiled = Compiler.compileWithWarnings("""
+                module demo
+
+                data U = Int
+                    invariant nonNeg = value >= 0
+
+                behavior a : (xs: List<U>) -> U
+                    constructs U
+                let a (xs) = U(List.fold((acc, x) -> acc + x.value, 0, xs))
+
+                behavior b : (xs: List<U>) -> U
+                    constructs U
+                let b (xs) = U(List.sum(List.map(x -> x.value, xs)))
+                """);
+        assertEquals(List.of(), compiled.warnings().stream()
+                        .filter(d -> d.severity() == Severity.WARNING)
+                        .map(Diagnostic::code).toList(),
+                "the two lines say the same thing about the same list");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest.java
@@ -191,6 +191,56 @@ class WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest {
     }
 
     /**
+     * A helper the discharge tree expanded is the value it answers.
+     *
+     * <p>The tree this reads keeps the library's own operations standing and expands a module's
+     * helpers into bindings, so {@code x -> innerOf(x)} is {@code let $0 = x in $0.inner} by the
+     * time it is read. Which is a way of writing the same value, as a name given to a container is
+     * — and every reader that answered that question for itself answered it for the shapes its
+     * author had met. So where a value is written is asked in one place ({@code Terms.given}), and
+     * what is left to a reader is what is genuinely about the value.
+     *
+     * <p>What stays outside is a record answered by a branch: two arms are two values, and what
+     * holds of both is a question this does not ask yet. It answers nothing there rather than
+     * answering from one arm.
+     */
+    @Test
+    void aHelperTheTreeExpandedIsTheValueItAnswers() {
+        String helper = """
+                module demo
+
+                data Inner =
+                    { amount: Int
+                    }
+
+                data Outer =
+                    { inner: Inner
+                    }
+                    invariant nonNeg = inner.amount >= 0
+
+                data Money = Int
+                    invariant nonNeg = value >= 0
+
+                let innerOf (x: Outer): Inner = x.inner
+                let lowered (x: Outer): Inner = Inner { amount = x.inner.amount - 1 }
+
+                behavior walkIt : (xs: List<Outer>) -> Money
+                    constructs Money%s
+                let walkIt (xs) = Money(%s)
+                """;
+        assertFalse(owedIn(helper.formatted("",
+                        "List.fold((acc, y) -> acc + y.amount, 0, List.map(x -> x.inner, xs))")),
+                "the closure reads a place of the element");
+        assertFalse(owedIn(helper.formatted("",
+                        "List.fold((acc, y) -> acc + y.amount, 0, List.map(x -> innerOf(x), xs))")),
+                "and the same place read through a helper, which the tree expanded into a binding");
+        assertTrue(owedIn(helper.formatted(", Inner",
+                        "List.fold((acc, y) -> acc + y.amount, 0, List.map(x -> lowered(x), xs))")),
+                "and a helper that lowers what it was handed hands on what it answered, not what it"
+                        + " was given");
+    }
+
+    /**
      * An element that is one of two things is bounded by both.
      *
      * <p>{@code Map.updateIfPresent} answers the map it was given with one value replaced, and its

--- a/souther-compiler/src/test/java/souther/compiler/WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest.java
@@ -39,12 +39,25 @@ class WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest {
             """;
 
     private static boolean owed(String expression) {
+        return owedIn("let total (xs, ns) = Money(%s)".formatted(expression));
+    }
+
+    /** The same total, with the container bound to a name first. */
+    private static boolean owedWhereTheContainerIsNamed(String container, String walk) {
+        return owedIn("""
+                let total (xs, ns) = {
+                    let ys = %s
+                    Money(%s)
+                }""".formatted(container, walk));
+    }
+
+    private static boolean owedIn(String body) {
         Compiler.Compiled compiled = Compiler.compileWithWarnings(TYPES + "\n" + """
                 behavior total : (xs: List<U>, ns: List<Int>) -> Money
                     constructs Money
 
-                let total (xs, ns) = Money(%s)
-                """.formatted(expression));
+                %s
+                """.formatted(body));
         return compiled.warnings().stream()
                 .anyMatch(d -> d.severity() == Severity.WARNING && "E2011".equals(d.code()));
     }
@@ -93,6 +106,25 @@ class WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest {
                 "some of the same three numbers, and nothing else is there");
         assertFalse(owed("List.fold((acc, x) -> acc + x, 0, List.map(x -> x, [1, 2, 3]))"),
                 "each of them answered as it stands");
+    }
+
+    /**
+     * A container bound to a name is the container it was given.
+     *
+     * <p>The name was followed for the elements a container is written out with and not for what a
+     * construction kept, so a total written in one line was read and the same total with its list
+     * given a name was not. Two answers to "which container is this", inside the one reading written
+     * to stop a fact depending on how it was spelled.
+     */
+    @Test
+    void aContainerGivenANameIsTheContainerItWasGiven() {
+        assertFalse(owedWhereTheContainerIsNamed(
+                "List.map(x -> x.value, xs)", "List.fold((acc, x) -> acc + x, 0, ys)"));
+        assertFalse(owedWhereTheContainerIsNamed(
+                "List.reverse([1, 2, 3])", "List.fold((acc, x) -> acc + x, 0, ys)"));
+        assertTrue(owedWhereTheContainerIsNamed(
+                "List.map(x -> x, ns)", "List.fold((acc, x) -> acc + x, 0, ys)"),
+                "and a name given to a list nothing bounds bounds nothing");
     }
 
     /** The neighbour that stays reported: a list of numbers nothing bounds is one nothing bounds,

--- a/souther-compiler/src/test/java/souther/compiler/WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest.java
@@ -126,6 +126,71 @@ class WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest {
     }
 
     /**
+     * What a closure answered is answered by the path under it, and not only where it ends at a
+     * number.
+     *
+     * <p>These facts are about places under an element — {@code ""}, {@code amount}, {@code a.b} —
+     * and the mapped case used to answer at the root or not at all. So a closure that answered a
+     * record answered nothing: {@code x -> x.inner} keeps everything that was said under
+     * {@code inner}, and {@code x -> Row { amount = ... }} keeps at {@code amount} whatever the
+     * field was made from, and neither of those is a number the whole of the answer is.
+     */
+    @Test
+    void whatAClosureAnsweredIsAnsweredByThePathUnderIt() {
+        String nested = """
+                module demo
+
+                data Inner =
+                    { amount: Int
+                    }
+
+                data Outer =
+                    { inner: Inner
+                    }
+                    invariant nonNeg = inner.amount >= 0
+
+                data Money = Int
+                    invariant nonNeg = value >= 0
+
+                behavior walkIt : (xs: List<Outer>) -> Money
+                    constructs Money
+                let walkIt (xs) = Money(%s)
+                """;
+        assertFalse(owedIn(nested.formatted(
+                        "List.fold((acc, x) -> acc + x.inner.amount, 0, xs)")),
+                "what the element guarantees under a field of a field");
+        assertFalse(owedIn(nested.formatted(
+                        "List.fold((acc, y) -> acc + y.amount, 0, List.map(x -> x.inner, xs))")),
+                "and the same, read under one field of what the map answered");
+
+        String built = """
+                module demo
+
+                data U = Int
+                    invariant nonNeg = value >= 0
+
+                data Row =
+                    { amount: Int
+                    }
+
+                data Money = Int
+                    invariant nonNeg = value >= 0
+
+                behavior walkIt : (us: List<U>) -> Money
+                    constructs Money, Row
+                let walkIt (us) = Money(%s)
+                """;
+        assertFalse(owedIn(built.formatted(
+                        "List.fold((acc, r) -> acc + r.amount, 0,"
+                                + " List.map(x -> Row { amount = x.value }, us))")),
+                "a field is what it was made from, and it was made from a place at or above nought");
+        assertTrue(owedIn(built.formatted(
+                        "List.fold((acc, r) -> acc + r.amount, 0,"
+                                + " List.map(x -> Row { amount = x.value - 1 }, us))")),
+                "and one less than that may be below nought, so the total may be");
+    }
+
+    /**
      * An element that is one of two things is bounded by both.
      *
      * <p>{@code Map.updateIfPresent} answers the map it was given with one value replaced, and its

--- a/souther-compiler/src/test/java/souther/compiler/WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest.java
@@ -52,13 +52,16 @@ class WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest {
     }
 
     private static boolean owedIn(String body) {
-        Compiler.Compiled compiled = Compiler.compileWithWarnings(TYPES + "\n" + """
+        return owedInModule(body.startsWith("module ") ? body : TYPES + "\n" + """
                 behavior total : (xs: List<U>, ns: List<Int>) -> Money
                     constructs Money
 
                 %s
                 """.formatted(body));
-        return compiled.warnings().stream()
+    }
+
+    private static boolean owedInModule(String source) {
+        return Compiler.compileWithWarnings(source).warnings().stream()
                 .anyMatch(d -> d.severity() == Severity.WARNING && "E2011".equals(d.code()));
     }
 
@@ -81,13 +84,54 @@ class WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest {
                         + " same place of each of them");
     }
 
-    /** A closure that computes rather than reads answers something this says nothing of, and the
-     * walk is reported — which is what says the mapped case carries what a place guaranteed and not
-     * whatever the closure was written with. */
+    /**
+     * What a closure answered is read from what it was applied to.
+     *
+     * <p>Not a projection of the paths. A closure that reads a place hands on what was true there,
+     * and one that computes hands on what the arithmetic makes of it — {@code x -> 0} answers nought
+     * whatever it was handed, and one more than a number at or above nought is at or above one. Both
+     * are the same question asked of the reading that owns it, on a domain holding the facts every
+     * element satisfies and nothing else.
+     */
     @Test
-    void aClosureThatComputesItsAnswerCarriesNothing() {
+    void whatAClosureAnsweredIsReadFromWhatItWasAppliedTo() {
+        assertFalse(owed("List.fold((acc, x) -> acc + x, 0, List.map(x -> 0, xs))"),
+                "nought, whatever the element was");
+        assertFalse(owed("List.fold((acc, x) -> acc + x, 0, List.map(x -> x.value + 1, xs))"),
+                "one more than a number at or above nought");
         assertTrue(owed("List.fold((acc, x) -> acc + x, 0, List.map(x -> x.value - 1, xs))"),
-                "one less than a number at or above nought is a number this is told nothing about");
+                "and one less than one may be below nought, so the total may be");
+    }
+
+    /**
+     * An element that is one of two things is bounded by both.
+     *
+     * <p>{@code Map.updateIfPresent} answers the map it was given with one value replaced, and its
+     * rule used to say every value was the closure's answer. Read that way beside a closure that
+     * raises what it was handed, the values that were already there would be credited with what the
+     * closure promised and were never given to it. So the two are held apart here: the same closure
+     * through {@code Map.mapValues}, which does answer every value, proves the product; through
+     * {@code Map.updateIfPresent} it does not.
+     */
+    @Test
+    void anElementThatIsOneOfTwoThingsIsBoundedByBoth() {
+        String product = """
+                module demo
+
+                data U = Int
+                    invariant nonNeg = value >= 0
+
+                data AtLeastOne = Int
+                    invariant one = value >= 1
+
+                behavior total : (m: Map<String, U>) -> AtLeastOne
+                    constructs AtLeastOne, U
+                let total (m) = AtLeastOne(Map.fold((acc, k, v) -> acc * v.value, 1, %s))
+                """;
+        assertFalse(owedIn(product.formatted("Map.mapValues((k, v) -> U(v.value + 1), m)")),
+                "every value of a mapped map is what the closure answered, which is at or above one");
+        assertTrue(owedIn(product.formatted("Map.updateIfPresent(\"a\", v -> U(v.value + 1), m)")),
+                "a value the closure never saw is the one that was there, which may be nought");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest.java
@@ -1,0 +1,115 @@
+package souther.compiler;
+
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a reduction may assume of the element it is handed is read of the container it walks
+ * (spec §invariant-discharge-reduction).
+ *
+ * <p>It used to be read of the element's own type and of the line the container was written on, and
+ * those are two of the things a container says — they are not the container. So a walk over a list a
+ * {@code List.map} had built knew nothing of its elements, however much was known of the elements
+ * they were built from and however plainly the closure said which place of them it answered: the
+ * facts were held against the binder the producer was written with, and the consumer had never met
+ * it. Eleven totals in one model were rewritten to avoid it.
+ *
+ * <p>So the reading is of the container expression, by the path under an element each bound is about
+ * ({@code UniversalElementFacts}), and the fold instantiates those paths at the place its element
+ * arrives. Every case here is one walk written two ways, or one walk over two containers that hold
+ * the same elements — and the neighbours that stay reported are what says the reading is of the
+ * elements rather than of the shape of the tree.
+ */
+class WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest {
+
+    private static final String TYPES = """
+            module demo
+
+            data U = Int
+                invariant nonNeg = value >= 0
+
+            data Money = Int
+                invariant nonNeg = value >= 0
+
+            let over (n: Int): Bool = n > 1
+            """;
+
+    private static boolean owed(String expression) {
+        Compiler.Compiled compiled = Compiler.compileWithWarnings(TYPES + "\n" + """
+                behavior total : (xs: List<U>, ns: List<Int>) -> Money
+                    constructs Money
+
+                let total (xs, ns) = Money(%s)
+                """.formatted(expression));
+        return compiled.warnings().stream()
+                .anyMatch(d -> d.severity() == Severity.WARNING && "E2011".equals(d.code()));
+    }
+
+    /** The walk the fix is about: the same total, written as a fold over the elements and as a fold
+     * over a list mapped from them. Neither is more true than the other. */
+    @Test
+    void aFoldOverWhatAMapBuiltReadsWhatTheMappedPlaceGuaranteed() {
+        assertFalse(owed("List.fold((acc, x) -> acc + x.value, 0, xs)"),
+                "the element's own type says its carrier is at or above nought");
+        assertFalse(owed("List.fold((acc, x) -> acc + x, 0, List.map(x -> x.value, xs))"),
+                "and the list mapped from that place holds the same numbers");
+    }
+
+    /** The reading travels as far as the container was built through: what was kept of a list is
+     * kept of a list built from that one. */
+    @Test
+    void whatWasKeptTravelsThroughEveryConstructionThatKeptIt() {
+        assertFalse(owed("List.fold((acc, x) -> acc + x, 0, List.map(x -> x.value, List.reverse(xs)))"),
+                "the same elements in another order are the same elements, and the map reads the"
+                        + " same place of each of them");
+    }
+
+    /** A closure that computes rather than reads answers something this says nothing of, and the
+     * walk is reported — which is what says the mapped case carries what a place guaranteed and not
+     * whatever the closure was written with. */
+    @Test
+    void aClosureThatComputesItsAnswerCarriesNothing() {
+        assertTrue(owed("List.fold((acc, x) -> acc + x, 0, List.map(x -> x.value - 1, xs))"),
+                "one less than a number at or above nought is a number this is told nothing about");
+    }
+
+    /**
+     * A container written out bounds its elements, and goes on bounding them through a construction
+     * that kept them.
+     *
+     * <p>The written-out elements were read of the container the walk was handed and of nothing
+     * else, so {@code [1, 2, 3]} bounded a fold and {@code List.reverse([1, 2, 3])} bounded none.
+     */
+    @Test
+    void elementsWrittenOutBoundAWalkThroughWhatKeepsThem() {
+        assertFalse(owed("List.fold((acc, x) -> acc + x, 0, [1, 2, 3])"));
+        assertFalse(owed("List.fold((acc, x) -> acc + x, 0, List.reverse([1, 2, 3]))"),
+                "the same three numbers in another order");
+        assertFalse(owed("List.fold((acc, x) -> acc + x, 0, List.filter(x -> over(x), [1, 2, 3]))"),
+                "some of the same three numbers, and nothing else is there");
+        assertFalse(owed("List.fold((acc, x) -> acc + x, 0, List.map(x -> x, [1, 2, 3]))"),
+                "each of them answered as it stands");
+    }
+
+    /** The neighbour that stays reported: a list of numbers nothing bounds is one nothing bounds,
+     * however it is written. */
+    @Test
+    void aContainerThatGuaranteesNothingBoundsNothing() {
+        assertTrue(owed("List.fold((acc, x) -> acc + x, 0, ns)"));
+        assertTrue(owed("List.fold((acc, x) -> acc + x, 0, List.reverse(ns))"));
+        assertTrue(owed("List.fold((acc, x) -> acc + x, 0, List.map(x -> x, ns))"));
+    }
+
+    /** And what a walk over a list ordered or thinned reads is what it read before this was written:
+     * both were already answered by the element's own type, and moving where the answer comes from
+     * left them where they were. */
+    @Test
+    void aWalkOverAListOrderedOrThinnedReadsWhatItAlwaysRead() {
+        assertFalse(owed("List.fold((acc, x) -> acc + x.value, 0, List.reverse(xs))"));
+        assertFalse(owed("List.fold((acc, x) -> acc + x.value, 0, List.filter(x -> over(x.value), xs))"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest.java
@@ -104,6 +104,28 @@ class WhatHoldsOfEveryElementIsReadOfTheContainerItWalksTest {
     }
 
     /**
+     * And it is read by the reading that reads recipes and what values carry, not by a domain
+     * assembled beside it.
+     *
+     * <p>A product of two places is an atom the affine fragment holds nothing of, and what it is a
+     * product of is a recipe; that the library's {@code Int.abs} never answers below nought is
+     * something the atom carries. Both are read where a fold's step is read, so a walk over what a
+     * closure built has to be read the same way — asked of a raw domain, the value would be readable
+     * or not by where the tree put it, which is the defect this class is for.
+     */
+    @Test
+    void whatAClosureAnsweredIsReadByTheReadingThatReadsRecipes() {
+        assertFalse(owed("List.fold((acc, x) -> acc + x.value * x.value, 0, xs)"),
+                "a square of a number at or above nought, read in the step");
+        assertFalse(owed("List.fold((acc, y) -> acc + y, 0, List.map(x -> x.value * x.value, xs))"),
+                "and the same square read through the map that built the list");
+        assertFalse(owed("List.fold((acc, x) -> acc + Int.abs(x), 0, ns)"),
+                "what the library says of its own operation, read in the step");
+        assertFalse(owed("List.fold((acc, y) -> acc + y, 0, List.map(x -> Int.abs(x), ns))"),
+                "and read through the map");
+    }
+
+    /**
      * An element that is one of two things is bounded by both.
      *
      * <p>{@code Map.updateIfPresent} answers the map it was given with one value replaced, and its

--- a/souther-compiler/src/test/java/souther/compiler/check/APredicateCarriesExactlyAsFarAsItsRuleSaysTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/APredicateCarriesExactlyAsFarAsItsRuleSaysTest.java
@@ -85,10 +85,12 @@ class APredicateCarriesExactlyAsFarAsItsRuleSaysTest {
                             Travels.NO_SUCH_CONSTRUCTION, Travels.STOPS)),
             // A mapping over a map answers one value for each key and leaves the keys alone, so a key
             // being there does survive it — and `MAPS` does not say that, being about the elements
-            // and not about what they are held under. Stating it would need a shape that does.
+            // and not about what they are held under. Stating it would need a shape that does. The
+            // same is true through `Map.updateIfPresent`, which replaces one value and removes no
+            // key: what the four words say of a run holding some of each is nothing.
             new Predicate("Map", "Map<String, Int>", "Map.containsKey(\"a\", %s)",
                     travels(Travels.NO_SUCH_CONSTRUCTION, Travels.STOPS, Travels.STOPS,
-                            Travels.NO_SUCH_CONSTRUCTION)));
+                            Travels.STOPS)));
 
     /** How a container of each kind is built from another of the same kind, by shape, or null where
      * the library has no such construction. */
@@ -102,6 +104,7 @@ class APredicateCarriesExactlyAsFarAsItsRuleSaysTest {
             case "Set.COLLAPSES" -> "Set.map(n -> 0, c)";
             case "Map.SUBSET" -> "Map.filterEntries((k, v) -> v >= 5, c)";
             case "Map.MAPS" -> "Map.mapValues((k, v) -> 0, c)";
+            case "Map.COLLAPSES" -> "Map.updateIfPresent(\"a\", v -> v + 1, c)";
             default -> null;
         };
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/AReductionsShapeIsReadOffItsDeclarationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AReductionsShapeIsReadOffItsDeclarationTest.java
@@ -99,7 +99,7 @@ class AReductionsShapeIsReadOffItsDeclarationTest {
     @Test
     void aStepNothingIsKnownOfProposesTheSeedAndTheTwoDirections() {
         assertEquals(List.of(only(0), new Bounds(at(0), null), new Bounds(null, at(0))),
-                InvariantCandidates.from(only(0), new Bounds(null, null)));
+                InvariantCandidates.from(only(0), new Bounds(null, null), List.of()));
     }
 
     /** Where the step answers something bounded without the accumulator being assumed, the seed and
@@ -110,7 +110,23 @@ class AReductionsShapeIsReadOffItsDeclarationTest {
         assertEquals(
                 List.of(only(0), new Bounds(at(0), null), new Bounds(null, at(0)),
                         new Bounds(at(0), at(7))),
-                InvariantCandidates.from(only(0), only(7)));
+                InvariantCandidates.from(only(0), only(7), List.of()));
+    }
+
+    /**
+     * What the step is handed is proposed beside the seed as well, which is the range a product of
+     * elements at or above nought needs and no reading of the seed alone reaches.
+     *
+     * <p>Each input separately and no reading of which of them the step uses: a guess that follows
+     * neither of a {@code Map.fold}'s two is one check and is discarded.
+     */
+    @Test
+    void whatTheStepIsHandedIsProposedBesideTheSeed() {
+        assertEquals(
+                List.of(only(1), new Bounds(at(1), null), new Bounds(null, at(1)),
+                        new Bounds(at(0), null)),
+                InvariantCandidates.from(only(1), new Bounds(null, null),
+                        List.of(new Bounds(at(0), null))));
     }
 
     /** A seed nothing bounds proposes nothing to prove: every range made from it is the one with no
@@ -118,6 +134,6 @@ class AReductionsShapeIsReadOffItsDeclarationTest {
     @Test
     void aSeedNothingBoundsProposesNothing() {
         assertEquals(List.of(),
-                InvariantCandidates.from(new Bounds(null, null), new Bounds(null, null)));
+                InvariantCandidates.from(new Bounds(null, null), new Bounds(null, null), List.of()));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/AnAccumulationIsWrittenForWhatItMeansAndNotForWhatCanReadItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnAccumulationIsWrittenForWhatItMeansAndNotForWhatCanReadItTest.java
@@ -1,0 +1,90 @@
+package souther.compiler.check;
+
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * {@link Question#ACCUMULATION} asks what an operation means, and {@link Accumulations} answers it
+ * for every operation in range — including the two that answer a string, which no check that reads
+ * numbers will ever ask about.
+ *
+ * <p>That is the whole of what this holds. A registry written to suit the one reader it has today
+ * says of {@code String.concat} that the library's own reading of it — {@code join("", xs)} — is not
+ * a reading at all, and the next question asked of the table gets the answer the last reader's
+ * limits shaped. What may be carried as a number is asked after this table, of its answer.
+ */
+class AnAccumulationIsWrittenForWhatItMeansAndNotForWhatCanReadItTest {
+
+    @Test
+    void everyOperationAnsweringWhatItsContainerHoldsIsAsked() {
+        List<String> inRange = new ArrayList<>();
+        for (Map.Entry<String, Prelude.PreludeEntry> e : Prelude.entries().entrySet()) {
+            if (Question.askedOf(e.getValue().signature()).contains(Question.ACCUMULATION)) {
+                inRange.add(e.getKey());
+            }
+        }
+        assertEquals(List.of("List.concat", "List.product", "List.sum", "String.concat",
+                        "String.join"),
+                inRange.stream().sorted().toList(),
+                "these are the operations that answer a value of the type a container argument"
+                        + " holds, and each of them is asked whether it accumulates");
+    }
+
+    @Test
+    void whatEachAccumulatesIsWhatItStartsFromAndTheStepItRepeats() {
+        assertEquals(new Accumulations.Accumulation(
+                        Accumulations.Identity.ZERO, Accumulations.Combine.ADD),
+                Accumulations.of(op("List", "sum")));
+        assertEquals(new Accumulations.Accumulation(
+                        Accumulations.Identity.ONE, Accumulations.Combine.MULTIPLY),
+                Accumulations.of(op("List", "product")));
+        assertEquals(new Accumulations.Accumulation(
+                        Accumulations.Identity.EMPTY, Accumulations.Combine.APPEND),
+                Accumulations.of(op("List", "concat")),
+                "a list of lists is joined from the empty list through the same append two lists"
+                        + " are joined by");
+    }
+
+    @Test
+    void aStringIsAccumulatedAsAListIsAndIsWrittenDownAsOne() {
+        assertEquals(new Accumulations.Accumulation(
+                        Accumulations.Identity.EMPTY, Accumulations.Combine.APPEND),
+                Accumulations.of(op("String", "concat")),
+                "the library states String.concat as join(\"\", xs), and what it means does not"
+                        + " depend on there being a check that can read it");
+    }
+
+    @Test
+    void aSeparatorStandingBetweenElementsIsNotOneStepOverTwoValues() {
+        assertNull(Accumulations.of(op("String", "join")),
+                "join carries whether anything came before the element it is at, which an identity"
+                        + " and a combine over two values of one type have nowhere to keep");
+        assertEquals(true, Accumulations.NO_SIMPLE_ACCUMULATION.contains(op("String", "join")),
+                "so it answers by being named as one there is nothing of this to say of");
+    }
+
+    /**
+     * The range holds an operation nobody thought of. It is read off the shape of a declaration, so
+     * a set summed, or a map's values joined, would be asked the day the library declares one —
+     * which is what makes the question a check on the library rather than a list of what it has.
+     */
+    @Test
+    void anOperationTheLibraryDoesNotHaveYetIsInRangeByItsShape() {
+        Prelude.Signature setSummed = new Prelude.Signature(
+                List.of(new Type.SetOf(Type.Prim.INT)), Type.Prim.INT);
+        assertEquals(true, Question.askedOf(setSummed).contains(Question.ACCUMULATION));
+    }
+
+    private static ValueName op(String alias, String name) {
+        return new ValueName.Stdlib(alias, name);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhereAnAnswersElementsCameFromCanBeSaidTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhereAnAnswersElementsCameFromCanBeSaidTest.java
@@ -131,6 +131,44 @@ class WhereAnAnswersElementsCameFromCanBeSaidTest {
         assertThrows(IllegalStateException.class, built::shape);
     }
     /**
+     * An element that is one of several things that happened to it, all at one place.
+     *
+     * <p>{@code Map.updateIfPresent} answers the map it was given with the value under one key
+     * replaced. Every value in the answer came from that argument, and each is either the value that
+     * was there or what the closure made of it — so what is unsettled is what happened, not where it
+     * came from, and a reader asking where is owed the argument.
+     */
+    @Test
+    void anElementThatIsOneOfSeveralThingsAtOnePlace() {
+        ElementLineage said = new ElementLineage.OneOf(List.of(
+                new ElementLineage.SameAs(new Source(CONTAINER, 1)),
+                new ElementLineage.ClosureResult(new Source(CONTAINER, 1))));
+
+        assertEquals(new Source(CONTAINER, 1), said.source(),
+                "they came from one place, whatever happened to them there");
+    }
+
+    /**
+     * And the word the four-word projection reads of it is the one that licenses nothing.
+     *
+     * <p>Neither {@code PERMUTES} nor {@code MAPS} is true of a run holding some of each: a reader
+     * of the four words that took the first would assume of every value what is true of the ones the
+     * closure never saw, and one that took the second would assume of them what is true of the one
+     * it did. So the projection answers with the word for elements nothing was kept of, and a reader
+     * that wants more asks the lineage, which says both.
+     */
+    @Test
+    void aRunHoldingSomeOfEachIsProjectedToTheWordThatLicensesNothing() {
+        DischargeRules.Built updated = new DischargeRules.Built(
+                new ElementLineage.OneOf(List.of(
+                        new ElementLineage.SameAs(new Source(CONTAINER, 1)),
+                        new ElementLineage.ClosureResult(new Source(CONTAINER, 1)))),
+                DischargeRules.Cardinality.SAME);
+
+        assertEquals(DischargeRules.Shape.COLLAPSES, updated.shape());
+    }
+
+    /**
      * And the shape is coarser than what it is read off, which is why it is read off and not
      * declared.
      *


### PR DESCRIPTION
Closes #963 once it reaches `main`.

`List.sum` and `List.product` are primitives over a numeric element (ADR-0082), and the
invariant-discharge fragment had no reading of them. The issue's two behaviors say the same thing
about the same list and only one of them was read. Three separate gaps stood between the two lines,
and each is one commit here.

## What was missing

- **The primitive was not a walk.** The only walk the check read was one it had been handed a step
  and a seed for, and `List.sum` takes a container and nothing else.
- **What a `List.map` kept did not travel.** The two sources a step's inputs were read from — the
  element's own type, and the elements a container is written out with — were read of the container
  the walk was handed and of no container that one was built from.
- **The proof read what the step is handed; the candidate search did not.** So a product of elements
  at or above nought, started at one, had no range anybody proposed and could not be proved.

## What is here

`Accumulations` states what each accumulation starts from and the step it repeats, beside
`Reductions` and read by a new `Question.ACCUMULATION` whose range is the shape of the declaration.
Five operations are in range and each answers, `String.join` by being named as one there is no
single step for. `String.concat` and `List.concat` are written down for what they mean: what the
numeric domain can carry is asked after the table, of its answer.

`UniversalElementFacts` answers what holds of every element of a container expression, read off the
tree the discharge check is given, held by the path under an element rather than by a subject — so a
producer and a consumer that share no binder share a fact. Each of `DischargeRules.Shape`'s four
words has an answer written for it; `COLLAPSES` keeps nothing, and says so.

The accumulation is then made into the walk it means and put through `InductiveBounds` unchanged,
and the candidates propose the seed joined with each of the things the step is handed.

## What changes for a model

| written | before | after |
|---|---|---|
| `List.sum(List.map(x -> x.value, xs))` | E2011 | read |
| `List.fold((acc, x) -> acc + x, 0, List.map(x -> x.value, xs))` | E2011 | read |
| `List.fold((acc, x) -> acc + x, 0, List.reverse([1, 2, 3]))` | E2011 | read |
| `List.product` / its fold, elements at or above nought | E2011 | read |
| `List.sum(ns)`, elements nothing bounds | E2011 | E2011 |

## Not here

The empty container answering its seed is a fact about how many elements there are and not about
what any of them is, and it stays out: putting it here would widen this reading from "what holds of
every element" to "what can be concluded from the whole container". A richer reading of `InsideClosureResult` — what a `List.filterMap` answers, where an element is
inside what the closure answered rather than the answer itself — and gathering the constraints the
compiler imposes but no declaration states, are the same kind of separate. The transfer reads the
lineage rather than the four words now, so `Set.map` and `Map.updateIfPresent` are read where the
word `COLLAPSES` alone would have kept nothing.

`mvn -o test` is green across the reactor.
