### PR TITLE
Hold a bound implementation to what the behavior states

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/examples/BoundExamples.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/BoundExamples.java
@@ -128,6 +128,52 @@ public final class BoundExamples {
     }
 
     /**
+     * What the bound implementation answered for {@code row}'s inputs, held to what the behavior
+     * declares of what it answers — and to nothing the row records.
+     *
+     * <p>A different oracle from {@link #evaluate}'s, which holds an answer to the declaration and
+     * to the value somebody wrote out. Where the recorded answer is no longer the answer — a world
+     * the rows were not recorded in — what the behavior states still is, and this is the face that
+     * asks only that.
+     *
+     * <p>Applied once per call, as {@code evaluate} is and for the same reason: what the
+     * implementation answers comes out of world state the caller arranges between calls, and two
+     * answers under two worlds are two observations rather than a contradiction.
+     *
+     * <p>A behavior that states nothing is answered {@link ContractObservation.NothingStated}
+     * without the implementation being applied. To leave such a behavior's rows out rather than be
+     * told about each of them, read {@link #behaviorsStatingContracts()}.
+     */
+    public ContractObservation checkContract(RecordedRow row) {
+        if (row == null || row.enumeratedBy() != this) {
+            throw new IllegalArgumentException("a row belongs to the enumeration that made it");
+        }
+        return verifier.contractOnly(row.behavior(), row.written());
+    }
+
+    /**
+     * Which of the bound behaviors state something of what they answer.
+     *
+     * <p>What a behavior declares, asked without applying anything — a behavior writing no
+     * {@code ensures} is not among the module's contracts at all, so this reads a declaration rather
+     * than predicting a run. For a suite that means to hold only the behaviors with a contract to
+     * one, and that would otherwise have to write their names down beside the model.
+     *
+     * <p>Beside {@link ContractObservation.NothingStated} and not instead of it. This is for an
+     * author who means to leave a behavior out; the arm is for one who did not mean to and would
+     * otherwise have a green suite asserting that a call did not throw.
+     */
+    public List<String> behaviorsStatingContracts() {
+        List<String> stating = new ArrayList<>();
+        for (String behavior : bound) {
+            if (verifier.states(behavior)) {
+                stating.add(behavior);
+            }
+        }
+        return List.copyOf(stating);
+    }
+
+    /**
      * What the implementation answered for {@code entry}'s input, held to what the entry states.
      *
      * <p>Enumerated and observed one at a time, as rows are and for the same reason: what the

--- a/souther-compiler/src/main/java/souther/compiler/examples/BoundExamples.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/BoundExamples.java
@@ -145,7 +145,7 @@ public final class BoundExamples {
      * nothing may be handed to is answered for first: an implementation of another build states
      * nothing that can run, and calling that "the model states nothing" would send its author to
      * write a clause that still would not. To leave a behavior that states nothing out rather than
-     * be told about each of its rows, read {@link #behaviorsStatingContracts()}.
+     * be told about each of its rows, read {@link #behaviorsWithContracts()}.
      */
     public ContractObservation checkContract(RecordedRow row) {
         if (row == null || row.enumeratedBy() != this) {
@@ -155,18 +155,22 @@ public final class BoundExamples {
     }
 
     /**
-     * Which of the bound behaviors state something of what they answer.
+     * Which of the bound behaviors have a contract — an {@code ensures} saying something of what
+     * they answer.
      *
      * <p>What a behavior declares, asked without applying anything — a behavior writing no
      * {@code ensures} is not among the module's contracts at all, so this reads a declaration rather
      * than predicting a run. For a suite that means to hold only the behaviors with a contract to
      * one, and that would otherwise have to write their names down beside the model.
      *
-     * <p>Beside {@link ContractObservation.NothingStated} and not instead of it. This is for an
-     * author who means to leave a behavior out; the arm is for one who did not mean to and would
-     * otherwise have a green suite asserting that a call did not throw.
+     * <p>Beside {@link ContractObservation.NothingStated} and not instead of it. A suite over every
+     * row is the ordinary way to write one — the arm is what tells an author who did not mean to
+     * leave a behavior out — and narrowing by this is the deliberate exception.
+     *
+     * <p>Walks what is bound on each call and answers a fresh list, so a loop that narrows by it
+     * reads it once rather than once per row.
      */
-    public List<String> behaviorsStatingContracts() {
+    public List<String> behaviorsWithContracts() {
         List<String> stating = new ArrayList<>();
         for (String behavior : bound) {
             if (verifier.states(behavior)) {

--- a/souther-compiler/src/main/java/souther/compiler/examples/BoundExamples.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/BoundExamples.java
@@ -140,9 +140,12 @@ public final class BoundExamples {
      * implementation answers comes out of world state the caller arranges between calls, and two
      * answers under two worlds are two observations rather than a contradiction.
      *
-     * <p>A behavior that states nothing is answered {@link ContractObservation.NothingStated}
-     * without the implementation being applied. To leave such a behavior's rows out rather than be
-     * told about each of them, read {@link #behaviorsStatingContracts()}.
+     * <p>Once the binding has been established, a behavior that states nothing is answered
+     * {@link ContractObservation.NothingStated} without the implementation being applied. A binding
+     * nothing may be handed to is answered for first: an implementation of another build states
+     * nothing that can run, and calling that "the model states nothing" would send its author to
+     * write a clause that still would not. To leave a behavior that states nothing out rather than
+     * be told about each of its rows, read {@link #behaviorsStatingContracts()}.
      */
     public ContractObservation checkContract(RecordedRow row) {
         if (row == null || row.enumeratedBy() != this) {

--- a/souther-compiler/src/main/java/souther/compiler/examples/ContractObservation.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ContractObservation.java
@@ -63,9 +63,12 @@ public sealed interface ContractObservation {
             return "no clause of the behavior was broken by what was answered";
         }
 
+        /** Its name. The other arms are records and carry what they hold; this one holds nothing
+         *  yet, and the default would be an address. Read off the class rather than written out, so
+         *  a rename does not leave the old word behind. */
         @Override
         public String toString() {
-            return "NoClauseWasBroken";
+            return getClass().getSimpleName();
         }
     }
 
@@ -89,7 +92,7 @@ public sealed interface ContractObservation {
             implements ContractObservation {
 
         public Broken {
-            if (why == null || shownAnswered == null) {
+            if (why == null || answered == null || shownAnswered == null) {
                 throw new IllegalArgumentException("a broken clause said something about a value");
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/examples/ContractObservation.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ContractObservation.java
@@ -1,0 +1,128 @@
+package souther.compiler.examples;
+
+import souther.compiler.observe.ObservedValue;
+
+import java.util.Locale;
+
+/**
+ * What a bound implementation answered for a row's inputs, held to what the behavior declares of
+ * what it answers — and to nothing the row records.
+ *
+ * <p>A different oracle from {@link RowEvaluation}'s, not a different world. {@code evaluate} holds
+ * an answer to the declaration <em>and</em> to the value somebody wrote out; this holds it to the
+ * declaration alone. The two part inside one world as readily as across two: a behavior that states
+ * nothing about the order of what it answers admits a page the recorded one is a permutation of, and
+ * that answer keeps the declaration while differing from the record.
+ *
+ * <p>Where the two most often part is a world the rows were not recorded in — a shared database, a
+ * snapshot, a seed of another size. There what was written out is no longer the answer and what the
+ * behavior states still is. That is what this face is for, and it is a use of the distinction rather
+ * than the distinction itself.
+ *
+ * <p>An observation and not a verdict, for the reason {@link StandinObservation} is one: whether an
+ * arm fails a build is a policy, and a policy is the consumer's. Nothing here carries a severity.
+ */
+public sealed interface ContractObservation {
+
+    /**
+     * What to say about this observation, in one line per thing said.
+     *
+     * <p>The language is handed in and not picked here, for the reason
+     * {@link RowEvaluation#shown(Locale)} takes one: what answers a reader has to say which reader,
+     * and that is the consumer.
+     */
+    String shown(Locale locale);
+
+    /**
+     * No clause of the behavior was shown to be broken by what the implementation answered.
+     *
+     * <p><strong>This does not say that every clause bore on the answer.</strong> A clause is
+     * vacuous for an input it says nothing about — {@code readArticles}'s rule about what a page
+     * holds says nothing about a query filtering on something the page does not carry — and such a
+     * row arrives here having proved nothing. What is claimed is the absence of a violation, which
+     * is what the check answers, and the name says that and no more.
+     *
+     * <p>Not a record, and alone among the arms in that. The other three are what they carry: an
+     * observation of a finite number of parts, worth taking apart. This one carries nothing
+     * <em>yet</em> — which clauses bore on the answer is the evidence it is to hold — and a record
+     * would put the absence into the API twice over: as a canonical constructor callers may write
+     * and a later component would break, and as an equality over instances this is not yet ready to
+     * define. So the arm is a class, its constructor is this package's, and nothing is promised
+     * about how many of them there are.
+     */
+    final class NoClauseWasBroken implements ContractObservation {
+
+        NoClauseWasBroken() {}
+
+        @Override
+        public String shown(Locale locale) {
+            return "no clause was broken";
+        }
+
+        @Override
+        public String toString() {
+            return "NoClauseWasBroken";
+        }
+    }
+
+    /**
+     * A clause did not hold of what the implementation answered.
+     *
+     * @param why      what the clause said when it did not hold, in the words the runtime writes
+     *                 about one
+     * @param answered what the implementation answered, so a reader is told what broke it and not
+     *                 only that something did
+     */
+    record Broken(String why, ObservedValue answered) implements ContractObservation {
+
+        public Broken {
+            if (why == null) {
+                throw new IllegalArgumentException("a broken clause said something");
+            }
+        }
+
+        @Override
+        public String shown(Locale locale) {
+            return "a clause did not hold: " + why
+                    + System.lineSeparator() + "  answered: " + answered;
+        }
+    }
+
+    /**
+     * The behavior states nothing, so this row held the implementation to nothing.
+     *
+     * <p>An arm and not a quiet yes. A suite written over a behavior with no {@code ensures} would
+     * otherwise be green while asserting only that the call did not throw, and say so to nobody.
+     * What the author does about it — write the clause, or leave the behavior out with
+     * {@link BoundExamples#behaviorsStatingContracts()} — is theirs; being told is not.
+     *
+     * @param behavior which behavior states nothing, for a suite over several
+     */
+    record NothingStated(String behavior) implements ContractObservation {
+
+        @Override
+        public String shown(Locale locale) {
+            return "`" + behavior + "` states nothing of what it answers,"
+                    + " so this row held the implementation to nothing";
+        }
+    }
+
+    /**
+     * No answer was held to anything.
+     *
+     * <p>What keeps the other three meaning that one was. An implementation that aborted, or an
+     * answer that could not be read in the classes the check reads, has not kept the declaration and
+     * has not broken it.
+     *
+     * <p>Reuses {@link StandinObservation.Reason}: how far an observation got is the same question
+     * whichever of the two faces asked it, and a second vocabulary saying the same six things would
+     * be a second answer to it.
+     */
+    record Unobserved(StandinObservation.Reason why) implements ContractObservation {
+
+        @Override
+        public String shown(Locale locale) {
+            return "nothing was held to the declaration: " + why.said();
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/examples/ContractObservation.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ContractObservation.java
@@ -75,32 +75,65 @@ public sealed interface ContractObservation {
     /**
      * A clause did not hold of what the implementation answered.
      *
-     * <p>What was answered is carried twice, and on purpose. {@link StandinEntry} keeps a stated
-     * value and its shown text apart for the reason given there — what a machine reads and what a
-     * person reads must not be one String — and the same holds here from the other side: a consumer
-     * given only the {@link ObservedValue} could not render it, the writer that does being this
-     * package's and needing the module's declarations to tell a newtype from what it wraps. So the
-     * text is written where those are in reach and travels beside the value rather than instead of
-     * it.
+     * <p>What was answered is carried twice, and on purpose: structurally, for a reader that takes
+     * it apart, and written the way a fixture writes a value, for one that shows it. A consumer
+     * given only the {@link ObservedValue} could not render it — the writer that does is this
+     * package's, and it needs the module's declarations to tell a newtype from what it wraps — so
+     * the text travels beside the value rather than instead of it. {@link StandinEntry} keeps a
+     * stated value and its shown text apart for the same reason.
      *
-     * @param why           what the clause said when it did not hold, in the words the runtime
-     *                      writes about one
-     * @param answered      what the implementation answered, structural and loader-free
-     * @param shownAnswered the same, written the way a fixture writes a value
+     * <p>Not a record, and for a different reason from {@link NoClauseWasBroken}'s. A record's
+     * canonical constructor says that any combination of its components is a value: true of two
+     * independent observations, and false the moment one of them is a rendering of another. Written
+     * as one, an {@code answered} of seven could be built beside a {@code shownAnswered} of
+     * {@code "TodoId(99)"} and the two accessors would say different things about one observation;
+     * and the rendering would sit inside {@code equals}, so writing a value differently would make
+     * it a different observation. So the constructor is this package's, and the two are written
+     * together where the declarations that relate them are in reach.
+     *
+     * <p>No equality is defined. Two applications are two observations rather than one answered
+     * twice — which is what this face says everywhere about asking a row again — so there is nothing
+     * for a value equality over them to mean.
      */
-    record Broken(String why, ObservedValue answered, String shownAnswered)
-            implements ContractObservation {
+    final class Broken implements ContractObservation {
 
-        public Broken {
+        private final String why;
+        private final ObservedValue answered;
+        private final String shownAnswered;
+
+        Broken(String why, ObservedValue answered, String shownAnswered) {
             if (why == null || answered == null || shownAnswered == null) {
                 throw new IllegalArgumentException("a broken clause said something about a value");
             }
+            this.why = why;
+            this.answered = answered;
+            this.shownAnswered = shownAnswered;
+        }
+
+        /** What the clause said when it did not hold, in the words the runtime writes about one. */
+        public String why() {
+            return why;
+        }
+
+        /** What the implementation answered, structural and loader-free. */
+        public ObservedValue answered() {
+            return answered;
+        }
+
+        /** The same, written the way a fixture writes a value. */
+        public String shownAnswered() {
+            return shownAnswered;
         }
 
         @Override
         public String shown() {
             return "a clause did not hold: " + why
                     + System.lineSeparator() + "  answered: " + shownAnswered;
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "(" + why + ")";
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/examples/ContractObservation.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ContractObservation.java
@@ -143,7 +143,7 @@ public sealed interface ContractObservation {
      * <p>An arm and not a quiet yes. A suite written over a behavior with no {@code ensures} would
      * otherwise be green while asserting only that the call did not throw, and say so to nobody.
      * What the author does about it — write the clause, or leave the behavior out with
-     * {@link BoundExamples#behaviorsStatingContracts()} — is theirs; being told is not.
+     * {@link BoundExamples#behaviorsWithContracts()} — is theirs; being told is not.
      *
      * @param behavior which behavior states nothing, for a suite over several
      */

--- a/souther-compiler/src/main/java/souther/compiler/examples/ContractObservation.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ContractObservation.java
@@ -2,8 +2,6 @@ package souther.compiler.examples;
 
 import souther.compiler.observe.ObservedValue;
 
-import java.util.Locale;
-
 /**
  * What a bound implementation answered for a row's inputs, held to what the behavior declares of
  * what it answers — and to nothing the row records.
@@ -25,13 +23,19 @@ import java.util.Locale;
 public sealed interface ContractObservation {
 
     /**
-     * What to say about this observation, in one line per thing said.
+     * What to say about this observation, for a consumer building an assertion message.
      *
-     * <p>The language is handed in and not picked here, for the reason
-     * {@link RowEvaluation#shown(Locale)} takes one: what answers a reader has to say which reader,
-     * and that is the consumer.
+     * <p>Takes no language, and that is the difference from {@link RowEvaluation#shown(java.util.Locale)}
+     * rather than an omission from it. That one renders <em>diagnostics</em>, which are what a
+     * compile reports and are written in the catalogs the compiler ships; handing it a language is
+     * how a reader picks one. Nothing here is a diagnostic. No compile reports that a clause held,
+     * and a sentence in the catalog is one classified as either a rule reported or a word said
+     * beside one — these are neither.
+     *
+     * <p>So they are this face's own words, as {@link StandinObservation.Reason#said()}'s are, and
+     * taking a language only to ignore it would promise a choice that is not there.
      */
-    String shown(Locale locale);
+    String shown();
 
     /**
      * No clause of the behavior was shown to be broken by what the implementation answered.
@@ -55,8 +59,8 @@ public sealed interface ContractObservation {
         NoClauseWasBroken() {}
 
         @Override
-        public String shown(Locale locale) {
-            return "no clause was broken";
+        public String shown() {
+            return "no clause of the behavior was broken by what was answered";
         }
 
         @Override
@@ -68,23 +72,32 @@ public sealed interface ContractObservation {
     /**
      * A clause did not hold of what the implementation answered.
      *
-     * @param why      what the clause said when it did not hold, in the words the runtime writes
-     *                 about one
-     * @param answered what the implementation answered, so a reader is told what broke it and not
-     *                 only that something did
+     * <p>What was answered is carried twice, and on purpose. {@link StandinEntry} keeps a stated
+     * value and its shown text apart for the reason given there — what a machine reads and what a
+     * person reads must not be one String — and the same holds here from the other side: a consumer
+     * given only the {@link ObservedValue} could not render it, the writer that does being this
+     * package's and needing the module's declarations to tell a newtype from what it wraps. So the
+     * text is written where those are in reach and travels beside the value rather than instead of
+     * it.
+     *
+     * @param why           what the clause said when it did not hold, in the words the runtime
+     *                      writes about one
+     * @param answered      what the implementation answered, structural and loader-free
+     * @param shownAnswered the same, written the way a fixture writes a value
      */
-    record Broken(String why, ObservedValue answered) implements ContractObservation {
+    record Broken(String why, ObservedValue answered, String shownAnswered)
+            implements ContractObservation {
 
         public Broken {
-            if (why == null) {
-                throw new IllegalArgumentException("a broken clause said something");
+            if (why == null || shownAnswered == null) {
+                throw new IllegalArgumentException("a broken clause said something about a value");
             }
         }
 
         @Override
-        public String shown(Locale locale) {
+        public String shown() {
             return "a clause did not hold: " + why
-                    + System.lineSeparator() + "  answered: " + answered;
+                    + System.lineSeparator() + "  answered: " + shownAnswered;
         }
     }
 
@@ -101,7 +114,7 @@ public sealed interface ContractObservation {
     record NothingStated(String behavior) implements ContractObservation {
 
         @Override
-        public String shown(Locale locale) {
+        public String shown() {
             return "`" + behavior + "` states nothing of what it answers,"
                     + " so this row held the implementation to nothing";
         }
@@ -121,7 +134,7 @@ public sealed interface ContractObservation {
     record Unobserved(StandinObservation.Reason why) implements ContractObservation {
 
         @Override
-        public String shown(Locale locale) {
+        public String shown() {
             return "nothing was held to the declaration: " + why.said();
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/examples/EnsuresChecks.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/EnsuresChecks.java
@@ -75,6 +75,19 @@ final class EnsuresChecks {
     }
 
     /**
+     * Whether {@code behavior} states anything of what it answers.
+     *
+     * <p>Asked of the contracts, which is where the answer is: a behavior writing no {@code ensures}
+     * is not put in them ({@code Bodies.Contracts}), so being absent and stating nothing are one
+     * fact rather than two that agree. Answerable without applying anything, because what a behavior
+     * declares does not turn on an input — {@link #contractOf} reads the name and uses the arguments
+     * only to check their number against it.
+     */
+    boolean states(String behavior) {
+        return contracts.containsKey(behavior);
+    }
+
+    /**
      * What {@code behavior}'s check said of an answer of {@code answer} to {@code args}, or null
      * where every rule held — and where the behavior states nothing, which is every rule it has
      * holding.

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -396,9 +396,127 @@ public final class ExampleVerifier {
                                         + deadline.budgetMs() + "ms"));
             }
             case Deadline.Outcome.Threw(Throwable cause) -> {
-                return whatTheWorkerThrew(cause);
+                return new StandinObservation.Unobserved(whatTheWorkerThrew(cause));
             }
         }
+    }
+
+    /**
+     * Whether {@code behavior} states anything of what it answers.
+     *
+     * <p>Declaration metadata, so nothing is applied to answer it. It is the same fact
+     * {@link ContractObservation.NothingStated} reports after a row has run, asked before one is.
+     */
+    boolean states(String behavior) {
+        return ensures.states(behavior);
+    }
+
+    /**
+     * What the bound implementation answered for {@code row}'s inputs, held to what {@code behavior}
+     * declares of what it answers and to nothing the row records.
+     *
+     * <p>Through the run's deadline, as a row and a stand-in's entry are, and for that reason: the
+     * binding decides where applied code runs and what bounds it, and a third route to it would be
+     * the binding meaning three things.
+     */
+    ContractObservation contractOnly(String behavior, Hir.ExampleRow row) {
+        switch (deadline.given(new Deadline.Work.Row(behavior, row.pos(), row.identity()),
+                () -> checkingContract(behavior, row))) {
+            case Deadline.Outcome.Finished(ContractObservation observed) -> {
+                return observed;
+            }
+            case Deadline.Outcome.Overran(Runnable abandon) -> {
+                abandon.run();
+                return new ContractObservation.Unobserved(
+                        new StandinObservation.Reason.TheObservationRanOut(
+                                "the implementation did not answer within "
+                                        + deadline.budgetMs() + "ms"));
+            }
+            case Deadline.Outcome.Threw(Throwable cause) -> {
+                return new ContractObservation.Unobserved(whatTheWorkerThrew(cause));
+            }
+        }
+    }
+
+    private ContractObservation checkingContract(String behavior, Hir.ExampleRow row) {
+        Sig sig = sigs.get(behavior);
+        ExampleTarget target = targetOf(behavior);
+        if (sig == null || target == null) {
+            return new ContractObservation.Unobserved(
+                    new StandinObservation.Reason.TheEntryWasNotRead(
+                            "`" + behavior + "` has nothing to apply its inputs to"));
+        }
+        Answerer.Answer.Something applies;
+        switch (target.handing()) {
+            case Handing.NothingApplies _ -> {
+                return new ContractObservation.Unobserved(
+                        new StandinObservation.Reason.TheImplementationWasNotReached(
+                                "nothing this run was given applies `" + behavior + "`"));
+            }
+            case Handing.NotEstablished(Agreement why) -> {
+                return new ContractObservation.Unobserved(
+                        new StandinObservation.Reason.TheImplementationIsOfAnotherBuild(
+                                String.valueOf(why)));
+            }
+            case Handing.MayApply(Answerer.Answer.Something something) -> applies = something;
+        }
+        // After the binding is known good and before anything is applied. A behavior that states
+        // nothing holds an implementation to nothing whatever it answers, so applying it would spend
+        // a call to learn what the declaration already said — and asking this first would answer
+        // "the model states nothing" for a binding nothing may be handed to, sending its author to
+        // write a clause that would still not run.
+        if (!ensures.states(behavior)) {
+            return new ContractObservation.NothingStated(behavior);
+        }
+        FixtureReader fixtures = newFixtureReader();
+        Object[] args;
+        try {
+            args = new Object[sig.ins().size()];
+            for (int i = 0; i < args.length; i++) {
+                args[i] = fixtures.built(row.inputs().get(i), sig.ins().get(i));
+            }
+        } catch (FixtureException fe) {
+            return new ContractObservation.Unobserved(
+                    new StandinObservation.Reason.TheEntryWasNotRead(
+                            String.valueOf(fe.getMessage())));
+        }
+        // What the row records is not read at all — not built, not compared. That is the whole of
+        // what makes this a different oracle from `evaluate`'s, and reading it here to report it
+        // beside a broken clause would put the recorded answer back into a face that does not have
+        // one.
+        Object answered;
+        try {
+            answered = applies.applying(List.of())
+                    .to(handed(fixtures, target, args, sig.ins()));
+        } catch (InvocationFailure f) {
+            return new ContractObservation.Unobserved(
+                    new StandinObservation.Reason.TheInvocationAborted(
+                            String.valueOf(f.getCause())));
+        } catch (ImplementationNotReached | StandinNotBuilt e) {
+            return new ContractObservation.Unobserved(
+                    new StandinObservation.Reason.TheImplementationWasNotReached(
+                            String.valueOf(e.getMessage())));
+        } catch (FixtureException fe) {
+            return new ContractObservation.Unobserved(
+                    new StandinObservation.Reason.AValueCouldNotCross(
+                            String.valueOf(fe.getMessage())));
+        }
+        answered = projected(answered, sig.outputType());
+        // Into this compile's classes before the check, for the reason
+        // `keepsWhatIsDeclaredOfWhatItAnswered` does it: the emitted check guards each rule with an
+        // `instanceof` against the class this compile emitted, so an answer of another loader's
+        // classes matches no guard and every rule is skipped — the check would run and say nothing.
+        Object here;
+        try {
+            here = inTheseClasses(fixtures, fixtures.typeOf(answered), sig, answered);
+        } catch (FixtureException | ImplementationNotReached e) {
+            return new ContractObservation.Unobserved(
+                    new StandinObservation.Reason.AValueCouldNotCross(
+                            String.valueOf(e.getMessage())));
+        }
+        String why = ensures.notHeld(new ValueName.Behavior(module.name(), behavior), args, here);
+        return why == null ? new ContractObservation.NoClauseWasBroken()
+                : new ContractObservation.Broken(why, fixtures.observed(answered));
     }
 
     /**
@@ -409,18 +527,20 @@ public final class ExampleVerifier {
      * defect in this machinery into an ordinary answer about a stand-in — a reader would be told the
      * two could not be compared where in fact this code failed. What the implementation itself threw
      * never arrives here: it is {@link InvocationFailure} and was already answered.
+     *
+     * <p>Answers the reason and not an observation, so both faces wrap it in their own. Answering one
+     * face's type and casting it in the other is a narrowing nothing checks, and it holds only while
+     * this has the one arm it has today.
      */
-    private static StandinObservation whatTheWorkerThrew(Throwable cause) {
+    private static StandinObservation.Reason whatTheWorkerThrew(Throwable cause) {
         FailurePhase overspent = overspending(cause);
         if (overspent != null) {
-            return new StandinObservation.Unobserved(
-                    new StandinObservation.Reason.TheObservationRanOut(
-                            "the observation went through more than " + overspent + " allows"));
+            return new StandinObservation.Reason.TheObservationRanOut(
+                    "the observation went through more than " + overspent + " allows");
         }
         if (cause instanceof StackExhaustedException || cause instanceof StackOverflowError) {
-            return new StandinObservation.Unobserved(
-                    new StandinObservation.Reason.TheObservationRanOut(
-                            "the observation ran out of stack"));
+            return new StandinObservation.Reason.TheObservationRanOut(
+                    "the observation ran out of stack");
         }
         if (cause instanceof java.util.concurrent.CancellationException) {
             throw new java.util.concurrent.CancellationException(

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -522,7 +522,13 @@ public final class ExampleVerifier {
         if (why == null) {
             return new ContractObservation.NoClauseWasBroken();
         }
-        ObservedValue observed = fixtures.observed(answered);
+        // Read off what the check was applied to and not off what came back. The two are one value
+        // — the second is the first through this module's own decoder — but only one of them is what
+        // the clause saw, and a report of a verdict shows what the verdict was about.
+        ObservedValue observed = fixtures.observed(here);
+        // The declared output is the position, which is what tells a set from a list where the
+        // answer is one. A union falls through it to the value itself, there being nothing at a
+        // union for a renderer to read.
         return new ContractObservation.Broken(why, observed,
                 fixtures.shown(observed, sig.outputType()));
     }

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -515,8 +515,16 @@ public final class ExampleVerifier {
                             String.valueOf(e.getMessage())));
         }
         String why = ensures.notHeld(new ValueName.Behavior(module.name(), behavior), args, here);
-        return why == null ? new ContractObservation.NoClauseWasBroken()
-                : new ContractObservation.Broken(why, fixtures.observed(answered));
+        // Written here and not in the arm. What writes a value the way a fixture writes one needs the
+        // module's declarations to tell a newtype from what it wraps, and an arm holding neither
+        // could only fall back on the value's own `toString` — a shape no report should be written
+        // from, and one that would differ from every other value this compiler shows a reader.
+        if (why == null) {
+            return new ContractObservation.NoClauseWasBroken();
+        }
+        ObservedValue observed = fixtures.observed(answered);
+        return new ContractObservation.Broken(why, observed,
+                fixtures.shown(observed, sig.outputType()));
     }
 
     /**
@@ -543,8 +551,11 @@ public final class ExampleVerifier {
                     "the observation ran out of stack");
         }
         if (cause instanceof java.util.concurrent.CancellationException) {
+            // Said of an observation and not of a stand-in's entry: a contract check comes through
+            // here as well, and naming one of the two callers would report the other's cancellation
+            // as something it is not.
             throw new java.util.concurrent.CancellationException(
-                    "interrupted while observing a stand-in's entry");
+                    "interrupted while making an observation");
         }
         if (cause instanceof RuntimeException re) {
             throw re;

--- a/souther-compiler/src/test/java/souther/compiler/examples/AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest.java
@@ -15,7 +15,6 @@ import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -159,8 +158,15 @@ class AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest {
                 assertInstanceOf(ContractObservation.Broken.class, seen);
         assertFalse(broken.why().isBlank(), "the clause said something about not holding");
 
-        String shown = seen.shown(Locale.ENGLISH);
-        assertTrue(shown.contains("7"), "what it answered is in what a suite would print: " + shown);
+        // Written the way a fixture writes a value, which is what tells a reader that the id wears
+        // `TodoId` rather than being a number that happens to be seven. The value's own `toString`
+        // says neither, and is what an arm with no declarations in reach would be left with.
+        assertEquals("Todo { done = false, id = TodoId(7), title = Title(\"write the SQL\") }",
+                broken.shownAnswered());
+        assertTrue(seen.shown().contains(broken.shownAnswered()),
+                "and it is what a suite would print: " + seen.shown());
+        assertInstanceOf(souther.compiler.observe.ObservedValue.Constructed.class, broken.answered(),
+                "beside the value itself, which is what a machine reads");
     }
 
     /**
@@ -180,7 +186,7 @@ class AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest {
                 assertInstanceOf(ContractObservation.NothingStated.class, seen,
                         "an implementation that throws when applied was not applied");
         assertEquals("findTodo", stated.behavior());
-        assertTrue(seen.shown(Locale.ENGLISH).contains("findTodo"));
+        assertTrue(seen.shown().contains("findTodo"));
     }
 
     /**
@@ -227,17 +233,38 @@ class AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest {
      */
     @Test
     void aModelWhoseClauseCannotBeReadMakesNoBoundExamples() {
-        String namesNothing = MODEL.replace(
-                "behavior findTodo : (id: TodoId) -> Todo | NotFound\n",
-                """
-                behavior findTodo : (id: TodoId) -> Todo | NotFound
-                    ensures Todo -> value.id.value == nobodyDeclaredThis(id)
-                """);
+        // `Bodies.Contracts` gives a behavior up in two ways, and both leave it out of the contracts
+        // exactly as a behavior that states nothing is left out. Both arms are held, because either
+        // one reaching `BoundExamples` would be reported as `NothingStated`.
 
+        // `Unanswerable`: the clause rests on a name that denotes nothing. It carries no diagnostic
+        // of its own — the name was reported where it was written — so what refuses the model is
+        // that report.
+        CompileException named = assertThrows(CompileException.class, () ->
+                        SoutherExamples.ofSource(declaring("value.id.value == nobodyDeclaredThis(id)")),
+                "a clause resting on a name that denotes nothing");
+        assertFalse(named.diagnostics().isEmpty(), "the name was reported where it was written");
+
+        // `CompileException`: the clause is read and refused. `BehaviorChecker` raises E1619 inside
+        // `contractOf`, and `Bodies.Contracts` files it as a report rather than raising.
         CompileException refused = assertThrows(CompileException.class,
-                () -> SoutherExamples.ofSource(namesNothing),
-                "the rows cannot be run: what the behavior states could not be read");
-        assertFalse(refused.diagnostics().isEmpty(), "and the name was reported where it was written");
+                () -> SoutherExamples.ofSource(MODEL.replace(
+                        "behavior findTodo : (id: TodoId) -> Todo | NotFound\n",
+                        """
+                        behavior findTodo : (id: TodoId) -> Todo | NotFound
+                            ensures Title -> value.id.value == id.value
+                        """)),
+                "an arm that is not a case of what the behavior answers");
+        assertEquals(List.of("E1619"),
+                refused.diagnostics().stream().map(souther.compiler.diag.Diagnostic::code).distinct().toList());
+    }
+
+    /** {@link #MODEL} with one clause written on {@code findTodo}. */
+    private static String declaring(String clause) {
+        return MODEL.replace(
+                "behavior findTodo : (id: TodoId) -> Todo | NotFound\n",
+                "behavior findTodo : (id: TodoId) -> Todo | NotFound\n"
+                        + "    ensures Todo -> " + clause + "\n");
     }
 
     // --- harness ---------------------------------------------------------------------------------

--- a/souther-compiler/src/test/java/souther/compiler/examples/AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest.java
@@ -59,12 +59,7 @@ class AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest {
             """;
 
     /** The same model, stating a relation between what it is given and what it answers. */
-    private static final String DECLARING = MODEL.replace(
-            "behavior findTodo : (id: TodoId) -> Todo | NotFound\n",
-            """
-            behavior findTodo : (id: TodoId) -> Todo | NotFound
-                ensures Todo -> value.id.value == id.value
-            """);
+    private static final String DECLARING = declaring("value.id.value == id.value");
 
     /** Answers both rows the way the model records them. */
     private static final String ANSWERS = """
@@ -103,6 +98,24 @@ class AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest {
                     return id.equals(new TodoId(1L))
                             ? new Todo(new TodoId(7L), new Title("write the SQL"), false)
                             : new NotFound(id);
+                }
+            }
+            """;
+
+    /**
+     * Answers within the clause once and outside it after.
+     *
+     * <p>A world that changed between two asks, which is the position every caller of this face is
+     * in: the rows are asked in whatever state the caller arranged, and this is that state written
+     * as the implementation rather than as a database.
+     */
+    private static final String ONCE_THEN_NOT = """
+            package example.todo;
+            public final class FindTodoImpl extends FindTodo {
+                private int asked = 0;
+                public FindTodoResult apply(TodoId id) {
+                    long answer = asked++ == 0 ? id.value() : 7L;
+                    return new Todo(new TodoId(answer), new Title("write the SQL"), false);
                 }
             }
             """;
@@ -208,6 +221,27 @@ class AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest {
                 assertInstanceOf(ContractObservation.Unobserved.class, seen);
         assertInstanceOf(StandinObservation.Reason.TheImplementationIsOfAnotherBuild.class,
                 unobserved.why());
+    }
+
+    /**
+     * The same row asked twice under two worlds is two observations.
+     *
+     * <p>What this face is for is asking a row where the world is not the one it was recorded in, so
+     * a caller asks the same row again after arranging something else. Nothing may be carried from
+     * the first ask to the second: an observation kept would answer about a world that is gone.
+     *
+     * <p>Measured rather than reasoned from the code that builds a fixture reader per call — that is
+     * why it holds today, and this is what says it still does.
+     */
+    @Test
+    void theSameRowAskedTwiceIsAskedAfreshEachTime() throws Exception {
+        BoundExamples bound = boundTo(DECLARING, ONCE_THEN_NOT);
+        RecordedRow stored = named(bound, "a todo that is stored");
+
+        assertInstanceOf(ContractObservation.NoClauseWasBroken.class, bound.checkContract(stored),
+                "the world as it stood for the first ask");
+        assertInstanceOf(ContractObservation.Broken.class, bound.checkContract(stored),
+                "and as it stood for the second, which is not the first answered again");
     }
 
     /** Which behaviors state something, answered from the declaration and without applying one. */

--- a/souther-compiler/src/test/java/souther/compiler/examples/AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest.java
@@ -1,0 +1,280 @@
+package souther.compiler.examples;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.observe.FailurePhase;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Output;
+
+import javax.tools.ToolProvider;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A bound implementation held to what the behavior states, and to nothing the row records.
+ *
+ * <p>A row carries inputs and a recorded answer, and until now the only question that could be asked
+ * of an implementation was whether it answered the value somebody wrote. What the model
+ * <em>states</em> — the {@code ensures} — could not be asked on its own, though it is the oracle a
+ * contract test wants: the rows supply the inputs, the declaration decides the answers.
+ *
+ * <p>The two oracles part inside one world as readily as across two, which is what
+ * {@link #anAnswerTheRecordDoesNotHaveCanStillKeepWhatIsDeclared} holds. Where they part in practice
+ * is a world the rows were not recorded in — a shared database, a snapshot — and there the recorded
+ * answer is no longer the answer while the declaration still is.
+ */
+class AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest {
+
+    private static final String MODEL = """
+            module example.todo
+            import String ( length )
+
+            data TodoId = Int
+            data Title = String
+                invariant length(value) > 0
+
+            data Todo = { id: TodoId, title: Title, done: Bool }
+            data NotFound = { id: TodoId }
+
+            behavior findTodo : (id: TodoId) -> Todo | NotFound
+
+            example findTodo
+                | "a todo that is stored" : (TodoId(1))
+                    -> Todo { id = TodoId(1), title = Title("write the SQL"), done = false }
+                | "an id nothing is stored under" : (TodoId(99))
+                    -> NotFound { id = TodoId(99) }
+            """;
+
+    /** The same model, stating a relation between what it is given and what it answers. */
+    private static final String DECLARING = MODEL.replace(
+            "behavior findTodo : (id: TodoId) -> Todo | NotFound\n",
+            """
+            behavior findTodo : (id: TodoId) -> Todo | NotFound
+                ensures Todo -> value.id.value == id.value
+            """);
+
+    /** Answers both rows the way the model records them. */
+    private static final String ANSWERS = """
+            package example.todo;
+            public final class FindTodoImpl extends FindTodo {
+                public FindTodoResult apply(TodoId id) {
+                    return id.equals(new TodoId(1L))
+                            ? new Todo(new TodoId(1L), new Title("write the SQL"), false)
+                            : new NotFound(id);
+                }
+            }
+            """;
+
+    /**
+     * Answers the stored id with another title.
+     *
+     * <p>The clause says nothing about the title, so this keeps what the behavior states and answers
+     * something the row does not record. That is the pair the two oracles disagree on.
+     */
+    private static final String ANOTHER_TITLE = """
+            package example.todo;
+            public final class FindTodoImpl extends FindTodo {
+                public FindTodoResult apply(TodoId id) {
+                    return id.equals(new TodoId(1L))
+                            ? new Todo(new TodoId(1L), new Title("read the SQL"), false)
+                            : new NotFound(id);
+                }
+            }
+            """;
+
+    /** Answers the stored row with a todo carrying an id nobody asked for. */
+    private static final String ANOTHER_ID = """
+            package example.todo;
+            public final class FindTodoImpl extends FindTodo {
+                public FindTodoResult apply(TodoId id) {
+                    return id.equals(new TodoId(1L))
+                            ? new Todo(new TodoId(7L), new Title("write the SQL"), false)
+                            : new NotFound(id);
+                }
+            }
+            """;
+
+    /** Applying it is the failure. Bound where nothing may apply it, it says so by never running. */
+    private static final String REFUSES = """
+            package example.todo;
+            public final class FindTodoImpl extends FindTodo {
+                public FindTodoResult apply(TodoId id) {
+                    throw new IllegalStateException("this implementation must not be applied");
+                }
+            }
+            """;
+
+    /**
+     * The fact the face exists for: one answer, two oracles, and they disagree.
+     *
+     * <p>{@code evaluate} refuses the row because the title is not the one written out.
+     * {@code checkContract} is told nothing about the title — the behavior states nothing about it —
+     * and answers that no clause was broken. Neither is wrong; they are two questions.
+     */
+    @Test
+    void anAnswerTheRecordDoesNotHaveCanStillKeepWhatIsDeclared() throws Exception {
+        BoundExamples bound = boundTo(DECLARING, ANOTHER_TITLE);
+        RecordedRow stored = named(bound, "a todo that is stored");
+
+        RowEvaluation evaluated = bound.evaluate(stored);
+        assertFalse(evaluated.held(), "the recorded oracle refuses it");
+        assertEquals(FailurePhase.COMPARISON, evaluated.outcome().failurePhase());
+
+        assertInstanceOf(ContractObservation.NoClauseWasBroken.class, bound.checkContract(stored),
+                "and the declared oracle does not, the clause saying nothing about a title");
+    }
+
+    /** The control: what the record and the declaration both admit is admitted by both. */
+    @Test
+    void anAnswerBothOraclesAdmitIsAdmittedByBoth() throws Exception {
+        BoundExamples bound = boundTo(DECLARING, ANSWERS);
+        for (RecordedRow row : bound.rows()) {
+            assertTrue(bound.evaluate(row).held(), row.shown());
+            assertInstanceOf(ContractObservation.NoClauseWasBroken.class,
+                    bound.checkContract(row), row.shown());
+        }
+    }
+
+    /** A clause that does not hold, said with what broke it. */
+    @Test
+    void aClauseThatDoesNotHoldSaysSoAndSaysWhatWasAnswered() throws Exception {
+        BoundExamples bound = boundTo(DECLARING, ANOTHER_ID);
+
+        ContractObservation seen = bound.checkContract(named(bound, "a todo that is stored"));
+        ContractObservation.Broken broken =
+                assertInstanceOf(ContractObservation.Broken.class, seen);
+        assertFalse(broken.why().isBlank(), "the clause said something about not holding");
+
+        String shown = seen.shown(Locale.ENGLISH);
+        assertTrue(shown.contains("7"), "what it answered is in what a suite would print: " + shown);
+    }
+
+    /**
+     * A behavior that states nothing is answered without the implementation being applied.
+     *
+     * <p>An arm rather than a quiet yes: a suite over such a behavior would otherwise be green while
+     * asserting that a call did not throw. That the implementation is not applied is measured and not
+     * asserted about — this one throws when applied, so an answer that is not {@code Unobserved} is
+     * the evidence.
+     */
+    @Test
+    void aBehaviorStatingNothingHoldsAnImplementationToNothingAndIsNotApplied() throws Exception {
+        BoundExamples bound = boundTo(MODEL, REFUSES);
+
+        ContractObservation seen = bound.checkContract(bound.rows().get(0));
+        ContractObservation.NothingStated stated =
+                assertInstanceOf(ContractObservation.NothingStated.class, seen,
+                        "an implementation that throws when applied was not applied");
+        assertEquals("findTodo", stated.behavior());
+        assertTrue(seen.shown(Locale.ENGLISH).contains("findTodo"));
+    }
+
+    /**
+     * A binding nothing may be handed to is said as that, and not as the model stating nothing.
+     *
+     * <p>Both are true of this row: the implementation is of a build whose {@code Title} admits
+     * values this one does not, and the model states nothing. Answering the second would send its
+     * author to write a clause that would still not run, so the binding is answered for first.
+     */
+    @Test
+    void anImplementationOfAnotherBuildIsSaidAsThatEvenWhereNothingIsStated() throws Exception {
+        String narrowed = MODEL.replace("    invariant length(value) > 0\n",
+                "    invariant length(value) > 3\n");
+        BoundExamples bound = SoutherExamples.ofSource(narrowed)
+                .bind(builtElsewhere(compiled(MODEL), ANSWERS));
+
+        ContractObservation seen = bound.checkContract(bound.rows().get(0));
+        ContractObservation.Unobserved unobserved =
+                assertInstanceOf(ContractObservation.Unobserved.class, seen);
+        assertInstanceOf(StandinObservation.Reason.TheImplementationIsOfAnotherBuild.class,
+                unobserved.why());
+    }
+
+    /** Which behaviors state something, answered from the declaration and without applying one. */
+    @Test
+    void whichBehaviorsStateSomethingIsAskedOfTheModel() throws Exception {
+        assertEquals(List.of(), boundTo(MODEL, REFUSES).behaviorsStatingContracts(),
+                "nothing is stated, so a suite meaning to hold contracts holds none of these rows");
+        assertEquals(List.of("findTodo"), boundTo(DECLARING, REFUSES).behaviorsStatingContracts());
+    }
+
+    /**
+     * The premise this face rests on: a model whose contract could not be read never gets here.
+     *
+     * <p>{@code Bodies.Contracts} leaves out a behavior whose clause it could not read, the same way
+     * it leaves out one that states nothing — so inside {@code BoundExamples} the two would be one
+     * answer, and a row would be told the behavior states nothing when what it states was
+     * unreadable. What keeps them apart is the entrance: a model that does not compile makes no
+     * {@code SoutherExamples}, and a clause naming what denotes nothing does not compile.
+     *
+     * <p>Held here rather than left to the reading of one call site, because it is what makes
+     * {@link ContractObservation.NothingStated} mean what it says. If the entrance is ever loosened,
+     * this is what says the premise went with it.
+     */
+    @Test
+    void aModelWhoseClauseCannotBeReadMakesNoBoundExamples() {
+        String namesNothing = MODEL.replace(
+                "behavior findTodo : (id: TodoId) -> Todo | NotFound\n",
+                """
+                behavior findTodo : (id: TodoId) -> Todo | NotFound
+                    ensures Todo -> value.id.value == nobodyDeclaredThis(id)
+                """);
+
+        CompileException refused = assertThrows(CompileException.class,
+                () -> SoutherExamples.ofSource(namesNothing),
+                "the rows cannot be run: what the behavior states could not be read");
+        assertFalse(refused.diagnostics().isEmpty(), "and the name was reported where it was written");
+    }
+
+    // --- harness ---------------------------------------------------------------------------------
+
+    private static BoundExamples boundTo(String model, String implementation) throws Exception {
+        return SoutherExamples.ofSource(model).bind(builtElsewhere(compiled(model), implementation));
+    }
+
+    private static RecordedRow named(BoundExamples bound, String name) {
+        return bound.rows().stream()
+                .filter(row -> row.shown().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no row named `" + name + "`"));
+    }
+
+    private static Map<String, byte[]> compiled(String model) {
+        return Compilation.ofSource(model, "Main").db().ask(new Output.All()).value();
+    }
+
+    private static Object builtElsewhere(Map<String, byte[]> generated, String source)
+            throws Exception {
+        Path classes = Files.createTempDirectory("souther-contract");
+        for (Map.Entry<String, byte[]> e : generated.entrySet()) {
+            Path at = classes.resolve(e.getKey().replace('.', '/') + ".class");
+            Files.createDirectories(at.getParent());
+            Files.write(at, e.getValue());
+        }
+        Path java = classes.resolve("example/todo/FindTodoImpl.java");
+        Files.createDirectories(java.getParent());
+        Files.writeString(java, source);
+        int rc = ToolProvider.getSystemJavaCompiler().run(null, null, null,
+                "-encoding", "UTF-8",
+                "-classpath", classes + File.pathSeparator + System.getProperty("java.class.path"),
+                "-d", classes.toString(), java.toString());
+        assertEquals(0, rc, "the implementation compiles against the module's classes");
+        URLClassLoader loader = new URLClassLoader(new URL[] {classes.toUri().toURL()},
+                ExampleVerifier.class.getClassLoader());
+        return loader.loadClass("example.todo.FindTodoImpl").getConstructor().newInstance();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/examples/AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest.java
@@ -247,9 +247,9 @@ class AnImplementationIsHeldToTheDeclarationAndNotToTheRecordTest {
     /** Which behaviors state something, answered from the declaration and without applying one. */
     @Test
     void whichBehaviorsStateSomethingIsAskedOfTheModel() throws Exception {
-        assertEquals(List.of(), boundTo(MODEL, REFUSES).behaviorsStatingContracts(),
+        assertEquals(List.of(), boundTo(MODEL, REFUSES).behaviorsWithContracts(),
                 "nothing is stated, so a suite meaning to hold contracts holds none of these rows");
-        assertEquals(List.of("findTodo"), boundTo(DECLARING, REFUSES).behaviorsStatingContracts());
+        assertEquals(List.of("findTodo"), boundTo(DECLARING, REFUSES).behaviorsWithContracts());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/examples/AnObservationIsOnlyEverMadeByWhatObservedItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/AnObservationIsOnlyEverMadeByWhatObservedItTest.java
@@ -1,0 +1,105 @@
+package souther.compiler.examples;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * An arm carrying something derived from something else it carries is made only where the two are
+ * written together.
+ *
+ * <p>{@link ContractObservation.Broken} holds what was answered twice: structurally, and written the
+ * way a fixture writes a value. The second is a rendering of the first, and only the place that made
+ * them has what relates the two — the module's declarations, which are what tell a newtype from what
+ * it wraps. A canonical constructor says that any combination of components is a value, which is
+ * true of independent observations and false of these: it would admit an answer of seven beside a
+ * text reading {@code TodoId(99)}, and put the rendering inside {@code equals}, so writing a value
+ * differently would make it a different observation.
+ *
+ * <p>{@link ContractObservation.NoClauseWasBroken} is closed for its own reason — what clauses bore
+ * on the answer is evidence it is to gain, and a constructor callers write is one a later component
+ * breaks.
+ *
+ * <p>Measured against the shape of the API rather than against an answer. Both reasons are written
+ * down where the arms are, and a sentence is kept by whoever reads it; a constructor is kept by
+ * everyone.
+ */
+class AnObservationIsOnlyEverMadeByWhatObservedItTest {
+
+    /** The arms nothing outside this package may make, and why each is one. */
+    private static final List<Class<?>> CLOSED = List.of(
+            ContractObservation.NoClauseWasBroken.class,
+            ContractObservation.Broken.class);
+
+    @Test
+    void aClosedArmHasNoConstructorAReaderCanReach() {
+        List<String> reachable = new ArrayList<>();
+        for (Class<?> arm : CLOSED) {
+            for (Constructor<?> c : arm.getDeclaredConstructors()) {
+                if (Modifier.isPublic(c.getModifiers()) || Modifier.isProtected(c.getModifiers())) {
+                    reachable.add(c.toString());
+                }
+            }
+        }
+        assertEquals(List.of(), reachable,
+                "a reader outside this package could state an observation nothing observed");
+    }
+
+    /**
+     * And they are not records, which is what would give them one back.
+     *
+     * <p>The constructor above is what the rule is about; this says where it would come from. A
+     * record written here compiles, ships a public canonical constructor, and reads as a tidying-up
+     * of an arm that looks like data — so the reason is written down beside the check.
+     */
+    @Test
+    void aClosedArmIsNotARecord() {
+        List<String> records = new ArrayList<>();
+        for (Class<?> arm : CLOSED) {
+            if (arm.isRecord()) {
+                records.add(arm.getName());
+            }
+        }
+        assertEquals(List.of(), records,
+                "a record's canonical constructor is public, and its equality is over every"
+                        + " component — including one that is a rendering of another");
+    }
+
+    /**
+     * The arms whose components are independent stay records, and this says which those are.
+     *
+     * <p>Without it the rule above reads as "observations are classes", and the next arm added would
+     * be closed for no reason. What decides is whether one component is derived from another.
+     */
+    @Test
+    void anArmOfIndependentComponentsIsARecord() {
+        List<String> notRecords = new ArrayList<>();
+        for (Class<?> arm : List.of(ContractObservation.NothingStated.class,
+                ContractObservation.Unobserved.class)) {
+            if (!arm.isRecord()) {
+                notRecords.add(arm.getName());
+            }
+        }
+        assertEquals(List.of(), notRecords,
+                "nothing these carry is worked out from anything else they carry");
+    }
+
+    /** Every arm is one of the two, so an arm added later is classified rather than defaulted. */
+    @Test
+    void everyArmIsClassifiedOneWayOrTheOther() {
+        List<String> unclassified = new ArrayList<>();
+        for (Class<?> arm : ContractObservation.class.getPermittedSubclasses()) {
+            boolean closed = CLOSED.contains(arm);
+            if (closed == arm.isRecord()) {
+                unclassified.add(arm.getName());
+            }
+        }
+        assertEquals(List.of(), unclassified,
+                "an arm is a record whose components are independent, or a class this package makes");
+    }
+}


### PR DESCRIPTION
Closes #1017.

A row carries inputs and a recorded answer, so the only question that could be asked of a bound
implementation was whether it answered the value somebody wrote out. What the model *states* — the
`ensures` — could not be asked on its own, though it is the oracle a contract test wants: the rows
are the inputs, the declaration decides the answers.

```java
BoundExamples bound = SoutherExamples.of(MODEL).bind(new JooqArticles.ReadPage(dsl));

return bound.rows().stream()
        .map(row -> dynamicTest(row.shown(), () -> {
            ContractObservation checked = bound.checkContract(row);
            assertInstanceOf(NoClauseWasBroken.class, checked, checked::shown);
        }));
```

Every row, including rows of a behavior that states nothing — those come back `NothingStated` and
turn the suite red, which is what the arm is for. A suite that means to hold only the behaviors with
a contract says so, reading the list once rather than once per row:

```java
List<String> contracted = bound.behaviorsWithContracts();

return bound.rows().stream()
        .filter(row -> contracted.contains(row.behavior()))
        ...
```

## A different oracle, not a different world

`evaluate` holds an answer to the declaration *and* to the record; this holds it to the declaration
alone. The two part inside one world as readily as across two — a behavior stating nothing about the
order of what it answers admits a page the recorded one is a permutation of — and the test that
decides the face holds exactly that pair: one binding, one row, `evaluate` refusing it at
`COMPARISON` and `checkContract` answering that no clause was broken.

Where they part in practice is a world the rows were not recorded in, a shared database or a
snapshot, and there the recorded answer is no longer the answer while the declaration still is. That
is a use of the distinction rather than the distinction itself, so `RowEvaluation` is not widened
here: one application settles both strengths, but exposing the second is a separate API request and
not a condition of this one.

## The arms

`NoClauseWasBroken` is named for the claim it makes. A clause is vacuous for an input it says
nothing about, and such a row proves nothing; `Kept` would be one word over that and over the answer
that keeps every clause that bore.

Two arms are classes rather than records, for two different reasons. `NoClauseWasBroken` is to gain
evidence — which clauses bore on the answer — that a later component would break for anyone writing
its constructor. `Broken` carries what was answered twice, structurally and written the way a
fixture writes a value, and a record's canonical constructor would say those two are independent:
it would admit an answer of seven beside a text reading `TodoId(99)`, and put the rendering inside
`equals`. `NothingStated` and `Unobserved` carry nothing worked out from anything else they carry
and stay records. That split is the API's shape and not a sentence about it — writing `Broken` as a
record again turns three assertions red, and an arm added later is classified rather than defaulted.

`shown()` takes no language. `RowEvaluation.shown(Locale)` renders diagnostics, which are what a
compile reports and live in the shipped catalogs; nothing here is a diagnostic, and a sentence in a
catalog is one classified as a rule reported or a word said beside one — these are neither. The
nearer neighbour is `StandinObservation.Reason.said()`, whose words are this package's.

The binding is answered for before the declaration is. An implementation of another build states
nothing that can run, and calling that "the model states nothing" sends its author to write a clause
that still would not.

## `Bodies.Contracts` is unchanged

It leaves out a behavior whose clause it could not read the same way it leaves out one that states
nothing, so inside `BoundExamples` those would be one answer. What keeps them apart is the entrance:
`SoutherExamples` refuses a model that does not compile. Both ways it gives a behavior up are held
by tests — `Unanswerable`, which carries no diagnostic because the name was already reported where
it was written, and the refusal `BehaviorChecker` raises inside `contractOf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)