### PR TITLE
Ask the language which qualifiers there are, not the loaded library

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Exposing.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Exposing.java
@@ -1,5 +1,6 @@
 package souther.compiler.check;
 
+import souther.compiler.Reserved;
 import souther.compiler.ast.Ast;
 import souther.compiler.types.ValueName;
 
@@ -125,7 +126,7 @@ public final class Exposing {
         List<Ast.Import> kept = new ArrayList<>();
         List<Refusal> refused = new ArrayList<>();
         for (Ast.Import imp : module.imports()) {
-            if (!Prelude.isQualifier(imp.module())) {
+            if (!Reserved.isQualifier(imp.module())) {
                 kept.add(imp);   // an ordinary user-module import — read where the universe is
                 continue;
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Prelude.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Prelude.java
@@ -45,10 +45,6 @@ import java.util.Set;
  */
 public final class Prelude {
 
-    /** Every qualifier a call may carry — the language's constant ({@link Reserved}), read from
-     *  there so nothing has to initialize this class to know it. */
-    private static final Set<String> QUALIFIERS = Reserved.QUALIFIERS;
-
     /** A declaration's resolved signature: its parameter types, and the success type of its declared
      *  return — or null where the declaration writes no return type and leaves its result to its
      *  body, which a Souther-bodied helper with parameters may and a kernel never does. A
@@ -122,18 +118,6 @@ public final class Prelude {
     }
 
     private Prelude() {
-    }
-
-    /** Whether {@code qualifier} names a standard-library namespace a call/import may use:
-     *  {@code List}/{@code String}/{@code Map}/{@code Bool}/{@code Int}/{@code Decimal} (spec §stdlib). */
-    public static boolean isQualifier(String qualifier) {
-        return QUALIFIERS.contains(qualifier);
-    }
-
-    /** Every standard-library qualifier ({@code List} / {@code Map} / … / {@code Option}). The
-     *  syntax highlighter derives its qualifier list from this so the two never drift apart. */
-    public static Set<String> qualifiers() {
-        return QUALIFIERS;
     }
 
     /** What a sugared name is sugar for: the call it becomes, and the arguments the rewrite supplies
@@ -264,7 +248,7 @@ public final class Prelude {
         }
         names.addAll(SUGARED.keySet());
         Set<String> byModule = new LinkedHashSet<>();
-        for (String qualifier : QUALIFIERS) {
+        for (String qualifier : Reserved.QUALIFIERS) {
             for (String name : names) {
                 if (OPERATIONS.get(name).alias().equals(qualifier)) {
                     byModule.add(name);

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -744,7 +744,7 @@ public final class Resolve {
         }
         String bare = written.substring(dot + 1);
         String qualifier = written.substring(0, dot);
-        if (Prelude.isQualifier(qualifier)) {
+        if (Reserved.isQualifier(qualifier)) {
             // a standard-library qualifier names a function, and a function is not a behavior
             return noBehavior(ref, unknown.report(ref, Set.of()));
         }
@@ -1403,7 +1403,7 @@ public final class Resolve {
         // values: the qualifier they typed and the operation they asked of it. Nothing downstream
         // splits it again — from here it is carried as the pair.
         int dot = written.lastIndexOf('.');
-        if (Prelude.isQualifier(dot < 0 ? written : written.substring(0, dot))) {
+        if (Reserved.isQualifier(dot < 0 ? written : written.substring(0, dot))) {
             if (Reserved.isNamespace(reachable.module()) || !Prelude.isPrivateMember(written)) {
                 return new Reach.Reaches(dot < 0 ? ValueName.Stdlib.namespace(written)
                         : new ValueName.Stdlib(written.substring(0, dot),
@@ -1556,7 +1556,7 @@ public final class Resolve {
     /** Whether {@code qualifier} names a namespace a member may be reached through: a
      *  standard-library one, or a module of this compilation (or an alias for one). */
     private boolean isNamespace(String qualifier) {
-        return Prelude.isQualifier(qualifier) || symbols.scope().moduleOfQualifier(qualifier) != null;
+        return Reserved.isQualifier(qualifier) || symbols.scope().moduleOfQualifier(qualifier) != null;
     }
 
     /** The name a chain of field reads is rooted at, or null where it is rooted at anything else —
@@ -1675,7 +1675,7 @@ public final class Resolve {
     private CompileException notALibraryMember(WrittenName written) {
         String name = written.canonical();
         int dot = name.lastIndexOf('.');
-        if (dot < 0 || !Prelude.isQualifier(name.substring(0, dot))) {
+        if (dot < 0 || !Reserved.isQualifier(name.substring(0, dot))) {
             return null;
         }
         return CompileException.of(Diagnostic

--- a/souther-compiler/src/main/java/souther/compiler/check/Scoping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Scoping.java
@@ -1,5 +1,6 @@
 package souther.compiler.check;
 
+import souther.compiler.Reserved;
 import souther.compiler.ast.Ast;
 import souther.compiler.ast.Hir;
 import souther.compiler.diag.SourcePos;
@@ -523,7 +524,7 @@ public final class Scoping {
         if (universe.module(alias).isThere()) {
             return alias;
         }
-        return Prelude.isQualifier(alias) ? "souther" : null;
+        return Reserved.isQualifier(alias) ? "souther" : null;
     }
 
     /**
@@ -648,7 +649,7 @@ public final class Scoping {
             // A standard-library qualifier is the only spelling that reaches the library, so a data
             // of that name hides it — from every module, since the qualifier is not this module's
             // to shadow. Refused where it is declared, as a reserved module name is.
-            if (Prelude.isQualifier(def.name())) {
+            if (Reserved.isQualifier(def.name())) {
                 refused.add(new Refusal.TakesTheLibraryQualifier(def));
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/doc/ApiCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/ApiCommand.java
@@ -1,5 +1,6 @@
 package souther.compiler.doc;
 
+import souther.compiler.Reserved;
 import souther.compiler.check.Prelude;
 import souther.compiler.ast.Hir;
 import souther.compiler.types.Type;
@@ -81,9 +82,9 @@ public final class ApiCommand {
             err.println(caller.stdlibSource(asked.substring(0, asked.indexOf('.'))));
             return 0;
         }
-        if (!Prelude.isQualifier(asked)) {
+        if (!Reserved.isQualifier(asked)) {
             err.println("no stdlib module `" + asked + "`");
-            err.println("modules: " + String.join(", ", Prelude.qualifiers().stream().sorted().toList()));
+            err.println("modules: " + String.join(", ", Reserved.QUALIFIERS.stream().sorted().toList()));
             return 2;
         }
         listPublished(out, asked + ".");
@@ -174,9 +175,9 @@ public final class ApiCommand {
     }
 
     private static int printSource(String alias, PrintStream out, PrintStream err) {
-        if (!Prelude.isQualifier(alias)) {
+        if (!Reserved.isQualifier(alias)) {
             err.println("no stdlib module `" + alias + "`");
-            err.println("modules: " + String.join(", ", Prelude.qualifiers().stream().sorted().toList()));
+            err.println("modules: " + String.join(", ", Reserved.QUALIFIERS.stream().sorted().toList()));
             return 2;
         }
         String resource = "/souther/" + alias.toLowerCase() + ".sou";

--- a/souther-compiler/src/main/java/souther/compiler/highlight/TmLanguageGenerator.java
+++ b/souther-compiler/src/main/java/souther/compiler/highlight/TmLanguageGenerator.java
@@ -62,8 +62,8 @@ public final class TmLanguageGenerator {
     private static final Set<String> BOOLEANS = Set.of("true", "false");
 
     /** The standard-library qualifiers, taken from {@link Reserved#QUALIFIERS} (the single source of
-     *  truth) and sorted for a stable grammar; highlighted before a dot. Adding a module to the
-     *  language's list extends this automatically — no separate list to keep in step. */
+     *  truth) and sorted for a stable grammar; highlighted before a dot. Adding a module to
+     *  {@link Reserved#MODULES} extends this automatically — no separate list to keep in step. */
     private static final List<String> QUALIFIERS =
             Reserved.QUALIFIERS.stream().sorted().toList();
 

--- a/souther-compiler/src/main/java/souther/compiler/highlight/TmLanguageGenerator.java
+++ b/souther-compiler/src/main/java/souther/compiler/highlight/TmLanguageGenerator.java
@@ -1,6 +1,6 @@
 package souther.compiler.highlight;
 
-import souther.compiler.check.Prelude;
+import souther.compiler.Reserved;
 import souther.compiler.cst.CstLexer;
 import souther.compiler.cst.IdentifierAlphabet;
 import souther.compiler.editor.EditorSymbols;
@@ -61,11 +61,11 @@ public final class TmLanguageGenerator {
     /** Boolean literals (scoped as language constants, not keywords). */
     private static final Set<String> BOOLEANS = Set.of("true", "false");
 
-    /** The standard-library qualifiers, taken from {@link Prelude#qualifiers()} (the single source of
-     *  truth) and sorted for a stable grammar; highlighted before a dot. Adding a module to the prelude
-     *  extends this automatically — no separate list to keep in step. */
+    /** The standard-library qualifiers, taken from {@link Reserved#QUALIFIERS} (the single source of
+     *  truth) and sorted for a stable grammar; highlighted before a dot. Adding a module to the
+     *  language's list extends this automatically — no separate list to keep in step. */
     private static final List<String> QUALIFIERS =
-            Prelude.qualifiers().stream().sorted().toList();
+            Reserved.QUALIFIERS.stream().sorted().toList();
 
     /** The operators as {@link EditorSymbols} classifies them, spelled by their kinds, longest first
      *  so a prefix ({@code >}) never masks a longer form ({@code >->}). Sorting by length is what

--- a/souther-compiler/src/main/java/souther/compiler/meta/DeclarationAgreement.java
+++ b/souther-compiler/src/main/java/souther/compiler/meta/DeclarationAgreement.java
@@ -1,10 +1,10 @@
 package souther.compiler.meta;
 
+import souther.compiler.Reserved;
 import souther.compiler.ast.DefinitionRole;
 import souther.compiler.ast.Hir;
 import souther.compiler.ast.RowPosition;
 import souther.compiler.ast.WrittenName;
-import souther.compiler.check.Prelude;
 import souther.compiler.diag.Region;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
@@ -216,7 +216,7 @@ public final class DeclarationAgreement {
          */
         private void reach(Reached what) {
             String module = what.module();
-            if (module == null || module.isEmpty() || Prelude.isQualifier(module)) {
+            if (module == null || module.isEmpty() || Reserved.isQualifier(module)) {
                 return;
             }
             if (reached.add(what)) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -1,8 +1,8 @@
 package souther.compiler.query;
 
+import souther.compiler.Reserved;
 import souther.compiler.source.SourceId;
 
-import souther.compiler.check.Prelude;
 import souther.compiler.ast.Ast;
 import souther.compiler.ast.WrittenName;
 import souther.compiler.diag.CompileException;
@@ -570,7 +570,7 @@ public final class Front {
                     if (read.containsKey(needed) || refused.containsKey(needed)
                             || unreadable.containsKey(needed)
                             || layout.idOfModule().containsKey(needed)
-                            || Prelude.isQualifier(needed)) {
+                            || Reserved.isQualifier(needed)) {
                         continue;
                     }
                     reports.add(saidAbout(reaching.getKey(), needs(needed, reaching.getKey()),
@@ -1223,7 +1223,7 @@ public final class Front {
         // The short qualifiers are how the standard library is reached (`List.map`, `import
         // String`); a user module by one of these names would shadow the library and could not be
         // imported.
-        if (Prelude.isQualifier(name)) {
+        if (Reserved.isQualifier(name)) {
             return Diagnostic.say(new ModuleMessage.TheModuleTakesTheStandardLibraryQualifier(name));
         }
         return null;

--- a/souther-compiler/src/test/java/souther/compiler/diag/EveryShippedMessageCatalogIsCompleteAndValidTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/EveryShippedMessageCatalogIsCompleteAndValidTest.java
@@ -10,6 +10,7 @@ import souther.compiler.diag.msg.MessageValues;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.check.Ordering;
+import souther.compiler.Reserved;
 import souther.compiler.check.Prelude;
 import souther.compiler.types.Type;
 
@@ -1029,7 +1030,7 @@ public class EveryShippedMessageCatalogIsCompleteAndValidTest {
         for (String line : Files.readAllLines(catalog, StandardCharsets.UTF_8)) {
             Matcher m = quoted.matcher(line);
             while (m.find()) {
-                if (!Prelude.isQualifier(m.group(1))) {
+                if (!Reserved.isQualifier(m.group(1))) {
                     continue;
                 }
                 String qualified = m.group(1) + "." + m.group(2);

--- a/souther-compiler/src/test/java/souther/compiler/doc/EveryOperationAModulePublishesIsListedInItsSectionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/EveryOperationAModulePublishesIsListedInItsSectionTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.doc;
 
+import souther.compiler.Reserved;
 import souther.compiler.check.Prelude;
 
 import org.junit.jupiter.api.Test;
@@ -59,7 +60,7 @@ class EveryOperationAModulePublishesIsListedInItsSectionTest {
         Map<String, Set<String>> published = publishedByModule();
         Map<String, Set<String>> publishes = new LinkedHashMap<>();
         Map<String, Set<String>> listed = new LinkedHashMap<>();
-        for (String module : new TreeSet<>(Prelude.qualifiers())) {
+        for (String module : new TreeSet<>(Reserved.QUALIFIERS)) {
             String anchor = "stdlib-" + module.toLowerCase(Locale.ROOT);
             SpecDocument.Section section = spec.section(anchor);
             assertNotNull(section, "`" + module + "` has no `" + anchor
@@ -80,8 +81,8 @@ class EveryOperationAModulePublishesIsListedInItsSectionTest {
      */
     @Test
     void thereIsSomethingToCompareSoTheAgreementIsNotBetweenTwoEmptyThings() {
-        assertFalse(Prelude.qualifiers().isEmpty(), "no module to compare a section against");
-        assertTrue(Prelude.qualifiers().containsAll(publishedByModule().keySet()),
+        assertFalse(Reserved.QUALIFIERS.isEmpty(), "no module to compare a section against");
+        assertTrue(Reserved.QUALIFIERS.containsAll(publishedByModule().keySet()),
                 "a module the library publishes under is a module the walk reaches");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/doc/NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.doc;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.Reserved;
 import souther.compiler.check.Prelude;
 import souther.compiler.types.Type;
 
@@ -380,7 +381,7 @@ class NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest {
         List<Call> calls = new ArrayList<>();
         Matcher m = CALL.matcher(adoc);
         while (m.find()) {
-            if (!Prelude.isQualifier(m.group(1))) {
+            if (!Reserved.isQualifier(m.group(1))) {
                 continue;
             }
             int open = m.end() - 1;

--- a/souther-syntax/src/main/java/souther/compiler/Reserved.java
+++ b/souther-syntax/src/main/java/souther/compiler/Reserved.java
@@ -98,6 +98,15 @@ public final class Reserved {
                 : java.text.Normalizer.normalize(spelling, java.text.Normalizer.Form.NFC);
     }
 
+    /** Whether {@code qualifier} names a standard-library namespace a call or an import may write:
+     *  {@code List} / {@code String} / {@code Map} / … (spec §stdlib). Asked here rather than of the
+     *  loaded library, because which qualifiers there are is settled by {@link #MODULES} and reading
+     *  it off the library made a reader that only wanted the names load and resolve every one of the
+     *  modules behind them. */
+    public static boolean isQualifier(String qualifier) {
+        return QUALIFIERS.contains(qualifier);
+    }
+
     /** Whether {@code moduleName} is the reserved namespace or a module inside it. The core
      *  privileges — declaring an {@code intrinsic}, declaring a {@code private let} — are the ones
      *  this answers for. */


### PR DESCRIPTION
First of two for #1010. Mechanical, and it stands on its own.

`Prelude.isQualifier` and `Prelude.qualifiers()` returned `Reserved.QUALIFIERS` and nothing else. Asking either of them runs `Prelude`'s static initializer, which parses, resolves and types the twelve standard-library modules — so a reader that only wanted to know whether `List` is a standard-library name took the whole of name resolution with it. Three packages read the library for that and for nothing else.

Which qualifiers there are is settled by `Reserved.MODULES`, which is where a module is added and which has no dependencies of its own. `isQualifier` moves there beside `QUALIFIERS` and `isNamespace`; both methods leave `Prelude`.

19 call sites move (15 in main, 4 in tests). `query`, `meta` and `highlight` drop their `check.Prelude` import entirely and no longer name `check` at all; `doc` keeps it for the surface listing. What is left on `Prelude` is what only the loaded library can answer, and its readers are now `check`, `codegen`, `doc` and `examples` — nine call sites outside `check`.

`mvn -o test`: all 10 modules SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)