### PR TITLE
Ask the position which order it is counted on, not the comparison it was written in

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
@@ -232,6 +232,23 @@ public sealed interface Carrier {
     }
 
     /**
+     * Whether a value on this order stands somewhere relative to a value on that one.
+     *
+     * <p>What a rule comparing two positions needs of the orders they are written back on, and the
+     * whole of it. Where the counts are one arithmetic the two stand a number apart; where the order
+     * is one and has no counts at all they stand above or below or level, which is a comparison and
+     * is not a distance. Both are lines a model draws and neither is a claim the other makes.
+     *
+     * <p>Written as the second disjunct rather than by making {@link #sharesCountSpaceWith}
+     * reflexive. A string shares its counts with nothing because it has none, and saying otherwise
+     * to make one caller shorter would leave that one meaning two things — the pair that has no
+     * number between them is exactly the pair a caller must not go on to measure.
+     */
+    default boolean standsAgainst(Carrier other) {
+        return sharesCountSpaceWith(other) || (equals(other) && !counts());
+    }
+
+    /**
      * Whether both carriers' counts are numbers of one origin and one scale, so that subtracting one
      * from the other with coefficients of one and minus one names a distance without converting
      * anything.

--- a/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
@@ -231,6 +231,47 @@ public sealed interface Carrier {
         return !(this instanceof Text);
     }
 
+    /**
+     * Whether both carriers' counts are numbers of one origin and one scale, so that subtracting one
+     * from the other with coefficients of one and minus one names a distance without converting
+     * anything.
+     *
+     * <p>What a quantity has to answer before it is read as how far two positions stand apart
+     * ({@code BorderQuantity.Apart}). A form over several positions needs nothing of the kind: its
+     * coefficients are where a conversion is written, which is how a date-time built out of a date
+     * and a time comes to {@code b - 86400 * d - t} over three carriers that share no counts at all.
+     * A distance has no coefficients to carry one, so what it takes is asked here.
+     *
+     * <p><b>Not "the same kind of number".</b> A second count and a nanosecond count are both a
+     * position on one timeline and are not one count: what a step of one means differs, so the
+     * difference of a second and a nanosecond is a number in neither. A second of the day and a
+     * second of an epoch are the same step from different origins, which is the same answer for the
+     * other reason. Told apart by whether a value could be converted, both pairs would have come
+     * back true and the distance would have been off by whatever the conversion was.
+     *
+     * <p><b>Not reflexive, and that is the definition rather than an omission.</b> A string has no
+     * count, so there is no count space it shares with anything — including another string. Two
+     * strings still stand in an order and still meet, which is a quantity's own answer
+     * ({@link #counts}) and not this one's. Made reflexive to look tidier, this would say two
+     * strings stand a measurable distance apart.
+     */
+    default boolean sharesCountSpaceWith(Carrier other) {
+        return switch (this) {
+            // Whole numbers and decimals are written on one line and step differently along it,
+            // which is a question about the values beside a distance and not about the distance.
+            case Whole _, Dense _ -> other instanceof Whole || other instanceof Dense;
+            case Days _ -> other instanceof Days;
+            case Seconds _ -> other instanceof Seconds;
+            case SecondsOfDay _ -> other instanceof SecondsOfDay;
+            case Nanos _ -> other instanceof Nanos;
+            // The enumeration and not the cases. What a count means here is the place in one
+            // declaration's order, so two sums are two spaces however alike their case lists are.
+            case Ordinal ordinal -> other instanceof Ordinal them
+                    && ordinal.enumeration().equals(them.enumeration());
+            case Text _ -> false;
+        };
+    }
+
     /** How the counts on this carrier are spaced, which is what decides whether a strict bound has a
      * next count to step to. */
     default Granularity spacing() {
@@ -387,18 +428,6 @@ public sealed interface Carrier {
             case Text _ -> e instanceof Hir.StringLit lit
                     ? souther.compiler.numeric.Text.of(lit.value()) : null;
         };
-    }
-
-    /**
-     * The value {@code e} writes down on the carrier of {@code type}, or null where it writes none.
-     *
-     * <p>Where a reader has the position's type rather than its carrier. A type nothing orders has
-     * no values to read here, and saying so once is what keeps every caller from deciding for
-     * itself what an unordered position's literals are.
-     */
-    static Place writtenOn(Core e, Type type, Symbols symbols) {
-        Carrier carrier = ofValue(type, symbols);
-        return carrier == null ? null : carrier.literalOf(e, symbols);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -6,6 +6,7 @@ import souther.compiler.check.DeclaredBounds;
 import souther.compiler.check.FieldDomains;
 import souther.compiler.check.NumericMeasures;
 import souther.compiler.check.ReadingPolicy;
+import souther.compiler.check.Shape;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeView;
@@ -237,14 +238,12 @@ public final class InputDomain {
      * nothing this can follow.
      *
      * <p>Below {@link #MAX_DEPTH} this is the only answer there is: the walk above stopped, so there
-     * is no position to ask and the type is what the declaration says at each step. One step at a
-     * time and through {@link StructuralDescent}, which is the one place that says what stands
-     * directly under a type — a second walk of that question is what that one exists to prevent.
+     * is no position to ask and the type is what the declaration says at each step.
      *
-     * <p>Fields and nothing else. An element is one of however many a sequence holds and a narrowing
-     * is a requirement rather than a place, and both are read where a position is made rather than
-     * here; a path carrying either below where this reading stops is one this answers nothing for,
-     * which is what it answered before there was any answer at all.
+     * <p>Step by step through {@link StructuralInspection}, which is what the walk above takes its
+     * own steps from. What is under a type is one fact, and a second reading of it here would be
+     * this and that walk disagreeing about what a path reaches — which is the shape of defect this
+     * whole change is about, one level down.
      */
     private Type declaredAt(TermPath path, Symbols symbols) {
         Type here = null;
@@ -255,14 +254,55 @@ public final class InputDomain {
             }
         }
         for (TermPath.Step step : path.steps()) {
-            if (here == null || !(step instanceof TermPath.Step.Field field)) {
-                return null;
-            }
-            StructuralDescent.Children under =
-                    StructuralDescent.of(TypeView.of(here, symbols).shape());
-            here = under == null ? null : under.under().get(field.name());
+            here = here == null ? null : under(here, step, symbols);
         }
         return here;
+    }
+
+    /**
+     * What one step of a path stands at, or null where the declarations put nothing there.
+     *
+     * <p><b>Exhaustive over the kinds of step, with no {@code default}.</b> A path goes into a
+     * field, into what a sequence holds, or nowhere at all while narrowing which values may stand
+     * where it already is ({@link Refinement}) — three, and a reading that answered one of them and
+     * let the rest fall to null would lose a line the model draws for every path carrying one. It
+     * did: written for fields alone, a rule comparing two fields of a list's elements was read as
+     * naming nothing, and the border it draws went away. A fourth kind is a compile error here
+     * rather than a fourth quiet absence.
+     */
+    private static Type under(Type type, TermPath.Step step, Symbols symbols) {
+        TypeView view = TypeView.of(type, symbols);
+        // Asked of the shape rather than through the proof a position is made with. What is under a
+        // type is a question about the type, and a type nothing can be read at answers nothing here
+        // rather than being refused as a position this compiler disagrees with itself about.
+        if (!(view.shape() instanceof Shape.ReadablePositionShape shape)) {
+            return null;
+        }
+        StructuralInspection under =
+                StructuralInspection.of(shape, true, Distinctions.ofType(view, symbols));
+        return switch (step) {
+            case TermPath.Step.Field field -> under instanceof StructuralInspection.Decomposed made
+                    ? made.under().get(field.name()) : null;
+            case TermPath.Step.Element _ -> under instanceof StructuralInspection.Retained on
+                    && on.continuation() instanceof StructuralInspection.Continuation.Elements held
+                    ? held.element() : null;
+            // The same position, read as the case it turned out to be. Null where the case puts
+            // nothing there, which is a case that is the whole of a value.
+            case TermPath.Step.Refine refine -> under instanceof StructuralInspection.Retained on
+                    && on.continuation() instanceof StructuralInspection.Continuation.Branches ways
+                    ? narrowed(ways, refine.refinement()) : null;
+        };
+    }
+
+    /** The type the branch for this narrowing stands at, or null where the sum has no such branch. */
+    private static Type narrowed(StructuralInspection.Continuation.Branches ways,
+                                 Refinement refinement) {
+        for (StructuralInspection.Branch branch : ways.branches()) {
+            if (refinement.equals(branch.refinement())) {
+                return branch.under();
+            }
+        }
+        return null;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -202,6 +202,70 @@ public final class InputDomain {
     }
 
     /**
+     * The order one term is read off a row and written back on, or null where it has none.
+     *
+     * <p><b>The one answer, so that nothing derives it from an expression.</b> A rule is written
+     * beside operands, and the type of an operand is not the type of the position the rule is about:
+     * an operation the arithmetic rewrote into a form of two positions is compared as what it
+     * answers with, so {@code Date.daysBetween(a, b) > 10} has {@code Int} on both sides and dates
+     * at both positions. Read off the comparison, every position of that rule was written back as a
+     * whole number and read off a row as one, and both directions agreed with each other and with
+     * nothing else (#1018).
+     *
+     * <p>Two questions, answered where each is known. What a term measures is the term's — a size is
+     * a whole number whatever it is taken of — and what the location holds is this reading's, which
+     * is why the two meet here rather than at whichever caller had both to hand.
+     *
+     * <p><b>A term under no position of this reading still has an order.</b> This reading stops at
+     * {@link #MAX_DEPTH}, where a report stops being about anything an author would call one input,
+     * and nothing stops a rule from naming what is under that. What a report is about and what a
+     * declaration says are two questions, and only the first of them stops there — so the type is
+     * followed down to wherever the rule named ({@link #declaredAt}) and the line is drawn.
+     *
+     * <p>The position first and the descent only where there is none. A position may stand under a
+     * narrowing, and what it holds there is what a row writes; walking the declaration again would
+     * answer with what the field was declared as before anything narrowed it.
+     */
+    public Carrier carrierOf(NumericTerm term, Symbols symbols) {
+        Position position = at(term.path());
+        return term.carrierAt(
+                position != null ? position.type() : declaredAt(term.path(), symbols), symbols);
+    }
+
+    /**
+     * What the declarations put at {@code path}, however far down it goes, or null where they put
+     * nothing this can follow.
+     *
+     * <p>Below {@link #MAX_DEPTH} this is the only answer there is: the walk above stopped, so there
+     * is no position to ask and the type is what the declaration says at each step. One step at a
+     * time and through {@link StructuralDescent}, which is the one place that says what stands
+     * directly under a type — a second walk of that question is what that one exists to prevent.
+     *
+     * <p>Fields and nothing else. An element is one of however many a sequence holds and a narrowing
+     * is a requirement rather than a place, and both are read where a position is made rather than
+     * here; a path carrying either below where this reading stops is one this answers nothing for,
+     * which is what it answered before there was any answer at all.
+     */
+    private Type declaredAt(TermPath path, Symbols symbols) {
+        Type here = null;
+        for (Parameter parameter : parameters) {
+            if (parameter.name().equals(path.head())) {
+                here = parameter.type();
+                break;
+            }
+        }
+        for (TermPath.Step step : path.steps()) {
+            if (here == null || !(step instanceof TermPath.Step.Field field)) {
+                return null;
+            }
+            StructuralDescent.Children under =
+                    StructuralDescent.of(TypeView.of(here, symbols).shape());
+            here = under == null ? null : under.under().get(field.name());
+        }
+        return here;
+    }
+
+    /**
      * The same input, asked about a quantity over several of its positions.
      *
      * <p>The relational half of what a reading of an input can say. A {@link Position} answers about

--- a/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AffineReading.java
@@ -295,30 +295,13 @@ record AffineReading(LinearForm<NumericTerm> form, BigDecimal cut, ComparisonCla
     java.util.Map<NumericTerm, Carrier> carriers(InputReads reads, Symbols symbols) {
         java.util.Map<NumericTerm, Carrier> on = new java.util.LinkedHashMap<>();
         for (NumericTerm term : form.coefs().keySet()) {
-            Carrier here = carrierOf(term, reads, symbols);
+            Carrier here = reads.read().carrierOf(term, symbols);
             if (here == null || !here.counts()) {
                 return null;
             }
             on.put(term, here);
         }
         return on.isEmpty() ? null : on;
-    }
-
-    /**
-     * The order one term's own position is counted on, or null where the reading has no position
-     * for it.
-     *
-     * <p>The position's, because that is whose values are being read and written: what a term is
-     * measured at is the term's question ({@link NumericTerm#carrierAt}) and what the position holds
-     * is the declaration's, and the two are answered together where the position was read.
-     */
-    static Carrier carrierOf(NumericTerm term, InputReads reads, Symbols symbols) {
-        for (souther.compiler.inputs.Position position : reads.read().positions()) {
-            if (position.term().equals(term)) {
-                return term.carrierAt(position.type(), symbols);
-            }
-        }
-        return null;
     }
 
     /** Whether the operator orders the values around the threshold rather than singling one out. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
@@ -163,9 +163,9 @@ public sealed interface BorderQuantity {
             }
             Carrier here = carriers.get(on);
             Carrier there = carriers.get(against);
-            if (!here.equals(there) && !here.sharesCountSpaceWith(there)) {
-                throw new IllegalArgumentException("a distance is a number both orders count in,"
-                        + " and these share none: " + here + " against " + there);
+            if (!here.standsAgainst(there)) {
+                throw new IllegalArgumentException("a distance is between two orders a value of"
+                        + " one stands somewhere on: " + here + " against " + there);
             }
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderQuantity.java
@@ -125,42 +125,99 @@ public sealed interface BorderQuantity {
      * one apart are one apart — read by walking, every such rule was met by no row and had no row
      * anything could compose.
      *
-     * <p>One carrier, because both sides are ordered by it. Two operands may be comparable and share
-     * no carrier — an enumeration's case is comparable on its sum's order without ranging over it —
-     * so what makes this line measurable is the carrier and not the type the comparison type-checked
-     * under.
+     * <p>An order apiece, and the two need not be one. Which order a position is read and written on
+     * is a question about that position, and a distance runs between two positions that answer it
+     * differently as readily as between two that agree: a decimal against a whole number is one
+     * distance written two ways. Held as one order for the pair, whichever of them a caller happened
+     * to have was used to write both back and to read both off a row — and where that order belonged
+     * to neither, the border was met by no row and composed for by none (#1018).
+     *
+     * <p>What the two do have to share is the counts, and only where there are counts to share.
+     * Where they meet is a place on both orders whatever they are; where they stand a number apart
+     * is a number in one arithmetic, and two orders with different origins or different steps have
+     * no such number ({@link Carrier#sharesCountSpaceWith}). A pair that shares none is an
+     * arithmetic form over both positions and is read as {@link OverAForm}, whose coefficients are
+     * where a conversion between two orders is written.
      */
-    record Apart(String behavior, NumericTerm on, NumericTerm against, Carrier of)
-            implements BorderQuantity {
+    record Apart(String behavior, NumericTerm on, NumericTerm against,
+                 Map<NumericTerm, Carrier> carriers) implements BorderQuantity {
 
         public Apart {
-            if (behavior == null || on == null || against == null || of == null) {
-                throw new IllegalArgumentException("a distance names two positions and one order");
+            if (behavior == null || on == null || against == null || carriers == null) {
+                throw new IllegalArgumentException("a distance names two positions and their orders");
             }
+            // First, because a distance between one position and itself is what the rest of this
+            // cannot be asked about: two terms that are one term are one key, and a map of them
+            // would refuse the pair with a sentence about maps.
+            if (on.equals(against)) {
+                throw new IllegalArgumentException(
+                        "a distance runs between two positions, and this names one twice: " + on);
+            }
+            carriers = Map.copyOf(carriers);
+            // An order per position, held here so no reader has to answer for a position with none.
+            // A map beside a pair is two structures, and two structures are what come apart.
+            if (!carriers.keySet().equals(java.util.Set.of(on, against))) {
+                throw new IllegalArgumentException("a distance is between the positions it names,"
+                        + " each on one order: " + java.util.Set.of(on, against) + " against "
+                        + carriers.keySet());
+            }
+            Carrier here = carriers.get(on);
+            Carrier there = carriers.get(against);
+            if (!here.equals(there) && !here.sharesCountSpaceWith(there)) {
+                throw new IllegalArgumentException("a distance is a number both orders count in,"
+                        + " and these share none: " + here + " against " + there);
+            }
+        }
+
+        /** The order the first position is read and written on. */
+        private Carrier onCarrier() {
+            return carriers.get(on);
+        }
+
+        /** The order the other position is read and written on. */
+        private Carrier againstCarrier() {
+            return carriers.get(against);
+        }
+
+        /** Whether the two positions stand on one order, which is every pair a rule names itself and
+         *  is what decides which search a point of this line is looked for by. */
+        private boolean onOneCarrier() {
+            return onCarrier().equals(againstCarrier());
+        }
+
+        /** Whether a distance between them is a number at all, which two strings give no. Asked of
+         *  either, since a pair that shares its counts shares whether it has any. */
+        private boolean counts() {
+            return onCarrier().counts();
         }
 
         /**
-         * A whole number of the carrier's own steps, where it has one; every number where it does
-         * not; and only the level where the two meet where the carrier's values do not count at all.
+         * A whole number of steps where both orders step; every number where either does not; and
+         * only the level where the two meet where their values do not count at all.
          *
          * <p>Three answers and not two. Two decimals stand every distance apart and no next distance
          * apart, and two strings stand no measurable distance apart and are still one above the
-         * other — so what a carrier says about its steps and what it says about its numbers are
-         * asked separately.
+         * other — so what an order says about its steps and what it says about its numbers are asked
+         * separately.
+         *
+         * <p>Of both orders and not of one, which is the same rule a form of several positions is
+         * spaced by ({@link LevelSpace#addedUpOver}): a distance between a whole number and a decimal
+         * lands wherever the decimal does.
          */
         @Override
         public LevelSpace levels() {
-            if (!of.counts()) {
+            if (!counts()) {
                 return LevelSpace.onlyWhereTheyMeet();
             }
-            return of.spacing() == souther.compiler.numeric.Granularity.DISCRETE
+            return LevelSpace.addedUpOver(carriers.values())
+                    == souther.compiler.numeric.Granularity.DISCRETE
                     ? LevelSpace.steppingBy(java.math.BigDecimal.ONE) : LevelSpace.dense();
         }
 
-        /** Either end's, which is the one order both are ordered by. */
+        /** That position's own, which is what it is read off a row and written back on. */
         @Override
         public Carrier carrierOf(NumericTerm asked) {
-            return on.equals(asked) || against.equals(asked) ? of : null;
+            return carriers.get(asked);
         }
 
         /**
@@ -177,8 +234,11 @@ public sealed interface BorderQuantity {
          */
         @Override
         public Stands standsAt(Criterion where, Observation row) {
-            NumericTerm.Reading here = on.read(row.at(on.path()), of);
-            NumericTerm.Reading there = against.read(row.at(against.path()), of);
+            // Each on its own order. Read on one order for the pair, a position written back
+            // differently from the other was read as a value it does not hold — a date read as a
+            // whole number is no number at all, and the row stood at nothing (#1018).
+            NumericTerm.Reading here = on.read(row.at(on.path()), onCarrier());
+            NumericTerm.Reading there = against.read(row.at(against.path()), againstCarrier());
             if (here instanceof NumericTerm.Reading.Missing
                     || there instanceof NumericTerm.Reading.Missing) {
                 return Stands.UNREADABLE;
@@ -187,7 +247,7 @@ public sealed interface BorderQuantity {
                     || !(there instanceof NumericTerm.Reading.Number againstAt)) {
                 return Stands.NO;
             }
-            if (!of.counts()) {
+            if (!counts()) {
                 // No number between them, and an order all the same. The only level such a quantity
                 // takes is the one where they meet, so what the item asks is which way round they
                 // stand from it.
@@ -213,9 +273,32 @@ public sealed interface BorderQuantity {
             };
         }
 
+        /**
+         * The pair's own search where both stand on one order, and the form's where they do not.
+         *
+         * <p>Two lowerings and not a search that takes two orders. What a point of this line asks
+         * for is an assignment of both positions, and there is already a search that assigns several
+         * positions each on its own order ({@link Standing.OfAForm}) — a distance is that form with
+         * coefficients of one and minus one. So the pair that needs it is handed to it, and the
+         * search written for one order is left answering for exactly the pairs it was written for.
+         *
+         * <p>Which is not a preference between them. A form adds its positions up and two strings
+         * add up to nothing, so a pair with no counts can only be searched for by the first;
+         * generalising that one to two orders would have left it deciding, per pair, which of them
+         * to walk along and which to land on — the same shape of premise this issue was about.
+         *
+         * <p>The quantity is unchanged either way. What a border is of and how a row for it is found
+         * are two questions ({@link Standing}), so a distance searched for as a form is still a
+         * distance, and a report still names it beside the other position rather than as a form.
+         */
         @Override
         public Standing standingAt(Criterion where) {
-            return new Standing.OfTwoOnOneCarrier(on, against, of, where);
+            if (onOneCarrier()) {
+                return new Standing.OfTwoOnOneCarrier(on, against, onCarrier(), where);
+            }
+            return new Standing.OfAForm(
+                    LinearForm.<NumericTerm>atom(on).minus(LinearForm.atom(against)),
+                    carriers, levels(), where);
         }
 
         @Override
@@ -328,17 +411,12 @@ public sealed interface BorderQuantity {
         /**
          * How the sum steps, which is how its positions step together.
          *
-         * <p>A sum steps only where every one of its terms does: a whole number added to a decimal
-         * lands wherever the decimal does. Read off the one order a form was held to, this was
-         * whatever that order said; a form of whole numbers still answers what it did.
+         * <p>Asked of {@link LevelSpace#addedUpOver}, which a distance asks too. The two are one
+         * question — a distance is a form of two positions weighed one and minus one — and answered
+         * apiece they were free to disagree about a pair of orders that step differently.
          */
         souther.compiler.numeric.Granularity spacing() {
-            for (Carrier each : on.values()) {
-                if (each.spacing() != souther.compiler.numeric.Granularity.DISCRETE) {
-                    return souther.compiler.numeric.Granularity.DENSE;
-                }
-            }
-            return souther.compiler.numeric.Granularity.DISCRETE;
+            return LevelSpace.addedUpOver(on.values());
         }
 
         /** The order that position is read and written on, and null for a position not in the

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparedLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparedLine.java
@@ -39,30 +39,36 @@ record ComparedLine(NumericTerm term, Place value, Carrier carrier,
      * What {@code comparison} draws, or null where it draws nothing.
      *
      * <p>The position-bearing side is read first and the comparison is turned round where it is on
-     * the right: {@code 100000 >= cost} says what {@code cost <= 100000} says. The carrier comes
-     * from the side that named the position, so the literal on the other side is read on the carrier
-     * the line is being drawn on — a size call is an {@code Int} there, and a position holding dates
+     * the right: {@code 100000 >= cost} says what {@code cost <= 100000} says. The carrier is the
+     * position's own ({@link souther.compiler.inputs.InputDomain#carrierOf}), and the literal on the
+     * other side is read on it — a size call is an {@code Int} there, and a position holding dates
      * is a day count.
+     *
+     * <p>The position's order and not the operand's type, which is a distinction that costs nothing
+     * here and everything next door. An operand that names a position is written as that position,
+     * so the two agreed wherever this reading reached an answer at all; the reading beside this one
+     * compares what an operation answered, and there the operands are whole numbers while the
+     * positions hold dates (#1018). One question with one place to ask it is what keeps that from
+     * depending on which reading a rule happens to fall into.
      */
     static ComparedLine of(Core.Binary comparison, AffineReading read, InputReads reads,
                            Symbols symbols) {
         BinOp op = comparison.op();
-        NumericTerm term = GuardThresholds.termOf(comparison.left(), reads, symbols);
-        Place value = Carrier.writtenOn(comparison.right(), comparison.left().type(), symbols);
-        if (term == null || value == null) {
-            term = GuardThresholds.termOf(comparison.right(), reads, symbols);
-            value = Carrier.writtenOn(comparison.left(), comparison.right().type(), symbols);
+        GuardThresholds.Named named = GuardThresholds.namedBy(comparison.left(), reads, symbols);
+        Place value = named == null ? null : named.on().literalOf(comparison.right(), symbols);
+        if (named == null || value == null) {
+            named = GuardThresholds.namedBy(comparison.right(), reads, symbols);
+            value = named == null ? null : named.on().literalOf(comparison.left(), symbols);
             op = mirrored(op);
         }
+        NumericTerm term = named == null ? null : named.term();
+        Carrier carrier = named == null ? null : named.on();
         if (term == null || value == null) {
             // Nothing here is a position against a value the carrier writes. It may still be a
             // statement about one position: `a + 1 <= 10` and `a <= b - b + 9` are both `a <= 9`,
             // and which quantity a rule cuts is the arithmetic's answer rather than the spelling's.
             return fromTheForm(read, reads, symbols);
         }
-        Carrier carrier = Carrier.ofValue(
-                op == comparison.op() ? comparison.left().type() : comparison.right().type(),
-                symbols);
         return switch (ComparisonClaim.of(op)) {
             case ComparisonClaim.Cut cut -> new ComparedLine(term, value, carrier,
                     cut.valueBelongsBelow(), cut.holdsAtTheValue(), false);
@@ -89,9 +95,9 @@ record ComparedLine(NumericTerm term, Place value, Carrier carrier,
         }
         NumericTerm term = read.oneCoordinate();
         // The position's own order, not the order of whichever operand it was written beside. The
-        // reading two methods up is careful about the same thing — it takes the type from the side
-        // that named the position — and `10 >= a + 1` names it on the right.
-        Carrier carrier = term == null ? null : AffineReading.carrierOf(term, reads, symbols);
+        // reading two methods up asks the same question of the same place, and `10 >= a + 1` names
+        // the position on the right.
+        Carrier carrier = term == null ? null : reads.read().carrierOf(term, symbols);
         if (carrier == null || !carrier.counts()) {
             return null;
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparedLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparedLine.java
@@ -55,14 +55,14 @@ record ComparedLine(NumericTerm term, Place value, Carrier carrier,
                            Symbols symbols) {
         BinOp op = comparison.op();
         GuardThresholds.Named named = GuardThresholds.namedBy(comparison.left(), reads, symbols);
-        Place value = named == null ? null : named.on().literalOf(comparison.right(), symbols);
+        Place value = named == null ? null : named.order().literalOf(comparison.right(), symbols);
         if (named == null || value == null) {
             named = GuardThresholds.namedBy(comparison.right(), reads, symbols);
-            value = named == null ? null : named.on().literalOf(comparison.left(), symbols);
+            value = named == null ? null : named.order().literalOf(comparison.left(), symbols);
             op = mirrored(op);
         }
         NumericTerm term = named == null ? null : named.term();
-        Carrier carrier = named == null ? null : named.on();
+        Carrier carrier = named == null ? null : named.order();
         if (term == null || value == null) {
             // Nothing here is a position against a value the carrier writes. It may still be a
             // statement about one position: `a + 1 <= 10` and `a <= b - b + 9` are both `a <= 9`,

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparedTerms.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparedTerms.java
@@ -25,16 +25,19 @@ import java.util.Map;
  * {@code ensures} draw the same line between the same two positions; what differs is what meeting it
  * takes, and that is the origin's to answer rather than this one's.
  *
- * <p>Asked of the carrier and not of the type. Two operands compare only when they are of one type,
- * and a type is not what makes a line measurable: an enumeration's case is comparable on its sum's
- * order while carrying no places of its own, and two newtypes of one base are two types whose values
- * are ordered alike. What both sides can be read as is the carrier, so that is what is asked about.
+ * <p>Asked of the orders and not of the types. A type is not what makes a line measurable: an
+ * enumeration's case is comparable on its sum's order while carrying no places of its own, and two
+ * newtypes of one base are two types whose values are ordered alike. What both positions can be read
+ * as is the order, so that is what is asked about — and what is asked of the pair is that their
+ * counts are one arithmetic, which is narrower than their being one order and wider than their being
+ * one type.
  *
- * <p><b>Of the positions' carriers, and never of the operands'.</b> The two agree wherever a rule
- * names its positions itself, and part company the moment an operation stands between them: the
- * operands of {@code Date.daysBetween(a, b) > 10} are whole numbers and its positions hold dates.
- * Read off the comparison, both positions were written back and read off a row as whole numbers, and
- * the border could be met by no row and composed for by none (#1018).
+ * <p><b>The positions' orders, and never the operands'.</b> The two agree wherever a rule names its
+ * positions itself, and part company the moment an operation stands between them: the operands of
+ * {@code Date.daysBetween(a, b) > 10} are whole numbers and its positions hold dates. Read off the
+ * comparison, both positions were written back and read off a row as whole numbers, and the border
+ * could be met by no row and composed for by none (#1018). Nothing here reads an operand's type, and
+ * the guard that used to — the two operands being of one order — was about neither position.
  *
  * @param holdsAtTheLine whether the line's own values satisfy the comparison, which is what tells
  *                       {@code <} from {@code <=} and is the whole of what the row on the line shows
@@ -64,7 +67,8 @@ record ComparedTerms(NumericTerm on, NumericTerm against, Map<NumericTerm, Carri
             GuardThresholds.Named against =
                     GuardThresholds.namedBy(comparison.right(), reads, symbols);
             Map<NumericTerm, Carrier> carriers = on == null || against == null ? null
-                    : aDistanceBetween(on.term(), on.on(), against.term(), against.on());
+                    : aDistanceBetween(on.term(), on.order(),
+                            against.term(), against.order());
             if (carriers != null) {
                 // The subject is the one the author wrote on the left, which the canonical form
                 // keeps too. Which of the two a line is named by is not something to derive where
@@ -81,12 +85,16 @@ record ComparedTerms(NumericTerm on, NumericTerm against, Map<NumericTerm, Carri
      * The two positions on the orders they are read and written on, or null where they are not two
      * positions a distance runs between.
      *
-     * <p>Three things make them one, and each of them is refused here rather than further down. One
-     * position is not two, and {@code a > a} names one twice — read as a distance it would be a line
-     * at nowhere between a position and itself. A position this reading has no order for is one
-     * nothing can be written at. And two orders that share no counts have no difference: a whole
-     * number of days and a whole number is not a number of anything, so such a pair is left to be
-     * read as the form it is, which carries the conversion in its coefficients.
+     * <p>Three things make them one, and each of them is a classification rather than a complaint:
+     * a pair refused here is read as whatever it is instead, and an arithmetic form is what it is
+     * instead. One position is not two, and {@code a > a} names one twice. A position this reading
+     * has no order for is one nothing can be written at. And two orders that share no counts have no
+     * difference — a whole number of days and a whole number is not a number of anything — so such a
+     * pair is left to the form it is, which carries the conversion in its coefficients.
+     *
+     * <p>Whether two orders make such a pair is {@link Carrier#standsAgainst}'s to say, and it is
+     * what refuses a distance built out of a pair that is not one. Classifying and refusing are two
+     * jobs and one rule, so the rule is in one place and neither writes it out again.
      *
      * <p>Which is why the answer is a carrier apiece and not one for the pair. A distance between
      * two positions written back differently — a decimal against a whole number is the pair that
@@ -94,13 +102,8 @@ record ComparedTerms(NumericTerm on, NumericTerm against, Map<NumericTerm, Carri
      */
     private static Map<NumericTerm, Carrier> aDistanceBetween(NumericTerm on, Carrier here,
                                                               NumericTerm against, Carrier there) {
-        if (on == null || against == null || here == null || there == null || on.equals(against)) {
-            return null;
-        }
-        // One order, or two whose counts are the same numbers. The first admits the pair that has no
-        // counts at all: two strings stand no measurable distance apart and still stand one above
-        // the other, which is a line this reading keeps.
-        if (!here.equals(there) && !here.sharesCountSpaceWith(there)) {
+        if (on == null || against == null || here == null || there == null
+                || on.equals(against) || !here.standsAgainst(there)) {
             return null;
         }
         Map<NumericTerm, Carrier> both = new LinkedHashMap<>();
@@ -129,17 +132,20 @@ record ComparedTerms(NumericTerm on, NumericTerm against, Map<NumericTerm, Carri
         if (two == null) {
             return null;
         }
-        // Here the orders come from the reading of the declarations and from nowhere else. A term
-        // the arithmetic produced has no expression that names it, so there is nothing to take a
-        // type off — which is the whole of what went wrong when one was taken off the comparison.
-        Map<NumericTerm, Carrier> carriers = aDistanceBetween(
-                two[0], reads.read().carrierOf(two[0], symbols),
-                two[1], reads.read().carrierOf(two[1], symbols));
-        // And here the counts are asked for, which the reading above does not ask. A form holds the
-        // two apart by a number it read off the rule, and a number of nothing is not a distance —
-        // where the pair meets is the only place such a rule could cut, and that is the line the
-        // reading above draws.
-        if (carriers == null || !carriers.get(two[0]).counts()) {
+        // The orders come from the reading of the declarations, the way they do above. A term the
+        // arithmetic produced has no expression naming it, so there is not even a type here to take
+        // one off — which is the whole of what went wrong when one was taken off the comparison.
+        Carrier here = reads.read().carrierOf(two[0], symbols);
+        Carrier there = reads.read().carrierOf(two[1], symbols);
+        // And the counts are asked for, which the reading above does not ask. A form holds the two
+        // apart by a number it read off the rule, and a number of nothing is not a distance — where
+        // the pair meets is the only place such a rule could cut, and that is the line the reading
+        // above draws. Of either order, since a pair that shares its counts has them or has neither.
+        if (here == null || !here.counts()) {
+            return null;
+        }
+        Map<NumericTerm, Carrier> carriers = aDistanceBetween(two[0], here, two[1], there);
+        if (carriers == null) {
             return null;
         }
         ComparisonClaim.Cut cut = (ComparisonClaim.Cut) read.claim();

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparedTerms.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparedTerms.java
@@ -9,6 +9,9 @@ import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.numeric.Count;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /**
  * The line a comparison between two positions draws: the place where the two hold one count.
  *
@@ -25,8 +28,13 @@ import souther.compiler.numeric.Count;
  * <p>Asked of the carrier and not of the type. Two operands compare only when they are of one type,
  * and a type is not what makes a line measurable: an enumeration's case is comparable on its sum's
  * order while carrying no places of its own, and two newtypes of one base are two types whose values
- * are ordered alike. What both sides can be read as is the carrier, so that is what is required to
- * be one.
+ * are ordered alike. What both sides can be read as is the carrier, so that is what is asked about.
+ *
+ * <p><b>Of the positions' carriers, and never of the operands'.</b> The two agree wherever a rule
+ * names its positions itself, and part company the moment an operation stands between them: the
+ * operands of {@code Date.daysBetween(a, b) > 10} are whole numbers and its positions hold dates.
+ * Read off the comparison, both positions were written back and read off a row as whole numbers, and
+ * the border could be met by no row and composed for by none (#1018).
  *
  * @param holdsAtTheLine whether the line's own values satisfy the comparison, which is what tells
  *                       {@code <} from {@code <=} and is the whole of what the row on the line shows
@@ -40,7 +48,7 @@ import souther.compiler.numeric.Count;
  *                       as one position against another. A number and not a count of steps: an order
  *                       with no smallest step still holds its values a distance apart
  */
-record ComparedTerms(NumericTerm on, NumericTerm against, Carrier carrier,
+record ComparedTerms(NumericTerm on, NumericTerm against, Map<NumericTerm, Carrier> carriers,
                      boolean holdsAtTheLine, boolean valueBelongsBelow, Count stepsApart) {
 
     /**
@@ -51,22 +59,54 @@ record ComparedTerms(NumericTerm on, NumericTerm against, Carrier carrier,
      */
     static ComparedTerms of(Core.Binary comparison, AffineReading read, InputReads reads,
                             Symbols symbols) {
-        Carrier carrier = Carrier.ofValue(comparison.left().type(), symbols);
-        if (carrier == null || !carrier.equals(Carrier.ofValue(comparison.right().type(), symbols))) {
-            return null;
-        }
         if (ordersStrictly(comparison.op())) {
-            NumericTerm on = GuardThresholds.termOf(comparison.left(), reads, symbols);
-            NumericTerm against = GuardThresholds.termOf(comparison.right(), reads, symbols);
-            if (on != null && against != null) {
+            GuardThresholds.Named on = GuardThresholds.namedBy(comparison.left(), reads, symbols);
+            GuardThresholds.Named against =
+                    GuardThresholds.namedBy(comparison.right(), reads, symbols);
+            Map<NumericTerm, Carrier> carriers = on == null || against == null ? null
+                    : aDistanceBetween(on.term(), on.on(), against.term(), against.on());
+            if (carriers != null) {
                 // The subject is the one the author wrote on the left, which the canonical form
                 // keeps too. Which of the two a line is named by is not something to derive where
                 // the source settles it: `charge > ceiling` is a line about the charge.
-                return new ComparedTerms(on, against, carrier, holdsAtTheLine(comparison.op()),
+                return new ComparedTerms(on.term(), against.term(), carriers,
+                        holdsAtTheLine(comparison.op()),
                         holdsAtTheLine(comparison.op()) == !onIsAbove(comparison.op()), Count.ZERO);
             }
         }
-        return fromTheForm(read, carrier);
+        return fromTheForm(read, reads, symbols);
+    }
+
+    /**
+     * The two positions on the orders they are read and written on, or null where they are not two
+     * positions a distance runs between.
+     *
+     * <p>Three things make them one, and each of them is refused here rather than further down. One
+     * position is not two, and {@code a > a} names one twice — read as a distance it would be a line
+     * at nowhere between a position and itself. A position this reading has no order for is one
+     * nothing can be written at. And two orders that share no counts have no difference: a whole
+     * number of days and a whole number is not a number of anything, so such a pair is left to be
+     * read as the form it is, which carries the conversion in its coefficients.
+     *
+     * <p>Which is why the answer is a carrier apiece and not one for the pair. A distance between
+     * two positions written back differently — a decimal against a whole number is the pair that
+     * exists — is still one distance, and it is only the writing that differs.
+     */
+    private static Map<NumericTerm, Carrier> aDistanceBetween(NumericTerm on, Carrier here,
+                                                              NumericTerm against, Carrier there) {
+        if (on == null || against == null || here == null || there == null || on.equals(against)) {
+            return null;
+        }
+        // One order, or two whose counts are the same numbers. The first admits the pair that has no
+        // counts at all: two strings stand no measurable distance apart and still stand one above
+        // the other, which is a line this reading keeps.
+        if (!here.equals(there) && !here.sharesCountSpaceWith(there)) {
+            return null;
+        }
+        Map<NumericTerm, Carrier> both = new LinkedHashMap<>();
+        both.put(on, here);
+        both.put(against, there);
+        return both;
     }
 
     /**
@@ -80,19 +120,33 @@ record ComparedTerms(NumericTerm on, NumericTerm against, Carrier carrier,
      * where they meet is not where that rule cuts — read as a line at zero it would ask for a pair
      * that proves nothing about it.
      */
-    private static ComparedTerms fromTheForm(AffineReading read, Carrier carrier) {
+    private static ComparedTerms fromTheForm(AffineReading read, InputReads reads,
+                                             Symbols symbols) {
         if (read == null || !read.orders()) {
             return null;
         }
         NumericTerm[] two = read.twoCoordinates();
-        if (two == null || !carrier.counts()) {
+        if (two == null) {
+            return null;
+        }
+        // Here the orders come from the reading of the declarations and from nowhere else. A term
+        // the arithmetic produced has no expression that names it, so there is nothing to take a
+        // type off — which is the whole of what went wrong when one was taken off the comparison.
+        Map<NumericTerm, Carrier> carriers = aDistanceBetween(
+                two[0], reads.read().carrierOf(two[0], symbols),
+                two[1], reads.read().carrierOf(two[1], symbols));
+        // And here the counts are asked for, which the reading above does not ask. A form holds the
+        // two apart by a number it read off the rule, and a number of nothing is not a distance —
+        // where the pair meets is the only place such a rule could cut, and that is the line the
+        // reading above draws.
+        if (carriers == null || !carriers.get(two[0]).counts()) {
             return null;
         }
         ComparisonClaim.Cut cut = (ComparisonClaim.Cut) read.claim();
         // The distance as the number it is. Held as a count of the carrier's steps, a threshold
         // that is not a whole number of them — which two decimals a rule holds half apart give —
         // was an exception thrown out of the measure.
-        return new ComparedTerms(two[0], two[1], carrier, cut.holdsAtTheValue(),
+        return new ComparedTerms(two[0], two[1], carriers, cut.holdsAtTheValue(),
                 cut.valueBelongsBelow(), new Count(read.cut()));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -61,7 +61,8 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
         ComparedTerms apart = ComparedTerms.of(comparison, read, reads, symbols);
         if (apart != null) {
             return new Cutting(
-                    new BorderQuantity.Apart(behavior, apart.on(), apart.against(), apart.carrier()),
+                    new BorderQuantity.Apart(behavior, apart.on(), apart.against(),
+                            apart.carriers()),
                     new Level.ACount(apart.stepsApart()),
                     new ComparisonClaim.Cut(apart.valueBelongsBelow(), apart.holdsAtTheLine()),
                     null);

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -638,5 +638,35 @@ public final class GuardThresholds {
         return Carrier.ofValue(type, symbols) != null;
     }
 
+    /**
+     * The number an expression names and the order that number is read and written on.
+     *
+     * @param term what the expression names
+     * @param on   the order it is counted on
+     */
+    record Named(NumericTerm term, Carrier on) {}
+
+    /**
+     * The same, or null where the expression names no number this can put an order under.
+     *
+     * <p>The two together because every reader of one wants the other, and each of them is asked of
+     * the one place that answers it: which position an expression names is {@link #termOf}'s, and
+     * which order that position is read and written on is the reading of the declarations'
+     * ({@link InputDomain#carrierOf}). Nothing here looks at what the expression's own type is. A
+     * rule compares what an operation answered rather than the positions the arithmetic rewrote it
+     * into, so the operands of {@code Date.daysBetween(a, b) > 10} are whole numbers where its
+     * positions hold dates — and a reading that took the order off the comparison wrote both
+     * positions back as whole numbers, read them off a row as whole numbers, and agreed with itself
+     * about a border nothing could meet (#1018).
+     */
+    static Named namedBy(Core e, InputReads reads, Symbols symbols) {
+        NumericTerm term = termOf(e, reads, symbols);
+        if (term == null) {
+            return null;
+        }
+        Carrier on = reads.read().carrierOf(term, symbols);
+        return on == null ? null : new Named(term, on);
+    }
+
     private GuardThresholds() {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -641,31 +641,33 @@ public final class GuardThresholds {
     /**
      * The number an expression names and the order that number is read and written on.
      *
-     * @param term what the expression names
-     * @param on   the order it is counted on
+     * @param term  what the expression names
+     * @param order what it is counted on
      */
-    record Named(NumericTerm term, Carrier on) {}
+    record Named(NumericTerm term, Carrier order) {}
 
     /**
      * The same, or null where the expression names no number this can put an order under.
      *
-     * <p>The two together because every reader of one wants the other, and each of them is asked of
-     * the one place that answers it: which position an expression names is {@link #termOf}'s, and
-     * which order that position is read and written on is the reading of the declarations'
-     * ({@link InputDomain#carrierOf}). Nothing here looks at what the expression's own type is. A
-     * rule compares what an operation answered rather than the positions the arithmetic rewrote it
-     * into, so the operands of {@code Date.daysBetween(a, b) > 10} are whole numbers where its
-     * positions hold dates — and a reading that took the order off the comparison wrote both
-     * positions back as whole numbers, read them off a row as whole numbers, and agreed with itself
-     * about a border nothing could meet (#1018).
+     * <p>The two together because no reader of a line wants one without the other, and both readings
+     * of a comparison want them the same way round. Neither answer is made here: which position an
+     * expression names is {@link #termOf}'s and which order that position is counted on is the
+     * reading of the declarations' ({@link InputDomain#carrierOf}).
+     *
+     * <p>In particular the expression's own type is not read, here or anywhere a line is drawn. It
+     * would agree wherever a rule names its positions itself and disagree wherever an operation
+     * stands between them: the operands of {@code Date.daysBetween(a, b) > 10} are whole numbers
+     * where its positions hold dates. Taking the order off the comparison wrote both positions back
+     * as whole numbers and read them off a row as whole numbers, which agreed with itself about a
+     * border nothing could meet (#1018).
      */
     static Named namedBy(Core e, InputReads reads, Symbols symbols) {
         NumericTerm term = termOf(e, reads, symbols);
         if (term == null) {
             return null;
         }
-        Carrier on = reads.read().carrierOf(term, symbols);
-        return on == null ? null : new Named(term, on);
+        Carrier order = reads.read().carrierOf(term, symbols);
+        return order == null ? null : new Named(term, order);
     }
 
     private GuardThresholds() {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/LevelSpace.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LevelSpace.java
@@ -5,6 +5,7 @@ import souther.compiler.inputs.BoundaryDomain;
 import souther.compiler.numeric.AdditiveImage;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.Granularity;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.numeric.OrderedInterval;
 import souther.compiler.numeric.Place;
@@ -473,6 +474,31 @@ public interface LevelSpace {
             }
 
         };
+    }
+
+    /**
+     * How a sum of counts on these orders is spaced, which is how its terms are spaced together.
+     *
+     * <p>A sum steps only where every one of its terms does: a whole number added to a decimal lands
+     * wherever the decimal does. So one dense order among them makes the sum dense, and it takes all
+     * of them stepping for the sum to step.
+     *
+     * <p>Of counting orders, which every order a sum is over has. A quantity whose orders do not
+     * count has no sum to be spaced and answers before it gets here ({@link #onlyWhereTheyMeet}) —
+     * asked of a string, {@link Carrier#spacing} says dense for a reason that has nothing to do with
+     * addition, and reading that as an answer about a sum is how the two meanings would meet.
+     */
+    static Granularity addedUpOver(java.util.Collection<Carrier> orders) {
+        for (Carrier each : orders) {
+            if (!each.counts()) {
+                throw new IllegalStateException(
+                        "a sum adds counts up, and this order has none: " + each);
+            }
+            if (each.spacing() != Granularity.DISCRETE) {
+                return Granularity.DENSE;
+            }
+        }
+        return Granularity.DISCRETE;
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/TwoOrdersShareTheirCountsOrTheyDoNotTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TwoOrdersShareTheirCountsOrTheyDoNotTest.java
@@ -90,17 +90,49 @@ class TwoOrdersShareTheirCountsOrTheyDoNotTest {
                 shared, "the orders whose counts are one arithmetic");
     }
 
-    /** And the answer does not depend on which of the two is asked. */
+    /**
+     * The pairs a rule can compare two positions on, which is those and the one with no counts.
+     *
+     * <p>The question a reading of a comparison actually asks, and the reason the one above is not
+     * made reflexive to answer it. Two strings stand one above the other and no number apart, so the
+     * pair is here and is not up there — and a caller that measured how far apart they stand would
+     * be reading this answer as that one.
+     */
+    @Test
+    void theseOrdersCanBeComparedAgainstEachOther() {
+        List<String> compared = new ArrayList<>();
+        ORDERS.forEach((here, one) -> ORDERS.forEach((there, other) -> {
+            if (one.standsAgainst(other)) {
+                compared.add(here + "/" + there);
+            }
+        }));
+
+        assertEquals(List.of(
+                        "Int/Int", "Int/Decimal",
+                        "Decimal/Int", "Decimal/Decimal",
+                        "Date/Date",
+                        "DateTime/DateTime",
+                        "Time/Time",
+                        "Instant/Instant",
+                        "String/String",
+                        "Colour/Colour",
+                        "Size/Size"),
+                compared, "the orders a rule can compare two positions on");
+    }
+
+    /** And neither answer depends on which of the two is asked. */
     @Test
     void neitherOrderOfAPairAnswersDifferently() {
         List<String> disagreed = new ArrayList<>();
         ORDERS.forEach((here, one) -> ORDERS.forEach((there, other) -> {
-            if (one.sharesCountSpaceWith(other) != other.sharesCountSpaceWith(one)) {
+            if (one.sharesCountSpaceWith(other) != other.sharesCountSpaceWith(one)
+                    || one.standsAgainst(other) != other.standsAgainst(one)) {
                 disagreed.add(here + "/" + there);
             }
         }));
 
         assertEquals(List.of(), disagreed,
-                "sharing a count space is a fact about the pair, not about which one was asked");
+                "what two orders are to each other is a fact about the pair, not about which one"
+                        + " was asked");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/TwoOrdersShareTheirCountsOrTheyDoNotTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TwoOrdersShareTheirCountsOrTheyDoNotTest.java
@@ -1,0 +1,106 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Which orders count in the same numbers, said once and both ways round.
+ *
+ * <p>What this decides is whether a rule comparing two positions is read as how far apart they stand
+ * or as an arithmetic form over both of them. A form carries a conversion in its coefficients and a
+ * distance has none, so a pair let through here that shares no counts would have its level measured
+ * in a unit belonging to neither position.
+ *
+ * <p>A table and not a rule read back off the implementation. What a carrier's counts mean is a
+ * decision — a second is a second of the day and a second of an epoch, and those are two decisions —
+ * and a test that recomputed it would agree with whatever was written. The pairs below are the
+ * answer, and the switch is exhaustive, so a ninth carrier fails to compile rather than falling into
+ * whichever arm was written last.
+ */
+class TwoOrdersShareTheirCountsOrTheyDoNotTest {
+
+    private static final TypeSymbol ONE_SUM = named("Colour");
+    private static final TypeSymbol ANOTHER_SUM = named("Size");
+
+    private static TypeSymbol named(String name) {
+        return TypeSymbols.declared(new TypeKey("demo", name));
+    }
+
+    /** Every carrier there is, under a name to say which is which. */
+    private static final Map<String, Carrier> ORDERS = orders();
+
+    private static Map<String, Carrier> orders() {
+        Map<String, Carrier> out = new LinkedHashMap<>();
+        out.put("Int", Carrier.WHOLE);
+        out.put("Decimal", Carrier.DENSE);
+        out.put("Date", Carrier.DATE);
+        out.put("DateTime", Carrier.MOMENT);
+        out.put("Time", Carrier.TIME);
+        out.put("Instant", Carrier.INSTANT);
+        out.put("String", Carrier.TEXT);
+        out.put("Colour", new Carrier.Ordinal(ONE_SUM, List.of(named("Red"))));
+        out.put("Size", new Carrier.Ordinal(ANOTHER_SUM, List.of(named("Big"))));
+        return out;
+    }
+
+    /**
+     * The pairs whose counts are the same numbers, and there are no others.
+     *
+     * <p>Read as pairs rather than as an answer per carrier, since that is what the question is. A
+     * whole number and a decimal are written on one line and step along it differently, which is a
+     * fact about the values beside a distance rather than about the distance.
+     */
+    @Test
+    void theseOrdersShareTheirCountsAndNoOthersDo() {
+        List<String> shared = new ArrayList<>();
+        ORDERS.forEach((here, one) -> ORDERS.forEach((there, other) -> {
+            if (one.sharesCountSpaceWith(other)) {
+                shared.add(here + "/" + there);
+            }
+        }));
+
+        assertEquals(List.of(
+                        "Int/Int", "Int/Decimal",
+                        "Decimal/Int", "Decimal/Decimal",
+                        "Date/Date",
+                        // A date-time counts seconds from an epoch and a time of day counts seconds
+                        // from midnight, so the same unit is two units of measurement from two
+                        // origins. An instant counts nanoseconds on the same timeline a date-time is
+                        // on, which is the other way for two orders to be one unit short of sharing
+                        // a number: told apart by whether one value converts to the other, both
+                        // pairs would be here.
+                        "DateTime/DateTime",
+                        "Time/Time",
+                        "Instant/Instant",
+                        // A string carries no count, so there is no number it shares with anything —
+                        // itself included. Two strings still stand in an order and still meet, and
+                        // that is `counts()`'s answer rather than this one's.
+                        "Colour/Colour",
+                        "Size/Size"),
+                shared, "the orders whose counts are one arithmetic");
+    }
+
+    /** And the answer does not depend on which of the two is asked. */
+    @Test
+    void neitherOrderOfAPairAnswersDifferently() {
+        List<String> disagreed = new ArrayList<>();
+        ORDERS.forEach((here, one) -> ORDERS.forEach((there, other) -> {
+            if (one.sharesCountSpaceWith(other) != other.sharesCountSpaceWith(one)) {
+                disagreed.add(here + "/" + there);
+            }
+        }));
+
+        assertEquals(List.of(), disagreed,
+                "sharing a count space is a fact about the pair, not about which one was asked");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowComposedForAPointIsWritableAndStandsAtItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowComposedForAPointIsWritableAndStandsAtItTest.java
@@ -1,0 +1,198 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.Located;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ItemAssessment;
+import souther.compiler.query.PartitionEvidence;
+import souther.compiler.source.SourceId;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * A row this compiler composed for a point is one a model can hold, and it stands at that point.
+ *
+ * <p>Two claims about one row, and neither implies the other. A row that cannot be written is one an
+ * author pastes and the compiler refuses; a row that can be written and stands somewhere else is one
+ * the report counts against a point it does not meet. Both were live at once and for one reason: the
+ * search, the writing and the reading each took the order a position is counted on from somewhere,
+ * and where they took it from the same wrong place they agreed with each other and with nothing in
+ * the model (#1018).
+ *
+ * <p><b>Which is why the compiler stands between them here.</b> A row put back into the model is
+ * type-checked and constructed by machinery that has never heard of borders, so a value written on
+ * an order that is not the position's is refused there whatever the reading of the border thinks. A
+ * round trip that only measured the row again would be asking the reader to confirm what the writer
+ * did, which is the arrangement that hid this.
+ *
+ * <p><b>Soundness and not completeness.</b> Nothing here asks that a point have a row. Whether the
+ * search reaches an assignment moves with what a model leaves each position, and a point with none
+ * is the search's answer rather than a broken promise (#949) — so every row offered is held to these
+ * two claims, and a point that offers none says nothing. What must exist is asked where it can be
+ * argued for: {@link ARowOfferedForABorderOverAnOperationStandsAtItTest} names one border and the
+ * four points it draws.
+ *
+ * <p>Over every operation declared to answer a form of its arguments, which is the set that puts an
+ * operation between a rule and the positions it is about. The models are the ones beside this, so an
+ * operation declared later is measured here without being added here.
+ */
+class ARowComposedForAPointIsWritableAndStandsAtItTest {
+
+    /**
+     * The answer written beside a composed row, which is not what this is about.
+     *
+     * <p>A row is offered with its result left for an author to fill in, and an example line needs
+     * one. Working it out would mean writing each model's rule a second time in Java, once per
+     * operation declared — so one is written down and the disagreement it may cause is allowed for
+     * below. What the row is being held to is that the inputs are writable and that they stand where
+     * they were composed to stand, and neither of those is a question about the answer.
+     */
+    private static final String WHATEVER = "Ok";
+
+    /**
+     * A row whose stated answer is wrong, which is the one thing said about these rows that is not
+     * being asked.
+     *
+     * <p>Allowed for rather than avoided. A row that ran, whose inputs were built and whose guard
+     * was taken, is complete evidence about which points it stands at however the answer beside it
+     * came out — the run reached the comparison to disagree at all. Any other diagnostic is a row
+     * this compiler composed and this compiler will not take.
+     */
+    private static final String THE_ANSWER_DISAGREES = "E1905";
+
+    /** Every row composed for a point of one of these models is one the model can hold. */
+    @Test
+    void everyRowComposedIsOneTheModelCanHold() {
+        Map<String, List<String>> refused = new LinkedHashMap<>();
+        forEachComposedRow((model, point, row) -> {
+            List<String> said = otherThanTheAnswer(model + example(row));
+            if (!said.isEmpty()) {
+                refused.put(point + " -> " + row, said);
+            }
+        });
+
+        assertEquals(Map.of(), refused,
+                "a row this compiler composed is one it will read back");
+    }
+
+    /** And once it is in, the point it was composed for is met. */
+    @Test
+    void everyRowComposedStandsAtThePointItWasComposedFor() {
+        List<String> missed = new ArrayList<>();
+        forEachComposedRow((model, point, row) -> {
+            if (!met(measured(model + example(row)), point)) {
+                missed.add(point + " -> " + row);
+            }
+        });
+
+        assertEquals(List.of(), missed,
+                "a row composed for a point stands at that point once it is in the model");
+    }
+
+    /** What each of the two claims is applied to: a model, a point of it, and the row composed
+     *  there. */
+    private interface OfAComposedRow {
+        void check(String model, String point, String row);
+    }
+
+    /**
+     * Every row every one of these models composes, one at a time.
+     *
+     * <p>One row per compilation and not all of a model's rows at once. Which point a row met is the
+     * claim being made, and a model holding every row it composed would have each point met by
+     * whichever row happened to reach it.
+     */
+    private static void forEachComposedRow(OfAComposedRow held) {
+        EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest.MEASURED.forEach((operation, observed) -> {
+            String model = modelOf(observed);
+            PartitionEvidence measured = measured(model);
+            for (BorderAssessment border : measured.boundaries()) {
+                border.items().forEach((role, item) -> {
+                    if (item instanceof ItemAssessment.Owed owed
+                            && owed.attempt() instanceof ItemAssessment.Attempt.Built built) {
+                        held.check(model, border.label() + " " + role, written(built.row()));
+                    }
+                });
+            }
+        });
+    }
+
+    /** A composed row's inputs, as an example line writes them. */
+    private static String written(Generator.GeneratedRow row) {
+        return "(" + String.join(", ",
+                row.inputs().stream().map(FixtureTemplate::text).toList()) + ")";
+    }
+
+    private static String example(String row) {
+        return "\nexample f\n    | " + row + " -> " + WHATEVER + "\n";
+    }
+
+    /** Whether the point is met, read off the item rather than out of a report's text. */
+    private static boolean met(PartitionEvidence evidence, String point) {
+        for (BorderAssessment border : evidence.boundaries()) {
+            for (Map.Entry<?, ? extends ItemAssessment> each : border.items().entrySet()) {
+                if (!point.equals(border.label() + " " + each.getKey())) {
+                    continue;
+                }
+                return each.getValue() instanceof ItemAssessment.Owed owed
+                        && ItemAssessment.Coverage.hit(owed.coverage());
+            }
+        }
+        return false;
+    }
+
+    /** What the compiler says about a model, less the one thing an invented answer causes. */
+    private static List<String> otherThanTheAnswer(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        List<String> said = new ArrayList<>();
+        for (Map.Entry<SourceId, List<Located>> each : compilation.diagnostics().entrySet()) {
+            for (Located found : each.getValue()) {
+                if (!THE_ANSWER_DISAGREES.equals(found.diagnostic().code())) {
+                    said.add(found.diagnostic().code());
+                }
+            }
+        }
+        return said;
+    }
+
+    /** The model a rule over one operation is measured in, which is the one beside this. */
+    private static String modelOf(
+            EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest.Observation observed) {
+        return """
+                module demo
+
+                data Ok
+                data No
+
+                behavior f : (%s) -> Ok | No
+                let f (%s) = {
+                    guard %s else No
+                    Ok
+                }
+                """.formatted(observed.parameters(),
+                observed.parameters().replaceAll(":\\s*[A-Za-z<>]+", ""), observed.condition());
+    }
+
+    private static PartitionEvidence measured(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, PartitionEvidence> coverage =
+                compilation.db().ask(new Adequacy.Coverage("demo")).value();
+        assertNotNull(coverage, () -> "the model under test compiles: " + source);
+        PartitionEvidence measured = coverage.get("f");
+        assertNotNull(measured, () -> "f was measured: " + source);
+        return measured;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowComposedForAPointIsWritableAndStandsAtItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowComposedForAPointIsWritableAndStandsAtItTest.java
@@ -113,7 +113,7 @@ class ARowComposedForAPointIsWritableAndStandsAtItTest {
      */
     private static void forEachComposedRow(OfAComposedRow held) {
         EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest.MEASURED.forEach((operation, observed) -> {
-            String model = modelOf(observed);
+            String model = EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest.modelOf(observed);
             PartitionEvidence measured = measured(model);
             for (BorderAssessment border : measured.boundaries()) {
                 border.items().forEach((role, item) -> {
@@ -139,7 +139,7 @@ class ARowComposedForAPointIsWritableAndStandsAtItTest {
     /** Whether the point is met, read off the item rather than out of a report's text. */
     private static boolean met(PartitionEvidence evidence, String point) {
         for (BorderAssessment border : evidence.boundaries()) {
-            for (Map.Entry<?, ? extends ItemAssessment> each : border.items().entrySet()) {
+            for (Map.Entry<PointRole, ItemAssessment> each : border.items().entrySet()) {
                 if (!point.equals(border.label() + " " + each.getKey())) {
                     continue;
                 }
@@ -164,24 +164,6 @@ class ARowComposedForAPointIsWritableAndStandsAtItTest {
             }
         }
         return said;
-    }
-
-    /** The model a rule over one operation is measured in, which is the one beside this. */
-    private static String modelOf(
-            EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest.Observation observed) {
-        return """
-                module demo
-
-                data Ok
-                data No
-
-                behavior f : (%s) -> Ok | No
-                let f (%s) = {
-                    guard %s else No
-                    Ok
-                }
-                """.formatted(observed.parameters(),
-                observed.parameters().replaceAll(":\\s*[A-Za-z<>]+", ""), observed.condition());
     }
 
     private static PartitionEvidence measured(String source) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowOfferedForABorderOverAnOperationStandsAtItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowOfferedForABorderOverAnOperationStandsAtItTest.java
@@ -98,6 +98,97 @@ class ARowOfferedForABorderOverAnOperationStandsAtItTest {
     }
 
     /**
+     * A distance between two positions written back differently, which is the other lowering.
+     *
+     * <p>{@code a} is a whole number and {@code b} a decimal, so the two are one distance on two
+     * orders — the pair the search for a distance on one order was never written for, and the pair
+     * {@link BorderQuantity.Apart} hands to the search over forms instead.
+     */
+    private static final String ACROSS_TWO_ORDERS = """
+            module demo
+
+            data Ok
+            data No
+
+            behavior f : (a: Int, b: Decimal) -> Ok | No
+            let f (a, b) = {
+                guard b > Decimal.fromInt(a) else No
+                Ok
+            }
+            """;
+
+    /**
+     * The points of that border are offered rows too, each position written on its own order.
+     *
+     * <p><b>Asked for the rows and not only for their soundness.</b> Every other test of this
+     * lowering holds a row that was offered to what it must be, and passes when none was: the branch
+     * could stop composing anything and each of them would go on saying nothing. So the rows are
+     * asked for here, where an empty answer is the failure.
+     *
+     * <p>And asked for the spelling, which is the defect itself. Both positions were written on
+     * whichever order the comparison happened to answer with, so an {@code Int} was offered
+     * {@code 0m} — a row the report counted and the compiler will not read.
+     */
+    @Test
+    void thePointsOfABorderAcrossTwoOrdersAreOfferedRowsWrittenOnEachOrder() {
+        Map<String, String> rows = inputsOf(measured(ACROSS_TWO_ORDERS));
+
+        assertEquals(List.of("b = a OFF", "b = a IN", "b = a OUT"),
+                rows.keySet().stream().filter(each -> each.startsWith("b = a ")).toList(),
+                "each point of `b > Decimal.fromInt(a)` that is owed a row has one: " + rows);
+        assertEquals(List.of("(0, 0m)", "(0, 1m)", "(0, -1m)"),
+                rows.entrySet().stream().filter(each -> each.getKey().startsWith("b = a "))
+                        .map(Map.Entry::getValue).toList(),
+                "and the whole number is written as one and the decimal as one: " + rows);
+    }
+
+    /**
+     * The same two orders, where the run one of them leaves has no value the other holds in it.
+     *
+     * <p>{@code b} runs between three tenths and seven tenths, so the line holds {@code a} between
+     * minus two tenths and two tenths — a run with one whole number in it and every decimal around
+     * that one.
+     */
+    private static final String A_RUN_ONE_ORDER_FILLS = """
+            module demo
+
+            data Ok
+            data No
+            data Amount = Decimal
+                invariant value >= 0.3m
+                invariant value <= 0.7m
+
+            behavior f : (a: Int, b: Amount) -> Ok | No
+            let f (a, b) = {
+                guard b.value > Decimal.fromInt(a) + 0.5m else No
+                Ok
+            }
+            """;
+
+    /**
+     * And the pair is searched for on both orders, not on whichever one of them the line was named
+     * by.
+     *
+     * <p><b>The test that fails if the lowering goes away.</b> The one above passes on either
+     * search: the run it leaves has whole numbers in it wherever a walk starts, so a search that
+     * walked the decimals landed on one anyway. Here it does not — the whole numbers are one value
+     * in a run the decimals fill — and a search holding both positions to the decimals hands the
+     * whole number three tenths, which is not a rounding error but a value of a type it is not.
+     *
+     * <p>Measured rather than argued: with both positions on the decimals this model does not come
+     * back with a worse row, it comes back with {@code ArithmeticException: Rounding necessary} out
+     * of the writing of the row.
+     */
+    @Test
+    void andThePairIsSearchedForOnBothOrders() {
+        Map<String, String> rows = inputsOf(measured(A_RUN_ONE_ORDER_FILLS));
+
+        assertEquals("(0, Amount(0.5m))", rows.get("b = a + 0.5 OFF"),
+                "the point on the line has the one whole number the line leaves, and the decimal"
+                        + " half a step above it: " + rows);
+    }
+
+    /**
      * And every row offered at a point stands at that point.
      *
      * <p>Read off the point's own attempt rather than out of the block a report prints: the row a
@@ -136,12 +227,25 @@ class ARowOfferedForABorderOverAnOperationStandsAtItTest {
      * happens is the search's answer and no part of what this holds.
      */
     private static Map<String, String> offeredAt(PartitionEvidence evidence) {
+        return offeredAt(evidence, ARowOfferedForABorderOverAnOperationStandsAtItTest::written);
+    }
+
+    /** The same, as each row's inputs alone — for a model whose rows are not written as dates and
+     *  whose answer nothing here works out. */
+    private static Map<String, String> inputsOf(PartitionEvidence evidence) {
+        return offeredAt(evidence, row -> "("
+                + String.join(", ", row.inputs().stream().map(FixtureTemplate::text).toList()) + ")");
+    }
+
+    private static Map<String, String> offeredAt(
+            PartitionEvidence evidence,
+            java.util.function.Function<Generator.GeneratedRow, String> as) {
         Map<String, String> rows = new LinkedHashMap<>();
         for (BorderAssessment border : evidence.boundaries()) {
             border.items().forEach((role, item) -> {
                 if (item instanceof ItemAssessment.Owed owed
                         && owed.attempt() instanceof ItemAssessment.Attempt.Built built) {
-                    rows.put(border.label() + " " + role, written(built.row()));
+                    rows.put(border.label() + " " + role, as.apply(built.row()));
                 }
             });
         }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowOfferedForABorderOverAnOperationStandsAtItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowOfferedForABorderOverAnOperationStandsAtItTest.java
@@ -78,6 +78,26 @@ class ARowOfferedForABorderOverAnOperationStandsAtItTest {
     }
 
     /**
+     * A row is offered at each of that border's own points.
+     *
+     * <p>What the round trip below is over. It holds every row offered to its own point and says
+     * nothing about there being any, so it passed while this border offered none at all and the only
+     * rows going round were the ones for the lines through each date's own values (#1018).
+     *
+     * <p>Which is not the general promise that a point has a row — a point nothing composes for is
+     * an answer the search is entitled to give. It is this border, over an operation whose positions
+     * are written back differently from what it answers, and the four points it draws.
+     */
+    @Test
+    void thePointsOfThatBorderAreOfferedRows() {
+        Map<String, String> rows = offeredAt(measured(SPAN));
+
+        assertEquals(List.of("a = b - 10 ON", "a = b - 10 OFF", "a = b - 10 IN", "a = b - 10 OUT"),
+                rows.keySet().stream().filter(each -> each.startsWith("a = b - 10 ")).toList(),
+                "each point of `Date.daysBetween(a, b) > 10` has a row: " + rows);
+    }
+
+    /**
      * And every row offered at a point stands at that point.
      *
      * <p>Read off the point's own attempt rather than out of the block a report prints: the row a

--- a/souther-compiler/src/test/java/souther/compiler/partition/ATermMayNameAPositionTheWalkStoppedShortOfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ATermMayNameAPositionTheWalkStoppedShortOfTest.java
@@ -58,6 +58,32 @@ class ATermMayNameAPositionTheWalkStoppedShortOfTest {
         assertTrue(report.contains("f/o.mid.inner.a = o.mid.inner.b"), report);
     }
 
+    /** The same two fields, held one apart, which is a rule no operand of the comparison names. */
+    private static final String REWRITTEN_BY_THE_ARITHMETIC = DEEPER_THAN_THE_WALK
+            .replace("o.mid.inner.a < o.mid.inner.b", "o.mid.inner.a + 1 < o.mid.inner.b");
+
+    /**
+     * And so is one the arithmetic had to rewrite to find the two positions in.
+     *
+     * <p>Which is the case that has nowhere else to get the answer. A comparison written between the
+     * two positions themselves names each of them with an operand, and something of the position can
+     * be had from what the checker gave that operand; {@code a + 1 < b} names neither, so the order
+     * each position is counted on is the reading of the declarations' to say or nobody's.
+     *
+     * <p>That reading stops at {@link souther.compiler.inputs.InputDomain#MAX_DEPTH} and the
+     * declarations do not, so it follows the type the rest of the way down. Made to stop where the
+     * positions stop — a null for a path with no position, which reads like tidying up — this line
+     * is not drawn at all.
+     */
+    @Test
+    void soIsALineTheArithmeticHadToRewriteToFind() {
+        String report = report(REWRITTEN_BY_THE_ARITHMETIC);
+
+        // The line is where `a` is one below `b`, so the point on it is the pair two apart: the
+        // rule is written `<` and the last pair satisfying it is the one before they are one apart.
+        assertTrue(report.contains("f/o.mid.inner.a = o.mid.inner.b - 2"), report);
+    }
+
     private static String report(String model) {
         Compilation compilation = Compilation.ofSource(model, "Main");
         compilation.measure(Adequacy.Asked.fullReport());

--- a/souther-compiler/src/test/java/souther/compiler/partition/ATermMayNameAPositionTheWalkStoppedShortOfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ATermMayNameAPositionTheWalkStoppedShortOfTest.java
@@ -84,6 +84,42 @@ class ATermMayNameAPositionTheWalkStoppedShortOfTest {
         assertTrue(report.contains("f/o.mid.inner.a = o.mid.inner.b - 2"), report);
     }
 
+    /** Two fields of what a list holds, compared inside a closure. The path reaches them through
+     *  what the sequence holds, which is a step of its own and not a field. */
+    private static final String UNDER_WHAT_A_SEQUENCE_HOLDS = """
+            module example.held
+
+            data Inner = { a: Int, b: Int }
+            data Item  = { inner: Inner }
+            data Cart  = { items: List<Item> }
+
+            data No = { why: Int }
+            data Yes = { v: Int }
+            data Result = No | Yes
+
+            behavior f : (cart: Cart) -> Result
+                constructs Yes, No
+            let f (cart) = {
+                guard List.all(i -> i.inner.a < i.inner.b, cart.items) else No { why = 0 }
+                Yes { v = 1 }
+            }
+            """;
+
+    /**
+     * And so is one under what a sequence holds, which the walk does not reach either.
+     *
+     * <p>A second kind of step and the reason the reading of a path is exhaustive over them. A path
+     * goes into a field, into what a sequence holds, or nowhere while narrowing where it already is;
+     * written for fields alone, the reading answered nothing for every path carrying one of the
+     * other two, and this line — which the compiler drew before any of this — went away.
+     */
+    @Test
+    void andSoIsOneUnderWhatASequenceHolds() {
+        String report = report(UNDER_WHAT_A_SEQUENCE_HOLDS);
+
+        assertTrue(report.contains("f/cart.items[*].inner.a = cart.items[*].inner.b"), report);
+    }
+
     private static String report(String model) {
         Compilation compilation = Compilation.ofSource(model, "Main");
         compilation.measure(Adequacy.Asked.fullReport());

--- a/souther-compiler/src/test/java/souther/compiler/partition/EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest.java
@@ -88,7 +88,7 @@ class EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest {
     void eachDrawsItsLineAtTheNumbersItWasDeclaredWith() {
         List<String> off = new ArrayList<>();
         MEASURED.forEach((operation, observed) -> {
-            List<String> drawn = labelsOf(observed.parameters(), observed.condition());
+            List<String> drawn = labelsOf(observed);
             if (!List.of(observed.label()).equals(drawn)) {
                 off.add(operation + ": " + observed.condition() + " draws " + drawn
                         + " and not [" + observed.label() + "]");
@@ -97,8 +97,16 @@ class EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest {
         assertEquals(List.of(), off);
     }
 
-    private static List<String> labelsOf(String parameters, String condition) {
-        String model = """
+    /**
+     * The model one of these rules is measured in.
+     *
+     * <p>Beside the table rather than beside each reader of it. {@link
+     * ARowComposedForAPointIsWritableAndStandsAtItTest} asks its own question of these same models,
+     * and a second copy of this would be two models under one table — measured here and not there
+     * the moment either copy moved.
+     */
+    static String modelOf(Observation observed) {
+        return """
                 module demo
 
                 data Ok
@@ -109,8 +117,12 @@ class EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest {
                     guard %s else No
                     Ok
                 }
-                """.formatted(parameters,
-                parameters.replaceAll(":\\s*[A-Za-z<>]+", ""), condition);
+                """.formatted(observed.parameters(),
+                observed.parameters().replaceAll(":\\s*[A-Za-z<>]+", ""), observed.condition());
+    }
+
+    private static List<String> labelsOf(Observation observed) {
+        String model = modelOf(observed);
         Compilation compilation = Compilation.ofSource(model, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();

--- a/souther-compiler/src/test/java/souther/compiler/partition/EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest {
 
     /** A rule written over the operation, and the line it draws. */
-    private record Observation(String parameters, String condition, String label) {}
+    record Observation(String parameters, String condition, String label) {}
 
     /**
      * One rule per declared operation, and the line each draws.
@@ -44,8 +44,13 @@ class EveryDeclaredFormIsMeasuredAtItsOwnCoefficientsTest {
      * <p>Written as a rule and read as a line, so what is measured is what a model would get. The
      * unit is in the number: two minutes is 120 of the seconds a date-time counts, two hours 7200,
      * two days 172800, and a day put together out of a date and a time is 86400 of them.
+     *
+     * <p>Reachable from beside this rather than copied there. {@link
+     * ARowComposedForAPointIsWritableAndStandsAtItTest} asks something else of the same models, and
+     * a second table would be a second list of which operations there are — which is the one thing
+     * the test above it exists to keep single.
      */
-    private static final Map<ValueName, Observation> MEASURED = measured();
+    static final Map<ValueName, Observation> MEASURED = measured();
 
     private static Map<ValueName, Observation> measured() {
         Map<ValueName, Observation> out = new LinkedHashMap<>();

--- a/souther-compiler/src/test/java/souther/compiler/partition/GivingASubexpressionANameDoesNotChangeWhatIsReadOfItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/GivingASubexpressionANameDoesNotChangeWhatIsReadOfItTest.java
@@ -233,7 +233,7 @@ class GivingASubexpressionANameDoesNotChangeWhatIsReadOfItTest {
             case BorderQuantity.OfACoordinate one -> one.term() + " on " + one.of();
             case BorderQuantity.OverAForm form -> form.form() + " on " + form.on();
             case BorderQuantity.Apart apart ->
-                    apart.on() + " vs " + apart.against() + " on " + apart.of();
+                    apart.on() + " vs " + apart.against() + " on " + apart.carriers();
         };
     }
 


### PR DESCRIPTION
Closes #1018.

## What was wrong

A border between two positions took the order both of them are read and written on
from the type of the comparison's operands. That is the position's own type wherever
a rule names its positions itself, and is not once an operation stands between them:
`Date.daysBetween(a, b) > 10` compares whole numbers at positions holding dates.

The search, the writing and the reading all took it from there, so they agreed with
each other and with nothing in the model. Measured on the model in the issue:

| | before | after |
| --- | --- | --- |
| a row composed for `a = b - 11` | `Day(10957)`, `ALL_CANDIDATES_REJECTED` | `Day(Date("2000-01-01")), Day(Date("2000-01-12"))` |
| four rows written by hand at those points | every one `NoHit` | every one `Hit` |

The reading half is not in the issue. `Apart.standsAt` read both positions on the same
wrong order, so a written date came back as no number and the row stood at nothing —
that border could be met by no row and composed for by none.

`Decimal.fromInt(a) < b` is the same defect the other way about, and is live on
`develop` today: the operands are decimals, `a` is an `Int`, and every row composed for
that border writes `0m` at it. Those rows are reported as composed and do not compile
(`E1812`).

## What changed

Four questions were one word. Each now has one place to be asked:

| question | who answers |
| --- | --- |
| what type an expression has | the checker, and no reader of borders |
| what order a position is read and written on | `InputDomain.carrierOf` |
| whether two orders count in the same numbers | `Carrier.sharesCountSpaceWith` |
| how a point of a quantity is found | `Standing`, chosen where the quantity is |

`BorderQuantity.Apart` holds an order per position rather than one for the pair, and
requires only that the two count in the same numbers — which admits a decimal against
a whole number, refuses a day count against a whole number, and leaves two strings the
line they already had. A pair on one order is searched for as it was; a pair on two is
lowered to the form it is, which has searched several positions on their own orders all
along. What a border is *of* does not move, so a report still reads `b = a`.

`Carrier.writtenOn` is gone. Its only callers were the two lines in `ComparedLine` that
this removes, and it hid the step this is about.

`InputDomain.carrierOf` follows the declaration past where the reading of an input
stops. `MAX_DEPTH` says how far a report is about one input; it does not say how far the
declarations go, and a rule may name a position deeper than either.

## Tests

Each was run against the pre-fix derivation and fails there.

- `ARowOfferedForABorderOverAnOperationStandsAtItTest` — the four points of the issue's
  border are offered rows. The round trip beside it held every row to its own point and
  said nothing about there being any, so it passed while this border offered none.
- `ARowComposedForAPointIsWritableAndStandsAtItTest` — over every operation declared to
  answer a form of its arguments: a composed row is one the model can hold, and once it
  is in, the point it was composed for is met. Soundness only; nothing here asks that a
  point have a row. `(0m, 0m)` is caught by the first half, which a "was a row built?"
  assertion misses.
- `TwoOrdersShareTheirCountsOrTheyDoNotTest` — the pairs that share a count space, and
  that neither order of a pair answers differently.
- `ATermMayNameAPositionTheWalkStoppedShortOfTest` — a line the arithmetic had to
  rewrite to find, between two positions below the walk. Fails if `carrierOf` is made to
  stop where the positions stop.

`mvn -o test`: 6782 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)