### PR TITLE
Answer for everything a generation was asked with, and stop reading a reason off an absence

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/partition/ArmDisposition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ArmDisposition.java
@@ -9,11 +9,10 @@ import java.util.List;
  *
  * <p>Which arm is the key it is filed under, the same way a class's is.
  *
- * <p>Three answers because they are three pieces of news. A row was composed; a search ran at every
- * place a row could have come from and came back with what each of them said; or there was nowhere
- * to look at all, which the reading of the body settles and no search is involved in. Told as one,
- * a reader could not tell an arm the model refuses from one this compiler could not state a way
- * into.
+ * <p>Three answers because they are three pieces of news. A row was composed; there is a reason
+ * there is none; or there was nowhere to look at all, which the reading of the body settles and no
+ * search is involved in. Told as one, a reader could not tell an arm the model refuses from one
+ * this compiler could not state a way into.
  */
 public sealed interface ArmDisposition {
 
@@ -21,12 +20,18 @@ public sealed interface ArmDisposition {
     record Built(RowId row) implements ArmDisposition {}
 
     /**
-     * No row came of the places a row could have come from, and what each of them came to.
+     * No row, and the reasons there is none.
      *
-     * <p>All of them, because they are not one fact. One place stopping at the search's budget and
-     * another the model's own rules refuse are different news — the first says a row may still be
-     * writable and the second says the model settles it — and the arm is answered by the whole of
-     * what was tried rather than by whichever was walked first.
+     * <p>Not only the reasons a search came back with. A run that never searched has one too — the
+     * rows could not be read, the classes would not link — and it is as much an answer about this
+     * arm as a refusal is. What this says is that there is no row and that the run can say why;
+     * whether anything was tried is in the words, where {@code THE_ROWS_WERE_NOT_READ} and
+     * {@code LINKAGE_FAILED} say it outright.
+     *
+     * <p>All of the reasons, because they are not one fact. One place stopping at the search's
+     * budget and another the model's own rules refuse are different news — the first says a row may
+     * still be writable and the second says the model settles it — and the arm is answered by the
+     * whole of what was tried rather than by whichever was walked first.
      */
     record Unresolved(List<Generator.UnresolvedCombination> why) implements ArmDisposition {
 
@@ -34,7 +39,7 @@ public sealed interface ArmDisposition {
             why = List.copyOf(why);
             if (why.isEmpty()) {
                 throw new IllegalArgumentException(
-                        "an arm nothing was tried at is one with no way into it");
+                        "an arm with no row and no reason for it is one nothing answered for");
             }
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ArmDisposition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ArmDisposition.java
@@ -17,7 +17,14 @@ import java.util.List;
 public sealed interface ArmDisposition {
 
     /** A row was composed for a combination that takes it, or along the way into it. */
-    record Built(RowId row) implements ArmDisposition {}
+    record Built(RowId row) implements ArmDisposition {
+
+        public Built {
+            if (row == null) {
+                throw new IllegalArgumentException("an arm a row was composed for names the row");
+            }
+        }
+    }
 
     /**
      * No row, and the reasons there is none.
@@ -54,6 +61,10 @@ public sealed interface ArmDisposition {
     record NoWayIn(PathAccess access) implements ArmDisposition {
 
         public NoWayIn {
+            if (access == null) {
+                throw new IllegalArgumentException(
+                        "an arm nothing was tried at says what the reading made of it");
+            }
             if (access instanceof PathAccess.Ways) {
                 throw new IllegalArgumentException(
                         "an arm with ways into it is one this search had somewhere to look");

--- a/souther-compiler/src/main/java/souther/compiler/partition/ArmDisposition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ArmDisposition.java
@@ -1,0 +1,58 @@
+package souther.compiler.partition;
+
+import souther.compiler.reading.PathAccess;
+
+import java.util.List;
+
+/**
+ * What one run of the generator did about one arm it was asked for.
+ *
+ * <p>Which arm is the key it is filed under, the same way a class's is.
+ *
+ * <p>Three answers because they are three pieces of news. A row was composed; a search ran at every
+ * place a row could have come from and came back with what each of them said; or there was nowhere
+ * to look at all, which the reading of the body settles and no search is involved in. Told as one,
+ * a reader could not tell an arm the model refuses from one this compiler could not state a way
+ * into.
+ */
+public sealed interface ArmDisposition {
+
+    /** A row was composed for a combination that takes it, or along the way into it. */
+    record Built(RowId row) implements ArmDisposition {}
+
+    /**
+     * No row came of the places a row could have come from, and what each of them came to.
+     *
+     * <p>All of them, because they are not one fact. One place stopping at the search's budget and
+     * another the model's own rules refuse are different news — the first says a row may still be
+     * writable and the second says the model settles it — and the arm is answered by the whole of
+     * what was tried rather than by whichever was walked first.
+     */
+    record Unresolved(List<Generator.UnresolvedCombination> why) implements ArmDisposition {
+
+        public Unresolved {
+            why = List.copyOf(why);
+            if (why.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "an arm nothing was tried at is one with no way into it");
+            }
+        }
+    }
+
+    /**
+     * Nothing was tried, because the reading of the body has no way into this arm to try.
+     *
+     * <p>Which is two pieces of news and the reading says which: no run reaches the arm at all, or
+     * this compiler cannot state what steers a row there. Neither is a search that failed, and
+     * carrying either as one would tell a reader a value was looked for.
+     */
+    record NoWayIn(PathAccess access) implements ArmDisposition {
+
+        public NoWayIn {
+            if (access instanceof PathAccess.Ways) {
+                throw new IllegalArgumentException(
+                        "an arm with ways into it is one this search had somewhere to look");
+            }
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/ClassDisposition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ClassDisposition.java
@@ -14,9 +14,24 @@ package souther.compiler.partition;
 public sealed interface ClassDisposition {
 
     /** A row was composed for it, which is this row. */
-    record Built(RowId row) implements ClassDisposition {}
+    record Built(RowId row) implements ClassDisposition {
 
-    /** No row came of it, and why. Never a statement that none exists. */
+        public Built {
+            if (row == null) {
+                throw new IllegalArgumentException("a class a row was composed for names the row");
+            }
+        }
+    }
+
+    /**
+     * No row came of it, and why.
+     *
+     * <p>Which of the two kinds of news that is belongs to the reason and not to this. A strategy
+     * took the class and composed nothing: sometimes because the rules leave no value there, which
+     * a reader may act on, and sometimes because this compiler fell short, which they may not.
+     * Said here as though it were always the second, a reason that settles the question would be
+     * printed under a sentence denying it.
+     */
     record Unresolved(Generator.UnresolvedCombination why) implements ClassDisposition {
 
         public Unresolved {

--- a/souther-compiler/src/main/java/souther/compiler/partition/ClassDisposition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ClassDisposition.java
@@ -1,0 +1,28 @@
+package souther.compiler.partition;
+
+/**
+ * What one run of the generator did about one class it was asked for.
+ *
+ * <p>Which class is the key it is filed under and is not repeated here. Carried inside as well, a
+ * map could hold an entry filed under one class whose value named another, and the identity a
+ * reader joined a finding by would be one of two answers.
+ *
+ * <p>Every class the plan names has one of these. A class with none used to mean the search never
+ * reached it, and what a reader made of that absence was a guess — so the absence is gone and each
+ * of the ways a run declines to look says so in its own entry.
+ */
+public sealed interface ClassDisposition {
+
+    /** A row was composed for it, which is this row. */
+    record Built(RowId row) implements ClassDisposition {}
+
+    /** No row came of it, and why. Never a statement that none exists. */
+    record Unresolved(Generator.UnresolvedCombination why) implements ClassDisposition {
+
+        public Unresolved {
+            if (why == null) {
+                throw new IllegalArgumentException("a class nothing came of says what happened");
+            }
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComposedRow.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComposedRow.java
@@ -1,0 +1,25 @@
+package souther.compiler.partition;
+
+import java.util.List;
+
+/**
+ * One row's worth of input, and nothing about what it was composed for.
+ *
+ * <p>What it answers is the discharge's to say. Held here as well, the two were free to disagree:
+ * a row composed for a class and later found to take an arm was merged into one line, the merged
+ * line replaced the row a reader is offered, and the class's own entry went on holding the line
+ * from before the merge. Nobody read the stale one, and the next reader would have.
+ *
+ * @param inputs one value per parameter, in the order the behavior takes them
+ */
+public record ComposedRow(List<FixtureTemplate> inputs) {
+
+    public ComposedRow {
+        inputs = List.copyOf(inputs);
+    }
+
+    /** What the row is written as, which is what tells one line of a file from another. */
+    public List<String> writtenAs() {
+        return inputs.stream().map(FixtureTemplate::text).toList();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Discharge.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Discharge.java
@@ -1,0 +1,38 @@
+package souther.compiler.partition;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * What became of each thing a run was asked for.
+ *
+ * <p>Keyed by the obligation itself, so what a reader joins a finding by is the identity the plan
+ * used to ask. The entries used to carry that identity inside them as well and be held in a list,
+ * which let one run hold an entry filed under one class whose value named another — and a reader
+ * looking a class up by identity found whichever of the two the search wrote first.
+ *
+ * <p>Whether it covers the plan is {@link FillResult}'s to hold, since that is where the plan is.
+ * This is the answers alone.
+ */
+public record Discharge(Map<Generator.ClassOwed, ClassDisposition> classes,
+                        Map<Generator.ArmOwed, ArmDisposition> arms) {
+
+    /** Nothing asked for and nothing answered, which is the only run this is right for. */
+    public static final Discharge NOTHING = new Discharge(Map.of(), Map.of());
+
+    public Discharge {
+        classes = Collections.unmodifiableMap(new LinkedHashMap<>(classes));
+        arms = Collections.unmodifiableMap(new LinkedHashMap<>(arms));
+    }
+
+    /** What became of one class, or null where this run was not asked about it. */
+    public ClassDisposition at(Generator.ClassOwed owed) {
+        return classes.get(owed);
+    }
+
+    /** What became of one arm, or null where this run was not asked about it. */
+    public ArmDisposition at(Generator.ArmOwed owed) {
+        return arms.get(owed);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Discharge.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Discharge.java
@@ -14,6 +14,10 @@ import java.util.Map;
  *
  * <p>Whether it covers the plan is {@link FillResult}'s to hold, since that is where the plan is.
  * This is the answers alone.
+ *
+ * <p>Nothing reads these in order. What a row is offered for is taken in the plan's order, and
+ * everything else asks by key — so the order the entries were written in is kept for the sake of a
+ * message about one run reading the same way twice, and is not something to build an answer from.
  */
 public record Discharge(Map<Generator.ClassOwed, ClassDisposition> classes,
                         Map<Generator.ArmOwed, ArmDisposition> arms) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Discharge.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Discharge.java
@@ -1,7 +1,5 @@
 package souther.compiler.partition;
 
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -26,8 +24,11 @@ public record Discharge(Map<Generator.ClassOwed, ClassDisposition> classes,
     public static final Discharge NOTHING = new Discharge(Map.of(), Map.of());
 
     public Discharge {
-        classes = Collections.unmodifiableMap(new LinkedHashMap<>(classes));
-        arms = Collections.unmodifiableMap(new LinkedHashMap<>(arms));
+        // Neither half of an entry missing. A key with nothing under it is an obligation that was
+        // asked about and not answered for, which is the absence every value here is arranged to
+        // have none of — and it satisfied a check written over the keys alone.
+        classes = Ordered.copyOf(classes);
+        arms = Ordered.copyOf(arms);
     }
 
     /** What became of one class, or null where this run was not asked about it. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/FillResult.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/FillResult.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.SequencedMap;
 import java.util.Set;
 
 /**
@@ -28,18 +29,19 @@ import java.util.Set;
  * line, and the class's own entry went on holding the line from before the merge.
  *
  * @param plan       what this run was asked for
- * @param composed   the rows, in the order they were composed
+ * @param composed   the rows, in the order they were composed, which is the order a reader is
+ *                   offered them in
  * @param unresolved what each place a row was looked for came to, said once apiece
  * @param reasons    what happened to this run as a whole, which is never an answer about one thing
  *                   the plan named
  * @param discharge  what became of each of them
  */
-public record FillResult(GenerationPlan plan, Map<RowId, ComposedRow> composed,
+public record FillResult(GenerationPlan plan, SequencedMap<RowId, ComposedRow> composed,
                          List<Generator.UnresolvedCombination> unresolved,
                          List<GenerationReason> reasons, Discharge discharge) {
 
     public FillResult {
-        composed = Collections.unmodifiableMap(new LinkedHashMap<>(composed));
+        composed = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(composed));
         unresolved = List.copyOf(unresolved);
         reasons = List.copyOf(reasons);
         if (!discharge.classes().keySet().equals(new LinkedHashSet<>(plan.classesOwed()))) {
@@ -78,7 +80,8 @@ public record FillResult(GenerationPlan plan, Map<RowId, ComposedRow> composed,
 
     /** Nothing asked for, nothing composed, nothing to answer for. */
     public static FillResult nothingAskedOf(GenerationPlan plan) {
-        return new FillResult(plan, Map.of(), List.of(), List.of(), Discharge.NOTHING);
+        return new FillResult(plan, new LinkedHashMap<>(), List.of(), List.of(),
+                Discharge.NOTHING);
     }
 
     /**
@@ -107,7 +110,8 @@ public record FillResult(GenerationPlan plan, Map<RowId, ComposedRow> composed,
             arms.put(owed, new ArmDisposition.Unresolved(
                     List.of(new Generator.UnresolvedCombination(List.of(), why))));
         }
-        return new FillResult(plan, Map.of(), List.of(), reasons, new Discharge(classes, arms));
+        return new FillResult(plan, new LinkedHashMap<>(), List.of(), reasons,
+                new Discharge(classes, arms));
     }
 
     /**
@@ -150,16 +154,5 @@ public record FillResult(GenerationPlan plan, Map<RowId, ComposedRow> composed,
             }
         }
         return new Generator.GeneratedRow(purposes, row.inputs());
-    }
-
-    /**
-     * The same run said the way a generation with no plan says it, for whoever is reading the offer
-     * rather than asking after one thing in it.
-     *
-     * <p>A projection and not a second value: what a reader gets here is what the plan and the
-     * discharge come to, worked out on the way past.
-     */
-    public Generator.GenerationResult asGenerationResult() {
-        return new Generator.GenerationResult(rows(), unresolved, reasons);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/FillResult.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/FillResult.java
@@ -1,7 +1,6 @@
 package souther.compiler.partition;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -41,7 +40,7 @@ public record FillResult(GenerationPlan plan, SequencedMap<RowId, ComposedRow> c
                          List<GenerationReason> reasons, Discharge discharge) {
 
     public FillResult {
-        composed = Collections.unmodifiableSequencedMap(new LinkedHashMap<>(composed));
+        composed = Ordered.copyOf(composed);
         unresolved = List.copyOf(unresolved);
         reasons = List.copyOf(reasons);
         if (!discharge.classes().keySet().equals(new LinkedHashSet<>(plan.classesOwed()))) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/FillResult.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/FillResult.java
@@ -1,0 +1,165 @@
+package souther.compiler.partition;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What one run of the generator came to, against the plan it was asked with.
+ *
+ * <p>A fill is total over its plan. Every class and every arm the plan names has an entry saying
+ * what became of it, and the constructor is where that is settled — so a way out of the search that
+ * writes no entry is a value nothing can build, rather than a silence a reader downstream has to
+ * make something of. What such a reader used to make of it was a sentence saying the generator had
+ * failed to say, which was true and was the only thing left to say.
+ *
+ * <p>Apart from {@link Generator.GenerationResult}, which is what a generation with no plan comes
+ * to. The rows offered at a behavior's boundaries are composed for points nobody was asked about
+ * and nothing is owed at, and holding both in one shape meant a result that had dropped its
+ * obligations and one that never had any were the same value.
+ *
+ * <p><b>What a row was composed for is not held here.</b> It is read back off the discharge, which
+ * is the one place that says which obligation a row answered. Written down beside the row as well,
+ * the two came apart: a row composed for a class and later found to take an arm was merged into one
+ * line, and the class's own entry went on holding the line from before the merge.
+ *
+ * @param plan       what this run was asked for
+ * @param composed   the rows, in the order they were composed
+ * @param unresolved what each place a row was looked for came to, said once apiece
+ * @param reasons    what happened to this run as a whole, which is never an answer about one thing
+ *                   the plan named
+ * @param discharge  what became of each of them
+ */
+public record FillResult(GenerationPlan plan, Map<RowId, ComposedRow> composed,
+                         List<Generator.UnresolvedCombination> unresolved,
+                         List<GenerationReason> reasons, Discharge discharge) {
+
+    public FillResult {
+        composed = Collections.unmodifiableMap(new LinkedHashMap<>(composed));
+        unresolved = List.copyOf(unresolved);
+        reasons = List.copyOf(reasons);
+        if (!discharge.classes().keySet().equals(new LinkedHashSet<>(plan.classesOwed()))) {
+            throw new IllegalStateException(
+                    "the classes this run was asked for and the ones it answered for are not the"
+                            + " same: asked " + plan.classesOwed()
+                            + ", answered " + discharge.classes().keySet());
+        }
+        if (!discharge.arms().keySet().equals(new LinkedHashSet<>(plan.armsOwed()))) {
+            throw new IllegalStateException(
+                    "the arms this run was asked for and the ones it answered for are not the same:"
+                            + " asked " + plan.armsOwed()
+                            + ", answered " + discharge.arms().keySet());
+        }
+        // And the rows against what the answers point at, in both directions. A row nothing points
+        // at is one nobody was offered — it would come out of the projection below with nothing to
+        // say it is for, which is not a row — and an answer pointing at a row that is not here is
+        // an obligation reported as met by a line the offer does not hold.
+        Set<RowId> answered = new LinkedHashSet<>();
+        for (ClassDisposition each : discharge.classes().values()) {
+            if (each instanceof ClassDisposition.Built built) {
+                answered.add(built.row());
+            }
+        }
+        for (ArmDisposition each : discharge.arms().values()) {
+            if (each instanceof ArmDisposition.Built built) {
+                answered.add(built.row());
+            }
+        }
+        if (!answered.equals(composed.keySet())) {
+            throw new IllegalStateException(
+                    "the rows this run composed and the rows its answers point at are not the same:"
+                            + " composed " + composed.keySet() + ", pointed at " + answered);
+        }
+    }
+
+    /** Nothing asked for, nothing composed, nothing to answer for. */
+    public static FillResult nothingAskedOf(GenerationPlan plan) {
+        return new FillResult(plan, Map.of(), List.of(), List.of(), Discharge.NOTHING);
+    }
+
+    /**
+     * A run that ended before it looked for anything, with every obligation told the same thing.
+     *
+     * <p>For the ways a generation stops without searching: the rows could not be read, the classes
+     * would not link. Each of those is one fact about the run, said in {@code reasons} — and each of
+     * them used to be the whole of what was recorded, so a reader asking after one class or one arm
+     * found nothing at all and said the generator had failed to say. The fact is the same for every
+     * obligation here, which is why one word serves them all; what it is not is a reason for a
+     * reader to work out from an absence.
+     *
+     * <p>No {@code unresolved} beside them. That list is the places a row was looked for, and this
+     * is a run in which none was.
+     */
+    public static FillResult nothingWasLookedFor(GenerationPlan plan,
+                                                 Generator.UnresolvedCombination.Reason why,
+                                                 List<GenerationReason> reasons) {
+        Map<Generator.ClassOwed, ClassDisposition> classes = new LinkedHashMap<>();
+        for (Generator.ClassOwed owed : plan.classesOwed()) {
+            classes.put(owed, new ClassDisposition.Unresolved(new Generator.UnresolvedCombination(
+                    List.of(Generator.labelOf(plan.subject(), owed)), why)));
+        }
+        Map<Generator.ArmOwed, ArmDisposition> arms = new LinkedHashMap<>();
+        for (Generator.ArmOwed owed : plan.armsOwed()) {
+            arms.put(owed, new ArmDisposition.Unresolved(
+                    List.of(new Generator.UnresolvedCombination(List.of(), why))));
+        }
+        return new FillResult(plan, Map.of(), List.of(), reasons, new Discharge(classes, arms));
+    }
+
+    /**
+     * The rows a reader is offered, each carrying what it was composed for.
+     *
+     * <p>Read off the discharge rather than kept beside the row, so a row that answers two
+     * obligations says so because both of them point at it.
+     *
+     * <p>In the plan's order, classes before arms. Which is one rule, said here: the obligations
+     * are held in the order they were gathered exactly so that this order is the same twice, and
+     * taking it off the discharge's own iteration would leave the purposes of one model coming out
+     * however a map happened to be walked.
+     */
+    public List<Generator.GeneratedRow> rows() {
+        List<Generator.GeneratedRow> out = new ArrayList<>();
+        for (RowId id : composed.keySet()) {
+            out.add(rowFor(id));
+        }
+        return List.copyOf(out);
+    }
+
+    /** One of them, for a reader holding an answer that points at it. */
+    public Generator.GeneratedRow rowFor(RowId id) {
+        ComposedRow row = composed.get(id);
+        if (row == null) {
+            throw new IllegalArgumentException("no row of this run is " + id);
+        }
+        List<Generator.Purpose> purposes = new ArrayList<>();
+        for (Generator.ClassOwed owed : plan.classesOwed()) {
+            if (discharge.at(owed) instanceof ClassDisposition.Built built
+                    && built.row().equals(id)) {
+                purposes.add(new Generator.Purpose.ForAClass(owed.at(), owed.classId(),
+                        Generator.labelOf(plan.subject(), owed)));
+            }
+        }
+        for (Generator.ArmOwed owed : plan.armsOwed()) {
+            if (discharge.at(owed) instanceof ArmDisposition.Built built
+                    && built.row().equals(id)) {
+                purposes.add(new Generator.Purpose.ForAnArm(owed.probe()));
+            }
+        }
+        return new Generator.GeneratedRow(purposes, row.inputs());
+    }
+
+    /**
+     * The same run said the way a generation with no plan says it, for whoever is reading the offer
+     * rather than asking after one thing in it.
+     *
+     * <p>A projection and not a second value: what a reader gets here is what the plan and the
+     * discharge come to, worked out on the way past.
+     */
+    public Generator.GenerationResult asGenerationResult() {
+        return new Generator.GenerationResult(rows(), unresolved, reasons);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/GenerationOutcome.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GenerationOutcome.java
@@ -40,8 +40,11 @@ public sealed interface GenerationOutcome {
     /**
      * A strategy applies, and it composed nothing.
      *
-     * <p>Never a claim that nothing can be written. What the attempt established is carried whole, and
-     * saying more than it is the thing this type exists to prevent.
+     * <p>And nothing more than that. Whether a row can be written at all is what the reasons carried
+     * here answer — some of them say the model leaves no value there and a reader may act on it,
+     * most of them say this compiler fell short and a reader may not — so the attempt is carried
+     * whole and this arm claims neither. Read as always meaning the second, a run that had settled
+     * the question would be printed under a sentence taking it back.
      *
      * <p><b>All of what was tried, and not the weakest of it.</b> An arm is looked for at every
      * combination claiming it, and those come to different things — one the model refuses, one the

--- a/souther-compiler/src/main/java/souther/compiler/partition/GenerationPlan.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GenerationPlan.java
@@ -1,0 +1,65 @@
+package souther.compiler.partition;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * What one run of the generator is asked for, and the only place it is said.
+ *
+ * <p>A class of a position no row sits in and an arm of the body no row goes through are the two
+ * things a row can be owed for. Which of them a run is asked about is established by whoever read
+ * the rows, and this carries that reading whole — so a search does not work the list out a second
+ * time, and nothing downstream decides from what a search happened to touch.
+ *
+ * <p><b>Settled before anything that can stop the run.</b> The classes would not link, the rows
+ * could not be read: each of those ends a generation, and each used to end it somewhere that had
+ * never asked what was owed. What a reader of such a result got was a reason about the run and no
+ * word about the thing they were asking after. Made here, every way out holds the same list.
+ *
+ * <p><b>Lists rather than sets, and the order is the contract.</b> What a row is composed for is
+ * written out beside it, and the order those are written in is this order — so a plan handed over
+ * as a set would leave the rows of one model coming out in whatever order a hash gave them, which
+ * is not the same order twice. Each obligation appears once, which is the whole of what being a set
+ * gave.
+ *
+ * @param subject     the behavior a row would be written for
+ * @param classesOwed one class of one position apiece, in the order they were gathered
+ * @param armsOwed    one arm apiece, in the order the plan numbered them
+ */
+public record GenerationPlan(Generator.Subject subject, List<Generator.ClassOwed> classesOwed,
+                             List<Generator.ArmOwed> armsOwed) {
+
+    public GenerationPlan {
+        classesOwed = List.copyOf(classesOwed);
+        armsOwed = List.copyOf(armsOwed);
+        if (subject == null) {
+            throw new IllegalArgumentException("a generation is asked for on behalf of a subject");
+        }
+        onlyOnce("class", classesOwed);
+        onlyOnce("arm", armsOwed);
+        // A class of another behavior, which is the same disagreement `Subject` refuses among its
+        // axes. Held here, one run would be answering for two behaviors and every sentence about
+        // what it was asked for would be right about one of them.
+        for (Generator.ClassOwed each : classesOwed) {
+            if (!each.at().behavior().equals(subject.behavior())) {
+                throw new IllegalArgumentException(
+                        "a class of " + each.at().behavior() + " in the plan for "
+                                + subject.behavior() + ": " + each);
+            }
+        }
+    }
+
+    /** Whether anything at all is owed, which is what a run with nothing to do looks like. */
+    public boolean isEmpty() {
+        return classesOwed.isEmpty() && armsOwed.isEmpty();
+    }
+
+    private static void onlyOnce(String kind, List<?> owed) {
+        Set<Object> seen = new LinkedHashSet<>(owed);
+        if (seen.size() != owed.size()) {
+            throw new IllegalArgumentException(
+                    "the same " + kind + " is owed twice in one plan: " + owed);
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -753,7 +753,8 @@ public final class Generator {
                                         CandidateCheck check,
                                         AdequacyPolicy.OfTheGeneration budget) {
         return fill(subject, existing, check,
-                new souther.compiler.reading.CoverageRead.Read(List.of(), Map.of()), budget);
+                new souther.compiler.reading.CoverageRead.Read(List.of(),
+                        new LinkedHashMap<>()), budget);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.SequencedMap;
 import java.util.Set;
 
 /**
@@ -786,22 +787,24 @@ public final class Generator {
                                         CandidateCheck check,
                                         souther.compiler.reading.CoverageRead.Read read,
                                         Trial trial, AdequacyPolicy.OfTheGeneration budget) {
+        // Both in the order their own walks reached them: the positions the search fixes them in,
+        // and the numbers the plan gave the arms. Each is what that walk means by its order.
         return fill(planOver(subject, everyClassNoRowSitsIn(subject, existing),
-                        read.arms().keySet()),
+                        List.copyOf(read.arms().keySet())),
                 existing, check, read, trial, List.of(), budget);
     }
 
     /**
      * A plan over what a caller gathered, in the order they gathered it.
      *
-     * <p>For the callers that hand their obligations over as sets, which is what a walk that
-     * gathers each thing once produces. What the plan wants is the order, and the order such a walk
-     * kept is the one to keep.
+     * <p>Ordered, because the plan is. Which order it is belongs to whoever gathered the
+     * obligations: a walk that gathers each thing once knows what its own order means, and a set
+     * handed over here would leave that to whatever collection the caller happened to hold — so
+     * this takes the answer rather than the collection it was kept in.
      */
-    public static GenerationPlan planOver(Subject subject, Set<ClassOwed> classes,
-                                          Set<Integer> arms) {
-        return new GenerationPlan(subject, List.copyOf(classes),
-                arms.stream().map(ArmOwed::new).toList());
+    public static GenerationPlan planOver(Subject subject, List<ClassOwed> classes,
+                                          List<Integer> arms) {
+        return new GenerationPlan(subject, classes, arms.stream().map(ArmOwed::new).toList());
     }
 
     /**
@@ -815,8 +818,8 @@ public final class Generator {
                                         CandidateCheck check,
                                         souther.compiler.reading.CoverageRead.Read read,
                                         Trial trial, List<Baseline> baselines,
-                                        Set<ClassOwed> classesOwed,
-                                        Set<Integer> armsOwed,
+                                        List<ClassOwed> classesOwed,
+                                        List<Integer> armsOwed,
                                         AdequacyPolicy.OfTheGeneration budget) {
         return fill(planOver(subject, classesOwed, armsOwed), existing, check, read, trial,
                 baselines, budget);
@@ -894,8 +897,11 @@ public final class Generator {
      * one element under a line and one over it — and each of them is covered. Read as one class,
      * the rest would be asked for again, which is work the author has already done.
      */
-    public static Set<ClassOwed> everyClassNoRowSitsIn(Subject subject,
+    public static List<ClassOwed> everyClassNoRowSitsIn(Subject subject,
                                                        List<ObservedRow> existing) {
+        // Gathered once apiece and handed over in the order the walk reached them, which is the
+        // order the search fixes the positions in. The set is how "once apiece" is kept; what a
+        // caller is given is the order, because that is what the plan is asking for.
         Set<ClassOwed> out = new LinkedHashSet<>();
         for (Axis axis : ordered(subject)) {
             Set<String> covered = new LinkedHashSet<>();
@@ -911,7 +917,7 @@ public final class Generator {
                 }
             }
         }
-        return out;
+        return List.copyOf(out);
     }
 
     /**
@@ -991,12 +997,15 @@ public final class Generator {
         // fact about the module rather than about the class asking.
         List<ResolvedOrigin> origins = resolve(subject, axes, baselines, check);
 
-        List<GeneratedRow> rows = new ArrayList<>();
+        // The rows this run composes, each numbered where it is composed. The number is an
+        // identity and nothing reads it as a place: what says two obligations were answered by one
+        // line is that both entries name the same one.
+        SequencedMap<RowId, ComposedRow> composed = new LinkedHashMap<>();
         List<ClassAttempt> attempts = new ArrayList<>();
-        // Which row answered which class, by where the row went. A row is a line in the file and
-        // the same line can answer several things, so what says a class was answered is the entry
-        // pointing at the row rather than anything written on the row itself.
-        Map<ClassOwed, Integer> answeredAt = new LinkedHashMap<>();
+        // Which row answered which class. A row is a line in the file and the same line can answer
+        // several things, so what says a class was answered is the entry naming the row rather than
+        // anything written on the row itself.
+        Map<ClassOwed, RowId> answeredAt = new LinkedHashMap<>();
         List<UnresolvedCombination> unresolved = new ArrayList<>();
         List<GenerationReason> reasons = new ArrayList<>(undecided);
         // The classes first. What each is owed is one row, and the arms below are looked for among
@@ -1011,7 +1020,7 @@ public final class Generator {
         int classesLeft = 0;
         for (int i = 0; i < owed.size(); i++) {
             int[] at = owed.get(i);
-            if (rows.size() >= budget.rows()) {
+            if (composed.size() >= budget.rows()) {
                 classesLeft = owed.size() - i;
                 for (int cut = i; cut < owed.size(); cut++) {
                     Axis axis = axes.get(owed.get(cut)[0]);
@@ -1028,11 +1037,12 @@ public final class Generator {
             attempts.add(attempt);
             switch (attempt) {
                 case ClassAttempt.Built made -> {
-                    // Where it went, and not what it was written as. Two classes can be answered by
-                    // rows written the same way and still be two rows the search composed one
-                    // apiece; matched back by their text, the second was read as the first.
-                    answeredAt.put(new ClassOwed(attempt.at(), attempt.classId()), rows.size());
-                    rows.add(made.row());
+                    // Its own row, whatever the ones beside it are written as. Two classes can be
+                    // answered by rows written the same way and are still two rows the search
+                    // composed one apiece — each is offered for its own class, and merging them
+                    // would take one of the two classes its answer.
+                    answeredAt.put(new ClassOwed(attempt.at(), attempt.classId()),
+                            compose(composed, made.row().inputs()));
                 }
                 case ClassAttempt.Unresolved none -> unresolved.add(none.why());
             }
@@ -1044,7 +1054,7 @@ public final class Generator {
         // in first — which is a preference between two answers and not one of them standing in for
         // the other. An arm no combination is over is answered from its way in all the same.
         Set<Integer> left = new LinkedHashSet<>(armsOwed);
-        Map<Integer, Integer> built = new LinkedHashMap<>();
+        Map<Integer, RowId> built = new LinkedHashMap<>();
         Map<Integer, List<UnresolvedCombination>> failed = new LinkedHashMap<>();
         // Arms the row budget ran out before, which is what the search stopping looks like from an
         // arm. Told apart from an arm with nowhere to look, because raising the budget changes one
@@ -1079,7 +1089,7 @@ public final class Generator {
                 continue;
             }
             for (WhereToLook place : whereToLookFor(probe, read, cells, axes)) {
-                if (rows.size() >= budget.rows()) {
+                if (composed.size() >= budget.rows()) {
                     cutOff.add(probe);
                     break;
                 }
@@ -1126,14 +1136,10 @@ public final class Generator {
                         unconfirmed = true;
                     }
                 }
-                // What the row is offered for, said here and not read off what the search happened
-                // to be called with. A cell searched once answers every arm looked for in it, and
-                // the row it composed carries the purpose of whichever arm asked first — so a row
-                // named by that would be offered for one arm and handed to another.
-                List<Purpose> purposes = new ArrayList<>();
-                purposes.add(new Purpose.ForAnArm(probe));
-                also.forEach(each -> purposes.add(new Purpose.ForAnArm(each)));
-                int kept = keep(rows, new GeneratedRow(purposes, row.inputs()));
+                // The row already offering these values where there is one, so that a class's row
+                // an arm also goes through is one line and not two. What each of them is offered for
+                // is the entries naming it, so nothing is written on the row here.
+                RowId kept = keep(composed, row.inputs());
                 built.put(probe, kept);
                 left.remove(probe);
                 also.forEach(each -> {
@@ -1166,24 +1172,14 @@ public final class Generator {
         // cut off carries that beside whatever was tried before it: a place the model refuses says
         // nothing about the ones nobody got to, and an arm answered by the first alone was reported
         // as settled by the model on the strength of a search that stopped.
-        // Which row is which, once the merging is done. A row is a line in the file, so two sets of
-        // values written the same way are one row however many obligations they answer — and what
-        // each of them is for is said by the entries below pointing here.
-        List<RowId> numbered = new ArrayList<>();
-        Map<RowId, ComposedRow> composed = new LinkedHashMap<>();
-        for (GeneratedRow row : rows) {
-            RowId id = new RowId(numbered.size());
-            numbered.add(id);
-            composed.put(id, new ComposedRow(row.inputs()));
-        }
         Map<ArmOwed, ArmDisposition> armAnswers = new LinkedHashMap<>();
         for (int probe : armsOwed) {
-            Integer row = built.get(probe);
+            RowId row = built.get(probe);
             List<UnresolvedCombination> why = new ArrayList<>(
                     failed.getOrDefault(probe, List.of()));
             ArmOwed asked = new ArmOwed(probe);
             if (row != null) {
-                armAnswers.put(asked, new ArmDisposition.Built(numbered.get(row)));
+                armAnswers.put(asked, new ArmDisposition.Built(row));
             } else if (cutOff.contains(probe)) {
                 why.add(new UnresolvedCombination(List.of(),
                         UnresolvedCombination.Reason.SEARCH_LIMIT));
@@ -1238,8 +1234,7 @@ public final class Generator {
         for (ClassAttempt attempt : attempts) {
             ClassOwed key = new ClassOwed(attempt.at(), attempt.classId());
             classAnswers.put(key, switch (attempt) {
-                case ClassAttempt.Built _ -> new ClassDisposition.Built(
-                        numbered.get(answeredAt.get(key)));
+                case ClassAttempt.Built _ -> new ClassDisposition.Built(answeredAt.get(key));
                 case ClassAttempt.Unresolved none -> new ClassDisposition.Unresolved(none.why());
             });
         }
@@ -1414,10 +1409,10 @@ public final class Generator {
      * ways in agree. Written down twice, an author is handed the same line twice and told it
      * answers two different things.
      */
-    private static int keep(List<GeneratedRow> rows, GeneratedRow row) {
-        List<String> written = writtenAs(row);
-        for (int i = 0; i < rows.size(); i++) {
-            GeneratedRow already = rows.get(i);
+    private static RowId keep(SequencedMap<RowId, ComposedRow> composed,
+                              List<FixtureTemplate> inputs) {
+        List<String> written = inputs.stream().map(FixtureTemplate::text).toList();
+        for (Map.Entry<RowId, ComposedRow> already : composed.entrySet()) {
             // Whatever the row beside it was composed for, and not the arms alone. One set of
             // values is one line in the file: a class's row and an arm's row of the same values are
             // one row that fills the class and goes through the arm, and written down twice the
@@ -1426,16 +1421,26 @@ public final class Generator {
             // By what the rows are written as, which is what "the same line" means and is a string
             // to compare. A template also carries the expression it stands for, and holding two
             // rows to that walks two trees for an answer the text already gave.
-            if (!writtenAs(already).equals(written)) {
-                continue;
+            if (already.getValue().writtenAs().equals(written)) {
+                return already.getKey();
             }
-            List<Purpose> both = new ArrayList<>(already.purposes());
-            row.purposes().stream().filter(each -> !both.contains(each)).forEach(both::add);
-            rows.set(i, new GeneratedRow(both, already.inputs()));
-            return i;
         }
-        rows.add(row);
-        return rows.size() - 1;
+        return compose(composed, inputs);
+    }
+
+    /**
+     * A row of these values, numbered where it is composed.
+     *
+     * <p>The number is minted here and read nowhere as a place. What the identity is for is saying
+     * that two entries name one line, and an identity that meant "the nth row offered" would move
+     * with whatever the offer was ordered by — which is the arrangement a row's own account of what
+     * it was composed for came apart under.
+     */
+    private static RowId compose(SequencedMap<RowId, ComposedRow> composed,
+                                 List<FixtureTemplate> inputs) {
+        RowId id = new RowId(composed.size());
+        composed.put(id, new ComposedRow(inputs));
+        return id;
     }
 
     /** What a row is written as, which is what tells one line of a file from another. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -88,12 +88,36 @@ public final class Generator {
      */
     private static final int MOST_RUNS_PER_INTERPRETATION = 3;
 
-    /** The behavior a row would be written for: what its inputs are called, what they are, and where
-     * the model divides them. */
-    public record Subject(BehaviorInputs inputs, List<Axis> axes, HeldCounts held) {
+    /**
+     * The behavior a row would be written for: what it is called, what its inputs are called, what
+     * they are, and where the model divides them.
+     *
+     * <p><b>Named here rather than read back off a position.</b> Which behavior this is about is a
+     * fact about the subject and holds whether or not the model divides any of its positions —
+     * while an axis carries the name only because a report names axes across behaviors. Taken from
+     * the first axis, a run with no divided position had nowhere to read it, and every sentence
+     * this generation says about the behavior as a whole was reachable only through a position.
+     *
+     * @param behavior what the behavior is called, which every axis of it agrees with
+     */
+    public record Subject(String behavior, BehaviorInputs inputs, List<Axis> axes,
+                          HeldCounts held) {
 
         public Subject {
             axes = List.copyOf(axes);
+            if (behavior == null || behavior.isEmpty()) {
+                throw new IllegalArgumentException("a row is written for a behavior with a name");
+            }
+            // An axis of another behavior, which is a subject assembled from two measurements. The
+            // name would then be one of two answers rather than the subject's, and whichever
+            // sentence read it would be right about one of them.
+            for (Axis axis : axes) {
+                if (!axis.id().behavior().equals(behavior)) {
+                    throw new IllegalArgumentException(
+                            "an axis of " + axis.id().behavior() + " in the subject of " + behavior
+                                    + ": " + axis.id());
+                }
+            }
         }
 
         /**
@@ -127,6 +151,28 @@ public final class Generator {
 
         public Symbols symbols() {
             return inputs.symbols();
+        }
+
+        /**
+         * Whether the model divides this position into a class spelled this way.
+         *
+         * <p>The one place the question is answered. A reader working it out from a partition's
+         * axes beside this one is a second reading of what a search's own universe is, and the two
+         * agree until either moves — which is how a case of an input came to be told there was no
+         * axis at its position by one reading while the search had classes there under the other.
+         */
+        public boolean divides(ClassOwed owed) {
+            for (Axis axis : axes) {
+                if (!axis.id().equals(owed.at())) {
+                    continue;
+                }
+                for (PartitionClass cls : axis.classes()) {
+                    if (cls.id().equals(owed.classId())) {
+                        return true;
+                    }
+                }
+            }
+            return false;
         }
     }
 
@@ -401,14 +447,20 @@ public final class Generator {
              */
             NO_CERTIFIED_WITNESS,
             /**
-             * A strategy that takes this class produced neither a row nor a reason for it.
+             * The walk ran to the end of what it had and put no candidate forward at all.
              *
-             * <p>Which is this compiler failing to say, and not something established about the
-             * class. Named rather than guessed at: the alternative is to write down whichever cause
-             * seemed likely when the branch was added, and a reason read off an empty result outlives
-             * whatever made it plausible.
+             * <p>Nothing was built, so nothing was refused, and nothing stopped it: what it had to
+             * offer was nothing. A fact about what this compiler can compose here, like
+             * {@link #NOTHING_COMPOSES_ONE} and unlike the two words about the model — another
+             * reading of the same position may well offer one.
+             *
+             * <p>It used to be spelled as no reason having been recorded, which was a confession
+             * this compiler had failed to say why. The confession was real and belonged somewhere
+             * else: a class or an arm the run never answered for. That absence cannot be built now,
+             * and what is left here is a walk that ran and came back empty — which is a thing that
+             * happened rather than a thing nobody wrote down.
              */
-            NO_REASON_RECORDED;
+            NO_CANDIDATE_WAS_OFFERED;
 
             /**
              * Whether this reason proves there is nothing to find, which one of them does.
@@ -432,7 +484,7 @@ public final class Generator {
                          NO_CERTIFIED_WITNESS, THE_GROUP_WAS_NOT_OFFERED,
                          THE_POSITION_WAS_WITHHELD, THE_ROWS_WERE_NOT_READ,
                          THE_WAY_IN_PLACES_AT_NO_CLASS,
-                         NO_REASON_RECORDED -> false;
+                         NO_CANDIDATE_WAS_OFFERED -> false;
                 };
             }
         }
@@ -462,65 +514,24 @@ public final class Generator {
         }
     }
 
+    /**
+     * What a generation with nothing owed came to.
+     *
+     * <p>The rows offered at a behavior's boundaries are this: composed for points, which nobody is
+     * asked about and nothing keeps a list of. What a run against a plan comes to is
+     * {@link FillResult}, and holding both in one shape meant a result that had dropped its
+     * obligations and one that never had any were the same value.
+     */
     public record GenerationResult(List<GeneratedRow> rows, List<UnresolvedCombination> unresolved,
-                                   List<GenerationReason> reasons, List<ClassAttempt> classes,
-                                   List<ArmAttempt> arms) {
+                                   List<GenerationReason> reasons) {
 
         public static final GenerationResult NONE =
-                new GenerationResult(List.of(), List.of(), List.of(), List.of(), List.of());
-
-        public GenerationResult(List<GeneratedRow> rows, List<UnresolvedCombination> unresolved,
-                                List<GenerationReason> reasons) {
-            this(rows, unresolved, reasons, List.of(), List.of());
-        }
+                new GenerationResult(List.of(), List.of(), List.of());
 
         public GenerationResult {
             rows = List.copyOf(rows);
             unresolved = List.copyOf(unresolved);
             reasons = List.copyOf(reasons);
-            classes = List.copyOf(classes);
-            arms = List.copyOf(arms);
-        }
-
-        /**
-         * What composing a row that takes {@code probe} came to, or null where no combination this
-         * run took claims it.
-         *
-         * <p>One entry per arm the run was asked about, made where the search ends and read here.
-         * A row through the arm is what it is owed and is the answer whatever the combinations
-         * beside it came to; where there is none, what every one of them came to is carried, the
-         * search's budget and the model's own refusal being different news.
-         *
-         * <p>Null is an answer and not a failure, and it is one thing: no combination of the body's
-         * own decisions claims this arm, so nothing here composes an input for it. An arm the
-         * search stopped short of says so in its own entry — read off an absent one, that arm was
-         * reported as one the body cannot reach, which is a fact about the model told on the
-         * strength of a limit (issue #967).
-         */
-        public ArmAttempt armAt(int probe) {
-            for (ArmAttempt each : arms) {
-                if (each.probe() == probe) {
-                    return each;
-                }
-            }
-            return null;
-        }
-
-        /**
-         * What composing a row for one class came to, or null where this run was not asked about it.
-         *
-         * <p>Asked by identity — the position's own name and the class's own id — so that a finding
-         * about a class and the attempt made for it are two readings of one thing. Matched on the
-         * words a report writes instead, a class and the row offered for it were joined by a label
-         * that two positions of one type spell the same way.
-         */
-        public ClassAttempt attemptAt(AxisId at, String classId) {
-            for (ClassAttempt each : classes) {
-                if (each.at().equals(at) && each.classId().equals(classId)) {
-                    return each;
-                }
-            }
-            return null;
         }
 
         /**
@@ -533,65 +544,6 @@ public final class Generator {
          */
         public boolean isEmpty() {
             return rows.isEmpty() && unresolved.isEmpty() && reasons.isEmpty();
-        }
-    }
-
-    /**
-     * What composing a row for one of the body's combinations came to, at one arm that row claims.
-     *
-     * <p>Per arm and keyed by the arm, because an arm is what a finding is about while a
-     * combination is what a search is asked for. One row claims several arms — a combination is
-     * what the body settles together, and taking it is taking a way through each of the forks it
-     * reads — so the row that answers a finding about one of them is found by that arm's own
-     * number and not by reading the combination's name.
-     *
-     * <p>The number the plan gave the arm ({@code ControlPointId.ArmOccurrence#probe}), which is
-     * the number the site carries ({@code CoverageSites.Site#index}). One identity, so a finding
-     * and the attempt made for it are two readings of one arm.
-     */
-    public sealed interface ArmAttempt {
-
-        /** Which arm, by the number the plan gave it. */
-        int probe();
-
-        /** A row composed for a combination that takes this arm. */
-        record Built(int probe, GeneratedRow row) implements ArmAttempt {}
-
-        /**
-         * Nothing was tried, because the reading of the body has no way into this arm to try.
-         *
-         * <p>Which is two pieces of news and the reading says which: no run reaches the arm at all,
-         * or this compiler cannot state what steers a row there. Neither is a search that failed,
-         * and carrying either as one would tell a reader a value was looked for.
-         */
-        record NoWayIn(int probe, souther.compiler.reading.PathAccess access)
-                implements ArmAttempt {
-
-            public NoWayIn {
-                if (access instanceof souther.compiler.reading.PathAccess.Ways) {
-                    throw new IllegalArgumentException(
-                            "an arm with ways into it is one this search had somewhere to look");
-                }
-            }
-        }
-
-        /**
-         * No row came of the combinations that would have taken it, and what each came to.
-         *
-         * <p>All of them, because they are not one fact. One combination stopping at the search's
-         * budget and another the model's own rules refuse are different news — the first says a row
-         * may still be writable and the second says the model settles it — and the arm is answered
-         * by the whole of what was tried rather than by whichever was walked first.
-         */
-        record Unresolved(int probe, List<UnresolvedCombination> why) implements ArmAttempt {
-
-            public Unresolved {
-                why = List.copyOf(why);
-                if (why.isEmpty()) {
-                    throw new IllegalArgumentException(
-                            "an arm nothing was tried at is one with no way into it");
-                }
-            }
         }
     }
 
@@ -645,7 +597,7 @@ public final class Generator {
      * left the two joined by whatever a reader could match — the words in a row's name — and a row
      * is named for what it was composed for rather than for everything it turns out to settle.
      */
-    public sealed interface ClassAttempt {
+    private sealed interface ClassAttempt {
 
         /** The position, by the name every reading of it uses. */
         AxisId at();
@@ -796,7 +748,7 @@ public final class Generator {
      * nothing consults a clock or a hash order — the same model and the same rows produce the same
      * rows twice. Nothing is asked about the body here, so no arm is looked for.
      */
-    public static GenerationResult fill(Subject subject, List<ObservedRow> existing,
+    public static FillResult fill(Subject subject, List<ObservedRow> existing,
                                         CandidateCheck check,
                                         AdequacyPolicy.OfTheGeneration budget) {
         return fill(subject, existing, check,
@@ -812,7 +764,7 @@ public final class Generator {
      * is owed is one row, and a budget the arms spent first left a class the report names with
      * nothing offered for it.
      */
-    public static GenerationResult fill(Subject subject, List<ObservedRow> existing,
+    public static FillResult fill(Subject subject, List<ObservedRow> existing,
                                         CandidateCheck check,
                                         souther.compiler.reading.CoverageRead.Read read,
                                         AdequacyPolicy.OfTheGeneration budget) {
@@ -830,12 +782,44 @@ public final class Generator {
      * <p>A row that missed is not offered and the arm stays unanswered. It is not evidence that the
      * arm is unreachable: what was shown is that these candidates were not witnesses (ADR-0091).
      */
-    public static GenerationResult fill(Subject subject, List<ObservedRow> existing,
+    public static FillResult fill(Subject subject, List<ObservedRow> existing,
                                         CandidateCheck check,
                                         souther.compiler.reading.CoverageRead.Read read,
                                         Trial trial, AdequacyPolicy.OfTheGeneration budget) {
-        return fill(subject, existing, check, read, trial, List.of(),
-                everyClassNoRowSitsIn(subject, existing), read.arms().keySet(), budget);
+        return fill(planOver(subject, everyClassNoRowSitsIn(subject, existing),
+                        read.arms().keySet()),
+                existing, check, read, trial, List.of(), budget);
+    }
+
+    /**
+     * A plan over what a caller gathered, in the order they gathered it.
+     *
+     * <p>For the callers that hand their obligations over as sets, which is what a walk that
+     * gathers each thing once produces. What the plan wants is the order, and the order such a walk
+     * kept is the one to keep.
+     */
+    public static GenerationPlan planOver(Subject subject, Set<ClassOwed> classes,
+                                          Set<Integer> arms) {
+        return new GenerationPlan(subject, List.copyOf(classes),
+                arms.stream().map(ArmOwed::new).toList());
+    }
+
+    /**
+     * The same, for a caller that gathered its obligations itself.
+     *
+     * <p>A test standing the search up on its own is the caller this is for. The plan is still what
+     * the search is asked with — there is no way in that does not carry one — and this is where the
+     * one such a caller holds is assembled.
+     */
+    public static FillResult fill(Subject subject, List<ObservedRow> existing,
+                                        CandidateCheck check,
+                                        souther.compiler.reading.CoverageRead.Read read,
+                                        Trial trial, List<Baseline> baselines,
+                                        Set<ClassOwed> classesOwed,
+                                        Set<Integer> armsOwed,
+                                        AdequacyPolicy.OfTheGeneration budget) {
+        return fill(planOver(subject, classesOwed, armsOwed), existing, check, read, trial,
+                baselines, budget);
     }
 
     /**
@@ -885,6 +869,16 @@ public final class Generator {
     public record ClassOwed(AxisId at, String classId) {}
 
     /**
+     * One arm of the body, which is the other thing a row can be owed for.
+     *
+     * <p>Named the way {@link ClassOwed} is rather than carried as the number the plan gave it. The
+     * two are the halves of what one run is asked for and are answered side by side; one of them
+     * spelled as a bare {@code int} put the obligations into two vocabularies, and anything holding
+     * both had to say which kind of thing a number was every time it read one.
+     */
+    public record ArmOwed(int probe) {}
+
+    /**
      * Every class of every position no row the author wrote sits in.
      *
      * <p><b>Not what a build asks for.</b> Which classes are owed a row is what the partition
@@ -929,19 +923,28 @@ public final class Generator {
      * stand, and a value the model already names is one a reader recognises — so the difference
      * between the row and what is already written is the class, and the class alone.
      */
-    public static GenerationResult fill(Subject subject, List<ObservedRow> existing,
+    public static FillResult fill(GenerationPlan plan, List<ObservedRow> existing,
                                         CandidateCheck check,
                                         souther.compiler.reading.CoverageRead.Read read,
                                         Trial trial, List<Baseline> baselines,
-                                        Set<ClassOwed> classesOwed,
-                                        Set<Integer> armsOwed,
                                         AdequacyPolicy.OfTheGeneration budget) {
+        Subject subject = plan.subject();
+        List<ClassOwed> classesOwed = plan.classesOwed();
+        List<Integer> armsOwed = plan.armsOwed().stream().map(ArmOwed::probe).toList();
         List<Axis> ordered = ordered(subject);
         // A position where some row's value could not be read is a position nothing is known about.
         // A row generated for a class there may be a row that is already written, and telling an
         // author to write one is worse than saying nothing: it is a specific piece of work that is
         // already done.
         List<GenerationReason> undecided = new ArrayList<>();
+        // The positions that were held back, kept so that the classes of one are answered for by
+        // name. A reason about the position says what happened to it; a class of it is a thing this
+        // run was asked for, and is owed an entry of its own saying it was never looked for.
+        Set<AxisId> withheld = new LinkedHashSet<>();
+        // And the positions the rules leave no room for anything at, kept for the same reason: a
+        // class of one is a thing this run was asked for, and what the rules leave there is an
+        // answer about the model rather than an absence.
+        Set<AxisId> leftNoRoom = new LinkedHashSet<>();
         List<Axis> axes = new ArrayList<>();
         for (Axis axis : ordered) {
             // A position inside a collection the rules leave no room in. No value stands there in
@@ -949,17 +952,22 @@ public final class Generator {
             // row would be one no row can be written for, including the ones that name a position
             // beside it and have nothing to do with this one.
             if (holdsNothing(subject, axis)) {
+                leftNoRoom.add(axis.id());
                 continue;
             }
             if (readEverywhere(axis, existing)) {
                 axes.add(axis);
             } else {
                 undecided.add(new GenerationReason.PositionWithheld(axis.id()));
+                withheld.add(axis.id());
             }
         }
-        if (axes.isEmpty()) {
-            return new GenerationResult(List.of(), List.of(), undecided);
-        }
+        // No return where nothing was kept. Nothing being divided is a fact about the classes, and
+        // the arms below do not read the classes for their answer: what it takes to arrive at an arm
+        // is what the reading of the body says, and that reading was made before this was called.
+        // Stopped here, an arm that reading had an answer for was left with no entry at all, and
+        // whoever read the result for one had nothing to go on but the absence.
+        //
         // Which class of which position is owed a row, handed in by whoever read the rows. The
         // search keeps no list of its own: a class is owed one where nothing sits in it, and what
         // sits where is what the partition measure reads off the rows — so a search working it out
@@ -985,7 +993,10 @@ public final class Generator {
 
         List<GeneratedRow> rows = new ArrayList<>();
         List<ClassAttempt> attempts = new ArrayList<>();
-        List<ArmAttempt> arms = new ArrayList<>();
+        // Which row answered which class, by where the row went. A row is a line in the file and
+        // the same line can answer several things, so what says a class was answered is the entry
+        // pointing at the row rather than anything written on the row itself.
+        Map<ClassOwed, Integer> answeredAt = new LinkedHashMap<>();
         List<UnresolvedCombination> unresolved = new ArrayList<>();
         List<GenerationReason> reasons = new ArrayList<>(undecided);
         // The classes first. What each is owed is one row, and the arms below are looked for among
@@ -1016,7 +1027,13 @@ public final class Generator {
             ClassAttempt attempt = rowFor(subject, axes, at[0], at[1], origins, check);
             attempts.add(attempt);
             switch (attempt) {
-                case ClassAttempt.Built made -> rows.add(made.row());
+                case ClassAttempt.Built made -> {
+                    // Where it went, and not what it was written as. Two classes can be answered by
+                    // rows written the same way and still be two rows the search composed one
+                    // apiece; matched back by their text, the second was read as the first.
+                    answeredAt.put(new ClassOwed(attempt.at(), attempt.classId()), rows.size());
+                    rows.add(made.row());
+                }
                 case ClassAttempt.Unresolved none -> unresolved.add(none.why());
             }
         }
@@ -1027,7 +1044,7 @@ public final class Generator {
         // in first — which is a preference between two answers and not one of them standing in for
         // the other. An arm no combination is over is answered from its way in all the same.
         Set<Integer> left = new LinkedHashSet<>(armsOwed);
-        Map<Integer, GeneratedRow> built = new LinkedHashMap<>();
+        Map<Integer, Integer> built = new LinkedHashMap<>();
         Map<Integer, List<UnresolvedCombination>> failed = new LinkedHashMap<>();
         // Arms the row budget ran out before, which is what the search stopping looks like from an
         // arm. Told apart from an arm with nowhere to look, because raising the budget changes one
@@ -1041,7 +1058,7 @@ public final class Generator {
         // The combinations worth looking in, built once. A group builds a cell where it is asked
         // for one, so a walk per arm builds every cell of it again for an answer that does not
         // depend on which arm is asking.
-        List<WhereToLook>cells = placesFor(armsOwed, offered);
+        List<WhereToLook>cells = placesFor(new LinkedHashSet<>(armsOwed), offered);
         Set<Integer> notOffered = new LinkedHashSet<>();
         // Which arms each held-back group could have been searched at, kept per group so that the
         // summary at the end can be counted off the entries rather than worked out a second way.
@@ -1116,15 +1133,7 @@ public final class Generator {
                 List<Purpose> purposes = new ArrayList<>();
                 purposes.add(new Purpose.ForAnArm(probe));
                 also.forEach(each -> purposes.add(new Purpose.ForAnArm(each)));
-                GeneratedRow offering = new GeneratedRow(purposes, row.inputs());
-                GeneratedRow kept = keep(rows, offering);
-                if (kept != offering) {
-                    // It merged into a row already offered, so an arm answered by that one is
-                    // answered by the merged one. The entries carry the row a reader is shown, and
-                    // two of them for one set of values would be the same line under two names.
-                    List<String> written = writtenAs(kept);
-                    built.replaceAll((_, was) -> writtenAs(was).equals(written) ? kept : was);
-                }
+                int kept = keep(rows, new GeneratedRow(purposes, row.inputs()));
                 built.put(probe, kept);
                 left.remove(probe);
                 also.forEach(each -> {
@@ -1157,23 +1166,35 @@ public final class Generator {
         // cut off carries that beside whatever was tried before it: a place the model refuses says
         // nothing about the ones nobody got to, and an arm answered by the first alone was reported
         // as settled by the model on the strength of a search that stopped.
+        // Which row is which, once the merging is done. A row is a line in the file, so two sets of
+        // values written the same way are one row however many obligations they answer — and what
+        // each of them is for is said by the entries below pointing here.
+        List<RowId> numbered = new ArrayList<>();
+        Map<RowId, ComposedRow> composed = new LinkedHashMap<>();
+        for (GeneratedRow row : rows) {
+            RowId id = new RowId(numbered.size());
+            numbered.add(id);
+            composed.put(id, new ComposedRow(row.inputs()));
+        }
+        Map<ArmOwed, ArmDisposition> armAnswers = new LinkedHashMap<>();
         for (int probe : armsOwed) {
-            GeneratedRow row = built.get(probe);
+            Integer row = built.get(probe);
             List<UnresolvedCombination> why = new ArrayList<>(
                     failed.getOrDefault(probe, List.of()));
+            ArmOwed asked = new ArmOwed(probe);
             if (row != null) {
-                arms.add(new ArmAttempt.Built(probe, row));
+                armAnswers.put(asked, new ArmDisposition.Built(numbered.get(row)));
             } else if (cutOff.contains(probe)) {
                 why.add(new UnresolvedCombination(List.of(),
                         UnresolvedCombination.Reason.SEARCH_LIMIT));
-                arms.add(new ArmAttempt.Unresolved(probe, why));
+                armAnswers.put(asked, new ArmDisposition.Unresolved(why));
             } else if (!why.isEmpty()) {
-                arms.add(new ArmAttempt.Unresolved(probe, why));
+                armAnswers.put(asked, new ArmDisposition.Unresolved(why));
             } else {
                 // Nothing was tried, and the reading says why: no run reaches the arm, or this
                 // compiler cannot state what steers a row there. Either way it is an answer about
                 // the arm and not an absence for a reader to make one of.
-                arms.add(new ArmAttempt.NoWayIn(probe, read.armAt(probe)));
+                armAnswers.put(asked, new ArmDisposition.NoWayIn(read.armAt(probe)));
             }
         }
         // Said once, at the end, and about both searches. One that ran out on the classes stopped
@@ -1183,7 +1204,7 @@ public final class Generator {
         // combination claiming it was refused is not one the limit cut off, and counting it here
         // told a reader to raise a limit that would change nothing.
         if (classesLeft + cutOff.size() > 0) {
-            reasons.add(new GenerationReason.SearchLimit(axes.get(0).id().behavior(),
+            reasons.add(new GenerationReason.SearchLimit(subject.behavior(),
                     classesLeft + cutOff.size()));
         }
         // And the groups the limit held back that this run was asked about an arm behind. What it
@@ -1203,13 +1224,44 @@ public final class Generator {
             }
         }
         if (heldBackAndAskedAbout > 0) {
-            reasons.add(new GenerationReason.GroupsNotOffered(axes.get(0).id().behavior(),
+            reasons.add(new GenerationReason.GroupsNotOffered(subject.behavior(),
                     heldBackAndAskedAbout));
         }
         if (unconfirmed) {
-            reasons.add(new GenerationReason.RowsNotConfirmed(axes.get(0).id().behavior()));
+            reasons.add(new GenerationReason.RowsNotConfirmed(subject.behavior()));
         }
-        return new GenerationResult(rows, unresolved, reasons, attempts, arms);
+        // One entry per class the plan named, which the walk above wrote for the ones it kept a
+        // position for. A class of a position that was held back was never a thing to look for, and
+        // it says that here rather than being left out — a class the plan named and nothing
+        // answered for is what a reader downstream had to invent a sentence about.
+        Map<ClassOwed, ClassDisposition> classAnswers = new LinkedHashMap<>();
+        for (ClassAttempt attempt : attempts) {
+            ClassOwed key = new ClassOwed(attempt.at(), attempt.classId());
+            classAnswers.put(key, switch (attempt) {
+                case ClassAttempt.Built _ -> new ClassDisposition.Built(
+                        numbered.get(answeredAt.get(key)));
+                case ClassAttempt.Unresolved none -> new ClassDisposition.Unresolved(none.why());
+            });
+        }
+        for (ClassOwed asked : classesOwed) {
+            if (classAnswers.containsKey(asked)) {
+                continue;
+            }
+            if (withheld.contains(asked.at())) {
+                classAnswers.put(asked, new ClassDisposition.Unresolved(
+                        new UnresolvedCombination(List.of(labelOf(subject, asked)),
+                                UnresolvedCombination.Reason.THE_POSITION_WAS_WITHHELD)));
+            } else if (leftNoRoom.contains(asked.at())) {
+                // The position is inside a collection the rules cap at none, so no value stands
+                // there in any row this model admits. Which is what the model says rather than what
+                // this search fell short of, and a reader may act on it.
+                classAnswers.put(asked, new ClassDisposition.Unresolved(
+                        new UnresolvedCombination(List.of(labelOf(subject, asked)),
+                                UnresolvedCombination.Reason.THE_RULES_LEAVE_NOTHING_THERE)));
+            }
+        }
+        return new FillResult(plan, composed, unresolved, reasons,
+                new Discharge(classAnswers, armAnswers));
     }
 
     /**
@@ -1362,7 +1414,7 @@ public final class Generator {
      * ways in agree. Written down twice, an author is handed the same line twice and told it
      * answers two different things.
      */
-    private static GeneratedRow keep(List<GeneratedRow> rows, GeneratedRow row) {
+    private static int keep(List<GeneratedRow> rows, GeneratedRow row) {
         List<String> written = writtenAs(row);
         for (int i = 0; i < rows.size(); i++) {
             GeneratedRow already = rows.get(i);
@@ -1379,12 +1431,11 @@ public final class Generator {
             }
             List<Purpose> both = new ArrayList<>(already.purposes());
             row.purposes().stream().filter(each -> !both.contains(each)).forEach(both::add);
-            GeneratedRow merged = new GeneratedRow(both, already.inputs());
-            rows.set(i, merged);
-            return merged;
+            rows.set(i, new GeneratedRow(both, already.inputs()));
+            return i;
         }
         rows.add(row);
-        return row;
+        return rows.size() - 1;
     }
 
     /** What a row is written as, which is what tells one line of a file from another. */
@@ -1498,7 +1549,7 @@ public final class Generator {
                     UnresolvedCombination.Reason.SEARCH_LIMIT);
             case Completeness.Nothing.LOOKED_EVERYWHERE -> last == null
                     ? new UnresolvedCombination(List.of(label),
-                            UnresolvedCombination.Reason.NO_REASON_RECORDED)
+                            UnresolvedCombination.Reason.NO_CANDIDATE_WAS_OFFERED)
                     : new UnresolvedCombination(List.of(label), last.reason(), last.detail(),
                             last.said());
         };
@@ -2452,6 +2503,28 @@ public final class Generator {
     }
 
     /**
+     * The same, for a class named the way an obligation names it.
+     *
+     * <p>What a report writes beside the row, worked out where the classes are rather than kept
+     * beside the obligation. A label copied into the obligation would be a second spelling of the
+     * class, free to disagree with the axis the day either moved.
+     */
+    static String labelOf(Subject subject, ClassOwed owed) {
+        for (Axis axis : subject.axes()) {
+            if (!axis.id().equals(owed.at())) {
+                continue;
+            }
+            for (PartitionClass cls : axis.classes()) {
+                if (cls.id().equals(owed.classId())) {
+                    return axis.path() + "=" + cls.label();
+                }
+            }
+        }
+        throw new IllegalStateException(
+                "a row was owed for a class the subject does not divide: " + owed);
+    }
+
+    /**
      * The positions the cell is about, at the classes the row came to hold.
      *
      * <p>The cell says which classes a position may hold and the row holds one of them, so the name
@@ -2676,7 +2749,8 @@ public final class Generator {
                     // leaving no assignment at all. Named rather than guessed at, the same way
                     // every other empty result here is.
                     yield new Witness.Exhausted(named,
-                            UnresolvedCombination.Reason.NO_REASON_RECORDED, null, Optional.empty());
+                            UnresolvedCombination.Reason.NO_CANDIDATE_WAS_OFFERED, null,
+                            Optional.empty());
                 }
             };
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Ordered.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Ordered.java
@@ -1,0 +1,38 @@
+package souther.compiler.partition;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.SequencedMap;
+
+/**
+ * Copying a map without giving up either of the two things a copy is made for.
+ *
+ * <p>{@link Map#copyOf} refuses null and loses the order it was handed; a {@link LinkedHashMap}
+ * keeps the order and admits null. Every value here that holds obligations against answers wants
+ * both, and taking the second on its own is how an absence walked back into the middle of a
+ * structure built to have none: a key present with nothing under it satisfied a check written over
+ * the keys, and the reader that looked the key up met the null the whole arrangement exists to
+ * stop.
+ *
+ * <p>So the rule is written once. A second spelling of it is a second place for one of the two
+ * halves to be forgotten.
+ */
+final class Ordered {
+
+    /** The same entries, in the order they were handed over, with neither half of any entry
+     *  missing. */
+    static <K, V> SequencedMap<K, V> copyOf(Map<K, V> entries) {
+        LinkedHashMap<K, V> out = new LinkedHashMap<>();
+        entries.forEach((key, value) -> {
+            if (key == null || value == null) {
+                throw new IllegalArgumentException(
+                        "an entry with nothing on one side of it: " + key + " -> " + value);
+            }
+            out.put(key, value);
+        });
+        return Collections.unmodifiableSequencedMap(out);
+    }
+
+    private Ordered() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/RowId.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/RowId.java
@@ -1,0 +1,27 @@
+package souther.compiler.partition;
+
+/**
+ * Which composed row, within one run of the generator and nowhere else.
+ *
+ * <p>An identity and not a position. One set of values answers as many obligations as it happens to
+ * — a row for a class of a position that also takes an arm of the body is one line in the file —
+ * and what says so is that both obligations name this. Read as an index into the rows a run offers,
+ * the identity would move with whatever the offer was ordered by, and two obligations answered by
+ * one row would come apart the day the order changed.
+ *
+ * <p>Opaque outside the run that made it. Nothing compares one of these with an id from another
+ * generation, and nothing reads the number for anything but telling one row from the next.
+ */
+public record RowId(int value) {
+
+    public RowId {
+        if (value < 0) {
+            throw new IllegalArgumentException("a row is numbered from nought: " + value);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "row " + value;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -2914,6 +2914,10 @@ public final class Adequacy {
             // A combination the body settles together is where one is looked for and is not itself
             // owed a row — nothing reports one — so what is searched follows from the findings
             // rather than from the shape of the search space.
+            // In the order the findings were established, which is the order this build raised
+            // them in. Handed over as a list rather than as the set that kept them once apiece:
+            // what the plan is asking for is the order, and this is where what the order means is
+            // known.
             Set<Integer> arms = new LinkedHashSet<>();
             for (Finding finding : owed) {
                 if (finding.about()
@@ -2922,7 +2926,7 @@ public final class Adequacy {
                     arms.add(arm.index());
                 }
             }
-            return Generator.planOver(subject, classesOwed(evidence), arms);
+            return Generator.planOver(subject, classesOwed(evidence), List.copyOf(arms));
         }
 
         /**
@@ -2941,7 +2945,10 @@ public final class Adequacy {
          * this replaces — and it would be one no test covers, the query answering every behavior
          * the generator reaches.
          */
-        private static Set<Generator.ClassOwed> classesOwed(PartitionEvidence evidence) {
+        private static List<Generator.ClassOwed> classesOwed(PartitionEvidence evidence) {
+            // Gathered once apiece and handed over in the order the measure holds the positions
+            // and their classes in, which is the order this walk reached them. The set keeps the
+            // once-apiece; the list is what says what the order is.
             Set<Generator.ClassOwed> out = new LinkedHashSet<>();
             for (PartitionEvidence.AxisCoverage axis : evidence.axes()) {
                 Set<String> covered = axis.reached().made()
@@ -2953,7 +2960,7 @@ public final class Adequacy {
                     }
                 }
             }
-            return out;
+            return List.copyOf(out);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1181,7 +1181,7 @@ public final class Adequacy {
                     new souther.compiler.partition.BehaviorInputs(parameters, sig.inputTypes(),
                             symbols, policy);
             return Answer.of(Coverages.searched(measured, inputs,
-                    probing(divided, sig, symbols, policy, parameters,
+                    probing(spec.name(), divided, sig, symbols, policy, parameters,
                             constructing(db, name, prepared.value().forExamples(), symbols),
                             domain),
                     domain.quantities(symbols), divided.reaching()));
@@ -1196,13 +1196,14 @@ public final class Adequacy {
          * are missing" into "the edge can be written".
          */
         private static Coverages.Probe probing(
+                String behavior,
                 souther.compiler.partition.Partitions.Partitioning partitioning, Sig sig,
                 Symbols symbols, souther.compiler.check.ReadingPolicy policy,
                 List<String> parameters, FixtureReader.Construction building, InputDomain domain) {
             if (building == null) {
                 return null;
             }
-            Generator.Subject subject = new Generator.Subject(
+            Generator.Subject subject = new Generator.Subject(behavior,
                     new souther.compiler.partition.BehaviorInputs(parameters, sig.inputTypes(),
                             symbols, policy), partitioning.axes(),
                     souther.compiler.partition.HeldCounts.of(domain, symbols));
@@ -1435,50 +1436,6 @@ public final class Adequacy {
             return List.copyOf(out);
         }
 
-        /**
-         * A way to try to build a row at a boundary, or nothing where there is nothing to try against.
-         *
-         * <p>Nothing rather than a check that refuses nothing. A row built without the decoder is a row
-         * nobody has put through anything, and counting one as a witness would turn "the classes are
-         * missing" into "the edge can be written".
-         */
-        private static Coverages.Probe probing(
-                souther.compiler.partition.Partitions.Partitioning partitioning, Sig sig,
-                Symbols symbols, souther.compiler.check.ReadingPolicy policy,
-                List<String> parameters, FixtureReader.Construction building, InputDomain domain) {
-            if (building == null) {
-                return null;
-            }
-            Generator.Subject subject = new Generator.Subject(
-                    new souther.compiler.partition.BehaviorInputs(parameters, sig.inputTypes(),
-                            symbols, policy), partitioning.axes(), souther.compiler.partition.HeldCounts.of(domain, symbols));
-            Generator.CandidateCheck check =
-                    (at, candidate) -> built(building.build(sig.ins().get(at), candidate.value()));
-            return new Coverages.Probe() {
-
-                @Override
-                public Generator.BoundaryAttempt attempt(String label,
-                        java.util.function.Function<souther.compiler.inputs.NumericTerm,
-                                souther.compiler.check.Carrier> on,
-                        java.util.Map<souther.compiler.inputs.NumericTerm,
-                                souther.compiler.numeric.Place> fixing) {
-                    return built(() ->
-                            Generator.probeFixing(subject, label, on, fixing, check));
-                }
-
-                private Generator.BoundaryAttempt built(
-                        java.util.function.Supplier<Generator.BoundaryAttempt> attempt) {
-                    try {
-                        return attempt.get();
-                    } catch (LinkageError _) {
-                        // The generated classes would not link, so nothing can be built to find out
-                        // what a model admits. Nothing was tried, which is not the same as everything
-                        // tried being refused, and neither of them says the edge cannot be written.
-                        return null;
-                    }
-                }
-            };
-        }
     }
 
 
@@ -2283,12 +2240,9 @@ public final class Adequacy {
      * edge are different requests, asked with different flags, and a caller that merged them could not
      * take one without the other.
      */
-    public record Filling(Generator.GenerationResult composed,
+    public record Filling(souther.compiler.partition.FillResult composed,
                           Generator.GenerationResult boundaries,
                           List<GenerationDisposition> generation) {
-
-        public static final Filling NONE = new Filling(Generator.GenerationResult.NONE,
-                Generator.GenerationResult.NONE, List.of());
 
         public Filling {
             generation = List.copyOf(generation);
@@ -2380,19 +2334,24 @@ public final class Adequacy {
             }
             List<Finding> owed = findings == null ? List.of()
                     : findings.getOrDefault(behavior, List.of());
-            Generator.GenerationResult composed;
+            InputDomain domain = domainOf(readInputs, spec);
+            // What this run is asked for, settled before the search and before anything that can
+            // stop it. Every way out of the generation below holds this same list.
+            souther.compiler.partition.GenerationPlan asked = planFor(spec, sig, symbols,
+                    db.ask(new Front.Reading()).value(), divided, domain, owed,
+                    PartitionEvidence.answeredFor(partitions, prepared.value(), spec));
+            souther.compiler.partition.FillResult composed;
             try {
-                composed = rowsFor(spec, sig, symbols, db.ask(new Front.Reading()).value(),
+                composed = rowsFor(spec, sig, symbols, asked,
                         baselines(name, spec, sig,
                                 db.ask(new Bodies.ModuleDefinitions(name)).value(),
                                 prepared.value(), symbols),
-                        owed, divided, bodies.get(behavior), plan,
+                        divided, bodies.get(behavior), plan,
                         Rows.readingFor(byTarget, behavior),
                         constructing(db, name, prepared.value().forExamples(), symbols),
-                        domainOf(readInputs, spec),
+                        domain,
                         runningRowsOf(trialling(db, name, prepared.value().forExamples(), symbols),
                                 behavior, sig),
-                        PartitionEvidence.answeredFor(partitions, prepared.value(), spec),
                         levelOf(db).runsInstrumentedRows(),
                         db.ask(new Front.Adequacy()).value().generation());
             } catch (LinkageError _) {
@@ -2405,12 +2364,13 @@ public final class Adequacy {
                 // findings would take them out of a list that is meant to hold every one —
                 // which is the same defect the list was written against, arriving as control
                 // flow rather than as a value.
-                composed = new Generator.GenerationResult(List.of(), List.of(),
+                composed = souther.compiler.partition.FillResult.nothingWasLookedFor(asked,
+                        Generator.UnresolvedCombination.Reason.LINKAGE_FAILED,
                         List.of(new souther.compiler.partition.GenerationReason
                                 .LinkageFailed(behavior)));
             }
             return Answer.of(new Filling(composed, offered(behavior, edges),
-                    dispositions(owed, edges, partitions.get(behavior), composed, spec)));
+                    dispositions(owed, edges, composed, spec)));
         }
 
         /**
@@ -2435,8 +2395,7 @@ public final class Adequacy {
          */
         private static List<GenerationDisposition> dispositions(List<Finding> findings,
                                                       List<BorderAssessment> edges,
-                                                      PartitionEvidence partition,
-                                                      Generator.GenerationResult composed,
+                                                      souther.compiler.partition.FillResult composed,
                                                       Hir.SpecBehavior spec) {
             List<GenerationDisposition> out = new ArrayList<>();
             for (Finding finding : findings) {
@@ -2445,7 +2404,7 @@ public final class Adequacy {
                         : switch (finding.about()) {
                             case About.APointOfABorder(var point) -> atEdge(finding, point, edges);
                             case About.ACaseNoRowAppliesItTo(var input, var missing) ->
-                                    atCase(input, missing, partition, composed, spec);
+                                    atCase(input, missing, composed, spec);
                             case About.AClassNoRowIsIn(var missing) -> atClass(missing, composed);
                             case About.AnArmNoRowGoesThrough(var arm) -> atArm(arm, composed);
                             // The eight above, which is what `none` was not null for.
@@ -2476,32 +2435,34 @@ public final class Adequacy {
          * arm — which is an answer about the arm and never an absence. An arm no combination
          * claimed used to have no entry at all, and the sentence read off that absence said rows
          * are composed for classes and combinations and nothing takes this arm, of a body two of
-         * whose own classes walk straight into it (issue #1009).
+         * whose own classes walk straight into it.
+         *
+         * <p>There is no absence to read now. A fill is total over the plan it was asked with, and
+         * this finding is one of the arms that plan names — so the entry is there whatever the run
+         * did, including the runs that never looked at anything.
          */
         private static GenerationOutcome atArm(souther.compiler.coverage.CoverageSites.Site arm,
-                                               Generator.GenerationResult composed) {
-            return switch (composed.armAt(arm.index())) {
-                case Generator.ArmAttempt.Built built ->
-                        new GenerationOutcome.Generated(List.of(built.row()));
+                                               souther.compiler.partition.FillResult composed) {
+            Generator.ArmOwed owed = new Generator.ArmOwed(arm.index());
+            souther.compiler.partition.ArmDisposition answer = composed.discharge().at(owed);
+            if (answer == null) {
+                throw new IllegalStateException(
+                        "a finding names an arm this run was not asked about: " + arm.index());
+            }
+            return switch (answer) {
+                case souther.compiler.partition.ArmDisposition.Built built ->
+                        new GenerationOutcome.Generated(List.of(composed.rowFor(built.row())));
                 // What every place a row was looked for came to, all of it. They are not one fact
                 // and they do not order against each other: one the model refuses says the arm may
                 // be unreachable, one the search stopped at says nothing at all, and a reader
                 // handed whichever came first was handed the order the search happened to walk.
-                case Generator.ArmAttempt.Unresolved none ->
+                case souther.compiler.partition.ArmDisposition.Unresolved none ->
                         new GenerationOutcome.CannotGenerate(none.why());
-                case Generator.ArmAttempt.NoWayIn none -> nothingReaches(none.access());
-                // No attempt was recorded for this arm, which is not a search that reached it and
-                // stopped: a run that never composed anything — the classes would not link, no
-                // position was left to divide — records why in its own words, and this asks for
-                // them. The same question a class with no attempt asks, answered in the same place
-                // (issue #1009): a word of this reading's own beside it would be a second answer to
-                // one question, free to disagree with the first the day either moves.
-                case null -> new GenerationOutcome.CannotGenerate(
-                        new Generator.UnresolvedCombination(
-                                List.of(souther.compiler.report.ArmVocabulary.label(arm)),
-                                whyNothingWasTried(composed)));
+                case souther.compiler.partition.ArmDisposition.NoWayIn none ->
+                        nothingReaches(none.access());
             };
         }
+
 
         /**
          * What a reader is told about an arm nothing was composed for, from what the reading of the
@@ -2552,13 +2513,12 @@ public final class Adequacy {
          * would differ the first time either side of the search moved.
          */
         private static GenerationOutcome atClass(PartitionEvidence.AxisClass missing,
-                                                 Generator.GenerationResult composed) {
+                                                 souther.compiler.partition.FillResult composed) {
             // The spelling the search labels this class with, which is what the block prints beside
             // the rows. Written another way here, one class came out under two names — the
             // search's `c.f=C` and this one's `C at c.f` — and the block, which drops a line it has
             // already said, said the same fact twice because the two lines were not the same line.
-            return atClass(missing.axis().at(), missing.name(),
-                    missing.axis().path() + "=" + missing.name(), composed);
+            return atClass(missing.axis().at(), missing.name(), composed);
         }
 
         /**
@@ -2568,72 +2528,26 @@ public final class Adequacy {
          * and a class of a position are two findings about one class, and answering them from two
          * readings of one search is two answers that agree until either moves.
          *
-         * @param said how the finding's own words name this class, for the one thing this has to
-         *             say in them: that nothing here reached it
+         * <p>Total over the plan, so there is no absence here to interpret. A class this run was
+         * not asked about is a finding and a plan disagreeing about what is owed, which is a defect
+         * in this compiler rather than something to write a sentence about — the two are made from
+         * one reading of the rows and cannot honestly differ.
          */
         private static GenerationOutcome atClass(souther.compiler.partition.AxisId at,
-                                                 String classId, String said,
-                                                 Generator.GenerationResult composed) {
-            return switch (composed.attemptAt(at, classId)) {
-                case Generator.ClassAttempt.Built built ->
-                        new GenerationOutcome.Generated(List.of(built.row()));
-                case Generator.ClassAttempt.Unresolved none ->
-                        new GenerationOutcome.CannotGenerate(none.why());
-                // No attempt was recorded for this class, which is not the same as a search that
-                // reached it and stopped. Which of them it was is what the run wrote down, and
-                // where it wrote nothing this says so rather than picking the likeliest — a reason
-                // read off an empty result outlives whatever made it plausible.
-                case null -> new GenerationOutcome.CannotGenerate(
-                        new Generator.UnresolvedCombination(List.of(said), whyNothingWasTried(composed)));
-            };
-        }
-
-        /**
-         * Why no attempt was recorded for a class, in the words the run wrote down.
-         *
-         * <p>Only the reasons that say a class was never searched for. A run that stopped before
-         * reaching one records it as the search limit itself, so this is asked where nothing was
-         * recorded at all — and what it must not do is decide which of them it was from the fact
-         * that there is nothing here. Where the run says nothing this says nothing: the class was
-         * owed a row, a strategy takes it, and it produced neither a row nor a reason, which is
-         * this compiler failing to say.
-         */
-        private static Generator.UnresolvedCombination.Reason whyNothingWasTried(
-                Generator.GenerationResult composed) {
-            for (souther.compiler.partition.GenerationReason why : composed.reasons()) {
-                switch (why) {
-                    case souther.compiler.partition.GenerationReason.NothingToBuildAgainst _ -> {
-                        return Generator.UnresolvedCombination.Reason.NOTHING_TO_BUILD_AGAINST;
-                    }
-                    case souther.compiler.partition.GenerationReason.NoValuesWereAskedFor _ -> {
-                        return Generator.UnresolvedCombination.Reason.NO_VALUES_WERE_ASKED_FOR;
-                    }
-                    case souther.compiler.partition.GenerationReason.LinkageFailed _ -> {
-                        return Generator.UnresolvedCombination.Reason.LINKAGE_FAILED;
-                    }
-                    // The position was held back, so no class of it was ever a thing to look for.
-                    case souther.compiler.partition.GenerationReason.PositionWithheld _ -> {
-                        return Generator.UnresolvedCombination.Reason.THE_POSITION_WAS_WITHHELD;
-                    }
-                    // Nothing was read, so nothing was searched for.
-                    case souther.compiler.partition.GenerationReason.RowsNotRead _ -> {
-                        return Generator.UnresolvedCombination.Reason.THE_ROWS_WERE_NOT_READ;
-                    }
-                    // About a search that happened, and said in their own words beside the rows.
-                    // Answering with one of them here would be the same fact under a second
-                    // spelling, over a class the search never got to.
-                    //
-                    // `GroupsNotOffered` is here for a different reason: it is not about classes at
-                    // all. A group of the body's decisions is where a row for an <em>arm</em> is
-                    // looked for, and the classes are walked in a loop that never consults one — so
-                    // a class with nothing recorded was not left that way by a group being held
-                    // back, and saying it was would be a cause this run has no evidence for.
-                    case souther.compiler.partition.GenerationReason.SearchLimit _,
-                            souther.compiler.partition.GenerationReason.GroupsNotOffered _,
-                            souther.compiler.partition.GenerationReason.RowsNotConfirmed _ -> { }
-                }
+                                                 String classId,
+                                                 souther.compiler.partition.FillResult composed) {
+            souther.compiler.partition.ClassDisposition answer =
+                    composed.discharge().at(new Generator.ClassOwed(at, classId));
+            if (answer == null) {
+                throw new IllegalStateException(
+                        "a finding names a class this run was not asked about: " + at + "=" + classId);
             }
-            return Generator.UnresolvedCombination.Reason.NO_REASON_RECORDED;
+            return switch (answer) {
+                case souther.compiler.partition.ClassDisposition.Built built ->
+                        new GenerationOutcome.Generated(List.of(composed.rowFor(built.row())));
+                case souther.compiler.partition.ClassDisposition.Unresolved none ->
+                        new GenerationOutcome.CannotGenerate(none.why());
+            };
         }
 
         /**
@@ -2710,22 +2624,27 @@ public final class Adequacy {
          * nothing a fact about the model.
          */
         private static GenerationOutcome atCase(InputCaseEvidence input, TypeSymbol case_,
-                                                PartitionEvidence partition,
-                                                Generator.GenerationResult composed,
+                                                souther.compiler.partition.FillResult composed,
                                                 Hir.SpecBehavior spec) {
             String missing = case_.name();
             int at = input.at();
             String parameter = at >= 0 && at < spec.params().size()
                     ? spec.params().get(at).name() : null;
-            boolean divided = partition != null && parameter != null
-                    && partition.axes().stream().anyMatch(
-                            axis -> axis.path().equals(parameter) && axis.classes().contains(missing));
-            if (!divided) {
+            if (parameter == null) {
                 return new GenerationOutcome.NotSupported(
                         GenerationOutcome.NotSupported.Reason.NO_AXIS_AT_THIS_POSITION);
             }
-            return atClass(new souther.compiler.partition.AxisId(spec.name(), parameter), missing,
-                    parameter + "=" + missing, composed);
+            // Asked of the subject the search was made over, which is what says what this run had
+            // classes for. Worked out from a partition's axes beside it, the answer was a second
+            // reading of the search's own universe, and a case whose position the search divides
+            // could be told there was no axis there.
+            Generator.ClassOwed owed = new Generator.ClassOwed(
+                    new souther.compiler.partition.AxisId(spec.name(), parameter), missing);
+            if (!composed.plan().subject().divides(owed)) {
+                return new GenerationOutcome.NotSupported(
+                        GenerationOutcome.NotSupported.Reason.NO_AXIS_AT_THIS_POSITION);
+            }
+            return atClass(owed.at(), owed.classId(), composed);
         }
 
         /**
@@ -2930,34 +2849,27 @@ public final class Adequacy {
             return out;
         }
 
-        private static Generator.GenerationResult rowsFor(
+        private static souther.compiler.partition.FillResult rowsFor(
                 Hir.SpecBehavior spec, Sig sig, Symbols symbols,
-                souther.compiler.check.ReadingPolicy policy,
-                List<Generator.Baseline> baselines, List<Finding> owed,
+                souther.compiler.partition.GenerationPlan asked,
+                List<Generator.Baseline> baselines,
                 souther.compiler.partition.Partitions.Partitioning partitioning,
                 souther.compiler.core.Core body,
                 souther.compiler.coverage.CoverageSites.Plan plan, RowReading observed,
                 FixtureReader.Construction building, InputDomain domain,
-                Generator.Trial trial,
-                PartitionEvidence evidence, boolean recording,
+                Generator.Trial trial, boolean recording,
                 souther.compiler.partition.AdequacyPolicy.OfTheGeneration budget) {
             if (observed.someRowsUnseen()) {
                 // Rows exist that nothing read. What they cover is unknown, so what is left uncovered
                 // is unknown too — and a generated row is a specific piece of work handed to a person,
                 // which may already be sitting in the file that could not be evaluated.
-                return new Generator.GenerationResult(List.of(), List.of(),
+                return souther.compiler.partition.FillResult.nothingWasLookedFor(asked,
+                        Generator.UnresolvedCombination.Reason.THE_ROWS_WERE_NOT_READ,
                         List.of(new souther.compiler.partition.GenerationReason.RowsNotRead(
                                 spec.name(), observed.gaps())));
             }
             List<RowOutcome> rows = observed.rowsSeen();
-            List<String> parameters = spec.params().stream().map(Hir.Param::name).toList();
-            // One reading of what the behavior takes, for both halves of this: the rows already
-            // written are read by it, and the rows offered are generated from it.
-            souther.compiler.partition.BehaviorInputs inputs =
-                    new souther.compiler.partition.BehaviorInputs(parameters, sig.inputTypes(),
-                            symbols, policy);
-            Generator.Subject subject =
-                    new Generator.Subject(inputs, partitioning.axes(), souther.compiler.partition.HeldCounts.of(domain, symbols));
+            souther.compiler.partition.BehaviorInputs inputs = asked.subject().inputs();
             Generator.CandidateCheck check = building == null ? Generator.CandidateCheck.ANY
                     : (at, candidate) -> built(building.build(sig.ins().get(at), candidate.value()));
 
@@ -2969,20 +2881,48 @@ public final class Adequacy {
                             InputClassifications.of(row.inputs(), inputs, partitioning.axes()),
                             watched(row, recording)))
                     .toList();
+            return Generator.fill(asked, existing, check,
+                    souther.compiler.reading.CoverageRead
+                            .of(spec.name(), body, plan, domain, symbols),
+                    trial, baselines, budget);
+        }
+
+        /**
+         * What this build is asking the generator for, settled before anything that can stop it.
+         *
+         * <p>The classes off the partition measure and the arms off the findings, which is where
+         * each of them was established. Made here rather than inside the search so that the ways a
+         * generation ends without searching — the rows could not be read, the classes would not
+         * link — hold the same list as the search does. Made there, each of them answered with a
+         * reason about the run and no word about the thing a reader was asking after.
+         */
+        private static souther.compiler.partition.GenerationPlan planFor(
+                Hir.SpecBehavior spec, Sig sig, Symbols symbols,
+                souther.compiler.check.ReadingPolicy policy,
+                souther.compiler.partition.Partitions.Partitioning partitioning,
+                InputDomain domain, List<Finding> owed, PartitionEvidence evidence) {
+            List<String> parameters = spec.params().stream().map(Hir.Param::name).toList();
+            // One reading of what the behavior takes, for both halves of this: the rows already
+            // written are read by it, and the rows offered are generated from it.
+            souther.compiler.partition.BehaviorInputs inputs =
+                    new souther.compiler.partition.BehaviorInputs(parameters, sig.inputTypes(),
+                            symbols, policy);
+            Generator.Subject subject =
+                    new Generator.Subject(spec.name(), inputs, partitioning.axes(),
+                            souther.compiler.partition.HeldCounts.of(domain, symbols));
             // The arms this build is owed a row at, which the measure established and this reads.
             // A combination the body settles together is where one is looked for and is not itself
             // owed a row — nothing reports one — so what is searched follows from the findings
             // rather than from the shape of the search space.
-            Set<Integer> armsOwed = new LinkedHashSet<>();
+            Set<Integer> arms = new LinkedHashSet<>();
             for (Finding finding : owed) {
-                if (finding.about() instanceof About.AnArmNoRowGoesThrough(var arm)) {
-                    armsOwed.add(arm.index());
+                if (finding.about()
+                        instanceof About.AnArmNoRowGoesThrough(
+                                souther.compiler.coverage.CoverageSites.Site arm)) {
+                    arms.add(arm.index());
                 }
             }
-            return Generator.fill(subject, existing, check,
-                    souther.compiler.reading.CoverageRead
-                            .of(spec.name(), body, plan, domain, symbols),
-                    trial, baselines, classesOwed(evidence), armsOwed, budget);
+            return Generator.planOver(subject, classesOwed(evidence), arms);
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/reading/Arms.java
+++ b/souther-compiler/src/main/java/souther/compiler/reading/Arms.java
@@ -61,8 +61,11 @@ final class Arms {
      * really is beyond what the path language states. The check would then hold of a walk that
      * stopped early, which is the whole of what it is for.
      */
-    Map<Integer, PathAccess> found(String behavior) {
-        Map<Integer, PathAccess> out = new LinkedHashMap<>();
+    java.util.SequencedMap<Integer, PathAccess> found(String behavior) {
+        // Walked over the plan's own arms, so the order these come back in is the order the plan
+        // holds the behavior's arms in. Which is what whoever asks for a row at each of them takes
+        // as the order to ask in, and it is only that because this walk is where it comes from.
+        java.util.SequencedMap<Integer, PathAccess> out = new LinkedHashMap<>();
         for (CoverageSites.Site arm : plan.arms(behavior)) {
             PathAccess access = byArm.get(arm.index());
             if (access == null) {
@@ -72,6 +75,6 @@ final class Arms {
             }
             out.put(arm.index(), access);
         }
-        return java.util.Collections.unmodifiableMap(out);
+        return java.util.Collections.unmodifiableSequencedMap(out);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/reading/CoverageRead.java
+++ b/souther-compiler/src/main/java/souther/compiler/reading/CoverageRead.java
@@ -10,7 +10,6 @@ import souther.compiler.inputs.InputReads;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * One reading of a body's decisions: where a run can get to, and what holds on the way.
@@ -118,13 +117,21 @@ public final class CoverageRead {
      *                     way round a fork above it a row goes
      * @param arms         one answer per arm of the behavior, by the number the plan gave it. Total
      *                     over the plan's arms: a key that is not there is not a thing to interpret,
-     *                     because there is no such key
+     *                     because there is no such key.
+     *
+     *                     <p>In the order the plan holds them, which a caller composing a row at
+     *                     each takes as the order to ask in — so what carries the order is the type
+     *                     and not a habit of whatever map was handed over. Written as any map, an
+     *                     unordered one was as admissible, and the order a plan is asked in would
+     *                     have come from wherever that map put its keys
      */
-    public record Read(List<Interaction> interactions, Map<Integer, PathAccess> arms) {
+    public record Read(List<Interaction> interactions,
+                       java.util.SequencedMap<Integer, PathAccess> arms) {
 
         public Read {
             interactions = List.copyOf(interactions);
-            arms = java.util.Collections.unmodifiableMap(new java.util.LinkedHashMap<>(arms));
+            arms = java.util.Collections.unmodifiableSequencedMap(
+                    new java.util.LinkedHashMap<>(arms));
         }
 
         /** How arm {@code probe} is reached, by the number the plan gave it. */

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1445,7 +1445,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     "a row's value at that position could not be read, so no class of it was"
                             + " looked for";
             case THE_ROWS_WERE_NOT_READ -> "the rows were not read, so nothing was looked for";
-            case NO_REASON_RECORDED -> "nothing was recorded about why";
+            case NO_CANDIDATE_WAS_OFFERED ->
+                    "the walk over what could stand there put no value forward";
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -501,8 +501,9 @@ public final class GeneratedRows {
                                 behavior, saidOf(why))));
                 // Told apart from the one above it in its own words. A strategy that tried and
                 // composed nothing and a finding nothing takes are different pieces of news: the
-                // first says a row may still be writable by hand, the second says no run of this
-                // will offer one until something is written for it.
+                // first says what the attempt came to, and whether a row can be written at all is
+                // its reason's to say; the second says no run of this will offer one until
+                // something is written for it.
                 case GenerationOutcome.NotSupported none -> say(out, said,
                         String.format("// nothing offers a row for `%s` in `%s`: %s%n",
                                 about(each.finding()), behavior, none.reason().said()));

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -672,9 +672,9 @@ public final class GeneratedRows {
             case THE_ROWS_WERE_NOT_READ ->
                     "the rows were not read, so nothing was looked for; what stopped them being"
                             + " read is said above";
-            case NO_REASON_RECORDED ->
-                    "the search that takes this class left no reason, which is this compiler failing"
-                            + " to say rather than anything established about the class";
+            case NO_CANDIDATE_WAS_OFFERED ->
+                    "the walk over what could stand there put no value forward, so nothing was"
+                            + " built and nothing was refused";
         };
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest.java
@@ -63,7 +63,7 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
      * written under leaves a model that does not compile, and a test asking such a model for its rows
      * gets an empty answer that agrees with whatever it expected of one.
      */
-    private static Generator.GenerationResult generated(String source) {
+    private static souther.compiler.partition.FillResult generated(String source) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
@@ -76,7 +76,7 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
 
     /** The one row the generator writes for that combination, as the text an author is offered. */
     private static String generatedRow(String source) {
-        Generator.GenerationResult filled = generated(source);
+        souther.compiler.partition.FillResult filled = generated(source);
         assertEquals(List.of(), filled.unresolved(),
                 "the combination is one a value exists for, so nothing is left unresolved");
         assertEquals(1, filled.rows().size(), "one combination is uncovered, so one row is written");
@@ -92,7 +92,7 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
      * holding an element there.
      */
     private static List<String> generatedRows(String source) {
-        Generator.GenerationResult filled = generated(source);
+        souther.compiler.partition.FillResult filled = generated(source);
         assertEquals(List.of(), filled.unresolved(),
                 "the combination is one a value exists for, so nothing is left unresolved");
         return filled.rows().stream().map(row -> row.inputs().get(0).text()).toList();
@@ -468,7 +468,7 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
 
                 let look (t) = 1
                 """;
-        Generator.GenerationResult filled = generated(source);
+        souther.compiler.partition.FillResult filled = generated(source);
 
         assertEquals(List.of(), filled.rows(),
                 "no row, rather than one carrying a million elements");
@@ -495,7 +495,7 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
         for (int i = 1; i <= 8; i++) {
             formats += "    invariant p%d = String.matches(\"[a-h]{%d}\", value)\n".formatted(i, i);
         }
-        Generator.GenerationResult filled = generated("""
+        souther.compiler.partition.FillResult filled = generated("""
                 module nd.gen
 
                 data Domestic
@@ -542,7 +542,7 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
         for (int i = 1; i <= 8; i++) {
             formats += "    invariant p%d = String.matches(\"[a-h]{%d}\", value)\n".formatted(i, i);
         }
-        Generator.GenerationResult filled = generated("""
+        souther.compiler.partition.FillResult filled = generated("""
                 module nd.gen
 
                 data Domestic
@@ -585,7 +585,7 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
      */
     @Test
     void aTypeWrittenInTermsOfItselfIsDescendedIntoAndComesBack() {
-        Generator.GenerationResult filled = generated("""
+        souther.compiler.partition.FillResult filled = generated("""
                 module nd.gen
 
                 data Domestic
@@ -645,7 +645,7 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
                         && List.length(value) >= 2
                     invariant notTwo = List.length(value) /= 2
                 """, "tags: Tags", "tags = Tags([\"a\", \"b\", \"c\"])");
-        Generator.GenerationResult filled = generated(source);
+        souther.compiler.partition.FillResult filled = generated(source);
 
         assertEquals(List.of(), filled.rows(), "two equal elements is not a list of two distinct ones");
         assertTrue(filled.unresolved().stream().allMatch(left ->

--- a/souther-compiler/src/test/java/souther/compiler/ACaseIsBuiltAtItsPositionWithoutBeingNamedHereTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACaseIsBuiltAtItsPositionWithoutBeingNamedHereTest.java
@@ -3,7 +3,6 @@ package souther.compiler;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.meta.ModulePath;
-import souther.compiler.partition.Generator;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 
@@ -65,7 +64,7 @@ class ACaseIsBuiltAtItsPositionWithoutBeingNamedHereTest {
                     | Resignation   -> Verdict { text = "resigned" }
             """;
 
-    private static Generator.GenerationResult filled() {
+    private static souther.compiler.partition.FillResult filled() {
         Compilation compilation = Compilation.ofSources(List.of(DOMAIN, CONSUMER), ModulePath.EMPTY);
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
@@ -76,7 +75,7 @@ class ACaseIsBuiltAtItsPositionWithoutBeingNamedHereTest {
 
     @Test
     void aLeafThisModuleCanNameGetsARowAndTheOthersGetTheirReason() {
-        Generator.GenerationResult filled = filled();
+        souther.compiler.partition.FillResult filled = filled();
 
         assertEquals(List.of("Resignation { note = \"x\" }"),
                 filled.rows().stream()

--- a/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
@@ -75,16 +75,25 @@ class AGenerationThatWentOnDoesNotSayItStoppedTest {
                 .filter(b -> b.name().equals("submit")).findFirst().orElseThrow();
         Sig sig = sigs.get("submit");
         InputDomain domain = InputDomain.of(spec, sig, symbols, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
-        return new Generator.Subject(new souther.compiler.partition.BehaviorInputs(
+        return new Generator.Subject(spec.name(), new souther.compiler.partition.BehaviorInputs(
                 spec.params().stream().map(Hir.Param::name).toList(), sig.inputTypes(), symbols,
                 souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
                 Partitions.of(spec.name(), domain, symbols, souther.compiler.query.ReadAs.THE_COMPILATION_DOES).axes(), souther.compiler.partition.HeldCounts.of(domain, symbols));
     }
 
-    private static String written(Generator.GenerationResult result) {
+    private static String written(souther.compiler.partition.FillResult result) {
         return GeneratedRows.of("example.trip",
-                Map.of("submit", new Adequacy.Filling(result, Generator.GenerationResult.NONE, List.of())),
+                Map.of("submit", new Adequacy.Filling(result, Generator.GenerationResult.NONE,
+                        List.of())),
                 Map.of(), false, SourceNameResolver.identity()).text();
+    }
+
+    /** A run asked for nothing, which is what a reason about the run alone is written against. */
+    private static souther.compiler.partition.FillResult stoppedWith(GenerationReason why) {
+        souther.compiler.partition.GenerationPlan plan =
+                new souther.compiler.partition.GenerationPlan(subject(), List.of(), List.of());
+        return new souther.compiler.partition.FillResult(plan, Map.of(), List.of(), List.of(why),
+                souther.compiler.partition.Discharge.NOTHING);
     }
 
     /**
@@ -104,7 +113,7 @@ class AGenerationThatWentOnDoesNotSayItStoppedTest {
                 Incompleteness.Code.VALUE_TRUNCATED, first.id().behavior(), first.id().term())));
         row.put(second.id(), Classification.in(second.classes().get(0).id()));
 
-        Generator.GenerationResult filled =
+        souther.compiler.partition.FillResult filled =
                 Generator.fill(subject, List.of(Generator.ObservedRow.unseen(row)),
                         Generator.CandidateCheck.ANY, Budgets.generation());
 
@@ -121,8 +130,7 @@ class AGenerationThatWentOnDoesNotSayItStoppedTest {
     /** And a run that did stop says so, in words a reader can act on. */
     @Test
     void aSearchThatRanOutSaysItStopped() {
-        String written = written(new Generator.GenerationResult(List.of(), List.of(),
-                List.of(new GenerationReason.SearchLimit("submit", 12))));
+        String written = written(stoppedWith(new GenerationReason.SearchLimit("submit", 12)));
 
         assertEquals("// generation stopped for `submit`: 12 classes and arms past the row limit"
                 + System.lineSeparator(), written);
@@ -131,8 +139,7 @@ class AGenerationThatWentOnDoesNotSayItStoppedTest {
     /** One left is one thing on the plan, which is a class or an arm and never a combination. */
     @Test
     void theCountIsWrittenAsACount() {
-        String written = written(new Generator.GenerationResult(List.of(), List.of(),
-                List.of(new GenerationReason.SearchLimit("submit", 1))));
+        String written = written(stoppedWith(new GenerationReason.SearchLimit("submit", 1)));
 
         assertTrue(written.contains("1 class or arm past"), written);
     }

--- a/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
@@ -92,7 +92,8 @@ class AGenerationThatWentOnDoesNotSayItStoppedTest {
     private static souther.compiler.partition.FillResult stoppedWith(GenerationReason why) {
         souther.compiler.partition.GenerationPlan plan =
                 new souther.compiler.partition.GenerationPlan(subject(), List.of(), List.of());
-        return new souther.compiler.partition.FillResult(plan, Map.of(), List.of(), List.of(why),
+        return new souther.compiler.partition.FillResult(plan, new LinkedHashMap<>(), List.of(),
+                List.of(why),
                 souther.compiler.partition.Discharge.NOTHING);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
@@ -59,6 +59,10 @@ class CompileExampleGenerateTest {
         return all;
     }
 
+    private static List<String> inputs(souther.compiler.partition.FillResult result) {
+        return inputs(result.rows());
+    }
+
     private static List<String> inputs(Generator.GenerationResult result) {
         return inputs(result.rows());
     }
@@ -72,7 +76,7 @@ class CompileExampleGenerateTest {
 
     @Test
     void whatTheWrittenRowAlreadyCoversIsNotGeneratedAgain() {
-        Generator.GenerationResult filled = generated(TRIP).get("submit").composed();
+        souther.compiler.partition.FillResult filled = generated(TRIP).get("submit").composed();
 
         // One row per class the written row is not in, and no more. The written row is
         // `Domestic, urgent = true`, so what is left is `Overseas` at one position and `false` at
@@ -114,7 +118,7 @@ class CompileExampleGenerateTest {
                     Accepted { at = "now" }
                 }
                 """;
-        Generator.GenerationResult filled = generated(correlated).get("submit").composed();
+        souther.compiler.partition.FillResult filled = generated(correlated).get("submit").composed();
 
         assertTrue(inputs(filled).stream().noneMatch(row -> row.contains("Amount(101)")),
                 "a value the model refuses is not written into a row: " + inputs(filled));
@@ -541,7 +545,7 @@ class CompileExampleGenerateTest {
                 let take (request, flag) = Ok { n = 0 }
                 """;
 
-        Generator.GenerationResult filled = generated(source).get("take").composed();
+        souther.compiler.partition.FillResult filled = generated(source).get("take").composed();
 
         assertEquals(List.of(), filled.unresolved(),
                 () -> "the value between the edges builds: " + filled.unresolved());
@@ -774,7 +778,7 @@ class CompileExampleGenerateTest {
 
     @Test
     void aRowForAClassIsWrittenAgainstTheValueTheModuleStates() {
-        Generator.GenerationResult filled = generated(AGAINST_A_LET).get("calc").composed();
+        souther.compiler.partition.FillResult filled = generated(AGAINST_A_LET).get("calc").composed();
 
         assertEquals(List.of("Cond { ...none, f = C }", "Cond { ...none, g = G2 }"),
                 inputs(filled));

--- a/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
@@ -480,8 +480,9 @@ class EveryFindingHasAGenerationDispositionTest {
                 new souther.compiler.partition.GenerationPlan(nothingIsDivided(), List.of(),
                         List.of());
         return why == null ? souther.compiler.partition.FillResult.nothingAskedOf(plan)
-                : new souther.compiler.partition.FillResult(plan, Map.of(), List.of(),
-                        List.of(why), souther.compiler.partition.Discharge.NOTHING);
+                : new souther.compiler.partition.FillResult(plan, new java.util.LinkedHashMap<>(),
+                        List.of(), List.of(why),
+                        souther.compiler.partition.Discharge.NOTHING);
     }
 
     /** The same at the boundaries, which nothing is owed at and which has no plan. */

--- a/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
@@ -205,23 +205,28 @@ class EveryFindingHasAGenerationDispositionTest {
     }
 
     /**
-     * An arm a strategy takes and composes nothing for is answered by what the search came to.
+     * An arm nothing was composed for is answered from the reading of the body, whatever the
+     * positions came to.
      *
      * <p>The way into this arm is a comparison between a value the body works out and a position
-     * beside it, and the classes it leaves are ones this can put a row at — so a search runs, and
-     * what it comes to is what a reader is told. Answered {@link GenerationOutcome.NotSupported}
-     * instead, an author would be told no strategy reaches the arm while one had just tried.
+     * beside it, and the ways to such a value could not all be written down — so the reading has an
+     * answer about the arm before any position is looked at. No position of this model is divided
+     * either, and the search over the classes has nothing to walk; read as though that were what
+     * happened to the arm, the answer was that a strategy took the arm and recorded neither a row
+     * nor a reason, which is this compiler failing to say rather than anything about the model.
      */
     @Test
-    void anArmAStrategyTriesAndComposesNothingForSaysWhatItCameTo() {
+    void anArmNothingWasComposedForIsAnsweredFromTheReadingOfTheBody() {
         Compilation compilation = compiled(POLICY);
         List<Adequacy.GenerationDisposition> arms =
                 filling(compilation, "example.policy", "fee").generation().stream()
                         .filter(d -> d.finding().kind() == Adequacy.Kind.ARM_UNREACHED).toList();
 
         assertEquals(1, arms.size());
-        assertTrue(arms.get(0).outcome() instanceof GenerationOutcome.CannotGenerate,
-                "a search ran at this arm and came to something: " + arms);
+        assertEquals(new GenerationOutcome.NotSupported(
+                        GenerationOutcome.NotSupported.Reason.THE_WAYS_INTO_THIS_ARM_ARE_NOT_ENUMERABLE),
+                arms.get(0).outcome(),
+                "the reading says the ways into this arm are not enumerable: " + arms);
     }
 
     /** A fork inside a block, whose body runs where something applies it. */
@@ -462,16 +467,37 @@ class EveryFindingHasAGenerationDispositionTest {
     private static String saidAbout(souther.compiler.partition.GenerationReason why,
                                     souther.compiler.partition.GenerationReason alsoAtTheEdges) {
         return GeneratedRows.of("example.kind",
-                Map.of("pick", new Adequacy.Filling(stopped(why), stopped(alsoAtTheEdges),
+                Map.of("pick", new Adequacy.Filling(stopped(why), atTheEdges(alsoAtTheEdges),
                         List.of())),
                 Map.of(), true, SourceNameResolver.identity()).text();
     }
 
-    private static souther.compiler.partition.Generator.GenerationResult stopped(
+    /** A run asked for nothing that came to a reason about itself, which is what a stopped
+     *  generation is when nothing was owed. */
+    private static souther.compiler.partition.FillResult stopped(
+            souther.compiler.partition.GenerationReason why) {
+        souther.compiler.partition.GenerationPlan plan =
+                new souther.compiler.partition.GenerationPlan(nothingIsDivided(), List.of(),
+                        List.of());
+        return why == null ? souther.compiler.partition.FillResult.nothingAskedOf(plan)
+                : new souther.compiler.partition.FillResult(plan, Map.of(), List.of(),
+                        List.of(why), souther.compiler.partition.Discharge.NOTHING);
+    }
+
+    /** The same at the boundaries, which nothing is owed at and which has no plan. */
+    private static souther.compiler.partition.Generator.GenerationResult atTheEdges(
             souther.compiler.partition.GenerationReason why) {
         return why == null ? souther.compiler.partition.Generator.GenerationResult.NONE
-                : new souther.compiler.partition.Generator.GenerationResult(
-                        List.of(), List.of(), List.of(why));
+                : new souther.compiler.partition.Generator.GenerationResult(List.of(), List.of(),
+                        List.of(why));
+    }
+
+    private static souther.compiler.partition.Generator.Subject nothingIsDivided() {
+        return new souther.compiler.partition.Generator.Subject("pick",
+                new souther.compiler.partition.BehaviorInputs(List.of(), List.of(),
+                        souther.compiler.check.Symbols.none(DefaultStdlib.get()),
+                        souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
+                List.of(), souther.compiler.partition.HeldCounts.NONE);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/WhatIsWrittenInAnEnsuresIsQuotedOverTheRowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatIsWrittenInAnEnsuresIsQuotedOverTheRowsTest.java
@@ -247,10 +247,25 @@ class WhatIsWrittenInAnEnsuresIsQuotedOverTheRowsTest {
     @Test
     void aBehaviorWithNoRowToFillIsNotQuoted() {
         String block = GeneratedRows.of("example.todo",
-                Map.of("findTodo", Adequacy.Filling.NONE),
+                Map.of("findTodo", nothingOffered()),
                 Map.of("findTodo", List.of("ensures asked = NotFound -> id.value > 0")),
                 true, SourceNameResolver.identity()).text();
 
         assertEquals("", block);
+    }
+
+    /** A behavior nothing was asked for and nothing composed for, which is what an empty offer is. */
+    private static Adequacy.Filling nothingOffered() {
+        souther.compiler.partition.Generator.Subject subject =
+                new souther.compiler.partition.Generator.Subject("findTodo",
+                        new souther.compiler.partition.BehaviorInputs(List.of(), List.of(),
+                                souther.compiler.check.Symbols.none(DefaultStdlib.get()),
+                                souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
+                        List.of(), souther.compiler.partition.HeldCounts.NONE);
+        return new Adequacy.Filling(
+                souther.compiler.partition.FillResult.nothingAskedOf(
+                        new souther.compiler.partition.GenerationPlan(subject, List.of(),
+                                List.of())),
+                souther.compiler.partition.Generator.GenerationResult.NONE, List.of());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABoundaryRowWearsEveryNameThePositionDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABoundaryRowWearsEveryNameThePositionDeclaresTest.java
@@ -103,7 +103,7 @@ class ABoundaryRowWearsEveryNameThePositionDeclaresTest {
 
         List<String> names = new ArrayList<>();
         spec.params().forEach(each -> names.add(each.name()));
-        Generator.Subject subject = new Generator.Subject(
+        Generator.Subject subject = new Generator.Subject(spec.name(),
                 new BehaviorInputs(names, sigs.get(spec.name()).inputTypes(), symbols, souther.compiler.query.ReadAs.THE_COMPILATION_DOES), p.axes(),
                 HeldCounts.of(domain, symbols));
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACandidateThatMissedIsNotOfferedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACandidateThatMissedIsNotOfferedTest.java
@@ -88,7 +88,7 @@ class ACandidateThatMissedIsNotOfferedTest {
     void aCombinationEveryCandidateMissedIsLeftUntried() {
         Model model = Model.of(SHIPPING, "shippingFee");
 
-        Generator.GenerationResult filled = fill(model, _ -> MISSED);
+        FillResult filled = fill(model, _ -> MISSED);
 
         assertTrue(filled.unresolved().stream().anyMatch(each -> each.reason()
                         == Generator.UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS),
@@ -104,7 +104,7 @@ class ACandidateThatMissedIsNotOfferedTest {
         Model model = Model.of(SHIPPING, "shippingFee");
         Observation everything = doing(everyClaimOf(model));
 
-        Generator.GenerationResult filled =
+        FillResult filled =
                 fill(model, _ -> new Generator.Watched.Ran(everything));
 
         assertTrue(filled.unresolved().stream().noneMatch(each -> each.reason()
@@ -158,7 +158,7 @@ class ACandidateThatMissedIsNotOfferedTest {
     void rowsNothingRanAreOfferedAndSaidToBeUnconfirmed() {
         Model model = Model.of(SHIPPING, "shippingFee");
 
-        Generator.GenerationResult filled = fill(model, Generator.Trial.NOTHING_RUNS);
+        FillResult filled = fill(model, Generator.Trial.NOTHING_RUNS);
 
         assertFalse(filled.rows().isEmpty(), "the rows are offered");
         assertEquals(1, filled.reasons().stream()
@@ -166,7 +166,7 @@ class ACandidateThatMissedIsNotOfferedTest {
                 "and the generation says once that nothing ran them: " + filled.reasons());
     }
 
-    private static Generator.GenerationResult fill(Model model, Generator.Trial trial) {
+    private static FillResult fill(Model model, Generator.Trial trial) {
         return Generator.fill(model.subject(), List.of(), Generator.CandidateCheck.ANY,
                 model.read(), trial, Budgets.generation());
     }
@@ -228,7 +228,7 @@ class ACandidateThatMissedIsNotOfferedTest {
             assertNotNull(inputs, "the behavior's inputs were read");
             Core body = checked.behaviorBodies().get(behavior);
             assertNotNull(body, "the behavior under test has a body");
-            return new Model(new Generator.Subject(
+            return new Model(new Generator.Subject(spec.name(),
                     new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
                             sig.inputTypes(), symbols,
                             souther.compiler.query.ReadAs.THE_COMPILATION_DOES),

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClassThatNarrowsStatesTheNarrowingAndNotAValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClassThatNarrowsStatesTheNarrowingAndNotAValueTest.java
@@ -102,8 +102,8 @@ class AClassThatNarrowsStatesTheNarrowingAndNotAValueTest {
                     symbols, ReadAs.THE_COMPILATION_DOES, guards.unread(), guards.singled(),
                     guards.between());
         }
-        Generator.GenerationResult filled = Generator.fill(
-                new Generator.Subject(new BehaviorInputs(
+        FillResult filled = Generator.fill(
+                new Generator.Subject(spec.name(), new BehaviorInputs(
                         spec.params().stream().map(Hir.Param::name).toList(), sig.inputTypes(),
                         symbols, ReadAs.THE_COMPILATION_DOES),
                         axes.axes(), HeldCounts.of(domain, symbols)),

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClassUnderACaseIsOfferedARowAtThatCaseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClassUnderACaseIsOfferedARowAtThatCaseTest.java
@@ -69,7 +69,7 @@ class AClassUnderACaseIsOfferedARowAtThatCaseTest {
         InputDomain domain = InputDomain.of(spec, sig, symbols, ReadAs.THE_COMPILATION_DOES);
         Partitions.Partitioning partitioning =
                 Partitions.of(spec.name(), domain, symbols, ReadAs.THE_COMPILATION_DOES);
-        return new Model(new Generator.Subject(
+        return new Model(new Generator.Subject(spec.name(),
                 new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
                         sig.inputTypes(), symbols, ReadAs.THE_COMPILATION_DOES),
                 partitioning.axes(), HeldCounts.of(domain, symbols)),
@@ -84,7 +84,7 @@ class AClassUnderACaseIsOfferedARowAtThatCaseTest {
     /** Every class of every position, including the ones only one case has. */
     @Test
     void aClassUnderACaseIsOfferedARow() {
-        Generator.GenerationResult filled = Generator.fill(model().subject(), List.of(),
+        FillResult filled = Generator.fill(model().subject(), List.of(),
                 Generator.CandidateCheck.ANY, Budgets.generation());
 
         assertEquals(List.of(), filled.unresolved(), filled.unresolved().toString());
@@ -97,7 +97,7 @@ class AClassUnderACaseIsOfferedARowAtThatCaseTest {
     /** And the row written for it is that case, because the class under it says so. */
     @Test
     void theRowWrittenForItIsThatCase() {
-        Generator.GenerationResult filled = Generator.fill(model().subject(), List.of(),
+        FillResult filled = Generator.fill(model().subject(), List.of(),
                 Generator.CandidateCheck.ANY, Budgets.generation());
 
         for (Generator.GeneratedRow row : filled.rows()) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/AFillIsTotalOverThePlanItWasAskedWithTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AFillIsTotalOverThePlanItWasAskedWithTest.java
@@ -49,7 +49,7 @@ class AFillIsTotalOverThePlanItWasAskedWithTest {
     @Test
     void aClassTheRunDidNotAnswerForIsRefused() {
         IllegalStateException refused = assertThrows(IllegalStateException.class,
-                () -> new FillResult(planOver(List.of(A_CLASS), List.of()), Map.of(), List.of(),
+                () -> new FillResult(planOver(List.of(A_CLASS), List.of()), new LinkedHashMap<>(), List.of(),
                         List.of(), Discharge.NOTHING));
 
         assertEquals(true, refused.getMessage().contains("days/low"), refused.getMessage());
@@ -58,14 +58,14 @@ class AFillIsTotalOverThePlanItWasAskedWithTest {
     @Test
     void anArmTheRunDidNotAnswerForIsRefused() {
         assertThrows(IllegalStateException.class,
-                () -> new FillResult(planOver(List.of(), List.of(AN_ARM)), Map.of(), List.of(),
+                () -> new FillResult(planOver(List.of(), List.of(AN_ARM)), new LinkedHashMap<>(), List.of(),
                         List.of(), Discharge.NOTHING));
     }
 
     @Test
     void aClassTheRunAnsweredForAndNobodyAskedAboutIsRefused() {
         assertThrows(IllegalStateException.class,
-                () -> new FillResult(planOver(List.of(A_CLASS), List.of()), Map.of(), List.of(),
+                () -> new FillResult(planOver(List.of(A_CLASS), List.of()), new LinkedHashMap<>(), List.of(),
                         List.of(), new Discharge(
                                 Map.of(A_CLASS, new ClassDisposition.Unresolved(NOTHING_CAME_OF_IT),
                                         ANOTHER_CLASS,
@@ -76,7 +76,7 @@ class AFillIsTotalOverThePlanItWasAskedWithTest {
     @Test
     void anArmTheRunAnsweredForAndNobodyAskedAboutIsRefused() {
         assertThrows(IllegalStateException.class,
-                () -> new FillResult(planOver(List.of(), List.of(AN_ARM)), Map.of(), List.of(),
+                () -> new FillResult(planOver(List.of(), List.of(AN_ARM)), new LinkedHashMap<>(), List.of(),
                         List.of(), new Discharge(Map.of(),
                                 Map.of(AN_ARM, new ArmDisposition.Unresolved(
                                                 List.of(NOTHING_CAME_OF_IT)),
@@ -87,7 +87,7 @@ class AFillIsTotalOverThePlanItWasAskedWithTest {
     @Test
     void anAnswerPointingAtARowTheOfferDoesNotHoldIsRefused() {
         assertThrows(IllegalStateException.class,
-                () -> new FillResult(planOver(List.of(A_CLASS), List.of()), Map.of(), List.of(),
+                () -> new FillResult(planOver(List.of(A_CLASS), List.of()), new LinkedHashMap<>(), List.of(),
                         List.of(), new Discharge(
                                 Map.of(A_CLASS, new ClassDisposition.Built(new RowId(0))),
                                 Map.of())));
@@ -95,7 +95,7 @@ class AFillIsTotalOverThePlanItWasAskedWithTest {
 
     @Test
     void aRowNothingPointsAtIsRefused() {
-        Map<RowId, ComposedRow> composed = new LinkedHashMap<>();
+        LinkedHashMap<RowId, ComposedRow> composed = new LinkedHashMap<>();
         composed.put(new RowId(0), new ComposedRow(List.of(FixtureTemplate.integer(1))));
 
         assertThrows(IllegalStateException.class,
@@ -110,7 +110,7 @@ class AFillIsTotalOverThePlanItWasAskedWithTest {
      *  like. */
     @Test
     void aRunThatAnsweredForEverythingItWasAskedIsBuilt() {
-        Map<RowId, ComposedRow> composed = new LinkedHashMap<>();
+        LinkedHashMap<RowId, ComposedRow> composed = new LinkedHashMap<>();
         composed.put(new RowId(0), new ComposedRow(List.of(FixtureTemplate.integer(1))));
 
         FillResult filled = new FillResult(planOver(List.of(A_CLASS), List.of(AN_ARM)), composed,

--- a/souther-compiler/src/test/java/souther/compiler/partition/AFillIsTotalOverThePlanItWasAskedWithTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AFillIsTotalOverThePlanItWasAskedWithTest.java
@@ -1,0 +1,141 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.check.Symbols;
+import souther.compiler.query.ReadAs;
+import souther.compiler.types.Type;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A run answers for everything its plan named, and offers no row nothing points at.
+ *
+ * <p>Two relations, each held as a set equality. The obligations against the answers, so a way out
+ * of the search that writes no entry cannot be built at all — which is what a reader downstream
+ * used to meet as an absence, and made a sentence out of saying this compiler had failed to say.
+ * And the rows against the answers that point at them, in both directions: an answer naming a row
+ * the offer does not hold reports an obligation met by a line nobody is shown, and a row nothing
+ * points at is a line offered for nothing.
+ *
+ * <p>Held here rather than in the search. The search is one producer and there are others — the
+ * rows could not be read, the classes would not link — and a rule kept where the searching happens
+ * is one the others are free to break.
+ */
+class AFillIsTotalOverThePlanItWasAskedWithTest {
+
+    private static final Symbols SYMBOLS = Symbols.none(DefaultStdlib.get());
+
+    private static final Generator.ClassOwed A_CLASS =
+            new Generator.ClassOwed(new AxisId("fee", "days"), "days/low");
+
+    private static final Generator.ClassOwed ANOTHER_CLASS =
+            new Generator.ClassOwed(new AxisId("fee", "days"), "days/high");
+
+    private static final Generator.ArmOwed AN_ARM = new Generator.ArmOwed(1);
+
+    private static final Generator.ArmOwed ANOTHER_ARM = new Generator.ArmOwed(2);
+
+    private static final Generator.UnresolvedCombination NOTHING_CAME_OF_IT =
+            new Generator.UnresolvedCombination(List.of("days=low"),
+                    Generator.UnresolvedCombination.Reason.NO_CANDIDATE_WAS_OFFERED);
+
+    @Test
+    void aClassTheRunDidNotAnswerForIsRefused() {
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> new FillResult(planOver(List.of(A_CLASS), List.of()), Map.of(), List.of(),
+                        List.of(), Discharge.NOTHING));
+
+        assertEquals(true, refused.getMessage().contains("days/low"), refused.getMessage());
+    }
+
+    @Test
+    void anArmTheRunDidNotAnswerForIsRefused() {
+        assertThrows(IllegalStateException.class,
+                () -> new FillResult(planOver(List.of(), List.of(AN_ARM)), Map.of(), List.of(),
+                        List.of(), Discharge.NOTHING));
+    }
+
+    @Test
+    void aClassTheRunAnsweredForAndNobodyAskedAboutIsRefused() {
+        assertThrows(IllegalStateException.class,
+                () -> new FillResult(planOver(List.of(A_CLASS), List.of()), Map.of(), List.of(),
+                        List.of(), new Discharge(
+                                Map.of(A_CLASS, new ClassDisposition.Unresolved(NOTHING_CAME_OF_IT),
+                                        ANOTHER_CLASS,
+                                        new ClassDisposition.Unresolved(NOTHING_CAME_OF_IT)),
+                                Map.of())));
+    }
+
+    @Test
+    void anArmTheRunAnsweredForAndNobodyAskedAboutIsRefused() {
+        assertThrows(IllegalStateException.class,
+                () -> new FillResult(planOver(List.of(), List.of(AN_ARM)), Map.of(), List.of(),
+                        List.of(), new Discharge(Map.of(),
+                                Map.of(AN_ARM, new ArmDisposition.Unresolved(
+                                                List.of(NOTHING_CAME_OF_IT)),
+                                        ANOTHER_ARM, new ArmDisposition.Unresolved(
+                                                List.of(NOTHING_CAME_OF_IT))))));
+    }
+
+    @Test
+    void anAnswerPointingAtARowTheOfferDoesNotHoldIsRefused() {
+        assertThrows(IllegalStateException.class,
+                () -> new FillResult(planOver(List.of(A_CLASS), List.of()), Map.of(), List.of(),
+                        List.of(), new Discharge(
+                                Map.of(A_CLASS, new ClassDisposition.Built(new RowId(0))),
+                                Map.of())));
+    }
+
+    @Test
+    void aRowNothingPointsAtIsRefused() {
+        Map<RowId, ComposedRow> composed = new LinkedHashMap<>();
+        composed.put(new RowId(0), new ComposedRow(List.of(FixtureTemplate.integer(1))));
+
+        assertThrows(IllegalStateException.class,
+                () -> new FillResult(planOver(List.of(A_CLASS), List.of()), composed, List.of(),
+                        List.of(), new Discharge(
+                                Map.of(A_CLASS,
+                                        new ClassDisposition.Unresolved(NOTHING_CAME_OF_IT)),
+                                Map.of())));
+    }
+
+    /** One answer per obligation and one row apiece, which is what a run that composed both looks
+     *  like. */
+    @Test
+    void aRunThatAnsweredForEverythingItWasAskedIsBuilt() {
+        Map<RowId, ComposedRow> composed = new LinkedHashMap<>();
+        composed.put(new RowId(0), new ComposedRow(List.of(FixtureTemplate.integer(1))));
+
+        FillResult filled = new FillResult(planOver(List.of(A_CLASS), List.of(AN_ARM)), composed,
+                List.of(), List.of(), new Discharge(
+                        Map.of(A_CLASS, new ClassDisposition.Built(new RowId(0))),
+                        Map.of(AN_ARM, new ArmDisposition.Built(new RowId(0)))));
+
+        assertEquals(1, filled.rows().size(), "one line, offered for both");
+    }
+
+    private static GenerationPlan planOver(List<Generator.ClassOwed> classes,
+                                           List<Generator.ArmOwed> arms) {
+        Axis days = new Axis(new AxisId("fee", "days"),
+                new souther.compiler.inputs.NumericTerm.ValueOf(
+                        souther.compiler.inputs.TermPath.of("days")),
+                Type.INT, List.of(divided("days/low", 1), divided("days/high", 9)), List.of());
+        Generator.Subject subject = new Generator.Subject("fee",
+                new BehaviorInputs(List.of("days"), List.of(Type.INT), SYMBOLS,
+                        ReadAs.THE_COMPILATION_DOES),
+                List.of(days), HeldCounts.NONE);
+        return new GenerationPlan(subject, classes, arms);
+    }
+
+    private static PartitionClass divided(String id, long value) {
+        return PartitionClass.of(id, id, new Recognition.Nothing(),
+                RepresentativeSource.of(List.of(FixtureTemplate.integer(value))));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AFillIsTotalOverThePlanItWasAskedWithTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AFillIsTotalOverThePlanItWasAskedWithTest.java
@@ -84,6 +84,43 @@ class AFillIsTotalOverThePlanItWasAskedWithTest {
                                                 List.of(NOTHING_CAME_OF_IT))))));
     }
 
+    /**
+     * A key with nothing under it is not an answer.
+     *
+     * <p>The check is over the obligations and what became of them, and holding it over the keys
+     * alone let the absence back in one layer down: the plan named the class, the discharge held
+     * the class, and what a reader looking it up got was the null every one of these values is
+     * arranged to have none of.
+     */
+    @Test
+    void aClassWithNothingUnderItIsNotAnAnswer() {
+        Map<Generator.ClassOwed, ClassDisposition> nothing = new LinkedHashMap<>();
+        nothing.put(A_CLASS, null);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> new Discharge(nothing, Map.of()),
+                "a class the run was asked about and did not answer for");
+    }
+
+    @Test
+    void anArmWithNothingUnderItIsNotAnAnswer() {
+        Map<Generator.ArmOwed, ArmDisposition> nothing = new LinkedHashMap<>();
+        nothing.put(AN_ARM, null);
+
+        assertThrows(IllegalArgumentException.class, () -> new Discharge(Map.of(), nothing));
+    }
+
+    /** And the rows the answers point at, for the same reason: an id under nothing is not a row. */
+    @Test
+    void aRowIdWithNothingUnderItIsNotARow() {
+        LinkedHashMap<RowId, ComposedRow> nothing = new LinkedHashMap<>();
+        nothing.put(new RowId(0), null);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> new FillResult(planOver(List.of(), List.of()), nothing, List.of(), List.of(),
+                        Discharge.NOTHING));
+    }
+
     @Test
     void anAnswerPointingAtARowTheOfferDoesNotHoldIsRefused() {
         assertThrows(IllegalStateException.class,

--- a/souther-compiler/src/test/java/souther/compiler/partition/AFloorNothingBuildsIsSaidTheSameWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AFloorNothingBuildsIsSaidTheSameWhereverItIsWrittenTest.java
@@ -54,7 +54,7 @@ class AFloorNothingBuildsIsSaidTheSameWhereverItIsWrittenTest {
         Sig sig = sigs.get(behavior);
         InputDomain domain = InputDomain.of(spec, sig, symbols, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
         Partitions.Partitioning partitioning = Partitions.of(spec.name(), domain, symbols, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
-        Generator.GenerationResult filled = Generator.fill(new Generator.Subject(
+        FillResult filled = Generator.fill(new Generator.Subject(spec.name(),
                 new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
                         sig.inputTypes(), symbols, souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
                 partitioning.axes(), HeldCounts.of(domain, symbols)), List.of(), REFUSED, Budgets.generation());

--- a/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
@@ -232,12 +232,12 @@ class AGroupTooWideToWalkSaysSoTest {
     void anArmBehindTheHeldGroupIsAnsweredFromTheWayIntoIt() {
         Model model = Model.of(THIRTEEN);
 
-        Generator.GenerationResult composed = Generator.fill(model.subject(), List.of(),
+        FillResult composed = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(), Generator.Trial.NOTHING_RUNS, Budgets.generation());
 
-        assertFalse(composed.arms().isEmpty(), () -> "the arms are answered: " + composed.arms());
-        assertTrue(composed.arms().stream().allMatch(Generator.ArmAttempt.Built.class::isInstance),
-                () -> "each of them with a row through it: " + composed.arms());
+        assertFalse(composed.discharge().arms().values().isEmpty(), () -> "the arms are answered: " + composed.discharge().arms().values());
+        assertTrue(composed.discharge().arms().values().stream().allMatch(ArmDisposition.Built.class::isInstance),
+                () -> "each of them with a row through it: " + composed.discharge().arms().values());
 
         List<GenerationReason.GroupsNotOffered> said = composed.reasons().stream()
                 .filter(GenerationReason.GroupsNotOffered.class::isInstance)
@@ -262,14 +262,14 @@ class AGroupTooWideToWalkSaysSoTest {
     void aGroupNothingWasAskedForBehindIsNotReported() {
         Model model = Model.of(THIRTEEN);
 
-        Generator.GenerationResult asked = Generator.fill(model.subject(), List.of(),
+        FillResult asked = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(), Generator.Trial.NOTHING_RUNS,
                 List.of(), Set.of(), Set.of(), Budgets.generation());
 
         assertEquals(List.of(), asked.reasons().stream()
                         .filter(GenerationReason.GroupsNotOffered.class::isInstance).toList(),
                 () -> "nothing was owed behind it: " + asked.reasons());
-        assertEquals(List.of(), asked.arms(), "and no arm was answered for");
+        assertEquals(Map.of(), asked.discharge().arms(), "and no arm was answered for");
     }
 
     /**
@@ -283,10 +283,10 @@ class AGroupTooWideToWalkSaysSoTest {
      */
     @Test
     void whatIsOwedIsAnsweredWhateverTheLimitDidToTheGroup() {
-        List<Generator.ArmAttempt> owed = armsFor(modelWithRows(13, false));
+        List<ArmDisposition> owed = armsFor(modelWithRows(13, false));
         assertFalse(owed.isEmpty(),
                 "one row leaves the other arm of each helper owed, and each is answered");
-        assertTrue(owed.stream().allMatch(Generator.ArmAttempt.Built.class::isInstance),
+        assertTrue(owed.stream().allMatch(ArmDisposition.Built.class::isInstance),
                 () -> "with a row through it, from the way in the reading has for it: " + owed);
         assertEquals(1, groupsNotOfferedFor(modelWithRows(13, false)).size(),
                 "and the group the limit held back is named, its combinations not being looked in");
@@ -298,8 +298,8 @@ class AGroupTooWideToWalkSaysSoTest {
     }
 
     /** What the compilation's own generation came to at each arm it was owed one at. */
-    private static List<Generator.ArmAttempt> armsFor(String source) {
-        return fillingFor(source).composed().arms();
+    private static List<ArmDisposition> armsFor(String source) {
+        return List.copyOf(fillingFor(source).composed().discharge().arms().values());
     }
 
     private static List<GenerationReason.GroupsNotOffered> groupsNotOfferedFor(String source) {
@@ -384,7 +384,7 @@ class AGroupTooWideToWalkSaysSoTest {
         assertEquals(1, offered.notOffered().size(), "the outer group is past the budget");
         assertEquals(3, offered.groups().size(), "and the three inner ones are offered");
 
-        Generator.GenerationResult composed = Generator.fill(model.subject(), List.of(),
+        FillResult composed = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(), Generator.Trial.NOTHING_RUNS, budget);
 
         // The held group is one arms were owed behind: without this, the answer below would hold of
@@ -396,8 +396,8 @@ class AGroupTooWideToWalkSaysSoTest {
         assertFalse(behindTheHeldGroup.isEmpty(),
                 "arms were owed behind the group that was held back");
 
-        assertTrue(composed.arms().stream().allMatch(Generator.ArmAttempt.Built.class::isInstance),
-                () -> "every arm behind it has a row through it: " + composed.arms());
+        assertTrue(composed.discharge().arms().values().stream().allMatch(ArmDisposition.Built.class::isInstance),
+                () -> "every arm behind it has a row through it: " + composed.discharge().arms().values());
         assertEquals(1, composed.reasons().stream()
                         .filter(GenerationReason.GroupsNotOffered.class::isInstance).count(),
                 () -> "and the walk that was not made is still said: " + composed.reasons());
@@ -445,7 +445,7 @@ class AGroupTooWideToWalkSaysSoTest {
             assertNotNull(body, "the behavior under test has a body");
             CoverageSites.Plan plan = CoverageSites.of(checked.behaviorBodies(), checked.decisions(),
                     checked.supplied());
-            return new Model(new Generator.Subject(
+            return new Model(new Generator.Subject(spec.name(),
                     new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
                             sigs.get("total").inputTypes(), symbols,
                             souther.compiler.query.ReadAs.THE_COMPILATION_DOES),

--- a/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AGroupTooWideToWalkSaysSoTest.java
@@ -264,7 +264,7 @@ class AGroupTooWideToWalkSaysSoTest {
 
         FillResult asked = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(), Generator.Trial.NOTHING_RUNS,
-                List.of(), Set.of(), Set.of(), Budgets.generation());
+                List.of(), List.of(), List.of(), Budgets.generation());
 
         assertEquals(List.of(), asked.reasons().stream()
                         .filter(GenerationReason.GroupsNotOffered.class::isInstance).toList(),

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionWithAFloorIsOfferedAValueThatMeetsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionWithAFloorIsOfferedAValueThatMeetsItTest.java
@@ -40,7 +40,7 @@ class APositionWithAFloorIsOfferedAValueThatMeetsItTest {
         Sig sig = sigs.get(behavior);
         InputDomain domain = InputDomain.of(spec, sig, symbols, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
         Partitions.Partitioning partitioning = Partitions.of(spec.name(), domain, symbols, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
-        return new Generator.Subject(
+        return new Generator.Subject(spec.name(),
                 new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
                         sig.inputTypes(), symbols, souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
                 partitioning.axes(), HeldCounts.of(domain, symbols));
@@ -48,7 +48,7 @@ class APositionWithAFloorIsOfferedAValueThatMeetsItTest {
 
     /** The value at the position the row wrote, which is the one the search reached first. */
     private static String firstValueAt(String source, String behavior, int position) {
-        Generator.GenerationResult filled =
+        FillResult filled =
                 Generator.fill(subjectOf(source, behavior), List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
         assertEquals(List.of(), filled.unresolved(), "nothing should have gone unresolved");
         return filled.rows().get(0).inputs().get(position).text();

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowIsAWitnessForAnArmOnlyByGoingThroughItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowIsAWitnessForAnArmOnlyByGoingThroughItTest.java
@@ -96,7 +96,7 @@ class ARowIsAWitnessForAnArmOnlyByGoingThroughItTest {
                 Generator.CandidateCheck.ANY, model.read(),
                 // Seen doing everything the ways in name, and seen at no arm at all.
                 _ -> new Generator.Watched.Ran(waysWithoutTheArms(model.read())),
-                List.of(), Set.of(), everyArm, Budgets.generation());
+                List.of(), List.of(), List.copyOf(everyArm), Budgets.generation());
 
         for (int probe : everyArm) {
             assertFalse(filled.discharge().at(new Generator.ArmOwed(probe)) instanceof ArmDisposition.Built,
@@ -116,7 +116,7 @@ class ARowIsAWitnessForAnArmOnlyByGoingThroughItTest {
         FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(),
                 _ -> new Generator.Watched.Ran(everywhere(model.read(), everyArm)),
-                List.of(), Set.of(), everyArm, Budgets.generation());
+                List.of(), List.of(), List.copyOf(everyArm), Budgets.generation());
 
         assertTrue(filled.discharge().arms().values().stream().allMatch(ArmDisposition.Built.class::isInstance),
                 () -> "each arm has a row through it: " + filled.discharge().arms().values());

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowIsAWitnessForAnArmOnlyByGoingThroughItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowIsAWitnessForAnArmOnlyByGoingThroughItTest.java
@@ -92,15 +92,15 @@ class ARowIsAWitnessForAnArmOnlyByGoingThroughItTest {
         Model model = Model.of(GATE);
         Set<Integer> everyArm = model.read().arms().keySet();
 
-        Generator.GenerationResult filled = Generator.fill(model.subject(), List.of(),
+        FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(),
                 // Seen doing everything the ways in name, and seen at no arm at all.
                 _ -> new Generator.Watched.Ran(waysWithoutTheArms(model.read())),
                 List.of(), Set.of(), everyArm, Budgets.generation());
 
         for (int probe : everyArm) {
-            assertFalse(filled.armAt(probe) instanceof Generator.ArmAttempt.Built,
-                    () -> "no row goes through an arm nothing was seen at: " + filled.arms());
+            assertFalse(filled.discharge().at(new Generator.ArmOwed(probe)) instanceof ArmDisposition.Built,
+                    () -> "no row goes through an arm nothing was seen at: " + filled.discharge().arms().values());
         }
         assertEquals(List.of(), filled.rows(),
                 () -> "so nothing is offered for one: " + filled.rows());
@@ -113,13 +113,13 @@ class ARowIsAWitnessForAnArmOnlyByGoingThroughItTest {
         Model model = Model.of(GATE);
         Set<Integer> everyArm = model.read().arms().keySet();
 
-        Generator.GenerationResult filled = Generator.fill(model.subject(), List.of(),
+        FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(),
                 _ -> new Generator.Watched.Ran(everywhere(model.read(), everyArm)),
                 List.of(), Set.of(), everyArm, Budgets.generation());
 
-        assertTrue(filled.arms().stream().allMatch(Generator.ArmAttempt.Built.class::isInstance),
-                () -> "each arm has a row through it: " + filled.arms());
+        assertTrue(filled.discharge().arms().values().stream().allMatch(ArmDisposition.Built.class::isInstance),
+                () -> "each arm has a row through it: " + filled.discharge().arms().values());
     }
 
     /** Everything the ways in name, and nothing at any arm. */
@@ -188,7 +188,7 @@ class ARowIsAWitnessForAnArmOnlyByGoingThroughItTest {
             assertFalse(partitioning.axes().isEmpty() || partitioning.axes().stream()
                             .allMatch(axis -> axis.classes().isEmpty()),
                     "and divides it into classes a row can be composed at");
-            return new Model(new Generator.Subject(
+            return new Model(new Generator.Subject(spec.name(),
                     new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
                             sigs.get("fee").inputTypes(), symbols, ReadAs.THE_COMPILATION_DOES),
                     partitioning.axes(), HeldCounts.of(inputs, symbols)),

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
@@ -127,7 +127,7 @@ class ARowNothingRanFillsNoCombinationTest {
 
         List<Generator.GeneratedRow> composed = Generator.fill(model.subject(), List.of(),
                         Generator.CandidateCheck.ANY, model.read(),
-                        Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), takes, Budgets.generation())
+                        Generator.Trial.NOTHING_RUNS, List.of(), List.of(), List.copyOf(takes), Budgets.generation())
                 .rows();
 
         assertEquals(1, composed.size(), "one row answers both: " + composed);
@@ -155,7 +155,7 @@ class ARowNothingRanFillsNoCombinationTest {
                 Generator.everyArmACombinationMayTake(model.subject(), model.groups(), Budgets.generation());
         FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.refusing((_, _) -> java.util.Optional.of("no")),
-                model.read(), Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), every, Budgets.generation());
+                model.read(), Generator.Trial.NOTHING_RUNS, List.of(), List.of(), List.copyOf(every), Budgets.generation());
 
         assertEquals(List.of(), filled.rows(), "nothing builds, so nothing is composed");
         for (int probe : every) {
@@ -186,7 +186,7 @@ class ARowNothingRanFillsNoCombinationTest {
                 Generator.CandidateCheck.refusing((_, candidate) ->
                         candidate.text().contains("Premium")
                                 ? java.util.Optional.of("no") : java.util.Optional.empty()),
-                model.read(), Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), every, Budgets.generation());
+                model.read(), Generator.Trial.NOTHING_RUNS, List.of(), List.of(), List.copyOf(every), Budgets.generation());
 
         assertFalse(filled.rows().isEmpty(), "the combinations that build compose their rows");
         List<Integer> built = every.stream()
@@ -255,7 +255,8 @@ class ARowNothingRanFillsNoCombinationTest {
 
         FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(), Generator.Trial.NOTHING_RUNS,
-                List.of(), Generator.everyClassNoRowSitsIn(model.subject(), List.of()), every, Budgets.generation());
+                List.of(), Generator.everyClassNoRowSitsIn(model.subject(), List.of()),
+                List.copyOf(every), Budgets.generation());
 
         assertTrue(filled.reasons().stream()
                         .anyMatch(GenerationReason.SearchLimit.class::isInstance),
@@ -293,23 +294,23 @@ class ARowNothingRanFillsNoCombinationTest {
     @Test
     void aClassIsComposedForWhenItIsOnTheListAndNotOtherwise() {
         Model model = Model.of(SHIPPING, "shippingFee");
-        Set<Generator.ClassOwed> every =
+        List<Generator.ClassOwed> every =
                 Generator.everyClassNoRowSitsIn(model.subject(), List.of());
         assertFalse(every.isEmpty(), "the model divides its positions");
-        Generator.ClassOwed one = every.iterator().next();
+        Generator.ClassOwed one = every.get(0);
 
-        assertEquals(List.of(), composedFor(model, Set.of()),
+        assertEquals(List.of(), composedFor(model, List.of()),
                 "asked for no class, nothing is composed");
-        assertEquals(List.of(one), composedFor(model, Set.of(one)),
+        assertEquals(List.of(one), composedFor(model, List.of(one)),
                 "and asked for one, that one and nothing beside it");
     }
 
     /** Which classes the generator composes a row for when it is asked about {@code classes}. */
     private static List<Generator.ClassOwed> composedFor(Model model,
-                                                         Set<Generator.ClassOwed> classes) {
+                                                         List<Generator.ClassOwed> classes) {
         return Generator.fill(model.subject(), List.of(), Generator.CandidateCheck.ANY,
                         model.read(), Generator.Trial.NOTHING_RUNS, List.of(), classes,
-                        java.util.Set.of(), Budgets.generation())
+                        List.of(), Budgets.generation())
                 .rows().stream().flatMap(row -> row.purposes().stream())
                 .map(Generator.Purpose.ForAClass.class::cast)
                 .map(at -> new Generator.ClassOwed(at.at(), at.classId())).toList();
@@ -318,7 +319,7 @@ class ARowNothingRanFillsNoCombinationTest {
     /** Which arms the generator composes a row for when it is asked about {@code arms}. */
     private static Set<Integer> offeredFor(Model model, Set<Integer> arms) {
         return Generator.fill(model.subject(), List.of(), Generator.CandidateCheck.ANY,
-                        model.read(), Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), arms, Budgets.generation())
+                        model.read(), Generator.Trial.NOTHING_RUNS, List.of(), List.of(), List.copyOf(arms), Budgets.generation())
                 .rows().stream().flatMap(row -> row.purposes().stream())
                 .map(Generator.Purpose.ForAnArm.class::cast)
                 .map(Generator.Purpose.ForAnArm::probe)

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowNothingRanFillsNoCombinationTest.java
@@ -153,16 +153,16 @@ class ARowNothingRanFillsNoCombinationTest {
         Model model = Model.of(SHIPPING, "shippingFee");
         Set<Integer> every =
                 Generator.everyArmACombinationMayTake(model.subject(), model.groups(), Budgets.generation());
-        Generator.GenerationResult filled = Generator.fill(model.subject(), List.of(),
+        FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.refusing((_, _) -> java.util.Optional.of("no")),
                 model.read(), Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), every, Budgets.generation());
 
         assertEquals(List.of(), filled.rows(), "nothing builds, so nothing is composed");
         for (int probe : every) {
-            Generator.ArmAttempt at = filled.armAt(probe);
-            assertInstanceOf(Generator.ArmAttempt.Unresolved.class, at,
+            ArmDisposition at = filled.discharge().at(new Generator.ArmOwed(probe));
+            assertInstanceOf(ArmDisposition.Unresolved.class, at,
                     "the arm was tried and says so: " + probe);
-            assertEquals(3, ((Generator.ArmAttempt.Unresolved) at).why().size(),
+            assertEquals(3, ((ArmDisposition.Unresolved) at).why().size(),
                     "and keeps what each place it was looked for came to — the two combinations"
                             + " claiming it and the way into it: " + at);
         }
@@ -182,7 +182,7 @@ class ARowNothingRanFillsNoCombinationTest {
                 Generator.everyArmACombinationMayTake(model.subject(), model.groups(), Budgets.generation());
         // Refuses the first case of the first position, so the combinations naming it fail and the
         // ones beside them build. Every arm of the second decision is claimed by both.
-        Generator.GenerationResult filled = Generator.fill(model.subject(), List.of(),
+        FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.refusing((_, candidate) ->
                         candidate.text().contains("Premium")
                                 ? java.util.Optional.of("no") : java.util.Optional.empty()),
@@ -190,11 +190,11 @@ class ARowNothingRanFillsNoCombinationTest {
 
         assertFalse(filled.rows().isEmpty(), "the combinations that build compose their rows");
         List<Integer> built = every.stream()
-                .filter(probe -> filled.armAt(probe) instanceof Generator.ArmAttempt.Built)
+                .filter(probe -> filled.discharge().at(new Generator.ArmOwed(probe)) instanceof ArmDisposition.Built)
                 .toList();
         assertEquals(3, built.size(),
                 "the arm nothing builds is the refused one; the three beside it are answered: "
-                        + filled.arms());
+                        + filled.discharge().arms().values());
     }
 
     /**
@@ -253,7 +253,7 @@ class ARowNothingRanFillsNoCombinationTest {
                 Generator.everyArmACombinationMayTake(model.subject(), model.groups(), Budgets.generation());
         assertFalse(every.isEmpty(), "the body has arms");
 
-        Generator.GenerationResult filled = Generator.fill(model.subject(), List.of(),
+        FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(), Generator.Trial.NOTHING_RUNS,
                 List.of(), Generator.everyClassNoRowSitsIn(model.subject(), List.of()), every, Budgets.generation());
 
@@ -261,11 +261,11 @@ class ARowNothingRanFillsNoCombinationTest {
                         .anyMatch(GenerationReason.SearchLimit.class::isInstance),
                 "the classes alone spend the budget: " + filled.reasons());
         for (int probe : every) {
-            Generator.ArmAttempt at = filled.armAt(probe);
-            assertInstanceOf(Generator.ArmAttempt.Unresolved.class, at,
+            ArmDisposition at = filled.discharge().at(new Generator.ArmOwed(probe));
+            assertInstanceOf(ArmDisposition.Unresolved.class, at,
                     "the arm has an entry rather than the silence of one nothing claims: " + probe);
             assertEquals(List.of(Generator.UnresolvedCombination.Reason.SEARCH_LIMIT),
-                    ((Generator.ArmAttempt.Unresolved) at).why().stream()
+                    ((ArmDisposition.Unresolved) at).why().stream()
                             .map(Generator.UnresolvedCombination::reason).toList(),
                     "and says the search stopped, nothing having been tried at it");
         }
@@ -401,7 +401,7 @@ class ARowNothingRanFillsNoCombinationTest {
             assertNotNull(body, "the behavior under test has a body");
             CoverageSites.Plan plan = CoverageSites.of(checked.behaviorBodies(), checked.decisions(),
                 checked.supplied());
-            return new Model(new Generator.Subject(
+            return new Model(new Generator.Subject(spec.name(),
                     new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
                             sig.inputTypes(), symbols,
                             souther.compiler.query.ReadAs.THE_COMPILATION_DOES),

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowThroughAnArmIsComposedFromTheWayIntoItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowThroughAnArmIsComposedFromTheWayIntoItTest.java
@@ -109,7 +109,8 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
 
         FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(), Generator.Trial.NOTHING_RUNS,
-                List.of(), Set.of(), model.read().arms().keySet(), Budgets.generation());
+                List.of(), List.of(), List.copyOf(model.read().arms().keySet()),
+                Budgets.generation());
 
         assertEquals(List.of(), model.read().interactions(),
                 "nothing in this body consumes two decided values into one");
@@ -135,7 +136,8 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
 
         FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(), Generator.Trial.NOTHING_RUNS,
-                List.of(), Set.of(), model.read().arms().keySet(), Budgets.generation());
+                List.of(), List.of(), List.copyOf(model.read().arms().keySet()),
+                Budgets.generation());
 
         assertEquals(4, model.read().arms().size(), "two arms in each of the two helpers");
         assertTrue(filled.discharge().arms().values().stream().allMatch(ArmDisposition.Built.class::isInstance),
@@ -165,7 +167,7 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
         FillResult watched = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(),
                 _ -> new Generator.Watched.Ran(everywhere),
-                List.of(), Set.of(), everyArm, Budgets.generation());
+                List.of(), List.of(), List.copyOf(everyArm), Budgets.generation());
 
         assertEquals(1, watched.rows().size(),
                 () -> "one row was seen going through every arm, so one row is offered: "
@@ -180,7 +182,7 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
         // is taken off the list by a reading of where a row would go.
         FillResult unwatched = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(), Generator.Trial.NOTHING_RUNS,
-                List.of(), Set.of(), everyArm, Budgets.generation());
+                List.of(), List.of(), List.copyOf(everyArm), Budgets.generation());
         assertTrue(unwatched.rows().size() > 1,
                 () -> "which nothing here does on the strength of the reading: "
                         + inputsOf(unwatched));
@@ -201,7 +203,7 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
         FillResult filled = Generator.fill(model.subject(), List.of(),
                 // Refuses every value, so every way in is a search that ran and composed nothing.
                 Generator.CandidateCheck.refusing((_, _) -> java.util.Optional.of("no")),
-                model.read(), Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), everyArm,
+                model.read(), Generator.Trial.NOTHING_RUNS, List.of(), List.of(), List.copyOf(everyArm),
                 Budgets.generation());
 
         for (int probe : everyArm) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowThroughAnArmIsComposedFromTheWayIntoItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowThroughAnArmIsComposedFromTheWayIntoItTest.java
@@ -107,15 +107,15 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
     void anArmNoCombinationIsOverIsComposedForFromItsWayIn() {
         Model model = Model.of(NESTED, "press");
 
-        Generator.GenerationResult filled = Generator.fill(model.subject(), List.of(),
+        FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(), Generator.Trial.NOTHING_RUNS,
                 List.of(), Set.of(), model.read().arms().keySet(), Budgets.generation());
 
         assertEquals(List.of(), model.read().interactions(),
                 "nothing in this body consumes two decided values into one");
-        assertFalse(filled.arms().isEmpty(), "and every arm is answered");
-        assertTrue(filled.arms().stream().allMatch(Generator.ArmAttempt.Built.class::isInstance),
-                () -> "with a row through it: " + filled.arms());
+        assertFalse(filled.discharge().arms().values().isEmpty(), "and every arm is answered");
+        assertTrue(filled.discharge().arms().values().stream().allMatch(ArmDisposition.Built.class::isInstance),
+                () -> "with a row through it: " + filled.discharge().arms().values());
         assertTrue(inputsOf(filled).contains(List.of("Ready", "Reset")),
                 () -> "including the pair the tutorial's model is short of: " + inputsOf(filled));
         assertTrue(inputsOf(filled).contains(List.of("Running", "Reset")),
@@ -133,14 +133,14 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
     void twoArmsThatCameToOneSetOfValuesAreOneRow() {
         Model model = Model.of(SHIPPING, "shippingFee");
 
-        Generator.GenerationResult filled = Generator.fill(model.subject(), List.of(),
+        FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(), Generator.Trial.NOTHING_RUNS,
                 List.of(), Set.of(), model.read().arms().keySet(), Budgets.generation());
 
         assertEquals(4, model.read().arms().size(), "two arms in each of the two helpers");
-        assertTrue(filled.arms().stream().allMatch(Generator.ArmAttempt.Built.class::isInstance),
-                () -> "each answered: " + filled.arms());
-        assertTrue(filled.rows().size() < filled.arms().size(),
+        assertTrue(filled.discharge().arms().values().stream().allMatch(ArmDisposition.Built.class::isInstance),
+                () -> "each answered: " + filled.discharge().arms().values());
+        assertTrue(filled.rows().size() < filled.discharge().arms().values().size(),
                 () -> "in fewer rows than there are arms: " + inputsOf(filled));
         assertEquals(filled.rows().size(), new LinkedHashSet<>(inputsOf(filled)).size(),
                 () -> "and no two of them are the same line twice: " + inputsOf(filled));
@@ -162,7 +162,7 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
         Set<Integer> everyArm = model.read().arms().keySet();
         Observation everywhere = doing(model.read());
 
-        Generator.GenerationResult watched = Generator.fill(model.subject(), List.of(),
+        FillResult watched = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(),
                 _ -> new Generator.Watched.Ran(everywhere),
                 List.of(), Set.of(), everyArm, Budgets.generation());
@@ -178,7 +178,7 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
 
         // The same search where nothing watched anything: one row per arm's own way in, and no arm
         // is taken off the list by a reading of where a row would go.
-        Generator.GenerationResult unwatched = Generator.fill(model.subject(), List.of(),
+        FillResult unwatched = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.ANY, model.read(), Generator.Trial.NOTHING_RUNS,
                 List.of(), Set.of(), everyArm, Budgets.generation());
         assertTrue(unwatched.rows().size() > 1,
@@ -198,14 +198,14 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
         Model model = Model.of(NESTED, "press");
         Set<Integer> everyArm = model.read().arms().keySet();
 
-        Generator.GenerationResult filled = Generator.fill(model.subject(), List.of(),
+        FillResult filled = Generator.fill(model.subject(), List.of(),
                 // Refuses every value, so every way in is a search that ran and composed nothing.
                 Generator.CandidateCheck.refusing((_, _) -> java.util.Optional.of("no")),
                 model.read(), Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), everyArm,
                 Budgets.generation());
 
         for (int probe : everyArm) {
-            assertInstanceOf(Generator.ArmAttempt.Unresolved.class, filled.armAt(probe),
+            assertInstanceOf(ArmDisposition.Unresolved.class, filled.discharge().at(new Generator.ArmOwed(probe)),
                     "a way in this tried and composed nothing at is not one it never had: " + probe);
         }
         assertTrue(model.read().arms().values().stream()
@@ -214,7 +214,7 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
     }
 
     /** The values of each row, in the order the row writes them. */
-    private static List<List<String>> inputsOf(Generator.GenerationResult filled) {
+    private static List<List<String>> inputsOf(FillResult filled) {
         return filled.rows().stream()
                 .map(row -> row.inputs().stream().map(FixtureTemplate::text).toList())
                 .toList();
@@ -265,7 +265,7 @@ class ARowThroughAnArmIsComposedFromTheWayIntoItTest {
                     checked.supplied());
             Partitions.Partitioning partitioning =
                     Partitions.of(spec.name(), inputs, symbols, ReadAs.THE_COMPILATION_DOES);
-            return new Model(new Generator.Subject(
+            return new Model(new Generator.Subject(spec.name(),
                     new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
                             sigs.get(behavior).inputTypes(), symbols, ReadAs.THE_COMPILATION_DOES),
                     partitioning.axes(), HeldCounts.of(inputs, symbols)),

--- a/souther-compiler/src/test/java/souther/compiler/partition/ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest.java
@@ -90,7 +90,7 @@ class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
      */
     @Test
     void aCombinationLeftWithAnUnrunCandidateSaysTheSearchStopped() {
-        Generator.GenerationResult filled = fill(Model.of(TWO_FREE, "shippingFee"), _ -> MISSED);
+        FillResult filled = fill(Model.of(TWO_FREE, "shippingFee"), _ -> MISSED);
 
         assertEquals(Generator.UnresolvedCombination.Reason.SEARCH_LIMIT,
                 reasonFor(filled, List.of("member=Premium", "delivery=Express")),
@@ -105,7 +105,7 @@ class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
      */
     @Test
     void aCombinationEveryCandidateMissedSaysTheCandidatesWereNotWitnesses() {
-        Generator.GenerationResult filled = fill(Model.of(ONE_FREE, "shippingFee"), _ -> MISSED);
+        FillResult filled = fill(Model.of(ONE_FREE, "shippingFee"), _ -> MISSED);
 
         assertEquals(Generator.UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS,
                 reasonFor(filled, List.of("member=Premium", "delivery=Express")),
@@ -126,7 +126,7 @@ class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
      */
     @Test
     void candidatesWhoseValuesAlreadyRanDoNotStopTheSearch() {
-        Generator.GenerationResult filled = fill(Model.of(ONE_FREE, "shippingFee"), _ -> MISSED);
+        FillResult filled = fill(Model.of(ONE_FREE, "shippingFee"), _ -> MISSED);
 
         assertEquals(Generator.UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS,
                 reasonFor(filled, List.of("member=Premium")),
@@ -159,7 +159,7 @@ class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
 
     /** What the search made of the one combination named by {@code classes}. */
     private static Generator.UnresolvedCombination.Reason reasonFor(
-            Generator.GenerationResult filled, List<String> classes) {
+            FillResult filled, List<String> classes) {
         return filled.unresolved().stream()
                 .filter(each -> each.classes().equals(classes))
                 .findFirst()
@@ -169,7 +169,7 @@ class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
                 .reason();
     }
 
-    private static Generator.GenerationResult fill(Model model, Generator.Trial trial) {
+    private static FillResult fill(Model model, Generator.Trial trial) {
         return Generator.fill(model.subject(), List.of(), Generator.CandidateCheck.ANY,
                 model.read(), trial, Budgets.generation());
     }
@@ -200,7 +200,7 @@ class ASearchThatStoppedSaysSoRatherThanNamingItsLastRefusalTest {
             assertNotNull(inputs, "the behavior's inputs were read");
             Core body = checked.behaviorBodies().get(behavior);
             assertNotNull(body, "the behavior under test has a body");
-            return new Model(new Generator.Subject(
+            return new Model(new Generator.Subject(spec.name(),
                     new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
                             sig.inputTypes(), symbols,
                             souther.compiler.query.ReadAs.THE_COMPILATION_DOES),

--- a/souther-compiler/src/test/java/souther/compiler/partition/ASubjectNamesTheBehaviorItsAxesAreOfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ASubjectNamesTheBehaviorItsAxesAreOfTest.java
@@ -1,0 +1,73 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.check.Symbols;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.query.ReadAs;
+import souther.compiler.types.Type;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Which behavior a subject is about is the subject's own answer.
+ *
+ * <p>It used to be read back off the first axis, which answers only where the model divides some
+ * position. A behavior whose inputs nothing bounds has no axis and still has a name, and every
+ * sentence a generation says about the behavior as a whole — what a search limit stopped, which
+ * groups went unoffered — had to reach that name through a position that may not be there.
+ *
+ * <p>Holding the name is half of it. The other half is that it agrees with the axes: a subject
+ * assembled from two measurements would have two answers to one question, and whichever sentence
+ * read one of them would be right about one behavior and wrong about the other.
+ */
+class ASubjectNamesTheBehaviorItsAxesAreOfTest {
+
+    private static final Symbols SYMBOLS = Symbols.none(DefaultStdlib.get());
+
+    /** A behavior with no divided position, which is where reading the name off an axis ran out. */
+    @Test
+    void theNameHoldsWhereNothingIsDivided() {
+        Generator.Subject subject = new Generator.Subject("fee",
+                new BehaviorInputs(List.of("days"), List.of(Type.INT), SYMBOLS,
+                        ReadAs.THE_COMPILATION_DOES),
+                List.of(), HeldCounts.NONE);
+
+        assertEquals("fee", subject.behavior(),
+                "the behavior is named whether or not anything divided its positions");
+    }
+
+    /** An axis of another behavior, which is what a subject built from two measurements holds. */
+    @Test
+    void anAxisOfAnotherBehaviorIsRefused() {
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> new Generator.Subject("fee",
+                        new BehaviorInputs(List.of("days"), List.of(Type.INT), SYMBOLS,
+                                ReadAs.THE_COMPILATION_DOES),
+                        List.of(axisOf("charge", "days")), HeldCounts.NONE));
+
+        assertEquals(true, refused.getMessage().contains("charge"),
+                "the refusal names the axis that disagrees: " + refused.getMessage());
+    }
+
+    /** And asked of all of them, not of whichever one the check happened to reach first. */
+    @Test
+    void everyAxisIsAsked() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Generator.Subject("fee",
+                        new BehaviorInputs(List.of("days", "cap"), List.of(Type.INT, Type.INT),
+                                SYMBOLS, ReadAs.THE_COMPILATION_DOES),
+                        List.of(axisOf("fee", "days"), axisOf("charge", "cap")), HeldCounts.NONE),
+                "an axis of another behavior standing second is still one");
+    }
+
+    private static Axis axisOf(String behavior, String position) {
+        return new Axis(new AxisId(behavior, position),
+                new NumericTerm.ValueOf(TermPath.of(position)), Type.INT, List.of(), List.of());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAlternativeAssignmentIsAsCompatibleAsTheFirstTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAlternativeAssignmentIsAsCompatibleAsTheFirstTest.java
@@ -128,7 +128,7 @@ class AnAlternativeAssignmentIsAsCompatibleAsTheFirstTest {
 
         FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.refusing(AnAlternativeAssignmentIsAsCompatibleAsTheFirstTest::notTheFirst),
-                model.read(), Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), every,
+                model.read(), Generator.Trial.NOTHING_RUNS, List.of(), List.of(), List.copyOf(every),
                 Budgets.generation());
 
         assertEquals(List.of(), filled.unresolved().stream()

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAlternativeAssignmentIsAsCompatibleAsTheFirstTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAlternativeAssignmentIsAsCompatibleAsTheFirstTest.java
@@ -97,7 +97,7 @@ class AnAlternativeAssignmentIsAsCompatibleAsTheFirstTest {
                 checked.supplied());
         Partitions.Partitioning axes =
                 Partitions.of(spec.name(), inputs, symbols, ReadAs.THE_COMPILATION_DOES);
-        return new Model(new Generator.Subject(
+        return new Model(new Generator.Subject(spec.name(),
                 new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
                         sig.inputTypes(), symbols, ReadAs.THE_COMPILATION_DOES),
                 axes.axes(), HeldCounts.of(inputs, symbols)),
@@ -126,7 +126,7 @@ class AnAlternativeAssignmentIsAsCompatibleAsTheFirstTest {
                 Budgets.generation());
         assertFalse(every.isEmpty(), "the body has arms a combination takes");
 
-        Generator.GenerationResult filled = Generator.fill(model.subject(), List.of(),
+        FillResult filled = Generator.fill(model.subject(), List.of(),
                 Generator.CandidateCheck.refusing(AnAlternativeAssignmentIsAsCompatibleAsTheFirstTest::notTheFirst),
                 model.read(), Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), every,
                 Budgets.generation());

--- a/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
@@ -110,13 +110,13 @@ class GeneratorTest {
         List<String> parameters = spec.params().stream().map(Hir.Param::name).toList();
         InputDomain domain = InputDomain.of(spec, sig, symbols, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
         Partitions.Partitioning partitioning = Partitions.of(spec.name(), domain, symbols, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
-        return new Model(new Generator.Subject(
+        return new Model(new Generator.Subject(spec.name(),
                 new BehaviorInputs(parameters, sig.inputTypes(), symbols, souther.compiler.query.ReadAs.THE_COMPILATION_DOES), partitioning.axes(),
                 HeldCounts.of(domain, symbols)),
                 symbols);
     }
 
-    private static List<String> texts(Generator.GenerationResult result) {
+    private static List<String> texts(FillResult result) {
         List<String> out = new ArrayList<>();
         for (Generator.GeneratedRow row : result.rows()) {
             out.add(String.join(", ", row.inputs().stream().map(FixtureTemplate::text).toList()));
@@ -135,7 +135,7 @@ class GeneratorTest {
      */
     @Test
     void everyClassNoRowIsInGetsARowAboutThatClassAlone() {
-        Generator.GenerationResult filled = Generator.fill(modelOf(TRIP, "submit").subject(),
+        FillResult filled = Generator.fill(modelOf(TRIP, "submit").subject(),
                 List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
 
         assertEquals(List.of(), filled.unresolved());
@@ -152,7 +152,7 @@ class GeneratorTest {
      * are two positions of one {@code Request}, and a row writes one of those. */
     @Test
     void positionsOfOneParameterCompoundIntoOneValue() {
-        Generator.GenerationResult filled = Generator.fill(modelOf(TRIP, "submit").subject(),
+        FillResult filled = Generator.fill(modelOf(TRIP, "submit").subject(),
                 List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
 
         assertEquals(1, filled.rows().get(0).inputs().size());
@@ -168,7 +168,7 @@ class GeneratorTest {
                 new AxisId("submit", "request.kind"), Classification.in("Domestic"),
                 new AxisId("submit", "request.urgent"), Classification.in("true"));
 
-        Generator.GenerationResult filled =
+        FillResult filled =
                 Generator.fill(subject, List.of(Generator.ObservedRow.unseen(written)),
                         Generator.CandidateCheck.ANY, Budgets.generation());
 
@@ -180,9 +180,9 @@ class GeneratorTest {
     /** A block that changed between two runs of one model could not be compared with the last one. */
     @Test
     void theSameModelGeneratesTheSameRowsTwice() {
-        Generator.GenerationResult once = Generator.fill(modelOf(TRIP, "submit").subject(),
+        FillResult once = Generator.fill(modelOf(TRIP, "submit").subject(),
                 List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
-        Generator.GenerationResult again = Generator.fill(modelOf(TRIP, "submit").subject(),
+        FillResult again = Generator.fill(modelOf(TRIP, "submit").subject(),
                 List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
 
         assertEquals(texts(once), texts(again));
@@ -201,7 +201,7 @@ class GeneratorTest {
                 List.of());
         // Axes written here rather than read off a model, so there is no reading of the input's
         // counts to hand over and none is invented.
-        return new Generator.Subject(
+        return new Generator.Subject("f",
                 new BehaviorInputs(List.of("a", "b"), List.of(Type.INT, Type.INT), symbols, souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
                 List.of(a, b), HeldCounts.NONE);
     }
@@ -231,7 +231,7 @@ class GeneratorTest {
                 (at, candidate) -> candidate.text().equals("1") || candidate.text().equals("10")
                         ? Optional.of("the first pair is not allowed together") : Optional.empty());
 
-        Generator.GenerationResult filled =
+        FillResult filled =
                 Generator.fill(subject, List.of(), refusesTheFirst, Budgets.generation());
 
         assertEquals(List.of(), filled.unresolved());
@@ -252,7 +252,7 @@ class GeneratorTest {
         Generator.Subject subject = twoNumbers(symbols, List.of(number("low", 1)),
                 List.of(number("high", 10)));
 
-        Generator.GenerationResult filled =
+        FillResult filled =
                 Generator.fill(subject, List.of(),
                         Generator.CandidateCheck.refusing((_, _) -> Optional.of("no")), Budgets.generation());
 
@@ -275,7 +275,7 @@ class GeneratorTest {
                 List.of(PartitionClass.ungeneratable("opaque", "opaque", new Recognition.Nothing(), "no value")),
                 List.of(number("high", 10)));
 
-        Generator.GenerationResult filled =
+        FillResult filled =
                 Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
 
         assertEquals(List.of(), filled.rows());
@@ -299,7 +299,7 @@ class GeneratorTest {
                         number("low", 1)),
                 List.of(number("high", 10), number("higher", 20)));
 
-        Generator.GenerationResult filled =
+        FillResult filled =
                 Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
 
         List<String> subjects = filled.unresolved().stream()
@@ -320,7 +320,7 @@ class GeneratorTest {
      */
     @Test
     void aRecordCaseOfASumIsComposedFromItsFields() {
-        Generator.GenerationResult filled = Generator.fill(modelOf(PAYMENT, "feeFor").subject(),
+        FillResult filled = Generator.fill(modelOf(PAYMENT, "feeFor").subject(),
                 List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
 
         assertEquals(List.of(), filled.unresolved(), filled.unresolved().toString());
@@ -338,7 +338,7 @@ class GeneratorTest {
      */
     @Test
     void anOptionalWhoseElementIsARecordIsOfferedARow() {
-        Generator.GenerationResult filled = Generator.fill(
+        FillResult filled = Generator.fill(
                 modelOf(OPTIONAL_RECORD, "feeOf").subject(), List.of(),
                 Generator.CandidateCheck.ANY, Budgets.generation());
 
@@ -364,7 +364,7 @@ class GeneratorTest {
                         "no value this position can hold lies inside this range")),
                 List.of(number("high", 10)));
 
-        Generator.GenerationResult filled =
+        FillResult filled =
                 Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
 
         assertEquals(List.of(), filled.rows(), "nothing was composed at the first position");
@@ -387,11 +387,11 @@ class GeneratorTest {
         Symbols symbols = modelOf(TRIP, "submit").symbols();
         Axis only = new Axis(new AxisId("f", "a"), new NumericTerm.ValueOf(TermPath.of("a")), Type.INT,
                 List.of(number("low", 1), number("high", 9)), List.of());
-        Generator.Subject subject = new Generator.Subject(
+        Generator.Subject subject = new Generator.Subject("f",
                 new BehaviorInputs(List.of("a"), List.of(Type.INT), symbols, souther.compiler.query.ReadAs.THE_COMPILATION_DOES), List.of(only),
                 HeldCounts.NONE);
 
-        Generator.GenerationResult filled =
+        FillResult filled =
                 Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY, Budgets.generation());
 
         assertEquals(List.of("1", "9"), texts(filled));

--- a/souther-compiler/src/test/java/souther/compiler/partition/NoAxesByItselfIsNotAGenerationReasonTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/NoAxesByItselfIsNotAGenerationReasonTest.java
@@ -1,0 +1,70 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.check.Symbols;
+import souther.compiler.query.ReadAs;
+import souther.compiler.reading.CoverageRead;
+import souther.compiler.reading.PathAccess;
+import souther.compiler.types.Type;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A behavior the model divides nowhere still gets the answers its arms have.
+ *
+ * <p>The search over the classes has nothing to walk where no position is divided, and it used to
+ * return there — taking the arms with it, which do not read the classes for their answer. What it
+ * takes to arrive at an arm is what the reading of the body says, and that reading is made before
+ * the search is called. An arm it has an answer for was left with no entry at all, and whoever read
+ * the result for one had nothing to go on but the absence.
+ *
+ * <p>And no reason is written for it either. Nothing being divided is a fact about the classes and
+ * not something that happened to this generation: a reason here would be a sentence about the whole
+ * run, read beside rows it is not short of. What does belong in the reasons — the rows could not be
+ * read, the classes would not link — is written by whatever established it, and having no axis is
+ * not one of those.
+ */
+class NoAxesByItselfIsNotAGenerationReasonTest {
+
+    private static final Symbols SYMBOLS = Symbols.none(DefaultStdlib.get());
+
+    private static final PathAccess NOT_ENUMERABLE =
+            new PathAccess.Unsupported(PathAccess.Unsupported.Why.WAYS_NOT_ENUMERABLE);
+
+    @Test
+    void anArmIsAnsweredWhereNoPositionIsDivided() {
+        FillResult filled = filledOverOneArm();
+
+        assertEquals(Map.of(new Generator.ArmOwed(1), new ArmDisposition.NoWayIn(NOT_ENUMERABLE)),
+                filled.discharge().arms(),
+                "the arm's own entry, in the words the reading of the body used");
+    }
+
+    @Test
+    void havingNoAxisIsNotWrittenDownAsAReason() {
+        FillResult filled = filledOverOneArm();
+
+        assertEquals(List.of(), filled.reasons(),
+                "nothing happened to this generation that a reader is owed a sentence about");
+    }
+
+    /** One arm the reading has an answer for, over a behavior whose position nothing divides. */
+    private static FillResult filledOverOneArm() {
+        Generator.Subject subject = new Generator.Subject("fee",
+                new BehaviorInputs(List.of("days"), List.of(Type.INT), SYMBOLS,
+                        ReadAs.THE_COMPILATION_DOES),
+                List.of(), HeldCounts.NONE);
+        CoverageRead.Read read =
+                new CoverageRead.Read(List.of(), Map.of(1, NOT_ENUMERABLE));
+
+        return Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY, read,
+                Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), Set.of(1),
+                Budgets.generation());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/NoAxesByItselfIsNotAGenerationReasonTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/NoAxesByItselfIsNotAGenerationReasonTest.java
@@ -11,7 +11,6 @@ import souther.compiler.types.Type;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -64,7 +63,7 @@ class NoAxesByItselfIsNotAGenerationReasonTest {
                 new CoverageRead.Read(List.of(), Map.of(1, NOT_ENUMERABLE));
 
         return Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY, read,
-                Generator.Trial.NOTHING_RUNS, List.of(), Set.of(), Set.of(1),
+                Generator.Trial.NOTHING_RUNS, List.of(), List.of(), List.of(1),
                 Budgets.generation());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/NoAxesByItselfIsNotAGenerationReasonTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/NoAxesByItselfIsNotAGenerationReasonTest.java
@@ -59,8 +59,9 @@ class NoAxesByItselfIsNotAGenerationReasonTest {
                 new BehaviorInputs(List.of("days"), List.of(Type.INT), SYMBOLS,
                         ReadAs.THE_COMPILATION_DOES),
                 List.of(), HeldCounts.NONE);
-        CoverageRead.Read read =
-                new CoverageRead.Read(List.of(), Map.of(1, NOT_ENUMERABLE));
+        java.util.SequencedMap<Integer, PathAccess> ways = new java.util.LinkedHashMap<>();
+        ways.put(1, NOT_ENUMERABLE);
+        CoverageRead.Read read = new CoverageRead.Read(List.of(), ways);
 
         return Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY, read,
                 Generator.Trial.NOTHING_RUNS, List.of(), List.of(), List.of(1),

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest.java
@@ -20,7 +20,6 @@ import souther.compiler.query.Shapes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -88,9 +87,9 @@ class OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest {
             for (Map.Entry<Integer, Integer> pin : onePinWaysInto(probe, model, axes)) {
                 Axis axis = axes.get(pin.getKey());
                 assertEquals(
-                        rowsOf(model, Set.of(new Generator.ClassOwed(axis.id(),
-                                axis.classes().get(pin.getValue()).id())), Set.of()),
-                        rowsOf(model, Set.of(), Set.of(probe)),
+                        rowsOf(model, List.of(new Generator.ClassOwed(axis.id(),
+                                axis.classes().get(pin.getValue()).id())), List.of()),
+                        rowsOf(model, List.of(), List.of(probe)),
                         "the class of " + axis.path() + " and the arm it is the way into");
                 asked++;
             }
@@ -124,8 +123,8 @@ class OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest {
     }
 
     /** What one run of the search offered, by the values each row carries. */
-    private static List<List<String>> rowsOf(Model model, Set<Generator.ClassOwed> classes,
-                                             Set<Integer> arms) {
+    private static List<List<String>> rowsOf(Model model, List<Generator.ClassOwed> classes,
+                                             List<Integer> arms) {
         return Generator.fill(model.subject(), List.of(), Generator.CandidateCheck.ANY,
                         model.read(), Generator.Trial.NOTHING_RUNS, List.of(), classes, arms,
                         Budgets.generation())

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest.java
@@ -160,7 +160,7 @@ class OneDemandOverOnePositionIsOneRowHoweverItIsAskedTest {
             assertNotNull(inputs, "the behavior's inputs were read");
             Core body = checked.behaviorBodies().get(behavior);
             assertNotNull(body, "the behavior under test has a body");
-            return new Model(new Generator.Subject(
+            return new Model(new Generator.Subject(spec.name(),
                     new BehaviorInputs(spec.params().stream().map(Hir.Param::name).toList(),
                             sig.inputTypes(), symbols,
                             souther.compiler.query.ReadAs.THE_COMPILATION_DOES),

--- a/souther-compiler/src/test/java/souther/compiler/partition/TheCompositionIsNotBehindTheBaselinesBudgetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/TheCompositionIsNotBehindTheBaselinesBudgetTest.java
@@ -84,23 +84,25 @@ class TheCompositionIsNotBehindTheBaselinesBudgetTest {
         Adequacy.Filling filling = generated(crowded()).get("submit");
         assertNotNull(filling, "the behavior under test is generated for");
 
-        Generator.ClassAttempt at = attemptAtTheLowerHi(filling);
+        ClassDisposition at = attemptAtTheLowerHi(filling);
         assertEquals(List.of("Request { lo = Amount(0), hi = Amount(0) }"),
-                ((Generator.ClassAttempt.Built) at).row().inputs().stream()
+                filling.composed().rowFor(((ClassDisposition.Built) at).row()).inputs().stream()
                         .map(FixtureTemplate::text).toList(),
                 "composed from the classes, which is what a row is where none of the values the "
                         + "model states can be written for it: " + at);
     }
 
     /** What the search made of the class {@code hi} takes below the line the body draws. */
-    private static Generator.ClassAttempt attemptAtTheLowerHi(Adequacy.Filling filling) {
-        for (Generator.ClassAttempt each : filling.composed().classes()) {
-            if (each.at().term().endsWith("hi") && each.classId().contains("0")) {
-                return each;
+    private static ClassDisposition attemptAtTheLowerHi(Adequacy.Filling filling) {
+        for (Map.Entry<Generator.ClassOwed, ClassDisposition> each
+                : filling.composed().discharge().classes().entrySet()) {
+            if (each.getKey().at().term().endsWith("hi")
+                    && each.getKey().classId().contains("0")) {
+                return each.getValue();
             }
         }
         throw new AssertionError("the lower class of `hi` is one the search was asked about: "
-                + filling.composed().classes());
+                + filling.composed().discharge().classes());
     }
 
     private static Map<String, Adequacy.Filling> generated(String source) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/TwoValuesStandingAlikeAreStillTwoValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/TwoValuesStandingAlikeAreStillTwoValuesTest.java
@@ -93,6 +93,6 @@ class TwoValuesStandingAlikeAreStillTwoValuesTest {
             }
         }
         throw new AssertionError("no row was offered for " + classId + ": "
-                + filling.composed().classes());
+                + filling.composed().discharge().classes().values());
     }
 }


### PR DESCRIPTION
Closes #1040.

## What was wrong

`EveryFindingHasAGenerationDispositionTest.POLICY` reached a reader as
`CannotGenerate[[then], NO_REASON_RECORDED]` — this compiler's own words for
having failed to say why. The issue reads that as a missing `GenerationReason`
at the place the search declines to start.

Measuring it says otherwise. What the gate at `Generator.fill`'s
`axes.isEmpty()` threw away was not a reason but an answer the run already had:
`read.armAt(1)` held `Unsupported(WAYS_NOT_ENUMERABLE)` before `fill` was
called. The gate is written for the classes half — no axis, no class to search —
and it took the arms half with it, and the arms do not read the classes for
their answer.

So the reason the issue proposes would install a wrong one. Two models that both
reach the gate deserve different answers:

| model | before | after |
| --- | --- | --- |
| `if accrued > policy.cap.value` (issue's) | `CannotGenerate[NO_REASON_RECORDED]` | `NotSupported[THE_WAYS_INTO_THIS_ARM_ARE_NOT_ENUMERABLE]` |
| `if days > cap then cap else days` | `CannotGenerate[NO_REASON_RECORDED]` | `CannotGenerate[THE_WAY_IN_PLACES_AT_NO_CLASS]` |

One word for both is false about the first, whose arm no amount of dividing
reaches. The issue's second question — whether to widen
`NotSupported.Reason.NO_AXIS_AT_THIS_POSITION` or put a sibling beside it — is
neither: that reason was produced by `atCase` re-deriving "is this position
divided" from a partition's axes, which is a second reading of what the search's
own universe is. That duplicate is removed rather than widened.

## The root cause

`fill` was handed two lists of obligations and returned two lists of attempts,
and nothing required the second to cover the first. The rule is stated in its own
comments; three exits broke it, and the reader coped by asking a behavior-level
list of reasons a question about one item — confessing when the list was empty.

## What this changes

The obligations are a value the run carries. `GenerationPlan` holds the subject,
the classes and the arms, settled before anything that can stop the run, so the
ways out that never search hold the same list the search does. `FillResult`
holds the plan beside what became of each entry, and its constructor settles
totality:

    keys(discharge.classes) == plan.classesOwed
    keys(discharge.arms)    == plan.armsOwed
    image of the Built answers == the rows composed

`whyNothingWasTried`, the null branches in `atClass`/`atArm`, `ArmAttempt` and
`NO_REASON_RECORDED` are gone. `GenerationResult` keeps only what a generation
with no plan comes to, which is the rows offered at the boundaries.

`GeneratedRow.purposes` is now a projection of the discharge, taken in the plan's
order — classes then arms. That closes a second inconsistency this uncovered:
`keep` merged an arm's row into a class's and replaced the entry in the offer,
updating the arm map and leaving the class's attempt holding the line from before
the merge. Reachable in a four-line model; nothing printed it yet.

## Two things measurement settled

- **A class inside a collection the rules cap at none is owed a row and was
  never answered for.** The new constructor fails on two models already in the
  suite. No new word was invented: nothing stands there in any row the model
  admits, which is `THE_RULES_LEAVE_NOTHING_THERE`, and a reader may act on it.
- **Numbering the composed rows by their text was wrong.** A class's row does not
  go through `keep`, so two classes answered by rows written alike are two rows.
  A row is numbered where it was composed and `keep` answers with that number,
  which also removes the compaction pass the stale entry came from.

## Also

- `Subject` carries the behavior it is of, checked against its axes, so a run
  with no divided position still has a name for what it says about itself. Three
  reads of `axes.get(0).id().behavior()` go.
- `NO_CANDIDATE_WAS_OFFERED` replaces the old confession where it was doing
  honest work: a walk that ran to the end and put no value forward.
- `Adequacy.Boundaries.probing` removed; no caller reached it after that search
  moved into `BoundarySearch`.
- `EveryFindingHasAGenerationDispositionTest.anArmAStrategyTriesAndComposesNothingForSaysWhatItCameTo`
  said a search runs at this arm. None does — the generation stops before the
  arms. Renamed and its assertion fixed to the value the run actually reaches,
  which is the line the issue asked to have corrected.

## Verification

`mvn -o test` from the reactor root: 6903 tests in souther-compiler, all
modules green. `AFillIsTotalOverThePlanItWasAskedWithTest` holds the three
invariants; disabling them in the constructor fails 6 of its 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
