### PR TITLE
Write a row for an arm the way a row for a class is written

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/partition/CellSelection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/CellSelection.java
@@ -57,6 +57,58 @@ public record CellSelection(InteractionCells.Cell cell, List<ControlClaim> claim
     }
 
     /**
+     * The readings of this combination a search may look for a row at, at most {@code most} of them.
+     *
+     * <p>What this asks of a row and nothing else: a class apiece at the positions it is about, and
+     * nothing said about the rest. Which positions those are, and how many readings the combination
+     * has, is answered here — a caller that worked it out from the classes each position admits
+     * would be reading this value's own shape, and would have to be rewritten the day a combination
+     * can say something about two positions together that it says about neither alone.
+     *
+     * <p>The first is every position at the first class it admits, and the rest are counted off from
+     * it in a fixed order, so one model offers the same rows twice.
+     *
+     * <p>None where a position this is about admits no class at all, which is not a reading that
+     * failed but a combination the model does not have.
+     */
+    public List<Interpretation> interpretations(int most) {
+        List<Integer> about = new java.util.ArrayList<>();
+        List<List<Integer>> admitted = new java.util.ArrayList<>();
+        for (int i = 0; i < cell.allowed().length; i++) {
+            if (!cell.narrows(i)) {
+                continue;
+            }
+            List<Integer> here = new java.util.ArrayList<>();
+            for (int c = 0; c < cell.allowed()[i].length; c++) {
+                if (cell.admits(i, c)) {
+                    here.add(c);
+                }
+            }
+            if (here.isEmpty()) {
+                return List.of();
+            }
+            about.add(i);
+            admitted.add(here);
+        }
+        List<Interpretation> out = new java.util.ArrayList<>();
+        for (int index = 0; index < most; index++) {
+            java.util.Map<Integer, Integer> pins = new java.util.LinkedHashMap<>();
+            int left = index;
+            for (int p = 0; p < about.size(); p++) {
+                List<Integer> here = admitted.get(p);
+                pins.put(about.get(p), here.get(left % here.size()));
+                left /= here.size();
+            }
+            Interpretation reading = new Interpretation(pins);
+            if (out.contains(reading)) {
+                break;   // the readings ran out before the bound did
+            }
+            out.add(reading);
+        }
+        return List.copyOf(out);
+    }
+
+    /**
      * Whether this asks for the same row as {@code other}: the same classes, held to the same run.
      *
      * <p>Asked rather than left to equality. A cell is a flag per class of each position, which is

--- a/souther-compiler/src/main/java/souther/compiler/partition/CellSelection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/CellSelection.java
@@ -57,21 +57,27 @@ public record CellSelection(InteractionCells.Cell cell, List<ControlClaim> claim
     }
 
     /**
-     * The readings of this combination a search may look for a row at, at most {@code most} of them.
+     * The readings of this combination a search may look for a row at, one at a time.
      *
      * <p>What this asks of a row and nothing else: a class apiece at the positions it is about, and
-     * nothing said about the rest. Which positions those are, and how many readings the combination
-     * has, is answered here — a caller that worked it out from the classes each position admits
-     * would be reading this value's own shape, and would have to be rewritten the day a combination
-     * can say something about two positions together that it says about neither alone.
+     * nothing said about the rest. Which positions those are, and what the readings of the
+     * combination are, is answered here — a caller that worked it out from the classes each position
+     * admits would be reading this value's own shape, and would have to be rewritten the day a
+     * combination can say something about two positions together that it says about neither alone.
      *
      * <p>The first is every position at the first class it admits, and the rest are counted off from
      * it in a fixed order, so one model offers the same rows twice.
      *
-     * <p>None where a position this is about admits no class at all, which is not a reading that
-     * failed but a combination the model does not have.
+     * <p><b>No bound here.</b> How many readings a search may look at is a fact about that search,
+     * and which of these are readings at all is the model's answer rather than this value's: a class
+     * apiece that no one value can hold is a combination of names and not a reading. Counted off
+     * here, the bound was spent on those before anything asked, and a combination whose first few
+     * names cannot be in one value went unanswered with its readings untried.
+     *
+     * <p>None handed over where a position this is about admits no class at all, which is not a
+     * reading that failed but a combination the model does not have.
      */
-    public List<Interpretation> interpretations(int most) {
+    public Traversal interpretations(Taking<Interpretation> taking) {
         List<Integer> about = new java.util.ArrayList<>();
         List<List<Integer>> admitted = new java.util.ArrayList<>();
         for (int i = 0; i < cell.allowed().length; i++) {
@@ -85,27 +91,28 @@ public record CellSelection(InteractionCells.Cell cell, List<ControlClaim> claim
                 }
             }
             if (here.isEmpty()) {
-                return List.of();
+                return Traversal.EXHAUSTED;
             }
             about.add(i);
             admitted.add(here);
         }
-        List<Interpretation> out = new java.util.ArrayList<>();
-        for (int index = 0; index < most; index++) {
+        long many = 1;
+        for (List<Integer> here : admitted) {
+            many *= here.size();
+        }
+        for (long index = 0; index < many; index++) {
             java.util.Map<Integer, Integer> pins = new java.util.LinkedHashMap<>();
-            int left = index;
+            long left = index;
             for (int p = 0; p < about.size(); p++) {
                 List<Integer> here = admitted.get(p);
-                pins.put(about.get(p), here.get(left % here.size()));
+                pins.put(about.get(p), here.get((int) (left % here.size())));
                 left /= here.size();
             }
-            Interpretation reading = new Interpretation(pins);
-            if (out.contains(reading)) {
-                break;   // the readings ran out before the bound did
+            if (!taking.take(new Interpretation(pins))) {
+                return Traversal.STOPPED;
             }
-            out.add(reading);
         }
-        return List.copyOf(out);
+        return Traversal.EXHAUSTED;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/CellSelection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/CellSelection.java
@@ -96,23 +96,39 @@ public record CellSelection(InteractionCells.Cell cell, List<ControlClaim> claim
             about.add(i);
             admitted.add(here);
         }
-        long many = 1;
-        for (List<Integer> here : admitted) {
-            many *= here.size();
-        }
-        for (long index = 0; index < many; index++) {
+        // Counted up one position at a time, and never counted out. How many readings there are is
+        // a number nobody here needs — a caller takes three of them and stops — and asking for it
+        // put the whole space inside a machine word: sixty-three positions of two classes apiece
+        // overflow it, and a walk that read the total back as a negative one handed nothing over and
+        // said it had run out.
+        int[] standing = new int[about.size()];
+        while (true) {
             java.util.Map<Integer, Integer> pins = new java.util.LinkedHashMap<>();
-            long left = index;
             for (int p = 0; p < about.size(); p++) {
-                List<Integer> here = admitted.get(p);
-                pins.put(about.get(p), here.get((int) (left % here.size())));
-                left /= here.size();
+                pins.put(about.get(p), admitted.get(p).get(standing[p]));
             }
-            if (!taking.take(new Interpretation(pins))) {
-                return Traversal.STOPPED;
+            switch (taking.take(new Interpretation(pins))) {
+                case NOT_TAKEN -> {
+                    return Traversal.STOPPED;
+                }
+                case AND_DONE -> {
+                    return Traversal.SATISFIED;
+                }
+                case AND_MORE -> { }
+            }
+            int carry = 0;
+            while (carry < about.size()) {
+                standing[carry]++;
+                if (standing[carry] < admitted.get(carry).size()) {
+                    break;
+                }
+                standing[carry] = 0;
+                carry++;
+            }
+            if (carry == about.size()) {
+                return Traversal.EXHAUSTED;   // the last position came back round to its first
             }
         }
-        return Traversal.EXHAUSTED;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Completeness.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Completeness.java
@@ -1,0 +1,64 @@
+package souther.compiler.partition;
+
+/**
+ * Whether a search that came back with nothing had looked everywhere.
+ *
+ * <p>Two facts about the search and none about the model, added up as its readings answer: whether
+ * there was a reading to search at all, and whether a bound stopped one of them with candidates it
+ * had not tried. What may be said when nothing was found follows from those two, and follows here
+ * rather than at each place a search gives up.
+ *
+ * <p>Read off a flag at the end of one loop, "every candidate was refused" and "this stopped
+ * looking" came out as the same sentence. They are different news: the first sends a person to
+ * change a rule, and the second sends them to widen a search over a row they can already write.
+ *
+ * <p><b>Not a reason a search failed.</b> Why the candidates that were tried did not answer is what
+ * each of them came to; this is whether the ones that were not tried exist. A search that was
+ * stopped is incomplete whatever the tried ones came to, which is why the bound outranks them.
+ *
+ * @param anyReading  whether what was asked for had a reading a row could be looked for at
+ * @param anyCutShort whether a bound stopped one of those readings before its candidates ran out
+ */
+public record Completeness(boolean anyReading, boolean anyCutShort) {
+
+    /** Before any reading has been searched. */
+    public static final Completeness NOTHING_YET = new Completeness(false, false);
+
+    /** With one more reading searched until its candidates ran out. */
+    public Completeness searched() {
+        return new Completeness(true, anyCutShort);
+    }
+
+    /** With one more reading a bound stopped. */
+    public Completeness cutShort() {
+        return new Completeness(true, true);
+    }
+
+    /**
+     * What a search that found nothing may say it found nothing of.
+     *
+     * <p>The order between them is the whole of this. A bound that stopped one reading is a fact
+     * about the search whatever the other readings came to, so it outranks their having been
+     * searched to the end; and something with no reading at all was never searched, so it outranks
+     * both.
+     */
+    public Nothing found() {
+        if (!anyReading) {
+            return Nothing.NO_READING;
+        }
+        return anyCutShort ? Nothing.SEARCH_STOPPED : Nothing.LOOKED_EVERYWHERE;
+    }
+
+    /** Which of the three ways a search comes back with nothing this was. */
+    public enum Nothing {
+
+        /** Nothing to look for: what was asked for has no reading a row could sit in. */
+        NO_READING,
+
+        /** A bound stopped the search with candidates it had not tried. */
+        SEARCH_STOPPED,
+
+        /** Every candidate of every reading was tried, and none of them answered. */
+        LOOKED_EVERYWHERE
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Delta.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Delta.java
@@ -24,11 +24,17 @@ public Delta {
         at = List.copyOf(at);
     }
 
-    /** Where {@code where} does not stand where {@code stands} does. */
+    /**
+     * Where {@code where} does not stand where {@code stands} does.
+     *
+     * <p>Both say where every position of one row is, so both are as long as there are positions.
+     * Asked of one and read off the other, a pair that disagreed about how many positions there are
+     * would come back as a distance rather than as the fault it is.
+     */
 public static Delta between(int[] stands, int[] where) {
         List<Integer> out = new ArrayList<>();
         for (int i = 0; i < where.length; i++) {
-            if (i >= stands.length || where[i] != stands[i]) {
+            if (where[i] != stands[i]) {
                 out.add(i);
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Delta.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Delta.java
@@ -1,0 +1,48 @@
+package souther.compiler.partition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Where a row does not stand where its origin does.
+ *
+ * <p>One difference and two readers. How far a row is from what a reader recognises is the size
+ * of this, and which fields a spread writes over is this projected onto the parameters — so the
+ * order the search walks in and the row it writes come off one value. Counted two ways they
+ * were free to disagree, and two positions under one parameter are two differences and one
+ * field either way.
+ *
+ * <p>Read off the assignment and never off what the search reached for. A supporting position
+ * the row stands at no class of is one no assignment moves, and counted as moved it put a row
+ * one difference from its origin behind rows two away.
+ *
+ * @param at the positions, in the axes' own order
+ */
+public record Delta(List<Integer> at) {
+
+public Delta {
+        at = List.copyOf(at);
+    }
+
+    /** Where {@code where} does not stand where {@code stands} does. */
+public static Delta between(int[] stands, int[] where) {
+        List<Integer> out = new ArrayList<>();
+        for (int i = 0; i < where.length; i++) {
+            if (i >= stands.length || where[i] != stands[i]) {
+                out.add(i);
+            }
+        }
+        return new Delta(out);
+    }
+
+    /** How far the row is from its origin. */
+public int size() {
+        return at.size();
+    }
+
+    /** Which of these positions are under {@code parameter}, which is what a spread over that
+     *  parameter writes over. */
+public List<Integer> under(List<Axis> axes, String parameter) {
+        return at.stream().filter(i -> axes.get(i).path().head().equals(parameter)).toList();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -959,6 +959,11 @@ public final class Generator {
             }
         }
 
+        // The values a row can be written against, resolved once for the behavior. Read per class,
+        // this was the same walk through the decoders for every class owed, for an answer that is a
+        // fact about the module rather than about the class asking.
+        List<ResolvedOrigin> origins = resolve(subject, axes, baselines, check);
+
         List<GeneratedRow> rows = new ArrayList<>();
         List<ClassAttempt> attempts = new ArrayList<>();
         List<ArmAttempt> arms = new ArrayList<>();
@@ -989,7 +994,7 @@ public final class Generator {
                 }
                 break;
             }
-            ClassAttempt attempt = rowFor(subject, axes, at[0], at[1], baselines, check);
+            ClassAttempt attempt = rowFor(subject, axes, at[0], at[1], origins, check);
             attempts.add(attempt);
             switch (attempt) {
                 case ClassAttempt.Built made -> rows.add(made.row());
@@ -1404,7 +1409,7 @@ public final class Generator {
      * ({@link Purpose.ForAClass}).
      */
     private static ClassAttempt rowFor(Subject subject, List<Axis> axes, int at, int cls,
-                                       List<Baseline> baselines, CandidateCheck check) {
+                                       List<ResolvedOrigin> origins, CandidateCheck check) {
         Axis axis = axes.get(at);
         String classId = axis.classes().get(cls).id();
         String label = label(axis, cls);
@@ -1414,12 +1419,12 @@ public final class Generator {
         // row of every behavior taking it — a change somewhere else in the file, answering a
         // question nobody asked it. What order they are walked in is
         // {@link #nearestFirst}'s to say.
-        Perturbations walk = nearestFirst(subject, axes, at, cls, baselines, check);
+        Perturbations walk = nearestFirst(axes, at, cls, origins);
         for (Candidate candidate : walk.candidates()) {
-            Map<String, FixtureTemplate> given = candidate.from().isEmpty() ? Map.of()
-                    : against(subject, axes, candidate.stands(), at, candidate.where(),
-                            candidate.from());
-            if (!candidate.from().isEmpty() && given.isEmpty()) {
+            Map<String, FixtureTemplate> given = candidate.from().composes() ? Map.of()
+                    : against(subject, axes, candidate.delta(), candidate.where(),
+                            candidate.from().baseline());
+            if (!candidate.from().composes() && given.isEmpty()) {
                 continue;   // nothing here can be written against the model's value
             }
             Attempt made = build(subject, axes, candidate.where(), check, given);
@@ -1449,15 +1454,95 @@ public final class Generator {
     }
 
     /**
+     * A value the module states, with where its own values already sit read off once.
+     *
+     * <p>Read once for the generation and never once per class. Where a baseline's values fall is a
+     * fact about the module, and asking it again for every class owed is the same walk through the
+     * decoders for the same answer.
+     *
+     * <p><b>Two origins standing alike are still two origins.</b> Where a row's values sit is what
+     * orders this search; what those values are is what the model builds and what a rule relating
+     * two of them accepts. So the same classes reached from two values of the module are two
+     * candidates and not one, and a search that dropped the second answered a class it could have
+     * written a row for.
+     *
+     * @param baseline what the module states, or a baseline naming nothing where the row is
+     *                 composed from the classes
+     * @param stands   where {@code baseline}'s own values already sit, which is what a move is
+     *                 measured against and what a spread writes over
+     * @param index    where this came in the order the origins were gathered, which is what orders
+     *                 two origins one distance away
+     */
+    private record ResolvedOrigin(Baseline baseline, int[] stands, int index) {
+
+        /** Whether this is the composition rather than a value the module states. */
+        boolean composes() {
+            return baseline.isEmpty();
+        }
+
+        /** Whether this states a value of {@code parameter}, which is the position a row is about
+         *  being one the origin says something of. */
+        boolean grounds(String parameter) {
+            return baseline.at().containsKey(parameter);
+        }
+    }
+
+    /**
+     * Where a row does not stand where its origin does.
+     *
+     * <p>One difference and two readers. How far a row is from what a reader recognises is the size
+     * of this, and which fields a spread writes over is this projected onto the parameters — so the
+     * order the search walks in and the row it writes come off one value. Counted two ways they
+     * were free to disagree, and two positions under one parameter are two differences and one
+     * field either way.
+     *
+     * <p>Read off the assignment and never off what the search reached for. A supporting position
+     * the row stands at no class of is one no assignment moves, and counted as moved it put a row
+     * one difference from its origin behind rows two away.
+     *
+     * @param at the positions, in the axes' own order
+     */
+    private record Delta(List<Integer> at) {
+
+        Delta {
+            at = List.copyOf(at);
+        }
+
+        /** Where {@code where} does not stand where {@code stands} does. */
+        static Delta between(int[] stands, int[] where) {
+            List<Integer> out = new ArrayList<>();
+            for (int i = 0; i < where.length; i++) {
+                if (i >= stands.length || where[i] != stands[i]) {
+                    out.add(i);
+                }
+            }
+            return new Delta(out);
+        }
+
+        /** How far the row is from its origin. */
+        int size() {
+            return at.size();
+        }
+
+        /** Which of these positions are under {@code parameter}, which is what a spread over that
+         *  parameter writes over. */
+        List<Integer> under(List<Axis> axes, String parameter) {
+            return at.stream().filter(i -> axes.get(i).path().head().equals(parameter)).toList();
+        }
+    }
+
+    /**
      * One assignment to try, and the origin it is a move away from.
      *
-     * @param from   the value the model states that this row is written against, or a baseline
-     *               naming nothing where the row is composed from the classes
-     * @param stands where {@code from}'s own values already sit, which is what the move is measured
-     *               against and what a spread writes over
-     * @param where  the classes this assignment puts every position at
+     * <p>The distance is a fact about the pair and travels with it. Worked out again where the row
+     * is written, the order the search went in and the row that came out of it were two readings of
+     * one thing.
+     *
+     * @param from  the origin this row is written against
+     * @param where the classes this assignment puts every position at
+     * @param delta where {@code where} does not stand where {@code from} does
      */
-    private record Candidate(Baseline from, int[] stands, int[] where) {}
+    private record Candidate(ResolvedOrigin from, int[] where, Delta delta) {}
 
     /**
      * The assignments a class was given to try, and whether they are all of them.
@@ -1508,65 +1593,109 @@ public final class Generator {
      * construction and says nothing about how far the row is from what a reader recognises. Put in
      * the same order, a row composed from the classes won against every baseline that needed one
      * supporting field — which is the objective read backwards.
+     *
+     * <p><b>Last, and reached whatever the baselines spent.</b> Behind the baselines' budget, a
+     * class the model can hold a row for came back saying the search had stopped, over a
+     * composition that would have built. The composition is not one of the values the model states
+     * and is not competing with them for their budget: it is what a row is when none of them can be
+     * written for it, so it has a budget of its own.
      */
-    private static Perturbations nearestFirst(Subject subject, List<Axis> axes, int at, int cls,
-                                              List<Baseline> baselines, CandidateCheck check) {
+    private static Perturbations nearestFirst(List<Axis> axes, int at, int cls,
+                                              List<ResolvedOrigin> origins) {
         List<Candidate> out = new ArrayList<>();
-        List<Baseline> stated = new ArrayList<>(baselines);
-        List<int[]> stand = new ArrayList<>();
-        for (Baseline baseline : stated) {
-            stand.add(stands(subject, axes, baseline, check));
-        }
-        // Set where an assignment was there to be taken and the budget was already full, which is
-        // the one place the two can be told apart. Read off the length instead, a list that filled
-        // the budget exactly and a space that had nothing more are the same list.
         boolean cutShort = false;
         // The position the row is about, which is what an origin either states a value of or does
         // not. Both kinds are walked and the grounding ones whole, at every distance, before any of
         // the others.
         String about = axes.get(at).path().head();
-        walk:
         for (boolean grounding : new boolean[] {true, false}) {
-            for (int moved = 0; moved < axes.size(); moved++) {
-                for (int origin = 0; origin < stated.size(); origin++) {
-                    if (stand.get(origin) == null) {
-                        continue;   // nothing built this origin's values, so nothing measures it
-                    }
-                    if (stated.get(origin).at().containsKey(about) != grounding) {
-                        continue;
-                    }
-                    for (int[] supporting : supportingSets(axes, at, moved)) {
-                        for (int[] where
-                                : assignmentsOver(axes, stand.get(origin), at, cls, supporting)) {
-                            if (out.size() >= MOST_REPAIRS) {
-                                cutShort = true;
-                                break walk;
-                            }
-                            out.add(new Candidate(stated.get(origin), stand.get(origin), where));
-                        }
-                    }
+            List<ResolvedOrigin> stated = new ArrayList<>();
+            for (ResolvedOrigin origin : origins) {
+                if (!origin.composes() && origin.grounds(about) == grounding) {
+                    stated.add(origin);
                 }
             }
+            cutShort |= gather(axes, at, cls, stated, out, MOST_REPAIRS);
         }
-        Baseline classes = new Baseline(Map.of());
-        int[] composed = composes(axes);
-        // Reached only where the baselines left room. A composition that builds sits behind a
-        // budget the baselines spent, and a caller told the baselines were all refused would go
-        // looking for a value the model cannot hold — so the fact that this was never reached is
-        // what {@code cutShort} carries.
-        composing:
-        for (int moved = 0; !cutShort && moved < axes.size(); moved++) {
-            for (int[] supporting : supportingSets(axes, at, moved)) {
-                for (int[] where : assignmentsOver(axes, composed, at, cls, supporting)) {
-                    if (out.size() >= MOST_REPAIRS) {
-                        cutShort = true;
-                        break composing;
-                    }
-                    out.add(new Candidate(classes, composed, where));
-                }
+        for (ResolvedOrigin origin : origins) {
+            if (origin.composes()) {
+                cutShort |= gather(axes, at, cls, List.of(origin), out, out.size() + MOST_REPAIRS);
             }
         }
         return new Perturbations(out, cutShort);
+    }
+
+    /**
+     * Every assignment these origins offer for one class, nearest first, onto the end of
+     * {@code out}.
+     *
+     * <p>Walked by the size of the supporting set and handed out by the distance the assignment
+     * came to, which are two numbers and not one. A set of {@code k} positions moves {@code k} of
+     * them; the pin may move more, where a class of the position the row is about cannot stand
+     * beside where the origin's own value does. So an assignment is never nearer than the set that
+     * produced it, and everything at one distance has been produced by the time the walk finishes
+     * the sets of that size — which is what lets this hand them out in distance order without
+     * holding the whole space to sort it.
+     *
+     * @param cut how large {@code out} may grow before this stops, which is a bound on the search
+     *            and not on the space
+     * @return whether the bound stopped this before the assignments ran out
+     */
+    private static boolean gather(List<Axis> axes, int at, int cls, List<ResolvedOrigin> origins,
+                                  List<Candidate> out, int cut) {
+        // Produced further away than the set that produced them, kept until the walk reaches that
+        // distance rather than handed out early.
+        Map<Integer, List<Candidate>> waiting = new LinkedHashMap<>();
+        for (int moved = 0; moved <= axes.size(); moved++) {
+            for (ResolvedOrigin origin : origins) {
+                // The class the row is about settled first, and the origin's own classes kept at
+                // every position that can keep them beside it.
+                int[] base = standing(axes, wanting(axes, origin.stands(), at, cls),
+                        new int[] {at});
+                if (base == null) {
+                    continue;   // a class that cannot stand at its own position is no assignment
+                }
+                for (int[] supporting : supportingSets(axes, at, moved, base)) {
+                    for (int[] where : assignmentsOver(axes, base, supporting)) {
+                        Candidate candidate = new Candidate(origin, where,
+                                Delta.between(origin.stands(), where));
+                        waiting.computeIfAbsent(candidate.delta().size(), _ -> new ArrayList<>())
+                                .add(candidate);
+                    }
+                }
+            }
+            // Everything this far and nearer. Asked of every distance up to this one rather than of
+            // this one alone: what is due is a fact about the distances, and a walk that read it off
+            // the size of the set it had just finished would leave a nearer assignment sitting in
+            // the map for as long as the set that produced it was larger than it.
+            for (int distance : new java.util.TreeSet<>(waiting.keySet())) {
+                if (distance > moved) {
+                    break;
+                }
+                // The origins in the order they were gathered, within the one distance. Sorted
+                // rather than generated that way, because an assignment reaches one distance from
+                // more than one size of supporting set.
+                List<Candidate> due = waiting.remove(distance);
+                due.sort(java.util.Comparator.comparingInt(candidate -> candidate.from().index()));
+                for (Candidate candidate : due) {
+                    if (out.size() >= cut) {
+                        return true;
+                    }
+                    out.add(candidate);
+                }
+            }
+        }
+        // What the pin moved beyond the largest set walked. Nothing generates at this distance any
+        // more, so it is handed out in order rather than dropped.
+        for (int distance : new java.util.TreeSet<>(waiting.keySet())) {
+            for (Candidate candidate : waiting.get(distance)) {
+                if (out.size() >= cut) {
+                    return true;
+                }
+                out.add(candidate);
+            }
+        }
+        return false;
     }
 
     /**
@@ -1574,45 +1703,51 @@ public final class Generator {
      *
      * <p>In the axes' own order and combinations of it, so two runs of one model walk the same
      * assignments in the same order and offer the same rows.
+     *
+     * <p><b>Only the positions the row stands somewhere at.</b> A position at no class of this row
+     * is one no assignment over it moves, so a set that names it moves fewer positions than it has
+     * members — and the walk over the sets is what tells the search how far a candidate is. Left in,
+     * a row one position from its origin was offered behind rows two away, and the number the budget
+     * was spent by counted what the search reached for rather than what it moved.
      */
-    private static List<int[]> supportingSets(List<Axis> axes, int at, int moved) {
+    private static List<int[]> supportingSets(List<Axis> axes, int at, int moved, int[] base) {
+        if (moved > axes.size()) {
+            return List.of();
+        }
         List<int[]> out = new ArrayList<>();
-        chooseSupporting(axes, at, moved, 0, new int[moved], 0, out);
+        chooseSupporting(axes, at, moved, 0, new int[moved], 0, out, base);
         return out;
     }
 
     private static void chooseSupporting(List<Axis> axes, int at, int moved, int from,
-                                         int[] taken, int filled, List<int[]> out) {
+                                         int[] taken, int filled, List<int[]> out, int[] base) {
         if (filled == moved) {
             out.add(taken.clone());
             return;
         }
         for (int i = from; i < axes.size(); i++) {
-            if (i == at) {
+            if (i == at || base[i] == NOT_HERE) {
                 continue;
             }
             taken[filled] = i;
-            chooseSupporting(axes, at, moved, i + 1, taken, filled + 1, out);
+            chooseSupporting(axes, at, moved, i + 1, taken, filled + 1, out, base);
         }
     }
 
     /**
-     * Every assignment that pins {@code at} to {@code cls} and moves the positions in
-     * {@code supporting}, each of the rest standing where a position a row is not about stands.
+     * Every assignment over {@code base} that moves the positions in {@code supporting}, each of the
+     * rest standing where {@code base} puts it.
      *
-     * <p>The supporting positions take each of their classes in turn, the first of them being where
-     * they would have stood anyway — so the first assignment of every set is the one that moves
-     * nothing beside the target, and a set larger than it is only reached once the smaller ones are
-     * spent.
+     * <p>The supporting positions take each of their classes in turn, and never the one they already
+     * stood at — so a set of {@code k} positions moves {@code k} of them, and the assignment that
+     * moves fewer is the one a smaller set already produced.
      */
-    private static List<int[]> assignmentsOver(List<Axis> axes, int[] from, int at, int cls,
-                                               int[] supporting) {
+    private static List<int[]> assignmentsOver(List<Axis> axes, int[] base, int[] supporting) {
         List<int[]> out = new ArrayList<>();
-        // What the row is about first, and the origin's own classes kept wherever they can be kept
-        // beside it. Cloned outright, a row about a class under one case of a sum would carry the
-        // classes of the positions under another, which is a row that has to be two things at once.
-        walkSupporting(axes, standing(axes, wanting(axes, from, at, cls), new int[] {at}),
-                supporting, 0, out);
+        // Cloned, because the walk settles the supporting positions in place and puts back what it
+        // found. A row about a class under one case of a sum would otherwise carry the classes of
+        // the positions under another, which is a row that has to be two things at once.
+        walkSupporting(axes, base.clone(), supporting, 0, out);
         return out;
     }
 
@@ -1662,6 +1797,34 @@ public final class Generator {
             }
         }
         return out;
+    }
+
+    /**
+     * The origins this generation has, in the order the search tries them.
+     *
+     * <p>Resolved once for the behavior. Where a baseline's own values sit is read through the same
+     * check every candidate goes through, and asking it again for each class owed is that walk done
+     * once per class for an answer that does not change with the class.
+     *
+     * <p>An origin nothing built is left out here, once. A distance measured from a baseline nothing
+     * looked at would be measured from a guess.
+     *
+     * <p>The composition last, and always there. It is not one of the values the model states —
+     * where it stands is where the classes put it, which the search itself named — so it is not
+     * ordered among them; and it is not a baseline that failed, so nothing the baselines spend takes
+     * it away.
+     */
+    private static List<ResolvedOrigin> resolve(Subject subject, List<Axis> axes,
+                                                List<Baseline> baselines, CandidateCheck check) {
+        List<ResolvedOrigin> out = new ArrayList<>();
+        for (Baseline baseline : baselines) {
+            int[] stands = stands(subject, axes, baseline, check);
+            if (stands != null) {
+                out.add(new ResolvedOrigin(baseline, stands, out.size()));
+            }
+        }
+        out.add(new ResolvedOrigin(new Baseline(Map.of()), composes(axes), out.size()));
+        return List.copyOf(out);
     }
 
     /** Whether {@code axis} is one of the positions an assignment is about. */
@@ -1746,6 +1909,13 @@ public final class Generator {
      * — the difference between it and what the model already says is what the row is for, and
      * everything else standing where the model puts it is what makes that readable (issue #967).
      *
+     * <p><b>Which fields those are is {@link Delta}'s to say and is not worked out again here.</b>
+     * How far a row is from its origin is what the search ordered itself by, and which fields a
+     * spread writes over is that same difference projected onto the parameters. Counted a second
+     * time here, the two were free to disagree: the position the row is about was written out even
+     * where the origin already stood in that class, so a row that is the model's own value came out
+     * as that value with a field set to what it already held.
+     *
      * <p>What a baseline cannot be written for is kept as it was composed, and silently: this is
      * how a row is written and not whether one could be. A position the baseline reaches through
      * more than one field, a class with no value to put there, a value the model refuses beside the
@@ -1753,7 +1923,7 @@ public final class Generator {
      * row that says the same thing in more words.
      */
     private static Map<String, FixtureTemplate> against(Subject subject, List<Axis> axes,
-                                                        int[] from, int target, int[] where,
+                                                        Delta delta, int[] where,
                                                         Baseline baseline) {
         Map<String, FixtureTemplate> out = new LinkedHashMap<>();
         for (int p = 0; p < subject.parameters().size() && p < subject.types().size(); p++) {
@@ -1763,9 +1933,9 @@ public final class Generator {
                 continue;
             }
             FixtureTemplate named = FixtureTemplate.named(at.module(), at.name());
-            FixtureTemplate written = movedUnder(axes, from, parameter, target, where).isEmpty()
-                    ? named
-                    : withFieldsMoved(subject, p, axes, from, parameter, target, where, named);
+            List<Integer> moved = delta.under(axes, parameter);
+            FixtureTemplate written = moved.isEmpty() ? named
+                    : withFieldsMoved(subject, p, axes, moved, where, named);
             // Left out where the baseline cannot be written for this assignment, which leaves that
             // parameter to be composed from its classes. How a row is written never decides
             // whether the model allows it — the check below asks that of every parameter alike.
@@ -1776,46 +1946,36 @@ public final class Generator {
         return Map.copyOf(out);
     }
 
-    /** Which axes this assignment moves under {@code parameter}: the one the row is about, and any
-     *  the search moved beside it to make the row buildable. */
-    private static List<Integer> movedUnder(List<Axis> axes, int[] from, String parameter,
-                                            int target, int[] where) {
-        List<Integer> moved = new ArrayList<>();
-        for (int i = 0; i < axes.size(); i++) {
-            if (!axes.get(i).path().head().equals(parameter)) {
-                continue;
-            }
-            // Moved against where the baseline's own value stands, which is what the spread writes
-            // over. Measured against a composition, a field the baseline already holds the right
-            // value in was written out again for no reason, and one it did not was left unwritten.
-            if (i == target || where[i] != from[i]) {
-                moved.add(i);
-            }
-        }
-        return moved;
-    }
-
     /**
-     * The baseline with the fields this assignment moves under {@code parameter} set to values of
-     * the classes it moves them to, or null where this cannot be written.
+     * The baseline with the fields this assignment moves under one parameter set to values of the
+     * classes it moves them to, or null where this cannot be written.
      *
      * <p>Each field reached in one step. A position further down is a record inside a record, and
      * writing it means spreading the value at every step on the way — which is a row that names
      * values this has not been asked whether it can name. Such a parameter keeps what the classes
      * composed for it, which says the same thing and says it in full.
+     *
+     * @param moved which axes under this parameter the row does not stand where the origin does,
+     *              read off the one difference the search ordered itself by
      */
     private static FixtureTemplate withFieldsMoved(Subject subject, int p, List<Axis> axes,
-                                                   int[] from, String parameter, int target,
-                                                   int[] where, FixtureTemplate baseline) {
+                                                   List<Integer> moved, int[] where,
+                                                   FixtureTemplate baseline) {
         if (!(subject.types().get(p) instanceof Type.Ref(TypeSymbol built))
                 || !(subject.symbols().scope().reach(built) instanceof TypeReachName.Written type)) {
             return null;
         }
-        Map<String, FixtureTemplate> moved = new LinkedHashMap<>();
-        for (int i : movedUnder(axes, from, parameter, target, where)) {
+        Map<String, FixtureTemplate> fields = new LinkedHashMap<>();
+        for (int i : moved) {
             Axis axis = axes.get(i);
             if (axis.path().steps().size() != 1
                     || !(axis.path().steps().get(0) instanceof TermPath.Step.Field field)) {
+                return null;
+            }
+            // A position the row stands at no class of. It differs from where the origin stands and
+            // there is no class to take a value from, so this parameter is one the baseline cannot
+            // be written for.
+            if (where[i] == NOT_HERE) {
                 return null;
             }
             // The class's own values, and only those: a class composed through a constructor is a
@@ -1825,9 +1985,9 @@ public final class Generator {
                     instanceof RepresentativeSource.Evaluation.Values values)) {
                 return null;
             }
-            moved.put(field.name(), values.written().get(0));
+            fields.put(field.name(), values.written().get(0));
         }
-        return moved.isEmpty() ? null : FixtureTemplate.spreading(type, baseline, moved);
+        return fields.isEmpty() ? null : FixtureTemplate.spreading(type, baseline, fields);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -1069,7 +1069,7 @@ public final class Generator {
                 }
                 if (place.tried == null) {
                     place.tried = witnessFor(subject, axes, place.at, check, trial, ran,
-                            List.of(probe));
+                            List.of(probe), origins);
                 }
                 // Each of the three, one at a time, so that a fourth added later has to be decided
                 // about here rather than fall in with whichever of these a cast happened to take.
@@ -1462,7 +1462,11 @@ public final class Generator {
         // row of every behavior taking it — a change somewhere else in the file, answering a
         // question nobody asked it. What order they are walked in is
         // {@link #nearestFirst}'s to say.
-        Perturbations walk = nearestFirst(axes, at, cls, origins);
+        // A class is a demand over one position: it asks for that class there and says nothing
+        // about anywhere else, which is what every other position being free means. Written as a
+        // reading, it goes through the same walk a combination's readings do.
+        Perturbations walk = nearestFirst(axes, new Interpretation(Map.of(at, cls)), origins,
+                (_, _) -> true);
         for (Candidate candidate : walk.candidates()) {
             Map<String, FixtureTemplate> given = candidate.from().composes() ? Map.of()
                     : against(subject, axes, candidate.delta(), candidate.where(),
@@ -1539,10 +1543,22 @@ public final class Generator {
             return baseline.isEmpty();
         }
 
-        /** Whether this states a value of {@code parameter}, which is the position a row is about
-         *  being one the origin says something of. */
-        boolean grounds(String parameter) {
-            return baseline.at().containsKey(parameter);
+        /**
+         * How much of what a demand is about this states a value of.
+         *
+         * <p>By the parameters and not by the positions. Two positions under one parameter are two
+         * things a demand may be about and one value an origin can state, and an origin counted
+         * once per position would be twice as grounded for a demand over two fields of one record
+         * as for one over two records.
+         */
+        int grounding(Set<String> asked) {
+            int out = 0;
+            for (String head : asked) {
+                if (baseline.at().containsKey(head)) {
+                    out++;
+                }
+            }
+            return out;
         }
     }
 
@@ -1604,7 +1620,7 @@ public final class Generator {
     private record Candidate(ResolvedOrigin from, int[] where, Delta delta) {}
 
     /**
-     * The assignments a class was given to try, and whether they are all of them.
+     * The assignments one reading of a demand was given to try, and whether they are all of them.
      *
      * <p><b>The budget is a fact about the search and travels with what the search returned.</b> A
      * list alone cannot say whether it ran out or was cut off, and a caller reading the end of it
@@ -1613,24 +1629,44 @@ public final class Generator {
      * one place further on. The same fault as an absent ledger entry: one silence standing for two
      * pieces of news, and the stronger one read off it.
      *
-     * @param candidates the assignments to try, nearest what the model already says first
-     * @param cutShort   whether the budget stopped this before the assignments ran out
+     * <p><b>The composition apart from the rest, and not at the end of them.</b> It is not one of
+     * the values the model states — where it stands is where the classes put it, which the search
+     * itself named — so it is not ordered among them and does not share what they may spend. Handed
+     * back as the tail of one list, a caller that walks the list until its own budget runs out
+     * never reaches it, which is the fault the class walk already had and the arm walk would have
+     * had the day it began counting runs.
+     *
+     * @param stated   the assignments written against a value the module states, nearest first
+     * @param composed the assignments composed from the classes, for a caller none of the stated
+     *                 ones answered
+     * @param cutShort whether a bound stopped this before the assignments ran out
      */
-    private record Perturbations(List<Candidate> candidates, boolean cutShort) {}
+    private record Perturbations(List<Candidate> stated, List<Candidate> composed,
+                                 boolean cutShort) {
+
+        /** Both, in the order a caller with one budget over the whole search walks them. */
+        List<Candidate> candidates() {
+            List<Candidate> out = new ArrayList<>(stated);
+            out.addAll(composed);
+            return out;
+        }
+    }
 
     /**
-     * The assignments to try for one class, nearest what the model already says first.
+     * The assignments to try for one reading of a demand, nearest what the model already says first.
      *
      * <p>Built whole and then walked, rather than walked as four nested loops. The budget is the
-     * length of this list, so it is a bound on the search rather than a test inside one — nested,
+     * length of these lists, so it is a bound on the search rather than a test inside one — nested,
      * the check that stopped the innermost walk left the three around it turning, and the number
      * bounded nothing.
      *
-     * <p><b>Whether the origin states the class's own position, before anything else.</b> A row for
-     * a class of {@code to} written against a value of {@code from} has {@code to} composed from
+     * <p><b>How much of what the demand is about the origin states, before anything else.</b> A row
+     * for a class of {@code to} written against a value of {@code from} has {@code to} composed from
      * its classes like any other position — so it is not that value with one field moved, which is
      * the thing this exists to offer. It is a row with a recognisable value somewhere else, worth
-     * offering after every origin that grounds the position and not among them.
+     * offering after every origin that grounds what the row is about and not among them. A demand
+     * over several positions is grounded by degrees, and the origins that state more of them come
+     * first.
      *
      * <p>Not a tie-break inside a distance. An origin that does not name the position is measured
      * against a tuple partly of the search's own making — {@link #stands} fills what the origin
@@ -1639,82 +1675,81 @@ public final class Generator {
      * model states of the position the row is about went untried.
      *
      * <p><b>Then distance, among the values the model states.</b> How far a row moves from the
-     * value it is written against is what this is minimising, so every baseline is tried at the
-     * target alone before any is tried with a supporting field moved. Within one distance the
-     * origins keep the order they were gathered in, which puts a value the author's own rows name
-     * before one the module merely states — the whole of one origin's moves at that distance
-     * before the next origin's. Ordered with the supporting sets outside the origins, provenance
-     * decided only which origin won a given set of supporting positions, and a later origin that
-     * happened to repair on an earlier set beat an earlier origin that repaired on a later one.
+     * value it is written against is what this is minimising, so every baseline is tried at what
+     * the demand asks for alone before any is tried with a supporting field moved. Within one
+     * distance the origins keep the order they were gathered in, which puts a value the author's
+     * own rows name before one the module merely states — the whole of one origin's moves at that
+     * distance before the next origin's. Ordered with the supporting sets outside the origins,
+     * provenance decided only which origin won a given set of supporting positions, and a later
+     * origin that happened to repair on an earlier set beat an earlier origin that repaired on a
+     * later one.
      *
-     * <p><b>And the classes last, whatever their distance.</b> A composed row is not a nearer
+     * <p><b>And the classes apart, whatever their distance.</b> A composed row is not a nearer
      * baseline: its distance is measured from values the search itself named, so it is zero by
      * construction and says nothing about how far the row is from what a reader recognises. Put in
      * the same order, a row composed from the classes won against every baseline that needed one
      * supporting field — which is the objective read backwards.
-     *
-     * <p><b>Last, and reached whatever the baselines spent.</b> Behind the baselines' budget, a
-     * class the model can hold a row for came back saying the search had stopped, over a
-     * composition that would have built. The composition is not one of the values the model states
-     * and is not competing with them for their budget: it is what a row is when none of them can be
-     * written for it, so it has a budget of its own.
      */
-    private static Perturbations nearestFirst(List<Axis> axes, int at, int cls,
-                                              List<ResolvedOrigin> origins) {
-        List<Candidate> out = new ArrayList<>();
+    private static Perturbations nearestFirst(List<Axis> axes, Interpretation reading,
+                                              List<ResolvedOrigin> origins, Admits admits) {
+        int[] about = about(reading);
+        Set<String> asked = reading.heads(axes);
+        List<Candidate> stated = new ArrayList<>();
         boolean cutShort = false;
-        // The position the row is about, which is what an origin either states a value of or does
-        // not. Both kinds are walked and the grounding ones whole, at every distance, before any of
-        // the others.
-        String about = axes.get(at).path().head();
-        for (boolean grounding : new boolean[] {true, false}) {
-            List<ResolvedOrigin> stated = new ArrayList<>();
+        // The origins that state most of what the demand is about, whole and at every distance,
+        // before any that state less of it.
+        for (int grounds = asked.size(); grounds >= 0; grounds--) {
+            List<ResolvedOrigin> here = new ArrayList<>();
             for (ResolvedOrigin origin : origins) {
-                if (!origin.composes() && origin.grounds(about) == grounding) {
-                    stated.add(origin);
+                if (!origin.composes() && origin.grounding(asked) == grounds) {
+                    here.add(origin);
                 }
             }
-            cutShort |= gather(axes, at, cls, stated, out, MOST_REPAIRS);
-        }
-        for (ResolvedOrigin origin : origins) {
-            if (origin.composes()) {
-                cutShort |= gather(axes, at, cls, List.of(origin), out, out.size() + MOST_REPAIRS);
+            if (!here.isEmpty()) {
+                cutShort |= gather(axes, reading, about, here, admits, stated, MOST_REPAIRS);
             }
         }
-        return new Perturbations(out, cutShort);
+        List<Candidate> composed = new ArrayList<>();
+        for (ResolvedOrigin origin : origins) {
+            if (origin.composes()) {
+                cutShort |= gather(axes, reading, about, List.of(origin), admits, composed,
+                        MOST_REPAIRS);
+            }
+        }
+        return new Perturbations(List.copyOf(stated), List.copyOf(composed), cutShort);
     }
 
     /**
-     * Every assignment these origins offer for one class, nearest first, onto the end of
+     * Every assignment these origins offer for one reading, nearest first, onto the end of
      * {@code out}.
      *
      * <p>Walked by the size of the supporting set and handed out by the distance the assignment
      * came to, which are two numbers and not one. A set of {@code k} positions moves {@code k} of
-     * them; the pin may move more, where a class of the position the row is about cannot stand
-     * beside where the origin's own value does. So an assignment is never nearer than the set that
-     * produced it, and everything at one distance has been produced by the time the walk finishes
-     * the sets of that size — which is what lets this hand them out in distance order without
-     * holding the whole space to sort it.
+     * them; the reading may move more, where a class it asks for cannot stand beside where the
+     * origin's own value does. So an assignment is never nearer than the set that produced it, and
+     * everything at one distance has been produced by the time the walk finishes the sets of that
+     * size — which is what lets this hand them out in distance order without holding the whole
+     * space to sort it.
      *
      * @param cut how large {@code out} may grow before this stops, which is a bound on the search
      *            and not on the space
      * @return whether the bound stopped this before the assignments ran out
      */
-    private static boolean gather(List<Axis> axes, int at, int cls, List<ResolvedOrigin> origins,
+    private static boolean gather(List<Axis> axes, Interpretation reading, int[] about,
+                                  List<ResolvedOrigin> origins, Admits admits,
                                   List<Candidate> out, int cut) {
         // Produced further away than the set that produced them, kept until the walk reaches that
         // distance rather than handed out early.
         Map<Integer, List<Candidate>> waiting = new LinkedHashMap<>();
         for (int moved = 0; moved <= axes.size(); moved++) {
             for (ResolvedOrigin origin : origins) {
-                // The class the row is about settled first, and the origin's own classes kept at
+                // What the demand asks for settled first, and the origin's own classes kept at
                 // every position that can keep them beside it.
-                int[] base = standing(axes, wanting(axes, origin.stands(), at, cls),
-                        new int[] {at});
+                int[] base = standing(axes, wanting(axes, origin.stands(), reading), about, admits);
                 if (base == null) {
-                    continue;   // a class that cannot stand at its own position is no assignment
+                    continue;   // this reading is not one value, under this origin
                 }
-                for (int[] supporting : supportingSets(axes, new int[] {at}, moved, base)) {
+                for (int[] supporting : supportingSets(axes, about, moved, base)) {
                     for (int[] where : assignmentsOver(axes, base, supporting)) {
                         Candidate candidate = new Candidate(origin, where,
                                 Delta.between(origin.stands(), where));
@@ -1744,8 +1779,8 @@ public final class Generator {
                 }
             }
         }
-        // What the pin moved beyond the largest set walked. Nothing generates at this distance any
-        // more, so it is handed out in order rather than dropped.
+        // What the reading moved beyond the largest set walked. Nothing generates at this distance
+        // any more, so it is handed out in order rather than dropped.
         for (int distance : new java.util.TreeSet<>(waiting.keySet())) {
             for (Candidate candidate : waiting.get(distance)) {
                 if (out.size() >= cut) {
@@ -2064,7 +2099,8 @@ public final class Generator {
      * merely the first thing this can name. What the row is about does not change with it.
      */
     private static int[] movingOnly(List<Axis> axes, int at, int cls) {
-        return standing(axes, wanting(axes, null, at, cls), new int[] {at});
+        return standing(axes, wanting(axes, null, new Interpretation(Map.of(at, cls))),
+                new int[] {at});
     }
 
     /**
@@ -2429,126 +2465,207 @@ public final class Generator {
      */
     private static Witness witnessFor(Subject subject, List<Axis> axes,
                                       CellSelection selection, CandidateCheck check, Trial trial,
-                                      Map<List<String>, Watched> applied, List<Integer> takes) {
+                                      Map<List<String>, Watched> applied, List<Integer> takes,
+                                      List<ResolvedOrigin> origins) {
         InteractionCells.Cell cell = selection.cell();
         // What the combination can be asking, worked out by the combination. A reading is a class
         // apiece at the positions it is about; where a row stands anywhere else is this search's own
         // choice, and counted as a reading it spent the bound on rows that ask the same thing.
         List<Interpretation> readings = selection.interpretations(MOST_INTERPRETATIONS);
-        Attempt last = null;
-        int[] where = null;
-        boolean missed = false;
-        // Whether this looked everywhere, added up as the readings answer rather than read off the
-        // state the loop happened to end in.
-        Completeness looked = Completeness.NOTHING_YET;
+        Looking looking = new Looking(subject, axes, selection, check, trial, applied, takes);
         for (Interpretation reading : readings) {
-            int[] about = about(reading);
-            int[] base = standing(axes, wanting(axes, reading, axes.size()), about, cell::admits);
-            if (base == null) {
+            Perturbations walk = nearestFirst(axes, reading, origins, cell::admits);
+            if (walk.candidates().isEmpty()) {
                 continue;   // this reading is not one value, and another of them may be
             }
-            boolean stopped = false;
-            int runs = 0;
-            // Outward from where the reading leaves every other position: the reading alone first,
-            // then one position beside it moved, then two. What the combination asks for is settled
-            // at every one of them, so each is a row for this reading and they differ in what else
-            // they cover.
-            walk:
-            for (int moved = 0; moved <= axes.size(); moved++) {
-                for (int[] supporting : supportingSets(axes, about, moved, base)) {
-                    for (int[] at : assignmentsOver(axes, base, supporting)) {
-                        where = at;
-                        last = build(subject, axes, at, check);
-                        if (last.row() == null) {
-                            continue;   // nothing composed here; another assignment may compose
+            // The values the model states first, nearest first, and what they may spend counted in
+            // runs. Then the composition, whatever they spent: it is not one of them and was not
+            // competing with them for their share, and a caller told the stated values were all
+            // refused would go looking for a value the model cannot hold.
+            Witness found = looking.run(walk.stated(), MOST_RUNS_PER_INTERPRETATION);
+            if (found != null) {
+                return found;
+            }
+            boolean stopped = looking.stopped() || walk.cutShort();
+            found = looking.run(walk.composed(), MOST_RUNS_PER_INTERPRETATION);
+            if (found != null) {
+                return found;
+            }
+            // Stopped where a bound was reached, whether or not a candidate was left. Which of the
+            // two it was cannot be known without composing the next one, and of the two ways to be
+            // wrong only one of them is a claim about the model: said to have looked everywhere, a
+            // search that had not sends a person to change a rule over a row it never tried.
+            looking.reading(stopped || looking.stopped());
+        }
+        return looking.nothing(readings.isEmpty());
+    }
+
+    /**
+     * Looking for a row at one combination, across the readings of it.
+     *
+     * <p>Its own value because what the walk leaves behind is read after it: which candidate was
+     * last, whether any row ran and went elsewhere, and whether the search was complete. Kept as
+     * locals across two loops and a helper, the last of those was read off whichever of them the
+     * control flow happened to leave set.
+     */
+    private static final class Looking {
+
+        private final Subject subject;
+
+        private final List<Axis> axes;
+
+        private final CellSelection selection;
+
+        private final CandidateCheck check;
+
+        private final Trial trial;
+
+        private final Map<List<String>, Watched> applied;
+
+        private final List<Integer> takes;
+
+        /** What the last candidate that composed nothing came to, for a search that tried them
+         *  all. */
+        private Attempt last;
+
+        /** Where the last candidate stood, which is what names the combination in a report. */
+        private int[] where;
+
+        /** Whether a row was composed, run, and seen going somewhere else. */
+        private boolean missed;
+
+        /** Whether the bound stopped the run of candidates just walked. */
+        private boolean stopped;
+
+        private Completeness looked = Completeness.NOTHING_YET;
+
+        private Looking(Subject subject, List<Axis> axes, CellSelection selection,
+                        CandidateCheck check, Trial trial, Map<List<String>, Watched> applied,
+                        List<Integer> takes) {
+            this.subject = subject;
+            this.axes = axes;
+            this.selection = selection;
+            this.check = check;
+            this.trial = trial;
+            this.applied = applied;
+            this.takes = takes;
+        }
+
+        /**
+         * The first of {@code candidates} seen filling the combination, or null where none of the
+         * ones this was allowed to run was.
+         *
+         * @param runs how many of them may be put through the behavior. Counted in runs and not in
+         *             candidates: a candidate the model refuses never reached the behavior, and
+         *             counting it would let a model whose rules refuse a few compositions spend a
+         *             reading's whole share without asking the behavior anything
+         */
+        private Witness run(List<Candidate> candidates, int runs) {
+            stopped = false;
+            int spent = 0;
+            for (Candidate candidate : candidates) {
+                Map<String, FixtureTemplate> given = candidate.from().composes() ? Map.of()
+                        : against(subject, axes, candidate.delta(), candidate.where(),
+                                candidate.from().baseline());
+                if (!candidate.from().composes() && given.isEmpty()) {
+                    continue;   // nothing here can be written against the model's value
+                }
+                where = candidate.where();
+                last = build(subject, axes, candidate.where(), check, given);
+                if (last.row() == null) {
+                    continue;   // nothing composed here; another assignment may compose
+                }
+                // Composed for the arms it was looked for, and not for the combination it was found
+                // at. The combination is where the search went; the arms are what somebody is owed
+                // a row at. One row answering two of them is two answers and not one composite
+                // thing.
+                GeneratedRow named = new GeneratedRow(
+                        takes.stream().map(Purpose.ForAnArm::new).map(Purpose.class::cast).toList(),
+                        last.row().inputs());
+                // Run once per set of values, however many places a row of them was looked for.
+                // What a run of one row did is one fact: two arms searched on their own can come to
+                // the same values, and running them again would be the same row applied twice and
+                // counted twice.
+                //
+                // Keyed by what the row is written as. A template is the text and the expression it
+                // stands for, and the second is a tree whose equality is its own — so a pair of
+                // them makes no key, while the text is the whole of what a row applied twice would
+                // be.
+                Watched watched = applied.computeIfAbsent(
+                        named.inputs().stream().map(FixtureTemplate::text).toList(),
+                        _ -> trial.run(named.inputs()));
+                switch (watched) {
+                    // Nothing can say where it went, so nothing certifies it and nothing refutes
+                    // it. Offered as it was before anything ran, and said to be. Both of the ways
+                    // that happens come here: nothing applied the row, or nothing was recording
+                    // while it was applied.
+                    case Watched.NoAccount _ -> {
+                        return new Witness.Unconfirmed(named, candidate.where());
+                    }
+                    case Watched.Ran ran -> {
+                        // Through the one thing that can say a row filled a combination, which is
+                        // the same thing a row already in the file is put through.
+                        Optional<CellSelection.CertifiedWitness> found =
+                                selection.certifying(candidate.where(), ran.seen());
+                        if (found.isPresent()) {
+                            return new Witness.Certified(named, found.get());
                         }
-                        // Composed for the arms it was looked for, and not for the combination it
-                        // was found at. The combination is where the search went; the arms are what
-                        // somebody is owed a row at. One row answering two of them is two answers
-                        // and not one composite thing.
-                        GeneratedRow named = new GeneratedRow(
-                                takes.stream().map(Purpose.ForAnArm::new).map(Purpose.class::cast)
-                                        .toList(),
-                                last.row().inputs());
-                        // Run once per set of values, however many places a row of them was looked
-                        // for. What a run of one row did is one fact: two arms searched on their own
-                        // can come to the same values, and running them again would be the same row
-                        // applied twice and counted twice.
-                        //
-                        // Keyed by what the row is written as. A template is the text and the
-                        // expression it stands for, and the second is a tree whose equality is its
-                        // own — so a pair of them makes no key, while the text is the whole of what
-                        // a row applied twice would be.
-                        Watched watched = applied.computeIfAbsent(
-                                named.inputs().stream().map(FixtureTemplate::text).toList(),
-                                _ -> trial.run(named.inputs()));
-                        switch (watched) {
-                            // Nothing can say where it went, so nothing certifies it and nothing
-                            // refutes it. Offered as it was before anything ran, and said to be.
-                            // Both of the ways that happens come here: nothing applied the row, or
-                            // nothing was recording while it was applied.
-                            case Watched.NoAccount _ -> {
-                                return new Witness.Unconfirmed(named, at);
-                            }
-                            case Watched.Ran ran -> {
-                                // Through the one thing that can say a row filled a combination,
-                                // which is the same thing a row already in the file is put through.
-                                Optional<CellSelection.CertifiedWitness> found =
-                                        selection.certifying(at, ran.seen());
-                                if (found.isPresent()) {
-                                    return new Witness.Certified(named, found.get());
-                                }
-                                missed = true;
-                            }
-                        }
-                        // Counted here and nowhere else. What this bounds is how much of a run
-                        // budget one reading may spend, and an assignment nothing composed put
-                        // nothing through the behavior — so counting it would let a model whose
-                        // rules refuse a few compositions spend the reading's whole share on rows
-                        // that never ran.
-                        if (++runs >= MOST_RUNS_PER_INTERPRETATION) {
-                            stopped = true;
-                            break walk;
-                        }
+                        missed = true;
                     }
                 }
+                if (++spent >= runs) {
+                    stopped = true;
+                    return null;
+                }
             }
-            // Stopped where the bound was reached, whether or not a candidate was left. Which of
-            // the two it was cannot be known without composing the next one, and of the two ways to
-            // be wrong only one of them is a claim about the model: said to have looked everywhere,
-            // a search that had not sends a person to change a rule over a row it never tried.
-            looked = stopped ? looked.cutShort() : looked.searched();
+            return null;
         }
-        List<String> named = where == null ? List.of() : labels(axes, cell, where);
-        return switch (looked.found()) {
-            // No reading to look at. Either the combination leaves a position nothing, or none of
-            // its readings is one value — and both are the model not having this combination rather
-            // than a search that failed at it.
-            case Completeness.Nothing.NO_READING -> new Witness.NoCombination(
-                    readings.isEmpty() ? "a position this combination names has nothing left at it"
-                            : "the positions this combination names are not in one value");
-            // A bound stopped one of the readings. Said whatever the candidates it did try came to:
-            // the refusal of the third of them is a fact about that candidate, and offered as the
-            // combination's answer it stands for a space this never entered.
-            case Completeness.Nothing.SEARCH_STOPPED -> new Witness.Limited(named);
-            case Completeness.Nothing.LOOKED_EVERYWHERE -> {
-                if (missed) {
-                    // Rows were composed and run, and went somewhere else. Which says they were not
-                    // witnesses, and not that the combination is unreachable.
+
+        /** Whether the last run of candidates was stopped by its bound. */
+        private boolean stopped() {
+            return stopped;
+        }
+
+        /** One more reading answered, and whether anything about it was left untried. */
+        private void reading(boolean cutShort) {
+            looked = cutShort ? looked.cutShort() : looked.searched();
+        }
+
+        /** What to say when no reading answered. */
+        private Witness nothing(boolean noReadings) {
+            List<String> named =
+                    where == null ? List.of() : labels(axes, selection.cell(), where);
+            return switch (looked.found()) {
+                // No reading to look at. Either the combination leaves a position nothing, or none
+                // of its readings is one value — and both are the model not having this combination
+                // rather than a search that failed at it.
+                case Completeness.Nothing.NO_READING -> new Witness.NoCombination(
+                        noReadings ? "a position this combination names has nothing left at it"
+                                : "the positions this combination names are not in one value");
+                // A bound stopped one of the readings. Said whatever the candidates it did try came
+                // to: the refusal of the third of them is a fact about that candidate, and offered
+                // as the combination's answer it stands for a space this never entered.
+                case Completeness.Nothing.SEARCH_STOPPED -> new Witness.Limited(named);
+                case Completeness.Nothing.LOOKED_EVERYWHERE -> {
+                    if (missed) {
+                        // Rows were composed and run, and went somewhere else. Which says they were
+                        // not witnesses, and not that the combination is unreachable.
+                        yield new Witness.Exhausted(named,
+                                UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS, null,
+                                Optional.empty());
+                    }
+                    if (last != null && last.row() == null) {
+                        yield new Witness.Exhausted(named, last.reason(), last.detail(),
+                                last.said());
+                    }
+                    // Nothing was composed and nothing was refused, which takes every reading
+                    // leaving no assignment at all. Named rather than guessed at, the same way
+                    // every other empty result here is.
                     yield new Witness.Exhausted(named,
-                            UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS, null,
-                            Optional.empty());
+                            UnresolvedCombination.Reason.NO_REASON_RECORDED, null, Optional.empty());
                 }
-                if (last != null && last.row() == null) {
-                    yield new Witness.Exhausted(named, last.reason(), last.detail(), last.said());
-                }
-                // Nothing was composed and nothing was refused, which takes every reading leaving no
-                // assignment at all. Named rather than guessed at, the same way every other empty
-                // result here is.
-                yield new Witness.Exhausted(named, UnresolvedCombination.Reason.NO_REASON_RECORDED,
-                        null, Optional.empty());
-            }
-        };
+            };
+        }
     }
 
     /** The positions one reading is about, in the axes' own order. */
@@ -2557,16 +2674,7 @@ public final class Generator {
         return out;
     }
 
-    /** What a row for one reading starts from: the classes the reading pins, and nothing said
-     *  anywhere else. */
-    private static int[] wanting(List<Axis> axes, Interpretation reading, int size) {
-        int[] wanted = new int[size];
-        java.util.Arrays.fill(wanted, NOT_HERE);
-        for (Map.Entry<Integer, Integer> pin : reading.pins().entrySet()) {
-            wanted[pin.getKey()] = pin.getValue();
-        }
-        return wanted;
-    }
+
 
 
     // --- turning classes into a row -------------------------------------------------------------
@@ -3142,13 +3250,15 @@ public final class Generator {
      * <p>What a row about one class starts from: the class it is for, and whatever an origin put at
      * the positions beside it.
      */
-    private static int[] wanting(List<Axis> axes, int[] from, int at, int cls) {
+    private static int[] wanting(List<Axis> axes, int[] from, Interpretation reading) {
         int[] wanted = new int[axes.size()];
         java.util.Arrays.fill(wanted, NOT_HERE);
         if (from != null) {
             System.arraycopy(from, 0, wanted, 0, Math.min(from.length, wanted.length));
         }
-        wanted[at] = cls;
+        for (Map.Entry<Integer, Integer> pin : reading.pins().entrySet()) {
+            wanted[pin.getKey()] = pin.getValue();
+        }
         return wanted;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -1490,7 +1490,7 @@ public final class Generator {
         // What the walk came to, added up the way a combination's readings are. A class has the
         // one reading — its own class at its own position — so what is left to say is whether the
         // walk over the origins reached the end of itself.
-        Completeness looked = walk.candidates().isEmpty()
+        Completeness looked = walk.isEmpty()
                 ? Completeness.NOTHING_YET : Completeness.NOTHING_YET.searched();
         if (walk.cutShort()) {
             looked = looked.cutShort();
@@ -1606,6 +1606,12 @@ public final class Generator {
             out.addAll(composed);
             return out;
         }
+
+        /** Whether there is anything to try, asked without building the pair of them into one
+         *  list. */
+        boolean isEmpty() {
+            return stated.isEmpty() && composed.isEmpty();
+        }
     }
 
     /**
@@ -1694,21 +1700,28 @@ public final class Generator {
     private static boolean gather(List<Axis> axes, Interpretation reading, int[] about,
                                   List<ResolvedOrigin> origins, Admits admits,
                                   List<Candidate> out, int cut) {
+        // What the demand asks for settled first, and each origin's own classes kept at every
+        // position that can keep them beside it. Worked out once per origin: it is where that
+        // origin's walk starts from and does not change with how far the walk has gone.
+        List<Started> bases = new ArrayList<>();
+        for (ResolvedOrigin origin : origins) {
+            int[] base = standing(axes, wanting(axes, origin.stands(), reading), about, admits);
+            if (base != null) {
+                bases.add(new Started(origin, base));   // null is this reading not being one value
+            }
+        }
         // Produced further away than the set that produced them, kept until the walk reaches that
         // distance rather than handed out early.
         Map<Integer, List<Candidate>> waiting = new LinkedHashMap<>();
-        for (int moved = 0; moved <= axes.size(); moved++) {
-            for (ResolvedOrigin origin : origins) {
-                // What the demand asks for settled first, and the origin's own classes kept at
-                // every position that can keep them beside it.
-                int[] base = standing(axes, wanting(axes, origin.stands(), reading), about, admits);
-                if (base == null) {
-                    continue;   // this reading is not one value, under this origin
-                }
-                for (int[] supporting : supportingSets(axes, about, moved, base)) {
-                    for (int[] where : assignmentsOver(axes, base, supporting)) {
-                        Candidate candidate = new Candidate(origin, where,
-                                Delta.between(origin.stands(), where));
+        // A set names positions the row is not about, so the largest one is every position but
+        // those. Walked further, the sets are empty and the only thing left to do is hand out what
+        // the readings moved beyond them, which is what happens below either way.
+        for (int moved = 0; moved <= axes.size() - about.length; moved++) {
+            for (Started origin : bases) {
+                for (int[] supporting : supportingSets(axes, about, moved, origin.base())) {
+                    for (int[] where : assignmentsOver(axes, origin.base(), supporting)) {
+                        Candidate candidate = new Candidate(origin.from(), where,
+                                Delta.between(origin.from().stands(), where));
                         waiting.computeIfAbsent(candidate.delta().size(), _ -> new ArrayList<>())
                                 .add(candidate);
                     }
@@ -1718,27 +1731,44 @@ public final class Generator {
             // this one alone: what is due is a fact about the distances, and a walk that read it off
             // the size of the set it had just finished would leave a nearer assignment sitting in
             // the map for as long as the set that produced it was larger than it.
-            for (int distance : new java.util.TreeSet<>(waiting.keySet())) {
-                if (distance > moved) {
-                    break;
-                }
-                // The origins in the order they were gathered, within the one distance. Sorted
-                // rather than generated that way, because an assignment reaches one distance from
-                // more than one size of supporting set.
-                List<Candidate> due = waiting.remove(distance);
-                due.sort(java.util.Comparator.comparingInt(candidate -> candidate.from().index()));
-                for (Candidate candidate : due) {
-                    if (out.size() >= cut) {
-                        return true;
-                    }
-                    out.add(candidate);
-                }
+            if (handOut(waiting, moved, out, cut)) {
+                return true;
             }
         }
-        // What the reading moved beyond the largest set walked. Nothing generates at this distance
-        // any more, so it is handed out in order rather than dropped.
+        // What the readings moved beyond the largest set walked. Nothing generates at these
+        // distances any more, so they are handed out rather than dropped — and handed out the same
+        // way, because which of two candidates one distance apart comes first is one rule and not
+        // one per place a candidate leaves this walk.
+        return handOut(waiting, Integer.MAX_VALUE, out, cut);
+    }
+
+    /**
+     * Where one origin's walk for one reading starts: what the reading asks for, and the origin's
+     * own classes wherever they can be kept beside it.
+     *
+     * <p>A pair and not a map keyed by the origin. An origin holds where its values stand, which is
+     * an array, and an array's equality is its own — so a map of them works only for as long as
+     * every key is the one instance that was put there, and reads as though it worked either way.
+     */
+    private record Started(ResolvedOrigin from, int[] base) {}
+
+    /**
+     * Every candidate of {@code waiting} no further than {@code upTo}, nearest first, onto the end
+     * of {@code out}.
+     *
+     * <p>Within one distance the origins keep the order they were gathered in. Sorted rather than
+     * generated that way, because an assignment reaches one distance from more than one size of
+     * supporting set.
+     *
+     * @return whether {@code cut} stopped this with candidates still waiting
+     */
+    private static boolean handOut(Map<Integer, List<Candidate>> waiting, int upTo,
+                                   List<Candidate> out, int cut) {
         for (int distance : new java.util.TreeSet<>(waiting.keySet())) {
-            for (Candidate candidate : waiting.get(distance)) {
+            if (distance > upTo) {
+                return false;
+            }
+            for (Candidate candidate : sortedByOrigin(waiting.remove(distance))) {
                 if (out.size() >= cut) {
                     return true;
                 }
@@ -1746,6 +1776,11 @@ public final class Generator {
             }
         }
         return false;
+    }
+
+    private static List<Candidate> sortedByOrigin(List<Candidate> due) {
+        due.sort(java.util.Comparator.comparingInt(candidate -> candidate.from().index()));
+        return due;
     }
 
     /**
@@ -1761,9 +1796,6 @@ public final class Generator {
      * was spent by counted what the search reached for rather than what it moved.
      */
     private static List<int[]> supportingSets(List<Axis> axes, int[] about, int moved, int[] base) {
-        if (moved > axes.size()) {
-            return List.of();
-        }
         List<int[]> out = new ArrayList<>();
         chooseSupporting(axes, about, moved, 0, new int[moved], 0, out, base);
         return out;
@@ -2074,25 +2106,6 @@ public final class Generator {
                 && !data.newtype()
                 ? List.copyOf(TypeOps.fieldTypes(data, subject.symbols()).keySet())
                 : null;
-    }
-
-    /**
-     * The assignment a row about one class is written at: that class, and every other position at
-     * the first of its own.
-     *
-     * <p>One position moved and no more, which is what makes the row readable as being about that
-     * class. A row that also moved the positions beside it would be several answers a person has to
-     * separate before any of them says anything, and which of the three the answer turned on would
-     * be exactly what it does not say (issue #967).
-     *
-     * <p>The first class is where the others stand for now, and it is a stand-in for something
-     * better: a value the model already states — a {@code let} in scope, or the value a row already
-     * written puts there — is what a reader would recognise, and the first class of a position is
-     * merely the first thing this can name. What the row is about does not change with it.
-     */
-    private static int[] movingOnly(List<Axis> axes, int at, int cls) {
-        return standing(axes, wanting(axes, null, new Interpretation(Map.of(at, cls))),
-                new int[] {at});
     }
 
     /**
@@ -2467,7 +2480,7 @@ public final class Generator {
         Looking looking = new Looking(subject, axes, selection, check, trial, applied, takes);
         for (Interpretation reading : readings) {
             Perturbations walk = nearestFirst(axes, reading, origins, cell::admits);
-            if (walk.candidates().isEmpty()) {
+            if (walk.isEmpty()) {
                 continue;   // this reading is not one value, and another of them may be
             }
             // The values the model states first, nearest first, and what they may spend counted in
@@ -2478,7 +2491,6 @@ public final class Generator {
             if (found != null) {
                 return found;
             }
-            boolean stopped = looking.stopped() || walk.cutShort();
             found = looking.run(walk.composed(), MOST_RUNS_PER_INTERPRETATION);
             if (found != null) {
                 return found;
@@ -2487,7 +2499,7 @@ public final class Generator {
             // two it was cannot be known without composing the next one, and of the two ways to be
             // wrong only one of them is a claim about the model: said to have looked everywhere, a
             // search that had not sends a person to change a rule over a row it never tried.
-            looking.reading(stopped || looking.stopped());
+            looking.reading(walk.cutShort());
         }
         return looking.nothing(readings.isEmpty());
     }
@@ -2526,7 +2538,9 @@ public final class Generator {
         /** Whether a row was composed, run, and seen going somewhere else. */
         private boolean missed;
 
-        /** Whether the bound stopped the run of candidates just walked. */
+        /** Whether a bound stopped one of the runs of candidates this reading has had. Held
+         *  across them and cleared when the reading answers, because a reading is stopped if any of
+         *  its runs was — read after the next run instead, the first one's stopping was gone. */
         private boolean stopped;
 
         private Completeness looked = Completeness.NOTHING_YET;
@@ -2553,7 +2567,6 @@ public final class Generator {
          *             reading's whole share without asking the behavior anything
          */
         private Witness run(List<Candidate> candidates, int runs) {
-            stopped = false;
             int spent = 0;
             for (Candidate candidate : candidates) {
                 Map<String, FixtureTemplate> given = candidate.from().composes() ? Map.of()
@@ -2613,14 +2626,15 @@ public final class Generator {
             return null;
         }
 
-        /** Whether the last run of candidates was stopped by its bound. */
-        private boolean stopped() {
-            return stopped;
-        }
-
-        /** One more reading answered, and whether anything about it was left untried. */
+        /**
+         * One more reading answered, and whether anything about it was left untried.
+         *
+         * @param cutShort whether the walk had more assignments than it handed over, which is a
+         *                 second way to have stopped beside the runs this counted itself
+         */
         private void reading(boolean cutShort) {
-            looked = cutShort ? looked.cutShort() : looked.searched();
+            looked = cutShort || stopped ? looked.cutShort() : looked.searched();
+            stopped = false;
         }
 
         /** What to say when no reading answered. */
@@ -2662,8 +2676,7 @@ public final class Generator {
 
     /** The positions one reading is about, in the axes' own order. */
     private static int[] about(Interpretation reading) {
-        int[] out = reading.at().stream().mapToInt(Integer::intValue).sorted().toArray();
-        return out;
+        return reading.at().stream().mapToInt(Integer::intValue).sorted().toArray();
     }
 
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -1563,50 +1563,6 @@ public final class Generator {
     }
 
     /**
-     * Where a row does not stand where its origin does.
-     *
-     * <p>One difference and two readers. How far a row is from what a reader recognises is the size
-     * of this, and which fields a spread writes over is this projected onto the parameters — so the
-     * order the search walks in and the row it writes come off one value. Counted two ways they
-     * were free to disagree, and two positions under one parameter are two differences and one
-     * field either way.
-     *
-     * <p>Read off the assignment and never off what the search reached for. A supporting position
-     * the row stands at no class of is one no assignment moves, and counted as moved it put a row
-     * one difference from its origin behind rows two away.
-     *
-     * @param at the positions, in the axes' own order
-     */
-    private record Delta(List<Integer> at) {
-
-        Delta {
-            at = List.copyOf(at);
-        }
-
-        /** Where {@code where} does not stand where {@code stands} does. */
-        static Delta between(int[] stands, int[] where) {
-            List<Integer> out = new ArrayList<>();
-            for (int i = 0; i < where.length; i++) {
-                if (i >= stands.length || where[i] != stands[i]) {
-                    out.add(i);
-                }
-            }
-            return new Delta(out);
-        }
-
-        /** How far the row is from its origin. */
-        int size() {
-            return at.size();
-        }
-
-        /** Which of these positions are under {@code parameter}, which is what a spread over that
-         *  parameter writes over. */
-        List<Integer> under(List<Axis> axes, String parameter) {
-            return at.stream().filter(i -> axes.get(i).path().head().equals(parameter)).toList();
-        }
-    }
-
-    /**
      * One assignment to try, and the origin it is a move away from.
      *
      * <p>The distance is a fact about the pair and travels with it. Worked out again where the row

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -1456,45 +1456,35 @@ public final class Generator {
         Axis axis = axes.get(at);
         String classId = axis.classes().get(cls).id();
         String label = label(axis, cls);
-        Attempt last = null;
-        // Every baseline the module states rather than the one this compiler picked. Narrowed to
-        // the only value of a type, a module that states a second one lost the spread from every
-        // row of every behavior taking it — a change somewhere else in the file, answering a
-        // question nobody asked it. What order they are walked in is
-        // {@link #nearestFirst}'s to say.
         // A class is a demand over one position: it asks for that class there and says nothing
         // about anywhere else, which is what every other position being free means. Written as a
         // reading, it goes through the same walk a combination's readings do.
-        Perturbations walk = nearestFirst(axes, new Interpretation(Map.of(at, cls)), origins,
-                (_, _) -> true);
-        for (Candidate candidate : walk.candidates()) {
-            Map<String, FixtureTemplate> given = candidate.from().composes() ? Map.of()
-                    : against(subject, axes, candidate.delta(), candidate.where(),
-                            candidate.from().baseline());
-            if (!candidate.from().composes() && given.isEmpty()) {
-                continue;   // nothing here can be written against the model's value
-            }
-            Attempt made = build(subject, axes, candidate.where(), check, given);
-            if (made.row() == null) {
-                last = made;
-                continue;
-            }
-            if (!inTheClass(subject, axes, at, classId, made.row().inputs(), check)) {
-                last = new Attempt(null, UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS, label,
-                        Optional.empty());
-                continue;
-            }
-            return new ClassAttempt.Built(axis.id(), classId, new GeneratedRow(
-                    new Purpose.ForAClass(axis.id(), classId, label), made.row().inputs()));
+        Interpretation reading = new Interpretation(Map.of(at, cls));
+        // Every baseline the module states rather than the one this compiler picked. Narrowed to
+        // the only value of a type, a module that states a second one lost the spread from every
+        // row of every behavior taking it — a change somewhere else in the file, answering a
+        // question nobody asked it. What order they are walked in is {@link #nearestFirst}'s to
+        // say; how many of them may be built is this class's own budget.
+        Building building = new Building(subject, axes, at, classId, label, check, MOST_REPAIRS);
+        Traversal stated = nearestFirst(axes, reading, origins, (_, _) -> true, building);
+        if (building.found != null) {
+            return new ClassAttempt.Built(axis.id(), classId, building.found);
         }
-        // What the walk came to, added up the way a combination's readings are. A class has the
-        // one reading — its own class at its own position — so what is left to say is whether the
-        // walk over the origins reached the end of itself.
-        Completeness looked = walk.isEmpty()
+        // The composition, whatever the stated values spent, and with a budget of its own.
+        Building composing = new Building(subject, axes, at, classId, label, check, MOST_REPAIRS);
+        Traversal composed = composing(axes, reading, origins, (_, _) -> true, composing);
+        if (composing.found != null) {
+            return new ClassAttempt.Built(axis.id(), classId, composing.found);
+        }
+        // What the walks came to, added up the way a combination's readings are. A class has the
+        // one reading — its own class at its own position — so what is left to say is whether
+        // either walk was stopped in front of work nobody did.
+        Completeness looked = building.builds == 0 && composing.builds == 0
                 ? Completeness.NOTHING_YET : Completeness.NOTHING_YET.searched();
-        if (walk.cutShort()) {
+        if (stated == Traversal.STOPPED || composed == Traversal.STOPPED) {
             looked = looked.cutShort();
         }
+        Attempt last = composing.last == null ? building.last : composing.last;
         UnresolvedCombination why = switch (looked.found()) {
             // Nothing to try: the class cannot stand at its own position beside what the position
             // itself requires, under any origin. Which is the model not having this row rather than
@@ -1502,9 +1492,9 @@ public final class Generator {
             case Completeness.Nothing.NO_READING -> new UnresolvedCombination(List.of(label),
                     UnresolvedCombination.Reason.ONE_POSITION_CANNOT_BE_BOTH, null,
                     Optional.of("nothing this class can stand beside was left to try"));
-            // The search stopped. Said so whatever the last assignment it got to came to: the
-            // refusal of the sixty-fourth candidate is a fact about that candidate, and offered as
-            // the class's answer it stands for a space the search never entered.
+            // The search stopped in front of a candidate it did not build. Said so whatever the ones
+            // it did build came to: the refusal of the sixty-fourth is a fact about that candidate,
+            // and offered as the class's answer it stands for a space the search never entered.
             case Completeness.Nothing.SEARCH_STOPPED -> new UnresolvedCombination(List.of(label),
                     UnresolvedCombination.Reason.SEARCH_LIMIT);
             case Completeness.Nothing.LOOKED_EVERYWHERE -> last == null
@@ -1514,6 +1504,82 @@ public final class Generator {
                             last.said());
         };
         return new ClassAttempt.Unresolved(axis.id(), classId, why);
+    }
+
+    /**
+     * Building the candidates offered for one class, up to what this class may spend.
+     *
+     * <p>What it costs to try a candidate here is one build, so that is what is counted. A candidate
+     * no baseline can be written for costs nothing and is not counted: it is a way of writing a row
+     * that this origin does not have, and the budget is over the rows built rather than over the
+     * walk.
+     *
+     * <p>The bound is refused in front of the candidate rather than taken after it. A consumer that
+     * did exactly as many as it was allowed and then reported having stopped said a candidate was
+     * left where none was ({@link Traversal}).
+     */
+    private static final class Building implements Taking<Candidate> {
+
+        private final Subject subject;
+
+        private final List<Axis> axes;
+
+        private final int at;
+
+        private final String classId;
+
+        private final String label;
+
+        private final CandidateCheck check;
+
+        private final int most;
+
+        /** What the last candidate that composed nothing came to. */
+        private Attempt last;
+
+        /** How many were built, which is what this is allowed so many of. */
+        private int builds;
+
+        /** The row, once one lands in the class. */
+        private GeneratedRow found;
+
+        private Building(Subject subject, List<Axis> axes, int at, String classId, String label,
+                         CandidateCheck check, int most) {
+            this.subject = subject;
+            this.axes = axes;
+            this.at = at;
+            this.classId = classId;
+            this.label = label;
+            this.check = check;
+            this.most = most;
+        }
+
+        @Override
+        public boolean take(Candidate candidate) {
+            Map<String, FixtureTemplate> given = candidate.from().composes() ? Map.of()
+                    : against(subject, axes, candidate.delta(), candidate.where(),
+                            candidate.from().baseline());
+            if (!candidate.from().composes() && given.isEmpty()) {
+                return true;   // nothing here can be written against the model's value
+            }
+            if (builds >= most) {
+                return false;   // this candidate is the work nobody did
+            }
+            builds++;
+            Attempt made = build(subject, axes, candidate.where(), check, given);
+            if (made.row() == null) {
+                last = made;
+                return true;
+            }
+            if (!inTheClass(subject, axes, at, classId, made.row().inputs(), check)) {
+                last = new Attempt(null, UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS, label,
+                        Optional.empty());
+                return true;
+            }
+            found = new GeneratedRow(new Purpose.ForAClass(axes.get(at).id(), classId, label),
+                    made.row().inputs());
+            return false;
+        }
     }
 
     /**
@@ -1576,51 +1642,13 @@ public final class Generator {
     private record Candidate(ResolvedOrigin from, int[] where, Delta delta) {}
 
     /**
-     * The assignments one reading of a demand was given to try, and whether they are all of them.
+     * The assignments written against a value the module states, nearest first, one at a time.
      *
-     * <p><b>The budget is a fact about the search and travels with what the search returned.</b> A
-     * list alone cannot say whether it ran out or was cut off, and a caller reading the end of it
-     * as the end of the space answered a class with the last refusal it saw — "every value tried
-     * was refused" over a search that stopped at the sixty-fourth of them, with a value that builds
-     * one place further on. The same fault as an absent ledger entry: one silence standing for two
-     * pieces of news, and the stronger one read off it.
-     *
-     * <p><b>The composition apart from the rest, and not at the end of them.</b> It is not one of
-     * the values the model states — where it stands is where the classes put it, which the search
-     * itself named — so it is not ordered among them and does not share what they may spend. Handed
-     * back as the tail of one list, a caller that walks the list until its own budget runs out
-     * never reaches it, which is the fault the class walk already had and the arm walk would have
-     * had the day it began counting runs.
-     *
-     * @param stated   the assignments written against a value the module states, nearest first
-     * @param composed the assignments composed from the classes, for a caller none of the stated
-     *                 ones answered
-     * @param cutShort whether a bound stopped this before the assignments ran out
-     */
-    private record Perturbations(List<Candidate> stated, List<Candidate> composed,
-                                 boolean cutShort) {
-
-        /** Both, in the order a caller with one budget over the whole search walks them. */
-        List<Candidate> candidates() {
-            List<Candidate> out = new ArrayList<>(stated);
-            out.addAll(composed);
-            return out;
-        }
-
-        /** Whether there is anything to try, asked without building the pair of them into one
-         *  list. */
-        boolean isEmpty() {
-            return stated.isEmpty() && composed.isEmpty();
-        }
-    }
-
-    /**
-     * The assignments to try for one reading of a demand, nearest what the model already says first.
-     *
-     * <p>Built whole and then walked, rather than walked as four nested loops. The budget is the
-     * length of these lists, so it is a bound on the search rather than a test inside one — nested,
-     * the check that stopped the innermost walk left the three around it turning, and the number
-     * bounded nothing.
+     * <p>Handed over rather than handed back. What a walk may cost is a fact about whoever is paying
+     * — a class counts what it builds, an arm counts what it runs, and a candidate the model refuses
+     * costs neither of them anything — so the bound belongs to the consumer and the order belongs
+     * here. Bounded here instead, one number stood for two kinds of work, and the arm was held to
+     * the class's.
      *
      * <p><b>How much of what the demand is about the origin states, before anything else.</b> A row
      * for a class of {@code to} written against a value of {@code from} has {@code to} composed from
@@ -1645,19 +1673,12 @@ public final class Generator {
      * provenance decided only which origin won a given set of supporting positions, and a later
      * origin that happened to repair on an earlier set beat an earlier origin that repaired on a
      * later one.
-     *
-     * <p><b>And the classes apart, whatever their distance.</b> A composed row is not a nearer
-     * baseline: its distance is measured from values the search itself named, so it is zero by
-     * construction and says nothing about how far the row is from what a reader recognises. Put in
-     * the same order, a row composed from the classes won against every baseline that needed one
-     * supporting field — which is the objective read backwards.
      */
-    private static Perturbations nearestFirst(List<Axis> axes, Interpretation reading,
-                                              List<ResolvedOrigin> origins, Admits admits) {
+    private static Traversal nearestFirst(List<Axis> axes, Interpretation reading,
+                                          List<ResolvedOrigin> origins, Admits admits,
+                                          Taking<Candidate> taking) {
         int[] about = about(reading);
         Set<String> asked = reading.heads(axes);
-        List<Candidate> stated = new ArrayList<>();
-        boolean cutShort = false;
         // The origins that state most of what the demand is about, whole and at every distance,
         // before any that state less of it.
         for (int grounds = asked.size(); grounds >= 0; grounds--) {
@@ -1667,39 +1688,57 @@ public final class Generator {
                     here.add(origin);
                 }
             }
-            if (!here.isEmpty()) {
-                cutShort |= gather(axes, reading, about, here, admits, stated, MOST_REPAIRS);
+            if (!here.isEmpty()
+                    && gather(axes, reading, about, here, admits, taking) == Traversal.STOPPED) {
+                return Traversal.STOPPED;
             }
         }
-        List<Candidate> composed = new ArrayList<>();
-        for (ResolvedOrigin origin : origins) {
-            if (origin.composes()) {
-                cutShort |= gather(axes, reading, about, List.of(origin), admits, composed,
-                        MOST_REPAIRS);
-            }
-        }
-        return new Perturbations(List.copyOf(stated), List.copyOf(composed), cutShort);
+        return Traversal.EXHAUSTED;
     }
 
     /**
-     * Every assignment these origins offer for one reading, nearest first, onto the end of
-     * {@code out}.
+     * The assignments composed from the classes, for a consumer none of the stated ones answered.
      *
-     * <p>Walked by the size of the supporting set and handed out by the distance the assignment
+     * <p><b>Its own walk and not the tail of the other one.</b> A composed row is not a nearer
+     * baseline: its distance is measured from values the search itself named, so it is zero by
+     * construction and says nothing about how far the row is from what a reader recognises. Put in
+     * the same order, a row composed from the classes won against every baseline that needed one
+     * supporting field — which is the objective read backwards.
+     *
+     * <p>And walked whatever the stated values spent. It is not one of them and was not competing
+     * with them for what they may cost, so a consumer that walked one list until its own bound ran
+     * out never reached it — which is what left a class the model can hold a row for saying the
+     * search had stopped.
+     */
+    private static Traversal composing(List<Axis> axes, Interpretation reading,
+                                       List<ResolvedOrigin> origins, Admits admits,
+                                       Taking<Candidate> taking) {
+        int[] about = about(reading);
+        for (ResolvedOrigin origin : origins) {
+            if (origin.composes()
+                    && gather(axes, reading, about, List.of(origin), admits, taking)
+                            == Traversal.STOPPED) {
+                return Traversal.STOPPED;
+            }
+        }
+        return Traversal.EXHAUSTED;
+    }
+
+    /**
+     * Every assignment these origins offer for one reading, nearest first, handed to
+     * {@code taking}.
+     *
+     * <p>Walked by the size of the supporting set and handed over by the distance the assignment
      * came to, which are two numbers and not one. A set of {@code k} positions moves {@code k} of
      * them; the reading may move more, where a class it asks for cannot stand beside where the
      * origin's own value does. So an assignment is never nearer than the set that produced it, and
      * everything at one distance has been produced by the time the walk finishes the sets of that
-     * size — which is what lets this hand them out in distance order without holding the whole
+     * size — which is what lets this hand them over in distance order without holding the whole
      * space to sort it.
-     *
-     * @param cut how large {@code out} may grow before this stops, which is a bound on the search
-     *            and not on the space
-     * @return whether the bound stopped this before the assignments ran out
      */
-    private static boolean gather(List<Axis> axes, Interpretation reading, int[] about,
-                                  List<ResolvedOrigin> origins, Admits admits,
-                                  List<Candidate> out, int cut) {
+    private static Traversal gather(List<Axis> axes, Interpretation reading, int[] about,
+                                    List<ResolvedOrigin> origins, Admits admits,
+                                    Taking<Candidate> taking) {
         // What the demand asks for settled first, and each origin's own classes kept at every
         // position that can keep them beside it. Worked out once per origin: it is where that
         // origin's walk starts from and does not change with how far the walk has gone.
@@ -1711,10 +1750,10 @@ public final class Generator {
             }
         }
         // Produced further away than the set that produced them, kept until the walk reaches that
-        // distance rather than handed out early.
+        // distance rather than handed over early.
         Map<Integer, List<Candidate>> waiting = new LinkedHashMap<>();
         // A set names positions the row is not about, so the largest one is every position but
-        // those. Walked further, the sets are empty and the only thing left to do is hand out what
+        // those. Walked further, the sets are empty and the only thing left to do is hand over what
         // the readings moved beyond them, which is what happens below either way.
         for (int moved = 0; moved <= axes.size() - about.length; moved++) {
             for (Started origin : bases) {
@@ -1731,15 +1770,15 @@ public final class Generator {
             // this one alone: what is due is a fact about the distances, and a walk that read it off
             // the size of the set it had just finished would leave a nearer assignment sitting in
             // the map for as long as the set that produced it was larger than it.
-            if (handOut(waiting, moved, out, cut)) {
-                return true;
+            if (handOut(waiting, moved, taking) == Traversal.STOPPED) {
+                return Traversal.STOPPED;
             }
         }
         // What the readings moved beyond the largest set walked. Nothing generates at these
-        // distances any more, so they are handed out rather than dropped — and handed out the same
+        // distances any more, so they are handed over rather than dropped — and handed over the same
         // way, because which of two candidates one distance apart comes first is one rule and not
         // one per place a candidate leaves this walk.
-        return handOut(waiting, Integer.MAX_VALUE, out, cut);
+        return handOut(waiting, Integer.MAX_VALUE, taking);
     }
 
     /**
@@ -1753,35 +1792,33 @@ public final class Generator {
     private record Started(ResolvedOrigin from, int[] base) {}
 
     /**
-     * Every candidate of {@code waiting} no further than {@code upTo}, nearest first, onto the end
-     * of {@code out}.
+     * Every candidate of {@code waiting} no further than {@code upTo}, nearest first, handed to
+     * {@code taking}.
      *
      * <p>Within one distance the origins keep the order they were gathered in. Sorted rather than
      * generated that way, because an assignment reaches one distance from more than one size of
      * supporting set.
-     *
-     * @return whether {@code cut} stopped this with candidates still waiting
      */
-    private static boolean handOut(Map<Integer, List<Candidate>> waiting, int upTo,
-                                   List<Candidate> out, int cut) {
+    private static Traversal handOut(Map<Integer, List<Candidate>> waiting, int upTo,
+                                     Taking<Candidate> taking) {
         for (int distance : new java.util.TreeSet<>(waiting.keySet())) {
             if (distance > upTo) {
-                return false;
+                return Traversal.EXHAUSTED;
             }
             for (Candidate candidate : sortedByOrigin(waiting.remove(distance))) {
-                if (out.size() >= cut) {
-                    return true;
+                if (!taking.take(candidate)) {
+                    return Traversal.STOPPED;
                 }
-                out.add(candidate);
             }
         }
-        return false;
+        return Traversal.EXHAUSTED;
     }
 
     private static List<Candidate> sortedByOrigin(List<Candidate> due) {
         due.sort(java.util.Comparator.comparingInt(candidate -> candidate.from().index()));
         return due;
     }
+
 
     /**
      * Which positions beside the ones a row is about it may move, {@code moved} at a time.
@@ -2472,47 +2509,27 @@ public final class Generator {
                                       CellSelection selection, CandidateCheck check, Trial trial,
                                       Map<List<String>, Watched> applied, List<Integer> takes,
                                       List<ResolvedOrigin> origins) {
-        InteractionCells.Cell cell = selection.cell();
-        // What the combination can be asking, worked out by the combination. A reading is a class
-        // apiece at the positions it is about; where a row stands anywhere else is this search's own
-        // choice, and counted as a reading it spent the bound on rows that ask the same thing.
-        List<Interpretation> readings = selection.interpretations(MOST_INTERPRETATIONS);
-        Looking looking = new Looking(subject, axes, selection, check, trial, applied, takes);
-        for (Interpretation reading : readings) {
-            Perturbations walk = nearestFirst(axes, reading, origins, cell::admits);
-            if (walk.isEmpty()) {
-                continue;   // this reading is not one value, and another of them may be
-            }
-            // The values the model states first, nearest first, and what they may spend counted in
-            // runs. Then the composition, whatever they spent: it is not one of them and was not
-            // competing with them for their share, and a caller told the stated values were all
-            // refused would go looking for a value the model cannot hold.
-            Witness found = looking.run(walk.stated(), MOST_RUNS_PER_INTERPRETATION);
-            if (found != null) {
-                return found;
-            }
-            found = looking.run(walk.composed(), MOST_RUNS_PER_INTERPRETATION);
-            if (found != null) {
-                return found;
-            }
-            // Stopped where a bound was reached, whether or not a candidate was left. Which of the
-            // two it was cannot be known without composing the next one, and of the two ways to be
-            // wrong only one of them is a claim about the model: said to have looked everywhere, a
-            // search that had not sends a person to change a rule over a row it never tried.
-            looking.reading(walk.cutShort());
-        }
-        return looking.nothing(readings.isEmpty());
+        Reading reading =
+                new Reading(subject, axes, selection, check, trial, applied, takes, origins);
+        Traversal walked = selection.interpretations(reading);
+        return reading.found != null ? reading.found : reading.nothing(walked);
     }
 
     /**
-     * Looking for a row at one combination, across the readings of it.
+     * Looking for a row at one combination, over the readings of what it asks.
      *
-     * <p>Its own value because what the walk leaves behind is read after it: which candidate was
-     * last, whether any row ran and went elsewhere, and whether the search was complete. Kept as
-     * locals across two loops and a helper, the last of those was read off whichever of them the
-     * control flow happened to leave set.
+     * <p>What the combination can be asking is the combination's to enumerate and how many of them
+     * this may look at is this search's to bound, which are two things and were one. Counted off by
+     * the enumeration, the bound was spent on combinations of names before anything asked whether a
+     * value could hold them — so a combination whose first few names cannot be in one value went
+     * unanswered with its readings untried.
+     *
+     * <p>So a reading no value can hold costs nothing here: it is not a reading. What is counted is
+     * the readings this actually searched, and the bound is refused in front of the one after them
+     * — which is a reading that exists and that nobody looked at, and the only thing that makes this
+     * search incomplete.
      */
-    private static final class Looking {
+    private static final class Reading implements Taking<Interpretation> {
 
         private final Subject subject;
 
@@ -2528,6 +2545,15 @@ public final class Generator {
 
         private final List<Integer> takes;
 
+        private final List<ResolvedOrigin> origins;
+
+        /** Whether the combination offered anything at all, which tells a combination the model
+         *  does not have from one whose readings are none of them one value. */
+        private boolean offered;
+
+        /** How many readings were searched, which is what this is allowed so many of. */
+        private int searched;
+
         /** What the last candidate that composed nothing came to, for a search that tried them
          *  all. */
         private Attempt last;
@@ -2538,16 +2564,15 @@ public final class Generator {
         /** Whether a row was composed, run, and seen going somewhere else. */
         private boolean missed;
 
-        /** Whether a bound stopped one of the runs of candidates this reading has had. Held
-         *  across them and cleared when the reading answers, because a reading is stopped if any of
-         *  its runs was — read after the next run instead, the first one's stopping was gone. */
-        private boolean stopped;
-
         private Completeness looked = Completeness.NOTHING_YET;
 
-        private Looking(Subject subject, List<Axis> axes, CellSelection selection,
+        /** The row, once one is seen filling the combination or offered because nothing watched
+         *  it. */
+        private Witness found;
+
+        private Reading(Subject subject, List<Axis> axes, CellSelection selection,
                         CandidateCheck check, Trial trial, Map<List<String>, Watched> applied,
-                        List<Integer> takes) {
+                        List<Integer> takes, List<ResolvedOrigin> origins) {
             this.subject = subject;
             this.axes = axes;
             this.selection = selection;
@@ -2555,102 +2580,63 @@ public final class Generator {
             this.trial = trial;
             this.applied = applied;
             this.takes = takes;
+            this.origins = origins;
         }
 
-        /**
-         * The first of {@code candidates} seen filling the combination, or null where none of the
-         * ones this was allowed to run was.
-         *
-         * @param runs how many of them may be put through the behavior. Counted in runs and not in
-         *             candidates: a candidate the model refuses never reached the behavior, and
-         *             counting it would let a model whose rules refuse a few compositions spend a
-         *             reading's whole share without asking the behavior anything
-         */
-        private Witness run(List<Candidate> candidates, int runs) {
-            int spent = 0;
-            for (Candidate candidate : candidates) {
-                Map<String, FixtureTemplate> given = candidate.from().composes() ? Map.of()
-                        : against(subject, axes, candidate.delta(), candidate.where(),
-                                candidate.from().baseline());
-                if (!candidate.from().composes() && given.isEmpty()) {
-                    continue;   // nothing here can be written against the model's value
-                }
-                where = candidate.where();
-                last = build(subject, axes, candidate.where(), check, given);
-                if (last.row() == null) {
-                    continue;   // nothing composed here; another assignment may compose
-                }
-                // Composed for the arms it was looked for, and not for the combination it was found
-                // at. The combination is where the search went; the arms are what somebody is owed
-                // a row at. One row answering two of them is two answers and not one composite
-                // thing.
-                GeneratedRow named = new GeneratedRow(
-                        takes.stream().map(Purpose.ForAnArm::new).map(Purpose.class::cast).toList(),
-                        last.row().inputs());
-                // Run once per set of values, however many places a row of them was looked for.
-                // What a run of one row did is one fact: two arms searched on their own can come to
-                // the same values, and running them again would be the same row applied twice and
-                // counted twice.
-                //
-                // Keyed by what the row is written as. A template is the text and the expression it
-                // stands for, and the second is a tree whose equality is its own — so a pair of
-                // them makes no key, while the text is the whole of what a row applied twice would
-                // be.
-                Watched watched = applied.computeIfAbsent(
-                        named.inputs().stream().map(FixtureTemplate::text).toList(),
-                        _ -> trial.run(named.inputs()));
-                switch (watched) {
-                    // Nothing can say where it went, so nothing certifies it and nothing refutes
-                    // it. Offered as it was before anything ran, and said to be. Both of the ways
-                    // that happens come here: nothing applied the row, or nothing was recording
-                    // while it was applied.
-                    case Watched.NoAccount _ -> {
-                        return new Witness.Unconfirmed(named, candidate.where());
-                    }
-                    case Watched.Ran ran -> {
-                        // Through the one thing that can say a row filled a combination, which is
-                        // the same thing a row already in the file is put through.
-                        Optional<CellSelection.CertifiedWitness> found =
-                                selection.certifying(candidate.where(), ran.seen());
-                        if (found.isPresent()) {
-                            return new Witness.Certified(named, found.get());
-                        }
-                        missed = true;
-                    }
-                }
-                if (++spent >= runs) {
-                    stopped = true;
-                    return null;
-                }
+        @Override
+        public boolean take(Interpretation reading) {
+            offered = true;
+            int[] about = about(reading);
+            // Whether one value can hold what this reading asks, which is the model's answer and not
+            // the combination's. Asked of the classes it pins alone: what they require is required
+            // whichever value the row is written against, so this does not change with the origin.
+            if (standing(axes, wanting(axes, null, reading), about, selection.cell()::admits)
+                    == null) {
+                return true;   // not a reading, and so no part of what this search is allowed
             }
-            return null;
-        }
-
-        /**
-         * One more reading answered, and whether anything about it was left untried.
-         *
-         * @param cutShort whether the walk had more assignments than it handed over, which is a
-         *                 second way to have stopped beside the runs this counted itself
-         */
-        private void reading(boolean cutShort) {
-            looked = cutShort || stopped ? looked.cutShort() : looked.searched();
-            stopped = false;
+            if (searched >= MOST_INTERPRETATIONS) {
+                return false;   // a reading of this combination that nobody looked at
+            }
+            searched++;
+            // The values the model states first, nearest first, and what they may spend counted in
+            // runs. Then the composition, whatever they spent: it is not one of them and was not
+            // competing with them for their share, and a caller told the stated values were all
+            // refused would go looking for a value the model cannot hold.
+            Running stated = new Running(MOST_RUNS_PER_INTERPRETATION);
+            Traversal walked = nearestFirst(axes, reading, origins, selection.cell()::admits,
+                    stated);
+            if (found != null) {
+                return false;
+            }
+            Running composed = new Running(MOST_RUNS_PER_INTERPRETATION);
+            Traversal composing = composing(axes, reading, origins, selection.cell()::admits,
+                    composed);
+            if (found != null) {
+                return false;
+            }
+            looked = walked == Traversal.STOPPED || composing == Traversal.STOPPED
+                    ? looked.cutShort() : looked.searched();
+            return true;
         }
 
         /** What to say when no reading answered. */
-        private Witness nothing(boolean noReadings) {
+        private Witness nothing(Traversal walked) {
+            if (walked == Traversal.STOPPED) {
+                looked = looked.cutShort();
+            }
             List<String> named =
                     where == null ? List.of() : labels(axes, selection.cell(), where);
             return switch (looked.found()) {
-                // No reading to look at. Either the combination leaves a position nothing, or none
-                // of its readings is one value — and both are the model not having this combination
-                // rather than a search that failed at it.
-                case Completeness.Nothing.NO_READING -> new Witness.NoCombination(
-                        noReadings ? "a position this combination names has nothing left at it"
-                                : "the positions this combination names are not in one value");
-                // A bound stopped one of the readings. Said whatever the candidates it did try came
-                // to: the refusal of the third of them is a fact about that candidate, and offered
-                // as the combination's answer it stands for a space this never entered.
+                // No reading to look at. Either the combination offered nothing, or none of what it
+                // offered is one value — and both are the model not having this combination rather
+                // than a search that failed at it.
+                case Completeness.Nothing.NO_READING -> new Witness.NoCombination(offered
+                        ? "the positions this combination names are not in one value"
+                        : "a position this combination names has nothing left at it");
+                // Something was left undone: a reading nobody looked at, or a candidate nobody ran.
+                // Said as that whatever the ones that were tried came to — the miss of the third of
+                // them is a fact about that candidate, and offered as the combination's answer it
+                // stands for a space this never entered.
                 case Completeness.Nothing.SEARCH_STOPPED -> new Witness.Limited(named);
                 case Completeness.Nothing.LOOKED_EVERYWHERE -> {
                     if (missed) {
@@ -2671,6 +2657,95 @@ public final class Generator {
                             UnresolvedCombination.Reason.NO_REASON_RECORDED, null, Optional.empty());
                 }
             };
+        }
+
+        /**
+         * Running the candidates offered for one reading, up to what that reading may cost.
+         *
+         * <p>Counted in runs, because a run is what this is protecting. Reaching the arm is what a
+         * row for a combination has to do and only the behavior can say whether it did — so a
+         * candidate the model refuses costs nothing, and neither does one whose values a run was
+         * already watched at. Counted per candidate instead, a model whose rules refuse a few
+         * compositions spent a reading's whole share without asking the behavior anything, and a
+         * reading whose remaining candidates were all values something had already run came back
+         * saying the search had stopped.
+         *
+         * <p>So the bound is refused in front of a candidate that needs a run there is none left
+         * for. That candidate is the run nobody did, and it is the only thing here that leaves this
+         * reading incomplete.
+         */
+        private final class Running implements Taking<Candidate> {
+
+            private final int most;
+
+            private int runs;
+
+            private Running(int most) {
+                this.most = most;
+            }
+
+            @Override
+            public boolean take(Candidate candidate) {
+                Map<String, FixtureTemplate> given = candidate.from().composes() ? Map.of()
+                        : against(subject, axes, candidate.delta(), candidate.where(),
+                                candidate.from().baseline());
+                if (!candidate.from().composes() && given.isEmpty()) {
+                    return true;   // nothing here can be written against the model's value
+                }
+                where = candidate.where();
+                last = build(subject, axes, candidate.where(), check, given);
+                if (last.row() == null) {
+                    return true;   // nothing composed here; another assignment may compose
+                }
+                // Composed for the arms it was looked for, and not for the combination it was found
+                // at. The combination is where the search went; the arms are what somebody is owed
+                // a row at. One row answering two of them is two answers and not one composite
+                // thing.
+                GeneratedRow named = new GeneratedRow(
+                        takes.stream().map(Purpose.ForAnArm::new).map(Purpose.class::cast).toList(),
+                        last.row().inputs());
+                // Run once per set of values, however many places a row of them was looked for.
+                // What a run of one row did is one fact: two arms searched on their own can come to
+                // the same values, and running them again would be the same row applied twice and
+                // counted twice.
+                //
+                // Keyed by what the row is written as. A template is the text and the expression it
+                // stands for, and the second is a tree whose equality is its own — so a pair of
+                // them makes no key, while the text is the whole of what a row applied twice would
+                // be.
+                List<String> written = named.inputs().stream().map(FixtureTemplate::text).toList();
+                Watched watched = applied.get(written);
+                if (watched == null) {
+                    if (runs >= most) {
+                        return false;   // this candidate is the run nobody did
+                    }
+                    runs++;
+                    watched = trial.run(named.inputs());
+                    applied.put(written, watched);
+                }
+                switch (watched) {
+                    // Nothing can say where it went, so nothing certifies it and nothing refutes
+                    // it. Offered as it was before anything ran, and said to be. Both of the ways
+                    // that happens come here: nothing applied the row, or nothing was recording
+                    // while it was applied.
+                    case Watched.NoAccount _ -> {
+                        found = new Witness.Unconfirmed(named, candidate.where());
+                        return false;
+                    }
+                    case Watched.Ran ran -> {
+                        // Through the one thing that can say a row filled a combination, which is
+                        // the same thing a row already in the file is put through.
+                        Optional<CellSelection.CertifiedWitness> seen =
+                                selection.certifying(candidate.where(), ran.seen());
+                        if (seen.isPresent()) {
+                            found = new Witness.Certified(named, seen.get());
+                            return false;
+                        }
+                        missed = true;
+                    }
+                }
+                return true;
+            }
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -1079,16 +1079,22 @@ public final class Generator {
                 GeneratedRow row;
                 List<Integer> also;
                 switch (place.tried) {
-                    case Witness.None none -> {
-                        UnresolvedCombination why = new UnresolvedCombination(
-                                none.classes(), none.reason(), none.detail(), none.said());
-                        // Said once for the cell and kept per arm. What a cell came to is one fact
-                        // about it, and a block printing it once per arm looked for there says the
-                        // same thing as many times as the body has arms.
-                        if (!unresolved.contains(why)) {
-                            unresolved.add(why);
-                        }
-                        failed.computeIfAbsent(probe, _ -> new ArrayList<>()).add(why);
+                    case Witness.NoCombination none -> {
+                        noRow(unresolved, failed, probe, new UnresolvedCombination(List.of(),
+                                UnresolvedCombination.Reason.ONE_POSITION_CANNOT_BE_BOTH, null,
+                                Optional.of(none.said())));
+                        continue;
+                    }
+                    case Witness.Exhausted none -> {
+                        noRow(unresolved, failed, probe, new UnresolvedCombination(
+                                none.classes(), none.reason(), none.detail(), none.said()));
+                        continue;
+                    }
+                    case Witness.Limited none -> {
+                        // The search stopped, which is this run's news and not the model's. Said as
+                        // that, whatever the candidates it did try came to.
+                        noRow(unresolved, failed, probe, new UnresolvedCombination(none.classes(),
+                                UnresolvedCombination.Reason.SEARCH_LIMIT));
                         continue;
                     }
                     case Witness.Certified made -> {
@@ -1314,6 +1320,23 @@ public final class Generator {
     }
 
     /**
+     * What one combination came to with no row, written down once for the cell and once per arm.
+     *
+     * <p>Said once for the cell, because what a cell came to is one fact about it and a block
+     * printing it once per arm looked for there says the same thing as many times as the body has
+     * arms. Kept per arm as well, because what an arm was owed and what it got is the arm's own
+     * account.
+     */
+    private static void noRow(List<UnresolvedCombination> unresolved,
+                              Map<Integer, List<UnresolvedCombination>> failed, int probe,
+                              UnresolvedCombination why) {
+        if (!unresolved.contains(why)) {
+            unresolved.add(why);
+        }
+        failed.computeIfAbsent(probe, _ -> new ArrayList<>()).add(why);
+    }
+
+    /**
      * Which other arms still owed a row this run was seen going through.
      *
      * <p>What a run did and not what a reading expects of it. One row can be a row through several
@@ -1460,16 +1483,32 @@ public final class Generator {
             return new ClassAttempt.Built(axis.id(), classId, new GeneratedRow(
                     new Purpose.ForAClass(axis.id(), classId, label), made.row().inputs()));
         }
-        // What the walk came to, and the budget first. A search that stopped says so whatever the
-        // last assignment it got to came to: the refusal of the sixty-fourth candidate is a fact
-        // about that candidate, and offered as the class's answer it stands for a space the search
-        // never entered — the value one place further on that builds, and the composition behind
-        // the baselines that was never reached.
-        UnresolvedCombination why = walk.cutShort() || last == null || last.row() != null
-                ? new UnresolvedCombination(List.of(label),
-                        UnresolvedCombination.Reason.SEARCH_LIMIT)
-                : new UnresolvedCombination(List.of(label), last.reason(), last.detail(),
-                        last.said());
+        // What the walk came to, added up the way a combination's readings are. A class has the
+        // one reading — its own class at its own position — so what is left to say is whether the
+        // walk over the origins reached the end of itself.
+        Completeness looked = walk.candidates().isEmpty()
+                ? Completeness.NOTHING_YET : Completeness.NOTHING_YET.searched();
+        if (walk.cutShort()) {
+            looked = looked.cutShort();
+        }
+        UnresolvedCombination why = switch (looked.found()) {
+            // Nothing to try: the class cannot stand at its own position beside what the position
+            // itself requires, under any origin. Which is the model not having this row rather than
+            // a search that failed to find it.
+            case Completeness.Nothing.NO_READING -> new UnresolvedCombination(List.of(label),
+                    UnresolvedCombination.Reason.ONE_POSITION_CANNOT_BE_BOTH, null,
+                    Optional.of("nothing this class can stand beside was left to try"));
+            // The search stopped. Said so whatever the last assignment it got to came to: the
+            // refusal of the sixty-fourth candidate is a fact about that candidate, and offered as
+            // the class's answer it stands for a space the search never entered.
+            case Completeness.Nothing.SEARCH_STOPPED -> new UnresolvedCombination(List.of(label),
+                    UnresolvedCombination.Reason.SEARCH_LIMIT);
+            case Completeness.Nothing.LOOKED_EVERYWHERE -> last == null
+                    ? new UnresolvedCombination(List.of(label),
+                            UnresolvedCombination.Reason.NO_REASON_RECORDED)
+                    : new UnresolvedCombination(List.of(label), last.reason(), last.detail(),
+                            last.said());
+        };
         return new ClassAttempt.Unresolved(axis.id(), classId, why);
     }
 
@@ -2337,11 +2376,18 @@ public final class Generator {
     /**
      * What the search for a row filling one combination came to.
      *
-     * <p>Three answers and not two, because a row seen filling the combination and a row offered
-     * because nothing could watch it are not the same thing to have found. They differ in what may
-     * afterwards be concluded from the row and in whether this generation may say its rows were
-     * confirmed, so which of them it is, is the answer — rather than something read back off an
-     * empty account of the run.
+     * <p>A row seen filling the combination and a row offered because nothing could watch it are
+     * not the same thing to have found. They differ in what may afterwards be concluded from the row
+     * and in whether this generation may say its rows were confirmed, so which of them it is, is the
+     * answer — rather than something read back off an empty account of the run.
+     *
+     * <p>And coming back with nothing is three answers rather than one. A combination the model does
+     * not have, a search that tried everything the combination leaves, and a search a bound stopped
+     * are three different pieces of news: the first takes the combination away, the second is about
+     * the model, and the third is about this search and says nothing about the model at all. Held as
+     * one value with a reason inside it, the third arrived wearing the second's clothes — the last
+     * candidate's refusal offered as the combination's answer, over candidates nothing tried
+     * ({@link Completeness}).
      */
     private sealed interface Witness {
 
@@ -2352,9 +2398,19 @@ public final class Generator {
         /** A row nothing could watch, offered on the strength of the reading alone. */
         record Unconfirmed(GeneratedRow row, int[] where) implements Witness {}
 
-        /** No row to offer, and why. Never a statement that none exists. */
-        record None(List<String> classes, UnresolvedCombination.Reason reason, String detail,
-                    Optional<String> said) implements Witness {}
+        /** No reading to look at: the model does not have this combination. Never a search that
+         *  failed. */
+        record NoCombination(String said) implements Witness {}
+
+        /** Every candidate of every reading was tried and none answered, and what the last of them
+         *  came to. Read as the combination's answer, that is what it is: nothing was left untried
+         *  behind it. */
+        record Exhausted(List<String> classes, UnresolvedCombination.Reason reason, String detail,
+                         Optional<String> said) implements Witness {}
+
+        /** A bound stopped the search with candidates it had not tried. What the ones it did try
+         *  came to is that candidate's news and not this combination's. */
+        record Limited(List<String> classes) implements Witness {}
     }
 
     /**
@@ -2382,14 +2438,16 @@ public final class Generator {
         Attempt last = null;
         int[] where = null;
         boolean missed = false;
-        boolean read = false;
+        // Whether this looked everywhere, added up as the readings answer rather than read off the
+        // state the loop happened to end in.
+        Completeness looked = Completeness.NOTHING_YET;
         for (Interpretation reading : readings) {
             int[] about = about(reading);
             int[] base = standing(axes, wanting(axes, reading, axes.size()), about, cell::admits);
             if (base == null) {
                 continue;   // this reading is not one value, and another of them may be
             }
-            read = true;
+            boolean stopped = false;
             int runs = 0;
             // Outward from where the reading leaves every other position: the reading alone first,
             // then one position beside it moved, then two. What the combination asks for is settled
@@ -2449,33 +2507,48 @@ public final class Generator {
                         // rules refuse a few compositions spend the reading's whole share on rows
                         // that never ran.
                         if (++runs >= MOST_RUNS_PER_INTERPRETATION) {
+                            stopped = true;
                             break walk;
                         }
                     }
                 }
             }
-        }
-        // A combination whose own positions cannot be in one value under any of its readings. Told
-        // apart from a search that tried what the combination leaves and came back with nothing:
-        // this is a combination the model does not have, and is not one this failed at.
-        if (!read) {
-            return new Witness.None(List.of(),
-                    UnresolvedCombination.Reason.ONE_POSITION_CANNOT_BE_BOTH, null,
-                    Optional.of("the positions this combination names are not in one value"));
+            // Stopped where the bound was reached, whether or not a candidate was left. Which of
+            // the two it was cannot be known without composing the next one, and of the two ways to
+            // be wrong only one of them is a claim about the model: said to have looked everywhere,
+            // a search that had not sends a person to change a rule over a row it never tried.
+            looked = stopped ? looked.cutShort() : looked.searched();
         }
         List<String> named = where == null ? List.of() : labels(axes, cell, where);
-        if (missed) {
-            return new Witness.None(named, UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS, null,
-                    Optional.empty());
-        }
-        if (last != null && last.row() == null) {
-            return new Witness.None(named, last.reason(), last.detail(), last.said());
-        }
-        // Nothing was composed and nothing was refused, which takes the combination leaving no
-        // assignment at all. Named rather than guessed at, the same way every other empty result
-        // here is.
-        return new Witness.None(named, UnresolvedCombination.Reason.NO_REASON_RECORDED, null,
-                Optional.empty());
+        return switch (looked.found()) {
+            // No reading to look at. Either the combination leaves a position nothing, or none of
+            // its readings is one value — and both are the model not having this combination rather
+            // than a search that failed at it.
+            case Completeness.Nothing.NO_READING -> new Witness.NoCombination(
+                    readings.isEmpty() ? "a position this combination names has nothing left at it"
+                            : "the positions this combination names are not in one value");
+            // A bound stopped one of the readings. Said whatever the candidates it did try came to:
+            // the refusal of the third of them is a fact about that candidate, and offered as the
+            // combination's answer it stands for a space this never entered.
+            case Completeness.Nothing.SEARCH_STOPPED -> new Witness.Limited(named);
+            case Completeness.Nothing.LOOKED_EVERYWHERE -> {
+                if (missed) {
+                    // Rows were composed and run, and went somewhere else. Which says they were not
+                    // witnesses, and not that the combination is unreachable.
+                    yield new Witness.Exhausted(named,
+                            UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS, null,
+                            Optional.empty());
+                }
+                if (last != null && last.row() == null) {
+                    yield new Witness.Exhausted(named, last.reason(), last.detail(), last.said());
+                }
+                // Nothing was composed and nothing was refused, which takes every reading leaving no
+                // assignment at all. Named rather than guessed at, the same way every other empty
+                // result here is.
+                yield new Witness.Exhausted(named, UnresolvedCombination.Reason.NO_REASON_RECORDED,
+                        null, Optional.empty());
+            }
+        };
     }
 
     /** The positions one reading is about, in the axes' own order. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -59,15 +59,35 @@ public final class Generator {
     private static final int MAX_TUPLES = 256;
 
     /**
-     * How many rows one combination is composed for before the search gives up on it.
+     * How many things one combination may be asking before the search gives up on it.
      *
-     * <p>What a combination leaves open is often several assignments, and the first of them is
-     * chosen for what else it covers rather than for reaching the meeting — so a second is worth
-     * trying where the first went somewhere else. What this bounds is how much of the search one
-     * combination may spend: a group whose reading is wrong misses at every assignment, and without
-     * a bound it would work its way through the whole space while every other group waited.
+     * <p>A combination is a class apiece at the positions it is about, and where it leaves a
+     * position more than one class it is asking more than one thing. What this bounds is how many of
+     * those a search may try: a group whose reading is wrong misses at every one of them, and
+     * without a bound it would work its way through the whole space while every other group waited.
+     *
+     * <p><b>Readings and not assignments.</b> Counted over whole assignments, most of what the bound
+     * was spent on differed only at positions the combination says nothing about — so three tries
+     * were three rows asking the same thing, and a combination's second meaning went untried however
+     * much of the bound was left ({@link Interpretation}).
      */
-    private static final int MOST_CANDIDATES = 3;
+    private static final int MOST_INTERPRETATIONS = 3;
+
+    /**
+     * How many rows one reading of a combination is run for before the search moves on.
+     *
+     * <p>Counted in runs, because a run is what this is protecting. Reaching the arm is what a row
+     * for a combination has to do and only the behavior can say whether it did, so every candidate
+     * that composes costs a run — while a candidate the model refuses costs nothing but the
+     * composing, and counting those would let a model whose rules refuse a few compositions spend a
+     * reading's whole share without ever asking the behavior anything.
+     *
+     * <p>Its own bound and not the class walk's. {@link #MOST_REPAIRS} bounds a walk whose every
+     * candidate is built and no more; this bounds one whose every candidate is run. The two are the
+     * same shape of search and are not the same cost, and one number over both would be set by
+     * whichever of them it hurt more.
+     */
+    private static final int MOST_RUNS_PER_INTERPRETATION = 3;
 
     /** The behavior a row would be written for: what its inputs are called, what they are, and where
      * the model divides them. */
@@ -1655,7 +1675,7 @@ public final class Generator {
                 if (base == null) {
                     continue;   // a class that cannot stand at its own position is no assignment
                 }
-                for (int[] supporting : supportingSets(axes, at, moved, base)) {
+                for (int[] supporting : supportingSets(axes, new int[] {at}, moved, base)) {
                     for (int[] where : assignmentsOver(axes, base, supporting)) {
                         Candidate candidate = new Candidate(origin, where,
                                 Delta.between(origin.stands(), where));
@@ -1699,7 +1719,7 @@ public final class Generator {
     }
 
     /**
-     * Which positions beside {@code at} a row may move, {@code moved} of them at a time.
+     * Which positions beside the ones a row is about it may move, {@code moved} at a time.
      *
      * <p>In the axes' own order and combinations of it, so two runs of one model walk the same
      * assignments in the same order and offer the same rows.
@@ -1710,27 +1730,27 @@ public final class Generator {
      * a row one position from its origin was offered behind rows two away, and the number the budget
      * was spent by counted what the search reached for rather than what it moved.
      */
-    private static List<int[]> supportingSets(List<Axis> axes, int at, int moved, int[] base) {
+    private static List<int[]> supportingSets(List<Axis> axes, int[] about, int moved, int[] base) {
         if (moved > axes.size()) {
             return List.of();
         }
         List<int[]> out = new ArrayList<>();
-        chooseSupporting(axes, at, moved, 0, new int[moved], 0, out, base);
+        chooseSupporting(axes, about, moved, 0, new int[moved], 0, out, base);
         return out;
     }
 
-    private static void chooseSupporting(List<Axis> axes, int at, int moved, int from,
+    private static void chooseSupporting(List<Axis> axes, int[] about, int moved, int from,
                                          int[] taken, int filled, List<int[]> out, int[] base) {
         if (filled == moved) {
             out.add(taken.clone());
             return;
         }
         for (int i = from; i < axes.size(); i++) {
-            if (i == at || base[i] == NOT_HERE) {
+            if (anchored(about, i) || base[i] == NOT_HERE) {
                 continue;
             }
             taken[filled] = i;
-            chooseSupporting(axes, at, moved, i + 1, taken, filled + 1, out, base);
+            chooseSupporting(axes, about, moved, i + 1, taken, filled + 1, out, base);
         }
     }
 
@@ -2281,64 +2301,8 @@ public final class Generator {
         return -1;
     }
 
-    /**
-    /**
-     * Every position at the first class {@code cell} admits it, which is the assignment a row for
-     * that cell is first tried at.
-     *
-     * <p>The positions the cell settles hold what it settles them at; the rest hold the first of
-     * what they may, because the row is not about them. A row that also moved the positions beside
-     * the combination would be several answers a person has to separate.
-     */
-    private static int[] firstAdmitted(List<Axis> axes, InteractionCells.Cell cell) {
-        int[] wanted = new int[axes.size()];
-        for (int i = 0; i < axes.size(); i++) {
-            int at = i;
-            wanted[i] = standingAt(axes.get(i), c -> cell.admits(at, c));
-        }
-        return standing(axes, wanted, narrowedBy(axes, cell), cell::admits);
-    }
 
-    /** The classes the cell admits at each position, or null where it admits none somewhere — which
-     *  is a position with nothing in it and so not a combination. */
-    private static List<List<Integer>> admittedBy(List<Axis> axes, InteractionCells.Cell cell) {
-        List<List<Integer>> admitted = new ArrayList<>();
-        for (int i = 0; i < axes.size(); i++) {
-            List<Integer> here = new ArrayList<>();
-            for (int c = 0; c < axes.get(i).classes().size(); c++) {
-                if (cell.admits(i, c)) {
-                    here.add(c);
-                }
-            }
-            if (here.isEmpty()) {
-                return null;
-            }
-            admitted.add(here);
-        }
-        return admitted;
-    }
 
-    /**
-     * Which positions a cell is about, which are the ones it narrows.
-     *
-     * <p>What an assignment for a cell keeps whatever else it has to give up. A cell says which
-     * classes each position may hold, and a position it says nothing about is one the row is free
-     * at — so a row that gave up a narrowed position to keep a free one would be a row for a
-     * combination the cell does not name.
-     */
-    private static int[] narrowedBy(List<Axis> axes, InteractionCells.Cell cell) {
-        List<Integer> out = new ArrayList<>();
-        for (int i = 0; i < axes.size(); i++) {
-            if (cell.narrows(i)) {
-                out.add(i);
-            }
-        }
-        int[] at = new int[out.size()];
-        for (int i = 0; i < out.size(); i++) {
-            at[i] = out.get(i);
-        }
-        return at;
-    }
 
     /** What a row is about, in the words the model uses. The class's label rather than its id: an id
      * is scoped by carrying its own path, and a description that carries the path already would say
@@ -2411,65 +2375,93 @@ public final class Generator {
                                       CellSelection selection, CandidateCheck check, Trial trial,
                                       Map<List<String>, Watched> applied, List<Integer> takes) {
         InteractionCells.Cell cell = selection.cell();
-        List<int[]> tried = new ArrayList<>();
+        // What the combination can be asking, worked out by the combination. A reading is a class
+        // apiece at the positions it is about; where a row stands anywhere else is this search's own
+        // choice, and counted as a reading it spent the bound on rows that ask the same thing.
+        List<Interpretation> readings = selection.interpretations(MOST_INTERPRETATIONS);
         Attempt last = null;
         int[] where = null;
         boolean missed = false;
-        // The first assignment, worked out once. A cell whose own positions cannot be in one value
-        // leaves none at all, and that is the one thing told apart from a search that has tried
-        // everything the cell leaves: a combination the model does not have is not one this failed
-        // at.
-        int[] first = firstAdmitted(axes, cell);
-        if (first == null) {
+        boolean read = false;
+        for (Interpretation reading : readings) {
+            int[] about = about(reading);
+            int[] base = standing(axes, wanting(axes, reading, axes.size()), about, cell::admits);
+            if (base == null) {
+                continue;   // this reading is not one value, and another of them may be
+            }
+            read = true;
+            int runs = 0;
+            // Outward from where the reading leaves every other position: the reading alone first,
+            // then one position beside it moved, then two. What the combination asks for is settled
+            // at every one of them, so each is a row for this reading and they differ in what else
+            // they cover.
+            walk:
+            for (int moved = 0; moved <= axes.size(); moved++) {
+                for (int[] supporting : supportingSets(axes, about, moved, base)) {
+                    for (int[] at : assignmentsOver(axes, base, supporting)) {
+                        where = at;
+                        last = build(subject, axes, at, check);
+                        if (last.row() == null) {
+                            continue;   // nothing composed here; another assignment may compose
+                        }
+                        // Composed for the arms it was looked for, and not for the combination it
+                        // was found at. The combination is where the search went; the arms are what
+                        // somebody is owed a row at. One row answering two of them is two answers
+                        // and not one composite thing.
+                        GeneratedRow named = new GeneratedRow(
+                                takes.stream().map(Purpose.ForAnArm::new).map(Purpose.class::cast)
+                                        .toList(),
+                                last.row().inputs());
+                        // Run once per set of values, however many places a row of them was looked
+                        // for. What a run of one row did is one fact: two arms searched on their own
+                        // can come to the same values, and running them again would be the same row
+                        // applied twice and counted twice.
+                        //
+                        // Keyed by what the row is written as. A template is the text and the
+                        // expression it stands for, and the second is a tree whose equality is its
+                        // own — so a pair of them makes no key, while the text is the whole of what
+                        // a row applied twice would be.
+                        Watched watched = applied.computeIfAbsent(
+                                named.inputs().stream().map(FixtureTemplate::text).toList(),
+                                _ -> trial.run(named.inputs()));
+                        switch (watched) {
+                            // Nothing can say where it went, so nothing certifies it and nothing
+                            // refutes it. Offered as it was before anything ran, and said to be.
+                            // Both of the ways that happens come here: nothing applied the row, or
+                            // nothing was recording while it was applied.
+                            case Watched.NoAccount _ -> {
+                                return new Witness.Unconfirmed(named, at);
+                            }
+                            case Watched.Ran ran -> {
+                                // Through the one thing that can say a row filled a combination,
+                                // which is the same thing a row already in the file is put through.
+                                Optional<CellSelection.CertifiedWitness> found =
+                                        selection.certifying(at, ran.seen());
+                                if (found.isPresent()) {
+                                    return new Witness.Certified(named, found.get());
+                                }
+                                missed = true;
+                            }
+                        }
+                        // Counted here and nowhere else. What this bounds is how much of a run
+                        // budget one reading may spend, and an assignment nothing composed put
+                        // nothing through the behavior — so counting it would let a model whose
+                        // rules refuse a few compositions spend the reading's whole share on rows
+                        // that never ran.
+                        if (++runs >= MOST_RUNS_PER_INTERPRETATION) {
+                            break walk;
+                        }
+                    }
+                }
+            }
+        }
+        // A combination whose own positions cannot be in one value under any of its readings. Told
+        // apart from a search that tried what the combination leaves and came back with nothing:
+        // this is a combination the model does not have, and is not one this failed at.
+        if (!read) {
             return new Witness.None(List.of(),
                     UnresolvedCombination.Reason.ONE_POSITION_CANNOT_BE_BOTH, null,
                     Optional.of("the positions this combination names are not in one value"));
-        }
-        for (int candidate = 0; candidate < MOST_CANDIDATES; candidate++) {
-            int[] at = candidate == 0 ? first : alternative(axes, cell, candidate, tried);
-            if (at == null) {
-                break;   // the combination leaves nothing this has not already tried
-            }
-            tried.add(at);
-            where = at;
-            last = build(subject, axes, at, check);
-            if (last.row() == null) {
-                continue;   // nothing composed here; another assignment may compose
-            }
-            // Composed for the arms it was looked for, and not for the combination it was found
-            // at. The combination is where the search went; the arms are what somebody is owed a
-            // row at. One row answering two of them is two answers and not one composite thing.
-            GeneratedRow named = new GeneratedRow(
-                    takes.stream().map(Purpose.ForAnArm::new).map(Purpose.class::cast).toList(),
-                    last.row().inputs());
-            // Run once per set of values, however many places a row of them was looked for. What a
-            // run of one row did is one fact: two arms searched on their own can come to the same
-            // values, and running them again would be the same row applied twice and counted twice.
-            //
-            // Keyed by what the row is written as. A template is the text and the expression it
-            // stands for, and the second is a tree whose equality is its own — so a pair of them
-            // makes no key, while the text is the whole of what a row applied twice would be.
-            switch (applied.computeIfAbsent(
-                    named.inputs().stream().map(FixtureTemplate::text).toList(),
-                    _ -> trial.run(named.inputs()))) {
-                // Nothing can say where it went, so nothing certifies it and nothing refutes it.
-                // Offered as it was before anything ran, and said to be. Both of the ways that
-                // happens come here: nothing applied the row, or nothing was recording while it
-                // was applied.
-                case Watched.NoAccount _ -> {
-                    return new Witness.Unconfirmed(named, at);
-                }
-                case Watched.Ran ran -> {
-                    // Through the one thing that can say a row filled a combination, which is the
-                    // same thing a row already in the file is put through.
-                    Optional<CellSelection.CertifiedWitness> found =
-                            selection.certifying(at, ran.seen());
-                    if (found.isPresent()) {
-                        return new Witness.Certified(named, found.get());
-                    }
-                    missed = true;
-                }
-            }
         }
         List<String> named = where == null ? List.of() : labels(axes, cell, where);
         if (missed) {
@@ -2486,54 +2478,23 @@ public final class Generator {
                 Optional.empty());
     }
 
-    /**
-     * An assignment for {@code cell} beside the first, or null where it leaves none this has not
-     * tried.
-     *
-     * <p>The first is {@link #firstAdmitted}: every position the combination does not settle at the
-     * first class the cell admits there, which is as much of the row as this is about. These are the
-     * others, counted off in order — a fixed order, so the same model offers the same rows twice.
-     *
-     * <p>Bounded by how many have been tried rather than by a walk over the space: at most
-     * {@link #MOST_CANDIDATES} assignments are ever tried, so one of the first that many is one
-     * that has not been.
-     */
-    private static int[] alternative(List<Axis> axes,
-                                     InteractionCells.Cell cell, int candidate, List<int[]> tried) {
-        List<List<Integer>> admitted = admittedBy(axes, cell);
-        if (admitted == null) {
-            return null;   // a position with nothing in it is not a combination
-        }
-        int[] anchors = narrowedBy(axes, cell);
-        for (int index = 0; index < MOST_CANDIDATES; index++) {
-            int[] wanted = new int[axes.size()];
-            int left = index;
-            for (int i = 0; i < axes.size(); i++) {
-                List<Integer> here = admitted.get(i);
-                wanted[i] = here.get(left % here.size());
-                left /= here.size();
-            }
-            // Each position's classes counted off on its own, which is what this assignment would
-            // like rather than one a value can be. Put through the same thing the first one is:
-            // counted off and taken as they came, the alternatives reach assignments no value has —
-            // a class under one case of a sum beside a class under another — and every one of them
-            // spends a try on a row nobody could write.
-            int[] where = standing(axes, wanted, anchors, cell::admits);
-            if (where != null && !alreadyTried(tried, where)) {
-                return where;
-            }
-        }
-        return null;
+    /** The positions one reading is about, in the axes' own order. */
+    private static int[] about(Interpretation reading) {
+        int[] out = reading.at().stream().mapToInt(Integer::intValue).sorted().toArray();
+        return out;
     }
 
-    private static boolean alreadyTried(List<int[]> tried, int[] where) {
-        for (int[] each : tried) {
-            if (java.util.Arrays.equals(each, where)) {
-                return true;
-            }
+    /** What a row for one reading starts from: the classes the reading pins, and nothing said
+     *  anywhere else. */
+    private static int[] wanting(List<Axis> axes, Interpretation reading, int size) {
+        int[] wanted = new int[size];
+        java.util.Arrays.fill(wanted, NOT_HERE);
+        for (Map.Entry<Integer, Integer> pin : reading.pins().entrySet()) {
+            wanted[pin.getKey()] = pin.getValue();
         }
-        return false;
+        return wanted;
     }
+
 
     // --- turning classes into a row -------------------------------------------------------------
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -1467,13 +1467,13 @@ public final class Generator {
         // say; how many of them may be built is this class's own budget.
         Building building = new Building(subject, axes, at, classId, label, check, MOST_REPAIRS);
         Traversal stated = nearestFirst(axes, reading, origins, (_, _) -> true, building);
-        if (building.found != null) {
+        if (stated == Traversal.SATISFIED) {
             return new ClassAttempt.Built(axis.id(), classId, building.found);
         }
         // The composition, whatever the stated values spent, and with a budget of its own.
         Building composing = new Building(subject, axes, at, classId, label, check, MOST_REPAIRS);
         Traversal composed = composing(axes, reading, origins, (_, _) -> true, composing);
-        if (composing.found != null) {
+        if (composed == Traversal.SATISFIED) {
             return new ClassAttempt.Built(axis.id(), classId, composing.found);
         }
         // What the walks came to, added up the way a combination's readings are. A class has the
@@ -1520,6 +1520,10 @@ public final class Generator {
      */
     private static final class Building implements Taking<Candidate> {
 
+        // The row this walk was for, once one lands in the class. Read where the walk says it was
+        // satisfied and nowhere else: a walk that stopped and a walk that finished are two answers
+        // now, and reading a field to tell them apart is what having three of them is for.
+
         private final Subject subject;
 
         private final List<Axis> axes;
@@ -1555,30 +1559,30 @@ public final class Generator {
         }
 
         @Override
-        public boolean take(Candidate candidate) {
+        public Taken take(Candidate candidate) {
             Map<String, FixtureTemplate> given = candidate.from().composes() ? Map.of()
                     : against(subject, axes, candidate.delta(), candidate.where(),
                             candidate.from().baseline());
             if (!candidate.from().composes() && given.isEmpty()) {
-                return true;   // nothing here can be written against the model's value
+                return Taken.AND_MORE;   // nothing here can be written against the model's value
             }
             if (builds >= most) {
-                return false;   // this candidate is the work nobody did
+                return Taken.NOT_TAKEN;   // this candidate is the work nobody did
             }
             builds++;
             Attempt made = build(subject, axes, candidate.where(), check, given);
             if (made.row() == null) {
                 last = made;
-                return true;
+                return Taken.AND_MORE;
             }
             if (!inTheClass(subject, axes, at, classId, made.row().inputs(), check)) {
                 last = new Attempt(null, UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS, label,
                         Optional.empty());
-                return true;
+                return Taken.AND_MORE;
             }
             found = new GeneratedRow(new Purpose.ForAClass(axes.get(at).id(), classId, label),
                     made.row().inputs());
-            return false;
+            return Taken.AND_DONE;
         }
     }
 
@@ -1688,9 +1692,12 @@ public final class Generator {
                     here.add(origin);
                 }
             }
-            if (!here.isEmpty()
-                    && gather(axes, reading, about, here, admits, taking) == Traversal.STOPPED) {
-                return Traversal.STOPPED;
+            if (here.isEmpty()) {
+                continue;
+            }
+            Traversal walked = gather(axes, reading, about, here, admits, taking);
+            if (walked != Traversal.EXHAUSTED) {
+                return walked;
             }
         }
         return Traversal.EXHAUSTED;
@@ -1715,10 +1722,12 @@ public final class Generator {
                                        Taking<Candidate> taking) {
         int[] about = about(reading);
         for (ResolvedOrigin origin : origins) {
-            if (origin.composes()
-                    && gather(axes, reading, about, List.of(origin), admits, taking)
-                            == Traversal.STOPPED) {
-                return Traversal.STOPPED;
+            if (!origin.composes()) {
+                continue;
+            }
+            Traversal walked = gather(axes, reading, about, List.of(origin), admits, taking);
+            if (walked != Traversal.EXHAUSTED) {
+                return walked;
             }
         }
         return Traversal.EXHAUSTED;
@@ -1770,8 +1779,9 @@ public final class Generator {
             // this one alone: what is due is a fact about the distances, and a walk that read it off
             // the size of the set it had just finished would leave a nearer assignment sitting in
             // the map for as long as the set that produced it was larger than it.
-            if (handOut(waiting, moved, taking) == Traversal.STOPPED) {
-                return Traversal.STOPPED;
+            Traversal walked = handOut(waiting, moved, taking);
+            if (walked != Traversal.EXHAUSTED) {
+                return walked;
             }
         }
         // What the readings moved beyond the largest set walked. Nothing generates at these
@@ -1806,8 +1816,14 @@ public final class Generator {
                 return Traversal.EXHAUSTED;
             }
             for (Candidate candidate : sortedByOrigin(waiting.remove(distance))) {
-                if (!taking.take(candidate)) {
-                    return Traversal.STOPPED;
+                switch (taking.take(candidate)) {
+                    case NOT_TAKEN -> {
+                        return Traversal.STOPPED;
+                    }
+                    case AND_DONE -> {
+                        return Traversal.SATISFIED;
+                    }
+                    case AND_MORE -> { }
                 }
             }
         }
@@ -2512,7 +2528,7 @@ public final class Generator {
         Reading reading =
                 new Reading(subject, axes, selection, check, trial, applied, takes, origins);
         Traversal walked = selection.interpretations(reading);
-        return reading.found != null ? reading.found : reading.nothing(walked);
+        return walked == Traversal.SATISFIED ? reading.found : reading.nothing(walked);
     }
 
     /**
@@ -2584,7 +2600,7 @@ public final class Generator {
         }
 
         @Override
-        public boolean take(Interpretation reading) {
+        public Taken take(Interpretation reading) {
             offered = true;
             int[] about = about(reading);
             // Whether one value can hold what this reading asks, which is the model's answer and not
@@ -2592,31 +2608,30 @@ public final class Generator {
             // whichever value the row is written against, so this does not change with the origin.
             if (standing(axes, wanting(axes, null, reading), about, selection.cell()::admits)
                     == null) {
-                return true;   // not a reading, and so no part of what this search is allowed
+                // not a reading, and so no part of what this search is allowed
+                return Taken.AND_MORE;
             }
             if (searched >= MOST_INTERPRETATIONS) {
-                return false;   // a reading of this combination that nobody looked at
+                return Taken.NOT_TAKEN;   // a reading of this combination that nobody looked at
             }
             searched++;
             // The values the model states first, nearest first, and what they may spend counted in
             // runs. Then the composition, whatever they spent: it is not one of them and was not
             // competing with them for their share, and a caller told the stated values were all
             // refused would go looking for a value the model cannot hold.
-            Running stated = new Running(MOST_RUNS_PER_INTERPRETATION);
             Traversal walked = nearestFirst(axes, reading, origins, selection.cell()::admits,
-                    stated);
-            if (found != null) {
-                return false;
+                    new Running(MOST_RUNS_PER_INTERPRETATION));
+            if (walked == Traversal.SATISFIED) {
+                return Taken.AND_DONE;
             }
-            Running composed = new Running(MOST_RUNS_PER_INTERPRETATION);
-            Traversal composing = composing(axes, reading, origins, selection.cell()::admits,
-                    composed);
-            if (found != null) {
-                return false;
+            Traversal composed = composing(axes, reading, origins, selection.cell()::admits,
+                    new Running(MOST_RUNS_PER_INTERPRETATION));
+            if (composed == Traversal.SATISFIED) {
+                return Taken.AND_DONE;
             }
-            looked = walked == Traversal.STOPPED || composing == Traversal.STOPPED
+            looked = walked == Traversal.STOPPED || composed == Traversal.STOPPED
                     ? looked.cutShort() : looked.searched();
-            return true;
+            return Taken.AND_MORE;
         }
 
         /** What to say when no reading answered. */
@@ -2685,17 +2700,19 @@ public final class Generator {
             }
 
             @Override
-            public boolean take(Candidate candidate) {
+            public Taken take(Candidate candidate) {
                 Map<String, FixtureTemplate> given = candidate.from().composes() ? Map.of()
                         : against(subject, axes, candidate.delta(), candidate.where(),
                                 candidate.from().baseline());
                 if (!candidate.from().composes() && given.isEmpty()) {
-                    return true;   // nothing here can be written against the model's value
+                    // nothing here can be written against the model's value
+                    return Taken.AND_MORE;
                 }
                 where = candidate.where();
                 last = build(subject, axes, candidate.where(), check, given);
                 if (last.row() == null) {
-                    return true;   // nothing composed here; another assignment may compose
+                    // nothing composed here; another assignment may compose
+                    return Taken.AND_MORE;
                 }
                 // Composed for the arms it was looked for, and not for the combination it was found
                 // at. The combination is where the search went; the arms are what somebody is owed
@@ -2717,7 +2734,7 @@ public final class Generator {
                 Watched watched = applied.get(written);
                 if (watched == null) {
                     if (runs >= most) {
-                        return false;   // this candidate is the run nobody did
+                        return Taken.NOT_TAKEN;   // this candidate is the run nobody did
                     }
                     runs++;
                     watched = trial.run(named.inputs());
@@ -2730,7 +2747,7 @@ public final class Generator {
                     // while it was applied.
                     case Watched.NoAccount _ -> {
                         found = new Witness.Unconfirmed(named, candidate.where());
-                        return false;
+                        return Taken.AND_DONE;
                     }
                     case Watched.Ran ran -> {
                         // Through the one thing that can say a row filled a combination, which is
@@ -2739,12 +2756,12 @@ public final class Generator {
                                 selection.certifying(candidate.where(), ran.seen());
                         if (seen.isPresent()) {
                             found = new Witness.Certified(named, seen.get());
-                            return false;
+                            return Taken.AND_DONE;
                         }
                         missed = true;
                     }
                 }
-                return true;
+                return Taken.AND_MORE;
             }
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -2081,7 +2081,43 @@ public final class Generator {
             }
             fields.put(field.name(), values.written().get(0));
         }
-        return fields.isEmpty() ? null : FixtureTemplate.spreading(type, baseline, fields);
+        if (fields.isEmpty()) {
+            return null;
+        }
+        // Written out rather than spread where the row moves every field the value has. The spread
+        // is what says the row is that value with something changed, and a spread whose moved fields
+        // cover the whole record says it over a value that contributes nothing — the same row in
+        // more words, and a reader comparing it against what the file states finds every field
+        // different.
+        //
+        // The values are the ones this candidate was built and run with. Composing the parameter
+        // again from its classes would be a different row wearing this one's answer: a rule relating
+        // two positions can refuse what the classes name while the model's own value builds, which
+        // is why the value the model states is where this search starts.
+        List<String> declared = fieldsOf(subject, built);
+        if (declared != null && fields.keySet().containsAll(declared)) {
+            Map<String, FixtureTemplate> written = new LinkedHashMap<>();
+            for (String field : declared) {
+                written.put(field, fields.get(field));
+            }
+            return FixtureTemplate.record(type, written);
+        }
+        return FixtureTemplate.spreading(type, baseline, fields);
+    }
+
+    /**
+     * The fields a value of {@code built} has, in the order they are written, or null where it is
+     * not a record.
+     *
+     * <p>Every field it has and not the ones its own declaration lists: a record that includes
+     * another's fields has those too, and a row that wrote over the listed ones and dropped the
+     * spread would drop the included ones with it.
+     */
+    private static List<String> fieldsOf(Subject subject, TypeSymbol built) {
+        return subject.symbols().declarations().declaration(built.key()) instanceof Hir.Data data
+                && !data.newtype()
+                ? List.copyOf(TypeOps.fieldTypes(data, subject.symbols()).keySet())
+                : null;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Interpretation.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Interpretation.java
@@ -1,0 +1,43 @@
+package souther.compiler.partition;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * One reading of what a combination asks of a row.
+ *
+ * <p>A class apiece at the positions the combination is about, and nothing said about the rest.
+ * Which positions those are is the combination's to answer: a row filling it has to sit in these
+ * classes, and where it stands anywhere else is the search's own choice rather than something the
+ * combination asked for.
+ *
+ * <p><b>What a search counts, and what it does not.</b> How many readings one combination has is how
+ * many different things it can be asking, and a bound on the search is a bound on those. Counted
+ * over whole assignments instead, most of what a search tried differed only at positions the
+ * combination says nothing about — so a bound meant to stop a wrong reading from walking the space
+ * was spent before the reading's second meaning was ever tried.
+ *
+ * @param pins the class each position the combination is about must hold, by the index of the
+ *             position in the order the axes are ordered
+ */
+public record Interpretation(Map<Integer, Integer> pins) {
+
+    public Interpretation {
+        pins = Map.copyOf(pins);
+    }
+
+    /** The positions this is about. */
+    public Set<Integer> at() {
+        return pins.keySet();
+    }
+
+    /** Which parameters this is about, which is what an origin either states a value of or does
+     *  not. */
+    public Set<String> heads(java.util.List<Axis> axes) {
+        java.util.Set<String> out = new java.util.LinkedHashSet<>();
+        for (int i : pins.keySet()) {
+            out.add(axes.get(i).path().head());
+        }
+        return out;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Interpretation.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Interpretation.java
@@ -1,5 +1,7 @@
 package souther.compiler.partition;
 
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -33,8 +35,8 @@ public record Interpretation(Map<Integer, Integer> pins) {
 
     /** Which parameters this is about, which is what an origin either states a value of or does
      *  not. */
-    public Set<String> heads(java.util.List<Axis> axes) {
-        java.util.Set<String> out = new java.util.LinkedHashSet<>();
+    public Set<String> heads(List<Axis> axes) {
+        Set<String> out = new LinkedHashSet<>();
         for (int i : pins.keySet()) {
             out.add(axes.get(i).path().head());
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Taking.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Taking.java
@@ -1,0 +1,25 @@
+package souther.compiler.partition;
+
+/**
+ * What a walk over work hands each piece to.
+ *
+ * <p>The consumer's answer is about the piece in front of it and nothing else: it did that piece, or
+ * it did not. Which makes the walk's own answer exact — a piece refused is a piece nobody did, so
+ * there is no guessing at whether anything was left ({@link Traversal}).
+ *
+ * <p><b>What a piece costs is the consumer's to say.</b> A class counts what it built and an arm
+ * counts what it ran, and a candidate the model refuses cost neither of them anything. Counted by
+ * the walk instead, one bound would be spent by work the other never did.
+ */
+@FunctionalInterface
+public interface Taking<T> {
+
+    /**
+     * Whether this took {@code each}.
+     *
+     * <p>False leaves it undone, which is what makes the walk {@link Traversal#STOPPED}. A consumer
+     * that has what it came for says so the same way: it is not taking this one either, and what it
+     * found is its own to hand back.
+     */
+    boolean take(T each);
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Taking.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Taking.java
@@ -3,9 +3,10 @@ package souther.compiler.partition;
 /**
  * What a walk over work hands each piece to.
  *
- * <p>The consumer's answer is about the piece in front of it and nothing else: it did that piece, or
- * it did not. Which makes the walk's own answer exact — a piece refused is a piece nobody did, so
- * there is no guessing at whether anything was left ({@link Traversal}).
+ * <p>The consumer's answer is about the piece in front of it: it did that piece or it did not, and
+ * if it did, whether that was the last one it needs. Which makes the walk's own answer exact — a
+ * piece refused is a piece nobody did, and a walk that ends because a consumer is finished is not a
+ * walk that left anything ({@link Traversal}).
  *
  * <p><b>What a piece costs is the consumer's to say.</b> A class counts what it built and an arm
  * counts what it ran, and a candidate the model refuses cost neither of them anything. Counted by
@@ -14,12 +15,19 @@ package souther.compiler.partition;
 @FunctionalInterface
 public interface Taking<T> {
 
-    /**
-     * Whether this took {@code each}.
-     *
-     * <p>False leaves it undone, which is what makes the walk {@link Traversal#STOPPED}. A consumer
-     * that has what it came for says so the same way: it is not taking this one either, and what it
-     * found is its own to hand back.
-     */
-    boolean take(T each);
+    /** What this did with {@code each}. */
+    Taken take(T each);
+
+    /** What a consumer did with the piece in front of it. */
+    enum Taken {
+
+        /** Did it, and will take another. */
+        AND_MORE,
+
+        /** Did it, and has what it came for. */
+        AND_DONE,
+
+        /** Did not do it, which leaves it as work nobody did. */
+        NOT_TAKEN
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Traversal.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Traversal.java
@@ -1,0 +1,24 @@
+package souther.compiler.partition;
+
+/**
+ * How a walk over work ended.
+ *
+ * <p>Two ends and the difference between them is what a caller may afterwards say. A walk that ran
+ * out handed over everything there was; a walk that was stopped left a piece of work in front of it
+ * that nobody did. Read off a counter reaching a number instead, the two came out the same — a
+ * consumer that did exactly as many pieces as it was allowed reported having stopped, over a walk
+ * that had nothing more to give it.
+ *
+ * <p><b>Which is why the walk answers this and not the bound.</b> A bound is a fact about the
+ * consumer: how many builds a class may spend, how many runs a reading may cost. Whether anything
+ * was left is a fact about the walk, and only the walk was holding the piece the consumer would not
+ * take.
+ */
+public enum Traversal {
+
+    /** Every piece was handed over and there was no more. */
+    EXHAUSTED,
+
+    /** A piece was in front of the walk and the consumer would not do it. */
+    STOPPED
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Traversal.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Traversal.java
@@ -3,22 +3,29 @@ package souther.compiler.partition;
 /**
  * How a walk over work ended.
  *
- * <p>Two ends and the difference between them is what a caller may afterwards say. A walk that ran
- * out handed over everything there was; a walk that was stopped left a piece of work in front of it
- * that nobody did. Read off a counter reaching a number instead, the two came out the same — a
- * consumer that did exactly as many pieces as it was allowed reported having stopped, over a walk
- * that had nothing more to give it.
+ * <p>Three ends, because two of them are a walk that stopped and only one of them is a walk that
+ * left something undone. A walk that ran out handed over everything there was; a walk a consumer
+ * ended because it had what it came for handed over everything it needed; a walk a consumer refused
+ * left a piece in front of it that nobody did. Only the third says the search was incomplete.
+ *
+ * <p>Held as two, the third had to be told from the second by looking at whether the consumer was
+ * holding an answer — which is a value whose meaning is somewhere else, and the next caller to read
+ * {@code STOPPED} as "something was left" would be right about the name and wrong about the run.
  *
  * <p><b>Which is why the walk answers this and not the bound.</b> A bound is a fact about the
  * consumer: how many builds a class may spend, how many runs a reading may cost. Whether anything
- * was left is a fact about the walk, and only the walk was holding the piece the consumer would not
- * take.
+ * was left is a fact about the walk, and only the walk was holding the piece the consumer refused.
  */
 public enum Traversal {
 
     /** Every piece was handed over and there was no more. */
     EXHAUSTED,
 
-    /** A piece was in front of the walk and the consumer would not do it. */
+    /** A consumer took a piece and had what it came for. Nothing was left undone; there was simply
+     *  no reason to go on. */
+    SATISFIED,
+
+    /** A piece was in front of the walk and the consumer would not do it. The one end that makes a
+     *  search incomplete. */
     STOPPED
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
@@ -968,13 +968,10 @@ class CompileExampleGenerateTest {
                             | "a near one" : (near) -> Accepted { at = "now" }
                         """;
 
-        // The rows composed for a class. A row through an arm is composed from the classes a way
-        // into it leaves and against no stated value — the origins are the class search's, and
-        // nothing here says an arm's row should be written the same way. Included, this would be
-        // asserting that of a search that was never given them.
+        // Every row offered, whatever it was composed for. A row through an arm is written against
+        // a value the model states the way a row for a class is, so a filter here would be leaving
+        // out the rows this used to be unable to say anything about (issue #1034).
         List<String> rows = generated(written).get("submit").composed().rows().stream()
-                .filter(row -> row.purposes().stream()
-                        .anyMatch(Generator.Purpose.ForAClass.class::isInstance))
                 .map(CompileExampleGenerateTest::inputsOf).toList();
         assertFalse(rows.isEmpty(), "there are classes the written row is not in");
         // Where a row keeps any of the value it was written from, that value is the author's own.

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
@@ -853,7 +853,8 @@ class CompileExampleGenerateTest {
         assertEquals(List.of(
                         // The target and one supporting field: `hi` at the bottom of its lower
                         // class is under `mid`'s `lo`, which the rule refuses, so `lo` moves too.
-                        "Request { ...mid, hi = Amount(0), lo = Amount(0) }",
+                        // Which is every field `Request` has, so the row is written out.
+                        "Request { lo = Amount(0), hi = Amount(0) }",
                         // `mid` is already in the upper class of `hi`, so the row is `mid`.
                         "mid",
                         "Request { ...mid, lo = Amount(0) }",
@@ -885,6 +886,32 @@ class CompileExampleGenerateTest {
 
         assertEquals(2, rows.stream().filter("mid"::equals).count(),
                 "`mid` is in the upper class of both positions: " + rows);
+    }
+
+    /**
+     * A row that moves every field of a value is written out rather than spread over it.
+     *
+     * <p>The spread is what says the row is a value the reader recognises with something changed.
+     * Where the row changes the whole record, the value it spreads contributes nothing to what is
+     * built — {@code Request &#123;...mid, hi = Amount(0), lo = Amount(0)&#125;} names {@code mid}
+     * and keeps none of it — and a reader comparing the row against the file finds every field
+     * different.
+     *
+     * <p>Written out, and not composed again. The values are the ones the search built and offered
+     * from {@code mid}: a rule relating {@code lo} and {@code hi} refuses the pair the classes name
+     * while the model's own value builds, so composing this parameter a second time would be a
+     * different row wearing this one's answer.
+     */
+    @Test
+    void aRowThatMovesEveryFieldIsWrittenOutRatherThanSpread() {
+        List<String> rows = generated(CORRELATED).get("submit").composed().rows().stream()
+                .map(CompileExampleGenerateTest::inputsOf).toList();
+
+        assertTrue(rows.contains("Request { lo = Amount(0), hi = Amount(0) }"),
+                "the row for the lower class of `hi` moves both fields: " + rows);
+        assertTrue(rows.stream().noneMatch(row -> row.startsWith("Request { ...mid, hi =")
+                        && row.contains("lo =")),
+                "and nothing is spread over a value it writes over entirely: " + rows);
     }
 
     /**
@@ -950,8 +977,14 @@ class CompileExampleGenerateTest {
                         .anyMatch(Generator.Purpose.ForAClass.class::isInstance))
                 .map(CompileExampleGenerateTest::inputsOf).toList();
         assertFalse(rows.isEmpty(), "there are classes the written row is not in");
-        assertTrue(rows.stream().allMatch(row -> row.contains("...near")),
-                "written against the value the author's own row names: " + rows);
+        // Where a row keeps any of the value it was written from, that value is the author's own.
+        // The row that keeps none of it moves every field, and is written out rather than spread
+        // over a value it contributes nothing to — which is a fact about how it reads and not about
+        // which value it came from.
+        assertTrue(rows.stream().anyMatch(row -> row.contains("...near")),
+                "the author's own value is what the rows are written from: " + rows);
+        assertTrue(rows.stream().noneMatch(row -> row.contains("...") && !row.contains("...near")),
+                "and no row is written from any other: " + rows);
     }
 
     /** Each named for the one class it is about, whatever it took to write one. */

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
@@ -854,13 +854,37 @@ class CompileExampleGenerateTest {
                         // The target and one supporting field: `hi` at the bottom of its lower
                         // class is under `mid`'s `lo`, which the rule refuses, so `lo` moves too.
                         "Request { ...mid, hi = Amount(0), lo = Amount(0) }",
-                        "Request { ...mid, hi = Amount(61) }",
+                        // `mid` is already in the upper class of `hi`, so the row is `mid`.
+                        "mid",
                         "Request { ...mid, lo = Amount(0) }",
-                        "Request { ...mid, lo = Amount(51) }"),
+                        // And already in the upper class of `lo`.
+                        "mid"),
                 filling.composed().rows().stream()
                         .map(CompileExampleGenerateTest::inputsOf).toList());
         assertEquals(List.of(), filling.composed().unresolved(),
                 "every class is written for, which composing them could not do");
+    }
+
+    /**
+     * A class the stated value already sits in is answered by that value, written out as it stands.
+     *
+     * <p>How far a row is from what a reader recognises is what the search minimises, and a value of
+     * the module already in the class is no distance from it. The position the row is about used to
+     * be written over whatever it held — the walk counted it as moved for being the target rather
+     * than for the row differing there — so a class {@code mid} answers came out as {@code mid} with
+     * {@code lo} set to a value of the class it already stood in.
+     *
+     * <p>Which says less than the value it was written from. A reader is told to write
+     * {@code Request &#123;...mid, lo = Amount(51)&#125;} where {@code mid} covers the class, and
+     * has to compare two numbers against a range to see the spread changes nothing.
+     */
+    @Test
+    void aClassTheStatedValueIsAlreadyInIsWrittenAsThatValue() {
+        List<String> rows = generated(CORRELATED).get("submit").composed().rows().stream()
+                .map(CompileExampleGenerateTest::inputsOf).toList();
+
+        assertEquals(2, rows.stream().filter("mid"::equals).count(),
+                "`mid` is in the upper class of both positions: " + rows);
     }
 
     /**
@@ -881,31 +905,40 @@ class CompileExampleGenerateTest {
                         let mid = Request { lo = Amount(60), hi = Amount(70) }
                         let wide = Request { lo = Amount(0), hi = Amount(200) }""");
 
-        assertTrue(generated(twice).get("submit").composed().rows().stream()
-                        .allMatch(row -> inputsOf(row).contains("...")),
-                "every row is still written against a value the model states: "
-                        + generated(twice).get("submit").composed().rows().stream()
-                                .map(CompileExampleGenerateTest::inputsOf).toList());
+        List<String> rows = generated(twice).get("submit").composed().rows().stream()
+                .map(CompileExampleGenerateTest::inputsOf).toList();
+
+        // Named outright where the value is already in the class, and spread where the row moves
+        // away from it. Both are the row written against what the module states; which of the two
+        // it is, is how far the row had to move.
+        assertTrue(rows.stream().allMatch(row -> row.equals("mid") || row.equals("wide")
+                        || row.contains("...mid") || row.contains("...wide")),
+                "every row is still written against a value the model states: " + rows);
     }
 
     /**
-     * The value a row already names comes before the ones only the module states.
+     * Between two values one distance away, the one a row already names comes first.
      *
      * <p>A row of the author's is what they reached for at this behavior, and it names its
      * positions together — which is more than this can say of one value chosen per position on its
      * own. So it is the first origin, and the rows offered beside it are written against the same
      * value the row beside them is.
+     *
+     * <p>Asked where the two are the same distance from the class, because distance is what this
+     * search minimises and provenance orders the origins within one distance. The two values here
+     * sit in the same classes as each other, so which is used is the order they were gathered in
+     * and nothing else.
      */
     @Test
     void theValueARowAlreadyNamesIsTheFirstOrigin() {
         String written = CORRELATED.replace("let mid = Request { lo = Amount(60), hi = Amount(70) }",
                 """
                         let mid = Request { lo = Amount(60), hi = Amount(70) }
-                        let wide = Request { lo = Amount(0), hi = Amount(200) }""")
+                        let near = Request { lo = Amount(62), hi = Amount(72) }""")
                 + """
 
                         example submit
-                            | "a wide one" : (wide) -> Accepted { at = "now" }
+                            | "a near one" : (near) -> Accepted { at = "now" }
                         """;
 
         // The rows composed for a class. A row through an arm is composed from the classes a way
@@ -917,7 +950,7 @@ class CompileExampleGenerateTest {
                         .anyMatch(Generator.Purpose.ForAClass.class::isInstance))
                 .map(CompileExampleGenerateTest::inputsOf).toList();
         assertFalse(rows.isEmpty(), "there are classes the written row is not in");
-        assertTrue(rows.stream().allMatch(row -> row.contains("...wide")),
+        assertTrue(rows.stream().allMatch(row -> row.contains("...near")),
                 "written against the value the author's own row names: " + rows);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowForAnArmIsWrittenTheWayARowForAClassIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowForAnArmIsWrittenTheWayARowForAClassIsTest.java
@@ -1,0 +1,103 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * A row offered for an arm, written against a value the module states.
+ *
+ * <p>A row for a class is composed against a value the model already states, so what differs between
+ * it and what is written in the file is the class and the class alone. A row for an arm was composed
+ * from the classes, and every position the way into the arm left free held whatever the search
+ * happened to name there. A reader was handed both in one block: the first says what it is about by
+ * differing from a value they recognise, and the second by being a row they have to read whole
+ * (issue #1034).
+ *
+ * <p>They are one search over two demands. A class asks for one class at one position; a way into an
+ * arm asks for a class apiece at the positions it settles; and what is nearest to what the model
+ * states is the same question either way. What differed was only that the values the model states
+ * never reached the second of them.
+ *
+ * <p>The arm here is behind a decision over two positions, so no row composed for a class of either
+ * of them arrives at it — which is what leaves the arm owed a row of its own for this to be about.
+ */
+class ARowForAnArmIsWrittenTheWayARowForAClassIsTest {
+
+    private static final String CORRELATED = """
+            module example.trip
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Request = { lo: Amount, hi: Amount }
+                invariant lo.value <= hi.value
+
+            data Flag = Off | On
+
+            data Accepted = { at: String }
+
+            let mid = Request { lo = Amount(60), hi = Amount(70) }
+
+            behavior submit : (request: Request, a: Flag, b: Flag) -> Accepted
+                constructs Accepted
+
+            let one (f: Flag): Int =
+                match f with
+                    | Off -> 0
+                    | On -> 1
+
+            let submit (request, a, b) = {
+                guard request.lo.value <= 50 else Accepted { at = "wide" }
+                guard one(a) + one(b) >= 2 else Accepted { at = "partial" }
+                Accepted { at = "both" }
+            }
+
+            example submit
+                | "a wide one" : (mid, Off, Off) -> Accepted { at = "wide" }
+            """;
+
+    /**
+     * The row offered for an arm names the value the model states, with the positions the arm needs
+     * moved and nothing else.
+     *
+     * <p>{@code request} takes no part in the decision this arm is behind, so the row says what it
+     * has always said about it: {@code mid}, with the one field the way in needs. Composed from the
+     * classes, both of its fields were written out at whatever the search named, and a reader had to
+     * work out which of the differences the arm turned on.
+     */
+    @Test
+    void aRowOfferedForAnArmNamesTheValueTheModelStates() {
+        List<String> rows = rowsForArmsAlone();
+
+        assertFalse(rows.isEmpty(), "this model leaves an arm no class's row arrives at");
+        assertEquals(List.of("Request { ...mid, lo = Amount(0) }, On, Off"), rows);
+    }
+
+    /** The rows offered for an arm and for nothing else, which are the ones the class search never
+     *  touched. */
+    private static List<String> rowsForArmsAlone() {
+        Compilation compilation = Compilation.ofSource(CORRELATED, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, Adequacy.Filling> all =
+                Adequacy.generatedOf(compilation.db(), compilation.modules().get(0));
+        assertNotNull(all, "the model under test compiles");
+        Adequacy.Filling filling = all.get("submit");
+        assertNotNull(filling, "the behavior under test is generated for");
+        return filling.composed().rows().stream()
+                .filter(row -> row.purposes().stream()
+                        .noneMatch(Generator.Purpose.ForAClass.class::isInstance))
+                .map(row -> String.join(", ",
+                        row.inputs().stream().map(FixtureTemplate::text).toList()))
+                .toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest.java
@@ -19,6 +19,8 @@ import souther.compiler.query.Scopes;
 import souther.compiler.query.Shapes;
 
 import java.util.List;
+import souther.compiler.coverage.Observation;
+
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,59 +30,74 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * What a combination comes to when the search for a row at it ran out of room.
  *
  * <p>A combination is looked for at each of the things it can be asking, and each of those is walked
- * outward from where the reading leaves the positions it says nothing about. Both walks are bounded,
- * and a bound is a fact about the search: past it are candidates nothing tried, and one of them may
- * be the row that arrives.
+ * outward from where the reading leaves the positions it says nothing about. What a walk may cost is
+ * counted in runs, because reaching the arm is what a row has to do and only the behavior can say
+ * whether it did.
  *
- * <p>Read off the state the loop ended in, a search that ran out of candidates and one that ran out
- * of budget came out the same. Both ended with rows that had been run and had gone elsewhere, so
- * both said the candidates tried were not witnesses — which over a search that stopped is a claim
- * about the model made on the strength of a limit.
+ * <p>So a bound leaves the search incomplete only where it was reached in front of a run that
+ * nobody did. A candidate the model refuses never reached the behavior; a candidate whose values
+ * something was already watched at has its answer already. Counted per candidate instead, a
+ * combination whose remaining candidates were all values a run had been seen at came back saying
+ * the search had stopped — a claim about the model made on the strength of a limit.
  *
- * <p>The two combinations asked about here are of one model, searched in one run, against runs that
- * all missed alike. What differs between them is how many positions each is about, which is how many
- * the search was left to choose — and so whether the bound was reached. Nothing about the model
- * differs, so what the two answers differ by is the search stopping.
+ * <p>The combinations here are of one model, searched in one run, against runs that all missed
+ * alike. What differs between them is how many positions each is about, which is how many the
+ * search was left to choose, and so how many of its candidates are values nothing has run yet.
  */
 class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
 
+    /** Two decisions and a position free of both, which is eight rows in all. */
+    private static final String ONE_FREE = shipping("rush: Bool");
+
+    /** The same with a second position free of both, which is more values than a reading may run
+     *  for. */
+    private static final String TWO_FREE = shipping("rush: Bool, gift: Bool");
+
+    private static String shipping(String free) {
+        return """
+                module example.shipping
+
+                data Membership = Premium | Standard
+
+                data Delivery = Express | Regular
+
+                data Fee = Int
+                    invariant value >= 0
+
+                behavior shippingFee : (member: Membership, delivery: Delivery, %1$s) -> Fee
+                    constructs Fee
+
+                let baseFee (tier: Membership): Int =
+                    match tier with
+                        | Premium -> 0
+                        | Standard -> 500
+
+                let expressFee (speed: Delivery): Int =
+                    match speed with
+                        | Express -> 500
+                        | Regular -> 0
+
+                let shippingFee (member, delivery, %2$s) =
+                    Fee(baseFee(member) + expressFee(delivery))
+                """.formatted(free, free.replaceAll(": Bool", ""));
+    }
+
     /**
-     * Two decisions and a position free of both.
+     * A combination the bound stopped in front of an unrun candidate says the search stopped.
      *
-     * <p>A combination over both decisions leaves the search one position to choose, and the two
-     * classes of it are inside the bound. A combination over one decision leaves it two, and the
-     * candidates over those run past the bound.
+     * <p>Two positions left to choose is four values, and a reading may be run for three. The fourth
+     * is a set of values nothing has been watched at: what the three that were run came to is those
+     * candidates' news, and offered as the combination's answer it stands for a space this search
+     * never entered.
      */
-    private static final String SHIPPING = """
-            module example.shipping
+    @Test
+    void aCombinationLeftWithAnUnrunCandidateSaysTheSearchStopped() {
+        Generator.GenerationResult filled = fill(Model.of(TWO_FREE, "shippingFee"), _ -> MISSED);
 
-            data Membership = Premium | Standard
-
-            data Delivery = Express | Regular
-
-            data Fee = Int
-                invariant value >= 0
-
-            behavior shippingFee : (member: Membership, delivery: Delivery, rush: Bool) -> Fee
-                constructs Fee
-
-            let baseFee (tier: Membership): Int =
-                match tier with
-                    | Premium -> 0
-                    | Standard -> 500
-
-            let expressFee (speed: Delivery): Int =
-                match speed with
-                    | Express -> 500
-                    | Regular -> 0
-
-            let shippingFee (member, delivery, rush) =
-                Fee(baseFee(member) + expressFee(delivery))
-            """;
-
-    /** A run that did nothing at all, which is a run that missed every combination. */
-    private static final Generator.Watched MISSED =
-            new Generator.Watched.Ran(Observation.NONE);
+        assertEquals(Generator.UnresolvedCombination.Reason.SEARCH_LIMIT,
+                reasonFor(filled, List.of("member=Premium", "delivery=Express")),
+                "a fourth set of values, and no run left to watch it at: " + filled.unresolved());
+    }
 
     /**
      * A combination whose candidates were all tried says the candidates were not witnesses.
@@ -90,31 +107,57 @@ class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
      */
     @Test
     void aCombinationEveryCandidateMissedSaysTheCandidatesWereNotWitnesses() {
-        Generator.GenerationResult filled = fill(Model.of(SHIPPING, "shippingFee"), _ -> MISSED);
+        Generator.GenerationResult filled = fill(Model.of(ONE_FREE, "shippingFee"), _ -> MISSED);
 
         assertEquals(Generator.UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS,
                 reasonFor(filled, List.of("member=Premium", "delivery=Express")),
-                "one position left to choose, and both of its classes were run: "
+                "one position left to choose, and both of its values were run: "
                         + filled.unresolved());
     }
 
     /**
-     * The same run of misses at a combination the bound stopped short of says the search stopped.
+     * A run already watched at some values costs nothing, so a search that ends on them is complete.
      *
-     * <p>Two positions left to choose is more candidates than a reading is run for. What the ones it
-     * did try came to is those candidates' news: offered as the combination's answer it stands for a
-     * space this search never entered, and sends a reader to change a rule over a row it never
-     * tried.
+     * <p>{@code member=Premium} leaves two positions to choose, which is four sets of values — more
+     * than the three a reading may be run for. By the time this combination is looked in, every one
+     * of them is a set something has already been watched at, so the reading spends nothing and
+     * reaches the end of its candidates.
+     *
+     * <p>Counted per candidate, the fourth of them stopped the search and the combination answered
+     * that this run had given up. What it has is four candidates and an answer for each.
      */
     @Test
-    void aCombinationTheBoundStoppedShortOfSaysTheSearchStopped() {
-        Generator.GenerationResult filled = fill(Model.of(SHIPPING, "shippingFee"), _ -> MISSED);
+    void candidatesWhoseValuesAlreadyRanDoNotStopTheSearch() {
+        Generator.GenerationResult filled = fill(Model.of(ONE_FREE, "shippingFee"), _ -> MISSED);
 
-        assertEquals(Generator.UnresolvedCombination.Reason.SEARCH_LIMIT,
+        assertEquals(Generator.UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS,
                 reasonFor(filled, List.of("member=Premium")),
-                "two positions left to choose, and the bound was reached before they ran out: "
+                "more candidates than a reading may run for, and every one of them already run: "
                         + filled.unresolved());
     }
+
+    /**
+     * One run per set of values, however many combinations were looked for at them.
+     *
+     * <p>Eight is every row this behavior has: two memberships, two deliveries, and the position
+     * free of both. Every combination of the body is looked in and none of them is a witness, so the
+     * search reaches all eight — and reaches each of them once.
+     */
+    @Test
+    void aSetOfValuesIsRunOnceHoweverManyCombinationsWantIt() {
+        int[] runs = {0};
+
+        fill(Model.of(ONE_FREE, "shippingFee"), _ -> {
+            runs[0]++;
+            return MISSED;
+        });
+
+        assertEquals(8, runs[0], "one run per set of values this behavior has");
+    }
+
+    /** A run that did nothing at all, which is a run that missed every combination. */
+    private static final Generator.Watched MISSED =
+            new Generator.Watched.Ran(Observation.NONE);
 
     /** What the search made of the one combination named by {@code classes}. */
     private static Generator.UnresolvedCombination.Reason reasonFor(

--- a/souther-compiler/src/test/java/souther/compiler/partition/ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest.java
@@ -1,0 +1,182 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.coverage.ComparisonOutcome;
+import souther.compiler.coverage.ControlClaim;
+import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.coverage.Observation;
+import souther.compiler.inputs.InputDomain;
+import souther.compiler.reading.Interaction;
+import souther.compiler.reading.CoverageRead;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a combination comes to when the search for a row at it ran out of room.
+ *
+ * <p>A combination is looked for at each of the things it can be asking, and each of those is walked
+ * outward from where the reading leaves the positions it says nothing about. Both walks are bounded,
+ * and a bound is a fact about the search: past it are candidates nothing tried, and one of them may
+ * be the row that arrives.
+ *
+ * <p>Read off the state the loop ended in, a search that ran out of candidates and one that ran out
+ * of budget came out the same. Both ended with rows that had been run and had gone elsewhere, so
+ * both said the candidates tried were not witnesses — which over a search that stopped is a claim
+ * about the model made on the strength of a limit.
+ *
+ * <p>The two combinations asked about here are of one model, searched in one run, against runs that
+ * all missed alike. What differs between them is how many positions each is about, which is how many
+ * the search was left to choose — and so whether the bound was reached. Nothing about the model
+ * differs, so what the two answers differ by is the search stopping.
+ */
+class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
+
+    /**
+     * Two decisions and a position free of both.
+     *
+     * <p>A combination over both decisions leaves the search one position to choose, and the two
+     * classes of it are inside the bound. A combination over one decision leaves it two, and the
+     * candidates over those run past the bound.
+     */
+    private static final String SHIPPING = """
+            module example.shipping
+
+            data Membership = Premium | Standard
+
+            data Delivery = Express | Regular
+
+            data Fee = Int
+                invariant value >= 0
+
+            behavior shippingFee : (member: Membership, delivery: Delivery, rush: Bool) -> Fee
+                constructs Fee
+
+            let baseFee (tier: Membership): Int =
+                match tier with
+                    | Premium -> 0
+                    | Standard -> 500
+
+            let expressFee (speed: Delivery): Int =
+                match speed with
+                    | Express -> 500
+                    | Regular -> 0
+
+            let shippingFee (member, delivery, rush) =
+                Fee(baseFee(member) + expressFee(delivery))
+            """;
+
+    /** A run that did nothing at all, which is a run that missed every combination. */
+    private static final Generator.Watched MISSED =
+            new Generator.Watched.Ran(Observation.NONE);
+
+    /**
+     * A combination whose candidates were all tried says the candidates were not witnesses.
+     *
+     * <p>Which is something about the model, and it may be said because nothing was left untried
+     * behind it.
+     */
+    @Test
+    void aCombinationEveryCandidateMissedSaysTheCandidatesWereNotWitnesses() {
+        Generator.GenerationResult filled = fill(Model.of(SHIPPING, "shippingFee"), _ -> MISSED);
+
+        assertEquals(Generator.UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS,
+                reasonFor(filled, List.of("member=Premium", "delivery=Express")),
+                "one position left to choose, and both of its classes were run: "
+                        + filled.unresolved());
+    }
+
+    /**
+     * The same run of misses at a combination the bound stopped short of says the search stopped.
+     *
+     * <p>Two positions left to choose is more candidates than a reading is run for. What the ones it
+     * did try came to is those candidates' news: offered as the combination's answer it stands for a
+     * space this search never entered, and sends a reader to change a rule over a row it never
+     * tried.
+     */
+    @Test
+    void aCombinationTheBoundStoppedShortOfSaysTheSearchStopped() {
+        Generator.GenerationResult filled = fill(Model.of(SHIPPING, "shippingFee"), _ -> MISSED);
+
+        assertEquals(Generator.UnresolvedCombination.Reason.SEARCH_LIMIT,
+                reasonFor(filled, List.of("member=Premium")),
+                "two positions left to choose, and the bound was reached before they ran out: "
+                        + filled.unresolved());
+    }
+
+    /** What the search made of the one combination named by {@code classes}. */
+    private static Generator.UnresolvedCombination.Reason reasonFor(
+            Generator.GenerationResult filled, List<String> classes) {
+        return filled.unresolved().stream()
+                .filter(each -> each.classes().equals(classes))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "the combination " + classes + " is one this run looked for a row at: "
+                                + filled.unresolved()))
+                .reason();
+    }
+
+    private static Generator.GenerationResult fill(Model model, Generator.Trial trial) {
+        return Generator.fill(model.subject(), List.of(), Generator.CandidateCheck.ANY,
+                model.read(), trial, Budgets.generation());
+    }
+
+    private record Model(Generator.Subject subject, CoverageRead.Read read) {
+
+        /** The groups of the one reading, for a caller asking about the combinations alone. */
+        List<Interaction> groups() {
+            return read.interactions();
+        }
+
+        static Model of(String source, String behavior) {
+            Compilation compilation = Compilation.ofSource(source, "Main");
+            compilation.answerEverything();
+            String module = compilation.modules().get(0);
+            Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+            Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+            Symbols symbols = Scopes.derived(compilation.db(), module).value();
+            Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
+            assertNotNull(prepared);
+            assertNotNull(sigs);
+            assertNotNull(checked);
+            Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                    .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
+            Sig sig = sigs.get(behavior);
+            InputDomain inputs =
+                    compilation.db().ask(new Adequacy.Inputs(module)).value().get(behavior);
+            assertNotNull(inputs, "the behavior's inputs were read");
+            Core body = checked.behaviorBodies().get(behavior);
+            assertNotNull(body, "the behavior under test has a body");
+            return new Model(new Generator.Subject(
+                    new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
+                            sig.inputTypes(), symbols,
+                            souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
+                    Partitions.of(spec.name(), inputs, symbols,
+                            souther.compiler.query.ReadAs.THE_COMPILATION_DOES).axes(), HeldCounts.of(inputs, symbols)),
+                    CoverageRead.of(spec.name(), body,
+                            CoverageSites.of(checked.behaviorBodies(), checked.decisions(),
+                checked.supplied()), inputs,
+                            symbols));
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest.java
@@ -7,9 +7,6 @@ import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
-import souther.compiler.coverage.ComparisonOutcome;
-import souther.compiler.coverage.ControlClaim;
-import souther.compiler.coverage.ControlPointId;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.coverage.Observation;
 import souther.compiler.inputs.InputDomain;
@@ -21,16 +18,11 @@ import souther.compiler.query.Compilation;
 import souther.compiler.query.Scopes;
 import souther.compiler.query.Shapes;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * What a combination comes to when the search for a row at it ran out of room.

--- a/souther-compiler/src/test/java/souther/compiler/partition/ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest.java
@@ -19,8 +19,6 @@ import souther.compiler.query.Scopes;
 import souther.compiler.query.Shapes;
 
 import java.util.List;
-import souther.compiler.coverage.Observation;
-
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/souther-compiler/src/test/java/souther/compiler/partition/HowFarARowIsFromItsOriginIsReadOffTheRowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/HowFarARowIsFromItsOriginIsReadOffTheRowTest.java
@@ -1,0 +1,52 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * How far a row is from the value it is written against, and which fields that means writing over.
+ *
+ * <p>One difference and two readers. The search walks the assignments nearest this first; the row is
+ * written as the origin with the fields this names moved over it. Counted twice — once as how many
+ * positions the walk reached for, once as which fields to write — the two were free to disagree, and
+ * did: the position a row was about was written over whatever it held, because the walk counted it
+ * as moved for being the target rather than for the row differing there.
+ */
+class HowFarARowIsFromItsOriginIsReadOffTheRowTest {
+
+    /** A row standing where its origin does at every position is no distance from it. */
+    @Test
+    void aRowStandingWhereItsOriginDoesIsNoDistanceFromIt() {
+        assertEquals(List.of(),
+                Delta.between(new int[] {0, 1, 2}, new int[] {0, 1, 2}).at());
+    }
+
+    /** Only the positions that differ, in the axes' own order. */
+    @Test
+    void onlyThePositionsThatDifferAreInIt() {
+        assertEquals(List.of(0, 2), Delta.between(new int[] {0, 1, 2}, new int[] {1, 1, 0}).at());
+        assertEquals(2, Delta.between(new int[] {0, 1, 2}, new int[] {1, 1, 0}).size());
+    }
+
+    /**
+     * A position the row stands at no class of differs from an origin that stands at one.
+     *
+     * <p>Which is a real difference and is written down as one. A row under one case of a sum is at
+     * no class of the positions under another, and an origin that stands at one of those is a value
+     * this row does not resemble there.
+     */
+    @Test
+    void standingNowhereDiffersFromStandingSomewhere() {
+        assertEquals(List.of(1), Delta.between(new int[] {0, 1}, new int[] {0, -1}).at());
+        assertEquals(List.of(1), Delta.between(new int[] {0, -1}, new int[] {0, 1}).at());
+    }
+
+    /** And standing nowhere in both is no difference: neither is a class the row holds. */
+    @Test
+    void standingNowhereInBothIsNoDifference() {
+        assertEquals(List.of(), Delta.between(new int[] {-1, -1}, new int[] {-1, -1}).at());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest.java
@@ -7,11 +7,7 @@ import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
-import souther.compiler.coverage.ComparisonOutcome;
-import souther.compiler.coverage.ControlClaim;
-import souther.compiler.coverage.ControlPointId;
 import souther.compiler.coverage.CoverageSites;
-import souther.compiler.coverage.Observation;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.reading.Interaction;
 import souther.compiler.reading.CoverageRead;
@@ -22,13 +18,11 @@ import souther.compiler.query.Scopes;
 import souther.compiler.query.Shapes;
 
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest.java
@@ -111,7 +111,8 @@ class OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest {
             if (at == null) {
                 continue;
             }
-            List<Interpretation> readings = at.interpretations(2);
+            List<Interpretation> readings = new ArrayList<>();
+            at.interpretations(reading -> readings.add(reading));
             if (readings.size() == 1 && readings.get(0).pins().size() == 1) {
                 out.addAll(readings.get(0).pins().entrySet());
             }

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest.java
@@ -112,7 +112,10 @@ class OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest {
                 continue;
             }
             List<Interpretation> readings = new ArrayList<>();
-            at.interpretations(reading -> readings.add(reading));
+            at.interpretations(reading -> {
+                readings.add(reading);
+                return Taking.Taken.AND_MORE;
+            });
             if (readings.size() == 1 && readings.get(0).pins().size() == 1) {
                 out.addAll(readings.get(0).pins().entrySet());
             }

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest.java
@@ -1,0 +1,177 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.core.Core;
+import souther.compiler.coverage.ComparisonOutcome;
+import souther.compiler.coverage.ControlClaim;
+import souther.compiler.coverage.ControlPointId;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.coverage.Observation;
+import souther.compiler.inputs.InputDomain;
+import souther.compiler.reading.Interaction;
+import souther.compiler.reading.CoverageRead;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * One demand over one position, asked as a class and asked as the way into an arm.
+ *
+ * <p>These are two questions a reader has and one search. A class is the model dividing a position;
+ * an arm is a place in the body, and what it takes to arrive there is what the reading says. What
+ * they have in common is the shape of the answer: a row that sits in some classes, written as near
+ * as it can be to what the model already states.
+ *
+ * <p>So a way into an arm that settles one position asks exactly what a class of that position asks,
+ * and the row offered is the same row. Where the two searches were written apart, the class's was
+ * composed against a value the module states and the arm's against nothing — the same question
+ * answered two ways in one block (issue #1034).
+ *
+ * <p>Asked of every such way the model has rather than of one named here. Which arms a body has and
+ * which of them one position settles is the reading's answer, and a test naming a probe would be
+ * asserting this of whichever arm a reading happened to number that way.
+ */
+class OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest {
+
+    private static final String SHIPPING = """
+            module example.shipping
+
+            data Membership = Premium | Standard
+
+            data Delivery = Express | Regular
+
+            data Fee = Int
+                invariant value >= 0
+
+            behavior shippingFee : (member: Membership, delivery: Delivery, rush: Bool) -> Fee
+                constructs Fee
+
+            let baseFee (tier: Membership): Int =
+                match tier with
+                    | Premium -> 0
+                    | Standard -> 500
+
+            let expressFee (speed: Delivery): Int =
+                match speed with
+                    | Express -> 500
+                    | Regular -> 0
+
+            let shippingFee (member, delivery, rush) =
+                Fee(baseFee(member) + expressFee(delivery))
+            """;
+
+    /**
+     * Every arm one position settles is offered the row that position's class is offered.
+     *
+     * <p>The two are asked separately here — one run owing the class and nothing else, one owing the
+     * arm and nothing else — so that neither answer can be the other one being handed on. What comes
+     * back is compared by the values the row carries, which is the whole of what an author is given.
+     */
+    @Test
+    void anArmOnePositionSettlesIsOfferedTheRowThatPositionsClassIs() {
+        Model model = Model.of(SHIPPING, "shippingFee");
+        List<Axis> axes = model.subject().axes();
+        int asked = 0;
+        for (int probe : model.read().arms().keySet()) {
+            for (Map.Entry<Integer, Integer> pin : onePinWaysInto(probe, model, axes)) {
+                Axis axis = axes.get(pin.getKey());
+                assertEquals(
+                        rowsOf(model, Set.of(new Generator.ClassOwed(axis.id(),
+                                axis.classes().get(pin.getValue()).id())), Set.of()),
+                        rowsOf(model, Set.of(), Set.of(probe)),
+                        "the class of " + axis.path() + " and the arm it is the way into");
+                asked++;
+            }
+        }
+        assertTrue(asked > 0, "this model has an arm one position is the way into");
+    }
+
+    /** The ways into {@code probe} that settle exactly one position, as that position and its
+     *  class. */
+    private static List<Map.Entry<Integer, Integer>> onePinWaysInto(int probe, Model model,
+                                                                    List<Axis> axes) {
+        List<Map.Entry<Integer, Integer>> out = new ArrayList<>();
+        if (!(model.read().armAt(probe) instanceof souther.compiler.reading.PathAccess.Ways ways)) {
+            return out;
+        }
+        for (souther.compiler.reading.WayIn way : ways.ways()) {
+            CellSelection at = InteractionCells.at(way, ways.arrivesAt(), axes);
+            if (at == null) {
+                continue;
+            }
+            List<Interpretation> readings = at.interpretations(2);
+            if (readings.size() == 1 && readings.get(0).pins().size() == 1) {
+                out.addAll(readings.get(0).pins().entrySet());
+            }
+        }
+        return out;
+    }
+
+    /** What one run of the search offered, by the values each row carries. */
+    private static List<List<String>> rowsOf(Model model, Set<Generator.ClassOwed> classes,
+                                             Set<Integer> arms) {
+        return Generator.fill(model.subject(), List.of(), Generator.CandidateCheck.ANY,
+                        model.read(), Generator.Trial.NOTHING_RUNS, List.of(), classes, arms,
+                        Budgets.generation())
+                .rows().stream()
+                .map(row -> row.inputs().stream().map(FixtureTemplate::text).toList())
+                .toList();
+    }
+
+    private record Model(Generator.Subject subject, CoverageRead.Read read) {
+
+        /** The groups of the one reading, for a caller asking about the combinations alone. */
+        List<Interaction> groups() {
+            return read.interactions();
+        }
+
+        static Model of(String source, String behavior) {
+            Compilation compilation = Compilation.ofSource(source, "Main");
+            compilation.answerEverything();
+            String module = compilation.modules().get(0);
+            Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+            Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+            Symbols symbols = Scopes.derived(compilation.db(), module).value();
+            Bodies.Elaborated checked = compilation.db().ask(new Bodies.Checked(module)).value();
+            assertNotNull(prepared);
+            assertNotNull(sigs);
+            assertNotNull(checked);
+            Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                    .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
+            Sig sig = sigs.get(behavior);
+            InputDomain inputs =
+                    compilation.db().ask(new Adequacy.Inputs(module)).value().get(behavior);
+            assertNotNull(inputs, "the behavior's inputs were read");
+            Core body = checked.behaviorBodies().get(behavior);
+            assertNotNull(body, "the behavior under test has a body");
+            return new Model(new Generator.Subject(
+                    new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
+                            sig.inputTypes(), symbols,
+                            souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
+                    Partitions.of(spec.name(), inputs, symbols,
+                            souther.compiler.query.ReadAs.THE_COMPILATION_DOES).axes(), HeldCounts.of(inputs, symbols)),
+                    CoverageRead.of(spec.name(), body,
+                            CoverageSites.of(checked.behaviorBodies(), checked.decisions(),
+                checked.supplied()), inputs,
+                            symbols));
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/TheCompositionIsNotBehindTheBaselinesBudgetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/TheCompositionIsNotBehindTheBaselinesBudgetTest.java
@@ -5,34 +5,40 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * What a class comes to when the search for it ran out of room.
+ * What a class comes to when the values the model states ran out of room.
  *
  * <p>A class is looked for against every value the model states, each walked outward from the
- * target alone, and the walk is bounded. The bound is a fact about the search: past it there are
- * assignments nothing tried, and one of them may be the one that builds. Read off the end of the
- * list of what was tried, the two came out the same — a walk that ran out of assignments and one
- * that ran out of budget both end, and the last refusal was offered as the class's answer either
- * way.
+ * target alone, and that walk is bounded. Behind the same bound sat the row composed from the
+ * classes, which is not one of those values: where it stands is where the classes put it, and the
+ * classes are what the search itself named. So it was not competing with the stated values for
+ * their budget, and a model that stated enough of them took away the one row that needed none.
  *
- * <p>Which is a claim about the model made on the strength of a limit. "Every value tried was
- * refused" over a search that stopped one short of the value that builds sends a reader looking for
- * a rule to change; what they have is a search to widen.
+ * <p>What the reader was handed instead was the search saying it had stopped, over a class the
+ * model can hold a row for. That is a claim about the model made on the strength of a limit: it
+ * sends a person looking for a rule to change where what they have is a row somebody can write in
+ * a line.
+ *
+ * <p>The bound still says what it says. A walk that ran out of assignments and one that ran out of
+ * budget are different facts about the search, and the second is what {@code SEARCH_LIMIT} is for —
+ * it decides the class's answer where nothing else could be written for it, rather than in front of
+ * the composition.
  */
-class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
+class TheCompositionIsNotBehindTheBaselinesBudgetTest {
 
     /**
      * A rule relating two fields, and more values of the type than the walk has room for.
      *
      * <p>Every one of them holds {@code lo} above the class {@code hi} is looked for in, so the
-     * target moved alone is refused at each — and the repair that works, moving {@code lo} beside
-     * it, sits one distance further out. The values are alike on purpose: what is being asked is
-     * what the search says when it stops, and a value that built would end the walk before it.
+     * target moved alone is refused at each, and there are more of them than the walk has room for.
+     * The values are alike on purpose: what is being asked is what is left once they are spent, and
+     * a value that built would end the walk before it.
      */
     private static String crowded() {
         StringBuilder lets = new StringBuilder();
@@ -65,23 +71,25 @@ class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
     }
 
     /**
-     * The class the walk did not reach the repair for says the search stopped.
+     * The class every stated value was spent on is answered by the composition.
      *
      * <p>{@code hi} at the bottom of its lower class is under every stated {@code lo}, which the
-     * rule refuses, so each of the sixty-five values fails at the target alone. The repair — moving
-     * {@code lo} down beside it — is a distance further out and the budget is spent before the walk
-     * gets there, and so is the composition from the classes that sits behind them all.
+     * rule refuses, so each of the sixty-five values fails at the target alone and the walk over
+     * them ends where its bound is. The row composed from the classes puts both positions at the
+     * bottom of their own, which the rule allows — so there is a row here, and it is one the reader
+     * gets rather than a sentence about a search.
      */
     @Test
-    void aClassTheBudgetStoppedShortOfSaysTheSearchStopped() {
+    void theCompositionAnswersAClassEveryStatedValueWasSpentOn() {
         Adequacy.Filling filling = generated(crowded()).get("submit");
         assertNotNull(filling, "the behavior under test is generated for");
 
         Generator.ClassAttempt at = attemptAtTheLowerHi(filling);
-        assertEquals(Generator.UnresolvedCombination.Reason.SEARCH_LIMIT,
-                ((Generator.ClassAttempt.Unresolved) at).why().reason(),
-                "the search stopped, and what the last value it got to came to is that value's "
-                        + "news and not the class's: " + at);
+        assertEquals(List.of("Request { lo = Amount(0), hi = Amount(0) }"),
+                ((Generator.ClassAttempt.Built) at).row().inputs().stream()
+                        .map(FixtureTemplate::text).toList(),
+                "composed from the classes, which is what a row is where none of the values the "
+                        + "model states can be written for it: " + at);
     }
 
     /** What the search made of the class {@code hi} takes below the line the body draws. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/TwoValuesStandingAlikeAreStillTwoValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/TwoValuesStandingAlikeAreStillTwoValuesTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/souther-compiler/src/test/java/souther/compiler/partition/TwoValuesStandingAlikeAreStillTwoValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/TwoValuesStandingAlikeAreStillTwoValuesTest.java
@@ -1,0 +1,99 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Two values of the module sitting in the same classes are two things to write a row against.
+ *
+ * <p>Where a row's values sit is what orders this search: how far a row moves from the value it is
+ * written against is what the walk minimises, and that is counted in classes. What the values
+ * <em>are</em> is a different question, and it is the one the model answers — a rule relating two
+ * fields accepts one pair and refuses another, and both pairs can sit in the same classes.
+ *
+ * <p>So the two are one candidate for the ordering and two candidates for the search. Taken as one,
+ * a class the model can hold a row for came back with nothing: the first of them was refused, and
+ * the second — which builds, at the same distance, in the same classes — was never tried.
+ */
+class TwoValuesStandingAlikeAreStillTwoValuesTest {
+
+    /**
+     * Two values in the same classes, and only one of them can hold the class {@code hi} is owed.
+     *
+     * <p>Both sit at {@code lo} in its lower class and at {@code hi} in its upper one. A row for the
+     * lower class of {@code hi} writes {@code hi} at the bottom of that class, which the rule
+     * refuses beside {@code tight}'s {@code lo} and allows beside {@code loose}'s. Moving
+     * {@code lo} as well does not save {@code tight}: its other class is above the one it is in,
+     * and further from what the row needs.
+     */
+    private static final String ALIKE = """
+            module example.trip
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Request = { lo: Amount, hi: Amount }
+                invariant lo.value <= hi.value
+
+            data Accepted = { at: String }
+
+            let tight = Request { lo = Amount(50), hi = Amount(70) }
+            let loose = Request { lo = Amount(0), hi = Amount(70) }
+
+            behavior submit : (request: Request) -> Accepted
+                constructs Accepted
+
+            let submit (request) = {
+                guard request.lo.value <= 50 else Accepted { at = "wide" }
+                guard request.hi.value <= 60 else Accepted { at = "tall" }
+                Accepted { at = "now" }
+            }
+            """;
+
+    /**
+     * The second of them answers the class the first cannot be written for.
+     *
+     * <p>Read by where the values sit, the two are one origin and the search ends at the first. What
+     * is asserted here is the row, and the row names the value that builds.
+     */
+    @Test
+    void theValueThatBuildsIsTriedThoughAnotherStandsWhereItDoes() {
+        assertEquals("Request { ...loose, hi = Amount(0) }", rowFor("request.hi/0 <= x <= 60"));
+    }
+
+    /** And the value written first is still the one used where both can be. */
+    @Test
+    void theFirstOfThemIsStillTheOneUsedWhereBothCanBe() {
+        assertEquals("Request { ...tight, lo = Amount(51) }", rowFor("request.lo/50 < x"));
+    }
+
+    private static String rowFor(String classId) {
+        Compilation compilation = Compilation.ofSource(ALIKE, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, Adequacy.Filling> all =
+                Adequacy.generatedOf(compilation.db(), compilation.modules().get(0));
+        assertNotNull(all, "the model under test compiles");
+        Adequacy.Filling filling = all.get("submit");
+        assertNotNull(filling, "the behavior under test is generated for");
+        for (Generator.GeneratedRow row : filling.composed().rows()) {
+            for (Generator.Purpose purpose : row.purposes()) {
+                if (purpose instanceof Generator.Purpose.ForAClass about
+                        && about.classId().equals(classId)) {
+                    return String.join(", ",
+                            row.inputs().stream().map(FixtureTemplate::text).toList());
+                }
+            }
+        }
+        throw new AssertionError("no row was offered for " + classId + ": "
+                + filling.composed().classes());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatACombinationAsksIsItsOwnToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatACombinationAsksIsItsOwnToSayTest.java
@@ -1,0 +1,94 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.coverage.ControlClaim;
+import souther.compiler.coverage.ControlPointId;
+
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalInt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * How many things a combination can be asking, and what each of them says.
+ *
+ * <p>A combination is a class apiece at the positions it is about. Where it leaves one of them more
+ * than one class it is asking more than one thing, and a search bounded at three tries should get
+ * three of those.
+ *
+ * <p>What it used to get was three assignments. An assignment fixes every position — the ones the
+ * combination is about and the ones it says nothing about alike — and the ones it says nothing about
+ * are the search's own choice. Counted off together, the first three assignments of a combination
+ * over one free position of four classes were one thing asked four ways, and the second thing the
+ * combination could have been asking went untried however much of the bound was left.
+ *
+ * <p>Built here rather than read off a model. A combination that leaves two positions open beside a
+ * free one is a shape a model in the corpus need not have, and a mechanism is untested for shapes
+ * its data never takes.
+ */
+class WhatACombinationAsksIsItsOwnToSayTest {
+
+    /** Four classes at each position, with the ones listed left open. */
+    private static boolean[] leaving(int... classes) {
+        boolean[] allowed = new boolean[4];
+        for (int each : classes) {
+            allowed[each] = true;
+        }
+        return allowed;
+    }
+
+    private static CellSelection over(boolean[]... positions) {
+        return new CellSelection(new InteractionCells.Cell(positions),
+                List.of(ControlClaim.of(new ControlPointId.ArmOccurrence(1, OptionalInt.of(1),
+                                null, null))
+                        .orElseThrow(() -> new AssertionError("an arm with a probe can be claimed"))));
+    }
+
+    /**
+     * A reading says where the positions the combination is about stand, and says nothing anywhere
+     * else.
+     */
+    @Test
+    void aReadingIsAboutThePositionsTheCombinationNarrows() {
+        CellSelection selection =
+                over(leaving(0, 1, 2, 3), leaving(0, 2), leaving(1));
+
+        assertEquals(List.of(Map.of(1, 0, 2, 1), Map.of(1, 2, 2, 1)),
+                selection.interpretations(8).stream().map(Interpretation::pins).toList(),
+                "the free position is no part of what the combination asks");
+    }
+
+    /**
+     * A position the combination says nothing about does not multiply what it is asking.
+     *
+     * <p>Which is the whole of what the bound is for. The two things this combination can be asking
+     * are both within three tries; counted over assignments, the first three were one of them at
+     * three of the free position's four classes.
+     */
+    @Test
+    void aFreePositionDoesNotMultiplyTheReadings() {
+        CellSelection selection =
+                over(leaving(0, 1, 2, 3), leaving(0, 2), leaving(1));
+
+        assertEquals(2, selection.interpretations(3).size(),
+                "two things asked, whatever the free position may hold");
+        assertTrue(selection.interpretations(3).stream()
+                        .allMatch(reading -> reading.at().equals(java.util.Set.of(1, 2))),
+                "and both of them are about the same two positions");
+    }
+
+    /**
+     * A position with nothing left at it is no combination, and is not a reading that failed.
+     *
+     * <p>Told apart because they are different news. A combination the model does not have is not
+     * one a search came back empty from, and the second sends a person looking for values to write.
+     */
+    @Test
+    void aPositionWithNothingLeftAtItIsNoCombination() {
+        assertEquals(List.of(), over(leaving(0, 1, 2, 3), leaving()).interpretations(3),
+                "nothing stands at the second position, so there is nothing to look for");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatACombinationAsksIsItsOwnToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatACombinationAsksIsItsOwnToSayTest.java
@@ -60,15 +60,23 @@ class WhatACombinationAsksIsItsOwnToSayTest {
     void aWalkSaysWhetherAnyReadingWasLeft() {
         CellSelection selection = over(leaving(0, 1, 2, 3), leaving(0, 2), leaving(1));
 
-        assertEquals(Traversal.EXHAUSTED, selection.interpretations(_ -> true));
-        assertEquals(Traversal.STOPPED, selection.interpretations(_ -> false));
+        assertEquals(Traversal.EXHAUSTED,
+                selection.interpretations(_ -> Taking.Taken.AND_MORE));
+        assertEquals(Traversal.STOPPED,
+                selection.interpretations(_ -> Taking.Taken.NOT_TAKEN));
+        assertEquals(Traversal.SATISFIED,
+                selection.interpretations(_ -> Taking.Taken.AND_DONE),
+                "a consumer that has what it came for left nothing undone");
     }
 
     /** Every reading the combination has, for a test asking what they are rather than how many of
      *  them something looked at. */
     private static List<Interpretation> everythingAsked(CellSelection selection) {
         List<Interpretation> out = new java.util.ArrayList<>();
-        assertEquals(Traversal.EXHAUSTED, selection.interpretations(reading -> out.add(reading)),
+        assertEquals(Traversal.EXHAUSTED, selection.interpretations(reading -> {
+                    out.add(reading);
+                    return Taking.Taken.AND_MORE;
+                }),
                 "nothing here refuses a reading, so the walk runs out");
         return List.copyOf(out);
     }
@@ -104,6 +112,31 @@ class WhatACombinationAsksIsItsOwnToSayTest {
         assertTrue(everythingAsked(selection).stream()
                         .allMatch(reading -> reading.at().equals(java.util.Set.of(1, 2))),
                 "and both of them are about the same two positions");
+    }
+
+    /**
+     * A combination of more positions than a number can count is still walked one reading at a time.
+     *
+     * <p>Sixty-three positions of two classes apiece is more readings than fit in a machine word.
+     * Nobody needs that number: a search takes three readings and stops. Asked for it all the same,
+     * the count came back negative — so the walk handed nothing over and said it had run out, over a
+     * combination with more readings than anything will ever look at.
+     */
+    @Test
+    void aCombinationIsWalkedWithoutCountingHowManyReadingsItHas() {
+        boolean[][] wide = new boolean[63][];
+        for (int i = 0; i < wide.length; i++) {
+            wide[i] = leaving(0, 1);   // narrowed, and two of the four left open
+        }
+        int[] handed = {0};
+
+        Traversal walked = over(wide).interpretations(_ -> {
+            handed[0]++;
+            return Taking.Taken.NOT_TAKEN;
+        });
+
+        assertEquals(1, handed[0], "the first reading was handed over");
+        assertEquals(Traversal.STOPPED, walked, "and the rest of them are work nobody did");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatACombinationAsksIsItsOwnToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatACombinationAsksIsItsOwnToSayTest.java
@@ -48,6 +48,32 @@ class WhatACombinationAsksIsItsOwnToSayTest {
     }
 
     /**
+     * A walk that stops at the first reading is stopped, and one that is let run to the end is
+     * exhausted.
+     *
+     * <p>Which is the whole of what a caller reads to say whether it looked everywhere. The
+     * combination says how many readings there are by running out of them, and the caller says how
+     * many it will look at by refusing one — so the answer is about a reading that exists and was
+     * not looked at, rather than about a number a counter reached.
+     */
+    @Test
+    void aWalkSaysWhetherAnyReadingWasLeft() {
+        CellSelection selection = over(leaving(0, 1, 2, 3), leaving(0, 2), leaving(1));
+
+        assertEquals(Traversal.EXHAUSTED, selection.interpretations(_ -> true));
+        assertEquals(Traversal.STOPPED, selection.interpretations(_ -> false));
+    }
+
+    /** Every reading the combination has, for a test asking what they are rather than how many of
+     *  them something looked at. */
+    private static List<Interpretation> everythingAsked(CellSelection selection) {
+        List<Interpretation> out = new java.util.ArrayList<>();
+        assertEquals(Traversal.EXHAUSTED, selection.interpretations(reading -> out.add(reading)),
+                "nothing here refuses a reading, so the walk runs out");
+        return List.copyOf(out);
+    }
+
+    /**
      * A reading says where the positions the combination is about stand, and says nothing anywhere
      * else.
      */
@@ -57,7 +83,7 @@ class WhatACombinationAsksIsItsOwnToSayTest {
                 over(leaving(0, 1, 2, 3), leaving(0, 2), leaving(1));
 
         assertEquals(List.of(Map.of(1, 0, 2, 1), Map.of(1, 2, 2, 1)),
-                selection.interpretations(8).stream().map(Interpretation::pins).toList(),
+                everythingAsked(selection).stream().map(Interpretation::pins).toList(),
                 "the free position is no part of what the combination asks");
     }
 
@@ -73,9 +99,9 @@ class WhatACombinationAsksIsItsOwnToSayTest {
         CellSelection selection =
                 over(leaving(0, 1, 2, 3), leaving(0, 2), leaving(1));
 
-        assertEquals(2, selection.interpretations(3).size(),
+        assertEquals(2, everythingAsked(selection).size(),
                 "two things asked, whatever the free position may hold");
-        assertTrue(selection.interpretations(3).stream()
+        assertTrue(everythingAsked(selection).stream()
                         .allMatch(reading -> reading.at().equals(java.util.Set.of(1, 2))),
                 "and both of them are about the same two positions");
     }
@@ -88,7 +114,7 @@ class WhatACombinationAsksIsItsOwnToSayTest {
      */
     @Test
     void aPositionWithNothingLeftAtItIsNoCombination() {
-        assertEquals(List.of(), over(leaving(0, 1, 2, 3), leaving()).interpretations(3),
+        assertEquals(List.of(), everythingAsked(over(leaving(0, 1, 2, 3), leaving())),
                 "nothing stands at the second position, so there is nothing to look for");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatASearchFoundNothingOfIsAddedUpTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatASearchFoundNothingOfIsAddedUpTest.java
@@ -1,0 +1,53 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Which of the three ways a search comes back with nothing, and the order between them.
+ *
+ * <p>The rule is short and is the whole of what a caller may say when it found nothing, so it is
+ * asked here rather than at each search. Written at each of them, a search that had stopped and one
+ * that had tried everything ended in the same sentence — and the two send a reader to different
+ * work: one to widen a search, the other to change a rule.
+ */
+class WhatASearchFoundNothingOfIsAddedUpTest {
+
+    /** Nothing was searched, which is not a search that came back empty. */
+    @Test
+    void withNoReadingThereWasNoSearch() {
+        assertEquals(Completeness.Nothing.NO_READING, Completeness.NOTHING_YET.found());
+    }
+
+    /** Every reading searched until its candidates ran out. */
+    @Test
+    void everyReadingSearchedToTheEndIsHavingLookedEverywhere() {
+        assertEquals(Completeness.Nothing.LOOKED_EVERYWHERE,
+                Completeness.NOTHING_YET.searched().searched().found());
+    }
+
+    /**
+     * One reading stopped is the search having stopped, whatever the others came to.
+     *
+     * <p>Both ways round, because this is the one place the order between them is decided. A search
+     * with candidates it never tried is incomplete however many of its other readings were walked to
+     * the end, and read the other way it would answer "everything was refused" over a space it never
+     * entered.
+     */
+    @Test
+    void oneReadingCutShortIsTheSearchHavingStopped() {
+        assertEquals(Completeness.Nothing.SEARCH_STOPPED,
+                Completeness.NOTHING_YET.searched().cutShort().searched().found(),
+                "a reading searched after the one that stopped does not undo the stopping");
+        assertEquals(Completeness.Nothing.SEARCH_STOPPED,
+                Completeness.NOTHING_YET.cutShort().searched().found());
+    }
+
+    /** A reading that was stopped is still a reading that was searched. */
+    @Test
+    void aReadingThatWasStoppedIsStillOneThatWasSearched() {
+        assertEquals(new Completeness(true, true), Completeness.NOTHING_YET.cutShort(),
+                "the bound stopped a search rather than saying there was none");
+    }
+}


### PR DESCRIPTION
Closes #1034.

A row offered for a class is composed against a value the module already
states, so what differs between it and what is written in the file is the
class and the class alone. A row offered for an arm was composed from the
classes, and every position the way in left free held whatever the search
happened to name there. A reader was handed both in one block.

Trip's arm behind a decision over two positions was offered
`Request { lo = Amount(0), hi = Amount(0) }, On, Off`. It is offered
`Request { ...mid, lo = Amount(0) }, On, Off`.

## What this turned out to be

Not a wiring fix. The origin machinery was written around a class of one
position: the walk asked whether an origin states a value of *the* position
the row is about, and the writing treated *the* target as moved whatever it
held. A way into an arm settles several positions at once and has no such
target, so there was no argument to pass it.

What is shared is the answer's shape: a row that sits in some classes,
written as near as it can be to what the model already states. What differs
is only how what is asked for is arrived at.

    Demand
      |
      +- interpretations()          class: one pin / arm: what the cell asks
           |
           +- ResolvedOrigin x Completion -> Candidate
           |    ordered by grounding -> |Delta| -> origin -> completion
           |    build(given) -> run -> certify -> render
           |
           +- Composition            outside the origins' budget

## The pieces

**Delta** is where a row does not stand where its origin does, read off the
assignment. The search orders itself by its size and the row is written from
its projection onto the parameters. Counted twice, the two were free to
disagree: a class a stated value already sits in came out as that value with
a field set to something of the class it already held, and a supporting
position the row stands at no class of counted as a move it never made.

**Interpretation** is what a combination asks: a class apiece at the
positions it is about. Where a row stands anywhere else is the search's own
choice.

**Completeness** says which of the three ways a search came back with
nothing, and the order between them. A search a bound stopped ended holding
rows that had been run and gone elsewhere, so it answered that the candidates
tried were not witnesses -- over candidates nothing tried.

**The composition** is no longer behind the values the model states. It is not
one of them and was not competing with them for their budget.

**A spread that writes over the whole value** is written out instead. The
values stay the ones built from the model's own value.

## Who owns a bound

Every bound was applied where the enumeration was convenient rather than
where the quantity it names lives, and whether it had truncated was left at
that place instead of travelling with what it returned. So the walks stopped
counting.

    enumeration owns the order
    consumer owns the cost
    Taken says what happened to the piece in front of the consumer
    Traversal says why the enumeration ended
    Completeness aggregates only unfinished work

`CellSelection` hands over the readings it has, counting them up one position
at a time rather than asking how many there are -- sixty-three positions of
two classes apiece is more than a machine word holds, and the count came back
negative. The nearest walk hands over the assignments it has. A class counts
builds, an arm counts new runs, and a candidate the model refuses or one whose
values a run was already watched at costs neither of them anything.
`Traversal.STOPPED` means work nobody did, because `SATISFIED` took the other
meaning away from it.

## Behaviour that changed

- A class a stated value already sits in is answered by that value:
  `Request { ...mid, lo = Amount(51) }` becomes `mid`.
- A row that moves every field is written out:
  `Request { ...mid, hi = Amount(0), lo = Amount(0) }` becomes
  `Request { lo = Amount(0), hi = Amount(0) }`.
- A class the values the model states were all spent on is answered by the
  composition rather than by a search limit.
- A combination the bound stopped in front of an unrun candidate says the
  search stopped rather than naming its last refusal. One whose remaining
  candidates were values something had already run says the candidates were
  not witnesses.

## Not covered

`Witness.NoCombination` is a defensive branch. Its two halves are pinned
apart -- a cell that leaves a position nothing has no readings, and no
readings is not a search -- but no model reaches the join.

`MOST_INTERPRETATIONS` is non-binding today: every cell the reading produces
pins one class per narrowed position, so every combination has exactly one
reading. The producer's contract and the three ends of a walk are pinned; the
consumer's counting rule -- skip what is not a reading without counting it,
refuse the one after the last it may search -- waits for a reading that
produces several. Reaching it now would take a hand-built `Cut` and `Seam`,
which is the reading's own answer written a second time in a test.

6849 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)