### PR TITLE
Ask the identity what declares it, and stop reading it off a spelling

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodegenContext.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodegenContext.java
@@ -415,9 +415,10 @@ final class CodegenContext {
     }
 
     /** Whether {@code member} is a type this module declares, and so carries its result unions
-     * itself. A primitive never is; nor is a type another module emitted. */
+     * itself. What the language declares never is — no module emits a primitive or the prelude's
+     * data — nor is a type another module emitted. */
     boolean isLocalMember(TypeSymbol member) {
-        return !member.isPrimitive() && member.module().equals(pkg);
+        return !member.isDeclaredByLanguage() && member.module().equals(pkg);
     }
 
     /** The members of {@code out} that reach their union through a bridge case, in the order the
@@ -440,7 +441,7 @@ final class CodegenContext {
         }
         List<TypeSymbol> bridged = new ArrayList<>();
         for (TypeSymbol member : AtomSpace.subjectAtoms(out, symbols)) {
-            if (member.isPrimitive() || !member.module().equals(module)) {
+            if (member.isDeclaredByLanguage() || !member.module().equals(module)) {
                 bridged.add(member);
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/ExampleVerifier.java
@@ -1680,7 +1680,7 @@ public final class ExampleVerifier {
             return result;
         }
         for (TypeSymbol member : AtomSpace.subjectAtoms(out, symbols)) {
-            if (!member.isPrimitive() && member.module().equals(module.name())) {
+            if (!member.isDeclaredByLanguage() && member.module().equals(module.name())) {
                 continue;
             }
             if (SoutherJvmAbi.nameOf(new GeneratedClass.BridgeCase(module.name(), member)).is(result.getClass())) {

--- a/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/examples/FixtureReader.java
@@ -372,7 +372,7 @@ public final class FixtureReader {
             default -> null;
         };
         String is = value.getClass().getName();
-        return TypeSymbol.PRIMITIVE.equals(candidate.module())
+        return candidate.isPrimitive()
                 ? carried != null && carried.equals(is)
                 : is.equals(candidate.qualified());
     }

--- a/souther-compiler/src/main/java/souther/compiler/meta/DeclarationAgreement.java
+++ b/souther-compiler/src/main/java/souther/compiler/meta/DeclarationAgreement.java
@@ -110,9 +110,13 @@ public final class DeclarationAgreement {
         Agreement heldFrom(ValueName.Behavior behavior) {
             // Compared, not reached. What `reach` decides is which of the things a walk finds a
             // crossing follows, and the behavior asked about was not found — it is what this was
-            // given. Put through `reach`, a root it declined would come back held while nothing had
-            // been held at all; the only root it declines is one of the language's own namespace,
-            // which is a caller's mistake and is said as one by `notInSight`.
+            // given. Put through `reach`, a root it declined would come back `Agree` while nothing
+            // had been held at all, which is an answer this may not give.
+            //
+            // No caller reaches that today: the one there is passes the module being evaluated,
+            // which a compilation refuses to let take a reserved name. So this is what the method
+            // says rather than a case anything meets, and the root it would decline is said as a
+            // mistake by `notInSight` instead of answered.
             Reached root = new Reached.ABehavior(behavior);
             reached.add(root);
             toCompare.addLast(root);

--- a/souther-compiler/src/main/java/souther/compiler/meta/DeclarationAgreement.java
+++ b/souther-compiler/src/main/java/souther/compiler/meta/DeclarationAgreement.java
@@ -108,7 +108,14 @@ public final class DeclarationAgreement {
 
         /** What the two builds say about everything {@code behavior}'s crossing reaches. */
         Agreement heldFrom(ValueName.Behavior behavior) {
-            reach(new Reached.ABehavior(behavior));
+            // Compared, not reached. What `reach` decides is which of the things a walk finds a
+            // crossing follows, and the behavior asked about was not found — it is what this was
+            // given. Put through `reach`, a root it declined would come back held while nothing had
+            // been held at all; the only root it declines is one of the language's own namespace,
+            // which is a caller's mistake and is said as one by `notInSight`.
+            Reached root = new Reached.ABehavior(behavior);
+            reached.add(root);
+            toCompare.addLast(root);
             while (!toCompare.isEmpty()) {
                 Agreement said = held(toCompare.removeFirst());
                 if (!(said instanceof Agreement.Agree)) {
@@ -161,6 +168,19 @@ public final class DeclarationAgreement {
          * can be answered; what is asked for here is narrower and is the crossing's.
          */
         private Agreement notInSight(String module) {
+            // Not a second place the language is left out — `reach` decides that, and this states
+            // what has to be true once it has. A reserved name arriving here is a walk that reached
+            // something nobody publishes, which is this compiler's mistake and not an author's:
+            // both sides would answer `SaysNothing`, and what an author would be shown is E1927
+            // asking for a dependency on `souther`, which no artifact carries and no model can add
+            // (#1049). Raised rather than returned, so that a route opened later fails where it is
+            // written instead of arriving at a reader as advice that cannot be taken.
+            if (Reserved.isNamespace(module)) {
+                throw new IllegalStateException("`" + module + "` is the language's own namespace,"
+                        + " which no build publishes, so a crossing does not read declarations of"
+                        + " it: whether two builds have the same ones is what the boundary revision"
+                        + " on each of them says");
+            }
             if (ourSide.containsKey(module)) {
                 return null;
             }
@@ -201,8 +221,34 @@ public final class DeclarationAgreement {
             walk(parts, new IdentityHashMap<>(), part -> {
                 switch (part) {
                     case TypeSymbol type -> reach(new Reached.ADeclaration(type));
-                    case ValueName.Behavior behavior -> reach(new Reached.ABehavior(behavior));
-                    case ValueName.Helper helper -> reach(new Reached.AHelper(helper));
+                    // Every kind of value name, written out. What the walk carries is `Object`, so
+                    // the outer switch is an open world and needs its default; a name that has
+                    // arrived at `ValueName` is a closed one again, and stepping into it is what
+                    // buys back the guarantee that type has — a case added there is a compile error
+                    // here rather than a name silently followed by nothing. It was not: a library
+                    // call fell through the default, so one spelling of a rule crossed and the same
+                    // rule written as a `match` did not (#1049).
+                    case ValueName value -> {
+                        switch (value) {
+                            case ValueName.Behavior behavior ->
+                                    reach(new Reached.ABehavior(behavior));
+                            case ValueName.Helper helper -> reach(new Reached.AHelper(helper));
+                            // The standard library, for the reason the language's own declarations
+                            // are left out of `reach`: nobody publishes it, and whether two builds
+                            // have the same one is what the boundary revision on each says.
+                            case ValueName.Stdlib _ -> { }
+                            // A binding is not a declaration. Which binding a use is of is compared
+                            // where the two sides' forms are held together (`sameShape`), and there
+                            // is nothing beyond this name to reach.
+                            case ValueName.Local _ -> { }
+                            // A type written where a value goes. The declaration it names is
+                            // reached as the type it is, from the same part.
+                            case ValueName.OfType _ -> { }
+                            // A meaning the language gives and no module declares: `None`, a
+                            // rounding mode. Nothing publishes one.
+                            case ValueName.Builtin _ -> { }
+                        }
+                    }
                     default -> { }
                 }
             });
@@ -211,13 +257,23 @@ public final class DeclarationAgreement {
         /**
          * Reaches one thing, once.
          *
-         * <p>The standard library is not one of them. Nobody publishes it, and whether two builds
-         * have the same one is what the boundary revision on each of them says. Neither is anything
+         * <p>What the language declares is not one of them. Nobody publishes the primitives,
+         * {@code Option}'s cases or the prelude's data — there is no {@code souther/$Module.class}
+         * for either side's path to carry — and whether two builds have the same ones is what the
+         * boundary revision on each of them says ({@link ModuleReadback#read}). Neither is anything
          * of no module: a signature written over a primitive names no declaration.
+         *
+         * <p>Asked of the identity, which is what has the answer. This used to hold the module name
+         * against {@link Reserved#isQualifier}, and a qualifier is the surface spelling a call
+         * writes — {@code List}, {@code Option} — never the module of a name resolution has already
+         * settled. So the test was one no reached thing could pass, and a rule reaching
+         * {@code Some} or {@code Int} through a {@code match} arm sent the walk after a module
+         * nobody ships; what came back was E1927, telling an author to depend on {@code souther}
+         * (#1049).
          */
         private void reach(Reached what) {
             String module = what.module();
-            if (module == null || module.isEmpty() || Reserved.isQualifier(module)) {
+            if (module == null || module.isEmpty() || what.isDeclaredByLanguage()) {
                 return;
             }
             if (reached.add(what)) {
@@ -239,6 +295,12 @@ public final class DeclarationAgreement {
 
         String name();
 
+        /** Whether the language declares it rather than a module of some compilation. Delegated to
+         *  the identity this stands for, which is where the answer is
+         *  ({@link TypeSymbol#isDeclaredByLanguage()}); read off {@link #module()} here, it would be
+         *  the namespace rule restated a fourth time. */
+        boolean isDeclaredByLanguage();
+
         /** What of {@code m} this is, as what a crossing depends on — null where m has no such
          *  thing. */
         List<Object> partsIn(Hir.Module m);
@@ -253,6 +315,11 @@ public final class DeclarationAgreement {
             @Override
             public String name() {
                 return type.name();
+            }
+
+            @Override
+            public boolean isDeclaredByLanguage() {
+                return type.isDeclaredByLanguage();
             }
 
             @Override
@@ -279,6 +346,11 @@ public final class DeclarationAgreement {
             }
 
             @Override
+            public boolean isDeclaredByLanguage() {
+                return behavior.isDeclaredByLanguage();
+            }
+
+            @Override
             public List<Object> partsIn(Hir.Module m) {
                 for (Hir.BehaviorDef b : m.behaviors()) {
                     if (b.name().equals(name())) {
@@ -299,6 +371,11 @@ public final class DeclarationAgreement {
             @Override
             public String name() {
                 return helper.name();
+            }
+
+            @Override
+            public boolean isDeclaredByLanguage() {
+                return helper.isDeclaredByLanguage();
             }
 
             @Override

--- a/souther-compiler/src/main/java/souther/compiler/types/TypeSymbol.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/TypeSymbol.java
@@ -1,5 +1,7 @@
 package souther.compiler.types;
 
+import souther.compiler.Reserved;
+
 /**
  * A data type's identity: the module that declares it and the name written there. Two modules may
  * both declare {@code 金額}; those are different types, and only the pair tells them apart.
@@ -20,8 +22,12 @@ public final class TypeSymbol implements Comparable<TypeSymbol> {
 
     /** The module a primitive case name belongs to. {@code Int | DivisionByZero} unions a primitive
      * with a data case, so a primitive needs a name of this shape to sit in {@link Type.Union}; it
-     * never reaches codegen as a class, since a primitive case maps to its boxed class by name. */
-    public static final String PRIMITIVE = "souther";
+     * never reaches codegen as a class, since a primitive case maps to its boxed class by name.
+     *
+     * <p>Not readable from outside. What a caller wants of it is {@link #isPrimitive()}, and a
+     * caller that had the spelling wrote that question itself — which is the same question with
+     * one more place to get it wrong. */
+    private static final String PRIMITIVE = "souther";
 
     /** The module of the built-in error cases ({@code DivisionByZero}, {@code NotANumber}). It is
      * their real runtime package, so they need no special case when a class name is derived. */
@@ -105,8 +111,38 @@ public final class TypeSymbol implements Comparable<TypeSymbol> {
         };
     }
 
+    /** Whether this is a primitive case name — the {@code Int} of {@code Int | DivisionByZero}. */
     public boolean isPrimitive() {
         return module().equals(PRIMITIVE);
+    }
+
+    /**
+     * Whether the language declares this rather than a module of some compilation.
+     *
+     * <p>The primitives, {@code Option}'s two cases and the prelude's runtime-backed data, together
+     * and as one answer. Nothing publishes any of them — there is no {@code souther/$Module.class}
+     * for a path to carry — so a reader that goes looking for the module behind one is asking after
+     * an artifact that cannot exist, and the reader that did was told to add a dependency nobody
+     * ships (#1049).
+     *
+     * <p>Read off the address and not off how the identity was minted. {@link TypeSymbols} has two
+     * ways in, and which of them a given identity came through is not a fact about the declaration:
+     * {@code Declarations.identify} answers for the language's own vocabulary through
+     * {@link TypeSymbols#declared}, so one address would carry different origins by route. What is
+     * asked here is what the declaration <em>is</em>, which its address settles, so two equal
+     * identities answer alike.
+     *
+     * <p>{@link Reserved#isNamespace} is where that is written down, and this is the only place in
+     * the compiler that reads it of a declaration. A caller holding an identity asks the identity.
+     *
+     * <p>Not the same question as which class carries it. {@code souther.runtime} is both the
+     * namespace the prelude's data is addressed under and the package one backend ships it in, and
+     * the readers that mean the second still spell {@link #RUNTIME} — that is #1038's inventory and
+     * #1039's rule, and answering them through this would tidy the spelling away while leaving what
+     * those two are about exactly where it is.
+     */
+    public boolean isDeclaredByLanguage() {
+        return Reserved.isNamespace(module());
     }
 
     /** The fully qualified form, {@code probe.b.金額}. Also the generated class's binary name. */

--- a/souther-compiler/src/main/java/souther/compiler/types/ValueName.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/ValueName.java
@@ -1,5 +1,7 @@
 package souther.compiler.types;
 
+import souther.compiler.Reserved;
+
 /**
  * What a name written in the value namespace denotes — the answer {@link TypeSymbol} gives for the
  * type namespace.
@@ -34,6 +36,12 @@ public sealed interface ValueName {
 
     /** A module's own {@code let} — a helper, which is expanded into the body that called it. */
     record Helper(String module, String name) implements ValueName {
+
+        /** Whether the language declares it rather than a module of some compilation.
+         *  @see TypeSymbol#isDeclaredByLanguage() */
+        public boolean isDeclaredByLanguage() {
+            return Reserved.isNamespace(module);
+        }
 
         @Override
         public String toString() {
@@ -184,6 +192,12 @@ public sealed interface ValueName {
                 throw new IllegalArgumentException("module and name are required: " + module + "."
                         + name);
             }
+        }
+
+        /** Whether the language declares it rather than a module of some compilation.
+         *  @see TypeSymbol#isDeclaredByLanguage() */
+        public boolean isDeclaredByLanguage() {
+            return Reserved.isNamespace(module);
         }
 
         @Override

--- a/souther-compiler/src/test/java/souther/compiler/examples/ARuleThatMatchesOnAnOptionalStillEstablishesAnAnswererTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/examples/ARuleThatMatchesOnAnOptionalStillEstablishesAnAnswererTest.java
@@ -1,0 +1,137 @@
+package souther.compiler.examples;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.observe.FailurePhase;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Output;
+
+import javax.tools.ToolProvider;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A behavior whose rule matches on an optional is applied, and what it answers is held to what the
+ * behavior states.
+ *
+ * <p>#1049 as it was met: every row of such a behavior stopped at
+ * {@link FailurePhase#ANSWERER_ESTABLISHMENT}, nothing was applied, and {@code checkContract}
+ * answered {@link ContractObservation.Unobserved}. What the run said was that the module
+ * {@code souther} could not be read on this compile's side, and that the way to fix it was to add
+ * {@code souther} to the project's dependencies — a module the compiler ships as its own
+ * resources, which no artifact carries and no model can depend on.
+ *
+ * <p>Held end to end and not only over the agreement, because that is where it was found: the
+ * declarations agreeing is what establishing an answerer asks for, and a reader of a contract test
+ * meets the answer two stages further on.
+ */
+class ARuleThatMatchesOnAnOptionalStillEstablishesAnAnswererTest {
+
+    private static final String MODEL = """
+            module probe.opt
+
+            data Tag = String
+            data Query = { tag: Tag? }
+            data Page = { tags: List<Tag> }
+
+            behavior pick : (query: Query) -> Page
+                ensures carries(query, value)
+
+            let carries (query: Query, page: Page): Bool =
+                match query.tag with
+                    | None   -> true
+                    | Some t -> List.contains(t, page.tags)
+
+            example pick
+                | "a tag" : (Query { tag = Tag("dragons") }) -> Page { tags = [Tag("dragons")] }
+            """;
+
+    private static final String ANSWERS = """
+            package probe.opt;
+            public final class PickImpl extends Pick {
+                @Override public Page apply(Query query) {
+                    return new Page(java.util.List.of(new Tag("dragons")));
+                }
+            }
+            """;
+
+    /** An answer that carries the tag it was asked for: both oracles admit it. */
+    private static final String DROPS_THE_TAG = """
+            package probe.opt;
+            public final class PickImpl extends Pick {
+                @Override public Page apply(Query query) {
+                    return new Page(java.util.List.of());
+                }
+            }
+            """;
+
+    @Test
+    void aRowOfItIsApplied() throws Exception {
+        BoundExamples bound = boundTo(ANSWERS);
+        RecordedRow row = bound.rows().getFirst();
+
+        RowEvaluation evaluated = bound.evaluate(row);
+
+        assertEquals(FailurePhase.NONE, evaluated.outcome().failurePhase(),
+                () -> "nothing stopped before the implementation was reached: " + evaluated);
+        assertTrue(evaluated.held(), row::shown);
+    }
+
+    @Test
+    void andWhatItAnswersIsHeldToWhatTheBehaviorStates() throws Exception {
+        BoundExamples bound = boundTo(ANSWERS);
+
+        assertInstanceOf(ContractObservation.NoClauseWasBroken.class,
+                bound.checkContract(bound.rows().getFirst()),
+                "the rule was read, and the answer keeps it");
+    }
+
+    /** The control: the clause is being asked, and an answer that does not keep it is said as
+     *  broken rather than as unobserved. */
+    @Test
+    void andAnAnswerThatDoesNotKeepItIsSaidAsBroken() throws Exception {
+        BoundExamples bound = boundTo(DROPS_THE_TAG);
+
+        assertInstanceOf(ContractObservation.Broken.class,
+                bound.checkContract(bound.rows().getFirst()),
+                "the answer carries no tag, and the rule says it must");
+    }
+
+    // --- harness ---------------------------------------------------------------------------------
+
+    private static BoundExamples boundTo(String implementation) throws Exception {
+        Map<String, byte[]> generated =
+                Compilation.ofSource(MODEL, "Main").db().ask(new Output.All()).value();
+        return SoutherExamples.ofSource(MODEL).bind(builtElsewhere(generated, implementation));
+    }
+
+    private static Object builtElsewhere(Map<String, byte[]> generated, String source)
+            throws Exception {
+        Path classes = Files.createTempDirectory("souther-optional-contract");
+        for (Map.Entry<String, byte[]> e : generated.entrySet()) {
+            Path at = classes.resolve(e.getKey().replace('.', '/') + ".class");
+            Files.createDirectories(at.getParent());
+            Files.write(at, e.getValue());
+        }
+        Path java = classes.resolve("probe/opt/PickImpl.java");
+        Files.createDirectories(java.getParent());
+        Files.writeString(java, source);
+        int rc = ToolProvider.getSystemJavaCompiler().run(null, null, null,
+                "-encoding", "UTF-8",
+                "-classpath", classes + File.pathSeparator + System.getProperty("java.class.path"),
+                "-d", classes.toString(), java.toString());
+        assertEquals(0, rc, "the implementation compiles against the module's classes");
+        URLClassLoader loader = new URLClassLoader(new URL[] {classes.toUri().toURL()},
+                ExampleVerifier.class.getClassLoader());
+        return loader.loadClass("probe.opt.PickImpl").getConstructor().newInstance();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/meta/TheLanguagesOwnDeclarationsAreNotAskedOfEitherBuildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/TheLanguagesOwnDeclarationsAreNotAskedOfEitherBuildTest.java
@@ -1,0 +1,222 @@
+package souther.compiler.meta;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.Reserved;
+import souther.compiler.diag.Severity;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Output;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What the language declares is not something either build publishes, so a crossing does not go
+ * looking for it.
+ *
+ * <p>The primitives, {@code Option}'s two cases and the prelude's runtime-backed data are declared
+ * by no module. Nothing emits a {@code souther/$Module.class}, no artifact in
+ * {@code org.souther-lang} carries one, and no model can be made to produce one — so a walk that
+ * reaches one of them and asks the classes about its module is asking after an artifact that
+ * cannot exist.
+ * Whether two builds have the same ones is settled elsewhere and by something else: each side's
+ * classes carry the boundary revision they were written at, and a set that does not agree with this
+ * compiler's is refused while it is read ({@link ModuleReadback}).
+ *
+ * <p>What it cost is #1049. The exclusion was written as a test of the module name against the
+ * standard library's <em>qualifiers</em> — {@code List}, {@code Option}, the spellings a call
+ * writes — and a qualifier is never the module of a name resolution has settled, so the test was one
+ * no reached thing could pass. A rule naming {@code Some} or {@code Int} in a {@code match} arm sent
+ * the walk to {@code souther}, both sides answered that they carry nothing of that name, and the
+ * author of the model was told to add {@code souther} to their dependencies.
+ *
+ * <p>Held over what is asked of the classes and not only over what comes back. An agreement that
+ * comes out right while the walk still reads the language's namespace is one route away from saying
+ * E1927 again, and the two spellings below already differ in which of them reaches it.
+ */
+class TheLanguagesOwnDeclarationsAreNotAskedOfEitherBuildTest {
+
+    /** A rule reached from an {@code ensures} that matches on an optional: the arms name
+     *  {@code Some} and {@code None}, which the language declares and no module does. */
+    private static final String MATCHING = """
+            module probe.opt
+
+            data Tag = String
+            data Query = { tag: Tag? }
+            data Page = { tags: List<Tag> }
+
+            behavior pick : (query: Query) -> Page
+                ensures carries(query, value)
+
+            let carries (query: Query, page: Page): Bool =
+                match query.tag with
+                    | None   -> true
+                    | Some t -> List.contains(t, page.tags)
+            """;
+
+    /** The same rule written down the pipe, which reaches the library as a library name and never
+     *  names a case. This spelling crossed while the one above did not, which is the asymmetry. */
+    private static final String PIPING = """
+            module probe.opt
+
+            data Tag = String
+            data Query = { tag: Tag? }
+            data Page = { tags: List<Tag> }
+
+            behavior pick : (query: Query) -> Page
+                ensures carries(query, value)
+
+            let carries (query: Query, page: Page): Bool =
+                Option.withDefault(true, Option.map(t -> List.contains(t, page.tags), query.tag))
+            """;
+
+    /**
+     * A helper an invariant is read through whose arms name a primitive case and a built-in error
+     * case: {@code souther} and {@code souther.runtime}, the two halves of the namespace.
+     *
+     * <p>Here because {@code Option} was never what was wrong. Every case name the language gives
+     * reaches this the same way, and {@code Int} being found first is the only reason the report
+     * named {@code souther} rather than {@code souther.runtime} — excluding one of them would
+     * have left the walk stopping at the other.
+     */
+    private static final String UNIONING = """
+            module probe.uni
+
+            import Int ( divide )
+
+            data Amount = Int
+                invariant ok(value)
+
+            behavior half : (a: Amount) -> Amount
+                constructs Amount
+
+            let ok (v: Int): Bool =
+                match divide(v, 2) with
+                    | Int as q -> q >= 0
+                    | DivisionByZero -> false
+
+            let half (a) = Amount(a.value)
+            """;
+
+    /** The same model with the invariant narrowed, for what an ordinary module's declaration moving
+     *  still is. */
+    private static final String UNIONING_NARROWED = UNIONING.replace("q >= 0", "q >= 1");
+
+    @Test
+    void aRuleThatMatchesOnAnOptionalIsHeld() {
+        assertInstanceOf(Agreement.Agree.class, heldFrom("probe.opt", "pick", MATCHING, MATCHING),
+                "the arms name what the language declares, which is not a module to be read");
+    }
+
+    @Test
+    void andTheSameRuleWrittenDownThePipeIsHeldAlike() {
+        assertInstanceOf(Agreement.Agree.class, heldFrom("probe.opt", "pick", PIPING, PIPING),
+                "which spelling a rule is written in is not a fact about what crosses");
+    }
+
+    @Test
+    void aRuleThatNamesAPrimitiveCaseAndABuiltInErrorCaseIsHeld() {
+        assertInstanceOf(Agreement.Agree.class, heldFrom("probe.uni", "half", UNIONING, UNIONING),
+                "`Int` and `DivisionByZero` are declared by the language, not by `probe.uni`");
+    }
+
+    @Test
+    void neitherSidesClassesAreAskedForAnythingTheLanguageDeclares() {
+        Asked ours = new Asked(declarationsOf(UNIONING));
+        Asked theirs = new Asked(declarationsOf(UNIONING));
+
+        DeclarationAgreement.of("probe.uni", "half", ours, theirs, DefaultStdlib.get());
+
+        assertEquals(List.of(), ours.reserved(), "the module being evaluated is not asked");
+        assertEquals(List.of(), theirs.reserved(), "and neither is the answer");
+        assertTrue(ours.asked.contains("probe.uni.$Module"),
+                () -> "that is not a crossing at all: " + ours.asked);
+    }
+
+    /**
+     * The walk still crosses an ordinary module: leaving the language out is not leaving the
+     * question out.
+     *
+     * <p>The helper and not the data, because the helper is what moved. An invariant carries the
+     * call it writes, which is the same call on both sides; what the two say differently is the
+     * body behind it, and reaching that body is the walk doing its job.
+     */
+    @Test
+    void aDeclarationOfAnOrdinaryModuleIsStillHeld() {
+        Agreement held = heldFrom("probe.uni", "half", UNIONING, UNIONING_NARROWED);
+
+        Agreement.Disagree said = assertInstanceOf(Agreement.Disagree.class, held,
+                "the rule the answer was built against admits something else");
+        assertEquals("probe.uni", said.module());
+        assertEquals("ok", said.declaration());
+    }
+
+    /**
+     * A reserved name arriving where a module is read is this compiler's mistake, and is raised.
+     *
+     * <p>Not a second place the language is left out — {@code reach} decides that. What is held
+     * here is that a route opened later fails where it is written, rather than reaching an author as
+     * E1927 telling them to depend on something nobody ships.
+     */
+    @Test
+    void readingAModuleOfTheLanguagesNamespaceIsRefusedRatherThanReported() {
+        PublishedClasses classes = declarationsOf(UNIONING);
+
+        IllegalStateException raised = assertThrows(IllegalStateException.class,
+                () -> DeclarationAgreement.of("souther", "half", classes, classes,
+                        DefaultStdlib.get()));
+
+        assertTrue(raised.getMessage().contains("souther"), raised::getMessage);
+    }
+
+    private static Agreement heldFrom(String module, String behavior, String ours, String theirs) {
+        return DeclarationAgreement.of(module, behavior, declarationsOf(ours),
+                declarationsOf(theirs), DefaultStdlib.get());
+    }
+
+    /** What was asked of one side's classes, kept as it was asked. */
+    private static final class Asked implements PublishedClasses {
+
+        private final PublishedClasses of;
+        private final List<String> asked = new ArrayList<>();
+
+        private Asked(PublishedClasses of) {
+            this.of = of;
+        }
+
+        @Override
+        public Carried of(String binaryName) {
+            asked.add(binaryName);
+            return of.of(binaryName);
+        }
+
+        /** The names asked for that address something of the language's namespace. */
+        private List<String> reserved() {
+            return asked.stream().filter(name -> Reserved.isNamespace(moduleOf(name))).toList();
+        }
+
+        /** The module part of a binary name — everything before the last dot, which is where the
+         *  class the declarations are stamped on hangs. */
+        private static String moduleOf(String binaryName) {
+            int dot = binaryName.lastIndexOf('.');
+            return dot < 0 ? binaryName : binaryName.substring(0, dot);
+        }
+    }
+
+    private static PublishedClasses declarationsOf(String source) {
+        Compilation compiled = Compilation.ofSource(source, "Main");
+        Map<String, byte[]> classes = compiled.db().ask(new Output.All()).value();
+        assertEquals(List.of(), compiled.diagnostics().values().stream().flatMap(List::stream)
+                        .filter(d -> d.diagnostic().severity() == Severity.ERROR)
+                        .map(d -> String.valueOf(d.diagnostic().code())).toList(),
+                "the model this is measured against compiles");
+        return new ClassFileDeclarations(classes::get);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/meta/TheLanguagesOwnDeclarationsAreNotAskedOfEitherBuildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/TheLanguagesOwnDeclarationsAreNotAskedOfEitherBuildTest.java
@@ -136,8 +136,12 @@ class TheLanguagesOwnDeclarationsAreNotAskedOfEitherBuildTest {
 
         assertEquals(List.of(), ours.reserved(), "the module being evaluated is not asked");
         assertEquals(List.of(), theirs.reserved(), "and neither is the answer");
+        // The denominator, for both sides. An empty list of reserved names is what a crossing that
+        // asked nothing at all also answers, and each side is read separately.
         assertTrue(ours.asked.contains("probe.uni.$Module"),
                 () -> "that is not a crossing at all: " + ours.asked);
+        assertTrue(theirs.asked.contains("probe.uni.$Module"),
+                () -> "the answer's classes were never read: " + theirs.asked);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/types/AnIdentitySaysWhetherTheLanguageDeclaresItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/types/AnIdentitySaysWhetherTheLanguageDeclaresItTest.java
@@ -1,0 +1,114 @@
+package souther.compiler.types;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.Reserved;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Whether a module of some compilation declared something, or the language did, is a question the
+ * identity answers.
+ *
+ * <p>A reader that works it out from the module name is a reader that has to know the namespace
+ * rule, and every one that did knew a different half of it: {@code isPrimitive()} for {@code
+ * souther}, a comparison against {@code TypeSymbol.RUNTIME} for {@code souther.runtime}, and in one
+ * place a test against the standard library's qualifiers, which are not module names at all
+ * (#1049). One question, asked of the thing that has the answer.
+ *
+ * <p>Off the address and not off how the identity was minted. {@link TypeSymbols} has two ways in —
+ * {@code declared} and {@code ofLanguage} — and which one a given identity came through is not a
+ * fact about the declaration: {@code Declarations.identify} answers for the language's own
+ * vocabulary through {@code declared}, so an origin kept from the factory would make one address two
+ * different things by route. Held here as: equal identities answer alike.
+ */
+class AnIdentitySaysWhetherTheLanguageDeclaresItTest {
+
+    @Test
+    void aPrimitiveCaseNameIsDeclaredByTheLanguage() {
+        assertTrue(TypeSymbol.primitive("Int").isDeclaredByLanguage());
+    }
+
+    @Test
+    void soAreOptionsTwoCases() {
+        assertTrue(TypeSymbol.SOME.isDeclaredByLanguage());
+        assertTrue(TypeSymbol.NONE.isDeclaredByLanguage());
+    }
+
+    /** The other half of the namespace, which {@code isPrimitive()} does not answer for. */
+    @Test
+    void soIsABuiltInErrorCase() {
+        TypeSymbol error = TypeSymbol.runtime("DivisionByZero");
+
+        assertTrue(error.isDeclaredByLanguage());
+        assertFalse(error.isPrimitive(), "which is not the same question");
+    }
+
+    @Test
+    void aTypeAModuleDeclaresIsNot() {
+        assertFalse(TypeSymbols.declared(new TypeKey("probe.uni", "Amount"))
+                .isDeclaredByLanguage());
+    }
+
+    /** A module may not take a reserved name, so nothing a compilation declares can answer yes by
+     *  being spelled like one. */
+    @Test
+    void norIsATypeOfAModuleWhoseNameMerelyStartsWithTheSameWord() {
+        assertFalse(TypeSymbols.declared(new TypeKey("southerly.billing", "Amount"))
+                .isDeclaredByLanguage());
+    }
+
+    @Test
+    void aHelperAndABehaviorAnswerTheSameWay() {
+        assertFalse(new ValueName.Helper("probe.uni", "ok").isDeclaredByLanguage());
+        assertFalse(new ValueName.Behavior("probe.uni", "half").isDeclaredByLanguage());
+        assertTrue(new ValueName.Helper("souther.option", "withDefault").isDeclaredByLanguage());
+    }
+
+    /** How the question was got wrong: two identities equal to each other answering differently is
+     *  what a provenance kept from the factory would have allowed. */
+    @Test
+    void twoIdentitiesOfOneAddressAnswerAlike() {
+        TypeSymbol minted = TypeSymbol.runtime("RoundingMode");
+        TypeSymbol identified = TypeSymbols.declared(minted.key());
+
+        assertEquals(minted, identified);
+        assertEquals(minted.isDeclaredByLanguage(), identified.isDeclaredByLanguage());
+    }
+
+    /**
+     * A standard-library qualifier is not a module name, and no module name is a qualifier.
+     *
+     * <p>The two are different vocabularies: a qualifier is what a call writes ({@code Option}), and
+     * a module name is what resolution settled ({@code souther.option}). Holding a resolved module
+     * against {@link Reserved#isQualifier} is a test nothing can pass, which is why the crossing's
+     * exclusion of the standard library never fired and a {@code match} on an optional went looking
+     * for a {@code souther} artifact.
+     */
+    @Test
+    void aQualifierIsNeverTheModuleOfAnIdentity() {
+        List<String> qualifiersThatAreModuleNames = new ArrayList<>();
+        List<String> moduleNamesOutsideTheNamespace = new ArrayList<>();
+        for (Reserved.StdlibModule each : Reserved.MODULES) {
+            assertTrue(Reserved.isQualifier(each.qualifier()), each::qualifier);
+            if (Reserved.isQualifier(each.moduleName())) {
+                qualifiersThatAreModuleNames.add(each.moduleName());
+            }
+            if (!Reserved.isNamespace(each.moduleName())) {
+                moduleNamesOutsideTheNamespace.add(each.moduleName());
+            }
+        }
+
+        assertEquals(List.of(), qualifiersThatAreModuleNames,
+                "a qualifier is the spelling a call writes, and never a module a name resolves to");
+        assertEquals(List.of(), moduleNamesOutsideTheNamespace,
+                "and every library module is inside the namespace, which is what answers for it");
+        assertFalse(Reserved.isQualifier("souther"),
+                "nor is the module the language's own vocabulary is addressed under");
+    }
+}


### PR DESCRIPTION
Closes #1049.

## What was wrong

A `let` reached from an `ensures` that matches on an optional left every row of its behavior at
`ANSWERER_ESTABLISHMENT`. Nothing was applied, `checkContract` answered `Unobserved`, and E1927 told
the author to add `souther` to their dependencies — the compiler's own resources, which no artifact
carries and no model can depend on.

`Crossing.reach` excluded the standard library by holding a reached thing's module against
`Reserved.isQualifier`. A qualifier is the spelling a call writes — `List`, `Option` — and never the
module a name resolution has settled, so the test was one no reached thing could pass and the
exclusion never fired. The vocabulary came from `Front.reaches`, whose keys really are qualifiers;
it does not survive the move to the resolved side.

`Option` was not what was wrong. Measured through `DeclarationAgreement.of`:

```
| None / | Some t        -> Unreadable[SaysNothing[module=souther], THE_MODULE_BEING_EVALUATED]
| Int as q / | DivisionByZero -> Unreadable[SaysNothing[module=souther], …]
Option.map / Option.withDefault -> Agree[]
```

Every case name the language gives reaches it. `Int` being found first is the only reason the report
named `souther` rather than `souther.runtime`, so excluding one of them would have left the walk
stopping at the other.

The pipe spelling escaped for a second reason: a library name is a `ValueName.Stdlib`, and
`follow`'s switch dropped it through `default`.

## What this does

The question moves to what has the answer. `TypeSymbol.isDeclaredByLanguage()` reads the namespace
off the address; `ValueName.Helper` and `ValueName.Behavior` answer it the same way, and `Reached`
delegates to the identity it stands for. `TypeSymbol.PRIMITIVE` is no longer readable from outside.

Off the address and not off how the identity was minted. `TypeSymbols` has two ways in, and
`Declarations.identify` answers for the language's own vocabulary through the `declared` one — an
origin kept from the factory would make one address two different things by route, and then either
`equals` splits one declaration in two or two equal identities answer differently.

The same question was being spelled by hand where a module decides what it emits
(`!isPrimitive() && module().equals(pkg)`, three sites). Those go through the identity too. They are
behaviour-neutral: the two spellings part only where the module being emitted is itself of the
reserved namespace, and `pkg` is `module.name()` of a module of the compilation, which may not take
one. `isPrimitive()` was answering half the question and the `module().equals(pkg)` half happened to
cover the rest.

`heldFrom` now seeds its root into the queue instead of putting it through `reach`, so a root
`reach` would decline cannot come back `Agree` having held nothing. Behaviour-neutral for the one
caller there is, which passes the module being evaluated.

Two more shapes closed while the walk is open:

- `notInSight` raises on a reserved name. Not a second exclusion — `reach` decides that — but the
  statement of what has to be true once it has, so a route opened later fails where it is written
  instead of reaching an author as advice that cannot be taken.
- `follow` steps into `ValueName` and writes out every case. The walk carries `Object`, so its outer
  switch is an open world; a name that has arrived at `ValueName` is a closed one again, and a case
  added there is now a compile error here.

## What this deliberately does not do

The readers that ask which class souther-runtime carries — `SoutherJvmAbi`, `Intrinsics`,
`Arithmetic`, `TypeScope`, `Stdlib`, `StdlibLoader`, `Declarations` — are asking a different
question and are left alone. That is #1038 (the namespace being both an identity and a JVM package)
and #1039 (a rounding rule branching on a type's name). Routing them through a predicate here would
tidy the spelling away, shrink `TheRuntimeNamespaceIsNotSpreadAnyFurtherTest`'s inventory of seven
files, and leave both issues exactly where they are. That test is untouched and still passes.

## What holds it

`TheLanguagesOwnDeclarationsAreNotAskedOfEitherBuildTest` — the optional match and the pipe spelling
both held; a primitive case and a built-in error case held; an ordinary module still crossed and
still reported when it moves; a reserved module raising rather than reporting; and neither side's
classes asked for anything of the namespace, checked over the binary names actually requested. That
last one is not independent evidence on the crossing's own path — `notInSight` raises before a
reading is made, so nothing being thrown already implies it. What it covers is the other route to
the same classes: `PublishedUniverse` follows the modules a published module's declarations name,
and is asked by module name rather than by anything the crossing decided.

`ARuleThatMatchesOnAnOptionalStillEstablishesAnAnswererTest` — the issue end to end: the row is
applied (`FailurePhase.NONE`), `checkContract` observes, and an answer that drops the tag is `Broken`
rather than `Unobserved`.

`AnIdentitySaysWhetherTheLanguageDeclaresItTest` — the identity-level answers, that two identities of
one address answer alike, and that no library qualifier is a module name and no library module name
is outside the namespace, which is the confusion that started this.

Measured: 6 of the 9 new behavioural assertions fail with only the predicate reverted. Full
`mvn -o test` from the reactor root is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
