### PR TITLE
An operation says what it answers in what it was given, and one walk reads it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/AffineForms.java
@@ -6,6 +6,7 @@ import souther.compiler.numeric.NumericDomain.LinearForm;
 import souther.compiler.types.BindingId;
 
 import java.math.BigDecimal;
+import java.util.Map;
 
 /**
  * Reading an expression as {@code const + Σ coef·atom}, over whatever a caller counts as an atom.
@@ -271,6 +272,16 @@ public final class AffineForms {
             case Core.Binary b when b.op() == BinOp.MUL ->
                     Terms.scale(formOf(b.left(), at, reading, following, stopped),
                             formOf(b.right(), at, reading, following, stopped));
+            // An operation the library says answers arithmetic over what it was given is that
+            // arithmetic here: `Decimal.fromInt(n)` is `n`, `Date.daysBetween(a, b)` is `b - a`,
+            // and a rule about the arguments is a rule about the call. Composed here beside the
+            // operators, because that is what such an operation is — read at either caller's leaf
+            // instead, one of the two would have it and a statement the model makes would be
+            // measured by one reader and not the other.
+            case Core.PreservedCall _ when formSaidOf(e) != null ->
+                    answered(e, at, reading, following, stopped);
+            case Core.Call _ when formSaidOf(e) != null ->
+                    answered(e, at, reading, following, stopped);
             case Core.FieldAccess fa when reading.readsThrough(fa, at) ->
                     formOf(fa.target(), at, reading, following, stopped);
             // A binding an expansion introduced (`let $0_n = n.value in $0_n * 2`) is what a helper
@@ -282,6 +293,70 @@ public final class AffineForms {
                     stopped);
             default -> null;
         };
+    }
+
+    /**
+     * {@code call} read as the form the library says it answers, or null where one of the arguments
+     * it is written over does not compose.
+     *
+     * <p>Over what each argument is counted as, which is the form that argument itself reads as
+     * here. So a shift of a position by a written number and a shift of one position by another are
+     * one rule with two readings, and neither is a case anybody wrote.
+     */
+    private static <A, E> LinearForm<A> answered(Core call, E at, Reading<A, E> reading,
+                                                 java.util.Set<BindingId> following,
+                                                 Stop<A, E> stopped) {
+        LinearForm<souther.compiler.semantics.ArgumentRef> says = formSaidOf(call);
+        java.util.List<Core> args = Terms.argsOf(call);
+        // The expansion's own stops, kept off the walk's. What is inside a declared form is not
+        // what an author wrote: the arguments stand where they stand because the library says the
+        // operation answers this much of them, and a reader that cannot carry one of them has not
+        // met an expression an author would change — it has met this call.
+        Stop<A, E> inside = new Stop<>();
+        LinearForm<A> form = LinearForm.constant(says.constant());
+        for (Map.Entry<souther.compiler.semantics.ArgumentRef, BigDecimal> each
+                : says.coefs().entrySet()) {
+            int position = CallArguments.positionIn(each.getKey(), Terms.operationOf(call));
+            if (position < 0 || position >= args.size()) {
+                return stoppedAtTheCall(call, at, stopped);
+            }
+            LinearForm<A> argument = formOf(args.get(position), at, reading, following, inside);
+            if (argument == null) {
+                return stoppedAtTheCall(call, at, stopped);
+            }
+            form = form.plus(argument.times(each.getValue()));
+        }
+        return form;
+    }
+
+    /**
+     * No form, and the call recorded as where the reading stopped.
+     *
+     * <p>The call and not what was found inside it. A stop is reported at the most particular
+     * expression with no rule here, which is what an author would change — and inside a form the
+     * library declares there is no such expression: the author wrote the call. Reported from
+     * within, a rule over what {@code Date.daysBetween} answers came back as a rule about the field
+     * the expansion reached, which is a rule the model does not state and a spelling nobody wrote.
+     */
+    private static <A, E> LinearForm<A> stoppedAtTheCall(Core call, E at, Stop<A, E> stopped) {
+        if (stopped.at == null) {
+            stopped.at = new Outcome.StoppedAt<>(call, at);
+        }
+        return null;
+    }
+
+    /**
+     * What the library says {@code e} answers in what it was given, or null where it says nothing —
+     * including where {@code e} is no call at all.
+     *
+     * <p>Asked of the operation the call resolved to and not of which of the two shapes of call node
+     * it is. A body that runs holds a library call one way and the tree a declaration's rules are
+     * read in holds it another, and the fact is about the operation either way; read off one shape,
+     * the same statement would be composed in one representation and left a leaf in the other.
+     */
+    private static LinearForm<souther.compiler.semantics.ArgumentRef> formSaidOf(Core e) {
+        souther.compiler.types.ValueName operation = Terms.operationOf(e);
+        return operation == null ? null : DischargeRules.answersAFormOf(operation);
     }
 
     private AffineForms() {}

--- a/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
@@ -147,8 +147,10 @@ public sealed interface Carrier {
      * which sum places a case and what a newtype wraps are answers only the declarations have. So a
      * name comes back unanswered here rather than guessed at.
      *
-     * <p>What asks this way is a reading of the library's own signatures, whose names are its error
-     * unions and its enumerations — neither of them a value whose count anything is written over.
+     * <p>So a question asked this way is not asked of an operation declared over a name, and what
+     * that costs is measurable: the names in the library's own signatures are its error unions and
+     * the sum a rounding mode is, and every operation carrying one carries a primitive beside it
+     * that answers. None of them falls out of range on this account.
      */
     static Carrier ofPrimitive(Type type) {
         return type instanceof Type.Prim ? ofValue(type, null) : null;

--- a/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
@@ -139,6 +139,22 @@ public sealed interface Carrier {
     Carrier TEXT = new Text();
 
     /**
+     * The carrier of {@code type} where the type settles it without the declarations, and null where
+     * answering would need them or nothing orders it.
+     *
+     * <p>Beside {@link #ofValue} and not instead of it — the same table, asked where there are no
+     * declarations to hand. A primitive is what it is; a name is a declaration's question, since
+     * which sum places a case and what a newtype wraps are answers only the declarations have. So a
+     * name comes back unanswered here rather than guessed at.
+     *
+     * <p>What asks this way is a reading of the library's own signatures, whose names are its error
+     * unions and its enumerations — neither of them a value whose count anything is written over.
+     */
+    static Carrier ofPrimitive(Type type) {
+        return type instanceof Type.Prim ? ofValue(type, null) : null;
+    }
+
+    /**
      * The carrier a location's own content is counted on, or null where nothing here orders it.
      *
      * <p>Asked of what the names wrap, so a newtype answers as the value it carries — which is what

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -170,8 +170,38 @@ final class DischargeRules {
         return Bound.statesTheOrder();
     }
 
+    /**
+     * The operations that answer, counted, some arithmetic over what they were given.
+     *
+     * <p>Two sources and one question. Most of them say so by declaring the form
+     * ({@link OperationFacts#answersAFormOfItsArguments}); a sum and a difference say it by being
+     * the arithmetic they are, which {@link OperationFact.ComputesANumber} already records and
+     * {@link Terms#asOperator} already reads. Declaring the form for those as well would be the
+     * same statement twice, and leaving them out of the question altogether would be worse: the
+     * silence beside it says there is nothing true here, and of {@code Int.add} that is false.
+     */
     static Set<ValueName> formOperations() {
-        return Bound.answersAFormOfItsArguments();
+        Set<ValueName> answered = new LinkedHashSet<>(Bound.answersAFormOfItsArguments());
+        for (ValueName operation : Bound.computesANumber()) {
+            if (isASumOrADifference(Bound.computesANumber(operation))) {
+                answered.add(operation);
+            }
+        }
+        return answered;
+    }
+
+    /**
+     * Whether what it computes is a sum or a difference of what it was given, at every call.
+     *
+     * <p>All three conditions. A product is a form only where one operand is written down, so it is
+     * no form of its arguments; a quotient answers a case other than the number's where its divisor
+     * is nought, and a form that holds unless something is not a form.
+     */
+    private static boolean isASumOrADifference(NumericResult computed) {
+        return computed.unless() == null
+                && computed.at() instanceof NumericResult.Answered.Directly
+                && computed.computes() instanceof Arithmetic.TheOperator operator
+                && (operator.op() == BinOp.ADD || operator.op() == BinOp.SUB);
     }
 
     /** What {@code operation} answers, counted, in what its arguments are counted as — or null
@@ -196,8 +226,11 @@ final class DischargeRules {
      */
     private static Set<ValueName> formOperationsThisCarries() {
         Set<ValueName> carried = new LinkedHashSet<>();
-        for (ValueName operation : formOperations()) {
-            if (everyArgumentIsANumber(operation)) {
+        // Over the declared forms and not over everything that answers the question. A sum and a
+        // difference answer it by being the arithmetic they are, and what reads them is the
+        // grammar; a program firing one would be firing the operator.
+        for (ValueName operation : Bound.answersAFormOfItsArguments()) {
+            if (everyPartIsANumber(operation)) {
                 carried.add(operation);
             }
         }
@@ -205,20 +238,31 @@ final class DischargeRules {
     }
 
     /**
-     * Whether every argument the declared form names stands at a number this check relates.
+     * Whether the result and every argument the declared form names stand at a number this check
+     * relates.
+     *
+     * <p>Both ends, because the fact is an equation between them: what the operation answers,
+     * counted, and what it was given, counted. A form whose arguments this can carry and whose
+     * result it cannot is a form it cannot carry.
+     *
+     * <p>Asked with {@link Question#isANumber} where the binding asks
+     * {@link Question#countsToANumber}. That is the difference between what is true of the
+     * operation and what this check can do with it — a date counts and is no number, so
+     * {@code Date.daysBetween} is declared and is not carried here.
      *
      * <p>The library has the operation and the argument is one it takes, both of which
      * {@link OperationFactBinder} held before any of this was asked. What is left to decide is what
      * stands there.
      */
-    private static boolean everyArgumentIsANumber(ValueName operation) {
-        Prelude.PreludeEntry entry = Prelude.entry(((ValueName.Stdlib) operation).qualified());
-        List<Type> params = entry.signature().params();
-        return answersAFormOf(operation).coefs().keySet().stream().allMatch(argument -> {
-            int position = CallArguments.positionIn(argument, operation);
-            return position >= 0 && position < params.size()
-                    && Question.isANumber(params.get(position));
-        });
+    private static boolean everyPartIsANumber(ValueName operation) {
+        Prelude.Signature signature =
+                Prelude.entry(((ValueName.Stdlib) operation).qualified()).signature();
+        if (!Question.isANumber(signature.result())) {
+            return false;
+        }
+        List<Type> params = signature.params();
+        return answersAFormOf(operation).coefs().keySet().stream().allMatch(argument ->
+                Question.isANumber(params.get(CallArguments.positionIn(argument, operation))));
     }
 
     /** Those of them the read-through table has, by name, for the test that holds each to a

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -194,7 +194,7 @@ final class DischargeRules {
      * a capability, wrong the day the capability changes; asked this way, the operations that arrive
      * are exactly the ones an author could write a discharging program for.
      */
-    static Set<ValueName> formOperationsThisCarries() {
+    private static Set<ValueName> formOperationsThisCarries() {
         Set<ValueName> carried = new LinkedHashSet<>();
         for (ValueName operation : formOperations()) {
             if (everyArgumentIsANumber(operation)) {
@@ -204,13 +204,15 @@ final class DischargeRules {
         return carried;
     }
 
-    /** Whether every argument the declared form names stands at a number this check relates. */
+    /**
+     * Whether every argument the declared form names stands at a number this check relates.
+     *
+     * <p>The library has the operation and the argument is one it takes, both of which
+     * {@link OperationFactBinder} held before any of this was asked. What is left to decide is what
+     * stands there.
+     */
     private static boolean everyArgumentIsANumber(ValueName operation) {
-        Prelude.PreludeEntry entry = operation instanceof ValueName.Stdlib library
-                ? Prelude.entry(library.qualified()) : null;
-        if (entry == null) {
-            return false;
-        }
+        Prelude.PreludeEntry entry = Prelude.entry(((ValueName.Stdlib) operation).qualified());
         List<Type> params = entry.signature().params();
         return answersAFormOf(operation).coefs().keySet().stream().allMatch(argument -> {
             int position = CallArguments.positionIn(argument, operation);

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -175,33 +175,28 @@ final class DischargeRules {
      *
      * <p>Two sources and one question. Most of them say so by declaring the form
      * ({@link OperationFacts#answersAFormOfItsArguments}); a sum and a difference say it by being
-     * the arithmetic they are, which {@link OperationFact.ComputesANumber} already records and
-     * {@link Terms#asOperator} already reads. Declaring the form for those as well would be the
-     * same statement twice, and leaving them out of the question altogether would be worse: the
-     * silence beside it says there is nothing true here, and of {@code Int.add} that is false.
+     * the arithmetic they are. Declaring the form for those as well would be the same statement
+     * twice, and leaving them out of the question altogether would be worse: the silence beside it
+     * says there is nothing true here, and of {@code Int.add} that is false.
+     *
+     * <p>Which of them are is {@link #operator} and not a reading of its own. What that answers is
+     * what a call to such an operation is read as where it stands ({@link Terms#asOperator}), so
+     * asking it here is what makes the two the same statement — a second reading agreeing with it
+     * today is a second reading to keep agreeing with it, and where they came apart this question
+     * would want a silence written for an operation the grammar reads as a {@code +}.
+     *
+     * <p>A product is left out because it is a form only where an operand is written down: what
+     * multiplies each is the other.
      */
     static Set<ValueName> formOperations() {
         Set<ValueName> answered = new LinkedHashSet<>(Bound.answersAFormOfItsArguments());
         for (ValueName operation : Bound.computesANumber()) {
-            if (isASumOrADifference(Bound.computesANumber(operation))) {
+            BinOp written = operator(operation);
+            if (written == BinOp.ADD || written == BinOp.SUB) {
                 answered.add(operation);
             }
         }
         return answered;
-    }
-
-    /**
-     * Whether what it computes is a sum or a difference of what it was given, at every call.
-     *
-     * <p>All three conditions. A product is a form only where one operand is written down, so it is
-     * no form of its arguments; a quotient answers a case other than the number's where its divisor
-     * is nought, and a form that holds unless something is not a form.
-     */
-    private static boolean isASumOrADifference(NumericResult computed) {
-        return computed.unless() == null
-                && computed.at() instanceof NumericResult.Answered.Directly
-                && computed.computes() instanceof Arithmetic.TheOperator operator
-                && (operator.op() == BinOp.ADD || operator.op() == BinOp.SUB);
     }
 
     /** What {@code operation} answers, counted, in what its arguments are counted as — or null
@@ -698,16 +693,14 @@ final class DischargeRules {
      * form is about a count and a bound about a number, and the difference between those two is a
      * difference between the propositions and not between two ways of holding one.
      */
-    static Prelude.Signature holdTheResultToTheDeclaration(ValueName operation,
-            Predicate<Type> required, String what) {
-        Prelude.Signature signature = holdTheOperationToTheLibrary(operation).signature();
-        Type result = signature.result();
+    static void holdTheResultToTheDeclaration(ValueName operation, Predicate<Type> required,
+            String what) {
+        Type result = holdTheOperationToTheLibrary(operation).signature().result();
         if (result == null || !required.test(result)) {
             throw new IllegalStateException("what " + ((ValueName.Stdlib) operation).qualified()
                     + " answers is " + (result == null ? "left to its body" : Type.show(result))
                     + ", which is not " + what);
         }
-        return signature;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -519,12 +519,7 @@ final class DischargeRules {
      * anywhere. Held here, before any call is read.
      */
     static void holdNumericResult(ValueName operation, NumericResult rule) {
-        Prelude.PreludeEntry entry = Prelude.entry(((ValueName.Stdlib) operation).qualified());
-        if (entry == null) {
-            throw new IllegalStateException("a rule about what number it computes is written for "
-                    + operation + ", which the library does not declare");
-        }
-        Prelude.Signature signature = entry.signature();
+        Prelude.Signature signature = holdTheOperationToTheLibrary(operation).signature();
         Type answers = Question.numberAnsweredBy(signature.result());
         List<Arithmetic.Reads> reads = rule.computes().reads();
         if (signature.params().size() != reads.size()) {
@@ -539,13 +534,9 @@ final class DischargeRules {
             }
         }
         switch (rule.at()) {
-            case NumericResult.Answered.Directly ignored -> {
-                if (!Question.isANumber(signature.result())) {
-                    throw new IllegalStateException(operation + " answers "
-                            + Type.show(signature.result())
-                            + ", so the number it computes is not its result");
-                }
-            }
+            case NumericResult.Answered.Directly ignored ->
+                    holdTheResultToTheDeclaration(operation, Question::isANumber,
+                            "a number for the arithmetic it computes to be answered at");
             case NumericResult.Answered.InTheCaseCarrying(Type carried) -> {
                 if (!(signature.result() instanceof Type.Union(Set<TypeSymbol> members))) {
                     throw new IllegalStateException(operation + " answers "
@@ -596,7 +587,7 @@ final class DischargeRules {
             throw new IllegalStateException("the rule about " + operation + " counts through "
                     + shift.measure().qualified() + ", which the library does not declare");
         }
-        Prelude.PreludeEntry shifted = Prelude.entry(((ValueName.Stdlib) operation).qualified());
+        Prelude.PreludeEntry shifted = holdTheOperationToTheLibrary(operation);
         List<Type> counted = counts.signature().params();
         if (counted.size() != 2 || !Question.isANumber(counts.signature().result())
                 || !counted.get(0).equals(shifted.signature().result())
@@ -611,6 +602,8 @@ final class DischargeRules {
     /** As {@link #bind}, for the arguments a case names: the one it answers, and the two sides of
      * each condition it is reached under. */
     static void holdCase(ValueName operation, OperationFact.Case one) {
+        holdTheResultToTheDeclaration(operation, Question::isANumber,
+                "a number for a case of the definition to answer");
         List<ArgumentRef> named = new ArrayList<>();
         named.add(one.answers());
         one.given().forEach(stands -> {
@@ -624,6 +617,8 @@ final class DischargeRules {
     /** As {@link #bind}, for the arguments a bound names: the one the result is bounded against, and
      * the one a condition on the rule reads. Each is a separate claim about a separate argument. */
     static void holdBound(ValueName operation, ResultBound bound) {
+        holdTheResultToTheDeclaration(operation, Question::isANumber,
+                "a number for a bound on the result to hold of");
         List<ArgumentRef> named = new ArrayList<>();
         if (bound.against() != null) {
             named.add(bound.against());
@@ -686,6 +681,57 @@ final class DischargeRules {
                     + ", which the library does not declare");
         }
         return entry;
+    }
+
+    /**
+     * The library's declaration of {@code operation}, once what it answers is what a fact about its
+     * result is about.
+     *
+     * <p>Beside {@link #holdToTheDeclaration} and for the half it cannot reach. That one names an
+     * argument, so a fact whose proposition mentions the result had nothing to say it with, and
+     * each kind that needed the result said it its own way or not at all: {@code BoundsItsResult}
+     * and {@code IsDefinedByCases} are stated of a number and were held only of their arguments.
+     * Improvising a check per kind defaults to omitting it, which is how a fact naming no argument
+     * once went through an empty arm ({@link #holdTheOperationToTheLibrary}).
+     *
+     * <p>What is required is the caller's, since what a fact says of the result is the fact's. A
+     * form is about a count and a bound about a number, and the difference between those two is a
+     * difference between the propositions and not between two ways of holding one.
+     */
+    static Prelude.Signature holdTheResultToTheDeclaration(ValueName operation,
+            Predicate<Type> required, String what) {
+        Prelude.Signature signature = holdTheOperationToTheLibrary(operation).signature();
+        Type result = signature.result();
+        if (result == null || !required.test(result)) {
+            throw new IllegalStateException("what " + ((ValueName.Stdlib) operation).qualified()
+                    + " answers is " + (result == null ? "left to its body" : Type.show(result))
+                    + ", which is not " + what);
+        }
+        return signature;
+    }
+
+    /**
+     * Holds a declared form to the library: what it answers counts, and so does every argument it
+     * is written over.
+     *
+     * <p>Both ends, because the fact is an equation between them —
+     * {@code count(result) = Σ cᵢ·count(argᵢ) + k}. Held of the arguments alone it was half a
+     * statement: {@code List.take(n, xs)} declared to answer the number of its first argument
+     * passed, that argument being an {@code Int}, while what it answers is a list and has no count
+     * for the equation to be about.
+     *
+     * <p>Counted rather than a number, because that is what the fact says. A date is no number and
+     * counts days; whether this check can then do anything with such a form is a different question
+     * and belongs to the check ({@link #formOperationsThisCarries}).
+     */
+    static void holdAFormOfItsArguments(ValueName operation,
+            souther.compiler.numeric.NumericDomain.LinearForm<ArgumentRef> form) {
+        holdTheResultToTheDeclaration(operation, Question::countsToANumber,
+                "a value with a count for a form of its arguments to be about");
+        for (ArgumentRef argument : form.coefs().keySet()) {
+            holdToTheDeclaration(operation, argument, null, Question::countsToANumber,
+                    "an argument the result is a form of");
+        }
     }
 
     /** The same, for one rule. Asked per rule so that whatever holds a whole declaration source can

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -171,14 +171,59 @@ final class DischargeRules {
     }
 
     static Set<ValueName> formOperations() {
-        return Bound.answersItsArgument();
+        return Bound.answersAFormOfItsArguments();
+    }
+
+    /** What {@code operation} answers, counted, in what its arguments are counted as — or null
+     *  where it states no such form. */
+    static souther.compiler.numeric.NumericDomain.LinearForm<ArgumentRef> answersAFormOf(
+            ValueName operation) {
+        return Bound.answersAFormOfItsArguments(operation);
+    }
+
+    /**
+     * Those of them this check can carry, by name.
+     *
+     * <p>Every declaration is about the operation and not about a reader, so the ones here are a
+     * subset of what is declared: what an operation answers is stated over the counts of its
+     * arguments, and this check's arithmetic is over the numbers a model wrote. A date counts days
+     * and is no number, so {@code Date.daysBetween} states a form this reads and cannot carry — the
+     * partition can, since a position's count is what it works in.
+     *
+     * <p>Derived from what this side relates and not written as a list. A list is a second copy of
+     * a capability, wrong the day the capability changes; asked this way, the operations that arrive
+     * are exactly the ones an author could write a discharging program for.
+     */
+    static Set<ValueName> formOperationsThisCarries() {
+        Set<ValueName> carried = new LinkedHashSet<>();
+        for (ValueName operation : formOperations()) {
+            if (everyArgumentIsANumber(operation)) {
+                carried.add(operation);
+            }
+        }
+        return carried;
+    }
+
+    /** Whether every argument the declared form names stands at a number this check relates. */
+    private static boolean everyArgumentIsANumber(ValueName operation) {
+        Prelude.PreludeEntry entry = operation instanceof ValueName.Stdlib library
+                ? Prelude.entry(library.qualified()) : null;
+        if (entry == null) {
+            return false;
+        }
+        List<Type> params = entry.signature().params();
+        return answersAFormOf(operation).coefs().keySet().stream().allMatch(argument -> {
+            int position = CallArguments.positionIn(argument, operation);
+            return position >= 0 && position < params.size()
+                    && Question.isANumber(params.get(position));
+        });
     }
 
     /** Those of them the read-through table has, by name, for the test that holds each to a
      * construction it discharges. */
     static Set<String> formNames() {
         Set<String> names = new LinkedHashSet<>();
-        formOperations().forEach(operation -> names.add(operation.toString()));
+        formOperationsThisCarries().forEach(operation -> names.add(operation.toString()));
         return names;
     }
 
@@ -267,17 +312,6 @@ final class DischargeRules {
         return holding;
     }
 
-    /** The argument whose number {@code e} answers, or null where it is not a call this reads as one
-     * of its arguments. The value itself and not a term for it: what it is read as is the form the
-     * argument already has, which is the caller's to build. */
-    static Core answersItsArgument(Core e) {
-        if (!(e instanceof Core.PreservedCall call)) {
-            return null;
-        }
-        ArgumentRef reads = Bound.answersItsArgument(call.operation());
-        return reads == null ? null : CallArguments.of(reads, call);
-    }
-
     /** Those of them the building table has, by name, for the test that holds each to a construction
      * it discharges. */
     static Set<String> builtNames() {
@@ -362,14 +396,15 @@ final class DischargeRules {
          * declaration's; what asking through here adds is that it has been held to the library
          * first.
          */
-        private static ArgumentRef answersItsArgument(ValueName operation) {
-            return OperationFacts.answersItsArgument(operation);
+        private static souther.compiler.numeric.NumericDomain.LinearForm<ArgumentRef>
+                answersAFormOfItsArguments(ValueName operation) {
+            return OperationFacts.answersAFormOfItsArguments(operation);
         }
 
-        /** The operations declared to answer one of their arguments, for the checks that hold each
-         *  of them to firing. */
-        private static Set<ValueName> answersItsArgument() {
-            return OperationFacts.answersItsArgument();
+        /** The operations declared to answer a form of their arguments, for the checks that hold
+         *  each of them to firing. */
+        private static Set<ValueName> answersAFormOfItsArguments() {
+            return OperationFacts.answersAFormOfItsArguments();
         }
 
         private static Set<ValueName> statesTheOrder() {

--- a/souther-compiler/src/main/java/souther/compiler/check/OperationFactBinder.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OperationFactBinder.java
@@ -59,14 +59,8 @@ final class OperationFactBinder {
             // No default. A kind of fact added is a kind this has to say how to hold, rather than
             // one that passes through unchecked because nothing here mentions it.
             switch (each.fact()) {
-                // Every argument the form names, and each held to having a count: the form is
-                // arithmetic over what its arguments are counted as, so an argument with no number
-                // under it is one the form could not be about.
                 case OperationFact.AnswersAFormOfItsArguments answers ->
-                        answers.form().coefs().keySet().forEach(argument ->
-                                DischargeRules.holdToTheDeclaration(each.operation(), argument,
-                                        null, Question::countsToANumber,
-                                        "an argument the result is a form of"));
+                        DischargeRules.holdAFormOfItsArguments(each.operation(), answers.form());
                 // Both arguments, because which is the greater and which the lesser are one
                 // statement and a signature could disagree with either half.
                 case OperationFact.StatesTheOrderOfItsArguments states -> {

--- a/souther-compiler/src/main/java/souther/compiler/check/OperationFactBinder.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OperationFactBinder.java
@@ -59,10 +59,14 @@ final class OperationFactBinder {
             // No default. A kind of fact added is a kind this has to say how to hold, rather than
             // one that passes through unchecked because nothing here mentions it.
             switch (each.fact()) {
-                case OperationFact.AnswersItsArgument answers ->
-                        DischargeRules.holdToTheDeclaration(each.operation(), answers.argument(),
-                                null, Question::isANumber,
-                                "the argument whose number the result is");
+                // Every argument the form names, and each held to having a count: the form is
+                // arithmetic over what its arguments are counted as, so an argument with no number
+                // under it is one the form could not be about.
+                case OperationFact.AnswersAFormOfItsArguments answers ->
+                        answers.form().coefs().keySet().forEach(argument ->
+                                DischargeRules.holdToTheDeclaration(each.operation(), argument,
+                                        null, Question::countsToANumber,
+                                        "an argument the result is a form of"));
                 // Both arguments, because which is the greater and which the lesser are one
                 // statement and a signature could disagree with either half.
                 case OperationFact.StatesTheOrderOfItsArguments states -> {

--- a/souther-compiler/src/main/java/souther/compiler/check/Question.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Question.java
@@ -373,7 +373,7 @@ enum Question {
             return signature.result() != null && !isANumber(signature.result())
                     && signature.params().contains(signature.result())
                     && signature.params().stream().anyMatch(Question::isANumber)
-                    && isCounted(signature.result());
+                    && hasAMeasureCountingTwoApart(signature.result());
         }
 
         @Override
@@ -421,15 +421,21 @@ enum Question {
     },
 
     /**
-     * Whether the number it answers is a number it was given ({@link DischargeRules#answersItsArgument}).
-     * Asked of an operation answering a number from a number, which is the shape a value re-expressed
-     * has — the result may be one of the arguments read again rather than a number computed from them.
+     * What it answers, counted, in what its arguments are counted as
+     * ({@link DischargeRules#answersAFormOf}). Asked of an operation whose result counts and that
+     * was given something that counts, which is the shape a value re-expressed has — the result may
+     * be arithmetic over what it was given rather than a number of its own.
+     *
+     * <p>Counted and not a number, so the dates are in range. {@code Date.daysBetween} answers a
+     * number from two values that are not numbers, and {@code Date.addDays} a value that is not one
+     * — asked of numbers alone, neither is even a question, and the operations this exists for
+     * would have been out of range of it.
      */
-    FORM("whether the number it answers is one it was given") {
+    FORM("what it answers, counted, in what its arguments are counted as") {
         @Override
         boolean asksOf(Prelude.Signature signature) {
-            return isANumber(signature.result())
-                    && signature.params().stream().anyMatch(Question::isANumber);
+            return countsToANumber(signature.result())
+                    && signature.params().stream().anyMatch(Question::countsToANumber);
         }
 
         @Override
@@ -542,7 +548,7 @@ enum Question {
      * strings apart — a size counts one of them. So the range is read off the declarations, and the
      * day the library gains such a measure the operations of that kind come into range and are asked.
      */
-    private static boolean isCounted(Type t) {
+    private static boolean hasAMeasureCountingTwoApart(Type t) {
         return Prelude.entries().values().stream().anyMatch(entry -> {
             List<Type> counted = entry.signature().params();
             return isANumber(entry.signature().result()) && counted.size() == 2
@@ -555,6 +561,25 @@ enum Question {
      * as what puts an operation in range of one. */
     static boolean isANumber(Type t) {
         return t == Type.Prim.INT || t == Type.Prim.DECIMAL;
+    }
+
+    /**
+     * Whether values of {@code t} count to a number.
+     *
+     * <p>Wider than {@link #isANumber} and asked where the arithmetic is over counts rather than
+     * over numbers a model wrote: a date is not a number and counts days, so a difference of two of
+     * them is a number of days. Asked of {@link Carrier}, which is the one table saying which types
+     * have an order with counts under it — a second answer here would be a second table, and a type
+     * that is a carrier to one of them and not to the other is what that costs.
+     *
+     * <p>Asked without the declarations, which is what a reading of the library's own signatures
+     * has: {@link Carrier#ofPrimitive} answers where the type settles it and leaves a name
+     * unanswered. The names in those signatures are the error unions and {@code RoundingMode}, and
+     * a form is written over none of them.
+     */
+    static boolean countsToANumber(Type t) {
+        Carrier carrier = Carrier.ofPrimitive(t);
+        return carrier != null && carrier.counts();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -605,14 +605,6 @@ final class Terms {
         if (written != null && written != n) {
             return affineOf(written, at);
         }
-        // An operation answering a number it was given is that number here, whatever type it
-        // answers it in: `Decimal.fromInt(n)` is `n`, so a guard about `n` is about the call as
-        // well. Read through rather than made an atom of its own, which would leave the two
-        // unrelated and the guard saying nothing about the construction.
-        Core answered = DischargeRules.answersItsArgument(n);
-        if (answered != null) {
-            return affineOf(answered, at);
-        }
         // A list written out has as many elements as it is written with, whatever they are.
         BigDecimal counted = writtenSize(n, at);
         if (counted != null) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
@@ -157,12 +157,22 @@ public record FixtureTemplate(String text, Hir.Expr value) {
      * declaring it does not expose, which a value can be of and no author can write down. Every
      * other carrier writes a literal, which needs no name from anyone.
      *
+     * <p>Null too where no value of the order stands at {@code at}. A count is arithmetic and the
+     * order it is a count on may stop: a time of day counts seconds from midnight and has 86400 of
+     * them, so the count below its first is a count no time has. Asked of the order's own ends
+     * ({@link Carrier#extent()}) rather than restated here, since a second statement of where an
+     * order stops is a second thing to keep true. What such a point leaves is a point nothing
+     * composes a value at, which is what the callers already read a null as.
+     *
      * <p>Bare. How many names the value wears at the position it is going to is a different question
      * with its own answer ({@link Witnesses#wrapped}), which walks every layer; answered here as
      * well, it was answered one layer deep, and a value of a newtype over a newtype came back
      * missing the name in the middle.
      */
     public static FixtureTemplate on(Carrier carrier, Place at, TypeReachName.Naming naming) {
+        if (!carrier.extent().admits(at)) {
+            return null;
+        }
         return switch (carrier) {
             case Carrier.Whole _ -> integer(Count.number(at).at().longValueExact());
             case Carrier.Dense _ -> decimal(Count.number(at).at());

--- a/souther-compiler/src/main/java/souther/compiler/semantics/OperationFact.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/OperationFact.java
@@ -16,23 +16,42 @@ package souther.compiler.semantics;
 public sealed interface OperationFact {
 
     /**
-     * The result is the number an argument already is, and this says which argument.
+     * What the operation answers, counted, is this much of what its arguments are counted as.
      *
-     * <p>Such a call is read into the form its argument has rather than given an atom of its own, so
-     * a rule about the argument settles one about the call. {@code Decimal.fromInt(n)} is the one
-     * the library has: every {@code Int} is a {@code Decimal} exactly, and the widening states
-     * nothing of its own.
+     * <p>Exact and unconditional: {@code count(result) = Σ cᵢ·count(argᵢ) + k} at every call.
+     * {@code Decimal.fromInt(n)} is {@code n}; {@code Date.daysBetween(from, to)} is
+     * {@code -from + to}; {@code Date.addDays(days, date)} is {@code date + days}. Such a call is
+     * read into that form rather than given an atom of its own, so a rule about the arguments
+     * settles one about the call.
+     *
+     * <p><b>Counted, so a date takes part.</b> What a date's count is belongs to its carrier, and
+     * the arithmetic here is over counts and not over values — which is what lets a difference of
+     * two dates be a number of days while neither of them is a number. Written as a relation
+     * between values, the two dates would have had nothing to say and the fact would have been
+     * unstateable for the operations it exists for.
      *
      * <p>Not a choice among arguments. What a choice answers is one of two values, decided by the
      * arguments, and which one it is has to be reasoned about case by case; this answers one value
-     * unconditionally, in another type. Read as a choice with one candidate, every value-preserving
-     * conversion would be filed under selection, and the two stop being one question the moment the
-     * library gains a conversion that is not a widening.
+     * unconditionally. Read as a choice with one candidate, every value-preserving conversion would
+     * be filed under selection, and the two stop being one question the moment the library gains a
+     * conversion that is not a widening.
+     *
+     * <p><b>Not for arithmetic the language composes.</b> {@code Int.add(a, b)} answers
+     * {@code a + b} and is not declared here: {@code Terms.asOperator} reads such a call as the
+     * operator it stands for, so a fact would be a second path saying what the grammar already
+     * says.
      */
-    record AnswersItsArgument(ArgumentRef argument) implements OperationFact {
+    record AnswersAFormOfItsArguments(
+            souther.compiler.numeric.NumericDomain.LinearForm<ArgumentRef> form)
+            implements OperationFact {
 
-        public AnswersItsArgument {
-            java.util.Objects.requireNonNull(argument, "this one names an argument");
+        public AnswersAFormOfItsArguments {
+            java.util.Objects.requireNonNull(form, "this one says what it answers");
+            if (form.coefs().isEmpty()) {
+                throw new IllegalArgumentException(
+                        "a form of its arguments names one: a result that is a constant whatever it"
+                                + " was given is a bound and not this");
+            }
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/semantics/OperationFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/OperationFacts.java
@@ -305,9 +305,13 @@ public final class OperationFacts {
 
         // What they answer is no form of what they were given, for three reasons.
         //
-        // Arithmetic the language composes: `Int.add(a, b)` answers `a + b`, and a fact here would
-        // be a second path saying what the grammar already reads — such a call is read as the
-        // operator it stands for before anything asks about the operation.
+        // A product is one only where an operand is written down: `Int.multiply(a, b)` is
+        // arithmetic over `a` and `b` and is a form of neither, since what multiplies each is the
+        // other. A sum and a difference are not here at all — what they answer is a form of what
+        // they were given, and they say so by being the arithmetic they are
+        // (`ComputesANumber`, read by `DischargeRules.formOperations`). A silence here would deny
+        // that, which is why the two cannot both be written: a name under a subject says nothing is
+        // true of it there.
         //
         // A number of their own: `compare` answers a sign, `floorMod` a remainder, `abs` a distance
         // with the sign dropped, `toInt` a whole number, `round` a value at another scale. What such
@@ -323,8 +327,8 @@ public final class OperationFacts {
         // for, and why the refusal is written down beside the ones that are accepted. A component
         // is read out of a count by dividing or by taking a remainder: the year a day falls in, the
         // second within a minute, the day a second falls in, the second within a day.
-        out.addAll(saysNothing(OperationSubject.FORM, op("Int", "add"), op("Int", "subtract"), op("Int", "multiply"),
-                op("Decimal", "add"), op("Decimal", "subtract"), op("Decimal", "multiply"), op("Int", "compare"),
+        out.addAll(saysNothing(OperationSubject.FORM, op("Int", "multiply"),
+                op("Decimal", "multiply"), op("Int", "compare"),
                 op("Decimal", "compare"), op("Int", "floorMod"), op("Int", "abs"), op("Decimal", "abs"), op("Decimal", "toInt"),
                 op("Decimal", "round"), op("Int", "min"), op("Int", "max"), op("Int", "clamp"), op("Decimal", "min"), op("Decimal", "max"),
                 op("Decimal", "clamp"), op("Date", "addMonths"), op("Date", "addYears"),

--- a/souther-compiler/src/main/java/souther/compiler/semantics/OperationFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/OperationFacts.java
@@ -279,25 +279,6 @@ public final class OperationFacts {
         // measure a pair of dates has.
         out.addAll(saysNothing(OperationSubject.MEASURE, op("Date", "addMonths"), op("Date", "addYears")));
 
-        // What the temporal operations answer, counted, where it is not arithmetic over what they
-        // were given.
-        //
-        // Months and years hold different numbers of days, so neither shift moves a date by any
-        // number of them. `DateTime.minutesBetween` counts whole minutes over a carrier counting
-        // seconds and drops the remainder toward zero, so it is not the difference of the two
-        // counts — which is why it is the operation an author of the next such fact would reach
-        // for, and why the refusal is written down beside the ones that are accepted.
-        //
-        // A component is read out of a count by dividing or by taking a remainder, and neither is a
-        // form of it: the year a day falls in, the second within a minute, the day a second falls
-        // in, the second within a day.
-        out.addAll(saysNothing(OperationSubject.FORM, op("Date", "addMonths"), op("Date", "addYears"),
-                op("DateTime", "minutesBetween"), op("Date", "year"), op("Date", "month"),
-                op("Date", "day"), op("Time", "hour"), op("Time", "minute"), op("Time", "second"),
-                op("DateTime", "toDate"), op("DateTime", "toTime")));
-
-        // They answer no number they were given. Arithmetic computes a new one from its operands;
-
         // They compute a new number rather than answering one they were given: what `a + b`
         // answers is neither `a` nor `b`, `compare` answers a sign, `floorMod` a remainder,
         // `abs` a distance, `toInt` a whole number, `round` a value at another scale.
@@ -322,21 +303,34 @@ public final class OperationFacts {
         out.addAll(saysNothing(OperationSubject.ORDER, op("Int", "add"), op("Int", "subtract"), op("Int", "multiply"),
                 op("Int", "min"), op("Int", "max"), op("Int", "floorMod"), op("DateTime", "minutesBetween")));
 
-        // Arithmetic the language composes. `Int.add(a, b)` answers `a + b` and a fact here would be
-        // a second path saying what the grammar already reads: such a call is read as the operator
-        // it stands for before anything asks about the operation.
+        // What they answer is no form of what they were given, for three reasons.
         //
-        // Below them, the operations that answer a number of their own: `compare` answers a sign,
-        // `compare` answers a sign, `floorMod` a remainder, `abs` a distance with the sign dropped,
-        // `toInt` a whole number, `round` a value at another scale — what such a result is bounded
-        // by is a different statement from its being a value that was already there; and `min`,
-        // `max` and `clamp` answer one of their arguments, which one depending on the arguments,
-        // and that is what their cases say.
+        // Arithmetic the language composes: `Int.add(a, b)` answers `a + b`, and a fact here would
+        // be a second path saying what the grammar already reads — such a call is read as the
+        // operator it stands for before anything asks about the operation.
+        //
+        // A number of their own: `compare` answers a sign, `floorMod` a remainder, `abs` a distance
+        // with the sign dropped, `toInt` a whole number, `round` a value at another scale. What such
+        // a result is bounded by is a different statement from its being a value that was already
+        // there; and `min`, `max` and `clamp` answer one of their arguments, which one depending on
+        // the arguments, and that is what their cases say.
+        //
+        // And, among the temporal ones, a count that is not arithmetic over the counts it was
+        // given. Months and years hold different numbers of days, so neither shift moves a date by
+        // any number of them. `DateTime.minutesBetween` counts whole minutes over a carrier
+        // counting seconds and drops the remainder toward zero, so it is not the difference of the
+        // two counts — which is why it is the operation an author of the next such fact would reach
+        // for, and why the refusal is written down beside the ones that are accepted. A component
+        // is read out of a count by dividing or by taking a remainder: the year a day falls in, the
+        // second within a minute, the day a second falls in, the second within a day.
         out.addAll(saysNothing(OperationSubject.FORM, op("Int", "add"), op("Int", "subtract"), op("Int", "multiply"),
                 op("Decimal", "add"), op("Decimal", "subtract"), op("Decimal", "multiply"), op("Int", "compare"),
                 op("Decimal", "compare"), op("Int", "floorMod"), op("Int", "abs"), op("Decimal", "abs"), op("Decimal", "toInt"),
                 op("Decimal", "round"), op("Int", "min"), op("Int", "max"), op("Int", "clamp"), op("Decimal", "min"), op("Decimal", "max"),
-                op("Decimal", "clamp")));
+                op("Decimal", "clamp"), op("Date", "addMonths"), op("Date", "addYears"),
+                op("DateTime", "minutesBetween"), op("Date", "year"), op("Date", "month"),
+                op("Date", "day"), op("Time", "hour"), op("Time", "minute"), op("Time", "second"),
+                op("DateTime", "toDate"), op("DateTime", "toTime")));
         return List.copyOf(out);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/semantics/OperationFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/OperationFacts.java
@@ -308,8 +308,8 @@ public final class OperationFacts {
         // A product is one only where an operand is written down: `Int.multiply(a, b)` is
         // arithmetic over `a` and `b` and is a form of neither, since what multiplies each is the
         // other. A sum and a difference are not here at all — what they answer is a form of what
-        // they were given, and they say so by being the arithmetic they are
-        // (`ComputesANumber`, read by `DischargeRules.formOperations`). A silence here would deny
+        // they were given, and they say so by being the arithmetic they are — the operator a call
+        // to them is read as, which `ComputesANumber` records. A silence here would deny
         // that, which is why the two cannot both be written: a name under a subject says nothing is
         // true of it there.
         //

--- a/souther-compiler/src/main/java/souther/compiler/semantics/OperationFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/OperationFacts.java
@@ -60,7 +60,23 @@ public final class OperationFacts {
 
     private static List<Declared> declared() {
         List<Declared> out = new ArrayList<>(List.of(
-            about("Decimal", "fromInt", new OperationFact.AnswersItsArgument(at(0))),
+            // What each answers, counted, in what its arguments are counted as. A date's count is
+            // its carrier's, so a difference of two of them is a number of days while neither is a
+            // number — which is the whole of why these can be said at all.
+            about("Decimal", "fromInt", answers(form(at(0), 1))),
+            about("Date", "daysBetween", answers(form(at(0), -1).plus(form(at(1), 1)))),
+            about("Date", "addDays", answers(form(at(0), 1).plus(form(at(1), 1)))),
+            // The same over the second the date-times count, which is the epoch second a local
+            // value stands at: a day is eighty-six thousand four hundred of them, exactly, because
+            // the value carries no zone for anything to shift it by.
+            about("DateTime", "addMinutes", answers(form(at(0), 60).plus(form(at(1), 1)))),
+            about("DateTime", "addHours", answers(form(at(0), 3600).plus(form(at(1), 1)))),
+            about("DateTime", "addDays", answers(form(at(0), 86400).plus(form(at(1), 1)))),
+            // And the one that puts two counts together: a date counts days from the epoch and a
+            // time counts seconds into its day, so the date-time they make counts the first at a
+            // day's worth of seconds and the second as it stands.
+            about("DateTime", "fromDateAndTime",
+                    answers(form(at(0), 86400).plus(form(at(1), 1)))),
 
             // The operations whose result is a number taken of the one value they are given.
             about("List", "length", new OperationFact.CountsWhatItIsGiven()),
@@ -263,6 +279,25 @@ public final class OperationFacts {
         // measure a pair of dates has.
         out.addAll(saysNothing(OperationSubject.MEASURE, op("Date", "addMonths"), op("Date", "addYears")));
 
+        // What the temporal operations answer, counted, where it is not arithmetic over what they
+        // were given.
+        //
+        // Months and years hold different numbers of days, so neither shift moves a date by any
+        // number of them. `DateTime.minutesBetween` counts whole minutes over a carrier counting
+        // seconds and drops the remainder toward zero, so it is not the difference of the two
+        // counts — which is why it is the operation an author of the next such fact would reach
+        // for, and why the refusal is written down beside the ones that are accepted.
+        //
+        // A component is read out of a count by dividing or by taking a remainder, and neither is a
+        // form of it: the year a day falls in, the second within a minute, the day a second falls
+        // in, the second within a day.
+        out.addAll(saysNothing(OperationSubject.FORM, op("Date", "addMonths"), op("Date", "addYears"),
+                op("DateTime", "minutesBetween"), op("Date", "year"), op("Date", "month"),
+                op("Date", "day"), op("Time", "hour"), op("Time", "minute"), op("Time", "second"),
+                op("DateTime", "toDate"), op("DateTime", "toTime")));
+
+        // They answer no number they were given. Arithmetic computes a new one from its operands;
+
         // They compute a new number rather than answering one they were given: what `a + b`
         // answers is neither `a` nor `b`, `compare` answers a sign, `floorMod` a remainder,
         // `abs` a distance, `toInt` a whole number, `round` a value at another scale.
@@ -287,7 +322,11 @@ public final class OperationFacts {
         out.addAll(saysNothing(OperationSubject.ORDER, op("Int", "add"), op("Int", "subtract"), op("Int", "multiply"),
                 op("Int", "min"), op("Int", "max"), op("Int", "floorMod"), op("DateTime", "minutesBetween")));
 
-        // They answer no number they were given. Arithmetic computes a new one from its operands;
+        // Arithmetic the language composes. `Int.add(a, b)` answers `a + b` and a fact here would be
+        // a second path saying what the grammar already reads: such a call is read as the operator
+        // it stands for before anything asks about the operation.
+        //
+        // Below them, the operations that answer a number of their own: `compare` answers a sign,
         // `compare` answers a sign, `floorMod` a remainder, `abs` a distance with the sign dropped,
         // `toInt` a whole number, `round` a value at another scale — what such a result is bounded
         // by is a different statement from its being a value that was already there; and `min`,
@@ -364,6 +403,18 @@ public final class OperationFacts {
                 new ElementLineage.ClosureResult(new ElementLineage.Source(source, 1)), size));
     }
 
+    /** {@code times} of what one argument is counted as. */
+    private static souther.compiler.numeric.NumericDomain.LinearForm<ArgumentRef> form(
+            ArgumentRef argument, long times) {
+        return souther.compiler.numeric.NumericDomain.LinearForm.<ArgumentRef>atom(argument)
+                .times(java.math.BigDecimal.valueOf(times));
+    }
+
+    private static OperationFact answers(
+            souther.compiler.numeric.NumericDomain.LinearForm<ArgumentRef> form) {
+        return new OperationFact.AnswersAFormOfItsArguments(form);
+    }
+
     private static OperationFact bounded(Rel rel, long n) {
         return bounded(rel, null, n, new ResultBound.Provided.Always());
     }
@@ -397,15 +448,16 @@ public final class OperationFacts {
         return DECLARED;
     }
 
-    /** The argument whose number {@code operation} answers, or null where it answers none of them
-     *  back. */
-    public static ArgumentRef answersItsArgument(ValueName operation) {
-        return Index.ANSWERS_ITS_ARGUMENT.get(operation);
+    /** What {@code operation} answers, counted, in what its arguments are counted as — or null
+     *  where it states no such form. */
+    public static souther.compiler.numeric.NumericDomain.LinearForm<ArgumentRef>
+            answersAFormOfItsArguments(ValueName operation) {
+        return Index.ANSWERS_A_FORM.get(operation);
     }
 
-    /** The operations declared to answer one of their arguments. */
-    public static java.util.Set<ValueName> answersItsArgument() {
-        return Index.ANSWERS_ITS_ARGUMENT.keySet();
+    /** The operations declared to answer a form of their arguments. */
+    public static java.util.Set<ValueName> answersAFormOfItsArguments() {
+        return Index.ANSWERS_A_FORM.keySet();
     }
 
     /** Which of {@code operation}'s two arguments a positive answer names as the greater, or null
@@ -537,9 +589,10 @@ public final class OperationFacts {
     /** The indexes, read off the declarations on the first ask. */
     private static final class Index {
 
-        private static final Map<ValueName, ArgumentRef> ANSWERS_ITS_ARGUMENT =
-                index(OperationFact.AnswersItsArgument.class,
-                        OperationFact.AnswersItsArgument::argument);
+        private static final Map<ValueName,
+                souther.compiler.numeric.NumericDomain.LinearForm<ArgumentRef>> ANSWERS_A_FORM =
+                index(OperationFact.AnswersAFormOfItsArguments.class,
+                        OperationFact.AnswersAFormOfItsArguments::form);
 
         private static final Map<ValueName, PositiveOrder> ORDERS =
                 index(OperationFact.StatesTheOrderOfItsArguments.class,

--- a/souther-compiler/src/main/java/souther/compiler/semantics/OperationSubject.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/OperationSubject.java
@@ -28,7 +28,7 @@ public enum OperationSubject {
     BOUNDS("what bounds the number it answers"),
     MEASURE("what it states through the measure counting the two apart"),
     CHOICE("whether it answers one of its arguments, and in which cases"),
-    FORM("whether the number it answers is one it was given"),
+    FORM("what it answers, counted, in what its arguments are counted as"),
     NUMERIC_RESULT("what number it computes, and where it answers it");
 
     private final String asked;

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperationTheLibraryGainsIsAnsweredForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperationTheLibraryGainsIsAnsweredForTest.java
@@ -76,6 +76,35 @@ class AnOperationTheLibraryGainsIsAnsweredForTest {
     }
 
     /**
+     * And no operation is on both sides of a question at once. A silence is a decision that nothing
+     * is true under the subject, so beside a rule saying what is it is not a spare row — it is the
+     * denial of what the rule says, and the two cannot both be read without one of them being
+     * wrong.
+     *
+     * <p>The direction the other two cannot see. Both of them read the union: a range covered is a
+     * range where every operation has a rule <em>or</em> a silence, and a name written down is a
+     * name the question asks of either way. So a silence was only ever tested as a filler, and one
+     * that had become false stayed where it was — {@code Int.add} was declared to say nothing of
+     * what it answers in what it was given, next to the arithmetic the language reads it as, for as
+     * long as no rule for it reached this question. Nothing here fell over, because covering a
+     * range is all either of them asks.
+     */
+    @Test
+    void noOperationBothAnswersAQuestionAndIsSilentUnderIt() {
+        List<String> saidBothWays = new ArrayList<>();
+        for (Question question : Question.values()) {
+            for (ValueName operation : question.answeredOperations()) {
+                if (question.nothingSaidOf().contains(operation)) {
+                    saidBothWays.add(operation + " — " + question);
+                }
+            }
+        }
+        assertEquals(List.of(), saidBothWays,
+                "these answer a question with a rule and are also declared to say nothing under it,"
+                        + " so the silence beside the rule denies it");
+    }
+
+    /**
      * A question reads the declaration for what it asks about and no more. What an operation hands
      * its closure is a question about its arguments, so a declaration that leaves its result to its
      * body — which the library allows a helper with parameters to do — is still asked it. Nothing in

--- a/souther-compiler/src/test/java/souther/compiler/check/EverySemanticDeclarationIsHeldToTheLibraryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EverySemanticDeclarationIsHeldToTheLibraryTest.java
@@ -5,8 +5,11 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.semantics.ArgumentRef;
 import souther.compiler.semantics.OperationFact;
 import souther.compiler.semantics.OperationFacts;
+import souther.compiler.semantics.ResultBound;
+import souther.compiler.numeric.NumericDomain.Rel;
 import souther.compiler.types.ValueName;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -67,6 +70,63 @@ class EverySemanticDeclarationIsHeldToTheLibraryTest {
         assertTrue(refused.getMessage().contains("argument 8"),
                 "the argument the added fact names, which the operation does not take: "
                         + refused.getMessage());
+    }
+
+    /**
+     * What a fact says of the result is held to the library as well as what it says of an argument.
+     *
+     * <p>The half the tests above cannot see. Each of them adds a fact naming an argument the
+     * operation does not have, so what they show is that the argument side of a proposition is held.
+     * Only one primitive existed and it named an argument, so a fact about the result was held by
+     * whatever its own arm remembered to write — and a form is an equation between the two ends.
+     * {@code List.get(index, xs)} declared to answer the count of its first argument passes on the
+     * argument side, that argument being an {@code Int}, while what it answers is an
+     * {@code Option<'a>} and has no count for the equation to be about.
+     */
+    @Test
+    void whatAFactSaysOfTheResultIsHeldToTheLibraryToo() {
+        List<OperationFacts.Declared> gained =
+                new ArrayList<>(OperationFacts.declarations());
+        gained.add(new OperationFacts.Declared(
+                new ValueName.Stdlib("List", "get"),
+                new OperationFact.AnswersAFormOfItsArguments(
+                        souther.compiler.numeric.NumericDomain.LinearForm.atom(
+                                new ArgumentRef.At(0)))));
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> OperationFactBinder.bindAll(gained),
+                "a form is an equation between what an operation answers and what it was given, so"
+                        + " a result with no count is a result the equation is not about");
+
+        assertTrue(refused.getMessage().contains("List.get"), refused.getMessage());
+        assertTrue(refused.getMessage().contains("what"),
+                "what it answers is what is wrong, and the message says so: "
+                        + refused.getMessage());
+    }
+
+    /**
+     * And a fact stated of the result that names no argument at all.
+     *
+     * <p>Beside the above because nothing else in it reaches a signature. A bound with no argument
+     * to hold the result against names none, so its arm held the operation and stopped; a bound on
+     * what {@code List.get} answers went through it. Two kinds were in this position —
+     * {@code BoundsItsResult} and {@code IsDefinedByCases} — and both are stated of a number.
+     */
+    @Test
+    void aFactStatedOfTheResultAndNamingNoArgumentIsHeldToo() {
+        List<OperationFacts.Declared> gained =
+                new ArrayList<>(OperationFacts.declarations());
+        gained.add(new OperationFacts.Declared(
+                new ValueName.Stdlib("List", "get"),
+                new OperationFact.BoundsItsResult(new ResultBound(null, BigDecimal.ZERO,
+                        Rel.GE, new ResultBound.Provided.Always()))));
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> OperationFactBinder.bindAll(gained),
+                "a bound is stated of the number an operation answers, and List.get answers no"
+                        + " number");
+
+        assertTrue(refused.getMessage().contains("List.get"), refused.getMessage());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/EverySemanticDeclarationIsHeldToTheLibraryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EverySemanticDeclarationIsHeldToTheLibraryTest.java
@@ -56,7 +56,9 @@ class EverySemanticDeclarationIsHeldToTheLibraryTest {
                 new ArrayList<>(OperationFacts.declarations());
         gained.add(new OperationFacts.Declared(
                 new ValueName.Stdlib("Decimal", "fromInt"),
-                new OperationFact.AnswersItsArgument(new ArgumentRef.At(7))));
+                new OperationFact.AnswersAFormOfItsArguments(
+                        souther.compiler.numeric.NumericDomain.LinearForm.atom(
+                                new ArgumentRef.At(7)))));
 
         IllegalStateException refused = assertThrows(IllegalStateException.class,
                 () -> OperationFactBinder.bindAll(gained));
@@ -110,7 +112,9 @@ class EverySemanticDeclarationIsHeldToTheLibraryTest {
                 new ArrayList<>(OperationFacts.declarations());
         gained.add(new OperationFacts.Declared(
                 new ValueName.Stdlib("Decimal", "fromNothingAtAll"),
-                new OperationFact.AnswersItsArgument(new ArgumentRef.At(0))));
+                new OperationFact.AnswersAFormOfItsArguments(
+                        souther.compiler.numeric.NumericDomain.LinearForm.atom(
+                                new ArgumentRef.At(0)))));
 
         IllegalStateException refused = assertThrows(IllegalStateException.class,
                 () -> OperationFactBinder.bindAll(gained));

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatTheCheckCarriesDecidesAClauseOverDatesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatTheCheckCarriesDecidesAClauseOverDatesTest.java
@@ -1,0 +1,132 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.check.InvariantChecker.Said;
+import souther.compiler.check.InvariantChecker.Verdict;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * What this check makes of a clause counting two dates apart, over the model #949 is written about.
+ *
+ * <p>Here because one reading now has two readers. {@code AffineForms.composed} is read by the
+ * discharge check and by the partition, and what an operation answers in what it was given is
+ * declared once for both — so a date is now a carrier the composition walks, and the operations over
+ * dates say what they answer in it. The partition's side of that is pinned where it is measured; this
+ * check's side was measured by hand, and a shared reader with one pinned reader moves the other with
+ * nothing failing.
+ *
+ * <p>Every verdict below is what was read at {@code c9ef497f} — the develop these declarations
+ * arrived on — and is unchanged by them. That is the claim: the semantics widened and this check's
+ * answers did not.
+ *
+ * <p>What decides them is what this check can carry and not what the library declares. Its
+ * arithmetic is over the numbers a model wrote, and a date is not one
+ * ({@link DischargeRules#formOperationsThisCarries}), so a clause is discharged here through the
+ * measure that counts two dates apart — which is what a shift states ({@code Date.addDays}) and what
+ * a guard writing the clause states of itself. The same statement spelled as two shifted dates
+ * compared is not carried, and the two spellings coming to one answer is the partition's, where a
+ * border is drawn over the numbers themselves.
+ */
+class WhatTheCheckCarriesDecidesAClauseOverDatesTest {
+
+    /** #949's model, as the issue writes it. */
+    private static final String MODEL = """
+            module demo
+            data Span = { from: Date, to: Date }
+                invariant within = Date.daysBetween(from, to) <= 30
+            """;
+
+    @Test
+    void aShiftInsideTheBoundIsDischargedThroughTheMeasureThatCountsIt() {
+        reads(Verdict.PROVED, MODEL + """
+                behavior makeSpan : (d: Date) -> Span constructs Span
+                let makeSpan (d) = Span { from = d, to = Date.addDays(10, d) }
+                """);
+    }
+
+    @Test
+    void aShiftPastTheBoundIsRefutedOnTheValuesAlone() {
+        reads(Verdict.REFUTED_ALONE, MODEL + """
+                behavior makeSpan : (d: Date) -> Span constructs Span
+                let makeSpan (d) = Span { from = d, to = Date.addDays(40, d) }
+                """);
+    }
+
+    @Test
+    void twoDatesWithNothingStatedBetweenThemLeaveTheClauseUnproven() {
+        reads(Verdict.UNKNOWN, MODEL + """
+                behavior makeSpan : (a: Date, b: Date) -> Span constructs Span
+                let makeSpan (a, b) = Span { from = a, to = b }
+                """);
+    }
+
+    /** A guard writing the clause states it of the values the construction is over. */
+    @Test
+    void theClauseInTheGuardDischargesIt() {
+        reads(Verdict.PROVED, MODEL + """
+                data TooWide
+                behavior makeSpan : (a: Date, b: Date) -> Span | TooWide constructs Span
+                let makeSpan (a, b) =
+                    if Date.daysBetween(a, b) <= 30 then Span { from = a, to = b }
+                    else TooWide
+                """);
+    }
+
+    /**
+     * And the same statement spelled as a comparison of two shifted dates does not, which is what
+     * this check carrying no date says. The two spellings are one statement — the partition draws one
+     * border for both — and here they come to different answers, so this is the boundary of what the
+     * declarations bought and not an incidental gap.
+     */
+    @Test
+    void theSameStatementSpelledAsShiftedDatesComparedDoesNot() {
+        reads(Verdict.UNKNOWN, MODEL + """
+                data TooWide
+                behavior makeSpan : (a: Date, n: Int) -> Span | TooWide constructs Span
+                let makeSpan (a, n) =
+                    if Date.addDays(30, a) >= Date.addDays(n, a) then
+                        Span { from = a, to = Date.addDays(n, a) }
+                    else TooWide
+                """);
+    }
+
+    /** A shift by months moves a date by no number of days, so the measure says nothing of it. */
+    @Test
+    void aShiftByMonthsLeavesTheClauseUnproven() {
+        reads(Verdict.UNKNOWN, MODEL + """
+                behavior makeSpan : (d: Date) -> Span constructs Span
+                let makeSpan (d) = Span { from = d, to = Date.addMonths(1, d) }
+                """);
+    }
+
+    /** The verdicts this check reached on constructions of {@code Span}, and that it reached one:
+     *  a construction nothing judged would otherwise be read as a construction nothing is owed on. */
+    private static void reads(Verdict expected, String source) {
+        List<Said> said = Collections.synchronizedList(new ArrayList<>());
+        InvariantChecker.WATCHING = said;
+        try {
+            Compiler.compileWithWarnings(source);
+        } catch (souther.compiler.diag.CompileException refused) {
+            // A construction the values refute is reported, and the verdict saying so was reached
+            // before it was. Any other refusal is this test's own program being wrong, and
+            // swallowing it would leave `no construction was judged` standing for `it did not
+            // compile`.
+            if (!expected.refuted()) {
+                throw refused;
+            }
+        } finally {
+            InvariantChecker.WATCHING = null;
+        }
+        List<Verdict> reached = said.stream().map(Said::verdict).toList();
+        assertFalse(reached.isEmpty(), "no construction of Span was judged at all");
+        assertEquals(List.of(expected), reached);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACountNoValueOfTheOrderStandsAtComposesNothingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACountNoValueOfTheOrderStandsAtComposesNothingTest.java
@@ -1,0 +1,116 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ItemAssessment;
+import souther.compiler.query.PartitionEvidence;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A point whose count no value of the order stands at is a point nothing composes a value for.
+ *
+ * <p>An order that counts may stop. A time of day counts seconds from midnight and has 86400 of
+ * them, so the count below its first is a count no time has — and the arithmetic that puts a point
+ * beside a line knows nothing of that, since a count is a number and the ends are the order's.
+ * Written out regardless, the conversion refused it the only way it could: {@code Time} came back
+ * from {@code LocalTime.ofSecondOfDay(-1)} as a {@code DateTimeException}, out of the middle of a
+ * measurement, on a model that compiles.
+ *
+ * <p>Reached through {@code DateTime.fromDateAndTime}, which is what first puts a time of day where
+ * a line is drawn: a date-time counts seconds and is a day count and a second of one put together,
+ * so a rule over it has a position on the bounded order. Every other order a line had been drawn on
+ * stops nowhere a count reaches.
+ *
+ * <p>What such a point leaves is what a point nothing can be written at has always left, and the
+ * border beside it is unaffected — the line is still drawn, and the points that do have values keep
+ * them.
+ */
+class ACountNoValueOfTheOrderStandsAtComposesNothingTest {
+
+    private static final String MODEL = """
+            module demo
+
+            data Ok
+            data No
+
+            behavior f : (d: Date, t: Time, b: DateTime) -> Ok | No
+            let f (d, t, b) = {
+                guard b > DateTime.fromDateAndTime(d, t) else No
+                Ok
+            }
+            """;
+
+    /** The line is drawn, over the counts the operation was declared with. */
+    @Test
+    void theLineIsStillDrawn() {
+        assertEquals(List.of("b - 86400 * d - t = 0"), measured().boundaries().stream()
+                .map(BorderAssessment::label).toList());
+    }
+
+    /**
+     * The point below it composes nothing, and says so.
+     *
+     * <p>The band this line leaves has its points at nought and beside it, and a time of day at the
+     * bottom of its order has nothing below it: the point wants a second before midnight of the
+     * first day there is. So it is unresolved for the reason a point nothing can be written at is
+     * unresolved, which is the answer that was already there for a case no module can name.
+     */
+    @Test
+    void thePointBelowItIsUnresolvedRatherThanThrown() {
+        List<String> reasons = new ArrayList<>();
+        for (BorderAssessment border : measured().boundaries()) {
+            border.items().forEach((role, item) -> {
+                if (item instanceof ItemAssessment.Owed owed
+                        && owed.attempt() instanceof ItemAssessment.Attempt.Unresolved unresolved) {
+                    reasons.add(unresolved.why().reason().toString());
+                }
+            });
+        }
+        assertTrue(!reasons.isEmpty(), "a point of this line was owed a row and got none");
+        assertEquals(List.of(), reasons.stream()
+                        .filter(each -> !each.equals("NOTHING_COMPOSES_ONE")).toList(),
+                "and that is what a point nothing composes a value at says: " + reasons);
+    }
+
+    /** And the points that do have values keep them, so the line was not emptied to get here. */
+    @Test
+    void thePointsWithValuesKeepThem() {
+        List<String> rows = new ArrayList<>();
+        for (BorderAssessment border : measured().boundaries()) {
+            border.items().forEach((role, item) -> {
+                if (item instanceof ItemAssessment.Owed owed
+                        && owed.attempt() instanceof ItemAssessment.Attempt.Built built) {
+                    rows.add(built.row().inputs().stream().map(FixtureTemplate::text).toList()
+                            .toString());
+                }
+            });
+        }
+        assertEquals(List.of(
+                        "[Date(\"1970-01-01\"), Time(\"00:00:00\"), DateTime(\"1970-01-01T00:00:00\")]",
+                        "[Date(\"1970-01-01\"), Time(\"00:00:01\"), DateTime(\"1970-01-01T00:00:00\")]"),
+                rows,
+                "the two points that have a value, at the counts the declared form puts them at");
+    }
+
+    private static PartitionEvidence measured() {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, PartitionEvidence> coverage =
+                compilation.db().ask(new Adequacy.Coverage("demo")).value();
+        assertNotNull(coverage, "the model under test compiles");
+        PartitionEvidence measured = coverage.get("f");
+        assertNotNull(measured, "f was measured");
+        return measured;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowOfferedForABorderOverAnOperationStandsAtItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowOfferedForABorderOverAnOperationStandsAtItTest.java
@@ -1,0 +1,155 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ItemAssessment;
+import souther.compiler.query.PartitionEvidence;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A row offered at a point of a border stands at the point it was offered for.
+ *
+ * <p>A border being drawn is one thing and a row for it being writable is another. What must hold is
+ * the round trip: a row offered for a point, put back into the model and measured again, is at that
+ * point. A row offered for one point and standing at another sends an author to write something that
+ * answers a question it was not written for, and the report would say the point was covered.
+ *
+ * <p><b>How many rows there are is not asked.</b> Whether the search reaches an assignment is its
+ * own answer and moves with what a model leaves each position — a point nothing could be composed
+ * for is a point with no row here, which is a fact about the search rather than a broken promise.
+ * So the rows are taken as offered and each is held to its own point, and none of it says there
+ * must be any.
+ *
+ * <p>What <em>is</em> asked is that the border this is about is here with points still open. Without
+ * it the round trip is over nothing and passes quietly, which is how the first version of this test
+ * passed while comparing one empty list to another.
+ */
+class ARowOfferedForABorderOverAnOperationStandsAtItTest {
+
+    private static final String SPAN = """
+            module demo
+
+            data Ok
+            data No
+            data Day = Date
+                invariant value >= Date("2000-01-01")
+                invariant value <= Date("2030-12-31")
+
+            behavior f : (a: Day, b: Day) -> Ok | No
+            let f (a, b) = {
+                guard Date.daysBetween(a.value, b.value) > 10 else No
+                Ok
+            }
+            """;
+
+    /** {@code Day(Date("2000-01-01"))}, as a row's input is written. */
+    private static final Pattern WRITTEN_DATE = Pattern.compile("Date\\(\"([0-9-]+)\"\\)");
+
+    /**
+     * The border the operation draws is here, and its points are open.
+     *
+     * <p>The guard on everything below. A model whose border went away, or whose points were all
+     * covered by something else, would leave the round trip with nothing to make and nothing to say.
+     */
+    @Test
+    void theBorderThisIsAboutIsDrawnAndItsPointsAreOpen() {
+        PartitionEvidence measured = measured(SPAN);
+
+        assertEquals(List.of("b - 10"), measured.boundaries().stream()
+                .map(BorderAssessment::value).filter(each -> each.contains("b")).toList(),
+                "the line `Date.daysBetween(a, b) > 10` draws");
+        assertTrue(!open(measured).isEmpty(),
+                "and points of it nothing has covered, for a row to be offered at");
+    }
+
+    /**
+     * And every row offered at a point stands at that point.
+     *
+     * <p>Read off the point's own attempt rather than out of the block a report prints: the row a
+     * point was composed for is the one recorded against it, and matching them up again by parsing
+     * text would be a second answer to a question already answered.
+     */
+    @Test
+    void everyRowOfferedAtAPointStandsAtIt() {
+        Map<String, String> rows = offeredAt(measured(SPAN));
+
+        PartitionEvidence again = measured(SPAN + "\nexample f\n"
+                + String.join("\n", rows.values()) + "\n");
+
+        assertEquals(List.of(), open(again).stream().filter(rows::containsKey).toList(),
+                "each point a row was offered at was met once that row was in: " + rows);
+    }
+
+    /** The points of every border a row is owed at and nothing stands at. */
+    private static List<String> open(PartitionEvidence evidence) {
+        List<String> points = new ArrayList<>();
+        for (BorderAssessment border : evidence.boundaries()) {
+            border.items().forEach((role, item) -> {
+                if (item instanceof ItemAssessment.Owed owed
+                        && !ItemAssessment.Coverage.hit(owed.coverage())) {
+                    points.add(border.label() + " " + role);
+                }
+            });
+        }
+        return points;
+    }
+
+    /**
+     * The row offered at each point that has one, by the point it was offered at.
+     *
+     * <p>Empty where the search composed nothing, which is what a point with no row is. Whether that
+     * happens is the search's answer and no part of what this holds.
+     */
+    private static Map<String, String> offeredAt(PartitionEvidence evidence) {
+        Map<String, String> rows = new LinkedHashMap<>();
+        for (BorderAssessment border : evidence.boundaries()) {
+            border.items().forEach((role, item) -> {
+                if (item instanceof ItemAssessment.Owed owed
+                        && owed.attempt() instanceof ItemAssessment.Attempt.Built built) {
+                    rows.put(border.label() + " " + role, written(built.row()));
+                }
+            });
+        }
+        return rows;
+    }
+
+    /** A built row as an example line, answered the way the behavior answers it. */
+    private static String written(Generator.GeneratedRow row) {
+        List<String> inputs = row.inputs().stream().map(FixtureTemplate::text).toList();
+        List<LocalDate> dates = new ArrayList<>();
+        for (String each : inputs) {
+            Matcher found = WRITTEN_DATE.matcher(each);
+            dates.add(found.find() ? LocalDate.parse(found.group(1)) : null);
+        }
+        String answers = dates.size() == 2 && dates.get(0) != null && dates.get(1) != null
+                && ChronoUnit.DAYS.between(dates.get(0), dates.get(1)) > 10 ? "Ok" : "No";
+        return "    | (" + String.join(", ", inputs) + ") -> " + answers;
+    }
+
+    private static PartitionEvidence measured(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, PartitionEvidence> coverage = compilation.db()
+                .ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
+        assertNotNull(coverage, () -> "the model under test compiles: " + source);
+        PartitionEvidence measured = coverage.get("f");
+        assertNotNull(measured, () -> "f was measured: " + source);
+        return measured;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowOfferedForABorderOverAnOperationStandsAtItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowOfferedForABorderOverAnOperationStandsAtItTest.java
@@ -128,17 +128,29 @@ class ARowOfferedForABorderOverAnOperationStandsAtItTest {
         return rows;
     }
 
-    /** A built row as an example line, answered the way the behavior answers it. */
+    /**
+     * A built row as an example line, answered the way {@link #SPAN}'s guard answers it.
+     *
+     * <p>The answer is worked out here because a row is offered with its result left for an author
+     * to fill in, and the round trip needs it filled. That makes this the fixture's guard written a
+     * second time, and the two have to move together — which is why it is the guard of a model
+     * three lines long rather than of anything a reader would have to think about.
+     *
+     * <p>A row that is not two written dates is refused rather than answered {@code No}. What a row
+     * looks like is the generator's to decide, and guessing at one this does not recognise would
+     * fill every point with the same answer and call the round trip green.
+     */
     private static String written(Generator.GeneratedRow row) {
         List<String> inputs = row.inputs().stream().map(FixtureTemplate::text).toList();
         List<LocalDate> dates = new ArrayList<>();
         for (String each : inputs) {
             Matcher found = WRITTEN_DATE.matcher(each);
-            dates.add(found.find() ? LocalDate.parse(found.group(1)) : null);
+            assertTrue(found.find(), () -> "a row of this behavior is written as two dates: " + each);
+            dates.add(LocalDate.parse(found.group(1)));
         }
-        String answers = dates.size() == 2 && dates.get(0) != null && dates.get(1) != null
-                && ChronoUnit.DAYS.between(dates.get(0), dates.get(1)) > 10 ? "Ok" : "No";
-        return "    | (" + String.join(", ", inputs) + ") -> " + answers;
+        assertEquals(2, dates.size(), () -> "and there are two of them: " + inputs);
+        return "    | (" + String.join(", ", inputs) + ") -> "
+                + (ChronoUnit.DAYS.between(dates.get(0), dates.get(1)) > 10 ? "Ok" : "No");
     }
 
     private static PartitionEvidence measured(String source) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest.java
@@ -1,0 +1,119 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.PartitionEvidence;
+import souther.compiler.semantics.OperationFacts;
+import souther.compiler.types.ValueName;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * The line a rule over one of these operations draws is at the numbers the operation was declared
+ * with.
+ *
+ * <p>A border being drawn says the reading reached the form; it does not say the form is the right
+ * one. {@code DateTime.addHours} declared to move a date-time by 360 seconds an hour draws a line
+ * just as readily as one declared to move it by 3600, and a test asking only that a line is there
+ * passes on both. What the coefficient is is the whole of what these declarations say — the values
+ * are the carrier's units, and the carrier is not written down beside them — so it is what is read
+ * here, off the label the border keeps.
+ *
+ * <p>Held to the declarations rather than to a list of its own. An operation declared to answer a
+ * form of its arguments is an operation whose coefficients somebody chose, and a table written here
+ * would cover the ones chosen today; this fails until the new one is measured, and the measurement
+ * is where the next reader finds out what the numbers mean.
+ */
+class EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest {
+
+    /** A rule written over the operation, and the line it draws. */
+    private record Observation(String parameters, String condition, String label) {}
+
+    /**
+     * One rule per declared operation, and the line each draws.
+     *
+     * <p>Written as a rule and read as a line, so what is measured is what a model would get. The
+     * unit is in the number: two minutes is 120 of the seconds a date-time counts, two hours 7200,
+     * two days 172800, and a day put together out of a date and a time is 86400 of them.
+     */
+    private static final Map<ValueName, Observation> MEASURED = measured();
+
+    private static Map<ValueName, Observation> measured() {
+        Map<ValueName, Observation> out = new LinkedHashMap<>();
+        out.put(new ValueName.Stdlib("Decimal", "fromInt"),
+                new Observation("a: Int, b: Decimal", "b > Decimal.fromInt(a)", "b = a"));
+        out.put(new ValueName.Stdlib("Date", "daysBetween"),
+                new Observation("a: Date, b: Date", "Date.daysBetween(a, b) > 10", "a = b - 10"));
+        out.put(new ValueName.Stdlib("Date", "addDays"),
+                new Observation("a: Date, b: Date", "b > Date.addDays(10, a)", "b = a + 10"));
+        out.put(new ValueName.Stdlib("DateTime", "addMinutes"),
+                new Observation("a: DateTime, b: DateTime", "b > DateTime.addMinutes(2, a)",
+                        "b = a + 120"));
+        out.put(new ValueName.Stdlib("DateTime", "addHours"),
+                new Observation("a: DateTime, b: DateTime", "b > DateTime.addHours(2, a)",
+                        "b = a + 7200"));
+        out.put(new ValueName.Stdlib("DateTime", "addDays"),
+                new Observation("a: DateTime, b: DateTime", "b > DateTime.addDays(2, a)",
+                        "b = a + 172800"));
+        out.put(new ValueName.Stdlib("DateTime", "fromDateAndTime"),
+                new Observation("d: Date, t: Time, b: DateTime",
+                        "b > DateTime.fromDateAndTime(d, t)", "b - 86400 * d - t = 0"));
+        return out;
+    }
+
+    /** Every operation declared to answer a form of its arguments is measured here. */
+    @Test
+    void everyDeclaredFormIsMeasuredHere() {
+        assertEquals(OperationFacts.answersAFormOfItsArguments(), MEASURED.keySet(),
+                "an operation declared to answer a form of its arguments has its coefficients"
+                        + " measured, and one measured here is one that is declared");
+    }
+
+    /** And each draws its line at the numbers it was declared with. */
+    @Test
+    void eachDrawsItsLineAtTheNumbersItWasDeclaredWith() {
+        List<String> off = new ArrayList<>();
+        MEASURED.forEach((operation, observed) -> {
+            List<String> drawn = labelsOf(observed.parameters(), observed.condition());
+            if (!List.of(observed.label()).equals(drawn)) {
+                off.add(operation + ": " + observed.condition() + " draws " + drawn
+                        + " and not [" + observed.label() + "]");
+            }
+        });
+        assertEquals(List.of(), off);
+    }
+
+    private static List<String> labelsOf(String parameters, String condition) {
+        String model = """
+                module demo
+
+                data Ok
+                data No
+
+                behavior f : (%s) -> Ok | No
+                let f (%s) = {
+                    guard %s else No
+                    Ok
+                }
+                """.formatted(parameters,
+                parameters.replaceAll(":\\s*[A-Za-z<>]+", ""), condition);
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, PartitionEvidence> coverage =
+                compilation.db().ask(new Adequacy.Coverage("demo")).value();
+        assertNotNull(coverage, () -> "the model under test compiles: " + model);
+        PartitionEvidence measured = coverage.get("f");
+        assertNotNull(measured, () -> "f was measured: " + model);
+        return measured.boundaries().stream().map(BorderAssessment::label).toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneStatementDrawsOneBorderHoweverItIsSpelledTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneStatementDrawsOneBorderHoweverItIsSpelledTest.java
@@ -1,0 +1,162 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.PartitionEvidence;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A rule written over a standard-library operation draws the line the same rule written in
+ * arithmetic draws.
+ *
+ * <p>{@code Date.daysBetween(a, b) > 10} and {@code b > Date.addDays(10, a)} are one statement, and
+ * both are {@code b - a > 10}. Neither drew a line: the reading had no rule for what such an
+ * operation answers, so the comparison came back as one this compiler does not read — while the
+ * same statement over {@code Int.subtract} was measured.
+ *
+ * <p>What closed it is one fact per operation, said where nothing reads it and composed by the
+ * walk both readers share. So the operations below cost the partition no arm of its own, and an
+ * operation the library declares tomorrow costs it none either.
+ */
+class OneStatementDrawsOneBorderHoweverItIsSpelledTest {
+
+    /** {@code Date.daysBetween(a, b) > 10} draws the border, and at the value it names. */
+    @Test
+    void aComparisonOverAMeasureOfTwoDatesDrawsTheLineTheirDifferenceDraws() {
+        assertEquals(List.of("b - 10"), bordersOf("a: Date, b: Date",
+                "Date.daysBetween(a, b) > 10"));
+    }
+
+    /**
+     * And the same statement spelled as a shift draws the same line, from the other end.
+     *
+     * <p>{@code b > Date.addDays(10, a)} says what {@code Date.daysBetween(a, b) > 10} says. The
+     * borders name different positions because each is written beside a different one, which is
+     * what a line between two positions is: one line, said from whichever end the rule named.
+     */
+    @Test
+    void theSameStatementSpelledAsAShiftDrawsTheSameLine() {
+        assertEquals(List.of("a + 10"), bordersOf("a: Date, b: Date",
+                "b > Date.addDays(10, a)"));
+    }
+
+    /** Turned round, the border is at the other position. */
+    @Test
+    void theMeasureTheOtherWayRoundDrawsTheBorderTheOtherWayRound() {
+        assertEquals(List.of("a - 10"), bordersOf("a: Date, b: Date",
+                "Date.daysBetween(b, a) > 10"));
+    }
+
+    /**
+     * Against a position rather than a written number, both spellings reach the form.
+     *
+     * <p>{@code b - a - n} over {@code DATE}, {@code DATE} and {@code WHOLE} — the form a quantity
+     * could not be over until its terms carried their own orders. The level is nought because the
+     * threshold has been moved into it, which is what a form quantity is.
+     */
+    @Test
+    void aMeasureAgainstAPositionReachesTheFormBothWaysRound() {
+        assertEquals(List.of("0"), bordersOf("a: Date, b: Date, n: Int",
+                "Date.daysBetween(a, b) > n"));
+        assertEquals(List.of("0"), bordersOf("a: Date, b: Date, n: Int",
+                "b > Date.addDays(n, a)"));
+    }
+
+    /**
+     * And what it answers is what the arithmetic spelling has always answered.
+     *
+     * <p>Asserted against {@code Int.subtract} rather than against a value written here, so that
+     * the two cannot drift apart: the point is not that a date rule reaches some particular border
+     * but that it reaches the one its arithmetic reaches.
+     */
+    @Test
+    void aDateRuleIsMeasuredTheWayItsArithmeticSpellingIsMeasured() {
+        assertEquals(bordersOf("a: Int, b: Int, n: Int", "Int.subtract(b, a) > n"),
+                bordersOf("a: Date, b: Date, n: Int", "Date.daysBetween(a, b) > n"),
+                "one statement, one quantity, whatever the operands are counted on");
+        assertEquals(reasonsOf("a: Int, b: Int", "Int.subtract(b, a) > 10"),
+                reasonsOf("a: Date, b: Date", "Date.daysBetween(a, b) > 10"),
+                "and no partition either way: a line between two positions divides neither");
+    }
+
+    /**
+     * An operation stating no such form is still what it was.
+     *
+     * <p>{@code DateTime.minutesBetween} counts whole minutes over an order counting seconds and
+     * drops the remainder toward zero, so it is not the difference of two counts. The declaration
+     * says there is nothing to say of it, and the report says the rule is about a value made from
+     * the positions — which is what it is.
+     */
+    @Test
+    void anOperationDeclaredToStateNoSuchFormIsStillARuleAboutADerivedValue() {
+        assertEquals(List.of(), bordersOf("a: DateTime, b: DateTime",
+                "DateTime.minutesBetween(a, b) > 10"));
+        assertEquals(List.of(UndividedPosition.Reason.RULE_ABOUT_A_DERIVED_VALUE,
+                        UndividedPosition.Reason.RULE_ABOUT_A_DERIVED_VALUE),
+                reasonsOf("a: DateTime, b: DateTime", "DateTime.minutesBetween(a, b) > 10"));
+    }
+
+    /** And the same of a component, which is a count divided rather than a form of one. */
+    @Test
+    void aComponentOfAValueIsARuleAboutADerivedValue() {
+        assertEquals(List.of(), bordersOf("a: Date", "Date.year(a) > 2020"));
+        assertEquals(List.of(UndividedPosition.Reason.RULE_ABOUT_A_DERIVED_VALUE),
+                reasonsOf("a: Date", "Date.year(a) > 2020"));
+    }
+
+    /**
+     * A shift over the seconds a date-time counts, which is the same fact at another unit.
+     *
+     * <p>Declared beside the dates because it is exact for the same reason: the value carries no
+     * zone, so a day is eighty-six thousand four hundred seconds of it and nothing shifts that.
+     */
+    @Test
+    void aShiftOfADateTimeIsMeasuredToo() {
+        assertTrue(!bordersOf("a: DateTime, b: DateTime", "b > DateTime.addHours(2, a)").isEmpty(),
+                "a rule over a shifted date-time draws a line");
+    }
+
+    private static PartitionEvidence measured(String parameters, String condition) {
+        String model = """
+                module demo
+
+                data Ok
+                data No
+
+                behavior f : (%s) -> Ok | No
+                let f (%s) = {
+                    guard %s else No
+                    Ok
+                }
+                """.formatted(parameters,
+                parameters.replaceAll(":\\s*[A-Za-z<>]+", ""), condition);
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, PartitionEvidence> coverage =
+                compilation.db().ask(new Adequacy.Coverage("demo")).value();
+        assertNotNull(coverage, () -> "the model under test compiles: " + model);
+        PartitionEvidence measured = coverage.get("f");
+        assertNotNull(measured, () -> "f was measured: " + model);
+        return measured;
+    }
+
+    private static List<String> bordersOf(String parameters, String condition) {
+        return measured(parameters, condition).boundaries().stream()
+                .map(BorderAssessment::value).toList();
+    }
+
+    private static List<UndividedPosition.Reason> reasonsOf(String parameters, String condition) {
+        return measured(parameters, condition).notRead().stream()
+                .map(PartitionEvidence.NotRead::reason).toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneStatementDrawsOneBorderHoweverItIsSpelledTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneStatementDrawsOneBorderHoweverItIsSpelledTest.java
@@ -125,6 +125,22 @@ class OneStatementDrawsOneBorderHoweverItIsSpelledTest {
                 "a rule over a shifted date-time draws a line");
     }
 
+    /**
+     * An exclusion inside the call stops the reading there, which is why the corpus did not move.
+     *
+     * <p>The conformance corpus writes {@code Date.daysBetween(受付日, DateTime.toDate(締切))}, and
+     * its report is the same document as before. That is not because nothing was gained: the one
+     * place it uses the measure has an operation inside it that is declared to state no form, so the
+     * reading reaches the argument and stops. Written without it, the same rule draws a line.
+     */
+    @Test
+    void anExclusionInsideTheCallStopsTheReadingThere() {
+        assertEquals(List.of(), bordersOf("a: Date, d: DateTime",
+                "Date.daysBetween(a, DateTime.toDate(d)) <= 1"));
+        assertEquals(List.of("b - 1"), bordersOf("a: Date, b: Date",
+                "Date.daysBetween(a, b) <= 1"));
+    }
+
     private static PartitionEvidence measured(String parameters, String condition) {
         String model = """
                 module demo

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatStoppedAComparisonIsReadOffWhatItIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatStoppedAComparisonIsReadOffWhatItIsTest.java
@@ -59,9 +59,9 @@ class WhatStoppedAComparisonIsReadOffWhatItIsTest {
     @Test
     void anOperationsAnswerIsARuleAboutAValueMadeFromThePosition() {
         assertEquals(List.of(UndividedPosition.Reason.RULE_ABOUT_A_DERIVED_VALUE),
-                whyAt(guard("a: Date, b: Date", "Date.daysBetween(a, b) > 10"), "a"));
+                whyAt(guard("a: DateTime, b: DateTime", "DateTime.minutesBetween(a, b) > 10"), "a"));
         assertEquals(List.of(UndividedPosition.Reason.RULE_ABOUT_A_DERIVED_VALUE),
-                whyAt(guard("a: Date, b: Date", "Date.daysBetween(a, b) > 10"), "b"));
+                whyAt(guard("a: DateTime, b: DateTime", "DateTime.minutesBetween(a, b) > 10"), "b"));
     }
 
     /**
@@ -85,7 +85,8 @@ class WhatStoppedAComparisonIsReadOffWhatItIsTest {
      */
     @Test
     void bothArgumentsOfAnOperationAreNamed() {
-        PartitionEvidence measured = guard("a: Date, b: Date", "Date.daysBetween(b, a) > 10");
+        PartitionEvidence measured =
+                guard("a: DateTime, b: DateTime", "DateTime.minutesBetween(b, a) > 10");
 
         assertEquals(List.of(UndividedPosition.Reason.RULE_ABOUT_A_DERIVED_VALUE),
                 whyAt(measured, "a"));
@@ -116,7 +117,7 @@ class WhatStoppedAComparisonIsReadOffWhatItIsTest {
     @Test
     void anOperationThisDoesNotReadIsNamed() {
         assertEquals(List.of(UndividedPosition.Reason.RULE_ABOUT_A_DERIVED_VALUE),
-                whyAt(guard("a: Date", "Date.daysBetween(a, a) > 10"), "a"));
+                whyAt(guard("a: DateTime", "DateTime.minutesBetween(a, a) > 10"), "a"));
     }
 
     /**
@@ -214,11 +215,11 @@ class WhatStoppedAComparisonIsReadOffWhatItIsTest {
      */
     @Test
     void arithmeticRoundAnOperationDoesNotChangeWhatStoppedTheReading() {
-        for (String condition : List.of("Date.daysBetween(a, b) <= 30",
-                "Int.add(Date.daysBetween(a, b), 1) <= 30",
-                "Int.add(1, Date.daysBetween(a, b)) <= 30")) {
+        for (String condition : List.of("DateTime.minutesBetween(a, b) <= 30",
+                "Int.add(DateTime.minutesBetween(a, b), 1) <= 30",
+                "Int.add(1, DateTime.minutesBetween(a, b)) <= 30")) {
             assertEquals(List.of(UndividedPosition.Reason.RULE_ABOUT_A_DERIVED_VALUE),
-                    whyAt(guard("a: Date, b: Date", condition), "a"), condition);
+                    whyAt(guard("a: DateTime, b: DateTime", condition), "a"), condition);
         }
     }
 


### PR DESCRIPTION
The last of four steps towards #949, and what closes it. `Date.daysBetween(a, b) > 10` and
`b > Date.addDays(10, a)` are one statement and are `b - a > 10`; neither drew a line while the same
statement over `Int.subtract` was measured.

## One fact, not two

What is wanted is `count(result) = Σ cᵢ·count(argᵢ) + k`. A kind already said the unit case of it —
`AnswersItsArgument`, declared for `Decimal.fromInt` alone, whose own javadoc says such a call is
"read into the form its argument has". A second kind beside it would be two statements of one
proposition, which is what this series exists to remove, so the special case folds into the general
one: `AnswersAFormOfItsArguments(LinearForm<ArgumentRef>)`.

Counted rather than valued, which is what lets it be said at all: a date is no number and counts
days, so a difference of two of them is a number of days. `FORM`'s range widens from "a number" to
"counts to a number" for the same reason — asked of numbers alone, the operations this exists for
are not even questions.

`Int.add` is not declared. `Terms.asOperator` reads such a call as the operator it stands for, and
its comment already gives the reason: a fact would be "a second path that would have to be kept
saying the same thing".

## Read where the grammar is, not at either leaf

`AffineForms.composed` gains one arm, so the discharge check and the partition read one semantics
and an operation declared later costs neither an arm. `Terms.leafOf`'s own read-through goes with it
— that was the same reading, living in one of the two readers.

A stop inside such an expansion is reported at the call. A stop names the most particular expression
an author would change, and inside a form the library declares there is no such expression: the
author wrote the call. Reported from within, `Date.daysBetween(from, to) <= 30` came back as a rule
about the field the expansion reached — a spelling nobody wrote, and a regression on what that
clause said before.

## What the widened range brought in

Fifteen operations, each owed a declaration or a stated silence. Four are exact and are declared:
the date-time shifts move a local value by a whole number of its own seconds, and
`fromDateAndTime` puts a day count and a second-of-day together. Eleven say nothing, each with its
reason — months and years hold different numbers of days, `minutesBetween` drops the remainder
toward zero, and a component is a count divided or a remainder taken.

## What the check can carry is the check's answer

The declarations are about the operations and not about a reader, so what the check can discharge is
a subset: its arithmetic is over the numbers a model wrote, and a date is not one.
`formOperationsThisCarries` derives that from what this side relates rather than listing it, so an
operation declared tomorrow needs no list updated — and no capability of a consumer is written
beside the facts. Making the check itself count-aware is a separate question and is not this.

## Measurement

| written | border |
| --- | --- |
| `Date.daysBetween(a, b) > 10` | `b - 10` |
| `b > Date.addDays(10, a)` | `a + 10` |
| `Date.daysBetween(b, a) > 10` | `a - 10` |
| `Date.daysBetween(a, b) > n` | `0`, the form `+b - a - n` |
| `b > Date.addDays(n, a)` | the same |

Asserted against what `Int.subtract` answers rather than against values written in the test, so the
two spellings cannot drift apart. No partition either way, which is what a line between two
positions has always said. `DateTime.minutesBetween` and `Date.year` still report a rule about a
value made from the positions, and both are now operations declared to say nothing rather than
operations nobody wrote a fact for.

## The two acceptance items that ask for evidence

**A row offered at a point stands at it.** The round trip, and not that any rows exist — #949 says
so: "rows are not asserted to be non-empty; the round trip is what is asked." The fixture is guarded
instead, so the test cannot pass while measuring nothing; the first version of it did exactly that.

Four rows round-trip. The points of the `b - 10` border contribute none: a two-position line at a
level away from zero composes nothing on a date carrier, which the same geometry over `Int` does
compose and the same carrier at level zero does compose. That is a capability below this one and is
now #1018, with the triangulation as its acceptance.

**The corpus held still, and why.** It writes `Date.daysBetween(受付日, DateTime.toDate(締切))` and
its report is the same document. Not because nothing was gained: `DateTime.toDate` is declared to
state no form, so the reading reaches it and stops. Written without it, the same rule draws a line.
Both are pinned, so the explanation cannot rot into a coincidence.

## Verification

`mvn -o test` from the reactor root: all nine modules green.
