### PR TITLE
Adequacy resource budgets are compilation inputs, and exhaustion is observable (#1005)

### DIFF
--- a/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
+++ b/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
@@ -59,7 +59,7 @@ class AMeasureIsIntroducedInOnePlaceTest {
      */
     private static final Map<String, Integer> INTRODUCED_BY = new LinkedHashMap<>(
             Map.ofEntries(
-            Map.entry("souther.compiler.query.Coverages#pairsOf(Ljava/lang/String;Ljava/util/List;Lsouther/compiler/query/Coverages$Readings;Z)Lsouther/compiler/query/PartitionEvidence$PairSpace;", 2),
+            Map.entry("souther.compiler.query.Coverages#pairsOf(Ljava/lang/String;Ljava/util/List;Lsouther/compiler/query/Coverages$Readings;ZLsouther/compiler/partition/AdequacyPolicy$OfTheMeasures;)Lsouther/compiler/query/PartitionEvidence$PairSpace;", 2),
             Map.entry("souther.compiler.query.Coverages#coverageOf(Lsouther/compiler/partition/Axis;Lsouther/compiler/query/Coverages$Readings;Z)Lsouther/compiler/query/PartitionEvidence$AxisCoverage;", 2),
             Map.entry("souther.compiler.query.Coverages#verdictOf(Lsouther/compiler/query/Coverages$Met;ZLsouther/compiler/partition/Border;Lsouther/compiler/query/Adequacy$Observed;)Lsouther/compiler/query/Measurement;", 3),
             Map.entry("souther.compiler.query.Coverages#whyNoGuardLine(Lsouther/compiler/query/Adequacy$Observed;Lsouther/compiler/query/Adequacy$Level;)Lsouther/compiler/query/Measurement;", 2),

--- a/souther-compiler/src/main/java/souther/compiler/partition/AdequacyPolicy.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AdequacyPolicy.java
@@ -58,11 +58,20 @@ public record AdequacyPolicy(OfTheMeasures measures, OfTheGeneration generation)
      *                     something a person reads and pastes, and what the search did not reach is
      *                     written down rather than left absent
      * @param cellsPerGroup how many ways of choosing an outcome from each factor a group may have
-     *                     and still be offered. It bounds the walk over a group's choices, which
-     *                     goes on past the ones already answered and the ones nothing could be
-     *                     built for — and a group whose choices run to the billions would have that
-     *                     walk stand between the author and every other group. A group past it is
-     *                     named as one nothing was offered for
+     *                     and still be offered, which it may have exactly. It bounds the walk over a
+     *                     group's choices, which goes on past the ones already answered and the ones
+     *                     nothing could be built for — and a group whose choices run to the billions
+     *                     would have that walk stand between the author and every other group. A
+     *                     group past it is named as one nothing was offered for.
+     *
+     *                     <p>A capacity, like the two beside it: a pair space of {@code n} is walked
+     *                     at {@code n} and a generation of {@code n} rows writes the {@code n}th.
+     *                     This was an exclusive cutoff while it was a private constant, where
+     *                     nothing had to say which it was; as a component with a name it is one or
+     *                     the other, and a policy whose three numbers do not mean the same thing is
+     *                     a policy a caller has to read the implementation of. At one, the smallest
+     *                     group there is — a single choice — is offered, which is what a limit of
+     *                     one should admit
      */
     public record OfTheGeneration(int rows, int cellsPerGroup) {
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/AdequacyPolicy.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AdequacyPolicy.java
@@ -1,0 +1,82 @@
+package souther.compiler.partition;
+
+/**
+ * What measuring one behavior and composing rows for it may spend.
+ *
+ * <p>Three numbers that were three private constants in three classes, none of them reachable from
+ * a caller — which is the absence issue #969 opened on, and it was never only about the one limit
+ * that issue removed. A limit is an input the query graph hands to the analysis (rule 4 of this
+ * package's documentation), the way {@link souther.compiler.check.ReadingPolicy} and
+ * {@link souther.compiler.examples.EvaluationPolicy} already are.
+ *
+ * <p><b>Grouped by which result each weakens, and not by being numbers.</b> A budget is only ever
+ * read beside the answer it makes partial, and the two halves here are not interchangeable: the
+ * pair space exhausting leaves a <em>measurement</em> partial and is reported as
+ * {@code Weakening.PairSpaceTruncated}, while the row limit and the cell limit leave a
+ * <em>generation</em> incomplete and are reported as {@link GenerationReason}s. Held as three
+ * {@code int}s side by side, a caller raising one to fix a partial measurement would as readily
+ * raise one that cannot change it.
+ *
+ * <p><b>Owned by the compilation and not made here.</b> Nothing that measures a behavior decides
+ * what it may be measured with: a policy made where it is needed is one that can differ between two
+ * measurements of the same behavior, and the two would report different coverage of one model while
+ * each stayed sound. So this arrives from the query graph and the analysis takes it.
+ */
+public record AdequacyPolicy(OfTheMeasures measures, OfTheGeneration generation) {
+
+    public AdequacyPolicy {
+        java.util.Objects.requireNonNull(measures, "a compilation measures under some budget");
+        java.util.Objects.requireNonNull(generation, "a compilation composes under some budget");
+    }
+
+    /**
+     * What a measure of one behavior may walk.
+     *
+     * @param pairSpace how many two-class combinations across the behavior's positions are counted
+     *                  off the rows. The space grows with the positions and their cardinalities
+     *                  together, so what bounds it is the space itself and never a count of
+     *                  positions (rules 1 and 2). Past it the measure is partial and says so
+     */
+    public record OfTheMeasures(int pairSpace) {
+
+        public OfTheMeasures {
+            // A guardrail is a positive number a count is compared against. Refused here rather
+            // than left to whoever writes it: a bound that admits nothing measures nothing, and a
+            // bound of nought would report every behavior as partial over a space it never walked.
+            if (pairSpace < 1) {
+                throw new IllegalArgumentException(
+                        "a pair space holds at least one combination, so a limit below one bounds"
+                                + " nothing: " + pairSpace);
+            }
+        }
+    }
+
+    /**
+     * What composing rows for one behavior may spend.
+     *
+     * @param rows         how many rows one call will write. Past this the output stops being
+     *                     something a person reads and pastes, and what the search did not reach is
+     *                     written down rather than left absent
+     * @param cellsPerGroup how many ways of choosing an outcome from each factor a group may have
+     *                     and still be offered. It bounds the walk over a group's choices, which
+     *                     goes on past the ones already answered and the ones nothing could be
+     *                     built for — and a group whose choices run to the billions would have that
+     *                     walk stand between the author and every other group. A group past it is
+     *                     named as one nothing was offered for
+     */
+    public record OfTheGeneration(int rows, int cellsPerGroup) {
+
+        public OfTheGeneration {
+            if (rows < 1) {
+                throw new IllegalArgumentException(
+                        "a generation writes at least one row, so a limit below one bounds nothing: "
+                                + rows);
+            }
+            if (cellsPerGroup < 1) {
+                throw new IllegalArgumentException(
+                        "a group has at least one choice, so a limit below one bounds nothing: "
+                                + cellsPerGroup);
+            }
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/GenerationReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GenerationReason.java
@@ -72,12 +72,13 @@ public sealed interface GenerationReason {
      * at all, and no number of rows reaches it. A reader acting on the first would raise a limit
      * that changes nothing here.
      *
-     * <p>And only the ones that were carrying an arm this generation was asked for. What a run owes
-     * is the classes and the arms a caller names; walking a group is how a row for an arm is looked
-     * for, not something anybody is owed. So a group claiming nothing on the list cost the run
-     * nothing, and a line about it would say rows were due where none were.
+     * <p>And only the ones an arm was left waiting on. What a run owes is the classes and the arms
+     * a caller names; walking a group is how a row for an arm is looked for, not something anybody
+     * is owed. So a group claiming nothing this run was asked for cost it nothing — and neither did
+     * one whose arms another group reached, or whose arms the row budget stopped at first, since
+     * those arms have an entry of their own saying what happened to them.
      *
-     * @param groups how many were held back <em>and</em> claimed an arm this run was owed, which is
+     * @param groups how many were held back with an arm still waiting on them at the end, which is
      *               the group's own count and not a count of the combinations in them — the whole
      *               of what this says is that the walk was never made, so how many cells it would
      *               have had is not something anything counted

--- a/souther-compiler/src/main/java/souther/compiler/partition/GenerationReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GenerationReason.java
@@ -72,9 +72,15 @@ public sealed interface GenerationReason {
      * at all, and no number of rows reaches it. A reader acting on the first would raise a limit
      * that changes nothing here.
      *
-     * @param groups how many were held back, which is the group's own count and not a count of the
-     *               combinations in them — the whole of what this says is that the walk was never
-     *               made, so how many cells it would have had is not something anything counted
+     * <p>And only the ones that were carrying an arm this generation was asked for. What a run owes
+     * is the classes and the arms a caller names; walking a group is how a row for an arm is looked
+     * for, not something anybody is owed. So a group claiming nothing on the list cost the run
+     * nothing, and a line about it would say rows were due where none were.
+     *
+     * @param groups how many were held back <em>and</em> claimed an arm this run was owed, which is
+     *               the group's own count and not a count of the combinations in them — the whole
+     *               of what this says is that the walk was never made, so how many cells it would
+     *               have had is not something anything counted
      */
     record GroupsNotOffered(String behavior, int groups) implements GenerationReason {}
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/GenerationReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GenerationReason.java
@@ -64,6 +64,21 @@ public sealed interface GenerationReason {
     record SearchLimit(String behavior, int owed) implements GenerationReason {}
 
     /**
+     * Groups of the body's decisions this did not offer any combination of, because each was wider
+     * than the walk offers.
+     *
+     * <p>Beside {@link SearchLimit} rather than folded into it. That one is a budget that ran out
+     * part way through a plan and is lifted by allowing more rows; this is a group nothing walked
+     * at all, and no number of rows reaches it. A reader acting on the first would raise a limit
+     * that changes nothing here.
+     *
+     * @param groups how many were held back, which is the group's own count and not a count of the
+     *               combinations in them — the whole of what this says is that the walk was never
+     *               made, so how many cells it would have had is not something anything counted
+     */
+    record GroupsNotOffered(String behavior, int groups) implements GenerationReason {}
+
+    /**
      * The module's classes were not there to put a candidate through.
      *
      * <p>Which is not the classes refusing to link — that is {@link LinkageFailed}, and it is what

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -977,8 +977,19 @@ public final class Generator {
         // the offer never opened, and raising the budget does not reach it.
         InteractionCells.Offered offered = InteractionCells.of(groups, axes, budget);
         Set<Integer> notOffered = new LinkedHashSet<>();
+        // And which of the groups held back were carrying an arm this run was asked for. A group
+        // claiming nothing on the list cost this generation nothing: what was owed was the arms and
+        // the classes, and walking a group is how a row for an arm is looked for rather than
+        // something anybody is owed. Counted off the obligation for the reason the search limit
+        // below is — a number counted off the search space instead tells a reader to raise a limit
+        // that would change nothing.
+        int heldBackAndOwed = 0;
         for (InteractionCells.NotOffered held : offered.notOffered()) {
-            notOffered.addAll(armsIn(held.claims()));
+            List<Integer> behindIt = armsIn(held.claims());
+            notOffered.addAll(behindIt);
+            if (behindIt.stream().anyMatch(armsOwed::contains)) {
+                heldBackAndOwed++;
+            }
         }
         boolean unconfirmed = false;
         for (InteractionCells.Group group : offered.groups()) {
@@ -1061,13 +1072,20 @@ public final class Generator {
             reasons.add(new GenerationReason.SearchLimit(axes.get(0).id().behavior(),
                     classesLeft + cutOff.size()));
         }
-        // Said whether or not any arm on the list was behind one of them. A group held back is work
-        // this generation did not do, and a reader is owed that whether the arms it claimed were
-        // reached another way or were never asked for — the count is of the groups, since the
-        // combinations in them are what nothing walked.
-        if (!offered.notOffered().isEmpty()) {
+        // And the groups the limit held back that were carrying one of them. Not every group it
+        // held back: a run asked for nothing behind a group lost nothing by not walking it, and a
+        // line saying no rows were offered there says rows were due where none were. Which is also
+        // what keeps this in step with the entries above — an arm gets its
+        // `THE_GROUP_WAS_NOT_OFFERED` only where it was owed, so a summary counting more than those
+        // is a number with no entry under it.
+        //
+        // Asked of the arms the group may claim, which is a superset
+        // ({@link #everyArmACombinationMayTake}). A group named for an arm no combination of it
+        // actually reaches is the safe direction: the other one drops the news that a walk was not
+        // made, over an arm the report is about to call unreached.
+        if (heldBackAndOwed > 0) {
             reasons.add(new GenerationReason.GroupsNotOffered(axes.get(0).id().behavior(),
-                    offered.notOffered().size()));
+                    heldBackAndOwed));
         }
         if (unconfirmed) {
             reasons.add(new GenerationReason.RowsNotConfirmed(axes.get(0).id().behavior()));

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -325,6 +325,21 @@ public final class Generator {
              */
             THE_POSITION_WAS_WITHHELD,
             /**
+             * The group of decisions this belongs to was wider than the walk offers, so no
+             * combination of it was looked in.
+             *
+             * <p>Told apart from {@link #SEARCH_LIMIT} for the reason {@link
+             * #THE_POSITION_WAS_WITHHELD} is: that one says the budget ran out while walking, and
+             * this says the walk never started. Raising the row budget changes the first and not
+             * the second.
+             *
+             * <p>Named at all because the alternative is silence. An arm claimed only by a group
+             * held back leaves no entry, and an arm with no entry is one no combination claims —
+             * so the report said the body never reaches it, which is a statement about the model
+             * this compiler was not entitled to make.
+             */
+            THE_GROUP_WAS_NOT_OFFERED,
+            /**
              * The rows were not read, so nothing was searched for at all.
              *
              * <p>What made them unreadable is said in its own words beside this, and is a fact
@@ -378,7 +393,7 @@ public final class Generator {
                     // model saying anything: another value of the same classes may well build.
                     case NOTHING_COMPOSES_ONE, ALL_CANDIDATES_REJECTED, SEARCH_LIMIT,
                          NOTHING_TO_BUILD_AGAINST, NO_VALUES_WERE_ASKED_FOR, LINKAGE_FAILED,
-                         NO_CERTIFIED_WITNESS,
+                         NO_CERTIFIED_WITNESS, THE_GROUP_WAS_NOT_OFFERED,
                          THE_POSITION_WAS_WITHHELD, THE_ROWS_WERE_NOT_READ,
                          NO_REASON_RECORDED -> false;
                 };
@@ -777,13 +792,21 @@ public final class Generator {
     public static Set<Integer> everyArmTheCombinationsTake(
             Subject subject, List<souther.compiler.interaction.Interaction> groups) {
         Set<Integer> out = new LinkedHashSet<>();
-        for (InteractionCells.Group group : InteractionCells.of(groups, ordered(subject))) {
+        InteractionCells.Offered offered = InteractionCells.of(groups, ordered(subject));
+        for (InteractionCells.Group group : offered.groups()) {
             for (int index = 0; index < group.size(); index++) {
                 CellSelection selection = group.at(index);
                 if (selection != null) {
                     out.addAll(claimed(selection));
                 }
             }
+        }
+        // And the arms behind a group the limit held back. They are arms the combinations take —
+        // what the limit settled is that nothing walked them, which is the search's answer and not
+        // a fact about which arms exist. Left out, a caller with no measurement beside it asks for
+        // fewer arms because this compiler declined to look, and never learns that it did.
+        for (InteractionCells.NotOffered held : offered.notOffered()) {
+            out.addAll(armsIn(held.claims()));
         }
         return out;
     }
@@ -936,8 +959,16 @@ public final class Generator {
         // are one silence, and a reader told the second where the first happened is told the model
         // settles something it does not.
         Set<Integer> cutOff = new LinkedHashSet<>();
+        // And the arms behind a group nothing walked, which is a second silence with a different
+        // cause. The one above is a budget that ran out with the arm still owed; this is a group
+        // the offer never opened, and raising the budget does not reach it.
+        InteractionCells.Offered offered = InteractionCells.of(groups, axes);
+        Set<Integer> notOffered = new LinkedHashSet<>();
+        for (InteractionCells.NotOffered held : offered.notOffered()) {
+            notOffered.addAll(armsIn(held.claims()));
+        }
         boolean unconfirmed = false;
-        for (InteractionCells.Group group : InteractionCells.of(groups, axes)) {
+        for (InteractionCells.Group group : offered.groups()) {
             for (int index = 0; index < group.size() && !left.isEmpty(); index++) {
                 CellSelection selection = group.at(index);
                 if (selection == null) {
@@ -993,10 +1024,18 @@ public final class Generator {
                 why.add(new UnresolvedCombination(List.of(),
                         UnresolvedCombination.Reason.SEARCH_LIMIT));
                 arms.add(new ArmAttempt.Unresolved(probe, why));
+            } else if (notOffered.contains(probe)) {
+                // Asked after the two above, so an arm some offered group reached or the budget
+                // stopped at keeps that answer. What is left here is an arm whose only claim came
+                // from a group nothing walked, and the union a held-back group is named by is a
+                // superset — which is why this is the last of the three and not the first.
+                why.add(new UnresolvedCombination(List.of(),
+                        UnresolvedCombination.Reason.THE_GROUP_WAS_NOT_OFFERED));
+                arms.add(new ArmAttempt.Unresolved(probe, why));
             } else if (!why.isEmpty()) {
                 arms.add(new ArmAttempt.Unresolved(probe, why));
             }
-            // And an arm with neither is one no combination claims, which is the one thing an
+            // And an arm with none of them is one no combination claims, which is the one thing an
             // absent entry may mean.
         }
         // Said once, at the end, and about both searches. One that ran out on the classes stopped
@@ -1008,6 +1047,14 @@ public final class Generator {
         if (classesLeft + cutOff.size() > 0) {
             reasons.add(new GenerationReason.SearchLimit(axes.get(0).id().behavior(),
                     classesLeft + cutOff.size()));
+        }
+        // Said whether or not any arm on the list was behind one of them. A group held back is work
+        // this generation did not do, and a reader is owed that whether the arms it claimed were
+        // reached another way or were never asked for — the count is of the groups, since the
+        // combinations in them are what nothing walked.
+        if (!offered.notOffered().isEmpty()) {
+            reasons.add(new GenerationReason.GroupsNotOffered(axes.get(0).id().behavior(),
+                    offered.notOffered().size()));
         }
         if (unconfirmed) {
             reasons.add(new GenerationReason.RowsNotConfirmed(axes.get(0).id().behavior()));
@@ -1023,8 +1070,14 @@ public final class Generator {
      * nothing about an arm is owed for it.
      */
     private static List<Integer> claimed(CellSelection selection) {
+        return armsIn(selection.claims());
+    }
+
+    /** The arms a list of claims names, by the numbers the plan gave them. Shared with the groups
+     *  the limit held back, which have claims and no cell to read them off. */
+    private static List<Integer> armsIn(List<souther.compiler.coverage.ControlClaim> claims) {
         List<Integer> out = new ArrayList<>();
-        for (souther.compiler.coverage.ControlClaim claim : selection.claims()) {
+        for (souther.compiler.coverage.ControlClaim claim : claims) {
             if (claim.at() instanceof souther.compiler.coverage.ControlPointId.ArmOccurrence arm
                     && arm.probe().isPresent()) {
                 out.add(arm.probe().getAsInt());

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -972,24 +972,23 @@ public final class Generator {
         // are one silence, and a reader told the second where the first happened is told the model
         // settles something it does not.
         Set<Integer> cutOff = new LinkedHashSet<>();
+        // The arms this run ended up answering with a group nobody walked, collected as those
+        // answers are made rather than worked out again afterwards. What decides one is the order
+        // the three answers are asked in below; a set built here from `left`, `cutOff` and
+        // `notOffered` would be that order written a second time, free to stop agreeing with it.
+        Set<Integer> wentUnwalked = new LinkedHashSet<>();
         // And the arms behind a group nothing walked, which is a second silence with a different
         // cause. The one above is a budget that ran out with the arm still owed; this is a group
         // the offer never opened, and raising the budget does not reach it.
         InteractionCells.Offered offered = InteractionCells.of(groups, axes, budget);
         Set<Integer> notOffered = new LinkedHashSet<>();
-        // And which of the groups held back were carrying an arm this run was asked for. A group
-        // claiming nothing on the list cost this generation nothing: what was owed was the arms and
-        // the classes, and walking a group is how a row for an arm is looked for rather than
-        // something anybody is owed. Counted off the obligation for the reason the search limit
-        // below is — a number counted off the search space instead tells a reader to raise a limit
-        // that would change nothing.
-        int heldBackAndOwed = 0;
+        // Which arms each held-back group could have been searched at, kept per group so that the
+        // summary at the end can be counted off the entries rather than worked out a second way.
+        List<List<Integer>> behindEachHeldGroup = new ArrayList<>();
         for (InteractionCells.NotOffered held : offered.notOffered()) {
             List<Integer> behindIt = armsIn(held.claims());
+            behindEachHeldGroup.add(behindIt);
             notOffered.addAll(behindIt);
-            if (behindIt.stream().anyMatch(armsOwed::contains)) {
-                heldBackAndOwed++;
-            }
         }
         boolean unconfirmed = false;
         for (InteractionCells.Group group : offered.groups()) {
@@ -1056,6 +1055,7 @@ public final class Generator {
                 why.add(new UnresolvedCombination(List.of(),
                         UnresolvedCombination.Reason.THE_GROUP_WAS_NOT_OFFERED));
                 arms.add(new ArmAttempt.Unresolved(probe, why));
+                wentUnwalked.add(probe);
             } else if (!why.isEmpty()) {
                 arms.add(new ArmAttempt.Unresolved(probe, why));
             }
@@ -1072,20 +1072,27 @@ public final class Generator {
             reasons.add(new GenerationReason.SearchLimit(axes.get(0).id().behavior(),
                     classesLeft + cutOff.size()));
         }
-        // And the groups the limit held back that were carrying one of them. Not every group it
-        // held back: a run asked for nothing behind a group lost nothing by not walking it, and a
-        // line saying no rows were offered there says rows were due where none were. Which is also
-        // what keeps this in step with the entries above — an arm gets its
-        // `THE_GROUP_WAS_NOT_OFFERED` only where it was owed, so a summary counting more than those
-        // is a number with no entry under it.
+        // And the groups the limit held back that an arm was left waiting on. Counted off the
+        // entries just made and not off the obligation this run started with, because the two are
+        // different sets: an arm owed at the start may have been built from another group that was
+        // offered, or stopped at by the row budget, and either way the entry for it says so and the
+        // group is not what it is waiting on. `NotOffered`'s own contract is that what it names is
+        // read for "what is left owed after every offered group has been searched", which is
+        // available here and nowhere earlier.
         //
-        // Asked of the arms the group may claim, which is a superset
-        // ({@link #everyArmACombinationMayTake}). A group named for an arm no combination of it
-        // actually reaches is the safe direction: the other one drops the news that a walk was not
-        // made, over an arm the report is about to call unreached.
-        if (heldBackAndOwed > 0) {
+        // Read off `wentUnwalked` rather than rebuilt from `left`, `cutOff` and `notOffered`. Those
+        // three would be the order the answers are asked in, written a second time beside the one
+        // that decides — and a summary that disagrees with the entries under it is worse than no
+        // summary, since a reader checks the number against them.
+        int heldBackAndWaitedOn = 0;
+        for (List<Integer> behindIt : behindEachHeldGroup) {
+            if (behindIt.stream().anyMatch(wentUnwalked::contains)) {
+                heldBackAndWaitedOn++;
+            }
+        }
+        if (heldBackAndWaitedOn > 0) {
             reasons.add(new GenerationReason.GroupsNotOffered(axes.get(0).id().behavior(),
-                    heldBackAndOwed));
+                    heldBackAndWaitedOn));
         }
         if (unconfirmed) {
             reasons.add(new GenerationReason.RowsNotConfirmed(axes.get(0).id().behavior()));

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -776,18 +776,31 @@ public final class Generator {
                                         Trial trial, AdequacyPolicy.OfTheGeneration budget) {
         return fill(subject, existing, check, groups, trial, List.of(),
                 everyClassNoRowSitsIn(subject, existing),
-                everyArmTheCombinationsTake(subject, groups, budget), budget);
+                everyArmACombinationMayTake(subject, groups, budget), budget);
     }
 
     /**
-     * Every arm the body's combinations take.
+     * Every arm a combination of the body may take, which is at least every arm one does take.
      *
      * <p><b>Not what a build asks for.</b> Which arms are owed a row is what measuring them
      * established, and a build hands that in. This is for a caller with no measurement beside it —
      * a test standing the search up on its own — and it says so by being a list the caller passes
      * rather than one the search makes for itself.
+     *
+     * <p><b>And <em>may</em> rather than <em>does</em>, which the name carries because the answer
+     * cannot.</b> An offered group is walked, so what it contributes is exact: a choice whose
+     * factors leave a position nothing is not a combination and is not counted. A group the budget
+     * held back is not walked, and what it contributes is the union over the way in and every
+     * outcome of every factor — which includes arms no single combination of it claims, since two
+     * factors that disagree about a position have choices no row sits in.
+     *
+     * <p>That direction is the safe one and the other is not. An arm left out is an arm nothing
+     * asks for, and an arm nothing asks for is reported as one no combination claims — which says
+     * the body settles something it does not. An arm asked for and not found is answered
+     * {@link UnresolvedCombination.Reason#THE_GROUP_WAS_NOT_OFFERED}, which is true of it however
+     * many combinations of the held-back group would have claimed it.
      */
-    public static Set<Integer> everyArmTheCombinationsTake(
+    public static Set<Integer> everyArmACombinationMayTake(
             Subject subject, List<souther.compiler.interaction.Interaction> groups,
             AdequacyPolicy.OfTheGeneration budget) {
         Set<Integer> out = new LinkedHashSet<>();

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -50,10 +50,6 @@ import java.util.Set;
  */
 public final class Generator {
 
-    /** How many rows one call will write. Past this the output stops being something a person reads
-     * and pastes, and a model that wants more than this has axes it should be measured at fewer of. */
-    static final int MAX_ROWS = 200;
-
     /** How many assignments of values one parameter is tried at in one pass. The choices multiply, so
      * this is a bound on the search and not on any one position — and reaching it is reported as the
      * search having stopped, which is a different thing from every assignment having been refused. A
@@ -742,8 +738,9 @@ public final class Generator {
      * rows twice. Nothing is asked about the body here, so no arm is looked for.
      */
     public static GenerationResult fill(Subject subject, List<ObservedRow> existing,
-                                        CandidateCheck check) {
-        return fill(subject, existing, check, List.of());
+                                        CandidateCheck check,
+                                        AdequacyPolicy.OfTheGeneration budget) {
+        return fill(subject, existing, check, List.of(), budget);
     }
 
     /**
@@ -757,8 +754,9 @@ public final class Generator {
      */
     public static GenerationResult fill(Subject subject, List<ObservedRow> existing,
                                         CandidateCheck check,
-                                        List<souther.compiler.interaction.Interaction> groups) {
-        return fill(subject, existing, check, groups, Trial.NOTHING_RUNS);
+                                        List<souther.compiler.interaction.Interaction> groups,
+                                        AdequacyPolicy.OfTheGeneration budget) {
+        return fill(subject, existing, check, groups, Trial.NOTHING_RUNS, budget);
     }
 
     /**
@@ -775,10 +773,10 @@ public final class Generator {
     public static GenerationResult fill(Subject subject, List<ObservedRow> existing,
                                         CandidateCheck check,
                                         List<souther.compiler.interaction.Interaction> groups,
-                                        Trial trial) {
+                                        Trial trial, AdequacyPolicy.OfTheGeneration budget) {
         return fill(subject, existing, check, groups, trial, List.of(),
                 everyClassNoRowSitsIn(subject, existing),
-                everyArmTheCombinationsTake(subject, groups));
+                everyArmTheCombinationsTake(subject, groups, budget), budget);
     }
 
     /**
@@ -790,9 +788,10 @@ public final class Generator {
      * rather than one the search makes for itself.
      */
     public static Set<Integer> everyArmTheCombinationsTake(
-            Subject subject, List<souther.compiler.interaction.Interaction> groups) {
+            Subject subject, List<souther.compiler.interaction.Interaction> groups,
+            AdequacyPolicy.OfTheGeneration budget) {
         Set<Integer> out = new LinkedHashSet<>();
-        InteractionCells.Offered offered = InteractionCells.of(groups, ordered(subject));
+        InteractionCells.Offered offered = InteractionCells.of(groups, ordered(subject), budget);
         for (InteractionCells.Group group : offered.groups()) {
             for (int index = 0; index < group.size(); index++) {
                 CellSelection selection = group.at(index);
@@ -864,7 +863,8 @@ public final class Generator {
                                         List<souther.compiler.interaction.Interaction> groups,
                                         Trial trial, List<Baseline> baselines,
                                         Set<ClassOwed> classesOwed,
-                                        Set<Integer> armsOwed) {
+                                        Set<Integer> armsOwed,
+                                        AdequacyPolicy.OfTheGeneration budget) {
         List<Axis> ordered = ordered(subject);
         // A position where some row's value could not be read is a position nothing is known about.
         // A row generated for a class there may be a row that is already written, and telling an
@@ -924,7 +924,7 @@ public final class Generator {
         int classesLeft = 0;
         for (int i = 0; i < owed.size(); i++) {
             int[] at = owed.get(i);
-            if (rows.size() >= MAX_ROWS) {
+            if (rows.size() >= budget.rows()) {
                 classesLeft = owed.size() - i;
                 for (int cut = i; cut < owed.size(); cut++) {
                     Axis axis = axes.get(owed.get(cut)[0]);
@@ -962,7 +962,7 @@ public final class Generator {
         // And the arms behind a group nothing walked, which is a second silence with a different
         // cause. The one above is a budget that ran out with the arm still owed; this is a group
         // the offer never opened, and raising the budget does not reach it.
-        InteractionCells.Offered offered = InteractionCells.of(groups, axes);
+        InteractionCells.Offered offered = InteractionCells.of(groups, axes, budget);
         Set<Integer> notOffered = new LinkedHashSet<>();
         for (InteractionCells.NotOffered held : offered.notOffered()) {
             notOffered.addAll(armsIn(held.claims()));
@@ -981,7 +981,7 @@ public final class Generator {
                 if (takes.isEmpty()) {
                     continue;   // no arm on the list is looked for here
                 }
-                if (rows.size() >= MAX_ROWS) {
+                if (rows.size() >= budget.rows()) {
                     cutOff.addAll(takes);
                     continue;
                 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
@@ -132,12 +132,10 @@ public final class InteractionCells {
      * a combination a written row already sits in costs no row, so a caller that stopped enumerating
      * at the budget would leave the ones past that point untried while the budget still held.
      *
-     * @param reach     what the path to the meeting leaves open, which every combination is under
-     * @param byFactor  what each outcome of each factor leaves open, one list per factor
-     * @param mostCells what the walk over the choices is held to, carried here because {@link #size}
-     *                  is asked of the group after the compilation that set it is out of reach
+     * @param reach    what the path to the meeting leaves open, which every combination is under
+     * @param byFactor what each outcome of each factor leaves open, one list per factor
      */
-    public record Group(Placed reach, List<List<Placed>> byFactor, int mostCells) {
+    public record Group(Placed reach, List<List<Placed>> byFactor) {
 
         public Group {
             byFactor = List.copyOf(byFactor);
@@ -149,16 +147,18 @@ public final class InteractionCells {
          * <p>Not how many combinations the group has: two factors reading one position have choices
          * that leave it nothing, and no row is written at those. This is the space the choices are
          * counted off, and {@link #at} says which of them are cells.
+         *
+         * <p>The product itself, with nothing to saturate at. A group exists only where {@link #of}
+         * found the product within what the compilation allows, so the number fits an {@code int}
+         * by having been checked before this was built — and a limit carried in here to be reached
+         * would be the budget living on in a value the budget already admitted.
          */
         public int size() {
-            long size = 1;
+            int size = 1;
             for (List<Placed> factor : byFactor) {
                 size *= factor.size();
-                if (size >= mostCells) {
-                    return mostCells;
-                }
             }
-            return (int) size;
+            return size;
         }
 
         /**
@@ -250,11 +250,11 @@ public final class InteractionCells {
             // Past the limit, and said so rather than dropped. What this costs is the combinations
             // of one group going untried; what saying nothing cost is an arm among them reading as
             // one the body never reaches.
-            if (productOf(placed, budget.cellsPerGroup()) >= budget.cellsPerGroup()) {
+            if (productOf(placed, budget.cellsPerGroup()) > budget.cellsPerGroup()) {
                 held.add(new NotOffered(claimsOf(reach, placed)));
                 continue;
             }
-            Group built = new Group(reach, placed, budget.cellsPerGroup());
+            Group built = new Group(reach, placed);
             if (built.left(0) > 0) {
                 out.add(built);
             }
@@ -276,13 +276,20 @@ public final class InteractionCells {
         return List.copyOf(out);
     }
 
-    /** How far the product runs, stopping where it is past anything that would be offered. */
+    /**
+     * How far the product runs, stopping once it is past anything that would be offered.
+     *
+     * <p>Stopped rather than run to the end, because a body of enough factors multiplies past what a
+     * {@code long} holds and the answer this is asked for is only whether the limit was passed. One
+     * over the limit is as good an answer as the true product for that, and is the largest number
+     * this ever returns.
+     */
     private static long productOf(List<List<Placed>> placed, int mostCells) {
         long size = 1;
         for (List<Placed> factor : placed) {
             size *= factor.size();
-            if (size >= mostCells) {
-                return mostCells;
+            if (size > mostCells) {
+                return mostCells + 1L;
             }
         }
         return size;

--- a/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
@@ -207,21 +207,79 @@ public final class InteractionCells {
         }
     }
 
-    /** The groups worth offering, over the ordered {@code axes}. */
-    public static List<Group> of(List<Interaction> groups, List<Axis> axes) {
+    /**
+     * A group the limit kept from being offered, and what a run that took it would have been seen
+     * to do.
+     *
+     * <p>The claims and not the cells. Which combinations the group has is the product this declined
+     * to walk; which control points any of them could claim is the union over the way in and every
+     * outcome of every factor, which is one pass over what {@link #factorsOf} already built. So the
+     * arms behind the limit can be named without doing the work the limit exists to refuse.
+     *
+     * <p>A union and so a superset: no single combination claims all of these, and one of them may
+     * be claimed by another group that was offered. A caller reads it for what is left owed after
+     * every offered group has been searched, which is where the difference stops mattering.
+     */
+    public record NotOffered(List<souther.compiler.coverage.ControlClaim> claims) {
+
+        public NotOffered {
+            claims = List.copyOf(claims);
+        }
+    }
+
+    /**
+     * The groups to offer, and the ones the limit kept back.
+     *
+     * <p>Two answers because they are two facts and the second used to be neither returned nor
+     * recorded. A group dropped for its width claims arms, and an arm nothing offered a combination
+     * for is reported as an arm no combination claims — which says the body settles something it
+     * does not.
+     */
+    public record Offered(List<Group> groups, List<NotOffered> notOffered) {
+
+        public Offered {
+            groups = List.copyOf(groups);
+            notOffered = List.copyOf(notOffered);
+        }
+    }
+
+    /** The groups worth offering, over the ordered {@code axes}, and the ones held back. */
+    public static Offered of(List<Interaction> groups, List<Axis> axes) {
         List<Group> out = new ArrayList<>();
+        List<NotOffered> held = new ArrayList<>();
         for (Interaction group : groups) {
             Placed reach = placedBy(group.reach(), axes);
             if (reach == null) {
                 continue;
             }
             List<List<Placed>> placed = factorsOf(group, axes);
-            if (placed == null || productOf(placed) >= MOST_CELLS) {
+            if (placed == null) {
+                continue;
+            }
+            // Past the limit, and said so rather than dropped. What this costs is the combinations
+            // of one group going untried; what saying nothing cost is an arm among them reading as
+            // one the body never reaches.
+            if (productOf(placed) >= MOST_CELLS) {
+                held.add(new NotOffered(claimsOf(reach, placed)));
                 continue;
             }
             Group built = new Group(reach, placed);
             if (built.left(0) > 0) {
                 out.add(built);
+            }
+        }
+        return new Offered(out, held);
+    }
+
+    /** Every control point any combination of this group could claim, which is the union over the
+     *  way in and every outcome of every factor. One pass, and never the product. */
+    private static List<souther.compiler.coverage.ControlClaim> claimsOf(
+            Placed reach, List<List<Placed>> byFactor) {
+        java.util.LinkedHashSet<souther.compiler.coverage.ControlClaim> out =
+                new java.util.LinkedHashSet<>(reach.claims());
+        for (List<Placed> factor : byFactor) {
+            for (Placed outcome : factor) {
+                out.addAll(outcome.claims());
             }
         }
         return List.copyOf(out);

--- a/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/InteractionCells.java
@@ -38,18 +38,6 @@ import java.util.List;
  */
 public final class InteractionCells {
 
-    /**
-     * How many ways of choosing an outcome from each factor a group may have and still be offered.
-     *
-     * <p>A group is taken from while there is budget for a row and no further, so what this bounds
-     * is not how many rows come out of it. It bounds the walk over its choices, which goes on past
-     * the ones already answered, the ones the factors disagree about and the ones nothing could be
-     * built for — and a group whose choices run to the billions would have that walk stand between
-     * the author and every other group. The number is the group's own and known before any of it is
-     * built.
-     */
-    private static final int MOST_CELLS = 4096;
-
     private InteractionCells() {}
 
     /**
@@ -144,10 +132,12 @@ public final class InteractionCells {
      * a combination a written row already sits in costs no row, so a caller that stopped enumerating
      * at the budget would leave the ones past that point untried while the budget still held.
      *
-     * @param reach    what the path to the meeting leaves open, which every combination is under
-     * @param byFactor what each outcome of each factor leaves open, one list per factor
+     * @param reach     what the path to the meeting leaves open, which every combination is under
+     * @param byFactor  what each outcome of each factor leaves open, one list per factor
+     * @param mostCells what the walk over the choices is held to, carried here because {@link #size}
+     *                  is asked of the group after the compilation that set it is out of reach
      */
-    public record Group(Placed reach, List<List<Placed>> byFactor) {
+    public record Group(Placed reach, List<List<Placed>> byFactor, int mostCells) {
 
         public Group {
             byFactor = List.copyOf(byFactor);
@@ -164,8 +154,8 @@ public final class InteractionCells {
             long size = 1;
             for (List<Placed> factor : byFactor) {
                 size *= factor.size();
-                if (size >= MOST_CELLS) {
-                    return MOST_CELLS;
+                if (size >= mostCells) {
+                    return mostCells;
                 }
             }
             return (int) size;
@@ -244,7 +234,8 @@ public final class InteractionCells {
     }
 
     /** The groups worth offering, over the ordered {@code axes}, and the ones held back. */
-    public static Offered of(List<Interaction> groups, List<Axis> axes) {
+    public static Offered of(List<Interaction> groups, List<Axis> axes,
+                             AdequacyPolicy.OfTheGeneration budget) {
         List<Group> out = new ArrayList<>();
         List<NotOffered> held = new ArrayList<>();
         for (Interaction group : groups) {
@@ -259,11 +250,11 @@ public final class InteractionCells {
             // Past the limit, and said so rather than dropped. What this costs is the combinations
             // of one group going untried; what saying nothing cost is an arm among them reading as
             // one the body never reaches.
-            if (productOf(placed) >= MOST_CELLS) {
+            if (productOf(placed, budget.cellsPerGroup()) >= budget.cellsPerGroup()) {
                 held.add(new NotOffered(claimsOf(reach, placed)));
                 continue;
             }
-            Group built = new Group(reach, placed);
+            Group built = new Group(reach, placed, budget.cellsPerGroup());
             if (built.left(0) > 0) {
                 out.add(built);
             }
@@ -286,12 +277,12 @@ public final class InteractionCells {
     }
 
     /** How far the product runs, stopping where it is past anything that would be offered. */
-    private static long productOf(List<List<Placed>> placed) {
+    private static long productOf(List<List<Placed>> placed, int mostCells) {
         long size = 1;
         for (List<Placed> factor : placed) {
             size *= factor.size();
-            if (size >= MOST_CELLS) {
-                return MOST_CELLS;
+            if (size >= mostCells) {
+                return mostCells;
             }
         }
         return size;

--- a/souther-compiler/src/main/java/souther/compiler/partition/package-info.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/package-info.java
@@ -13,9 +13,10 @@
  * expands to. Four rules govern all of them, decided in ADR-0113. They are stated here rather than
  * beside any one limit, because what they are about is where a limit may be put at all.
  *
- * <p><b>This is what the subsystem is held to, and not a claim that every limit in it conforms
- * today.</b> Axis discovery conforms since #969. The three limits named above meet rule 1 and rule
- * 2; where they do not yet meet rules 3 and 4 is written down and tracked in #1005.
+ * <p><b>This is what the subsystem is held to.</b> Axis discovery conforms since #969, and the
+ * three limits above conform since #1005: each is held where its own cost is incurred, each says
+ * what exhausting it left undone, and all three are read off {@link
+ * souther.compiler.partition.AdequacyPolicy}, which the compilation sets and hands to the analysis.
  *
  * <p><b>1. Semantic evidence is never pre-selected by a resource budget.</b> Every semantic subject
  * the reading reaches is offered to the readers that measure it. A reading may still fail to derive
@@ -45,7 +46,10 @@
  * <p><b>4. Resource policy belongs to the compilation.</b> A limit is an input the query graph hands
  * to the analysis, the way {@link souther.compiler.check.ReadingPolicy} and
  * {@link souther.compiler.examples.EvaluationPolicy} already are, rather than a private constant or
- * a system property read wherever the work happens.
+ * a system property read wherever the work happens. {@link
+ * souther.compiler.partition.AdequacyPolicy} is where the three are written, grouped by which
+ * result each weakens — a caller raising one to lift a partial measurement should not as readily
+ * raise one that cannot change it.
  *
  * <h2>What these were written from</h2>
  *

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -2072,7 +2072,14 @@ public final class Adequacy {
                     // About a search that happened, and said in their own words beside the rows.
                     // Answering with one of them here would be the same fact under a second
                     // spelling, over a class the search never got to.
+                    //
+                    // `GroupsNotOffered` is here for a different reason: it is not about classes at
+                    // all. A group of the body's decisions is where a row for an <em>arm</em> is
+                    // looked for, and the classes are walked in a loop that never consults one — so
+                    // a class with nothing recorded was not left that way by a group being held
+                    // back, and saying it was would be a cause this run has no evidence for.
                     case souther.compiler.partition.GenerationReason.SearchLimit _,
+                            souther.compiler.partition.GenerationReason.GroupsNotOffered _,
                             souther.compiler.partition.GenerationReason.RowsNotConfirmed _ -> { }
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -969,7 +969,8 @@ public final class Adequacy {
                                 souther.compiler.check.ElementBindings.NONE), plan, seen,
                         level, boundaries == null ? List.of()
                                 : boundaries.getOrDefault(spec.name(), List.of()),
-                        arrivalsOf(arrives, spec), statedOf(declared, spec)));
+                        arrivalsOf(arrives, spec), statedOf(declared, spec),
+                        db.ask(new Front.Adequacy()).value().measures()));
             }
             return Answer.of(Ordered.map(out));
         }
@@ -1875,7 +1876,8 @@ public final class Adequacy {
                             statedOf(declared, spec), runningRowsOf(trials, spec.name(), sig),
                             partitions == null ? PartitionEvidence.NONE
                                     : partitions.getOrDefault(spec.name(), PartitionEvidence.NONE),
-                            levelOf(db).runsInstrumentedRows());
+                            levelOf(db).runsInstrumentedRows(),
+                            db.ask(new Front.Adequacy()).value().generation());
                 } catch (LinkageError _) {
                     // The generated classes would not link, so nothing can be built to find out
                     // what a model admits. Saying so is not the same as saying the combinations are
@@ -2398,7 +2400,8 @@ public final class Adequacy {
                 FixtureReader.Construction building, InputDomain domain,
                 souther.compiler.check.PathReachability.Answers arrives,
                 souther.compiler.check.StatedContract stated, Generator.Trial trial,
-                PartitionEvidence evidence, boolean recording) {
+                PartitionEvidence evidence, boolean recording,
+                souther.compiler.partition.AdequacyPolicy.OfTheGeneration budget) {
             if (observed.someRowsUnseen()) {
                 // Rows exist that nothing read. What they cover is unknown, so what is left uncovered
                 // is unknown too — and a generated row is a specific piece of work handed to a person,
@@ -2442,7 +2445,7 @@ public final class Adequacy {
             }
             return Generator.fill(subject, existing, check,
                     souther.compiler.interaction.Interactions.of(body, plan, domain, symbols),
-                    trial, baselines, classesOwed(evidence), armsOwed);
+                    trial, baselines, classesOwed(evidence), armsOwed, budget);
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -53,6 +53,10 @@ public final class Compilation {
         // The one place a reading policy is made. Everything that reads a declaration is handed
         // this one, so a declaration read twice in one compilation is read the same way both times.
         db.set(new Front.Reading(), Front.Reading.STANDARD);
+        // And the one place an adequacy budget is made. Every measure of one behavior is handed
+        // this one, so a behavior measured twice in one compilation is measured under the same
+        // limits both times.
+        db.set(new Front.Adequacy(), Front.Adequacy.STANDARD);
     }
 
     /** A compile of several sources identified by their position, the way a build hands them over.
@@ -377,6 +381,18 @@ public final class Compilation {
      */
     Compilation withReadingPolicy(souther.compiler.check.ReadingPolicy policy) {
         db.set(new Front.Reading(), policy);
+        return this;
+    }
+
+    /**
+     * The same for what measuring a behavior and composing rows for it may spend.
+     *
+     * <p>Not a knob a build has either. What it is here for is holding a measurement to a small
+     * limit and watching what the limit reports — a model that reaches any of the three defaults is
+     * larger than anything in this repository, so the paths past them would rot unread otherwise.
+     */
+    Compilation withAdequacyPolicy(souther.compiler.partition.AdequacyPolicy policy) {
+        db.set(new Front.Adequacy(), policy);
         return this;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -123,7 +123,8 @@ final class Coverages {
                                 souther.compiler.query.Adequacy.Level level,
                                 List<BorderAssessment> boundaries,
                                 PathReachability.Answers arrives,
-                                souther.compiler.check.StatedContract stated) {
+                                souther.compiler.check.StatedContract stated,
+                                souther.compiler.partition.AdequacyPolicy.OfTheMeasures budget) {
         List<RowOutcome> rows = observed.rows();
         List<String> parameters = behavior.params().stream().map(Hir.Param::name).toList();
         // What a row's values are, where they sit and what they are written as, read together:
@@ -187,7 +188,7 @@ final class Coverages {
         return new PartitionEvidence(
                 PartitionDerivation.of(axes, partitioning.partitionClosure()),
                 BoundaryDerivation.of(boundaries, partitioning.borderClosure()),
-                pairsOf(behavior.name(), divided, readings, level.readsRows()),
+                pairsOf(behavior.name(), divided, readings, level.readsRows(), budget),
                 partitioning.undivided(), partitioning.unread(), partitioning.blocked(),
                 partitioning.notSeparated(), List.copyOf(standing),
                 whyUnclassified(readings.byRow(),
@@ -308,9 +309,6 @@ final class Coverages {
         }
     }
 
-    /** How many pairs of classes across two positions the rows are enough to sit in at once. */
-    private static final int PAIR_LIMIT = 20_000;
-
     /**
      * The two-class combinations the rows reach.
      *
@@ -325,7 +323,9 @@ final class Coverages {
      * single-position coverage is measured on its own and not derived from this.
      */
     private static PartitionEvidence.PairSpace pairsOf(String behavior, List<Axis> axes,
-                                                      Readings readings, boolean asked) {
+                                                      Readings readings, boolean asked,
+                                                      souther.compiler.partition.AdequacyPolicy
+                                                              .OfTheMeasures budget) {
         // The product of what a row can be written at, not of what the types declare. A case the
         // rules refuse is not a class of its position at all, so the slice of the product it would
         // have taken part in is not here to be counted — which is a different thing from a pair
@@ -350,8 +350,8 @@ final class Coverages {
         if (readings.noRows() && !readings.someRowsUnseen()) {
             return PartitionEvidence.PairSpace.noRows((int) Math.min(total, Integer.MAX_VALUE));
         }
-        if (total > PAIR_LIMIT) {
-            return PartitionEvidence.PairSpace.truncated(behavior, total, PAIR_LIMIT);
+        if (total > budget.pairSpace()) {
+            return PartitionEvidence.PairSpace.truncated(behavior, total, budget.pairSpace());
         }
         Set<String> covered = new LinkedHashSet<>();
         for (Map<AxisId, Classification> where : readings.byRow()) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -167,6 +167,38 @@ public final class Front {
                 new souther.compiler.check.ReadingPolicy(64, 1000);
     }
 
+    /**
+     * What measuring a behavior and composing rows for it may spend.
+     *
+     * <p>Held as an input for the reason the two above are: it belongs to the compilation, and every
+     * measurement of one behavior has to be under the same one. Read here and handed to the
+     * analysis, which never makes one — a budget made where it is needed is one two measurements of
+     * a model can differ by, and each would report different coverage of it while both stayed
+     * sound.
+     */
+    public record Adequacy()
+            implements Input<souther.compiler.partition.AdequacyPolicy> {
+
+        /**
+         * What a compilation sets, and the one place the three numbers are written.
+         *
+         * <p>Guardrails and not precision settings, each set with room over anything observed. The
+         * pair space is twenty thousand: a behavior of a dozen positions of a handful of classes
+         * each runs to hundreds, and past twenty thousand the count is of a space no set of rows
+         * addresses. The row limit is two hundred, which is where a block stops being something a
+         * person reads and pastes. A group's choices are capped at four thousand and ninety-six,
+         * which a body reaches only by settling thirteen decisions on one value.
+         *
+         * <p>Held here rather than beside the policy it makes, so that measuring a behavior cannot
+         * reach it: what governs a measurement is handed to it, and a default it could pick up is a
+         * default two measurements of one behavior can differ by.
+         */
+        static final souther.compiler.partition.AdequacyPolicy STANDARD =
+                new souther.compiler.partition.AdequacyPolicy(
+                        new souther.compiler.partition.AdequacyPolicy.OfTheMeasures(20_000),
+                        new souther.compiler.partition.AdequacyPolicy.OfTheGeneration(200, 4096));
+    }
+
     /** One source, parsed, with the text of each declaration kept for publishing. Every position in
      * what comes back names this source, so a writing that later joins another file's module still
      * says where it was written. */

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1309,6 +1309,12 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             case NOTHING_COMPOSES_ONE -> "nothing here could build a representative for " + at;
             case ALL_CANDIDATES_REJECTED -> "every value tried at " + at + " was refused";
             case SEARCH_LIMIT -> "the search stopped before reaching " + at;
+            // What is missing here, and not what cannot exist. The combinations are there and this
+            // declined to walk them, so a reader is told the offer was not made rather than that
+            // nothing reaches the arm — and told that raising the row budget is not what lifts it.
+            case THE_GROUP_WAS_NOT_OFFERED ->
+                    "the decisions that settle " + at + " have more combinations together than this"
+                            + " offers a row for, so none of them was looked in";
             case THE_RULES_LEAVE_NOTHING_THERE ->
                     "the rules leave no value at " + at;
             case NOTHING_TO_BUILD_AGAINST -> "there was nothing to build a candidate against";

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -521,6 +521,14 @@ public final class GeneratedRows {
                         "// generation stopped for `%s`: %d %s past the row limit%n",
                         limit.behavior(), limit.owed(),
                         limit.owed() == 1 ? "class or arm" : "classes and arms");
+                // Beside the line above rather than folded into it. That one is a budget an author
+                // can raise; this is a walk that was never made, and a reader told the first where
+                // the second happened would raise a limit that changes nothing.
+                case GenerationReason.GroupsNotOffered held -> String.format(
+                        "// no rows offered for %d %s of `%s`: each has more combinations together"
+                                + " than this walks, so none of them was looked in%n",
+                        held.groups(), held.groups() == 1 ? "group of decisions" : "groups of"
+                                + " decisions", held.behavior());
                 case GenerationReason.NothingToBuildAgainst none -> String.format(
                         "// generation stopped for `%s`: there was nothing to build a candidate"
                                 + " against%n", none.behavior());
@@ -626,6 +634,9 @@ public final class GeneratedRows {
                     "every value tried was refused at construction, which does not make the"
                             + " combination impossible";
             case SEARCH_LIMIT -> "the search stopped before reaching it";
+            case THE_GROUP_WAS_NOT_OFFERED ->
+                    "the decisions that settle it have more combinations together than this offers"
+                            + " a row for, so none of them was looked in";
             case NO_CERTIFIED_WITNESS ->
                     "no row composed for it was seen reaching it, which does not make the"
                             + " combination unreachable";

--- a/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
@@ -13,6 +13,7 @@ import souther.compiler.observe.Classification;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.partition.Axis;
 import souther.compiler.partition.AxisId;
+import souther.compiler.partition.Budgets;
 import souther.compiler.partition.GenerationReason;
 import souther.compiler.partition.Generator;
 import souther.compiler.partition.Partitions;
@@ -105,7 +106,7 @@ class AGenerationThatWentOnDoesNotSayItStoppedTest {
 
         Generator.GenerationResult filled =
                 Generator.fill(subject, List.of(Generator.ObservedRow.unseen(row)),
-                        Generator.CandidateCheck.ANY);
+                        Generator.CandidateCheck.ANY, Budgets.generation());
 
         assertFalse(filled.rows().isEmpty(), "the positions it could read were filled");
         assertInstanceOf(GenerationReason.PositionWithheld.class, filled.reasons().get(0));

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACandidateThatMissedIsNotOfferedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACandidateThatMissedIsNotOfferedTest.java
@@ -168,14 +168,13 @@ class ACandidateThatMissedIsNotOfferedTest {
 
     private static Generator.GenerationResult fill(Model model, Generator.Trial trial) {
         return Generator.fill(model.subject(), List.of(), Generator.CandidateCheck.ANY,
-                model.groups(), trial);
+                model.groups(), trial, Budgets.generation());
     }
 
     /** Every claim any combination of the model makes, so that one run answers all of them. */
     private static List<ControlClaim> everyClaimOf(Model model) {
         List<ControlClaim> out = new ArrayList<>();
-        for (InteractionCells.Group group : InteractionCells.of(model.groups(),
-                model.subject().axes()).groups()) {
+        for (InteractionCells.Group group : InteractionCells.of(model.groups(), model.subject().axes(), Budgets.generation()).groups()) {
             for (int index = 0; index < group.size(); index++) {
                 CellSelection selection = group.at(index);
                 if (selection != null) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACandidateThatMissedIsNotOfferedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACandidateThatMissedIsNotOfferedTest.java
@@ -175,7 +175,7 @@ class ACandidateThatMissedIsNotOfferedTest {
     private static List<ControlClaim> everyClaimOf(Model model) {
         List<ControlClaim> out = new ArrayList<>();
         for (InteractionCells.Group group : InteractionCells.of(model.groups(),
-                model.subject().axes())) {
+                model.subject().axes()).groups()) {
             for (int index = 0; index < group.size(); index++) {
                 CellSelection selection = group.at(index);
                 if (selection != null) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/AFloorNothingBuildsIsSaidTheSameWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AFloorNothingBuildsIsSaidTheSameWhereverItIsWrittenTest.java
@@ -57,7 +57,7 @@ class AFloorNothingBuildsIsSaidTheSameWhereverItIsWrittenTest {
         Generator.GenerationResult filled = Generator.fill(new Generator.Subject(
                 new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
                         sig.inputTypes(), symbols, souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
-                partitioning.axes(), HeldCounts.of(domain, symbols)), List.of(), REFUSED);
+                partitioning.axes(), HeldCounts.of(domain, symbols)), List.of(), REFUSED, Budgets.generation());
         assertFalse(filled.unresolved().isEmpty(), "nothing was written and nothing said why");
         return filled.unresolved().get(0).reason();
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
@@ -60,6 +60,29 @@ class AGroupTooWideToWalkSaysSoTest {
      *  can only be reached at a power of two; a budget the caller names can be reached anywhere. */
     private static final String TWO = model(2);
 
+    /** The same behavior with rows, so a compilation can be asked what it is still owed. Each row
+     *  settles every parameter the same way, which takes one arm of each helper. */
+    private static String modelWithRows(int decisions, boolean bothWays) {
+        StringBuilder rows = new StringBuilder();
+        for (String at : bothWays ? new String[] {"On", "Off"} : new String[] {"On"}) {
+            StringBuilder values = new StringBuilder();
+            int total = 0;
+            for (int i = 1; i <= decisions; i++) {
+                if (i > 1) {
+                    values.append(", ");
+                }
+                values.append(at);
+                total += at.equals("On") ? i : 0;
+            }
+            rows.append("""
+                    example total
+                        | "%s" : (%s) -> Fee(%d)
+
+                    """.formatted(at, values, total));
+        }
+        return model(decisions) + "\n" + rows;
+    }
+
     private static String model(int decisions) {
         StringBuilder params = new StringBuilder();
         StringBuilder names = new StringBuilder();
@@ -220,6 +243,69 @@ class AGroupTooWideToWalkSaysSoTest {
                         .anyMatch(why -> why.reason() == Generator.UnresolvedCombination.Reason
                                 .THE_GROUP_WAS_NOT_OFFERED)),
                 () -> "each saying the walk was never made: " + unresolved);
+    }
+
+    /**
+     * A group held back that nothing on the list was behind is not reported.
+     *
+     * <p>What a run owes is the classes and the arms a caller names. Walking a group is how a row
+     * for an arm is looked for and is not itself owed, so a run asked for nothing behind a group
+     * lost nothing by not walking it — and a line saying no rows were offered there says rows were
+     * due where none were.
+     *
+     * <p>Which is also what keeps the summary in step with the entries. An arm is answered
+     * {@code THE_GROUP_WAS_NOT_OFFERED} only where it was owed, so a count of every group held back
+     * is a number with no entry under it.
+     */
+    @Test
+    void aGroupNothingWasAskedForBehindIsNotReported() {
+        Model model = Model.of(THIRTEEN);
+
+        Generator.GenerationResult asked = Generator.fill(model.subject(), List.of(),
+                Generator.CandidateCheck.ANY, model.groups(), Generator.Trial.NOTHING_RUNS,
+                List.of(), Set.of(), Set.of(), Budgets.generation());
+
+        assertEquals(List.of(), asked.reasons().stream()
+                        .filter(GenerationReason.GroupsNotOffered.class::isInstance).toList(),
+                () -> "nothing was owed behind it: " + asked.reasons());
+        assertEquals(List.of(), asked.arms(), "and no arm was answered for");
+    }
+
+    /**
+     * Through a compilation, an arm still owed brings the group back and an arm covered does not.
+     *
+     * <p>The production path, where what is owed comes from what measuring the arms established
+     * rather than from a set a caller wrote. Held with the same model twice and only the rows
+     * differing, so the two answers are the rows' and not the model's — and the group is past the
+     * budget in both, which is what says the difference is the obligation and not the limit.
+     */
+    @Test
+    void whatIsOwedDecidesWhetherTheHeldGroupIsNamed() {
+        assertEquals(1, groupsNotOfferedFor(modelWithRows(13, false)).size(),
+                "one row leaves the other arm of each helper owed, and the group is named for it");
+        assertEquals(List.of(), groupsNotOfferedFor(modelWithRows(13, true)),
+                "two rows take every arm, so nothing is owed and the group is not named");
+    }
+
+    private static List<GenerationReason.GroupsNotOffered> groupsNotOfferedFor(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(souther.compiler.query.Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        // The rows have to have run for what is owed to be what the arms established. A model whose
+        // examples failed is owed nothing for a reason of its own, and an empty answer from one of
+        // those would look exactly like the answer this test is about.
+        assertEquals(List.of(), compilation.db().allReports().stream()
+                        .filter(found -> found.report().isError())
+                        .map(found -> found.report().diagnostic().code().toString()).toList(),
+                "the model compiles and its rows run");
+        Map<String, souther.compiler.query.Adequacy.Filling> filling = compilation.db()
+                .ask(new souther.compiler.query.Adequacy.Generated("example.wide")).value();
+        assertNotNull(filling, "the module was asked for rows");
+        souther.compiler.query.Adequacy.Filling total = filling.get("total");
+        assertNotNull(total, "the behavior was asked for rows");
+        return total.composed().reasons().stream()
+                .filter(GenerationReason.GroupsNotOffered.class::isInstance)
+                .map(GenerationReason.GroupsNotOffered.class::cast).toList();
     }
 
     /** The behavior's inputs, its axes and the groups its body meets at, off one compile. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
@@ -105,7 +105,7 @@ class AGroupTooWideToWalkSaysSoTest {
     void aGroupPastTheLimitIsHeldBackAndSaidSo() {
         Model model = Model.of(THIRTEEN);
         InteractionCells.Offered offered =
-                InteractionCells.of(model.groups(), model.subject().axes());
+                InteractionCells.of(model.groups(), model.subject().axes(), Budgets.generation());
 
         assertEquals(List.of(), offered.groups(),
                 "the group is not offered, which is what the limit is for");
@@ -120,7 +120,7 @@ class AGroupTooWideToWalkSaysSoTest {
     void andUnderTheLimitTheGroupIsOffered() {
         Model model = Model.of(ELEVEN);
         InteractionCells.Offered offered =
-                InteractionCells.of(model.groups(), model.subject().axes());
+                InteractionCells.of(model.groups(), model.subject().axes(), Budgets.generation());
 
         assertEquals(List.of(), offered.notOffered(),
                 "nothing is held back");
@@ -141,9 +141,9 @@ class AGroupTooWideToWalkSaysSoTest {
         Model narrow = Model.of(ELEVEN);
 
         Set<Integer> fromWide =
-                Generator.everyArmTheCombinationsTake(wide.subject(), wide.groups());
+                Generator.everyArmTheCombinationsTake(wide.subject(), wide.groups(), Budgets.generation());
         Set<Integer> fromNarrow =
-                Generator.everyArmTheCombinationsTake(narrow.subject(), narrow.groups());
+                Generator.everyArmTheCombinationsTake(narrow.subject(), narrow.groups(), Budgets.generation());
 
         assertFalse(fromWide.isEmpty(),
                 "the arms behind the group the limit held back are still named");
@@ -163,7 +163,7 @@ class AGroupTooWideToWalkSaysSoTest {
         Model model = Model.of(THIRTEEN);
 
         Generator.GenerationResult composed = Generator.fill(model.subject(), List.of(),
-                Generator.CandidateCheck.ANY, model.groups(), Generator.Trial.NOTHING_RUNS);
+                Generator.CandidateCheck.ANY, model.groups(), Generator.Trial.NOTHING_RUNS, Budgets.generation());
 
         List<GenerationReason.GroupsNotOffered> said = composed.reasons().stream()
                 .filter(GenerationReason.GroupsNotOffered.class::isInstance)

--- a/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
@@ -1,0 +1,218 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.inputs.InputDomain;
+import souther.compiler.interaction.Interaction;
+import souther.compiler.interaction.Interactions;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A group of decisions too wide to walk is reported, not dropped.
+ *
+ * <p>The limit itself is not the subject and neither is its number. What is held here is that
+ * exhausting it leaves something a reader can act on: an arm claimed only by a group nothing walked
+ * used to leave no entry at all, and an arm with no entry is one no combination claims — so the
+ * report said the body never reaches it. That is a statement about the model this compiler had no
+ * evidence for, and it is the one thing a limit must never produce.
+ *
+ * <p>Held against a source rather than by handing a fixture to the search. What decides whether a
+ * group is offered is the product of its factors' outcomes, which is read off the body; a fixture
+ * naming a group as too wide would be the test saying what the reading is supposed to say.
+ */
+class AGroupTooWideToWalkSaysSoTest {
+
+    /**
+     * As many decisions meeting on one value as it takes to go past the walk.
+     *
+     * <p>Each parameter is matched by its own helper and every result is added into one {@code Fee},
+     * so the thirteen meet at one operator and the group's choices are two to the thirteenth. The
+     * offer stops at four thousand and ninety-six and stops <em>at</em> it, so twelve decisions are
+     * already the limit and eleven is the last width that is offered — which is what {@link #ELEVEN}
+     * is.
+     */
+    private static final String THIRTEEN = model(13);
+
+    /** The widest model still offered, which is eleven. Without it, a group not offered would be as
+     *  good an account of a model this cannot read at all. */
+    private static final String ELEVEN = model(11);
+
+    private static String model(int decisions) {
+        StringBuilder params = new StringBuilder();
+        StringBuilder names = new StringBuilder();
+        StringBuilder helpers = new StringBuilder();
+        StringBuilder sum = new StringBuilder();
+        for (int at = 1; at <= decisions; at++) {
+            if (at > 1) {
+                params.append(", ");
+                names.append(", ");
+                sum.append(" + ");
+            }
+            params.append("p").append(at).append(": Flag");
+            names.append("p").append(at);
+            sum.append("fee").append(at).append("(p").append(at).append(")");
+            helpers.append("""
+                    let fee%d (f: Flag): Int =
+                        match f with
+                            | On  -> %d
+                            | Off -> 0
+
+                    """.formatted(at, at));
+        }
+        return """
+                module example.wide
+
+                data On
+                data Off
+                data Flag = On | Off
+
+                data Fee = Int
+                    invariant value >= 0
+
+                behavior total : (%s) -> Fee
+                    constructs Fee
+
+                %slet total (%s) = Fee(%s)
+                """.formatted(params, helpers, names, sum);
+    }
+
+    /**
+     * Past the limit, the group is named as one nothing was offered for.
+     *
+     * <p>Two facts and both are needed. That no group is offered is what the limit does; that the
+     * one held back is reported is what this change is. Read off the offered list alone, a model
+     * whose decisions this could not read at all looks the same.
+     */
+    @Test
+    void aGroupPastTheLimitIsHeldBackAndSaidSo() {
+        Model model = Model.of(THIRTEEN);
+        InteractionCells.Offered offered =
+                InteractionCells.of(model.groups(), model.subject().axes());
+
+        assertEquals(List.of(), offered.groups(),
+                "the group is not offered, which is what the limit is for");
+        assertEquals(1, offered.notOffered().size(),
+                () -> "and it is named rather than dropped: " + offered.notOffered());
+        assertFalse(offered.notOffered().get(0).claims().isEmpty(),
+                "carrying what a run through it would have been seen to do");
+    }
+
+    /** And one decision fewer is offered, so the answer above is the limit's and not the model's. */
+    @Test
+    void andUnderTheLimitTheGroupIsOffered() {
+        Model model = Model.of(ELEVEN);
+        InteractionCells.Offered offered =
+                InteractionCells.of(model.groups(), model.subject().axes());
+
+        assertEquals(List.of(), offered.notOffered(),
+                "nothing is held back");
+        assertFalse(offered.groups().isEmpty(),
+                "and the group is there to be walked");
+    }
+
+    /**
+     * The arms behind a held-back group are arms the combinations take.
+     *
+     * <p>Which is the half that used to go missing. A caller asking what the combinations reach got
+     * a smaller answer because this compiler declined to look, and nothing in the answer said so —
+     * so the arms simply were not asked for, and the report about them was that nothing claims them.
+     */
+    @Test
+    void theArmsBehindItAreStillArmsTheCombinationsTake() {
+        Model wide = Model.of(THIRTEEN);
+        Model narrow = Model.of(ELEVEN);
+
+        Set<Integer> fromWide =
+                Generator.everyArmTheCombinationsTake(wide.subject(), wide.groups());
+        Set<Integer> fromNarrow =
+                Generator.everyArmTheCombinationsTake(narrow.subject(), narrow.groups());
+
+        assertFalse(fromWide.isEmpty(),
+                "the arms behind the group the limit held back are still named");
+        assertTrue(fromWide.size() > fromNarrow.size(),
+                () -> "and a wider body claims more of them, not fewer: " + fromWide.size()
+                        + " against " + fromNarrow.size());
+    }
+
+    /**
+     * And the generation says the walk was not made, in words a row budget does not explain.
+     *
+     * <p>The reason is what a reader acts on. Told the row limit instead, an author raises a number
+     * that changes nothing here — the group was never walked, and no quantity of rows reaches it.
+     */
+    @Test
+    void theGenerationSaysTheWalkWasNotMade() {
+        Model model = Model.of(THIRTEEN);
+
+        Generator.GenerationResult composed = Generator.fill(model.subject(), List.of(),
+                Generator.CandidateCheck.ANY, model.groups(), Generator.Trial.NOTHING_RUNS);
+
+        List<GenerationReason.GroupsNotOffered> said = composed.reasons().stream()
+                .filter(GenerationReason.GroupsNotOffered.class::isInstance)
+                .map(GenerationReason.GroupsNotOffered.class::cast).toList();
+        assertEquals(1, said.size(), () -> "the generation says so once: " + composed.reasons());
+        assertEquals(1, said.get(0).groups(), "naming how many groups went unwalked");
+        // Every arm behind it is unresolved with that reason, rather than absent — an absent arm is
+        // one no combination claims, and that is what this must not be mistaken for.
+        List<Generator.ArmAttempt.Unresolved> unresolved = composed.arms().stream()
+                .filter(Generator.ArmAttempt.Unresolved.class::isInstance)
+                .map(Generator.ArmAttempt.Unresolved.class::cast).toList();
+        assertFalse(unresolved.isEmpty(), () -> "the arms are named: " + composed.arms());
+        assertTrue(unresolved.stream().allMatch(arm -> arm.why().stream()
+                        .anyMatch(why -> why.reason() == Generator.UnresolvedCombination.Reason
+                                .THE_GROUP_WAS_NOT_OFFERED)),
+                () -> "each saying the walk was never made: " + unresolved);
+    }
+
+    /** The behavior's inputs, its axes and the groups its body meets at, off one compile. */
+    private record Model(Generator.Subject subject, List<Interaction> groups) {
+
+        static Model of(String source) {
+            Compilation compilation = Compilation.ofSource(source, "Main");
+            compilation.answerEverything();
+            String module = compilation.modules().get(0);
+            Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+            Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+            Symbols symbols = Scopes.derived(compilation.db(), module).value();
+            Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
+            assertNotNull(prepared, "the model compiles");
+            assertNotNull(sigs);
+            assertNotNull(checked);
+            Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                    .filter(b -> b.name().equals("total")).findFirst().orElseThrow();
+            InputDomain inputs = compilation.db()
+                    .ask(new souther.compiler.query.Adequacy.Inputs(module)).value().get("total");
+            assertNotNull(inputs, "the behavior's inputs were read");
+            Partitions.Partitioning partitioning = Partitions.of(spec.name(), inputs, symbols,
+                    souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+            Core body = checked.behaviorBodies().get("total");
+            assertNotNull(body, "the behavior under test has a body");
+            CoverageSites.Plan plan = CoverageSites.of(checked.behaviorBodies(), checked.decisions(),
+                    checked.supplied());
+            return new Model(new Generator.Subject(
+                    new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
+                            sigs.get("total").inputTypes(), symbols,
+                            souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
+                    partitioning.axes(), HeldCounts.of(inputs, symbols)),
+                    Interactions.of(body, plan, inputs, symbols));
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
@@ -45,15 +45,20 @@ class AGroupTooWideToWalkSaysSoTest {
      *
      * <p>Each parameter is matched by its own helper and every result is added into one {@code Fee},
      * so the thirteen meet at one operator and the group's choices are two to the thirteenth. The
-     * offer stops at four thousand and ninety-six and stops <em>at</em> it, so twelve decisions are
-     * already the limit and eleven is the last width that is offered — which is what {@link #ELEVEN}
-     * is.
+     * standard budget is a capacity of four thousand and ninety-six, so twelve decisions are exactly
+     * it and are offered, and the thirteenth is the first width that is not.
      */
     private static final String THIRTEEN = model(13);
 
-    /** The widest model still offered, which is eleven. Without it, a group not offered would be as
-     *  good an account of a model this cannot read at all. */
-    private static final String ELEVEN = model(11);
+    /** The widest model still offered under the standard budget: twelve decisions are four thousand
+     *  and ninety-six choices, which is the capacity exactly. Without it, a group not offered would
+     *  be as good an account of a model this cannot read at all. */
+    private static final String TWELVE = model(12);
+
+    /** Two decisions, which is four choices — small enough that a budget written here can be put
+     *  either side of it exactly. Two to the thirteenth is where the default falls, and a default
+     *  can only be reached at a power of two; a budget the caller names can be reached anywhere. */
+    private static final String TWO = model(2);
 
     private static String model(int decisions) {
         StringBuilder params = new StringBuilder();
@@ -118,7 +123,7 @@ class AGroupTooWideToWalkSaysSoTest {
     /** And one decision fewer is offered, so the answer above is the limit's and not the model's. */
     @Test
     void andUnderTheLimitTheGroupIsOffered() {
-        Model model = Model.of(ELEVEN);
+        Model model = Model.of(TWELVE);
         InteractionCells.Offered offered =
                 InteractionCells.of(model.groups(), model.subject().axes(), Budgets.generation());
 
@@ -126,6 +131,41 @@ class AGroupTooWideToWalkSaysSoTest {
                 "nothing is held back");
         assertFalse(offered.groups().isEmpty(),
                 "and the group is there to be walked");
+    }
+
+    /**
+     * A group of exactly the budget is offered, and one choice more is not.
+     *
+     * <p>The point on the line, which the pair either side of it does not establish. Twelve
+     * decisions and thirteen are four thousand and ninety-six choices and eight thousand and
+     * one hundred and ninety-two, so the default can say which side of the limit a model falls on
+     * and never what happens at it — a default is reached only at a power of two, and the boundary
+     * is a single number.
+     *
+     * <p>Written by naming the budget instead, which is what having one as an input is for. Four
+     * choices against a capacity of four is the group being offered <em>at</em> the limit, and the
+     * same four against three is the first thing past it. Read the other way round, this is the
+     * assertion that {@code cellsPerGroup} is a capacity and not a cutoff: under a cutoff the first
+     * of these two would be held back.
+     */
+    @Test
+    void aGroupOfExactlyTheBudgetIsOffered() {
+        Model model = Model.of(TWO);
+        assertEquals(4, InteractionCells.of(model.groups(), model.subject().axes(),
+                        atMost(4)).groups().get(0).size(),
+                "two decisions of two outcomes are four choices");
+
+        assertEquals(List.of(), InteractionCells.of(model.groups(), model.subject().axes(),
+                        atMost(4)).notOffered(),
+                "a group of exactly the budget is offered");
+        assertEquals(1, InteractionCells.of(model.groups(), model.subject().axes(),
+                        atMost(3)).notOffered().size(),
+                "and one choice past it is not");
+    }
+
+
+    private static AdequacyPolicy.OfTheGeneration atMost(int cells) {
+        return new AdequacyPolicy.OfTheGeneration(Budgets.generation().rows(), cells);
     }
 
     /**
@@ -138,12 +178,12 @@ class AGroupTooWideToWalkSaysSoTest {
     @Test
     void theArmsBehindItAreStillArmsTheCombinationsTake() {
         Model wide = Model.of(THIRTEEN);
-        Model narrow = Model.of(ELEVEN);
+        Model narrow = Model.of(TWELVE);
 
         Set<Integer> fromWide =
-                Generator.everyArmTheCombinationsTake(wide.subject(), wide.groups(), Budgets.generation());
+                Generator.everyArmACombinationMayTake(wide.subject(), wide.groups(), Budgets.generation());
         Set<Integer> fromNarrow =
-                Generator.everyArmTheCombinationsTake(narrow.subject(), narrow.groups(), Budgets.generation());
+                Generator.everyArmACombinationMayTake(narrow.subject(), narrow.groups(), Budgets.generation());
 
         assertFalse(fromWide.isEmpty(),
                 "the arms behind the group the limit held back are still named");

--- a/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
@@ -16,6 +16,7 @@ import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
 import souther.compiler.query.Shapes;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -306,6 +307,96 @@ class AGroupTooWideToWalkSaysSoTest {
         return total.composed().reasons().stream()
                 .filter(GenerationReason.GroupsNotOffered.class::isInstance)
                 .map(GenerationReason.GroupsNotOffered.class::cast).toList();
+    }
+
+    /**
+     * Three inner meetings and an outer one over their values, so an arm is claimed by two groups.
+     *
+     * <p>Each {@code +} settles a value from two decisions, and the {@code *} over the three is a
+     * meeting of those values — so the outer group's factors are the inner values and its claims
+     * carry the arms on the way to them. The outer group has four times four times four choices and
+     * each inner one has four, which is a budget between them away from being reachable.
+     */
+    private static final String NESTED = """
+            module example.nested
+
+            data On
+            data Off
+            data Flag = On | Off
+
+            data Fee = Int
+                invariant value >= 0
+
+            let fee1 (f: Flag): Int = match f with | On -> 1 | Off -> 0
+            let fee2 (f: Flag): Int = match f with | On -> 2 | Off -> 0
+            let fee3 (f: Flag): Int = match f with | On -> 4 | Off -> 0
+            let fee4 (f: Flag): Int = match f with | On -> 8 | Off -> 0
+            let fee5 (f: Flag): Int = match f with | On -> 16 | Off -> 0
+            let fee6 (f: Flag): Int = match f with | On -> 32 | Off -> 0
+
+            behavior total : (p1: Flag, p2: Flag, p3: Flag, p4: Flag, p5: Flag, p6: Flag) -> Fee
+                constructs Fee
+
+            let total (p1, p2, p3, p4, p5, p6) =
+                Fee((fee1(p1) + fee2(p2)) * (fee3(p3) + fee4(p4)) * (fee5(p5) + fee6(p6)))
+
+            example total
+                | "one" : (On, On, On, On, On, On) -> Fee(3 * 12 * 48)
+            """;
+
+    /**
+     * A group held back that every arm behind it was answered elsewhere for is not reported.
+     *
+     * <p>The case an obligation read at the start cannot see. Every arm the outer group claims is
+     * also on the way into one of the three inner ones, and those are offered — so each arm ends up
+     * {@code Built} and nothing is left waiting on the walk that was not made. Counted against the
+     * arms this run began owing, the group would be named while every entry under it said a row was
+     * composed.
+     *
+     * <p>Which is why the count is read off the entries. A set rebuilt here from what was owed, what
+     * the row budget stopped at and what the held groups claim would be the order those answers are
+     * asked in, written twice.
+     */
+    @Test
+    void aHeldGroupEveryArmOfWhichWasAnsweredElsewhereIsNotReported() {
+        Model model = Model.of(NESTED);
+        AdequacyPolicy.OfTheGeneration budget = atMost(8);
+
+        InteractionCells.Offered offered =
+                InteractionCells.of(model.groups(), model.subject().axes(), budget);
+        assertEquals(1, offered.notOffered().size(), "the outer group is past the budget");
+        assertEquals(3, offered.groups().size(), "and the three inner ones are offered");
+
+        Generator.GenerationResult composed = Generator.fill(model.subject(), List.of(),
+                Generator.CandidateCheck.ANY, model.groups(), Generator.Trial.NOTHING_RUNS, budget);
+
+        // The held group is one arms were owed behind: without this, the answer below would hold of
+        // a group that claimed nothing and would say nothing about when a group is named.
+        Set<Integer> owed = Generator.everyArmACombinationMayTake(
+                model.subject(), model.groups(), budget);
+        Set<Integer> behindTheHeldGroup = new LinkedHashSet<>(armsIn(offered.notOffered().get(0)));
+        behindTheHeldGroup.retainAll(owed);
+        assertFalse(behindTheHeldGroup.isEmpty(),
+                "arms were owed behind the group that was held back");
+
+        assertTrue(composed.arms().stream().allMatch(Generator.ArmAttempt.Built.class::isInstance),
+                () -> "every arm was answered by an offered group: " + composed.arms());
+        assertEquals(List.of(), composed.reasons().stream()
+                        .filter(GenerationReason.GroupsNotOffered.class::isInstance).toList(),
+                () -> "so nothing was left waiting on the walk that was not made: "
+                        + composed.reasons());
+    }
+
+    /** Which arms a group the limit held back could have been searched at. */
+    private static List<Integer> armsIn(InteractionCells.NotOffered held) {
+        List<Integer> out = new java.util.ArrayList<>();
+        for (souther.compiler.coverage.ControlClaim claim : held.claims()) {
+            if (claim.at() instanceof souther.compiler.coverage.ControlPointId.ArmOccurrence arm
+                    && arm.probe().isPresent()) {
+                out.add(arm.probe().getAsInt());
+            }
+        }
+        return out;
     }
 
     /** The behavior's inputs, its axes and the groups its body meets at, off one compile. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionWithAFloorIsOfferedAValueThatMeetsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionWithAFloorIsOfferedAValueThatMeetsItTest.java
@@ -49,7 +49,7 @@ class APositionWithAFloorIsOfferedAValueThatMeetsItTest {
     /** The value at the position the row wrote, which is the one the search reached first. */
     private static String firstValueAt(String source, String behavior, int position) {
         Generator.GenerationResult filled =
-                Generator.fill(subjectOf(source, behavior), List.of(), Generator.CandidateCheck.ANY);
+                Generator.fill(subjectOf(source, behavior), List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
         assertEquals(List.of(), filled.unresolved(), "nothing should have gone unresolved");
         return filled.rows().get(0).inputs().get(position).text();
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
@@ -91,9 +91,12 @@ class ARowNothingRanFillsNoCombinationTest {
     @Test
     void aCombinationIsSearchedForAnArmOnTheListAndForNothingElse() {
         Model model = Model.of(SHIPPING, "shippingFee");
-        List<InteractionCells.Group> groups =
+        InteractionCells.Offered offered =
                 InteractionCells.of(model.groups(), model.subject().axes());
+        List<InteractionCells.Group> groups = offered.groups();
         assertEquals(1, groups.size(), "the two decisions meet once");
+        assertEquals(List.of(), offered.notOffered(),
+                "and none of them was held back, so what follows is about a group that was walked");
         CellSelection first = groups.get(0).at(0);
         assertNotNull(first, "and its first choice is a combination");
         assertFalse(first.claims().isEmpty(), "which a run can be held to");
@@ -116,8 +119,8 @@ class ARowNothingRanFillsNoCombinationTest {
     @Test
     void aRowIsComposedForTheArmsAndNotForWhereTheyWereFound() {
         Model model = Model.of(SHIPPING, "shippingFee");
-        CellSelection first =
-                InteractionCells.of(model.groups(), model.subject().axes()).get(0).at(0);
+        CellSelection first = InteractionCells.of(model.groups(), model.subject().axes())
+                .groups().get(0).at(0);
         assertNotNull(first);
         Set<Integer> takes = claimedBy(first);
         assertTrue(takes.size() > 1, "the combination takes an arm of each decision: " + takes);

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
@@ -102,7 +102,7 @@ class ARowNothingRanFillsNoCombinationTest {
         assertFalse(first.claims().isEmpty(), "which a run can be held to");
 
         Set<Integer> every =
-                Generator.everyArmTheCombinationsTake(model.subject(), model.groups(), Budgets.generation());
+                Generator.everyArmACombinationMayTake(model.subject(), model.groups(), Budgets.generation());
         assertTrue(offeredFor(model, every).containsAll(claimedBy(first)),
                 "asked about the arms this combination takes, a row is composed for each of them");
         assertEquals(Set.of(), offeredFor(model, Set.of()),
@@ -152,7 +152,7 @@ class ARowNothingRanFillsNoCombinationTest {
     void anArmKeepsWhatEveryCombinationClaimingItCameTo() {
         Model model = Model.of(SHIPPING, "shippingFee");
         Set<Integer> every =
-                Generator.everyArmTheCombinationsTake(model.subject(), model.groups(), Budgets.generation());
+                Generator.everyArmACombinationMayTake(model.subject(), model.groups(), Budgets.generation());
         Generator.GenerationResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.refusing((_, _) -> java.util.Optional.of("no")),
                 model.groups(), Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), every, Budgets.generation());
@@ -178,7 +178,7 @@ class ARowNothingRanFillsNoCombinationTest {
     void oneRowThroughAnArmIsTheAnswerWhateverTheOthersCameTo() {
         Model model = Model.of(SHIPPING, "shippingFee");
         Set<Integer> every =
-                Generator.everyArmTheCombinationsTake(model.subject(), model.groups(), Budgets.generation());
+                Generator.everyArmACombinationMayTake(model.subject(), model.groups(), Budgets.generation());
         // Refuses the first case of the first position, so the combinations naming it fail and the
         // ones beside them build. Every arm of the second decision is claimed by both.
         Generator.GenerationResult filled = Generator.fill(model.subject(), List.of(),
@@ -249,7 +249,7 @@ class ARowNothingRanFillsNoCombinationTest {
     void anArmTheLimitCutOffSaysSoRatherThanReadingAsUnreachable() {
         Model model = Model.of(wide(), "submit");
         Set<Integer> every =
-                Generator.everyArmTheCombinationsTake(model.subject(), model.groups(), Budgets.generation());
+                Generator.everyArmACombinationMayTake(model.subject(), model.groups(), Budgets.generation());
         assertFalse(every.isEmpty(), "the body has arms");
 
         Generator.GenerationResult filled = Generator.fill(model.subject(), List.of(),

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
@@ -92,7 +92,7 @@ class ARowNothingRanFillsNoCombinationTest {
     void aCombinationIsSearchedForAnArmOnTheListAndForNothingElse() {
         Model model = Model.of(SHIPPING, "shippingFee");
         InteractionCells.Offered offered =
-                InteractionCells.of(model.groups(), model.subject().axes());
+                InteractionCells.of(model.groups(), model.subject().axes(), Budgets.generation());
         List<InteractionCells.Group> groups = offered.groups();
         assertEquals(1, groups.size(), "the two decisions meet once");
         assertEquals(List.of(), offered.notOffered(),
@@ -102,7 +102,7 @@ class ARowNothingRanFillsNoCombinationTest {
         assertFalse(first.claims().isEmpty(), "which a run can be held to");
 
         Set<Integer> every =
-                Generator.everyArmTheCombinationsTake(model.subject(), model.groups());
+                Generator.everyArmTheCombinationsTake(model.subject(), model.groups(), Budgets.generation());
         assertTrue(offeredFor(model, every).containsAll(claimedBy(first)),
                 "asked about the arms this combination takes, a row is composed for each of them");
         assertEquals(Set.of(), offeredFor(model, Set.of()),
@@ -119,7 +119,7 @@ class ARowNothingRanFillsNoCombinationTest {
     @Test
     void aRowIsComposedForTheArmsAndNotForWhereTheyWereFound() {
         Model model = Model.of(SHIPPING, "shippingFee");
-        CellSelection first = InteractionCells.of(model.groups(), model.subject().axes())
+        CellSelection first = InteractionCells.of(model.groups(), model.subject().axes(), Budgets.generation())
                 .groups().get(0).at(0);
         assertNotNull(first);
         Set<Integer> takes = claimedBy(first);
@@ -127,7 +127,7 @@ class ARowNothingRanFillsNoCombinationTest {
 
         List<Generator.GeneratedRow> composed = Generator.fill(model.subject(), List.of(),
                         Generator.CandidateCheck.ANY, model.groups(),
-                        Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), takes)
+                        Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), takes, Budgets.generation())
                 .rows();
 
         assertEquals(1, composed.size(), "one row answers both: " + composed);
@@ -152,10 +152,10 @@ class ARowNothingRanFillsNoCombinationTest {
     void anArmKeepsWhatEveryCombinationClaimingItCameTo() {
         Model model = Model.of(SHIPPING, "shippingFee");
         Set<Integer> every =
-                Generator.everyArmTheCombinationsTake(model.subject(), model.groups());
+                Generator.everyArmTheCombinationsTake(model.subject(), model.groups(), Budgets.generation());
         Generator.GenerationResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.refusing((_, _) -> java.util.Optional.of("no")),
-                model.groups(), Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), every);
+                model.groups(), Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), every, Budgets.generation());
 
         assertEquals(List.of(), filled.rows(), "nothing builds, so nothing is composed");
         for (int probe : every) {
@@ -178,14 +178,14 @@ class ARowNothingRanFillsNoCombinationTest {
     void oneRowThroughAnArmIsTheAnswerWhateverTheOthersCameTo() {
         Model model = Model.of(SHIPPING, "shippingFee");
         Set<Integer> every =
-                Generator.everyArmTheCombinationsTake(model.subject(), model.groups());
+                Generator.everyArmTheCombinationsTake(model.subject(), model.groups(), Budgets.generation());
         // Refuses the first case of the first position, so the combinations naming it fail and the
         // ones beside them build. Every arm of the second decision is claimed by both.
         Generator.GenerationResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.refusing((_, candidate) ->
                         candidate.text().contains("Premium")
                                 ? java.util.Optional.of("no") : java.util.Optional.empty()),
-                model.groups(), Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), every);
+                model.groups(), Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), every, Budgets.generation());
 
         assertFalse(filled.rows().isEmpty(), "the combinations that build compose their rows");
         List<Integer> built = every.stream()
@@ -249,12 +249,12 @@ class ARowNothingRanFillsNoCombinationTest {
     void anArmTheLimitCutOffSaysSoRatherThanReadingAsUnreachable() {
         Model model = Model.of(wide(), "submit");
         Set<Integer> every =
-                Generator.everyArmTheCombinationsTake(model.subject(), model.groups());
+                Generator.everyArmTheCombinationsTake(model.subject(), model.groups(), Budgets.generation());
         assertFalse(every.isEmpty(), "the body has arms");
 
         Generator.GenerationResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.groups(), Generator.Trial.NOTHING_RUNS,
-                List.of(), Generator.everyClassNoRowSitsIn(model.subject(), List.of()), every);
+                List.of(), Generator.everyClassNoRowSitsIn(model.subject(), List.of()), every, Budgets.generation());
 
         assertTrue(filled.reasons().stream()
                         .anyMatch(GenerationReason.SearchLimit.class::isInstance),
@@ -308,7 +308,7 @@ class ARowNothingRanFillsNoCombinationTest {
                                                          Set<Generator.ClassOwed> classes) {
         return Generator.fill(model.subject(), List.of(), Generator.CandidateCheck.ANY,
                         model.groups(), Generator.Trial.NOTHING_RUNS, List.of(), classes,
-                        java.util.Set.of())
+                        java.util.Set.of(), Budgets.generation())
                 .rows().stream().flatMap(row -> row.purposes().stream())
                 .map(Generator.Purpose.ForAClass.class::cast)
                 .map(at -> new Generator.ClassOwed(at.at(), at.classId())).toList();
@@ -317,7 +317,7 @@ class ARowNothingRanFillsNoCombinationTest {
     /** Which arms the generator composes a row for when it is asked about {@code arms}. */
     private static Set<Integer> offeredFor(Model model, Set<Integer> arms) {
         return Generator.fill(model.subject(), List.of(), Generator.CandidateCheck.ANY,
-                        model.groups(), Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), arms)
+                        model.groups(), Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), arms, Budgets.generation())
                 .rows().stream().flatMap(row -> row.purposes().stream())
                 .map(Generator.Purpose.ForAnArm.class::cast)
                 .map(Generator.Purpose.ForAnArm::probe)

--- a/souther-compiler/src/test/java/souther/compiler/partition/ASelectionsClassesAndClaimsAreOfTheSameChoiceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ASelectionsClassesAndClaimsAreOfTheSameChoiceTest.java
@@ -72,7 +72,7 @@ class ASelectionsClassesAndClaimsAreOfTheSameChoiceTest {
                                 new InteractionCells.Placed(holding(2), List.of(at(11))),
                                 new InteractionCells.Placed(holding(3), List.of(at(12)))),
                         List.of(new InteractionCells.Placed(holding(0, 2, 3), List.of(at(20))),
-                                new InteractionCells.Placed(holding(1, 2, 3), List.of(at(21))))));
+                                new InteractionCells.Placed(holding(1, 2, 3), List.of(at(21))))), Budgets.generation().cellsPerGroup());
 
         assertEquals(6, group.size(), "three ways and two ways");
         List<List<Integer>> byIndex = List.of(
@@ -99,7 +99,7 @@ class ASelectionsClassesAndClaimsAreOfTheSameChoiceTest {
                         List.of(new InteractionCells.Placed(holding(0), List.of(at(10))),
                                 new InteractionCells.Placed(holding(1), List.of(at(11)))),
                         List.of(new InteractionCells.Placed(holding(0), List.of(at(20))),
-                                new InteractionCells.Placed(holding(1), List.of(at(21))))));
+                                new InteractionCells.Placed(holding(1), List.of(at(21))))), Budgets.generation().cellsPerGroup());
 
         assertEquals(2, group.left(0), "two of the four choices are combinations");
         assertNull(group.at(1), "the first way of one factor and the second of the other agree "
@@ -121,7 +121,7 @@ class ASelectionsClassesAndClaimsAreOfTheSameChoiceTest {
         InteractionCells.Group group = new InteractionCells.Group(
                 new InteractionCells.Placed(holding(0, 1, 2, 3), List.of(at(9))),
                 List.of(List.of(new InteractionCells.Placed(holding(0, 1), List.of(at(10))),
-                        new InteractionCells.Placed(holding(2, 3), List.of(at(11))))));
+                        new InteractionCells.Placed(holding(2, 3), List.of(at(11))))), Budgets.generation().cellsPerGroup());
         CellSelection selection = group.at(0);
 
         assertTrue(selection.certifying(new int[] {1}, lit(9, 10)).isPresent(),
@@ -156,7 +156,7 @@ class ASelectionsClassesAndClaimsAreOfTheSameChoiceTest {
         InteractionCells.Group group = new InteractionCells.Group(
                 new InteractionCells.Placed(holding(0, 1, 2, 3), List.of(at(9))),
                 List.of(List.of(new InteractionCells.Placed(holding(0, 1), List.of(at(10))),
-                        new InteractionCells.Placed(holding(2, 3), List.of(at(11))))));
+                        new InteractionCells.Placed(holding(2, 3), List.of(at(11))))), Budgets.generation().cellsPerGroup());
         CellSelection selection = group.at(0);
         int[] where = {0};
 
@@ -183,7 +183,7 @@ class ASelectionsClassesAndClaimsAreOfTheSameChoiceTest {
         InteractionCells.Group group = new InteractionCells.Group(
                 new InteractionCells.Placed(holding(0, 1, 2, 3), List.of(at(9))),
                 List.of(List.of(new InteractionCells.Placed(holding(0, 1), List.of(at(10))),
-                        new InteractionCells.Placed(holding(2, 3), List.of(at(11))))));
+                        new InteractionCells.Placed(holding(2, 3), List.of(at(11))))), Budgets.generation().cellsPerGroup());
         CellSelection selection = group.at(0);
 
         assertTrue(selection.certifiedBy(lit(9, 10)), "a run that did both did this combination");

--- a/souther-compiler/src/test/java/souther/compiler/partition/ASelectionsClassesAndClaimsAreOfTheSameChoiceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ASelectionsClassesAndClaimsAreOfTheSameChoiceTest.java
@@ -72,7 +72,7 @@ class ASelectionsClassesAndClaimsAreOfTheSameChoiceTest {
                                 new InteractionCells.Placed(holding(2), List.of(at(11))),
                                 new InteractionCells.Placed(holding(3), List.of(at(12)))),
                         List.of(new InteractionCells.Placed(holding(0, 2, 3), List.of(at(20))),
-                                new InteractionCells.Placed(holding(1, 2, 3), List.of(at(21))))), Budgets.generation().cellsPerGroup());
+                                new InteractionCells.Placed(holding(1, 2, 3), List.of(at(21))))));
 
         assertEquals(6, group.size(), "three ways and two ways");
         List<List<Integer>> byIndex = List.of(
@@ -99,7 +99,7 @@ class ASelectionsClassesAndClaimsAreOfTheSameChoiceTest {
                         List.of(new InteractionCells.Placed(holding(0), List.of(at(10))),
                                 new InteractionCells.Placed(holding(1), List.of(at(11)))),
                         List.of(new InteractionCells.Placed(holding(0), List.of(at(20))),
-                                new InteractionCells.Placed(holding(1), List.of(at(21))))), Budgets.generation().cellsPerGroup());
+                                new InteractionCells.Placed(holding(1), List.of(at(21))))));
 
         assertEquals(2, group.left(0), "two of the four choices are combinations");
         assertNull(group.at(1), "the first way of one factor and the second of the other agree "
@@ -121,7 +121,7 @@ class ASelectionsClassesAndClaimsAreOfTheSameChoiceTest {
         InteractionCells.Group group = new InteractionCells.Group(
                 new InteractionCells.Placed(holding(0, 1, 2, 3), List.of(at(9))),
                 List.of(List.of(new InteractionCells.Placed(holding(0, 1), List.of(at(10))),
-                        new InteractionCells.Placed(holding(2, 3), List.of(at(11))))), Budgets.generation().cellsPerGroup());
+                        new InteractionCells.Placed(holding(2, 3), List.of(at(11))))));
         CellSelection selection = group.at(0);
 
         assertTrue(selection.certifying(new int[] {1}, lit(9, 10)).isPresent(),
@@ -156,7 +156,7 @@ class ASelectionsClassesAndClaimsAreOfTheSameChoiceTest {
         InteractionCells.Group group = new InteractionCells.Group(
                 new InteractionCells.Placed(holding(0, 1, 2, 3), List.of(at(9))),
                 List.of(List.of(new InteractionCells.Placed(holding(0, 1), List.of(at(10))),
-                        new InteractionCells.Placed(holding(2, 3), List.of(at(11))))), Budgets.generation().cellsPerGroup());
+                        new InteractionCells.Placed(holding(2, 3), List.of(at(11))))));
         CellSelection selection = group.at(0);
         int[] where = {0};
 
@@ -183,7 +183,7 @@ class ASelectionsClassesAndClaimsAreOfTheSameChoiceTest {
         InteractionCells.Group group = new InteractionCells.Group(
                 new InteractionCells.Placed(holding(0, 1, 2, 3), List.of(at(9))),
                 List.of(List.of(new InteractionCells.Placed(holding(0, 1), List.of(at(10))),
-                        new InteractionCells.Placed(holding(2, 3), List.of(at(11))))), Budgets.generation().cellsPerGroup());
+                        new InteractionCells.Placed(holding(2, 3), List.of(at(11))))));
         CellSelection selection = group.at(0);
 
         assertTrue(selection.certifiedBy(lit(9, 10)), "a run that did both did this combination");

--- a/souther-compiler/src/test/java/souther/compiler/partition/Budgets.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/Budgets.java
@@ -1,0 +1,35 @@
+package souther.compiler.partition;
+
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Front;
+
+/**
+ * What a compilation sets, for a test standing the search up without one.
+ *
+ * <p>Asked of a compilation rather than written here. The numbers belong to
+ * {@code Front.Adequacy.STANDARD} and are held out of reach of everything that measures a behavior
+ * on purpose (rule 4 of this package's documentation) — so a test naming them again would be a
+ * second place they are written, free to go on saying two hundred after the one that matters says
+ * something else.
+ *
+ * <p>And asked rather than defaulted. A search handed no budget picking one up is the arrangement
+ * the rule exists against; a test is a caller like any other, and this is that caller saying which
+ * budget it is using.
+ */
+public final class Budgets {
+
+    private Budgets() {}
+
+    /** The policy a compilation that says nothing is held to. Built from an empty module, which
+     *  sets the inputs in its constructor and compiles nothing. */
+    private static final AdequacyPolicy STANDARD = Compilation.ofSource("module example.empty", "Main")
+            .db().ask(new Front.Adequacy()).value();
+
+    public static AdequacyPolicy.OfTheGeneration generation() {
+        return STANDARD.generation();
+    }
+
+    public static AdequacyPolicy.OfTheMeasures measures() {
+        return STANDARD.measures();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
@@ -137,7 +137,7 @@ class GeneratorTest {
     @Test
     void everyClassNoRowIsInGetsARowAboutThatClassAlone() {
         Generator.GenerationResult filled = Generator.fill(modelOf(TRIP, "submit").subject(),
-                List.of(), Generator.CandidateCheck.ANY);
+                List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
 
         assertEquals(List.of(), filled.unresolved());
         assertEquals(4, filled.rows().size(), texts(filled).toString());
@@ -154,7 +154,7 @@ class GeneratorTest {
     @Test
     void positionsOfOneParameterCompoundIntoOneValue() {
         Generator.GenerationResult filled = Generator.fill(modelOf(TRIP, "submit").subject(),
-                List.of(), Generator.CandidateCheck.ANY);
+                List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
 
         assertEquals(1, filled.rows().get(0).inputs().size());
         assertEquals("Request { kind = Domestic, urgent = true }",
@@ -171,7 +171,7 @@ class GeneratorTest {
 
         Generator.GenerationResult filled =
                 Generator.fill(subject, List.of(Generator.ObservedRow.unseen(written)),
-                        Generator.CandidateCheck.ANY);
+                        Generator.CandidateCheck.ANY, Budgets.generation());
 
         assertEquals(List.of(List.of("request.kind=Overseas"), List.of("request.urgent=false")),
                 filled.rows().stream().map(row -> row.labels()).toList(),
@@ -182,9 +182,9 @@ class GeneratorTest {
     @Test
     void theSameModelGeneratesTheSameRowsTwice() {
         Generator.GenerationResult once = Generator.fill(modelOf(TRIP, "submit").subject(),
-                List.of(), Generator.CandidateCheck.ANY);
+                List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
         Generator.GenerationResult again = Generator.fill(modelOf(TRIP, "submit").subject(),
-                List.of(), Generator.CandidateCheck.ANY);
+                List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
 
         assertEquals(texts(once), texts(again));
         assertEquals(once.rows().stream().map(row -> row.labels()).toList(),
@@ -233,7 +233,7 @@ class GeneratorTest {
                         ? Optional.of("the first pair is not allowed together") : Optional.empty());
 
         Generator.GenerationResult filled =
-                Generator.fill(subject, List.of(), refusesTheFirst);
+                Generator.fill(subject, List.of(), refusesTheFirst, Budgets.generation());
 
         assertEquals(List.of(), filled.unresolved());
         // One row per class owed, which here is one class at each of two positions. What this is
@@ -255,7 +255,7 @@ class GeneratorTest {
 
         Generator.GenerationResult filled =
                 Generator.fill(subject, List.of(),
-                        Generator.CandidateCheck.refusing((_, _) -> Optional.of("no")));
+                        Generator.CandidateCheck.refusing((_, _) -> Optional.of("no")), Budgets.generation());
 
         assertEquals(List.of(), filled.rows());
         assertTrue(filled.unresolved().stream().allMatch(left ->
@@ -277,7 +277,7 @@ class GeneratorTest {
                 List.of(number("high", 10)));
 
         Generator.GenerationResult filled =
-                Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY);
+                Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
 
         assertEquals(List.of(), filled.rows());
         assertTrue(filled.unresolved().stream()
@@ -301,7 +301,7 @@ class GeneratorTest {
                 List.of(number("high", 10), number("higher", 20)));
 
         Generator.GenerationResult filled =
-                Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY);
+                Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
 
         List<String> subjects = filled.unresolved().stream()
                 .map(Generator.UnresolvedCombination::subject).distinct().toList();
@@ -322,7 +322,7 @@ class GeneratorTest {
     @Test
     void aRecordCaseOfASumIsComposedFromItsFields() {
         Generator.GenerationResult filled = Generator.fill(modelOf(PAYMENT, "feeFor").subject(),
-                List.of(), Generator.CandidateCheck.ANY);
+                List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
 
         assertEquals(List.of(), filled.unresolved(), filled.unresolved().toString());
         assertEquals(List.of("Card { number = Amount(0m) }", "Cash { amount = Amount(0m) }"),
@@ -341,7 +341,7 @@ class GeneratorTest {
     void anOptionalWhoseElementIsARecordIsOfferedARow() {
         Generator.GenerationResult filled = Generator.fill(
                 modelOf(OPTIONAL_RECORD, "feeOf").subject(), List.of(),
-                Generator.CandidateCheck.ANY);
+                Generator.CandidateCheck.ANY, Budgets.generation());
 
         assertEquals(List.of(), filled.unresolved(), filled.unresolved().toString());
         assertTrue(texts(filled).contains("Request { card = Card { number = Amount(0m) } }"),
@@ -366,7 +366,7 @@ class GeneratorTest {
                 List.of(number("high", 10)));
 
         Generator.GenerationResult filled =
-                Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY);
+                Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
 
         assertEquals(List.of(), filled.rows(), "nothing was composed at the first position");
         Generator.UnresolvedCombination only = filled.unresolved().getFirst();
@@ -393,7 +393,7 @@ class GeneratorTest {
                 HeldCounts.NONE);
 
         Generator.GenerationResult filled =
-                Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY);
+                Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
 
         assertEquals(List.of("1", "9"), texts(filled));
         assertEquals(List.of(List.of("a=low"), List.of("a=high")),

--- a/souther-compiler/src/test/java/souther/compiler/query/ABudgetIsTheCompilationsToSetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ABudgetIsTheCompilationsToSetTest.java
@@ -1,0 +1,105 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.partition.AdequacyPolicy;
+import souther.compiler.partition.Budgets;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a measurement may spend is the compilation's to set, and what spending it costs is reported.
+ *
+ * <p>Two things and the second is why the first matters. That the number can be set is rule 4; that
+ * a measurement held to a small one says what it was short of is rule 3. Tested together because a
+ * budget that can be lowered and reports nothing is the arrangement issue #969 removed, under a new
+ * name.
+ *
+ * <p>Held against a small budget rather than a large model. Every default is set with room over
+ * anything in this repository, so the only way to reach the path past one is to say what the budget
+ * is — which is what having it as an input is for, and what a private constant made impossible.
+ */
+class ABudgetIsTheCompilationsToSetTest {
+
+    /** Two positions of two classes each, which is four pairs — one more than a budget of three. */
+    private static final String FOUR_PAIRS = """
+            module example.pairs
+
+            data A
+            data B
+            data Flag = A | B
+            data Res = { n: Int }
+
+            behavior pick : (x: Flag, y: Flag) -> Res
+                constructs Res
+            let pick (x, y) = Res { n = 1 }
+
+            example pick
+                | "one" : (A, A) -> Res { n = 1 }
+            """;
+
+    /**
+     * A pair space past the budget leaves the measure partial and says which limit did it.
+     *
+     * <p>The same model twice, and only the budget differs — so the two answers are the budget's
+     * and not the model's. Read with one compilation, a partial measurement is as good an account
+     * of a model this cannot read at all.
+     */
+    @Test
+    void aPairSpacePastTheBudgetIsReportedAsPartial() {
+        PartitionEvidence wide = evidenceFor(FOUR_PAIRS, Budgets.measures().pairSpace());
+        PartitionEvidence narrow = evidenceFor(FOUR_PAIRS, 3);
+
+        assertInstanceOf(Measurement.Complete.class, wide.pairs().counted(),
+                () -> "at the standard budget the space is walked: " + wide.pairs());
+        assertInstanceOf(Measurement.Partial.class, narrow.pairs().counted(),
+                () -> "and past a budget of three it is not: " + narrow.pairs());
+        assertEquals(4, narrow.pairs().total(),
+                "the size of the space is what the model says, whatever was walked of it");
+    }
+
+    /**
+     * A budget that admits nothing is refused where it is written.
+     *
+     * <p>Each of the three, because each is a different sentence about a different walk. A bound of
+     * nought is not a small bound: it measures nothing and reports every model as partial over a
+     * space it never entered, which is a compilation saying less about every model than one with no
+     * bound at all would.
+     */
+    @Test
+    void aBudgetBelowOneIsRefused() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new AdequacyPolicy.OfTheMeasures(0), "a pair space of nought");
+        assertThrows(IllegalArgumentException.class,
+                () -> new AdequacyPolicy.OfTheGeneration(0, 4096), "no rows");
+        assertThrows(IllegalArgumentException.class,
+                () -> new AdequacyPolicy.OfTheGeneration(200, 0), "no cells");
+    }
+
+    /** And the standard one is a policy, so the three numbers are read from one place. */
+    @Test
+    void theStandardBudgetIsWhatACompilationSets() {
+        assertTrue(Budgets.measures().pairSpace() > 0);
+        assertTrue(Budgets.generation().rows() > 0);
+        assertTrue(Budgets.generation().cellsPerGroup() > 0);
+    }
+
+    private static PartitionEvidence evidenceFor(String source, int pairSpace) {
+        Compilation compilation = Compilation.ofSource(source, "Main")
+                .withAdequacyPolicy(new AdequacyPolicy(
+                        new AdequacyPolicy.OfTheMeasures(pairSpace), Budgets.generation()));
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, PartitionEvidence> partitions = compilation.db()
+                .ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
+        PartitionEvidence evidence = partitions.get("pick");
+        assertNotNull(evidence, "the behavior was measured");
+        return evidence;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ABudgetIsTheCompilationsToSetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ABudgetIsTheCompilationsToSetTest.java
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.partition.AdequacyPolicy;
 import souther.compiler.partition.Budgets;
+import souther.compiler.partition.GenerationReason;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -82,6 +84,30 @@ class ABudgetIsTheCompilationsToSetTest {
                 () -> new AdequacyPolicy.OfTheGeneration(200, 0), "no cells");
     }
 
+    /**
+     * A cell budget the compilation sets reaches the generation, which is the other half of rule 4.
+     *
+     * <p>The measures' half is above and would hold on its own while the generation's wiring was
+     * cut. The two travel by different routes — one through {@code Adequacy.Coverage} and one
+     * through {@code Adequacy.Generated} and {@code rowsFor} — so a test of the first says nothing
+     * about the second, and the generation's budget reaching the search was, until this, held by
+     * nothing at all.
+     *
+     * <p>Held through the query and not by handing a budget to {@code Generator}. What is being
+     * tested is the handing over: a search given a budget directly would answer the same whether or
+     * not {@code Front.Adequacy} were still wired to it.
+     */
+    @Test
+    void aCellBudgetTheCompilationSetsReachesTheGeneration() {
+        assertTrue(offeredUnder(Budgets.generation().cellsPerGroup()).isEmpty(),
+                "at the standard budget the group is walked and nothing is held back");
+
+        List<GenerationReason.GroupsNotOffered> held = offeredUnder(1);
+        assertEquals(1, held.size(),
+                () -> "and at a budget of one it is not: " + held);
+        assertEquals(1, held.get(0).groups(), "one group went unwalked");
+    }
+
     /** And the standard one is a policy, so the three numbers are read from one place. */
     @Test
     void theStandardBudgetIsWhatACompilationSets() {
@@ -89,6 +115,61 @@ class ABudgetIsTheCompilationsToSetTest {
         assertTrue(Budgets.generation().rows() > 0);
         assertTrue(Budgets.generation().cellsPerGroup() > 0);
     }
+
+    /** What the generation said about groups it did not offer, over a model of two decisions
+     *  meeting on one value, compiled under a budget of {@code cells} choices per group. */
+    private static List<GenerationReason.GroupsNotOffered> offeredUnder(int cells) {
+        Compilation compilation = Compilation.ofSource(TWO_DECISIONS, "Main")
+                .withAdequacyPolicy(new AdequacyPolicy(
+                        Budgets.measures(),
+                        new AdequacyPolicy.OfTheGeneration(Budgets.generation().rows(), cells)));
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, Adequacy.Filling> filling = compilation.db()
+                .ask(new Adequacy.Generated("example.two")).value();
+        assertNotNull(filling, "the module was asked for rows");
+        Adequacy.Filling shipping = filling.get("shippingFee");
+        assertNotNull(shipping, "the behavior was asked for rows");
+        return shipping.composed().reasons().stream()
+                .filter(GenerationReason.GroupsNotOffered.class::isInstance)
+                .map(GenerationReason.GroupsNotOffered.class::cast).toList();
+    }
+
+    /** Two decisions consumed into one value, which is four ways of settling it. Both are matched
+     *  on, so no threshold is needed to divide anything. */
+    private static final String TWO_DECISIONS = """
+            module example.two
+
+            data Premium
+            data Standard
+            data Membership = Premium | Standard
+
+            data Express
+            data Regular
+            data Delivery = Express | Regular
+
+            data Fee = Int
+                invariant value >= 0
+
+            behavior shippingFee : (member: Membership, delivery: Delivery) -> Fee
+                constructs Fee
+
+            let baseFee (tier: Membership): Int =
+                match tier with
+                    | Premium  -> 0
+                    | Standard -> 500
+
+            let expressFee (speed: Delivery): Int =
+                match speed with
+                    | Express -> 500
+                    | Regular -> 0
+
+            let shippingFee (member, delivery) =
+                Fee(baseFee(member) + expressFee(delivery))
+
+            example shippingFee
+                | "one" : (Premium, Express) -> Fee(500)
+            """;
 
     private static PartitionEvidence evidenceFor(String source, int pairSpace) {
         Compilation compilation = Compilation.ofSource(source, "Main")


### PR DESCRIPTION
Closes #1005.

The three limits #969 deliberately left alone. Rule 3 first, then rule 4 — moving a limit that
weakens a result in silence into a policy a caller can set would make a silent loss into an
officially configurable one.

## Rule 3: `MOST_CELLS` said nothing

A group past the limit was dropped with a bare `continue`. The combinations it held stayed untried
and what came back read exactly like a body that had no such group.

Which matters because of what that silence is confused with. `fill` ends by saying an arm with no
entry is "one no combination claims, which is the one thing an absent entry may mean" — so an arm
claimed only by a held-back group was reported as one the body never reaches. The correct shape was
thirty lines away: `MAX_ROWS` collects `cutOff` for exactly this, its own comment calling the two
"one silence".

Naming the arms behind a group sounds like the walk the limit refuses and is not. `of` builds the
factors before it checks the size, and every `Placed` carries its `ControlClaim`s, so the arms are
the union over the way in and each factor's outcomes — one pass, never the product.

The union is a superset, so it is asked last: an arm any offered group built a row for keeps that
answer, one the row budget stopped at keeps `SEARCH_LIMIT`, and what is left takes
`THE_GROUP_WAS_NOT_OFFERED`. Told apart because raising the row budget does not reach it.

The exhaustive switches made three readers answer. Two print it. The third, `whyNothingWasTried`,
answers for a *class* — and a class is never left unsearched by a group being held back, since
groups are where a row for an arm is looked for and the classes are walked in a loop that consults
none. It says so rather than borrowing the nearest reason.

## Rule 4: `AdequacyPolicy`

Grouped by which result each weakens, not by being numbers:

| | bounds | exhaustion |
|---|---|---|
| `OfTheMeasures.pairSpace` | the pair space walked | measurement `Partial`, `Weakening.PairSpaceTruncated` |
| `OfTheGeneration.rows` | rows one call writes | `GenerationReason.SearchLimit` |
| `OfTheGeneration.cellsPerGroup` | a group's cell walk | `GenerationReason.GroupsNotOffered` |

All three are capacities: a pair space of `n` is walked at `n`, a generation of `n` rows writes the
`n`th, a group of `n` choices is offered. `MOST_CELLS` compared with `>=` and promised nothing while
it was private; as a named component it had to be one or the other, and a policy whose three numbers
do not mean the same thing is one a caller has to read the implementation of.

`Front.Adequacy` is where the numbers are written; `Compilation` sets it once beside the reading and
evaluation policies, so the analysis never makes one. `withAdequacyPolicy` is package-private like
`withReadingPolicy` — not a knob a build has, but the only way to reach the path past a default set
with room over anything in this repository.

A budget below one is refused where it is written: a bound of nought reports every model as partial
over a space it never entered, which says less than having no bound would.

`Group` carries no limit. It exists only where the factory found the product within the budget, so
`size()` computes the product with nothing to saturate at, and the budget lives only where the cost
is incurred. `productOf` keeps its early stop, which guards a `long` from overflowing rather than
enforcing the limit, and says so.

`everyArmACombinationMayTake` says *may*, because the answer cannot. An offered group contributes
exactly — it is walked, and a choice whose factors leave a position nothing is not counted — while a
group held back contributes the union over its outcomes, which includes arms no single combination
claims. Over-approximating is the safe direction: an arm left out is reported as one no combination
claims, and an arm asked for and not found is answered `THE_GROUP_WAS_NOT_OFFERED`.

## Tests

- **The boundary, on it.** Four choices against a capacity of four is offered and the same four
  against three is not, which is the pair that says this is a capacity rather than a cutoff. Written
  with a budget the caller names, because the default is reachable only at a power of two — twelve
  decisions and thirteen are 4096 and 8192, so a default can say which side a model falls on and
  never what happens at the line.
- **Thirteen decisions** past the standard budget: the group is held back *and named*, the arms
  behind it stay arms a combination may take, and the generation says the walk was not made.
  Twelve, which is 4096 exactly, is offered.
- **Rule 4 end to end, both halves.** Four pairs at a `pairSpace` of three gives `Complete` and
  `Partial` from one source; a `cellsPerGroup` of one set on the compilation reaches
  `Adequacy.Generated` and comes back as `GroupsNotOffered`. The two travel by different routes, so
  a test of the first says nothing about the second.
- `Budgets` asks a compilation for the standard policy rather than writing the numbers again.

`souther-bench` pins `pairsOf`'s descriptor to keep a measure introduced in one place; the pin moves
with the signature.

`mvn -o test` green across all ten modules; CI green on `29d4016`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)