### PR TITLE
Read a comparison over the answer as its own subject, not as a pair of inputs

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Required.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Required.java
@@ -148,7 +148,19 @@ public sealed interface Required {
          * position for anything to have read. A rule cannot cost a position it does not name, which
          * is what the reading of values says of its own failures for the same reason.
          */
-        IT_NAMES_NO_POSITION
+        IT_NAMES_NO_POSITION,
+
+        /**
+         * The rule reads what the behavior answers, and this reading does not project such a rule
+         * back onto the input space.
+         *
+         * <p>Told from {@link #IT_NAMES_NO_POSITION}, which is the reason a reader would otherwise
+         * be given. {@code List.length(value.articles) <= query.limit.value} does name a position —
+         * a row chooses {@code query.limit} — and what it raises nothing about is the input's own
+         * values, because what the clause bounds is on the other side of the behavior. An author
+         * told the rule names no position would go looking for the name that is plainly there.
+         */
+        IT_DEPENDS_ON_THE_ANSWER
     }
 
     /** What every invariant clause raises about a position it is written about. */
@@ -219,7 +231,18 @@ public sealed interface Required {
      * @param of    what it places it about, from the comparison alone as well
      */
     public static Required ofComparison(ComparisonClaim claim, ComparisonSubject of) {
-        if (of instanceof ComparisonSubject.Relation between) {
+        // One switch and no `default`, for the reason {@link #ofInvariant} gives: a subject added
+        // and not classified stops the build rather than arriving here as the arm that happens to be
+        // nearest. Written as a chain ending in "anything that is not an input", the arm added for
+        // issue #1013 could have been left out and every comparison reading the answer would have
+        // been reported as naming no position — the reason a reader is given, quietly wrong.
+        return switch (of) {
+            // A rule this reading does not put on the input space at all. Before anything about the
+            // two sides, because a comparison reading the answer is not a pair of inputs however
+            // its sides are spelled: read as one, an order against the answer raised the line a pair
+            // of inputs raises and nothing could ever answer it (issue #1013).
+            case ComparisonSubject.AnswerDependent _ ->
+                    new Irrelevant(Set.of(Because.IT_DEPENDS_ON_THE_ANSWER));
             // An order between two things that move with the row is a line rows are owed at — the
             // place they hold one count — and divides neither of them, so there is no class of one
             // for a row to be owed in. Raised whether or not this compiler can find that place: a
@@ -228,14 +251,18 @@ public sealed interface Required {
             //
             // An equality between them is not a line: it puts the whole of one arm on the place,
             // and that arm is a row the branch measure already asks for (`ComparedTerms`).
-            return claim instanceof ComparisonClaim.Cut
+            case ComparisonSubject.Relation between -> claim instanceof ComparisonClaim.Cut
                     ? new Some(new LinkedHashSet<>(java.util.List.of(
                             new Owed(CoverageObligation.BOUNDARY, between.at()))))
                     : new Irrelevant(Set.of(Because.IT_RELATES_TWO_POSITIONS));
-        }
-        if (!(of instanceof ComparisonSubject.AnInput input)) {
-            return new Irrelevant(Set.of(Because.IT_NAMES_NO_POSITION));
-        }
+            case ComparisonSubject.NoInput _ ->
+                    new Irrelevant(Set.of(Because.IT_NAMES_NO_POSITION));
+            case ComparisonSubject.AnInput input -> ofAnInput(claim, input);
+        };
+    }
+
+    /** What a comparison measuring one input by a number of it raises about that input. */
+    private static Required ofAnInput(ComparisonClaim claim, ComparisonSubject.AnInput input) {
         Set<Owed> owed = new LinkedHashSet<>();
         switch (claim) {
             // An order across the place it names, so rows are owed either side of it and the two
@@ -265,12 +292,18 @@ public sealed interface Required {
      * from the operator alone, {@code a == b} raised a question about a value singled out at
      * {@code a} that no rule wrote.
      *
-     * <p><b>Which of the two is decided by what moves with a row.</b> A comparison is about one
-     * position exactly where one side is a number taken of an input and the other side is the same
-     * for every row. Counted as positions named instead, {@code a <= a + 1} came back as one
-     * position's — one name, twice — and a clause comparing an answer to an input needed a rule of
-     * its own to be kept out. What a row chooses is the input; the answer moves with it, so a
-     * comparison against the answer is a relation like any other.
+     * <p><b>Which of them it is, is decided by what the two sides read.</b> A comparison is about
+     * one position exactly where one side is a number taken of an input and the other side is the
+     * same for every row. Counted as positions named instead, {@code a <= a + 1} came back as one
+     * position's — one name, twice.
+     *
+     * <p><b>And a comparison reading the answer is none of the three.</b> The answer does move with
+     * the row, which is what a clause of an {@code ensures} is written about; what does not follow
+     * is that two things moving with the row are one kind of subject here. Boundary coverage is over
+     * the values a row can choose, and those are the inputs — so an order between two inputs is a
+     * line rows are owed at, and an order between an input and the answer is not a line on the input
+     * space at all. Read as one, {@code List.length(value.articles) <= query.limit.value} raised a
+     * boundary obligation at a place no reading of the clause can reach (issue #1013).
      *
      * <p>Not read off what a reading managed. Whether this compiler could fold the other side is an
      * answer, and a question may not be decided by one (#851) — so {@code a == 10 * 2} is one
@@ -311,7 +344,32 @@ public sealed interface Required {
             }
         }
 
-        /** Neither side is an input's, so it says nothing about one. */
+        /**
+         * The comparison reads what the behavior answers, so this reading does not put it on the
+         * input space.
+         *
+         * <p>Apart from {@link NoInput}, which the shape used to fall into where the other side was
+         * a constant, and apart from {@link Relation}, which it fell into where the other side was
+         * an input. Both were silent about a different thing than this is: one says the rule names
+         * no input, and {@code List.length(value.articles) <= query.limit.value} names one.
+         *
+         * <p>Not a claim that no line exists. Eliminating the answer existentially can leave a
+         * constraint on the input — a length is never negative, so {@code List.length(value.items)
+         * <= n} has no satisfying answer below zero — and deriving that is constraint projection
+         * over several rules rather than the reading of one comparison. What this arm records is
+         * where the reading stops, so that adding the projection later contradicts nothing.
+         */
+        record AnswerDependent() implements ComparisonSubject {}
+
+        /**
+         * Neither side is an input's, so it says nothing about one.
+         *
+         * <p>Currently also where a side that does name an input falls when this classification
+         * cannot name a term for it. {@code a + 1 <= 10} draws a border at {@code a = 9} and
+         * arrives here, because the subject is taken from the operands as written while the line is
+         * cut from the canonical form — issue #1029, which is where that is settled. The sentence
+         * above is what this arm means; this paragraph goes when #1029 does.
+         */
         record NoInput() implements ComparisonSubject {}
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonSubjects.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonSubjects.java
@@ -1,0 +1,133 @@
+package souther.compiler.partition;
+
+import souther.compiler.check.Owed;
+import souther.compiler.check.Required;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.diag.Citation;
+import souther.compiler.inputs.InputReads;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.types.BindingId;
+
+/**
+ * What a comparison is a rule about, which the operator does not say.
+ *
+ * <p>The operator says what a comparison places — {@code x == 10} singles a value out and
+ * {@code x < 10} orders the values either side — and this says what it places it about. Neither is
+ * the other's, and taken from the operator alone {@code a == b} raised a question about a value
+ * singled out at {@code a} that no rule wrote.
+ *
+ * <p><b>Boundary coverage is over the values a row can choose, which are the behavior's inputs.</b>
+ * A comparison involving the answer may state a relation between an input and the answer, and this
+ * reading does not project that relation back onto the input space. Such a comparison is read and
+ * understood, and it raises no input-coverage obligation.
+ *
+ * <p><b>Two axes, and they were one.</b> Whether a side reads the answer and whether a side names
+ * an input position were asked as one question — "does this move with the row" — and both come back
+ * true, because the answer does move with the row. That much is a fact. What did not follow is that
+ * two things moving with the row are the same kind of subject on the input space: an order between
+ * two inputs is a line rows are owed at, and an order between an input and the answer is not a line
+ * at all. Read as one, {@code List.length(value.articles) <= query.limit.value} raised a boundary
+ * obligation at a place the reading of the clause can never reach, and the report said a rule went
+ * unaccounted for that nothing could ever account for (issue #1013).
+ *
+ * <p><b>Not a claim that no line exists.</b> Eliminating the answer existentially can leave a
+ * constraint on the input — {@code List.length(value.items) <= n} has no satisfying answer where
+ * {@code n} is negative, because a length is never negative — and deriving that is constraint
+ * projection rather than the reading of one comparison. What is written here is where this reading
+ * stops, so that adding the projection later does not contradict it.
+ */
+final class ComparisonSubjects {
+
+    /**
+     * What {@code comparison} is a rule about.
+     *
+     * <p>The one way in, and the only thing here that classifies anything. {@code answer} is the
+     * binding a clause calls what the behavior answers, or null where the comparison is written in
+     * a body and there is nothing to be the answer.
+     */
+    static Required.ComparisonSubject of(Core.Binary comparison, InputReads reads, Symbols symbols,
+                                         BindingId answer) {
+        // Asked first, and of the whole comparison. A rule that reads the answer anywhere in it is
+        // one this reading does not put on the input space, whichever side the answer is on and
+        // whatever else stands beside it: `value.n + query.offset <= 20` is about the answer and
+        // about an input, and the input is no more measurable here for the input being named.
+        if (readsAnswer(comparison, answer)) {
+            return new Required.ComparisonSubject.AnswerDependent();
+        }
+        boolean left = mentionsAnInput(comparison.left(), reads, symbols);
+        boolean right = mentionsAnInput(comparison.right(), reads, symbols);
+        if (left == right) {
+            // Both, which is a rule about a pair; or neither, which says nothing about an input.
+            // The place a relation's line falls is between the two sides, spelled as they are
+            // written — a reader meets them beside each other on the row owed there.
+            return left ? new Required.ComparisonSubject.Relation(
+                    new Owed.Subject.OfComparison(Citation.of(comparison.pos())))
+                    : new Required.ComparisonSubject.NoInput();
+        }
+        Core side = left ? comparison.left() : comparison.right();
+        NumericTerm term = GuardThresholds.termOf(side, reads, symbols);
+        if (term == null) {
+            // An input read a way the terms do not name. `NoInput` understates this — see the arm's
+            // own note and issue #1029 — and no arm of this classification says it better today.
+            return new Required.ComparisonSubject.NoInput();
+        }
+        return new Required.ComparisonSubject.AnInput(subjectOf(term), Owed.Subject.at(""));
+    }
+
+    /**
+     * Whether anything in {@code e} reads the binding a rule calls the answer.
+     *
+     * <p>A mechanical predicate over the tree, and it classifies nothing by itself. Two readers ask
+     * it and reach different conclusions: {@link #of} answers that the comparison raises no
+     * input-coverage obligation, and {@link EnsuresThresholds} answers that a rule about the answer
+     * is not one this compiler failed to read. Written twice, the two came apart — the second had
+     * the predicate and the first did not, which is the whole of issue #1013 — so it is written
+     * once and neither reader owns what the other makes of it.
+     *
+     * <p>Syntactic. {@code value.n - value.n + query.limit.value <= 20} does not depend on the
+     * answer once the arithmetic is read, and this answers that it does. Normalising first is a
+     * larger question about which reading of a comparison decides its subject (#1029), and a
+     * predicate that quietly did some of it would put that decision here.
+     *
+     * <p>False where there is no answer to read, which is every comparison written in a body.
+     */
+    static boolean readsAnswer(Core e, BindingId answer) {
+        if (answer == null) {
+            return false;
+        }
+        if (e instanceof Core.Read read && answer.equals(read.binding())) {
+            return true;
+        }
+        boolean[] found = {false};
+        Core.forEachChild(e, child -> found[0] |= readsAnswer(child, answer));
+        return found[0];
+    }
+
+    /**
+     * Whether {@code e} names a position of the behavior's input.
+     *
+     * <p>By the walk that names positions however they are written, which is the reading a body's
+     * conditions use. What it does not say is whether the position is one a line can be drawn on:
+     * a side may name an input and still have no term this reading can measure it by.
+     */
+    private static boolean mentionsAnInput(Core e, InputReads reads, Symbols symbols) {
+        return !GuardThresholds.mentionedIn(e, reads, symbols).isEmpty();
+    }
+
+    /**
+     * What the question is about, relative to the position it is filed at.
+     *
+     * <p>An invariant's subject is relative to the value its clause is on, and this is the same
+     * thing one frame out. Which of the two it is was settled by the reading that found the term: a
+     * {@code String} bounded on its length raises about the string and draws its line on the count,
+     * and a document promises both spellings.
+     */
+    private static Owed.Subject.OfAPosition subjectOf(NumericTerm term) {
+        // A term that is a count says the line is on the count; anything else — a term over the
+        // position's own value, or no term at all — leaves it on the position.
+        return new Owed.Subject.OfAPosition("", term instanceof NumericTerm.SizeOf);
+    }
+
+    private ComparisonSubjects() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -49,9 +49,12 @@ import java.util.Map;
  * is not a choice either, and stops at everything else.
  *
  * <p><b>And only about an input.</b> A comparison reading {@code value} is a line on the answer, and
- * a row cannot be written at one: what a row chooses is what the behavior is applied to. Nothing
- * turns such a comparison away — a term over the answer names no position of the input, so it draws
- * nothing, which is the same answer this gives any expression it cannot place.
+ * a row cannot be written at one: what a row chooses is what the behavior is applied to. Such a
+ * comparison is turned away by name rather than by drawing nothing — {@link ComparisonSubjects}
+ * answers that it is about the answer, and what it raises is nothing rather than a question about
+ * an input. Left to fall out as an expression this could not place, the clause was read as a rule
+ * about a pair of inputs, which owes a row where the two hold one count; nothing reaches that place,
+ * and the report named a rule unaccounted for that nothing could account for (issue #1013).
  *
  * <p>Two shapes of line, the two a body's conditions draw. One at a count of a position, which
  * divides it; one between two positions, which divides neither and is on neither — asked where the
@@ -199,7 +202,7 @@ public final class EnsuresThresholds {
             raises(out, rule, clause, comparison, rule.value(),
                     named.isEmpty() ? null : named.get(0),
                     GuardThresholds.comparedTerm(comparison, reads, symbols),
-                    GuardThresholds.subjectsOf(comparison, reads, symbols, rule.value()),
+                    ComparisonSubjects.of(comparison, reads, symbols, rule.value()),
                     new Required.LineRead.NoLine(
                             GuardThresholds.why(comparison, reads, symbols)));
             return;
@@ -233,14 +236,14 @@ public final class EnsuresThresholds {
             raises(out, rule, clause, comparison, rule.value(),
                     named.isEmpty() ? null : named.get(0),
                     GuardThresholds.comparedTerm(comparison, reads, symbols),
-                    GuardThresholds.subjectsOf(comparison, reads, symbols, rule.value()),
+                    ComparisonSubjects.of(comparison, reads, symbols, rule.value()),
                     made ? new Required.LineRead.ALineBetweenTwoPositions()
                             : new Required.LineRead.NoLine(
                                     GuardThresholds.why(comparison, reads, symbols)));
             return;
         }
         raises(out, rule, clause, comparison, rule.value(), divided.path(), divided,
-                GuardThresholds.subjectsOf(comparison, reads, symbols, rule.value()),
+                ComparisonSubjects.of(comparison, reads, symbols, rule.value()),
                 new Required.LineRead.ALineOnThePosition());
         // And the line itself, where the position has no value beside it for a row to be owed at,
         // for the reason a body's line is: the classes either side are what the model tells apart,
@@ -307,7 +310,7 @@ public final class EnsuresThresholds {
      */
     private static void reportUnread(RuleRef.Ensures rule, Core statement, BindingId answer,
                                      InputReads reads, Symbols symbols, List<UnreadRule> unread) {
-        if (readsTheAnswer(statement, answer)) {
+        if (ComparisonSubjects.readsAnswer(statement, answer)) {
             return;
         }
         BlockReason.AboutARule why = statement instanceof Core.Binary comparison
@@ -321,17 +324,6 @@ public final class EnsuresThresholds {
                 unread.add(here);
             }
         }
-    }
-
-    /** Whether anything in {@code e} reads what the rule calls the answer. */
-    private static boolean readsTheAnswer(Core e, BindingId answer) {
-        if (e instanceof Core.Read read && read.binding() != null
-                && read.binding().equals(answer)) {
-            return true;
-        }
-        boolean[] found = {false};
-        Core.forEachChild(e, child -> found[0] |= readsTheAnswer(child, answer));
-        return found[0];
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -2,7 +2,6 @@ package souther.compiler.partition;
 
 import souther.compiler.check.NumericMeasures;
 import souther.compiler.check.Carrier;
-import souther.compiler.check.Owed;
 import souther.compiler.check.Required;
 import souther.compiler.check.RuleAccounting;
 import souther.compiler.check.RuleRef;
@@ -21,7 +20,6 @@ import souther.compiler.core.Core;
 import souther.compiler.coverage.ComparisonCatalog;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.diag.Citation;
-import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
 
 import java.util.ArrayList;
@@ -518,7 +516,7 @@ public final class GuardThresholds {
             // would be read `on`. One comparison is one line however many positions it mentions.
             raises(accounting, behavior, plan.comparisons(), each, named.get(0),
                     comparedTerm(each, reads, symbols),
-                    subjectsOf(each, reads, symbols, null),
+                    ComparisonSubjects.of(each, reads, symbols, null),
                     new Required.LineRead.ALineBetweenTwoPositions());
             return;
         }
@@ -547,7 +545,7 @@ public final class GuardThresholds {
             between.add(new LineDrawn(cutting, origin));
         }
         raises(accounting, behavior, plan.comparisons(), each, divided.path(), divided,
-                subjectsOf(each, reads, symbols, null),
+                ComparisonSubjects.of(each, reads, symbols, null),
                 new Required.LineRead.ALineOnThePosition());
     }
 
@@ -563,78 +561,8 @@ public final class GuardThresholds {
         }
         raises(accounting, behavior, catalog, comparison, named.get(0),
                 comparedTerm(comparison, reads, symbols),
-                subjectsOf(comparison, reads, symbols, null),
+                ComparisonSubjects.of(comparison, reads, symbols, null),
                 new Required.LineRead.NoLine(why(comparison, reads, symbols)));
-    }
-
-    /**
-     * What the question is about, relative to the position it is filed at.
-     *
-     * <p>An invariant's subject is relative to the value its clause is on, and this is the same
-     * thing one frame out. Which of the two it is was settled by the reading that found the term: a
-     * {@code String} bounded on its length raises about the string and draws its line on the count,
-     * and a document promises both spellings.
-     */
-    static Owed.Subject.OfAPosition subjectOf(NumericTerm term) {
-        // A term that is a count says the line is on the count; anything else — a term over the
-        // position's own value, or no term at all — leaves it on the position.
-        return new Owed.Subject.OfAPosition("", term instanceof NumericTerm.SizeOf);
-    }
-
-    /**
-     * Whether the comparison is about one of the behavior's positions or about two.
-     *
-     * <p>Off the source, by the walk that names positions however they are written. The operator
-     * says what a comparison places and this says what it places it about, and neither is the
-     * other's: {@code x == 10} singles a value out and {@code x == y} is a rule about a pair, under
-     * one operator.
-     */
-    static Required.ComparisonSubject subjectsOf(Core.Binary comparison, InputReads reads,
-                                                 Symbols symbols, BindingId answer) {
-        boolean left = movesWithTheRow(comparison.left(), reads, symbols, answer);
-        boolean right = movesWithTheRow(comparison.right(), reads, symbols, answer);
-        if (left == right) {
-            // Both, which is a rule about a pair; or neither, which says nothing about an input.
-            // The place a relation's line falls is between the two sides, spelled as they are
-            // written — a reader meets them beside each other on the row owed there.
-            return left ? new Required.ComparisonSubject.Relation(
-                    new Owed.Subject.OfComparison(Citation.of(comparison.pos())))
-                    : new Required.ComparisonSubject.NoInput();
-        }
-        Core side = left ? comparison.left() : comparison.right();
-        NumericTerm term = termOf(side, reads, symbols);
-        if (term == null) {
-            // It moves with the row and is not a number this reads — the answer, or an input read a
-            // way the terms do not name. Nothing about an input's own values follows.
-            return new Required.ComparisonSubject.NoInput();
-        }
-        return new Required.ComparisonSubject.AnInput(subjectOf(term), Owed.Subject.at(""));
-    }
-
-    /**
-     * Whether what {@code e} comes to is chosen by the row.
-     *
-     * <p>An input's position is, and so is the answer a clause of an {@code ensures} names — what a
-     * row chooses is what the behavior is applied to, and the answer follows from it. Everything
-     * else is the same for every row, which is what makes the other side of a comparison a place
-     * rather than a second moving thing.
-     */
-    private static boolean movesWithTheRow(Core e, InputReads reads, Symbols symbols,
-                                           BindingId answer) {
-        if (!mentionedIn(e, reads, symbols).isEmpty()) {
-            return true;
-        }
-        return answer != null && reads(e, answer);
-    }
-
-    /** Whether anything in {@code e} reads the binding a rule calls the answer. */
-    private static boolean reads(Core e, BindingId answer) {
-        if (e instanceof Core.Read read && answer.equals(read.binding())) {
-            return true;
-        }
-        boolean[] found = {false};
-        Core.forEachChild(e, child -> found[0] |= reads(child, answer));
-        return found[0];
     }
 
     /** The number a comparison is about, from whichever side names one. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAClauseDrawsALineOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAClauseDrawsALineOnTest.java
@@ -6,6 +6,7 @@ import souther.compiler.query.Scopes;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.Prepared;
+import souther.compiler.check.Required;
 import souther.compiler.check.StatedContract;
 import souther.compiler.check.Symbols;
 import souther.compiler.inputs.InputDomain;
@@ -17,6 +18,7 @@ import souther.compiler.query.Shapes;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -192,6 +194,12 @@ class WhatAClauseDrawsALineOnTest {
      * <p>The other half of the same decision, and the opposite mistake. {@code value.sku ==
      * item.sku} was read and understood, and it draws no line a row can be written at — reported as
      * one this compiler did not read, it sends an author after a limit that is not there.
+     *
+     * <p><b>And the reason it raises nothing is the answer.</b> An equality between two things that
+     * both move with the row raises nothing either, so this clause came back raising nothing while
+     * classified as a rule about a pair of inputs — right for the wrong reason, and the reason is
+     * what a reader is given. What the same shape written {@code <=} did is issue #1013 and the
+     * test below.
      */
     @Test
     void aRuleRelatingTheAnswerToAnInputIsNotNamedAsUnread() {
@@ -209,6 +217,58 @@ class WhatAClauseDrawsALineOnTest {
         assertEquals(List.of(), valuesOf(clauses));
         assertEquals(List.of(), clauses.unread(),
                 "this read the rule; what it draws no line at is a decision and not a limit");
+        assertEquals(1, clauses.accounting().size(),
+                () -> "the rule was read and filed at the position it names: "
+                        + clauses.accounting());
+        assertEquals(Set.of(Required.Because.IT_DEPENDS_ON_THE_ANSWER),
+                reasonOf(clauses.accounting().get(0)),
+                "and it raises nothing because it reads the answer, not because it relates a pair");
+    }
+
+    /**
+     * The same shape written as an order raises nothing either (issue #1013).
+     *
+     * <p>Which it did not. An equality between two moving things raises nothing whatever they are,
+     * so the clause above was silent while misclassified; an order between two of them is a line
+     * rows are owed at, and where one of the two is the answer that line is at a place no reading
+     * of the clause can reach. So the report named a rule nothing accounted for, about a behavior
+     * whose every rule was read.
+     *
+     * <p>Not an empty accounting. The rule was read and it names {@code query.limit} — a row does
+     * choose that — and what follows is that it asks nothing of a measure over the input's values.
+     * A reading that filed nothing would be saying it never looked.
+     */
+    @Test
+    void anOrderBetweenTheAnswerAndAnInputRaisesNothing() {
+        EnsuresThresholds.Clauses clauses = drawn("""
+                module g
+
+                data Limit = Int
+                data GlobalQuery = { limit: Limit }
+                data Page = { articles: List<String> }
+
+                behavior readArticles : (query: GlobalQuery) -> Page
+                    ensures List.length(value.articles) <= query.limit.value
+                """, "readArticles");
+
+        assertEquals(List.of(), valuesOf(clauses), "the line is on the answer, and a row has none");
+        assertEquals(List.of(), clauses.between(), "and it is not a line between two inputs");
+        assertEquals(List.of(), clauses.unread(),
+                "this read the rule; that it draws no line is a decision and not a limit");
+
+        assertEquals(1, clauses.accounting().size(),
+                () -> "filed at the position the rule names: " + clauses.accounting());
+        GuardThresholds.Guards.AtAPosition filed = clauses.accounting().get(0);
+        assertEquals("query.limit", filed.at().toString());
+        assertEquals(Set.of(Required.Because.IT_DEPENDS_ON_THE_ANSWER), reasonOf(filed));
+        assertEquals(List.of(), filed.accounting().unansweredQuestions(),
+                "nothing is owed here, so there is nothing for a report to say went unanswered");
+    }
+
+    /** Why one filed rule raises nothing, which is what a reader of the report is given. */
+    private static Set<Required.Because> reasonOf(GuardThresholds.Guards.AtAPosition filed) {
+        return assertInstanceOf(Required.Irrelevant.class, filed.accounting().required(),
+                () -> "raises nothing: " + filed.accounting().required()).because();
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAComparisonIsARuleAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAComparisonIsARuleAboutTest.java
@@ -1,0 +1,130 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.BehaviorContract;
+import souther.compiler.check.Required;
+import souther.compiler.check.StatedContract;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.inputs.InputDomain;
+import souther.compiler.inputs.InputReads;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.types.BindingId;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * What a comparison is a rule about, which decides what it raises (issue #1013).
+ *
+ * <p><b>A table of what the two sides read, and nothing else.</b> Each row varies where the values
+ * in the comparison come from — a constant, an input the row chooses, the answer the behavior gives
+ * — and the classification is what that provenance comes to. How the arithmetic reads the operands
+ * is a different axis and is not measured here: {@code a + 1 <= 10} and {@code a <= b - b + 9} both
+ * cut one position at nine, and which subject follows from that is issue #1029. A row of this table
+ * written over one of those shapes would be two questions under one answer.
+ *
+ * <p>So the pair row is {@code a <= b} over two positions that stay two, and no row cancels.
+ * The one row that puts two provenances in one comparison does it on purpose: {@code value.n + a}
+ * reads the answer and names an input, and which of the two decides the classification is exactly
+ * what the row fixes.
+ */
+class WhatAComparisonIsARuleAboutTest {
+
+    /**
+     * What one clause's comparison is a rule about, through the classifier a report is built from.
+     *
+     * <p>The comparison is taken out of the declaration's own rules, which is where the reading
+     * that measures a behavior gets it — a clause is read in the representation that keeps the
+     * language's operations standing, and one built by hand here would be a shape no clause
+     * arrives in.
+     */
+    private static Required.ComparisonSubject about(String clause) {
+        String source = """
+                module g
+
+                data Ok = { n: Int }
+
+                behavior f : (a: Int, b: Int) -> Ok
+                    ensures %s
+                """.formatted(clause);
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        StatedContract stated =
+                compilation.db().ask(new Bodies.StatedContracts(module)).value().get("f");
+        InputDomain inputs =
+                compilation.db().ask(new Adequacy.Inputs(module)).value().get("f");
+
+        assertEquals(1, stated.rules().size(), "the model under test states one rule");
+        StatedContract.StatedRule rule = stated.rules().get(0);
+        assertEquals(1, rule.conjuncts().size(), "the rule states one comparison");
+        Core read = rule.conjuncts().get(0).stated().orNull();
+        Core.Binary comparison = assertInstanceOf(Core.Binary.class, read,
+                () -> clause + " arrives as a comparison");
+
+        Map<BindingId, String> roots = new LinkedHashMap<>();
+        for (BehaviorContract.ContractParam param : stated.params()) {
+            roots.putIfAbsent(param.binding(), param.name());
+        }
+        return ComparisonSubjects.of(comparison,
+                InputReads.ofWhatIsDeclared(inputs, roots), symbols, rule.value());
+    }
+
+    /** How a row of the table is written down, so that a mismatch names both shapes. */
+    private static String named(Required.ComparisonSubject of) {
+        return of.getClass().getSimpleName();
+    }
+
+    /**
+     * The table.
+     *
+     * <p>One assertion per row, and every row of the table in one test: what each of them fixes is
+     * the classification's <em>precedence</em>, and a row read on its own cannot say that the arm
+     * above it did not take the comparison first.
+     */
+    @Test
+    void whatTheTwoSidesReadDecidesWhatTheComparisonIsAbout() {
+        assertEquals("AnInput", named(about("a <= 20")),
+                "an input against a constant is measured at the input");
+        assertEquals("Relation", named(about("a <= b")),
+                "two inputs are a rule about the pair, and the line is on neither");
+        assertEquals("AnswerDependent", named(about("value.n <= 20")),
+                "a bound on the answer is not a bound on anything a row chooses");
+        assertEquals("AnswerDependent", named(about("value.n <= a")),
+                "and neither is one whose other side is an input — issue #1013");
+        assertEquals("AnswerDependent", named(about("value.n + a <= 20")),
+                "reading the answer decides it, whatever else the same side names");
+        assertEquals("NoInput", named(about("20 <= 30")),
+                "a comparison of two constants says nothing about an input");
+    }
+
+    /**
+     * And what each of them raises.
+     *
+     * <p>Beside the table rather than folded into it. What a comparison is about and what it asks
+     * of a measure of coverage are two questions with two answers, and a test that only read the
+     * second could not tell an arm that raises nothing from an arm that does not exist.
+     */
+    @Test
+    void anAnswerDependentComparisonRaisesNothingAndSaysWhy() {
+        Required required = Required.ofComparison(
+                new souther.compiler.check.ComparisonClaim.Cut(true, true),
+                about("value.n <= a"));
+
+        assertEquals(List.of(), List.copyOf(required.obligations()),
+                "a row cannot be written where this clause stops");
+        Required.Irrelevant why = assertInstanceOf(Required.Irrelevant.class, required);
+        assertEquals(java.util.Set.of(Required.Because.IT_DEPENDS_ON_THE_ANSWER), why.because(),
+                "and the reason is the answer, not that the rule names no position — it names one");
+    }
+}


### PR DESCRIPTION
An `ensures` bounding a measure of the output by a term of the input drew no line and was reported
as a rule nothing accounted for. It raised a boundary obligation nothing could ever answer.

Closes #1013.

## What was wrong

`subjectsOf` asked one question of each side of a comparison — does this move with the row — and an
input position and the answer both came back true. The answer does move with the row; that fact is
right. What did not follow is that two things moving with the row are one kind of subject on the
input space.

So `List.length(value.articles) <= query.limit.value` was classified as a rule about a pair of
inputs, which raises a `BOUNDARY` at the place the two hold one count. The answer is not a position
`InputReads` names, so no reading of the clause reaches that place, the obligation stood open, and
the report named a rule unaccounted for that nothing could account for.

Written `==`, the same clause was already silent — an equality between two moving things raises
nothing whatever they are. Right for a reason that was not the reason.

## What changed

The two axes are separated in a new `ComparisonSubjects`. It asks whether the comparison reads the
answer first, and asks what the sides name only where it does not.

`movesWithTheRow` is not kept with its meaning changed. It is `mentionsAnInput` — the half of it
that was about the input space — so the error stays recorded as what it was, rather than as a
mis-sorted case.

`Required.ComparisonSubject.AnswerDependent` and `Because.IT_DEPENDS_ON_THE_ANSWER` are new. Kept
apart from `NoInput` / `IT_NAMES_NO_POSITION`, which would tell an author the rule names no position
while `query.limit` is written two tokens away.

The decision is in `Required.ofComparison` and not in the reading. What a comparison asks is settled
by what it places and what it places it about; answering from `Cutting` would give a false question
a false answer, and suppressing the line in `AdequacyReport` would leave the false question standing
behind it.

`readsAnswer` is written once. `EnsuresThresholds` already had it, to keep a rule about the answer
out of the unread report; the classification had no such predicate, and the two paths disagreed
about one clause. It classifies nothing by itself — two readers ask the same syntactic fact and
reach their own conclusions.

## What this does not claim

Not that no line exists. Eliminating the answer existentially can leave a constraint on the input —
a length is never negative, so a bound by a negative input has no satisfying answer — and deriving
that is constraint projection over several rules rather than the reading of one comparison. The arm
records where this reading stops, so adding the projection later contradicts nothing.

`readsAnswer` is syntactic, and its javadoc says so: `value.n - value.n + q <= 20` does not depend
on the answer once the arithmetic is read, and this answers that it does.

## Reporting

Nothing added. A coverage report's lines are work owed, and there is none here. "Not accounted for"
goes back to meaning a clause that could have had a line and whose reading stopped.

## Found on the way: #1029

The subject of a comparison is taken from the operands as written, while its line is cut from the
canonical form. `a + 1 <= 10` draws a border at `a = 9` and raises nothing; `a <= b - b + 9` draws
the same border and raises a question about a pair. Split off as #1029 — settling it means weighing
`AnInput` / `Relation` / `NoInput` against one coordinate / two positions apart / a form over
several, which is a different decision from this one.

`NoInput` carries a note naming #1029, because "neither side reads an input" is not true of that arm
today. No temporary variant was added: #1029 may well be settled by deriving the subject from
`Cutting` rather than by making this classifier cleverer, and a variant here would close that off.
The note goes when #1029 does.

## Testing

`WhatAComparisonIsARuleAboutTest` fixes the six-row table of what the two sides read — provenance
only. Canonical numeric shapes are #1029's axis and deliberately absent: a row over `a + 1 <= 10`
would put two questions under one answer.

`WhatAClauseDrawsALineOnTest` gains the `<=` regression, and its existing `==` test now fixes the
exact reason rather than only that nothing went unanswered — it passed under the old
classification.

Reverting the classification turns 4 assertions red, including the issue's own symptom. Full
`mvn -o test`: 20021 tests, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
