### PR TITLE
Take what a source root is, rather than subtract what a build output is

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     </developers>
 
     <modules>
+        <module>souther-test-support</module>
         <module>souther-runtime</module>
         <module>souther-syntax</module>
         <module>souther-compiler</module>
@@ -123,6 +124,12 @@
                 <groupId>org.souther-lang</groupId>
                 <artifactId>souther-build-api</artifactId>
                 <version>${souther.build.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.souther-lang</groupId>
+                <artifactId>souther-test-support</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.souther-lang</groupId>

--- a/souther-bench/pom.xml
+++ b/souther-bench/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>souther-fmt</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.souther-lang</groupId>
+            <artifactId>souther-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/souther-bench/src/test/java/souther/bench/OnlyAProjectionSaysHowFarAMeasurementGotTest.java
+++ b/souther-bench/src/test/java/souther/bench/OnlyAProjectionSaysHowFarAMeasurementGotTest.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -222,16 +221,8 @@ class OnlyAProjectionSaysHowFarAMeasurementGotTest {
      *  are about is whether somebody wrote a thing down. */
     private static String allMainSources() throws IOException {
         StringBuilder out = new StringBuilder();
-        for (String module : Reactor.modules()) {
-            Path main = Reactor.root().resolve(module).resolve("src/main/java");
-            if (!Files.isDirectory(main)) {
-                continue;
-            }
-            try (Stream<Path> files = Files.walk(main)) {
-                for (Path each : files.filter(p -> p.toString().endsWith(".java")).toList()) {
-                    out.append(Files.readString(each, StandardCharsets.UTF_8));
-                }
-            }
+        for (Path each : Reactor.mainJavaSources()) {
+            out.append(Files.readString(each, StandardCharsets.UTF_8));
         }
         return out.toString();
     }

--- a/souther-bench/src/test/java/souther/bench/Reactor.java
+++ b/souther-bench/src/test/java/souther/bench/Reactor.java
@@ -1,13 +1,12 @@
 package souther.bench;
 
+import souther.test.RepositoryLayout;
+
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,21 +32,11 @@ final class Reactor {
 
     private Reactor() {}
 
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
     /** The modules the root pom names. */
     static List<String> modules() {
-        String pom;
-        try {
-            pom = Files.readString(root().resolve("pom.xml"));
-        } catch (IOException unreadable) {
-            throw new UncheckedIOException(unreadable);
-        }
-        List<String> out = new ArrayList<>();
-        Matcher named = Pattern.compile("<module>([^<]+)</module>").matcher(pom);
-        while (named.find()) {
-            out.add(named.group(1));
-        }
-        assertTrue(out.size() > 1, () -> "the root pom names " + out);
-        return List.copyOf(out);
+        return REPOSITORY.modules().stream().map(module -> module.getFileName().toString()).toList();
     }
 
     /**
@@ -82,6 +71,6 @@ final class Reactor {
 
     /** The repository, from the module this runs in. */
     static Path root() {
-        return Path.of("").toAbsolutePath().getParent();
+        return REPOSITORY.root();
     }
 }

--- a/souther-bench/src/test/java/souther/bench/Reactor.java
+++ b/souther-bench/src/test/java/souther/bench/Reactor.java
@@ -34,9 +34,14 @@ final class Reactor {
 
     private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
 
-    /** The modules the root pom names. */
-    static List<String> modules() {
-        return REPOSITORY.modules().stream().map(module -> module.getFileName().toString()).toList();
+    /** The modules the root pom names, as directories. */
+    static List<Path> modules() {
+        return REPOSITORY.modules();
+    }
+
+    /** What to call one of them in a message. */
+    static String name(Path module) {
+        return module.getFileName().toString();
     }
 
     /**
@@ -47,20 +52,25 @@ final class Reactor {
      * publishes, and stand where that artifact's consumer stands — has nothing here to walk, and
      * finding nothing is the whole answer rather than a gap in one.
      */
-    static boolean hasMainSources(String module) {
-        return Files.isDirectory(root().resolve(module).resolve("src/main/java"));
+    static boolean hasMainSources(Path module) {
+        return Files.isDirectory(module.resolve("src/main/java"));
+    }
+
+    /** Every {@code .java} of every one of them. */
+    static List<Path> mainJavaSources() {
+        return REPOSITORY.mainJavaSources();
     }
 
     /** Every compiled class of every one of them. */
     static List<Path> classes() throws IOException {
         List<Path> found = new ArrayList<>();
-        for (String module : modules()) {
+        for (Path module : modules()) {
             if (!hasMainSources(module)) {
                 continue;
             }
-            Path built = root().resolve(module).resolve("target/classes");
+            Path built = module.resolve("target/classes");
             assertTrue(Files.isDirectory(built),
-                    module + " has no built classes: this check covers what has been built, so a"
+                    name(module) + " has no built classes: this check covers what has been built, so a"
                             + " module that has not been is a hole rather than a pass");
             try (Stream<Path> walk = Files.walk(built)) {
                 walk.filter(each -> each.toString().endsWith(".class")).forEach(found::add);

--- a/souther-bench/src/test/java/souther/bench/TheAbiIsSpelledInOnePlaceTest.java
+++ b/souther-bench/src/test/java/souther/bench/TheAbiIsSpelledInOnePlaceTest.java
@@ -80,7 +80,7 @@ class TheAbiIsSpelledInOnePlaceTest {
         List<String> modules = Reactor.modules();
         for (String module : modules) {
             for (String where : List.of("target/classes", "target/test-classes")) {
-                Path classes = repoRoot().resolve(module).resolve(where);
+                Path classes = Reactor.root().resolve(module).resolve(where);
                 if (where.endsWith("test-classes") && !Files.isDirectory(classes)) {
                     continue;   // a module with no tests of its own
                 }
@@ -139,7 +139,7 @@ class TheAbiIsSpelledInOnePlaceTest {
             if (!Reactor.hasMainSources(module)) {
                 continue;   // a module with no main sources of its own
             }
-            Path classes = repoRoot().resolve(module).resolve("target/classes");
+            Path classes = Reactor.root().resolve(module).resolve("target/classes");
             assertTrue(Files.isDirectory(classes), module + " has no built classes");
             walkFor(classes, callers, TheAbiIsSpelledInOnePlaceTest::capitalizes);
         }
@@ -282,7 +282,4 @@ class TheAbiIsSpelledInOnePlaceTest {
     }
 
     /** The tree this module sits in. */
-    private static Path repoRoot() {
-        return Path.of("").toAbsolutePath().getParent();
-    }
 }

--- a/souther-bench/src/test/java/souther/bench/TheAbiIsSpelledInOnePlaceTest.java
+++ b/souther-bench/src/test/java/souther/bench/TheAbiIsSpelledInOnePlaceTest.java
@@ -76,11 +76,11 @@ class TheAbiIsSpelledInOnePlaceTest {
         assertFalse(spellings.contains(""), "a kind of class whose name is its base: " + spellings);
 
         List<String> violations = new ArrayList<>();
-        List<String> scanned = new ArrayList<>();
-        List<String> modules = Reactor.modules();
-        for (String module : modules) {
+        List<Path> scanned = new ArrayList<>();
+        List<Path> modules = Reactor.modules();
+        for (Path module : modules) {
             for (String where : List.of("target/classes", "target/test-classes")) {
-                Path classes = Reactor.root().resolve(module).resolve(where);
+                Path classes = module.resolve(where);
                 if (where.endsWith("test-classes") && !Files.isDirectory(classes)) {
                     continue;   // a module with no tests of its own
                 }
@@ -88,7 +88,8 @@ class TheAbiIsSpelledInOnePlaceTest {
                     continue;   // a module with no main sources of its own
                 }
                 assertTrue(Files.isDirectory(classes),
-                        module + " has no built classes: this test covers what has been built, so a"
+                        Reactor.name(module) + " has no built classes: this test covers what has been"
+                                + " built, so a"
                                 + " module that has not been is a hole rather than a pass");
                 walk(classes, violations, spellings);
             }
@@ -135,12 +136,12 @@ class TheAbiIsSpelledInOnePlaceTest {
     @Test
     void andNothingOutsideTheAbiCapitalizesABehaviorsFirstLetter() {
         List<String> callers = new ArrayList<>();
-        for (String module : Reactor.modules()) {
+        for (Path module : Reactor.modules()) {
             if (!Reactor.hasMainSources(module)) {
                 continue;   // a module with no main sources of its own
             }
-            Path classes = Reactor.root().resolve(module).resolve("target/classes");
-            assertTrue(Files.isDirectory(classes), module + " has no built classes");
+            Path classes = module.resolve("target/classes");
+            assertTrue(Files.isDirectory(classes), Reactor.name(module) + " has no built classes");
             walkFor(classes, callers, TheAbiIsSpelledInOnePlaceTest::capitalizes);
         }
         assertEquals(List.of(), callers,

--- a/souther-bench/src/test/java/souther/bench/TheNullnessGateRunsWhereItIsDeclaredTest.java
+++ b/souther-bench/src/test/java/souther/bench/TheNullnessGateRunsWhereItIsDeclaredTest.java
@@ -64,16 +64,15 @@ class TheNullnessGateRunsWhereItIsDeclaredTest {
 
     @Test
     void theGateIsConfiguredForEveryModuleThatDeclaresItAndNoOther() {
-        List<String> modules = Reactor.modules();
         Set<String> declared = new LinkedHashSet<>();
         Set<String> configured = new LinkedHashSet<>();
         boolean rootGates = gateIsInTheBuildOf(Reactor.root().resolve("pom.xml"));
-        for (String module : modules) {
+        for (Path module : Reactor.modules()) {
             if (declaresNullMarked(module)) {
-                declared.add(module);
+                declared.add(Reactor.name(module));
             }
-            if (rootGates || gateIsInTheBuildOf(Reactor.root().resolve(module).resolve("pom.xml"))) {
-                configured.add(module);
+            if (rootGates || gateIsInTheBuildOf(module.resolve("pom.xml"))) {
+                configured.add(Reactor.name(module));
             }
         }
 
@@ -96,13 +95,13 @@ class TheNullnessGateRunsWhereItIsDeclaredTest {
     }
 
     /** Whether any class the module built carries the annotation. */
-    private static boolean declaresNullMarked(String module) {
+    private static boolean declaresNullMarked(Path module) {
         if (!Reactor.hasMainSources(module)) {
             return false;   // nothing of its own to annotate
         }
-        Path classes = Reactor.root().resolve(module).resolve("target/classes");
+        Path classes = module.resolve("target/classes");
         assertTrue(Files.isDirectory(classes),
-                module + " has no built classes: this reads what has been built, so a module that has"
+                Reactor.name(module) + " has no built classes: this reads what has been built, so a module that has"
                         + " not been is a hole rather than a pass");
         try (Stream<Path> walk = Files.walk(classes)) {
             return walk.filter(p -> p.toString().endsWith(".class")).anyMatch(TheNullnessGateRunsWhereItIsDeclaredTest::carriesNullMarked);

--- a/souther-bench/src/test/java/souther/bench/TheNullnessGateRunsWhereItIsDeclaredTest.java
+++ b/souther-bench/src/test/java/souther/bench/TheNullnessGateRunsWhereItIsDeclaredTest.java
@@ -67,12 +67,12 @@ class TheNullnessGateRunsWhereItIsDeclaredTest {
         List<String> modules = Reactor.modules();
         Set<String> declared = new LinkedHashSet<>();
         Set<String> configured = new LinkedHashSet<>();
-        boolean rootGates = gateIsInTheBuildOf(repoRoot().resolve("pom.xml"));
+        boolean rootGates = gateIsInTheBuildOf(Reactor.root().resolve("pom.xml"));
         for (String module : modules) {
             if (declaresNullMarked(module)) {
                 declared.add(module);
             }
-            if (rootGates || gateIsInTheBuildOf(repoRoot().resolve(module).resolve("pom.xml"))) {
+            if (rootGates || gateIsInTheBuildOf(Reactor.root().resolve(module).resolve("pom.xml"))) {
                 configured.add(module);
             }
         }
@@ -100,7 +100,7 @@ class TheNullnessGateRunsWhereItIsDeclaredTest {
         if (!Reactor.hasMainSources(module)) {
             return false;   // nothing of its own to annotate
         }
-        Path classes = repoRoot().resolve(module).resolve("target/classes");
+        Path classes = Reactor.root().resolve(module).resolve("target/classes");
         assertTrue(Files.isDirectory(classes),
                 module + " has no built classes: this reads what has been built, so a module that has"
                         + " not been is a hole rather than a pass");
@@ -162,7 +162,7 @@ class TheNullnessGateRunsWhereItIsDeclaredTest {
     /** The root pom's {@code <properties>}, which is where the gate's options are named. */
     private static Map<String, String> rootProperties() {
         Map<String, String> properties = new LinkedHashMap<>();
-        for (Element block : childrenNamed(parse(repoRoot().resolve("pom.xml")), "properties")) {
+        for (Element block : childrenNamed(parse(Reactor.root().resolve("pom.xml")), "properties")) {
             NodeList children = block.getChildNodes();
             for (int i = 0; i < children.getLength(); i++) {
                 if (children.item(i) instanceof Element element) {
@@ -227,7 +227,4 @@ class TheNullnessGateRunsWhereItIsDeclaredTest {
      * check gives: a list of its own would say what was true when it was written.
      */
 
-    private static Path repoRoot() {
-        return Path.of("").toAbsolutePath().getParent();
-    }
 }

--- a/souther-compiler/pom.xml
+++ b/souther-compiler/pom.xml
@@ -86,6 +86,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.souther-lang</groupId>
+            <artifactId>souther-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/souther-compiler/src/test/java/souther/compiler/check/ASignatureIsMadeInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ASignatureIsMadeInOnePlaceTest.java
@@ -2,13 +2,14 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
+import souther.test.RepositoryLayout;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -53,21 +54,6 @@ class ASignatureIsMadeInOnePlaceTest {
     }
 
     private static List<Path> mainSources() throws IOException {
-        Path module = Path.of("").toAbsolutePath();
-        Path repo = Files.isDirectory(module.resolve(Path.of("src", "main", "java")))
-                ? module.getParent() : module;
-        List<Path> sources = new ArrayList<>();
-        try (Stream<Path> modules = Files.list(repo)) {
-            for (Path candidate : modules.toList()) {
-                Path root = candidate.resolve(Path.of("src", "main", "java"));
-                if (!Files.isDirectory(root)) {
-                    continue;
-                }
-                try (Stream<Path> walk = Files.walk(root)) {
-                    walk.filter(p -> p.toString().endsWith(".java")).forEach(sources::add);
-                }
-            }
-        }
-        return sources;
+        return RepositoryLayout.ofWorkingDirectory().mainJavaSources();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/ASignatureIsMadeInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ASignatureIsMadeInOnePlaceTest.java
@@ -30,6 +30,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  */
 class ASignatureIsMadeInOnePlaceTest {
 
+    /** Read once: what this asks of it does not change between its checks. */
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
     /** Where a signature is made: the query that owns the answer, and hands it to the check, the
      *  backend and whoever drives a behavior. */
     private static final String THE_ONE_PLACE = "query/Bodies.java";
@@ -54,6 +57,6 @@ class ASignatureIsMadeInOnePlaceTest {
     }
 
     private static List<Path> mainSources() throws IOException {
-        return RepositoryLayout.ofWorkingDirectory().mainJavaSources();
+        return REPOSITORY.mainJavaSources();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatACaseMeansIsDecidedInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatACaseMeansIsDecidedInOnePlaceTest.java
@@ -30,6 +30,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class WhatACaseMeansIsDecidedInOnePlaceTest {
 
+    /** Read once: what this asks of it does not change between its checks. */
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
     /**
      * Where reading a subject as an optional is part of the answer: where the forms are told apart,
      * which is the point of it, and nowhere else.
@@ -149,6 +152,6 @@ class WhatACaseMeansIsDecidedInOnePlaceTest {
     }
 
     private static List<Path> mainSources() throws IOException {
-        return RepositoryLayout.ofWorkingDirectory().mainJavaSources();
+        return REPOSITORY.mainJavaSources();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatACaseMeansIsDecidedInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatACaseMeansIsDecidedInOnePlaceTest.java
@@ -2,16 +2,16 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
+import souther.test.RepositoryLayout;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -149,22 +149,6 @@ class WhatACaseMeansIsDecidedInOnePlaceTest {
     }
 
     private static List<Path> mainSources() throws IOException {
-        Path module = Path.of("").toAbsolutePath();
-        Path repo = Files.isDirectory(module.resolve(Path.of("src", "main", "java")))
-                ? module.getParent() : module;
-        List<Path> sources = new ArrayList<>();
-        try (Stream<Path> modules = Files.list(repo)) {
-            for (Path candidate : modules.toList()) {
-                Path root = candidate.resolve(Path.of("src", "main", "java"));
-                if (!Files.isDirectory(root)) {
-                    continue;
-                }
-                try (Stream<Path> walk = Files.walk(root)) {
-                    walk.filter(p -> p.toString().endsWith(".java")).forEach(sources::add);
-                }
-            }
-        }
-        assertFalse(sources.isEmpty(), "found no sources at all — the scan missed the tree");
-        return sources;
+        return RepositoryLayout.ofWorkingDirectory().mainJavaSources();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatATypeIsMadeOfIsAnsweredInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatATypeIsMadeOfIsAnsweredInOnePlaceTest.java
@@ -2,6 +2,8 @@ package souther.compiler.check;
 
 import org.junit.jupiter.api.Test;
 
+import souther.test.RepositoryLayout;
+
 import souther.compiler.DefaultStdlib;
 import souther.compiler.ast.Hir;
 import souther.compiler.diag.msg.MessageValues;
@@ -22,7 +24,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -357,23 +358,7 @@ class WhatATypeIsMadeOfIsAnsweredInOnePlaceTest {
     }
 
     private static List<Path> mainSources() throws IOException {
-        Path module = Path.of("").toAbsolutePath();
-        Path repo = Files.isDirectory(module.resolve(Path.of("src", "main", "java")))
-                ? module.getParent() : module;
-        List<Path> sources = new ArrayList<>();
-        try (Stream<Path> modules = Files.list(repo)) {
-            for (Path candidate : modules.toList()) {
-                Path root = candidate.resolve(Path.of("src", "main", "java"));
-                if (!Files.isDirectory(root)) {
-                    continue;
-                }
-                try (Stream<Path> walk = Files.walk(root)) {
-                    walk.filter(each -> each.toString().endsWith(".java")).forEach(sources::add);
-                }
-            }
-        }
-        sources.sort(Path::compareTo);
-        return sources;
+        return RepositoryLayout.ofWorkingDirectory().mainJavaSources();
     }
 
     // --- helpers ---------------------------------------------------------------------------------

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatATypeIsMadeOfIsAnsweredInOnePlaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatATypeIsMadeOfIsAnsweredInOnePlaceTest.java
@@ -44,6 +44,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class WhatATypeIsMadeOfIsAnsweredInOnePlaceTest {
 
+    /** Read once: what this asks of it does not change between its checks. */
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
     /** A sum two deep, and a leaf two of its cases reach. */
     private static final String MODULE = """
             module m
@@ -358,7 +361,7 @@ class WhatATypeIsMadeOfIsAnsweredInOnePlaceTest {
     }
 
     private static List<Path> mainSources() throws IOException {
-        return RepositoryLayout.ofWorkingDirectory().mainJavaSources();
+        return REPOSITORY.mainJavaSources();
     }
 
     // --- helpers ---------------------------------------------------------------------------------

--- a/souther-compiler/src/test/java/souther/compiler/diag/EveryShippedMessageCatalogIsCompleteAndValidTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/EveryShippedMessageCatalogIsCompleteAndValidTest.java
@@ -68,6 +68,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 public class EveryShippedMessageCatalogIsCompleteAndValidTest {
 
+    /** Read once: what this asks of it does not change between its checks. */
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
     /** Where the bundle {@link Messages} reads lives, as a path under a module's resources. */
     private static final String PACKAGE = "souther/compiler/diag";
     /** The bundle's own name, so the base catalog is {@code messages.properties}. */
@@ -971,7 +974,7 @@ public class EveryShippedMessageCatalogIsCompleteAndValidTest {
     /** Every module's {@code src/main/<kind>}, for the modules that have one. The test runs in its
      *  own module directory, so the repository root is that directory's parent. */
     private static List<Path> moduleDirectories(String kind) throws IOException {
-        return RepositoryLayout.ofWorkingDirectory().mainTrees(kind);
+        return REPOSITORY.mainTrees(kind);
     }
 
     private static Properties load(Path catalog) throws IOException {

--- a/souther-compiler/src/test/java/souther/compiler/diag/EveryShippedMessageCatalogIsCompleteAndValidTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/EveryShippedMessageCatalogIsCompleteAndValidTest.java
@@ -10,6 +10,8 @@ import souther.compiler.diag.msg.MessageValues;
 
 import org.junit.jupiter.api.Test;
 
+import souther.test.RepositoryLayout;
+
 import souther.compiler.check.Ordering;
 import souther.compiler.Reserved;
 import souther.compiler.types.Type;
@@ -969,19 +971,7 @@ public class EveryShippedMessageCatalogIsCompleteAndValidTest {
     /** Every module's {@code src/main/<kind>}, for the modules that have one. The test runs in its
      *  own module directory, so the repository root is that directory's parent. */
     private static List<Path> moduleDirectories(String kind) throws IOException {
-        Path module = Path.of("").toAbsolutePath();
-        Path repo = Files.isDirectory(module.resolve(Path.of("src", "main", "java")))
-                ? module.getParent() : module;
-        List<Path> directories = new ArrayList<>();
-        try (Stream<Path> modules = Files.list(repo)) {
-            for (Path candidate : modules.map(m -> m.resolve(Path.of("src", "main", kind))).toList()) {
-                if (Files.isDirectory(candidate)) {
-                    directories.add(candidate);
-                }
-            }
-        }
-        directories.sort(Path::compareTo);
-        return directories;
+        return RepositoryLayout.ofWorkingDirectory().mainTrees(kind);
     }
 
     private static Properties load(Path catalog) throws IOException {

--- a/souther-compiler/src/test/java/souther/compiler/doc/ASpecificationCitationNamesASectionRatherThanItsNumberTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/ASpecificationCitationNamesASectionRatherThanItsNumberTest.java
@@ -2,6 +2,9 @@ package souther.compiler.doc;
 
 import org.junit.jupiter.api.Test;
 
+import souther.test.GitIndex;
+import souther.test.RepositoryLayout;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.MalformedInputException;
@@ -16,7 +19,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -178,55 +180,45 @@ class ASpecificationCitationNamesASectionRatherThanItsNumberTest {
     }
 
     /**
-     * Every text file in the repository, keyed by its path from the root, read once for the class.
+     * Every file the repository holds, keyed by its path from the root, read once for the class.
      *
-     * <p>Every text file the repository holds outside {@code target} and {@code .git}, which is
-     * what a citation could be written in. Nobody writes one while the class runs, and each of the
-     * four checks below was reading all of it again to ask its own question of the same text.
+     * <p>What a citation could be written in is anything the repository keeps — a document, an ADR,
+     * a source, the specification itself — so this is not a sweep of source trees. What it is not
+     * is anything a build wrote, and that is a question git already answers: {@code target/} and
+     * surefire's {@code .surefire-*} record are in {@code .gitignore} because that is where this
+     * repository declares what a build writes.
+     *
+     * <p>Asked of the working tree instead, this had stated the attributes of 18,209 entries — the
+     * whole of {@code .git} and the whole of every {@code target/} among them — and read 2,446 of
+     * them as text to find out whether they were text. It also read whatever anyone had left lying
+     * beside the modules, so what the checks below covered depended on the machine they ran on.
+     *
+     * <p>Nobody writes a citation while the class runs, and each of the four checks below was
+     * reading all of it again to ask its own question of the same text.
      */
     private static Map<String, String> read;
 
     private static Map<String, String> sources() {
         if (read == null) {
-            read = walk();
+            read = readTracked();
         }
         return read;
     }
 
-    /** The walk itself, taken the once. */
-    private static Map<String, String> walk() {
-        Path repo = repositoryRoot();
+    /** The reading itself, taken the once. */
+    private static Map<String, String> readTracked() {
+        GitIndex git = GitIndex.of(RepositoryLayout.ofWorkingDirectory());
         Map<String, String> files = new LinkedHashMap<>();
-        try (Stream<Path> walk = Files.walk(repo)) {
-            for (Path path : walk.filter(Files::isRegularFile).filter(p -> !isBuildOutput(repo, p)).toList()) {
-                try {
-                    files.put(repo.relativize(path).toString().replace('\\', '/'),
-                            Files.readString(path));
-                } catch (MalformedInputException notText) {
-                    // A jar or an image says nothing about the specification.
-                }
+        for (Path tracked : git.trackedFiles()) {
+            try {
+                files.put(tracked.toString().replace('\\', '/'),
+                        Files.readString(git.resolve(tracked)));
+            } catch (MalformedInputException notText) {
+                // A jar or an image says nothing about the specification.
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
             }
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
         }
         return files;
-    }
-
-    /** Whether {@code path} is generated or git's own, neither of which anyone writes a citation in. */
-    private static boolean isBuildOutput(Path repo, Path path) {
-        for (Path part : repo.relativize(path)) {
-            String name = part.toString();
-            if (name.equals("target") || name.equals(".git")) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /** The repository root. A test runs in its own module's directory, whose parent that is. */
-    private static Path repositoryRoot() {
-        Path module = Path.of("").toAbsolutePath();
-        return Files.isDirectory(module.resolve(Path.of("src", "main", "java")))
-                ? module.getParent() : module;
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/AnInputIsReadInOnePlaceAndNoClaimNarrowsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/AnInputIsReadInOnePlaceAndNoClaimNarrowsItTest.java
@@ -2,13 +2,14 @@ package souther.compiler.inputs;
 
 import org.junit.jupiter.api.Test;
 
+import souther.test.RepositoryLayout;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -114,22 +115,6 @@ class AnInputIsReadInOnePlaceAndNoClaimNarrowsItTest {
     }
 
     private static List<Path> mainSources() throws IOException {
-        Path module = Path.of("").toAbsolutePath();
-        Path repo = Files.isDirectory(module.resolve(Path.of("src", "main", "java")))
-                ? module.getParent() : module;
-        List<Path> sources = new ArrayList<>();
-        try (Stream<Path> modules = Files.list(repo)) {
-            for (Path candidate : modules.toList()) {
-                Path root = candidate.resolve(Path.of("src", "main", "java"));
-                if (!Files.isDirectory(root)) {
-                    continue;
-                }
-                try (Stream<Path> walk = Files.walk(root)) {
-                    walk.filter(p -> p.toString().endsWith(".java")).forEach(sources::add);
-                }
-            }
-        }
-        sources.sort(Path::compareTo);
-        return sources;
+        return RepositoryLayout.ofWorkingDirectory().mainJavaSources();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/AnInputIsReadInOnePlaceAndNoClaimNarrowsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/AnInputIsReadInOnePlaceAndNoClaimNarrowsItTest.java
@@ -34,6 +34,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class AnInputIsReadInOnePlaceAndNoClaimNarrowsItTest {
 
+    /** Read once: what this asks of it does not change between its checks. */
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
     /** Where a behavior's input is read: the query that owns the answer and hands it to every
      *  measure, to the generator, and to the check that refuses a claim the rules contradict. */
     private static final String THE_ONE_PLACE = "query/Adequacy.java";
@@ -115,6 +118,6 @@ class AnInputIsReadInOnePlaceAndNoClaimNarrowsItTest {
     }
 
     private static List<Path> mainSources() throws IOException {
-        return RepositoryLayout.ofWorkingDirectory().mainJavaSources();
+        return REPOSITORY.mainJavaSources();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/TheReadingAndThePlanTakeOneStepDownATypeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/TheReadingAndThePlanTakeOneStepDownATypeTest.java
@@ -2,13 +2,14 @@ package souther.compiler.inputs;
 
 import org.junit.jupiter.api.Test;
 
+import souther.test.RepositoryLayout;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -141,22 +142,6 @@ class TheReadingAndThePlanTakeOneStepDownATypeTest {
     }
 
     private static List<Path> mainSources() throws IOException {
-        Path module = Path.of("").toAbsolutePath();
-        Path repo = Files.isDirectory(module.resolve(Path.of("src", "main", "java")))
-                ? module.getParent() : module;
-        List<Path> sources = new ArrayList<>();
-        try (Stream<Path> modules = Files.list(repo)) {
-            for (Path candidate : modules.toList()) {
-                Path root = candidate.resolve(Path.of("src", "main", "java"));
-                if (!Files.isDirectory(root)) {
-                    continue;
-                }
-                try (Stream<Path> walk = Files.walk(root)) {
-                    walk.filter(each -> each.toString().endsWith(".java")).forEach(sources::add);
-                }
-            }
-        }
-        sources.sort(Path::compareTo);
-        return sources;
+        return RepositoryLayout.ofWorkingDirectory().mainJavaSources();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/TheReadingAndThePlanTakeOneStepDownATypeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/TheReadingAndThePlanTakeOneStepDownATypeTest.java
@@ -36,6 +36,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class TheReadingAndThePlanTakeOneStepDownATypeTest {
 
+    /** Read once: what this asks of it does not change between its checks. */
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
     /** Where the fields are taken off a product shape. */
     private static final String THE_ONE_PLACE = "inputs/StructuralDescent.java";
 
@@ -142,6 +145,6 @@ class TheReadingAndThePlanTakeOneStepDownATypeTest {
     }
 
     private static List<Path> mainSources() throws IOException {
-        return RepositoryLayout.ofWorkingDirectory().mainJavaSources();
+        return REPOSITORY.mainJavaSources();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AConstructionPositionIsNotAnInputPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AConstructionPositionIsNotAnInputPositionTest.java
@@ -2,6 +2,8 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import souther.test.RepositoryLayout;
+
 import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
@@ -27,7 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -216,23 +217,7 @@ class AConstructionPositionIsNotAnInputPositionTest {
     }
 
     private static List<Path> mainSources() throws IOException {
-        Path module = Path.of("").toAbsolutePath();
-        Path repo = Files.isDirectory(module.resolve(Path.of("src", "main", "java")))
-                ? module.getParent() : module;
-        List<Path> sources = new ArrayList<>();
-        try (Stream<Path> modules = Files.list(repo)) {
-            for (Path candidate : modules.toList()) {
-                Path root = candidate.resolve(Path.of("src", "main", "java"));
-                if (!Files.isDirectory(root)) {
-                    continue;
-                }
-                try (Stream<Path> walk = Files.walk(root)) {
-                    walk.filter(each -> each.toString().endsWith(".java")).forEach(sources::add);
-                }
-            }
-        }
-        sources.sort(Path::compareTo);
-        return sources;
+        return RepositoryLayout.ofWorkingDirectory().mainJavaSources();
     }
 
     /** The requirement a class of {@code d} states by being the {@code Approved} case of it. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/AConstructionPositionIsNotAnInputPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AConstructionPositionIsNotAnInputPositionTest.java
@@ -60,6 +60,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class AConstructionPositionIsNotAnInputPositionTest {
 
+    /** Read once: what this asks of it does not change between its checks. */
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
     private record Read(Hir.SpecBehavior spec, Sig sig, Symbols symbols) {}
 
     private static Read of(String source, String behavior) {
@@ -217,7 +220,7 @@ class AConstructionPositionIsNotAnInputPositionTest {
     }
 
     private static List<Path> mainSources() throws IOException {
-        return RepositoryLayout.ofWorkingDirectory().mainJavaSources();
+        return REPOSITORY.mainJavaSources();
     }
 
     /** The requirement a class of {@code d} states by being the {@code Approved} case of it. */

--- a/souther-fmt/pom.xml
+++ b/souther-fmt/pom.xml
@@ -25,6 +25,11 @@
             <artifactId>souther-syntax</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.souther-lang</groupId>
+            <artifactId>souther-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/souther-fmt/src/test/java/souther/compiler/fmt/ARowOfATableIsWrittenAtItsTablesColumnTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/ARowOfATableIsWrittenAtItsTablesColumnTest.java
@@ -449,27 +449,22 @@ class ARowOfATableIsWrittenAtItsTablesColumnTest {
      * fixture. The first two are what makes it about the cases a repository of well-written sources
      * does not contain: a corpus written by hand reaches no tab and no row too long for a line.
      */
+    private static final List<String> SOURCES = compose();
+
     private static List<String> sources() {
+        return SOURCES;
+    }
+
+    /**
+     * Composed once. Three of the checks above hold their property over the whole of it, and what
+     * it is made of does not change between them.
+     */
+    private static List<String> compose() {
         List<String> out = new ArrayList<>(
                 List.of(TWO_TABLES, A_TAB_REACHING_THE_COLUMN, A_TAB_AFTER_A_COLUMN,
                         NO_SEPARATOR, INDENTED_ONE_DEEPER, ONE_SEPARATOR_MISSING, FULL_WIDTH));
         out.addAll(WhatGoesBetweenTwoTokensOnALineTest.corpus());
-        out.addAll(inTheRepository());
-        return out;
-    }
-
-    /** Every {@code .sou} the repository holds, a build's copies of them left out. */
-    private static List<String> inTheRepository() {
-        try (java.util.stream.Stream<java.nio.file.Path> walk =
-                java.nio.file.Files.walk(java.nio.file.Path.of(".."))) {
-            List<String> out = new ArrayList<>();
-            for (java.nio.file.Path p : walk.filter(q -> q.toString().endsWith(".sou"))
-                    .filter(q -> !q.toString().contains("target")).sorted().toList()) {
-                out.add(java.nio.file.Files.readString(p));
-            }
-            return out;
-        } catch (java.io.IOException e) {
-            throw new java.io.UncheckedIOException(e);
-        }
+        out.addAll(FormatterCorpus.texts());
+        return List.copyOf(out);
     }
 }

--- a/souther-fmt/src/test/java/souther/compiler/fmt/FormatterCorpus.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/FormatterCorpus.java
@@ -1,0 +1,82 @@
+package souther.compiler.fmt;
+
+import souther.test.RepositoryLayout;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Every Souther source this repository holds, read once.
+ *
+ * <p>What the formatter's repository-wide properties are held over. Two of them sweep it, and each
+ * had found the files for itself by walking the reactor root and dropping whatever had
+ * {@code target} in its path. That walk descended into the module directories, where surefire
+ * writes the {@code .surefire-*} record naming which fork took which class — and writes it while
+ * the tests are running. {@link Files#walk} reads an entry's attributes after it has listed the
+ * parent, so an entry removed between the two ends the walk, and a filter downstream of the walk is
+ * downstream of the attributes too. About one full build in seven failed here, on branches touching
+ * nothing in this module.
+ *
+ * <p>{@link RepositoryLayout#southerSources} descends into {@code <module>/src} and nowhere else.
+ * The record and {@code target/} are siblings of {@code src}, so they are not entries this can
+ * reach rather than entries it drops, and there is no list of what a build writes to keep one name
+ * behind. What the sweep costs is set by how much source there is: {@code .git} and the build's
+ * output can grow without the formatter's tests noticing.
+ *
+ * <p>Read once because the sweeps read the same files repeatedly —
+ * {@link ARowOfATableIsWrittenAtItsTablesColumnTest} asks for the corpus from three of its checks —
+ * and the text of a file is the same answer each time. Only the text is held. What each check makes
+ * of it is that check's own: a parse, a formatting, a report kept here would make two checks share a
+ * result rather than each ask its own question.
+ */
+final class FormatterCorpus {
+
+    private FormatterCorpus() {}
+
+    private static final Map<Path, String> SOURCES = read();
+
+    private static Map<Path, String> read() {
+        RepositoryLayout repository = RepositoryLayout.ofWorkingDirectory();
+        Map<Path, String> out = new LinkedHashMap<>();
+        for (Path source : repository.southerSources()) {
+            try {
+                out.put(repository.root().relativize(source),
+                        Files.readString(source, StandardCharsets.UTF_8));
+            } catch (IOException unreadable) {
+                throw new UncheckedIOException(unreadable);
+            }
+        }
+        return Map.copyOf(out);
+    }
+
+    /**
+     * Where each of them is, relative to the repository root, sorted.
+     *
+     * <p>Relative because a check that names one names it the way the repository does, and because
+     * it is what a parameterized case is called: an absolute path would print whatever directory
+     * the machine happened to check out into.
+     */
+    static List<Path> paths() {
+        return SOURCES.keySet().stream().sorted().toList();
+    }
+
+    /** What is written in the one at {@code path}. */
+    static String textOf(Path path) {
+        String text = SOURCES.get(path);
+        if (text == null) {
+            throw new IllegalArgumentException(path + " is not a source this repository holds");
+        }
+        return text;
+    }
+
+    /** All of them, for a check that holds a property over the corpus rather than over a file. */
+    static List<String> texts() {
+        return paths().stream().map(FormatterCorpus::textOf).toList();
+    }
+}

--- a/souther-fmt/src/test/java/souther/compiler/fmt/RepairingWhatTheRulesSayWritesTheCanonicalFormTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/RepairingWhatTheRulesSayWritesTheCanonicalFormTest.java
@@ -6,10 +6,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import souther.compiler.cst.CstParser;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,22 +34,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class RepairingWhatTheRulesSayWritesTheCanonicalFormTest {
 
-    static Stream<Path> sources() throws IOException {
-        List<Path> out = new ArrayList<>();
-        try (Stream<Path> walk = Files.walk(Path.of(".."))) {
-            walk.filter(p -> p.toString().endsWith(".sou"))
-                    .filter(p -> !p.toString().contains("target"))   // a build's copy of one
-                    .sorted().forEach(out::add);
-        }
-        return out.stream();
-    }
-
-    private static String read(Path p) {
-        try {
-            return Files.readString(p, StandardCharsets.UTF_8);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+    static Stream<Path> sources() {
+        return FormatterCorpus.paths().stream();
     }
 
     /**
@@ -66,13 +48,13 @@ class RepairingWhatTheRulesSayWritesTheCanonicalFormTest {
     private static final Map<Path, Deviations.Report> REPORTS = new ConcurrentHashMap<>();
 
     private static Deviations.Report reportOn(Path path) {
-        return REPORTS.computeIfAbsent(path, p -> Deviations.of(read(p)));
+        return REPORTS.computeIfAbsent(path, p -> Deviations.of(FormatterCorpus.textOf(p)));
     }
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("sources")
     void everySourceIsWhollyNamed(Path path) {
-        String source = read(path);
+        String source = FormatterCorpus.textOf(path);
         assertEquals(List.of(), CstParser.parse(source).errors(), "this source does not parse");
 
         Deviations.Report report = reportOn(path);
@@ -89,11 +71,11 @@ class RepairingWhatTheRulesSayWritesTheCanonicalFormTest {
      * the report would be empty and repairing nothing would write the text back.
      */
     @Test
-    void andSomeOfThemHaveSomethingAgainstThem() throws IOException {
+    void andSomeOfThemHaveSomethingAgainstThem() {
         List<Path> differ = new ArrayList<>();
         int deviations = 0;
-        for (Path path : sources().toList()) {
-            String source = read(path);
+        for (Path path : FormatterCorpus.paths()) {
+            String source = FormatterCorpus.textOf(path);
             if (!Formatter.format(source).equals(source)) {
                 differ.add(path);
                 deviations += reportOn(path).deviations().size();

--- a/souther-test-support/pom.xml
+++ b/souther-test-support/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.souther-lang</groupId>
+        <artifactId>souther-parent</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>souther-test-support</artifactId>
+    <name>Souther Test Support</name>
+
+    <description>
+        What the checks in this repository need to know about the repository itself: where its root
+        is, which modules the reactor owns, where each of them keeps its sources, and which files
+        git holds. Every module depends on this at test scope. It depends on nothing, so it is the
+        first thing the reactor builds and a check in any module can ask it.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <!-- Infrastructure for checking this repository, not an API anyone outside it writes
+             against; keep it out of the Central bundle. Published, it would look like an artifact
+             with a compatibility promise, and the repository's own shape would become part of what
+             this project supports. -->
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <configuration>
+                            <skipPublishing>true</skipPublishing>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/souther-test-support/src/main/java/souther/test/GitIndex.java
+++ b/souther-test-support/src/main/java/souther/test/GitIndex.java
@@ -44,11 +44,27 @@ public final class GitIndex {
         this.tracked = List.copyOf(tracked);
     }
 
+    /**
+     * What git is asked. The index and not the working tree, and separated by NUL so that a file
+     * whose name would otherwise be quoted comes back as it is.
+     */
+    static final List<String> LS_FILES = List.of("ls-files", "-z", "--cached");
+
     /** What git holds in {@code layout}'s repository. */
     public static GitIndex of(RepositoryLayout layout) {
+        return of(layout, LS_FILES.toArray(String[]::new));
+    }
+
+    /**
+     * The same, asked with {@code arguments}.
+     *
+     * <p>Here so that a check can watch this refuse a git that refuses, which is the behaviour
+     * everything built on this depends on and the one that cannot be reached by asking correctly.
+     */
+    static GitIndex of(RepositoryLayout layout, String... arguments) {
         Path root = layout.root();
         List<Path> tracked = new ArrayList<>();
-        for (String name : run(root, "ls-files", "-z", "--cached").split("\0")) {
+        for (String name : run(root, arguments).split("\0")) {
             if (!name.isEmpty()) {
                 tracked.add(Path.of(name));
             }
@@ -86,49 +102,74 @@ public final class GitIndex {
     private static String run(Path root, String... arguments) {
         List<String> command = new ArrayList<>(List.of("git", "-C", root.toString()));
         command.addAll(List.of(arguments));
-        Path complaint;
+        Path answer = temporary("git-ls-files", ".out");
+        Path complaint = temporary("git-ls-files", ".err");
+        try {
+            return outcomeOf(command, answer, complaint);
+        } finally {
+            // A temporary file left in the temporary directory is not worth replacing the reason
+            // this is being unwound with. After a timeout the process may not have let go of it
+            // yet, and losing "git did not finish" to "could not delete a file" would answer a
+            // question nobody asked.
+            deleteQuietly(answer);
+            deleteQuietly(complaint);
+        }
+    }
+
+    /**
+     * What running {@code command} came to, with neither of its streams on a pipe.
+     *
+     * <p>Both go to files, so nothing here is reading the process while it runs. That is what makes
+     * the bound below a bound: reading a pipe is waiting for the process to write, and a wait for
+     * the process cannot be reached from inside a wait for its output. With the streams on files,
+     * the process is finished, or forced to be, before anything it wrote is read.
+     */
+    private static String outcomeOf(List<String> command, Path answer, Path complaint) {
         Process git;
         try {
-            // What git says about itself goes to a file rather than a pipe. Read from a pipe it
-            // would have to be read while the list is being read, and one reader cannot do both:
-            // git blocked writing a full stderr pipe never finishes writing the list this is
-            // blocked reading.
-            complaint = Files.createTempFile("git-ls-files", ".err");
             git = new ProcessBuilder(command)
-                    .redirectError(ProcessBuilder.Redirect.to(complaint.toFile()))
+                    .redirectOutput(answer.toFile())
+                    .redirectError(complaint.toFile())
                     .start();
         } catch (IOException noGit) {
             throw new IllegalStateException("cannot run " + String.join(" ", command)
                     + ": this reads what the repository holds and git is what holds it", noGit);
         }
-        byte[] out;
-        String err;
-        int status;
         try {
-            out = git.getInputStream().readAllBytes();
             if (!git.waitFor(2, TimeUnit.MINUTES)) {
                 git.destroyForcibly();
-                throw new IllegalStateException(String.join(" ", command) + " did not finish");
+                throw new IllegalStateException(String.join(" ", command)
+                        + " did not finish within two minutes: this refuses rather than waiting on"
+                        + " a git that is not going to answer");
             }
-            status = git.exitValue();
-            err = Files.readString(complaint, StandardCharsets.UTF_8).trim();
+            int status = git.exitValue();
+            if (status != 0) {
+                throw new IllegalStateException(String.join(" ", command) + " exited " + status
+                        + ": " + Files.readString(complaint, StandardCharsets.UTF_8).trim());
+            }
+            return Files.readString(answer, StandardCharsets.UTF_8);
         } catch (IOException unreadable) {
             throw new UncheckedIOException(unreadable);
         } catch (InterruptedException interrupted) {
             Thread.currentThread().interrupt();
             throw new IllegalStateException(String.join(" ", command) + " was interrupted",
                     interrupted);
-        } finally {
-            try {
-                Files.deleteIfExists(complaint);
-            } catch (IOException leftBehind) {
-                throw new UncheckedIOException(leftBehind);
-            }
         }
-        if (status != 0) {
-            throw new IllegalStateException(String.join(" ", command) + " exited " + status + ": "
-                    + err);
+    }
+
+    private static Path temporary(String name, String suffix) {
+        try {
+            return Files.createTempFile(name, suffix);
+        } catch (IOException noRoom) {
+            throw new UncheckedIOException(noRoom);
         }
-        return new String(out, StandardCharsets.UTF_8);
+    }
+
+    private static void deleteQuietly(Path path) {
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException leftBehind) {
+            // Said above: not worth the reason this is being unwound with.
+        }
     }
 }

--- a/souther-test-support/src/main/java/souther/test/GitIndex.java
+++ b/souther-test-support/src/main/java/souther/test/GitIndex.java
@@ -3,6 +3,7 @@ package souther.test;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -85,34 +86,48 @@ public final class GitIndex {
     private static String run(Path root, String... arguments) {
         List<String> command = new ArrayList<>(List.of("git", "-C", root.toString()));
         command.addAll(List.of(arguments));
+        Path complaint;
         Process git;
         try {
-            git = new ProcessBuilder(command).redirectErrorStream(false).start();
+            // What git says about itself goes to a file rather than a pipe. Read from a pipe it
+            // would have to be read while the list is being read, and one reader cannot do both:
+            // git blocked writing a full stderr pipe never finishes writing the list this is
+            // blocked reading.
+            complaint = Files.createTempFile("git-ls-files", ".err");
+            git = new ProcessBuilder(command)
+                    .redirectError(ProcessBuilder.Redirect.to(complaint.toFile()))
+                    .start();
         } catch (IOException noGit) {
             throw new IllegalStateException("cannot run " + String.join(" ", command)
                     + ": this reads what the repository holds and git is what holds it", noGit);
         }
         byte[] out;
-        byte[] err;
+        String err;
         int status;
         try {
             out = git.getInputStream().readAllBytes();
-            err = git.getErrorStream().readAllBytes();
             if (!git.waitFor(2, TimeUnit.MINUTES)) {
                 git.destroyForcibly();
                 throw new IllegalStateException(String.join(" ", command) + " did not finish");
             }
             status = git.exitValue();
+            err = Files.readString(complaint, StandardCharsets.UTF_8).trim();
         } catch (IOException unreadable) {
             throw new UncheckedIOException(unreadable);
         } catch (InterruptedException interrupted) {
             Thread.currentThread().interrupt();
             throw new IllegalStateException(String.join(" ", command) + " was interrupted",
                     interrupted);
+        } finally {
+            try {
+                Files.deleteIfExists(complaint);
+            } catch (IOException leftBehind) {
+                throw new UncheckedIOException(leftBehind);
+            }
         }
         if (status != 0) {
             throw new IllegalStateException(String.join(" ", command) + " exited " + status + ": "
-                    + new String(err, StandardCharsets.UTF_8).trim());
+                    + err);
         }
         return new String(out, StandardCharsets.UTF_8);
     }

--- a/souther-test-support/src/main/java/souther/test/GitIndex.java
+++ b/souther-test-support/src/main/java/souther/test/GitIndex.java
@@ -1,0 +1,119 @@
+package souther.test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The files this repository holds, as git has them.
+ *
+ * <p>{@link RepositoryLayout} answers where sources are kept; this answers what the repository
+ * owns. They are different questions and a check needs one or the other. What the formatter sweeps
+ * is sources, so it asks the layout. What a check about the repository's prose sweeps — a citation
+ * written in an ADR, a heading quoted in a document — is not source and lives nowhere near a
+ * {@code src}, so it asks this.
+ *
+ * <p>Asking git rather than the filesystem settles what a build wrote in one place, and it is a
+ * place the repository already keeps honest: {@code target/} and {@code .surefire-*} are in
+ * {@code .gitignore} because that is where a build's output is declared. A walk of the working tree
+ * would have to name them again, and name whatever is written next as well.
+ *
+ * <p>The index and not the working tree, so this is what has been committed or staged. A file
+ * nobody has added yet is a file the repository does not hold: a scratch directory somebody keeps
+ * beside the modules is theirs, and a repository-wide check whose answer changed because of it
+ * would be reporting on that machine rather than on this repository.
+ *
+ * <p>No git means no answer, and this refuses rather than returning an empty list or standing
+ * aside. The question is whether an invariant holds over the files the repository owns; without git
+ * that set is unobserved, which is not the same as its being empty. Nothing in
+ * {@link RepositoryLayout} needs git, so a check that only reads sources still runs where there is
+ * no work tree.
+ */
+public final class GitIndex {
+
+    private final Path root;
+    private final List<Path> tracked;
+
+    private GitIndex(Path root, List<Path> tracked) {
+        this.root = root;
+        this.tracked = List.copyOf(tracked);
+    }
+
+    /** What git holds in {@code layout}'s repository. */
+    public static GitIndex of(RepositoryLayout layout) {
+        Path root = layout.root();
+        List<Path> tracked = new ArrayList<>();
+        for (String name : run(root, "ls-files", "-z", "--cached").split("\0")) {
+            if (!name.isEmpty()) {
+                tracked.add(Path.of(name));
+            }
+        }
+        if (tracked.isEmpty()) {
+            throw new IllegalStateException("git holds no file under " + root
+                    + ": this reads the repository's own files and there are none to read");
+        }
+        tracked.sort(Path::compareTo);
+        return new GitIndex(root, tracked);
+    }
+
+    /**
+     * Every file git holds, relative to the repository root, sorted.
+     *
+     * <p>Relative because that is the identity git gives a file, and the same identity a check
+     * writes in an expected value. {@link #resolve} turns one into somewhere to read.
+     */
+    public List<Path> trackedFiles() {
+        return tracked;
+    }
+
+    /** Every {@code .sou} git holds. */
+    public List<Path> trackedSoutherSources() {
+        return tracked.stream()
+                .filter(each -> each.getFileName().toString().endsWith(".sou"))
+                .toList();
+    }
+
+    /** Where to read one of them. */
+    public Path resolve(Path tracked) {
+        return root.resolve(tracked);
+    }
+
+    private static String run(Path root, String... arguments) {
+        List<String> command = new ArrayList<>(List.of("git", "-C", root.toString()));
+        command.addAll(List.of(arguments));
+        Process git;
+        try {
+            git = new ProcessBuilder(command).redirectErrorStream(false).start();
+        } catch (IOException noGit) {
+            throw new IllegalStateException("cannot run " + String.join(" ", command)
+                    + ": this reads what the repository holds and git is what holds it", noGit);
+        }
+        byte[] out;
+        byte[] err;
+        int status;
+        try {
+            out = git.getInputStream().readAllBytes();
+            err = git.getErrorStream().readAllBytes();
+            if (!git.waitFor(2, TimeUnit.MINUTES)) {
+                git.destroyForcibly();
+                throw new IllegalStateException(String.join(" ", command) + " did not finish");
+            }
+            status = git.exitValue();
+        } catch (IOException unreadable) {
+            throw new UncheckedIOException(unreadable);
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(String.join(" ", command) + " was interrupted",
+                    interrupted);
+        }
+        if (status != 0) {
+            throw new IllegalStateException(String.join(" ", command) + " exited " + status + ": "
+                    + new String(err, StandardCharsets.UTF_8).trim());
+        }
+        return new String(out, StandardCharsets.UTF_8);
+    }
+}

--- a/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
+++ b/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
@@ -1,0 +1,250 @@
+package souther.test;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * The shape of this repository, read once.
+ *
+ * <p>A check that asks about the repository rather than about one class needs the same few answers:
+ * where the root is, which modules the reactor owns, and where each of them keeps its sources.
+ * Answered separately in each check, the answers drift, and the one that stops covering the module
+ * added next says nothing about it while still reporting a pass.
+ *
+ * <p>The modules come from the root pom, which is what the reactor itself reads. A list written
+ * here would be a copy of the reactor rather than a reading of it.
+ *
+ * <p>Everything below is stated positively: a source tree is {@code <module>/src}, and that is the
+ * whole of what a walk descends into. Nothing is subtracted. This matters beyond tidiness, because
+ * subtraction has to name every kind of file a build writes and is always one name short —
+ * {@code target/} was the first and surefire's {@code .surefire-*} record, written beside the
+ * module while the tests run, was the second. Both are siblings of {@code src} rather than children
+ * of it, so a walk given a source tree cannot reach either, and a walk that cannot reach them
+ * cannot race with the build writing them.
+ *
+ * <p>It follows that what such a walk costs is set by how much source there is, and not by how
+ * large {@code .git} has grown or how much a build has written. That is the property to hold on to:
+ * a check that reads sources should not get slower because the repository has more of something
+ * else in it.
+ *
+ * <p>A module the root pom names whose directory or pom is missing is refused rather than skipped:
+ * the reactor could not build such a repository, and a check that quietly walked one module fewer
+ * would answer about the modules it read and say nothing about the rest. A module with no
+ * {@code src} is not that — a module can legitimately have no sources of its own — so it
+ * contributes no source tree and no complaint.
+ */
+public final class RepositoryLayout {
+
+    private static final String PARENT_ARTIFACT_ID = "souther-parent";
+
+    private final Path root;
+    private final List<Path> modules;
+    private final List<Path> sourceTrees;
+
+    private RepositoryLayout(Path root, List<Path> modules, List<Path> sourceTrees) {
+        this.root = root;
+        this.modules = List.copyOf(modules);
+        this.sourceTrees = List.copyOf(sourceTrees);
+    }
+
+    /**
+     * The repository the working directory is in.
+     *
+     * <p>Found by walking up from the working directory to the pom that declares
+     * {@code souther-parent}, so a test run by Maven from a module's directory, run from the
+     * repository root, and run by an editor from somewhere else all get the same answer. Walking up
+     * also reads no more of the repository than the path it is standing on.
+     */
+    public static RepositoryLayout ofWorkingDirectory() {
+        return of(Path.of("").toAbsolutePath().normalize());
+    }
+
+    /** The repository {@code start} is in, for a caller that already knows where it is standing. */
+    public static RepositoryLayout of(Path start) {
+        Path root = rootAbove(start);
+        List<Path> modules = new ArrayList<>();
+        List<Path> sourceTrees = new ArrayList<>();
+        for (String named : modulesNamedBy(root.resolve("pom.xml"))) {
+            Path module = root.resolve(named).normalize();
+            if (!Files.isRegularFile(module.resolve("pom.xml"))) {
+                throw new IllegalStateException("the root pom names the module " + named
+                        + " but " + module + " holds no pom: the reactor could not build this"
+                        + " repository, and a check that walked one module fewer would answer"
+                        + " about the rest and say nothing about this one");
+            }
+            modules.add(module);
+            Path src = module.resolve("src");
+            if (Files.isDirectory(src)) {
+                sourceTrees.add(src);
+            }
+        }
+        return new RepositoryLayout(root, modules, sourceTrees);
+    }
+
+    /** The repository root, absolute and normalised. */
+    public Path root() {
+        return root;
+    }
+
+    /** Every module directory the root pom names, in the order it names them. */
+    public List<Path> modules() {
+        return modules;
+    }
+
+    /**
+     * The {@code src} of every module that has one.
+     *
+     * <p>A source tree and not a source root: {@code src/main/java} and {@code src/test/resources}
+     * are source roots, and this is what holds them. It is the boundary a search for sources
+     * descends into, whatever kind of source it is looking for.
+     */
+    public List<Path> sourceTrees() {
+        return sourceTrees;
+    }
+
+    /** The {@code src/main/java} of every module that has one. */
+    public List<Path> mainJavaTrees() {
+        List<Path> out = new ArrayList<>();
+        for (Path module : modules) {
+            Path main = module.resolve("src").resolve("main").resolve("java");
+            if (Files.isDirectory(main)) {
+                out.add(main);
+            }
+        }
+        return List.copyOf(out);
+    }
+
+    /** Every {@code .sou} in a source tree, sorted. */
+    public List<Path> southerSources() {
+        return filesUnderSourceTrees(".sou");
+    }
+
+    /**
+     * Every file in a source tree whose name ends with {@code suffix}, sorted.
+     *
+     * <p>Sorted and held rather than streamed: the walk's handles are closed before this returns,
+     * so a caller cannot leak one, and a parameterized test over the result names its cases in the
+     * same order on every machine.
+     */
+    public List<Path> filesUnderSourceTrees(String suffix) {
+        List<Path> out = new ArrayList<>();
+        for (Path tree : sourceTrees) {
+            try (Stream<Path> walk = Files.walk(tree)) {
+                walk.filter(Files::isRegularFile)
+                        .filter(each -> each.getFileName().toString().endsWith(suffix))
+                        .forEach(out::add);
+            } catch (IOException unreadable) {
+                throw new UncheckedIOException(unreadable);
+            }
+        }
+        out.sort(Path::compareTo);
+        return List.copyOf(out);
+    }
+
+    private static Path rootAbove(Path start) {
+        for (Path candidate = start; candidate != null; candidate = candidate.getParent()) {
+            Path pom = candidate.resolve("pom.xml");
+            if (Files.isRegularFile(pom) && PARENT_ARTIFACT_ID.equals(artifactIdOf(pom))) {
+                return candidate;
+            }
+        }
+        throw new IllegalStateException("no pom declaring " + PARENT_ARTIFACT_ID + " above " + start
+                + ": this reads the repository it is running in, and there is none here");
+    }
+
+    /**
+     * The {@code artifactId} the pom declares for itself.
+     *
+     * <p>Its own and not its parent's, which is why this reads the element rather than searching
+     * the text: every module in this repository names {@code souther-parent} in its {@code parent}
+     * block, so a pom found by its spelling would be whichever module the test happened to start
+     * in.
+     */
+    private static String artifactIdOf(Path pom) {
+        return childText(parse(pom).getDocumentElement(), "artifactId");
+    }
+
+    /**
+     * The modules {@code /project/modules/module} names.
+     *
+     * <p>Read as elements rather than matched as text, so that how the pom happens to be written —
+     * an attribute, a comment, whitespace inside the tag — is not what the answer depends on.
+     *
+     * <p>Deliberately blind to a {@code <modules>} inside a profile, and this refuses when it finds
+     * one. A profile that adds a module would make the reactor's module list depend on which
+     * profiles are active, and a reading that silently returned the unconditional ones would go on
+     * reporting passes about a module nobody was walking.
+     */
+    private static List<String> modulesNamedBy(Path pom) {
+        Document document = parse(pom);
+        Element project = document.getDocumentElement();
+        for (Element profiles : childElements(project, "profiles")) {
+            for (Element profile : childElements(profiles, "profile")) {
+                if (!childElements(profile, "modules").isEmpty()) {
+                    throw new IllegalStateException(pom + " declares modules inside a profile: which"
+                            + " modules the reactor has would then depend on which profiles are"
+                            + " active, and this reads the unconditional ones only");
+                }
+            }
+        }
+        List<String> named = new ArrayList<>();
+        for (Element modules : childElements(project, "modules")) {
+            for (Element module : childElements(modules, "module")) {
+                named.add(module.getTextContent().trim());
+            }
+        }
+        if (named.size() < 2) {
+            throw new IllegalStateException(pom + " names " + named
+                    + ": this is the aggregator of a repository with several modules");
+        }
+        return named;
+    }
+
+    private static Document parse(Path pom) {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        try {
+            // A pom is read for what it says, so nothing it names is fetched or expanded.
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setExpandEntityReferences(false);
+            return factory.newDocumentBuilder().parse(pom.toFile());
+        } catch (ParserConfigurationException | SAXException malformed) {
+            throw new IllegalStateException(pom + " does not parse", malformed);
+        } catch (IOException unreadable) {
+            throw new UncheckedIOException(unreadable);
+        }
+    }
+
+    private static String childText(Element parent, String name) {
+        List<Element> found = childElements(parent, name);
+        return found.isEmpty() ? "" : found.getFirst().getTextContent().trim();
+    }
+
+    /** The direct children of {@code parent} called {@code name}, and not its descendants. */
+    private static List<Element> childElements(Element parent, String name) {
+        List<Element> out = new ArrayList<>();
+        NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node child = children.item(i);
+            if (child instanceof Element element && element.getTagName().equals(name)) {
+                out.add(element);
+            }
+        }
+        return out;
+    }
+}

--- a/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
+++ b/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
@@ -70,12 +70,22 @@ public final class RepositoryLayout {
      * also reads no more of the repository than the path it is standing on.
      */
     public static RepositoryLayout ofWorkingDirectory() {
-        return of(Path.of("").toAbsolutePath().normalize());
+        return of(Path.of(""));
     }
 
-    /** The repository {@code start} is in, for a caller that already knows where it is standing. */
+    /**
+     * The repository {@code start} is in, for a caller that already knows where it is standing.
+     *
+     * <p>{@code start} is made absolute here, which is the one place a path from outside becomes
+     * one of this class's own. A relative path means whatever the working directory is, and this
+     * class exists so that nothing else has to know what that is; searching upward from one would
+     * reach the working directory's own parents through {@code ..} segments it never resolved, and
+     * from a bare name like {@code souther-compiler} it would reach nothing at all — its parent is
+     * null and the search would end at the first step. Making it absolute at the door is what stops
+     * that from being each caller's problem to remember.
+     */
     public static RepositoryLayout of(Path start) {
-        Path root = rootAbove(start);
+        Path root = rootAbove(start.toAbsolutePath().normalize());
         List<Path> modules = new ArrayList<>();
         List<Path> sourceTrees = new ArrayList<>();
         for (String named : modulesNamedBy(root.resolve("pom.xml"))) {

--- a/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
+++ b/souther-test-support/src/main/java/souther/test/RepositoryLayout.java
@@ -118,13 +118,49 @@ public final class RepositoryLayout {
 
     /** The {@code src/main/java} of every module that has one. */
     public List<Path> mainJavaTrees() {
+        return mainTrees("java");
+    }
+
+    /**
+     * The {@code src/main/<kind>} of every module that has one, sorted.
+     *
+     * <p>{@code java} for the sources, {@code resources} for what ships beside them.
+     */
+    public List<Path> mainTrees(String kind) {
         List<Path> out = new ArrayList<>();
         for (Path module : modules) {
-            Path main = module.resolve("src").resolve("main").resolve("java");
-            if (Files.isDirectory(main)) {
-                out.add(main);
+            Path tree = module.resolve("src").resolve("main").resolve(kind);
+            if (Files.isDirectory(tree)) {
+                out.add(tree);
             }
         }
+        out.sort(Path::compareTo);
+        return List.copyOf(out);
+    }
+
+    /**
+     * Every {@code .java} this repository's main sources have, sorted.
+     *
+     * <p>What the checks that hold a rule over the compiler itself read. Held as one answer because
+     * six of them had worked it out for themselves, and a rule about where something may be written
+     * says nothing about a module its scan did not reach.
+     */
+    public List<Path> mainJavaSources() {
+        List<Path> out = new ArrayList<>();
+        for (Path tree : mainJavaTrees()) {
+            try (Stream<Path> walk = Files.walk(tree)) {
+                walk.filter(Files::isRegularFile)
+                        .filter(each -> each.getFileName().toString().endsWith(".java"))
+                        .forEach(out::add);
+            } catch (IOException unreadable) {
+                throw new UncheckedIOException(unreadable);
+            }
+        }
+        if (out.isEmpty()) {
+            throw new IllegalStateException("no Java sources under " + mainJavaTrees()
+                    + ": a scan of nothing holds a rule over nothing");
+        }
+        out.sort(Path::compareTo);
         return List.copyOf(out);
     }
 

--- a/souther-test-support/src/test/java/souther/test/EverySourceTheRepositoryHoldsIsUnderASourceTreeTest.java
+++ b/souther-test-support/src/test/java/souther/test/EverySourceTheRepositoryHoldsIsUnderASourceTreeTest.java
@@ -1,0 +1,60 @@
+package souther.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * That looking only where sources are kept is not looking in too few places.
+ *
+ * <p>A sweep built on {@link RepositoryLayout#southerSources()} descends into
+ * {@code <module>/src} and nowhere else, which is what keeps a build's own files out of it. The
+ * cost of stating where to look rather than what to leave out is that a source put somewhere else
+ * is not looked at, and nothing about the sweep would say so: it would go on passing, over a
+ * corpus quietly one file short.
+ *
+ * <p>So this holds the one direction that matters. Every {@code .sou} the repository owns lies
+ * under some module's source tree; a {@code docs/tour/hello.sou} that somebody commits fails here,
+ * naming itself, rather than being silently left out of every check the formatter has.
+ *
+ * <p>Only that direction. The other — that every source found is one git holds — would be a
+ * different claim, and a false one while somebody is writing a file they have not added yet. That a
+ * new source is swept before it is committed is what the sweep is for.
+ */
+class EverySourceTheRepositoryHoldsIsUnderASourceTreeTest {
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    @Test
+    void everyTrackedSourceIsSomewhereTheSweepsLook() {
+        List<Path> swept = REPOSITORY.southerSources();
+        List<Path> missed = new ArrayList<>();
+        GitIndex git = GitIndex.of(REPOSITORY);
+        for (Path tracked : git.trackedSoutherSources()) {
+            if (!swept.contains(git.resolve(tracked).normalize())) {
+                missed.add(tracked);
+            }
+        }
+        assertEquals(List.of(), missed,
+                "these are Souther sources this repository holds that no module keeps under its"
+                        + " src, so every sweep that reads sources reads around them; put them"
+                        + " under a module's src, or teach RepositoryLayout the tree they are in");
+    }
+
+    /**
+     * And the sweep is reading something.
+     *
+     * <p>A layout that found no source trees at all would satisfy the check above by having nothing
+     * to compare, so the count is held from the other side too.
+     */
+    @Test
+    void andThereAreSourcesToHaveMissed() {
+        assertTrue(GitIndex.of(REPOSITORY).trackedSoutherSources().size() >= 20,
+                "this repository holds Souther sources for the check above to be about");
+    }
+}

--- a/souther-test-support/src/test/java/souther/test/TheRepositoryIsReadTheWayTheReactorReadsItTest.java
+++ b/souther-test-support/src/test/java/souther/test/TheRepositoryIsReadTheWayTheReactorReadsItTest.java
@@ -44,6 +44,24 @@ class TheRepositoryIsReadTheWayTheReactorReadsItTest {
         }
     }
 
+    /**
+     * Including from a path that means nothing on its own.
+     *
+     * <p>A relative path is a working directory away from being somewhere, and this class exists so
+     * that nothing else has to know what the working directory is. Left as written, {@code "."} has
+     * no parent to search upward through and {@code "souther-compiler"} has none either, so the
+     * search would end at the first step — for a path naming a real directory. The tests here run
+     * in a module, so both of these reach the same root as everything else.
+     */
+    @Test
+    void includingFromOneThatMeansNothingWithoutTheWorkingDirectory() {
+        Path root = REPOSITORY.root();
+        assertEquals(root, RepositoryLayout.of(Path.of(".")).root());
+        assertEquals(root, RepositoryLayout.of(Path.of("")).root());
+        assertEquals(root, RepositoryLayout.of(Path.of("src")).root(), "a directory of this module");
+        assertEquals(root, RepositoryLayout.of(Path.of("..")).root(), "and the root itself");
+    }
+
     @Test
     void theModulesAreTheOnesTheRootPomNames() {
         List<String> named = REPOSITORY.modules().stream()

--- a/souther-test-support/src/test/java/souther/test/TheRepositoryIsReadTheWayTheReactorReadsItTest.java
+++ b/souther-test-support/src/test/java/souther/test/TheRepositoryIsReadTheWayTheReactorReadsItTest.java
@@ -1,0 +1,100 @@
+package souther.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * That what {@link RepositoryLayout} answers is this repository and not something shaped like it.
+ *
+ * <p>Everything else built on it inherits whatever this gets wrong, and the way it would go wrong
+ * is quietly: a layout that found one module fewer would let every sweep over it report a pass
+ * about the modules it did read.
+ */
+class TheRepositoryIsReadTheWayTheReactorReadsItTest {
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    @Test
+    void theRootIsTheOneHoldingTheAggregator() {
+        assertTrue(Files.isRegularFile(REPOSITORY.root().resolve("pom.xml")));
+        assertTrue(Files.isDirectory(REPOSITORY.root().resolve(".github")),
+                "the repository root, and not a module that happens to have a pom");
+    }
+
+    /**
+     * And it is the same root from wherever a test is started.
+     *
+     * <p>Maven runs a test in its module's directory, an editor may run it from the repository
+     * root, and both have to reach the same answer or a check means something different depending
+     * on who ran it.
+     */
+    @Test
+    void andItIsFoundFromAnywhereBelowIt() {
+        Path root = REPOSITORY.root();
+        for (Path start : List.of(root, root.resolve("souther-compiler"),
+                root.resolve("souther-compiler").resolve("src").resolve("main").resolve("java"))) {
+            assertEquals(root, RepositoryLayout.of(start).root(), "started from " + start);
+        }
+    }
+
+    @Test
+    void theModulesAreTheOnesTheRootPomNames() {
+        List<String> named = REPOSITORY.modules().stream()
+                .map(module -> module.getFileName().toString()).toList();
+        assertEquals(List.of("souther-test-support", "souther-runtime", "souther-syntax",
+                        "souther-compiler", "souther-build-driver", "souther-fmt", "souther-lsp",
+                        "souther-cli", "souther-bench", "souther-program-api-test"), named,
+                "the reactor's modules, in the order the root pom names them");
+    }
+
+    /**
+     * A module with no sources of its own is not a hole.
+     *
+     * <p>{@code souther-program-api-test} exists to compile against what another module publishes
+     * and stand where that artifact's consumer stands, so it has tests and no main sources. That is
+     * an answer and not a gap in one, which is why only a missing module refuses.
+     */
+    @Test
+    void aModuleWithoutMainSourcesIsStillAModule() {
+        List<String> withMainJava = REPOSITORY.mainJavaTrees().stream()
+                .map(tree -> tree.getParent().getParent().getParent().getFileName().toString())
+                .toList();
+        assertTrue(REPOSITORY.modules().stream()
+                        .anyMatch(module -> module.getFileName().toString()
+                                .equals("souther-program-api-test")),
+                "the module is there");
+        assertFalse(withMainJava.contains("souther-program-api-test"),
+                "and it contributes no main sources: " + withMainJava);
+    }
+
+    /**
+     * The search space is the source trees, and nothing a build writes is in it.
+     *
+     * <p>This is the property the sweeps depend on rather than a restatement of the filter: both
+     * {@code target/} and surefire's {@code .surefire-*} record sit beside {@code src} rather than
+     * under it, so a walk given these roots cannot reach either — which is also why it cannot race
+     * with a build writing them.
+     */
+    @Test
+    void nothingABuildWritesIsUnderASourceTree() {
+        for (Path tree : REPOSITORY.sourceTrees()) {
+            assertEquals("src", tree.getFileName().toString());
+            assertTrue(REPOSITORY.modules().contains(tree.getParent()),
+                    tree + " is the src of a module the root pom names");
+        }
+        List<Path> sources = REPOSITORY.southerSources();
+        assertFalse(sources.isEmpty(), "this repository has Souther sources");
+        for (Path source : sources) {
+            assertFalse(source.toString().contains("/target/"), source.toString());
+            assertFalse(source.getFileName().toString().startsWith(".surefire-"), source.toString());
+        }
+        assertEquals(sources.stream().sorted().toList(), sources, "sorted, so a sweep is ordered");
+    }
+}

--- a/souther-test-support/src/test/java/souther/test/TheRepositorysShapeIsWorkedOutInOnePlaceTest.java
+++ b/souther-test-support/src/test/java/souther/test/TheRepositorysShapeIsWorkedOutInOnePlaceTest.java
@@ -39,6 +39,10 @@ class TheRepositorysShapeIsWorkedOutInOnePlaceTest {
     /** A way the shape has been worked out before, and what to ask instead. */
     private record Rederivation(String written, String instead) {}
 
+    /** The two files that write these words because of what they are for. */
+    private static final List<String> QUOTE_THEM =
+            List.of("RepositoryLayout.java", "TheRepositorysShapeIsWorkedOutInOnePlaceTest.java");
+
     private static final List<Rederivation> REDERIVATIONS = List.of(
             new Rederivation("Path.of(\"\").toAbsolutePath()",
                     "RepositoryLayout.ofWorkingDirectory().root()"),
@@ -81,21 +85,20 @@ class TheRepositorysShapeIsWorkedOutInOnePlaceTest {
     }
 
     /**
-     * Every Java source but this module's own.
+     * Every Java source but the two that have to write these words.
      *
      * <p>{@link RepositoryLayout} works the shape out because that is what it is for, and this
-     * class quotes the derivations in order to refuse them.
+     * class quotes the derivations in order to refuse them. Named one file at a time rather than by
+     * leaving out the module they are in: the rest of this module is held to the rule like
+     * everything else.
      */
     private static List<Path> sourcesThatCouldRederive() {
-        Path mine = REPOSITORY.root().resolve("souther-test-support");
         List<Path> out = new ArrayList<>();
         for (Path tree : REPOSITORY.sourceTrees()) {
-            if (tree.startsWith(mine)) {
-                continue;
-            }
             try (Stream<Path> walk = Files.walk(tree)) {
                 walk.filter(Files::isRegularFile)
                         .filter(each -> each.getFileName().toString().endsWith(".java"))
+                        .filter(each -> !QUOTE_THEM.contains(each.getFileName().toString()))
                         .forEach(out::add);
             } catch (IOException unreadable) {
                 throw new UncheckedIOException(unreadable);

--- a/souther-test-support/src/test/java/souther/test/TheRepositorysShapeIsWorkedOutInOnePlaceTest.java
+++ b/souther-test-support/src/test/java/souther/test/TheRepositorysShapeIsWorkedOutInOnePlaceTest.java
@@ -1,0 +1,117 @@
+package souther.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.MalformedInputException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * That nobody works out the repository's shape a second time.
+ *
+ * <p>Before {@link RepositoryLayout} there were eleven answers to where the repository root is and
+ * eight to which modules it has. None of them was wrong when it was written. What they cost was
+ * that each was one more place to be one module behind, and a check whose scan is one module behind
+ * reports a pass about the modules it read and says nothing about the rest — which is the shape
+ * those checks exist to refuse.
+ *
+ * <p>Moving them here fixes the eleven that existed. This is what stops the twelfth: a tripwire on
+ * the ways the answer has actually been worked out before, and not an analysis of every way it
+ * could be. It names what it caught, so the reply to it is to ask {@link RepositoryLayout} rather
+ * than to spell the same derivation differently.
+ *
+ * <p>Deliberately not covered: a path that names one directory of another module, as four checks
+ * spell the default library. That is a source this repository holds and not the shape of the
+ * repository, so no answer here would be the one they want.
+ */
+class TheRepositorysShapeIsWorkedOutInOnePlaceTest {
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    /** A way the shape has been worked out before, and what to ask instead. */
+    private record Rederivation(String written, String instead) {}
+
+    private static final List<Rederivation> REDERIVATIONS = List.of(
+            new Rederivation("Path.of(\"\").toAbsolutePath()",
+                    "RepositoryLayout.ofWorkingDirectory().root()"),
+            new Rederivation("Files.walk(Path.of(\"..\"))",
+                    "RepositoryLayout.southerSources(), or the source trees it names"),
+            new Rederivation("Files.list(Path.of(\"..\"))",
+                    "RepositoryLayout.modules()"),
+            new Rederivation("\"<module>",
+                    "RepositoryLayout.modules()"));
+
+    @Test
+    void nobodyWorksOutWhereTheRepositoryIsForThemselves() {
+        List<String> found = new ArrayList<>();
+        for (Path source : sourcesThatCouldRederive()) {
+            String text = read(source);
+            for (Rederivation rederivation : REDERIVATIONS) {
+                if (text.contains(rederivation.written())) {
+                    found.add(REPOSITORY.root().relativize(source) + " writes "
+                            + rederivation.written() + " — ask " + rederivation.instead());
+                }
+            }
+        }
+        assertEquals(List.of(), found,
+                "the repository's shape is RepositoryLayout's answer, and a second answer is a"
+                        + " second place to be one module behind");
+    }
+
+    /**
+     * And the scan reaches the files that would say so.
+     *
+     * <p>An empty scan satisfies the check above, and the way it would come to be empty is a source
+     * tree this stopped reaching — the very thing the check is about.
+     */
+    @Test
+    void andTheScanReachesTheSourcesToSayItOf() {
+        List<Path> scanned = sourcesThatCouldRederive();
+        assertTrue(scanned.size() > 500, "only " + scanned.size() + " sources scanned");
+        assertTrue(scanned.stream().anyMatch(each -> each.toString().contains("souther-bench")),
+                "including the module whose checks are about the repository");
+    }
+
+    /**
+     * Every Java source but this module's own.
+     *
+     * <p>{@link RepositoryLayout} works the shape out because that is what it is for, and this
+     * class quotes the derivations in order to refuse them.
+     */
+    private static List<Path> sourcesThatCouldRederive() {
+        Path mine = REPOSITORY.root().resolve("souther-test-support");
+        List<Path> out = new ArrayList<>();
+        for (Path tree : REPOSITORY.sourceTrees()) {
+            if (tree.startsWith(mine)) {
+                continue;
+            }
+            try (Stream<Path> walk = Files.walk(tree)) {
+                walk.filter(Files::isRegularFile)
+                        .filter(each -> each.getFileName().toString().endsWith(".java"))
+                        .forEach(out::add);
+            } catch (IOException unreadable) {
+                throw new UncheckedIOException(unreadable);
+            }
+        }
+        out.sort(Path::compareTo);
+        return out;
+    }
+
+    private static String read(Path source) {
+        try {
+            return Files.readString(source);
+        } catch (MalformedInputException notText) {
+            return "";
+        } catch (IOException unreadable) {
+            throw new UncheckedIOException(unreadable);
+        }
+    }
+}

--- a/souther-test-support/src/test/java/souther/test/WhenGitCannotAnswerNothingIsReturnedInsteadTest.java
+++ b/souther-test-support/src/test/java/souther/test/WhenGitCannotAnswerNothingIsReturnedInsteadTest.java
@@ -1,0 +1,53 @@
+package souther.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * That {@link GitIndex} refuses when git does not answer, rather than answering for it.
+ *
+ * <p>Everything built on it holds an invariant over the files the repository owns. Without git that
+ * set is unobserved, which is not the same as its being empty — an empty list would satisfy every
+ * one of those invariants by having nothing to hold them over.
+ *
+ * <p>What has no control here is the two-minute bound on a git that never finishes. Writing one
+ * would mean a process that hangs on purpose, and the portable ways to get one are worse than the
+ * thing they would be testing. What stands in its place is the order the streams are read in: both
+ * go to files, so the wait for the process is the first thing that blocks, and there is no read of
+ * a pipe for it to be unreachable behind.
+ */
+class WhenGitCannotAnswerNothingIsReturnedInsteadTest {
+
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    @Test
+    void gitRefusingIsRefusedAndNotReadAsAnEmptyRepository() {
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> GitIndex.of(REPOSITORY, "ls-files", "--no-such-option"));
+
+        assertTrue(refused.getMessage().contains("exited"),
+                "it says git refused: " + refused.getMessage());
+        assertTrue(refused.getMessage().contains("no-such-option"),
+                "and says what git said about it: " + refused.getMessage());
+    }
+
+    /** And the reading it is the refusal of works, so the refusal is about the option. */
+    @Test
+    void andTheSameReadingWithoutItAnswers() {
+        assertEquals(GitIndex.of(REPOSITORY).trackedFiles(),
+                GitIndex.of(REPOSITORY, "ls-files", "-z", "--cached").trackedFiles());
+        assertTrue(GitIndex.of(REPOSITORY).trackedFiles().size() > 1000,
+                "this repository holds files");
+    }
+
+    /** What the ordinary reading asks for, so the control above is the same question. */
+    @Test
+    void andThatIsTheReadingTheOrdinaryOneMakes() {
+        assertEquals(List.of("ls-files", "-z", "--cached"), GitIndex.LS_FILES);
+    }
+}


### PR DESCRIPTION
Closes #1035.

`RepairingWhatTheRulesSayWritesTheCanonicalFormTest` walked the reactor root and
dropped whatever had `target` in its path. The walk descended into the module
directories, where surefire writes the `.surefire-*` record naming which fork
took which class, and writes it while the tests run. `Files.walk` reads an
entry's attributes after it has listed the parent, so an entry removed between
the two ends the walk — and a filter downstream of the walk is downstream of the
attributes too. About one full build in seven failed there, on branches touching
nothing under `souther-fmt/`.

The issue asks that the walk take what a source root is rather than subtract
what a build output is. Following that through, the walk was not the only place
that had worked out the shape of this repository for itself. Eleven checks
derived the repository root, eight of them went on to find the modules by
listing it, and two more walked the reactor root the same way this one did.

## What is here

`souther-test-support` holds the two answers once. `RepositoryLayout` reads the
modules from the root pom, which is what the reactor reads, and says where
sources are: a source tree is `<module>/src` and that is the whole of what a
walk descends into. `target/` and `.surefire-*` are siblings of `src` rather
than children of it, so nothing subtracts them and no walk can reach them. There
is no list of what a build writes to keep one name behind, and no walk that can
race with the build writing it.

`GitIndex` answers the other question — what the repository owns — for the check
that sweeps the repository's prose rather than its sources. `.gitignore` is
where this repository already declares what a build writes, and it is already
right about `.surefire-*`.

Stating where to look costs what subtracting does not: a source put somewhere
else is not looked at, and nothing about the sweep would say so. One check holds
the one direction that matters — every `.sou` git holds lies under some module's
`src`. Not the other direction, which would be false while somebody is writing a
file they have not added yet.

A last check refuses the shapes the answer has been worked out in before, so
that moving the eleven is not undone by a twelfth.

## What this is not

It is not a formatter speed-up. The five reactor-root walks came to about 425ms
of a 25.9s formatter suite.

Nor, measured, is the citation sweep. Reading tracked files rather than walking
the working tree drops 18,209 entries stated and 10 files read, and over four
interleaved rounds it made no difference to the wall time: ~2.1s either way. The
walk was never what that check spent its time on — it spends it reading and
matching the 2,231 files it still reads. The change stands on what the sweep is
defined as, not on what it costs.

## Left alone

Four checks spell the default library as a path into another module. That is a
source this repository holds rather than the shape of the repository, so nothing
`RepositoryLayout` answers is what they want; the tripwire says so and does not
cover them.

`souther-test-support` is not published: it is infrastructure for checking this
repository, not an API anyone outside it writes against.

## Testing

`mvn -o test` from the reactor root: 10,030 tests, BUILD SUCCESS.

Both new checks were held against their negative controls — a tracked
`docs/tour/hello.sou` fails the placement check by name and an untracked one
does not, and a re-derived repository root fails the tripwire by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)