### PR TITLE
Answer for every behavior a measure of a module was asked about

### DIFF
--- a/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
+++ b/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
@@ -110,11 +110,11 @@ class AMeasureIsIntroducedInOnePlaceTest {
             // parameter to it — five factories and one introduction, which is what keeps them
             // saying the same thing.
             Map.entry("souther.compiler.query.BoundaryForMeasurement#failed(Ljava/lang/String;)Lsouther/compiler/query/Measurement;", 1),
-            // The positions of such a behavior, where its declaration writes them. What the
-            // parameters are is known and no case of any of them was read, which is neither of the
-            // two the factory above chooses between.
-            Map.entry("souther.compiler.query.Adequacy$SignatureEvidence#boundaryNotDerived(Lsouther/compiler/ast/Hir$BehaviorDef;)Lsouther/compiler/query/Adequacy$SignatureEvidence;", 1),
-            // And the positions of a signature that was read, which is every one of them.
+            // And the positions of a signature, which are its own measure: known where something
+            // wrote them down, whether that is the boundary or the declaration the boundary was to
+            // be built from, and unknown where a composition takes what a stage nobody could work
+            // out takes. Two states and one place that chooses between them — the cases at each
+            // position are that position's own answer and never this one's.
             Map.entry("souther.compiler.query.Adequacy$SignatureEvidence#at(Ljava/util/List;)Lsouther/compiler/query/Measure;", 1)));
 
     @Test

--- a/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
+++ b/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
@@ -104,7 +104,18 @@ class AMeasureIsIntroducedInOnePlaceTest {
             Map.entry("souther.compiler.query.Adequacy$SignatureEvidence#notAsked(Lsouther/compiler/query/OutputCaseEvidence;Ljava/util/List;)Lsouther/compiler/query/Adequacy$SignatureEvidence;", 1),
             Map.entry("souther.compiler.query.PartitionEvidence$AxisCoverage#notAsked(Lsouther/compiler/partition/AxisId;Ljava/lang/String;Ljava/util/List;Lsouther/compiler/query/PartitionEvidence$AxisCoverage$Reading;)Lsouther/compiler/query/PartitionEvidence$AxisCoverage;", 1),
             Map.entry("souther.compiler.query.PartitionEvidence$PairSpace#notAsked(I)Lsouther/compiler/query/PartitionEvidence$PairSpace;", 1),
-            Map.entry("souther.compiler.query.ItemAssessment#weakeningSource()Lsouther/compiler/query/Measurement;", 1)));
+            Map.entry("souther.compiler.query.ItemAssessment#weakeningSource()Lsouther/compiler/query/Measurement;", 1),
+            // A behavior whose boundary could not be worked out. Every measure of it is short of
+            // the same one thing, so the state is made here and each of them hands its own type
+            // parameter to it — five factories and one introduction, which is what keeps them
+            // saying the same thing.
+            Map.entry("souther.compiler.query.BoundaryForMeasurement#failed(Ljava/lang/String;)Lsouther/compiler/query/Measurement;", 1),
+            // The positions of such a behavior, where its declaration writes them. What the
+            // parameters are is known and no case of any of them was read, which is neither of the
+            // two the factory above chooses between.
+            Map.entry("souther.compiler.query.Adequacy$SignatureEvidence#boundaryNotDerived(Lsouther/compiler/ast/Hir$BehaviorDef;)Lsouther/compiler/query/Adequacy$SignatureEvidence;", 1),
+            // And the positions of a signature that was read, which is every one of them.
+            Map.entry("souther.compiler.query.Adequacy$SignatureEvidence#at(Ljava/util/List;)Lsouther/compiler/query/Measure;", 1)));
 
     @Test
     void nothingButTheIntroductionRuleMakesACaseOfAMeasure() throws Exception {

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -450,12 +450,19 @@ public final class Adequacy {
         /**
          * That the signature's cases were counted.
          *
-         * <p><b>Why the positions are inside a measure and not a bare list.</b> How many positions
-         * a behavior has is read off its boundary, so a behavior whose boundary was not worked out
-         * has a number of positions nobody knows. Held as a list, that state is an empty one — the
-         * same bytes as a behavior that takes nothing — and a reader counting the entries would
-         * answer "no positions" to a question nobody could answer. The same reason the positions of
-         * the partition measure are inside one ({@code PartitionEvidence.partitioned}).
+         * <p><b>Whether the positions are known is not whether the boundary was worked out.</b> They
+         * are two questions and this measure exists because they are: a declared behavior writes its
+         * parameters, so its layout is known off the declaration whatever the boundary did, and only
+         * the cases at each position go unread. A {@code >->} writes none — it takes what its first
+         * stage takes — so a composition is the one shape whose layout has nowhere else to come
+         * from, and the one whose positions can be unknown.
+         *
+         * <p><b>Which is why they are inside a measure and not a bare list.</b> Held as a list, an
+         * unknown layout is an empty one — the same bytes as a behavior that takes nothing — and a
+         * reader counting the entries would answer "no positions" to a question nobody could
+         * answer. The same reason the positions of the partition measure are inside one
+         * ({@code PartitionEvidence.partitioned}), which answers a different question about a
+         * different set: what the model divides, which no declaration gives.
          */
         public record Counted() {}
 
@@ -524,7 +531,8 @@ public final class Adequacy {
             return out;
         }
 
-        /** The positions of a signature that was read, which is every one of them. */
+        /** The positions, where something wrote them down — the boundary, or the declaration the
+         *  boundary was to have been built from. Every one of them, whatever was read at each. */
         static Measure<List<InputCaseEvidence>> at(List<InputCaseEvidence> inputs) {
             return new Measurement.Complete<>(List.copyOf(inputs));
         }
@@ -565,12 +573,17 @@ public final class Adequacy {
         }
 
         /**
-         * The positions, where the boundary they are read off was worked out.
+         * The positions, where anything said how many there are.
          *
-         * <p>Throws where it was not, the way {@link OutputCaseEvidence#seen()} and
-         * {@code PairSpace.counts()} do. An accessor that answered an empty list instead would be
-         * the thing the measure around it was introduced to remove: a reader would get an answer
-         * and no sign that nobody counted.
+         * <p>Which is not the same as the boundary having been worked out: a declared behavior's
+         * are its parameters, and they are here whatever became of the boundary — each of them
+         * saying for itself what was read of its cases. What has none is a composition whose first
+         * stage's boundary did not work out, which is the one shape with nowhere else to take a
+         * layout from.
+         *
+         * <p>Throws there, the way {@link OutputCaseEvidence#seen()} and {@code PairSpace.counts()}
+         * do. An accessor that answered an empty list instead would be the thing the measure around
+         * it was introduced to remove: a reader would get an answer and no sign that nobody counted.
          */
         public List<InputCaseEvidence> positions() {
             return inputs.made().orElseThrow(() -> new IllegalStateException(

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -410,8 +410,7 @@ public final class Adequacy {
      * skipped the behavior instead published a map with a hole in it — one its own readers then
      * read three ways: as a composition with nothing to measure, as the whole query not having
      * answered, and as this compiler disagreeing with itself. Two of those are wrong about a
-     * behavior whose declaration rests on a name nothing resolved, and the third stopped the report
-     * (issue #1044).
+     * behavior whose declaration rests on a name nothing resolved, and the third stops the report.
      *
      * <p>So the loop is here and the caller writes what one behavior comes to. It is handed a
      * declaration and owes a value: a mapper that answered {@code null} would be the skip again,
@@ -502,10 +501,14 @@ public final class Adequacy {
          */
         public static SignatureEvidence boundaryNotDerived(Hir.BehaviorDef behavior) {
             String name = behavior.name();
+            // The positions themselves, where the declaration writes them. They are read off the
+            // declaration and nothing about them went short — what could not be read is the cases
+            // at each of them, which is each position's own answer. A measurement of the list that
+            // said it was weakened would be a shortfall in a thing that has none, and the same two
+            // states this measure exists to tell apart would be three.
             Measure<List<InputCaseEvidence>> positions =
                     behavior instanceof Hir.SpecBehavior spec
-                            ? new Measurement.Partial<>(declaredPositions(name, spec),
-                                    BoundaryForMeasurement.wentWithout(name))
+                            ? at(declaredPositions(name, spec))
                             : BoundaryForMeasurement.failed(name);
             return new SignatureEvidence(OutputCaseEvidence.boundaryNotDerived(name), positions,
                     BoundaryForMeasurement.failed(name));
@@ -1056,10 +1059,10 @@ public final class Adequacy {
                             checkedBodies == null ? souther.compiler.coverage.SuppliedRules.NONE : checkedBodies.supplied());
             Map<String, souther.compiler.check.PathReachability.Answers.AsRun> reachableArms = db.ask(new Arrived(name)).value();
             return answerEveryBehavior(prepared.value(), behavior ->
-                    // What this measure works from, or the fact that it has none. A behavior whose
-                    // boundary did not work out used to be left out of this map, which reads as a
-                    // measure nobody asked for — so a behavior nothing could be established about
-                    // was held to no bar at all, silently (issue #1044).
+                    // What this measure works from, or the fact that it has none. A behavior left
+                    // out of this map reads as a measure nobody asked for, and a measure nobody
+                    // asked for goes without nothing — so a behavior nothing could be established
+                    // about would be held to no bar at all, and say nothing about it.
                     switch (BoundaryForMeasurement.of(sigs.value(), behavior.name())) {
                         case BoundaryForMeasurement.NotDerived _ ->
                                 SignatureEvidence.boundaryNotDerived(behavior);
@@ -1990,8 +1993,7 @@ public final class Adequacy {
 
             Map<String, souther.compiler.check.PathReachability.Answers.AsRun> reachable = db.ask(new Arrived(name)).value();
 
-            Map<String, BranchEvidence> out = new LinkedHashMap<>();
-            for (Hir.BehaviorDef behavior : prepared.value().behaviors()) {
+            return answerEveryBehavior(prepared.value(), behavior -> {
                 // The arms, and not every site of the behavior. A comparison of a guard's condition
                 // has a site of its own and is not a fork a row is in or out of, so counting it here
                 // would report an arm the body does not have.
@@ -2004,16 +2006,14 @@ public final class Adequacy {
                 BranchEvidence absent = whyNoArms(name, prepared.value().writesItsOwnBody(behavior),
                         bodiesRead, arms, arrives, instrumented, observed);
                 if (absent != null) {
-                    out.put(behavior.name(), absent);
-                    continue;
+                    return absent;
                 }
                 Set<Integer> covered = new LinkedHashSet<>(lit);
                 covered.retainAll(arms.stream()
                         .map(souther.compiler.coverage.CoverageSites.Site::index).toList());
-                out.put(behavior.name(), BranchEvidence.measured(behavior.name(), arms, covered,
-                        arrives, rowsBehind(observed)));
-            }
-            return Answer.of(Ordered.map(out));
+                return BranchEvidence.measured(behavior.name(), arms, covered,
+                        arrives, rowsBehind(observed));
+            });
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -403,6 +403,40 @@ public final class Adequacy {
     }
 
     /**
+     * One answer for every behavior a module declares, which is what a measure of a module answers.
+     *
+     * <p><b>The key set is the producer's and there is nowhere to drop one.</b> A measure whose
+     * question a behavior cannot be asked answers that it could not be asked, and a measure that
+     * skipped the behavior instead published a map with a hole in it — one its own readers then
+     * read three ways: as a composition with nothing to measure, as the whole query not having
+     * answered, and as this compiler disagreeing with itself. Two of those are wrong about a
+     * behavior whose declaration rests on a name nothing resolved, and the third stopped the report
+     * (issue #1044).
+     *
+     * <p>So the loop is here and the caller writes what one behavior comes to. It is handed a
+     * declaration and owes a value: a mapper that answered {@code null} would be the skip again,
+     * written as a return.
+     *
+     * <p>Two behaviors of one name would be one entry, which is why what went in is counted against
+     * what came out. Nothing produces that today — a module's declarations are settled before this
+     * — and a key set alone cannot tell it from an answer that was overwritten.
+     */
+    static <T> Answer<Map<String, T>> answerEveryBehavior(
+            souther.compiler.check.Prepared prepared,
+            java.util.function.Function<Hir.BehaviorDef, T> answer) {
+        Map<String, T> out = new LinkedHashMap<>();
+        for (Hir.BehaviorDef behavior : prepared.behaviors()) {
+            out.put(behavior.name(), java.util.Objects.requireNonNull(answer.apply(behavior),
+                    () -> "no answer for `" + behavior.name() + "` of `" + prepared.name() + "`"));
+        }
+        if (out.size() != prepared.behaviors().size()) {
+            throw new IllegalStateException("`" + prepared.name() + "` declares "
+                    + prepared.behaviors().size() + " behaviors and answered for " + out.size());
+        }
+        return Answer.of(Ordered.map(out));
+    }
+
+    /**
      * What the rows say about one behavior's signature.
      *
      * <p>An aggregate and not a number of its own: the numbers are the output's and the inputs'.
@@ -410,10 +444,20 @@ public final class Adequacy {
      * what it went without is the union of what its parts went without and what the signature
      * measure itself could not see.
      */
-    public record SignatureEvidence(OutputCaseEvidence output, List<InputCaseEvidence> inputs,
+    public record SignatureEvidence(OutputCaseEvidence output,
+                                    Measure<List<InputCaseEvidence>> inputs,
                                     Measure<Counted> counted) {
 
-        /** That the signature's cases were counted. */
+        /**
+         * That the signature's cases were counted.
+         *
+         * <p><b>Why the positions are inside a measure and not a bare list.</b> How many positions
+         * a behavior has is read off its boundary, so a behavior whose boundary was not worked out
+         * has a number of positions nobody knows. Held as a list, that state is an empty one — the
+         * same bytes as a behavior that takes nothing — and a reader counting the entries would
+         * answer "no positions" to a question nobody could answer. The same reason the positions of
+         * the partition measure are inside one ({@code PartitionEvidence.partitioned}).
+         */
         public record Counted() {}
 
         /** Why the signature has no numbers. */
@@ -433,14 +477,53 @@ public final class Adequacy {
 
         public static SignatureEvidence notASum(OutputCaseEvidence output,
                                                 List<InputCaseEvidence> inputs) {
-            return new SignatureEvidence(output, inputs,
+            return new SignatureEvidence(output, at(inputs),
                     new Measure.NotApplicable<>(NotASum.NOT_A_SUM));
         }
 
         public static SignatureEvidence noRows(OutputCaseEvidence output,
                                                List<InputCaseEvidence> inputs) {
-            return new SignatureEvidence(output, inputs,
+            return new SignatureEvidence(output, at(inputs),
                     new Measurement.NotMeasured<>(NoRows.NO_ROWS));
+        }
+
+        /**
+         * The boundary this measures was not worked out, so no case of it was read.
+         *
+         * <p><b>The positions are answered for where the declaration says how many there are, and
+         * not otherwise.</b> A declared behavior writes its parameters, so they are known and each
+         * of them says its own cases were not read. A {@code >->} composition writes none: it takes
+         * what its first stage takes, and that is what could not be worked out — so how many
+         * positions it has is unknown, and the measure says so rather than answering nought.
+         *
+         * <p>Which is the whole of why this measure holds a measurement and not a list. The two
+         * states are a behavior that takes nothing and a behavior nobody could count the positions
+         * of, and as a list they are the same empty one.
+         */
+        public static SignatureEvidence boundaryNotDerived(Hir.BehaviorDef behavior) {
+            String name = behavior.name();
+            Measure<List<InputCaseEvidence>> positions =
+                    behavior instanceof Hir.SpecBehavior spec
+                            ? new Measurement.Partial<>(declaredPositions(name, spec),
+                                    BoundaryForMeasurement.wentWithout(name))
+                            : BoundaryForMeasurement.failed(name);
+            return new SignatureEvidence(OutputCaseEvidence.boundaryNotDerived(name), positions,
+                    BoundaryForMeasurement.failed(name));
+        }
+
+        /** One entry per parameter the declaration writes, each saying its cases were not read. */
+        private static List<InputCaseEvidence> declaredPositions(String behavior,
+                                                                 Hir.SpecBehavior spec) {
+            List<InputCaseEvidence> out = new ArrayList<>(spec.params().size());
+            for (int at = 0; at < spec.params().size(); at++) {
+                out.add(InputCaseEvidence.boundaryNotDerived(at, behavior));
+            }
+            return out;
+        }
+
+        /** The positions of a signature that was read, which is every one of them. */
+        static Measure<List<InputCaseEvidence>> at(List<InputCaseEvidence> inputs) {
+            return new Measurement.Complete<>(List.copyOf(inputs));
         }
 
         /** Nobody asked for a measurement, so neither this nor anything under it was made. Its
@@ -449,7 +532,7 @@ public final class Adequacy {
          *  assembled that way over unmeasured parts would come out complete. */
         public static SignatureEvidence notAsked(OutputCaseEvidence output,
                                                  List<InputCaseEvidence> inputs) {
-            return new SignatureEvidence(output, inputs,
+            return new SignatureEvidence(output, at(inputs),
                     new Measurement.NotMeasured<>(NothingWasAsked.NOT_ASKED));
         }
 
@@ -463,7 +546,7 @@ public final class Adequacy {
             for (InputCaseEvidence each : inputs) {
                 by = by.union(each.cases().weakening());
             }
-            return new SignatureEvidence(output, inputs, by.isEmpty()
+            return new SignatureEvidence(output, at(inputs), by.isEmpty()
                     ? new Measurement.Complete<>(new Counted())
                     : new Measurement.Partial<>(new Counted(), by));
         }
@@ -473,18 +556,41 @@ public final class Adequacy {
             return counted.weakening();
         }
 
+        /** Whether this is what a behavior whose boundary could not be worked out comes to. */
+        public boolean boundaryNotDerived() {
+            return BoundaryForMeasurement.wasNotDerived(counted);
+        }
+
+        /**
+         * The positions, where the boundary they are read off was worked out.
+         *
+         * <p>Throws where it was not, the way {@link OutputCaseEvidence#seen()} and
+         * {@code PairSpace.counts()} do. An accessor that answered an empty list instead would be
+         * the thing the measure around it was introduced to remove: a reader would get an answer
+         * and no sign that nobody counted.
+         */
+        public List<InputCaseEvidence> positions() {
+            return inputs.made().orElseThrow(() -> new IllegalStateException(
+                    "a signature whose boundary was not read was asked for its positions"));
+        }
+
         public SignatureEvidence {
-            inputs = List.copyOf(inputs);
             // And each of them where it says it is. Two things say which input a piece of evidence
             // is about — where it sits in this list, which is what the document publishes as the
             // order of `signature.inputs`, and what the evidence answers, which is what a finding
             // names a position by. They are read by different surfaces, so a list assembled out of
             // step would publish an array whose first entry called itself the second, and each
             // surface would go on being right about the one it reads.
-            for (int i = 0; i < inputs.size(); i++) {
-                if (inputs.get(i).at() != i) {
-                    throw new IllegalArgumentException("the evidence at input " + i
-                            + " says it is input " + inputs.get(i).at());
+            //
+            // Asked of the positions where there are any. A measure that could not count them has
+            // none to be out of step with, which is not the same as having none.
+            List<InputCaseEvidence> at = inputs.made().orElse(null);
+            if (at != null) {
+                for (int i = 0; i < at.size(); i++) {
+                    if (at.get(i).at() != i) {
+                        throw new IllegalArgumentException("the evidence at input " + i
+                                + " says it is input " + at.get(i).at());
+                    }
                 }
             }
         }
@@ -949,23 +1055,28 @@ public final class Adequacy {
                                     : checkedBodies.decisions(),
                             checkedBodies == null ? souther.compiler.coverage.SuppliedRules.NONE : checkedBodies.supplied());
             Map<String, souther.compiler.check.PathReachability.Answers.AsRun> reachableArms = db.ask(new Arrived(name)).value();
-            Map<String, SignatureEvidence> out = new LinkedHashMap<>();
-            for (Hir.BehaviorDef behavior : prepared.value().behaviors()) {
-                Sig sig = sigs.value().get(behavior.name());
-                if (sig == null) {
-                    continue;   // a behavior whose signature did not work out has nothing to measure
-                }
-                out.put(behavior.name(), evidenceOf(behavior.name(), sig, scope.value(), asked,
-                        Rows.readingFor(byTarget, behavior.name()),
-                        behavior instanceof Hir.SpecBehavior spec ? spec.params().stream()
-                                .map(Hir.Param::name).toList() : List.of(),
-                        readInputs == null ? InputDomain.NONE
-                                : readInputs.getOrDefault(behavior.name(), InputDomain.NONE),
-                        producing.get(behavior.name()), producingPlan,
-                        reachableArms == null ? NOTHING_PROVEN
-                                : reachableArms.getOrDefault(behavior.name(), NOTHING_PROVEN)));
-            }
-            return Answer.of(Ordered.map(out));
+            return answerEveryBehavior(prepared.value(), behavior ->
+                    // What this measure works from, or the fact that it has none. A behavior whose
+                    // boundary did not work out used to be left out of this map, which reads as a
+                    // measure nobody asked for — so a behavior nothing could be established about
+                    // was held to no bar at all, silently (issue #1044).
+                    switch (BoundaryForMeasurement.of(sigs.value(), behavior.name())) {
+                        case BoundaryForMeasurement.NotDerived _ ->
+                                SignatureEvidence.boundaryNotDerived(behavior);
+                        case BoundaryForMeasurement.Derived(Sig sig) ->
+                                evidenceOf(behavior.name(), sig, scope.value(), asked,
+                                        Rows.readingFor(byTarget, behavior.name()),
+                                        behavior instanceof Hir.SpecBehavior spec
+                                                ? spec.params().stream().map(Hir.Param::name).toList()
+                                                : List.of(),
+                                        readInputs == null ? InputDomain.NONE
+                                                : readInputs.getOrDefault(behavior.name(),
+                                                        InputDomain.NONE),
+                                        producing.get(behavior.name()), producingPlan,
+                                        reachableArms == null ? NOTHING_PROVEN
+                                                : reachableArms.getOrDefault(behavior.name(),
+                                                        NOTHING_PROVEN));
+                    });
         }
 
     }
@@ -1019,48 +1130,62 @@ public final class Adequacy {
             Map<String, souther.compiler.check.StatedContract> declared =
                     db.ask(new Bodies.StatedContracts(name)).value();
 
-            Map<String, PartitionEvidence> out = new LinkedHashMap<>();
-            for (Hir.BehaviorDef behavior : prepared.value().behaviors()) {
+            // Whether there is a subject first, and what could be read of it second. The two
+            // questions are asked in that order because a measure that does not apply is owed no
+            // input: a composition is measured at its stages whether or not its own signature
+            // worked out, and answering "the boundary was not derived" for one would be this
+            // measure reporting a prerequisite it never had.
+            return answerEveryBehavior(prepared.value(), behavior -> {
                 if (!(behavior instanceof Hir.SpecBehavior spec)) {
-                    continue;   // a composition's inputs are its first stage's, measured there
+                    return PartitionEvidence.NONE;   // measured at its stages, not here
                 }
-                Sig sig = sigs.value().get(spec.name());
-                if (sig == null) {
-                    continue;
-                }
-                // A behavior with a signature is one the model divides somewhere or nowhere, and
-                // either is an answer. Nothing is a compile that stopped after this loop had already
-                // read the signature, which is the two disagreeing rather than a behavior to skip.
-                souther.compiler.partition.Partitions.Partitioning divided =
-                        db.ask(new Divided(name, spec.name())).value();
-                if (divided == null) {
-                    throw new IllegalStateException("`" + spec.name() + "` has a signature and no"
-                            + " reading of what the model divides it into");
-                }
-                RowReading seen = Rows.readingFor(byTarget, spec.name());
-                // Counted with nothing a body claims in scope. What was claimed travels beside the
-                // numbers rather than into them ({@link Claimed}), and the two meet where a report
-                // is written.
-                // Whether the values are composed is the build's to ask for, and it is asked here
-                // rather than inside either key. A level says how much work to do; what a search
-                // does when it is asked is not a thing it may decide, which is the reading that put
-                // the composing inside the measurement in the first place.
-                List<BorderAssessment> edges = level.composesValues()
-                        ? db.ask(new BoundarySearch(name, spec.name())).value()
-                        : db.ask(new Boundaries(name, spec.name())).value();
-                if (edges == null) {
-                    // Nothing came back about this behavior's lines, from a question that has
-                    // everything it needs to answer. Read as no lines, a behavior whose measure
-                    // stopped would be counted as one the model draws nothing about.
-                    throw new IllegalStateException("`" + spec.name() + "` has a signature and a"
-                            + " reading of what the model divides it into, and no answer about the"
-                            + " lines that reading drew");
-                }
-                out.put(spec.name(), Coverages.of(spec, domainOf(readInputs, spec), sig,
-                        scope.value(), db.ask(new Front.Reading()).value(), divided, seen,
-                        level, edges, db.ask(new Front.Adequacy()).value().measures()));
+                return switch (BoundaryForMeasurement.of(sigs.value(), spec.name())) {
+                    case BoundaryForMeasurement.NotDerived _ ->
+                            PartitionEvidence.boundaryNotDerived(spec.name());
+                    case BoundaryForMeasurement.Derived(Sig sig) ->
+                            measured(db, name, spec, sig, level, scope.value(), readInputs,
+                                    byTarget);
+                };
+            });
+        }
+
+        /** What one behavior whose boundary was worked out reaches of what its model divides it
+         *  into. */
+        private PartitionEvidence measured(Db db, String name, Hir.SpecBehavior spec, Sig sig,
+                                           Level level, Symbols scope,
+                                           Map<String, InputDomain> readInputs,
+                                           Map<String, RowReading> byTarget) {
+            // A behavior with a signature is one the model divides somewhere or nowhere, and
+            // either is an answer. Nothing is a compile that stopped after this had already
+            // read the signature, which is the two disagreeing rather than a behavior to skip.
+            souther.compiler.partition.Partitions.Partitioning divided =
+                    db.ask(new Divided(name, spec.name())).value();
+            if (divided == null) {
+                throw new IllegalStateException("`" + spec.name() + "` has a signature and no"
+                        + " reading of what the model divides it into");
             }
-            return Answer.of(Ordered.map(out));
+            RowReading seen = Rows.readingFor(byTarget, spec.name());
+            // Counted with nothing a body claims in scope. What was claimed travels beside the
+            // numbers rather than into them ({@link Claimed}), and the two meet where a report
+            // is written.
+            // Whether the values are composed is the build's to ask for, and it is asked here
+            // rather than inside either key. A level says how much work to do; what a search
+            // does when it is asked is not a thing it may decide, which is the reading that put
+            // the composing inside the measurement in the first place.
+            List<BorderAssessment> edges = level.composesValues()
+                    ? db.ask(new BoundarySearch(name, spec.name())).value()
+                    : db.ask(new Boundaries(name, spec.name())).value();
+            if (edges == null) {
+                // Nothing came back about this behavior's lines, from a question that has
+                // everything it needs to answer. Read as no lines, a behavior whose measure
+                // stopped would be counted as one the model draws nothing about.
+                throw new IllegalStateException("`" + spec.name() + "` has a signature and a"
+                        + " reading of what the model divides it into, and no answer about the"
+                        + " lines that reading drew");
+            }
+            return Coverages.of(spec, domainOf(readInputs, spec), sig, scope,
+                    db.ask(new Front.Reading()).value(), divided, seen, level, edges,
+                    db.ask(new Front.Adequacy()).value().measures());
         }
     }
 
@@ -2339,7 +2464,7 @@ public final class Adequacy {
             // stop it. Every way out of the generation below holds this same list.
             souther.compiler.partition.GenerationPlan asked = planFor(spec, sig, symbols,
                     db.ask(new Front.Reading()).value(), divided, domain, owed,
-                    PartitionEvidence.answeredFor(partitions, prepared.value(), spec));
+                    partitions.get(behavior));
             souther.compiler.partition.FillResult composed;
             try {
                 composed = rowsFor(spec, sig, symbols, asked,
@@ -3391,7 +3516,15 @@ public final class Adequacy {
             }
             // Walked as the evidence rather than by index: which input this is, is the evidence's
             // own answer now, so a finding is not handed a number worked out beside the list.
-            for (InputCaseEvidence input : signature.inputs()) {
+            //
+            // Over the positions there are, and asked rather than defaulted. A measure that did not
+            // reach the boundary has no position for a gap to be at; standing in an empty list for
+            // one would walk it and find nothing, which reads the same as a behavior every position
+            // of which is covered.
+            if (signature.inputs().made().isEmpty()) {
+                return;
+            }
+            for (InputCaseEvidence input : signature.positions()) {
                 for (TypeSymbol missing : input.unspecified()) {
                     // This input's own measurement. One position whose rows could not be classified
                     // says nothing about the position beside it, and a finding handed the signature's

--- a/souther-compiler/src/main/java/souther/compiler/query/BoundaryForMeasurement.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BoundaryForMeasurement.java
@@ -1,0 +1,80 @@
+package souther.compiler.query;
+
+import souther.compiler.check.Sig;
+import souther.compiler.observe.FailureReason;
+
+import java.util.Map;
+
+/**
+ * What a measure of one behavior has to work from at its boundary, or the fact that it has nothing.
+ *
+ * <p>The one place a missing signature becomes a measurement's business. {@code Bodies.Signatures}
+ * is a partial map on purpose: a behavior whose declaration rests on a name nothing resolved has no
+ * boundary to publish, so {@code SignatureBoundary} refuses to build one and the entry is never
+ * made. That is an analysis saying what it could not work out, and it is right.
+ *
+ * <p>What is not an analysis's to say is what a report should do about it. Read straight, the
+ * absence is a key a measure can skip — which is what both measures of a behavior's boundary did,
+ * and what left a report crashing on one and going quiet on the other. Read here, it is a value the
+ * measure carries: a measurement that was asked for, was started, and could not be finished.
+ *
+ * <p>So neither measure knows why there is no signature. Each asks this and answers for its own
+ * measure: {@link Derived} is the boundary it measures, {@link NotDerived} is its own
+ * {@code FailedToMeasure}. Which name went unresolved is reported where it was written, by the
+ * module error the author acts on.
+ */
+public sealed interface BoundaryForMeasurement {
+
+    /** The boundary a measure works from. */
+    record Derived(Sig sig) implements BoundaryForMeasurement {
+
+        public Derived {
+            java.util.Objects.requireNonNull(sig, "a derived boundary is a signature");
+        }
+    }
+
+    /**
+     * There is none, so nothing that reads one could be measured.
+     *
+     * <p>A {@link FailureReason} as well as an arm, because it is both: the fact a measure holds
+     * about its input, and the word every measure short of that input has no number for.
+     */
+    enum NotDerived implements BoundaryForMeasurement, FailureReason {
+        BEHAVIOR_BOUNDARY_NOT_DERIVED
+    }
+
+    /** What the signatures of a module say about one of its behaviors. */
+    static BoundaryForMeasurement of(Map<String, Sig> signatures, String behavior) {
+        Sig sig = signatures.get(behavior);
+        return sig == null ? NotDerived.BEHAVIOR_BOUNDARY_NOT_DERIVED : new Derived(sig);
+    }
+
+    /**
+     * What a measure short of a boundary went without, as the fact that made it so.
+     *
+     * <p>Named by the behavior alone. Every measure of that behavior is short of the same one
+     * thing, so the fact reaching a whole by two measures arrives once — which is what
+     * {@link WeakeningSet} is for. A measure named beside it would make one cause into as many
+     * facts as there are measures that read it.
+     */
+    static WeakeningSet wentWithout(String behavior) {
+        return WeakeningSet.of(new Weakening.BoundaryNotDerived(behavior));
+    }
+
+    /** The measurement a measure short of a boundary comes to, whatever it measures. */
+    static <T> Measurement<T> failed(String behavior) {
+        return new Measurement.FailedToMeasure<>(NotDerived.BEHAVIOR_BOUNDARY_NOT_DERIVED,
+                wentWithout(behavior));
+    }
+
+    /**
+     * Whether this is a measure that went without one.
+     *
+     * <p>Asked here so that it is asked one way. Two readers spelling the same question — one
+     * comparing the reason, one asking a measure of its own — are two places for the answer to
+     * move apart the day another reason is added.
+     */
+    static boolean wasNotDerived(Measure<?> measure) {
+        return measure.why() == NotDerived.BEHAVIOR_BOUNDARY_NOT_DERIVED;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/InputCaseEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/InputCaseEvidence.java
@@ -80,6 +80,14 @@ public record InputCaseEvidence(int at, Set<TypeSymbol> declared, Set<TypeSymbol
                 new Measure.NotApplicable<>(NotASum.NOT_A_SUM));
     }
 
+    /** The boundary this is read off was not worked out, so what the position's type has was never
+     *  seen. Empty here says nothing, for the reason {@link OutputCaseEvidence#boundaryNotDerived}
+     *  gives. */
+    public static InputCaseEvidence boundaryNotDerived(int at, String behavior) {
+        return new InputCaseEvidence(at, Set.of(), Set.of(),
+                BoundaryForMeasurement.failed(behavior));
+    }
+
     /** The same for one input, and for the reason {@link OutputCaseEvidence#notAsked} gives. */
     public static InputCaseEvidence notAsked(int at, Set<TypeSymbol> declared,
                                              Set<TypeSymbol> excluded) {

--- a/souther-compiler/src/main/java/souther/compiler/query/OutputCaseEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/OutputCaseEvidence.java
@@ -78,6 +78,18 @@ public record OutputCaseEvidence(Set<TypeSymbol> declared, Measure<Cases> cases)
         return new OutputCaseEvidence(Set.of(), new Measure.NotApplicable<>(NotASum.NOT_A_SUM));
     }
 
+    /**
+     * The boundary this is read off was not worked out, so what the output type has was never seen.
+     *
+     * <p>{@link #declared} is empty here and says nothing by being so. Which of the ways a case set
+     * comes out empty this is, is the measurement beside it: {@link NotASum} is a type that was read
+     * and holds one case, and it is a reason rather than something read back off the set for exactly
+     * this — a set nobody filled in and a set there was nothing to fill in with are the same bytes.
+     */
+    public static OutputCaseEvidence boundaryNotDerived(String behavior) {
+        return new OutputCaseEvidence(Set.of(), BoundaryForMeasurement.failed(behavior));
+    }
+
 
     /** What the model declares, with nothing counted against it, for a build that asked for no
      *  measurement. Made here rather than by emptying a measurement above, because this is where the

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -73,8 +73,8 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
      *
      * <p>The pair space is sized at nought because a size is a product over the positions, and the
      * positions are what was not derived. Nothing reads the number: the measurement beside it says
-     * none was made, and a document leaves the whole section out rather than writing a size nobody
-     * worked out.
+     * none could be finished, and a document leaves the whole section out rather than writing a
+     * size nobody worked out.
      */
     public static PartitionEvidence boundaryNotDerived(String behavior) {
         return new PartitionEvidence(

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -71,10 +71,15 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
      * key, which is how a behavior whose parameter named an unresolved type reached a reader with
      * nothing to read and nothing saying why.
      *
-     * <p>The pair space is sized at nought because a size is a product over the positions, and the
-     * positions are what was not derived. Nothing reads the number: the measurement beside it says
-     * none could be finished, and a document leaves the whole section out rather than writing a
-     * size nobody worked out.
+     * <p>Nothing here has a declaration to fall back on. The positions this measure is about are the
+     * ones the model divides, worked out from the boundary and from the rules written about it —
+     * unlike the positions of the signature measure, which a declared behavior writes down and which
+     * are known there whatever the boundary did. So both measures come back short and only one of
+     * them still knows how many places it was to have counted at.
+     *
+     * <p>The pair space is sized at nought for the same reason: a size is a product over those
+     * positions. Nothing reads the number — the measurement beside it says none could be finished,
+     * and a document leaves the whole section out rather than writing a size nobody worked out.
      */
     public static PartitionEvidence boundaryNotDerived(String behavior) {
         return new PartitionEvidence(

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -3,7 +3,6 @@ package souther.compiler.query;
 import souther.compiler.observe.Incompleteness;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -64,40 +63,29 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
             List.of(), List.of());
 
     /**
-     * What a coverage that came back says about one behavior.
+     * What the model divides a behavior into, where its boundary could not be worked out.
      *
-     * <p><b>{@link #NONE} is an answer and not a default.</b> It says the model holds no subject
-     * for either of these measures, which is true of a {@code >->} composition and of nothing else
-     * — so it may be handed out where the declarations say that, and nowhere else. Both readers of
-     * this map used to reach it with {@code getOrDefault}, which says it whenever a key is missing
-     * for any reason at all; one of them said it for the whole map being absent, which is the
-     * coverage query not having answered (issue #996).
+     * <p>Not {@link #NONE}. That says the model holds no subject for either measure and no row would
+     * change it, which is a claim about the model; this is a measure that was asked for, started and
+     * could not be finished, and what it went without is beside it. The two used to be one absent
+     * key, which is how a behavior whose parameter named an unresolved type reached a reader with
+     * nothing to read and nothing saying why.
      *
-     * <p>The absence of the map is the caller's to carry and is never a value here: a caller that
-     * cannot say "there is no coverage" has to stop rather than say "there is nothing to cover".
-     *
-     * <p>Missing for anything else is this map's contract broken. The coverage answers for every
-     * behavior it is asked about except compositions, so there is no reading for such a key that is
-     * not a guess — and a guess is what this exists to stop. It is fenced rather than given a
-     * measurement of its own: nothing produces the state today, and inventing what it would mean
-     * would be a consumer settling a producer's business.
-     *
-     * @throws IllegalStateException where {@code answered} omits a behavior that is not a
-     *                               composition
+     * <p>The pair space is sized at nought because a size is a product over the positions, and the
+     * positions are what was not derived. Nothing reads the number: the measurement beside it says
+     * none was made, and a document leaves the whole section out rather than writing a size nobody
+     * worked out.
      */
-    public static PartitionEvidence answeredFor(Map<String, PartitionEvidence> answered,
-                                                souther.compiler.check.Prepared module,
-                                                souther.compiler.ast.Hir.BehaviorDef behavior) {
-        PartitionEvidence found = answered.get(behavior.name());
-        if (found != null) {
-            return found;
-        }
-        if (module.isComposition(behavior)) {
-            return NONE;
-        }
-        throw new IllegalStateException("the coverage of `" + module.name()
-                + "` answered for " + answered.keySet() + " and left out `" + behavior.name()
-                + "`, which is not a composition");
+    public static PartitionEvidence boundaryNotDerived(String behavior) {
+        return new PartitionEvidence(
+                BoundaryForMeasurement.failed(behavior), BoundaryForMeasurement.failed(behavior),
+                PairSpace.boundaryNotDerived(behavior), List.of(), List.of(), List.of(), List.of(),
+                List.of(), List.of());
+    }
+
+    /** Whether this is what a behavior whose boundary could not be worked out comes to. */
+    public boolean boundaryNotDerived() {
+        return BoundaryForMeasurement.wasNotDerived(partitioned);
     }
 
     public PartitionEvidence {
@@ -360,6 +348,12 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
         /** The same, where nobody asked for a measurement at all. */
         public static PairSpace notAsked(int total) {
             return new PairSpace(total, new Measurement.NotMeasured<>(NothingWasAsked.NOT_ASKED));
+        }
+
+        /** A space whose size was never worked out, because the positions it is a product over
+         *  were not. What it is short of is what every measure of that behavior is short of. */
+        public static PairSpace boundaryNotDerived(String behavior) {
+            return new PairSpace(0, BoundaryForMeasurement.failed(behavior));
         }
 
         /** A space too large to walk to the end of. What it is measured in part by is the fact that

--- a/souther-compiler/src/main/java/souther/compiler/query/Weakening.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Weakening.java
@@ -76,6 +76,20 @@ public sealed interface Weakening {
     record BodiesNotElaborated(String module) implements Weakening {}
 
     /**
+     * The boundary of one behavior could not be worked out, so every measure that reads one is
+     * short of it.
+     *
+     * <p>Named by the behavior and by nothing else. Both measures of a behavior's boundary go
+     * without this one thing, and which of them was asking is not part of the fact — a measure
+     * named beside it would turn one cause into as many facts as there are measures that read it,
+     * which is counting the paths a fact arrived by ({@link WeakeningSet}).
+     *
+     * <p>Not the reason there is no boundary. A name that resolved to nothing is reported where it
+     * was written, and this says only what that left unmeasurable.
+     */
+    record BoundaryNotDerived(String behavior) implements Weakening {}
+
+    /**
      * The space of two-class combinations was too large to walk, so the counts describe part of it.
      *
      * <p>Not an observation that went missing and not a reading of the model that stopped: the model

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -672,8 +672,17 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 // Not a word for whatever is left. This measure carries one of the four reason
                 // types above and nothing else, so a fifth arriving here is a reason nobody decided
                 // a word for — and given the word of one of the others it would be printed as a
-                // state it is not, which is what `no_rows` was doing for every reason added after
-                // it was written (issue #1044).
+                // state it is not. A word standing in for every reason added after it was written
+                // is the same defect as a key standing in for every way a measure can have no
+                // answer, one surface further out.
+                //
+                // A throw and not exhaustiveness the compiler checks. What is switched on is a
+                // `MeasureReason`, which is a plain interface because two of the reasons here
+                // belong to no measure in particular — nobody asked is one fact about the run, and
+                // a boundary that could not be worked out is one fact about the behavior, each
+                // read by several measures. Sealing a reason type per measure would make those
+                // name every measure that reads them, which is the dependency the other way round.
+                // Worth revisiting only if the reasons stop being shared.
                 default -> throw new IllegalStateException(
                         "the signature measure has no word for " + counted.reason());
             };

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -296,10 +296,12 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             Adequacy.SignatureEvidence signature =
                     signatures == null ? null : signatures.get(behavior.name());
             // Null where the coverage did not answer at all, which is the compile not having got
-            // that far and is not this behavior having nothing to cover. `NONE` is the second of
-            // those and is reached only where the declarations say so.
+            // that far and is not this behavior having nothing to cover. Read and never worked out:
+            // a coverage that answered answers for every behavior of the module, so what a key is
+            // for is what the measure said about it — this used to reach `NONE` for a composition
+            // by asking the declarations again, which is a reader settling what a measure means.
             PartitionEvidence partition = partitions == null ? null
-                    : PartitionEvidence.answeredFor(partitions, module, behavior);
+                    : partitions.get(behavior.name());
             // Null where the compile did not get far enough to be asked, which is not a measure that
             // came back with nothing. Every measure that did run says why it has no number.
             Adequacy.BranchEvidence branch =
@@ -660,8 +662,20 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             String why = switch (counted.reason()) {
                 case Adequacy.SignatureEvidence.NotASum _ ->
                         "not applicable (this behavior's output is not a sum)";
+                case Adequacy.SignatureEvidence.NoRows _ ->
+                        "not measured (no row names this behavior)";
+                // What was read of the declaration is not said here. Which name resolved to nothing
+                // is reported where it was written, on the line the author edits.
+                case souther.compiler.query.BoundaryForMeasurement.NotDerived _ ->
+                        "not measured (this behavior's signature could not be read)";
                 case souther.compiler.query.NothingWasAsked _ -> null;
-                default -> "not measured (no row names this behavior)";
+                // Not a word for whatever is left. This measure carries one of the four reason
+                // types above and nothing else, so a fifth arriving here is a reason nobody decided
+                // a word for — and given the word of one of the others it would be printed as a
+                // state it is not, which is what `no_rows` was doing for every reason added after
+                // it was written (issue #1044).
+                default -> throw new IllegalStateException(
+                        "the signature measure has no word for " + counted.reason());
             };
             if (why != null) {
                 out.append(String.format("    signature   %s%n", why));
@@ -691,7 +705,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 }
             }
         }
-        for (InputCaseEvidence input : signature.inputs()) {
+        // The positions where the measure counted them. This section is reached only where the
+        // signature measure has a number, and a measure with one has read the boundary its
+        // positions come off — so there is nothing here that a measure short of one would print,
+        // and nothing to stand in for it either.
+        for (InputCaseEvidence input : signature.positions()) {
             // Under the same condition as the output line above it, which is the whole of why it is
             // spelled here. It asked its measurement for a number and took a nought where there was
             // none, so an input nobody measured printed `specified 0/3` — a measurement, made by
@@ -1792,6 +1810,15 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         if (signature == null) {
             return;
         }
+        // A behavior with no signature to read has no section, which is what this document has
+        // always said the absence of one means. Written out instead, the section would owe an
+        // `inputs` array of the positions — and how many there are is read off the very boundary
+        // that was not worked out, so a `>->` composition would publish an empty one and say that
+        // it takes nothing. Which behavior it happened to and what it cost is the behavior's
+        // `weakening`, where it is one fact rather than one per measure that went without it.
+        if (signature.boundaryNotDerived()) {
+            return;
+        }
         ObjectNode out = behavior.putObject("signature");
         measured(out, signature.counted());
         ObjectNode output = out.putObject("output");
@@ -1807,7 +1834,9 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             node.put("unclassifiedRows", cases.unclassifiedRows());
         });
         ArrayNode inputs = out.putArray("inputs");
-        for (InputCaseEvidence input : signature.inputs()) {
+        // Every position, and this section is written only where they were counted. The one state
+        // that has none to write is the one that returns above.
+        for (InputCaseEvidence input : signature.positions()) {
             ObjectNode in = inputs.addObject();
             names(in.putArray("declared"), input.declared());
             names(in.putArray("excluded"), input.excluded());
@@ -1823,6 +1852,13 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     private void partition(ObjectNode behavior, PartitionEvidence partition,
                                   ClaimAnnotations claimed, DocumentSources sources) {
         if (partition == null) {
+            return;
+        }
+        // And no section where the boundary the positions come off was not worked out, for the
+        // reason the signature section is left out: what this section owes is the positions, the
+        // lines and the size of the space they make, and every one of those is a product over
+        // positions nobody could count. Said here as the behavior's `weakening`, once.
+        if (partition.boundaryNotDerived()) {
             return;
         }
         ObjectNode out = behavior.putObject("partition");
@@ -2333,6 +2369,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                         WeakeningWord.RULES_NOT_REACHED;
             };
             case Weakening.BodiesNotElaborated _ -> WeakeningWord.BODIES_NOT_ELABORATED;
+            case Weakening.BoundaryNotDerived _ -> WeakeningWord.BEHAVIOR_BOUNDARY_NOT_DERIVED;
             case Weakening.PairSpaceTruncated _ -> WeakeningWord.PAIR_SPACE_TRUNCATED;
             case Weakening.ProofContradicted _ -> WeakeningWord.PROOF_CONTRADICTED;
             case Weakening.ArmsUnsettled _ -> WeakeningWord.ARMS_UNSETTLED;

--- a/souther-compiler/src/main/java/souther/compiler/report/WeakeningWord.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/WeakeningWord.java
@@ -44,6 +44,10 @@ public enum WeakeningWord {
     /** The bodies of the module were not elaborated, so what is inside them was not read. */
     BODIES_NOT_ELABORATED,
 
+    /** The boundary of the behavior could not be worked out, so no measure that reads one was
+     *  made. */
+    BEHAVIOR_BOUNDARY_NOT_DERIVED,
+
 
     /** The space of combinations was too large to walk to the end of. */
     PAIR_SPACE_TRUNCATED,

--- a/souther-compiler/src/main/java/souther/compiler/report/WeakeningWord.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/WeakeningWord.java
@@ -44,8 +44,9 @@ public enum WeakeningWord {
     /** The bodies of the module were not elaborated, so what is inside them was not read. */
     BODIES_NOT_ELABORATED,
 
-    /** The boundary of the behavior could not be worked out, so no measure that reads one was
-     *  made. */
+    /** The boundary of the behavior could not be worked out, so no measure that reads one could be
+     *  finished. Every one of them was asked for and started, which is what tells this from a
+     *  measure nobody asked for. */
     BEHAVIOR_BOUNDARY_NOT_DERIVED,
 
 

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-7.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-7.json
@@ -46,6 +46,7 @@
                  "output_cases_unreadable", "input_cases_unreadable", "row_did_not_finish",
                  "border_value_unreadable", "rule_unread", "position_not_read",
                  "question_unanswered", "rules_not_reached", "bodies_not_elaborated",
+                 "behavior_boundary_not_derived",
                  "pair_space_truncated", "proof_contradicted", "arms_unsettled"]
       }
     },
@@ -227,7 +228,7 @@
     },
     "partition": {
       "type": "object",
-      "description": "How much of what the model distinguishes about this behavior's inputs the rows reach.",
+      "description": "How much of what the model distinguishes about this behavior's inputs the rows reach. Absent where there were no positions to write: the boundary they are read off did not work out, so how many there are is unknown and an empty `axes` would say the model divides none of them. Said as `behavior_boundary_not_derived` in the behavior's `weakening`. A `>->` composition is not this — it is measured at its stages and carries a section saying so.",
       "required": ["axes", "boundaries", "pairs", "notDerivable"],
       "additionalProperties": false,
       "properties": {
@@ -525,7 +526,7 @@
     },
     "signature": {
       "type": "object",
-      "description": "What the rows establish about the cases of the behavior's inputs and its output. Absent where the behavior has no signature to read.",
+      "description": "What the rows establish about the cases of the behavior's inputs and its output. Absent where the behavior has no signature to read — which includes a declaration resting on a name that resolved to nothing, whose positions and cases were never seen. What that left unmeasured is the behavior's `weakening`, as `behavior_boundary_not_derived`; which name went unresolved is a compile error reported where it was written.",
       "required": ["status", "output", "inputs"],
       "additionalProperties": false,
       "properties": {

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-7.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-7.json
@@ -228,7 +228,7 @@
     },
     "partition": {
       "type": "object",
-      "description": "How much of what the model distinguishes about this behavior's inputs the rows reach. Absent where there were no positions to write: the boundary they are read off did not work out, so how many there are is unknown and an empty `axes` would say the model divides none of them. Said as `behavior_boundary_not_derived` in the behavior's `weakening`. A `>->` composition is not this — it is measured at its stages and carries a section saying so.",
+      "description": "How much of what the model distinguishes about this behavior's inputs the rows reach. Absent where there were no positions to write: the positions here are the ones the model divides, worked out from the behavior's boundary and the rules written about it, and no declaration gives them — so a boundary that did not work out leaves nothing to divide and an empty `axes` would say the model divides none of them. Said as `behavior_boundary_not_derived` in the behavior's `weakening`. A `>->` composition is not this — it is measured at its stages and carries a section saying so.",
       "required": ["axes", "boundaries", "pairs", "notDerivable"],
       "additionalProperties": false,
       "properties": {
@@ -526,7 +526,7 @@
     },
     "signature": {
       "type": "object",
-      "description": "What the rows establish about the cases of the behavior's inputs and its output. Absent where the behavior has no signature to read — which includes a declaration resting on a name that resolved to nothing, whose positions and cases were never seen. What that left unmeasured is the behavior's `weakening`, as `behavior_boundary_not_derived`; which name went unresolved is a compile error reported where it was written.",
+      "description": "What the rows establish about the cases of the behavior's inputs and its output. Absent where the behavior has no signature to read, which includes a declaration resting on a name that resolved to nothing. There is no section in that case whether or not the positions themselves are known: a declared behavior's are its parameters and are known from the declaration, but without a boundary nothing was read of the cases at any of them, and a `>->` composition takes what its first stage takes and so has no known layout either. What that left unmeasured is the behavior's `weakening`, as `behavior_boundary_not_derived`; which name went unresolved is a compile error reported where it was written.",
       "required": ["status", "output", "inputs"],
       "additionalProperties": false,
       "properties": {

--- a/souther-compiler/src/test/java/souther/compiler/ACaseTheModelRulesOutIsNotOwedARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACaseTheModelRulesOutIsNotOwedARowTest.java
@@ -108,7 +108,7 @@ class ACaseTheModelRulesOutIsNotOwedARowTest {
         Adequacy.SignatureEvidence signature = compilation.db()
                 .ask(new Adequacy.Witnesses(compilation.modules().get(0))).value().get("pick");
         assertNotNull(signature, "the model under test compiles");
-        return signature.inputs().get(at);
+        return signature.positions().get(at);
     }
 
     private static PartitionEvidence.AxisCoverage axis(String source) {

--- a/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
@@ -574,8 +574,11 @@ class AMeasureWithNoNumberSaysWhyTest {
         for (Map.Entry<String, Adequacy.SignatureEvidence> each : signatures().entrySet()) {
             measures.add(new Object[] {"signature " + each.getKey(), each.getValue().counted()});
             measures.add(new Object[] {"out " + each.getKey(), each.getValue().output().cases()});
-            each.getValue().inputs().forEach(in -> measures.add(
-                    new Object[] {"in " + each.getKey(), in.cases()}));
+            // The positions are a measure of their own: how many there are is read off the
+            // boundary, so a behavior whose boundary did not work out has a count nobody made.
+            measures.add(new Object[] {"positions " + each.getKey(), each.getValue().inputs()});
+            each.getValue().inputs().made().ifPresent(at -> at.forEach(in -> measures.add(
+                    new Object[] {"in " + each.getKey(), in.cases()})));
         }
         for (Map.Entry<String, PartitionEvidence> each : partitions().entrySet()) {
             PartitionEvidence partition = each.getValue();

--- a/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
@@ -575,7 +575,8 @@ class AMeasureWithNoNumberSaysWhyTest {
             measures.add(new Object[] {"signature " + each.getKey(), each.getValue().counted()});
             measures.add(new Object[] {"out " + each.getKey(), each.getValue().output().cases()});
             // The positions are a measure of their own: how many there are is read off the
-            // boundary, so a behavior whose boundary did not work out has a count nobody made.
+            // boundary, so a behavior whose boundary did not work out has a count nobody could
+            // arrive at.
             measures.add(new Object[] {"positions " + each.getKey(), each.getValue().inputs()});
             each.getValue().inputs().made().ifPresent(at -> at.forEach(in -> measures.add(
                     new Object[] {"in " + each.getKey(), in.cases()})));

--- a/souther-compiler/src/test/java/souther/compiler/AdequacyNeverAssertsFromPartOfTheRowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AdequacyNeverAssertsFromPartOfTheRowsTest.java
@@ -206,7 +206,7 @@ class AdequacyNeverAssertsFromPartOfTheRowsTest {
                 if (!signature.output().unspecified().isEmpty()) {
                     wrong.add("signature output: " + signature.output().unspecified());
                 }
-                signature.inputs().stream().filter(in -> !in.unspecified().isEmpty())
+                signature.positions().stream().filter(in -> !in.unspecified().isEmpty())
                         .forEach(in -> wrong.add("signature input: " + in.unspecified()));
             }
 

--- a/souther-compiler/src/test/java/souther/compiler/AskingForNothingIsAnAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AskingForNothingIsAnAnswerTest.java
@@ -68,9 +68,9 @@ class AskingForNothingIsAnAnswerTest {
                 "and its parts say it themselves, since a document writes them on their own");
         // The position that is a sum. The one beside it is not, which is the measure's own answer
         // and comes before this one: no build asking for anything would have counted it.
-        assertEquals(NothingWasAsked.NOT_ASKED, signature.inputs().get(0).cases().why());
+        assertEquals(NothingWasAsked.NOT_ASKED, signature.positions().get(0).cases().why());
         assertEquals(souther.compiler.query.InputCaseEvidence.NotASum.NOT_A_SUM,
-                signature.inputs().get(1).cases().why());
+                signature.positions().get(1).cases().why());
 
         PartitionEvidence partition = measured.partitions().get("submit");
         for (PartitionEvidence.AxisCoverage axis : partition.axes()) {

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleWitnessTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleWitnessTest.java
@@ -117,12 +117,12 @@ class CompileExampleWitnessTest {
                     | (MemberId("m-1"), Active) -> Found { id = MemberId("m-1") }
                 """).get("lookup");
 
-        assertEquals(2, lookup.inputs().size());
-        assertEquals(List.of(), names(lookup.inputs().get(0).declared()),
+        assertEquals(2, lookup.positions().size());
+        assertEquals(List.of(), names(lookup.positions().get(0).declared()),
                 "a parameter that is not a sum has nothing to cover");
-        assertEquals(List.of("Active", "Suspended"), names(lookup.inputs().get(1).declared()));
-        assertEquals(List.of("Active"), names(lookup.inputs().get(1).seen().specified()));
-        assertEquals(List.of("Suspended"), lookup.inputs().get(1).unspecified().stream()
+        assertEquals(List.of("Active", "Suspended"), names(lookup.positions().get(1).declared()));
+        assertEquals(List.of("Active"), names(lookup.positions().get(1).seen().specified()));
+        assertEquals(List.of("Suspended"), lookup.positions().get(1).unspecified().stream()
                 .map(TypeSymbol::name).toList());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/SignatureCoverageReadsAPositionThroughItsNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/SignatureCoverageReadsAPositionThroughItsNamesTest.java
@@ -180,8 +180,8 @@ class SignatureCoverageReadsAPositionThroughItsNamesTest {
     private static InputCaseEvidence input(String rows, String behavior) {
         Map<String, Adequacy.SignatureEvidence> all = signatures(rows);
         Adequacy.SignatureEvidence evidence = all.get(behavior);
-        assertEquals(1, evidence.inputs().size());
-        return evidence.inputs().get(0);
+        assertEquals(1, evidence.positions().size());
+        return evidence.positions().get(0);
     }
 
     private static Map<String, Adequacy.SignatureEvidence> signatures(String rows) {

--- a/souther-compiler/src/test/java/souther/compiler/WhatAFindingIsAboutIsHeldByTheTypeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatAFindingIsAboutIsHeldByTheTypeTest.java
@@ -88,7 +88,7 @@ class WhatAFindingIsAboutIsHeldByTheTypeTest {
         Adequacy.SignatureEvidence signature =
                 signature(List.of(InputCaseEvidence.none(0), InputCaseEvidence.none(1)));
 
-        assertEquals(List.of(0, 1), signature.inputs().stream().map(InputCaseEvidence::at).toList());
+        assertEquals(List.of(0, 1), signature.positions().stream().map(InputCaseEvidence::at).toList());
     }
 
     /** A position that is not one is not a position an input can be at. */

--- a/souther-compiler/src/test/java/souther/compiler/query/ABehaviorWithNoBoundaryIsMeasuredAsOneNobodyCouldMeasureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ABehaviorWithNoBoundaryIsMeasuredAsOneNobodyCouldMeasureTest.java
@@ -25,9 +25,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * no number that says what it went without. And the reading of what the model divides the behavior
  * into is never asked for, because the measure that would ask has already answered.
  *
- * <p>Read as one, they were: the two measures that read a boundary left the behavior out of their
- * maps, one reader of that stopped the report and one read it as a measure nobody asked for — so a
- * behavior nothing could be established about was held to no bar at all (issue #1044).
+ * <p>Read as one they are not distinguishable: a behavior left out of a measure's map reads to one
+ * reader as this compiler disagreeing with itself and to another as a measure nobody asked for, and
+ * a measure nobody asked for goes without nothing — so a behavior nothing could be established
+ * about is held to no bar at all and says nothing about it.
  */
 class ABehaviorWithNoBoundaryIsMeasuredAsOneNobodyCouldMeasureTest {
 
@@ -144,14 +145,25 @@ class ABehaviorWithNoBoundaryIsMeasuredAsOneNobodyCouldMeasureTest {
      * <p>Which is why the positions are a measurement. Both come out with no case counted anywhere,
      * and only one of them can say how many places there were to count at: a {@code >->} takes what
      * its first stage takes, and that is the boundary that did not work out.
+     *
+     * <p><b>Two states and not three.</b> The positions of a declared behavior are read off the
+     * declaration and nothing about them fell short — what could not be read is the cases at each
+     * of them, which each position answers for itself. A measurement saying the list itself was
+     * weakened would be a shortfall in a thing that has none, and the two states this measure
+     * exists to tell apart would be three.
      */
     @Test
     void thePositionsAreKnownOnlyWhereTheDeclarationWritesThem() {
         Map<String, Adequacy.SignatureEvidence> witnesses =
                 measured().db().ask(new Adequacy.Witnesses("probe.unresolved")).value();
 
-        assertEquals(1, witnesses.get("issue").positions().size(),
+        assertInstanceOf(Measurement.Complete.class, witnesses.get("issue").inputs(),
                 "`issue` writes one parameter, whatever its type resolved to");
+        assertEquals(1, witnesses.get("issue").positions().size());
+        assertEquals(BoundaryForMeasurement.NotDerived.BEHAVIOR_BOUNDARY_NOT_DERIVED,
+                witnesses.get("issue").positions().get(0).cases().why(),
+                "and the cases at it are what could not be read");
+
         assertInstanceOf(Measurement.FailedToMeasure.class, witnesses.get("whole").inputs(),
                 "a composition's positions are its first stage's, and that is what was not read");
     }
@@ -241,7 +253,8 @@ class ABehaviorWithNoBoundaryIsMeasuredAsOneNobodyCouldMeasureTest {
                 () -> "and not the state of a behavior nobody wrote a row for:\n" + text);
     }
 
-    /** And no measure the bar rests on was made, so the verdict is undetermined. */
+    /** And no measure the bar rests on could be finished, so the verdict is undetermined. Not a
+     *  build that asked for nothing: every one of them was asked for and started. */
     @Test
     void theVerdictIsUndetermined() {
         assertEquals(AdequacyReport.AdequacyStatus.UNDETERMINED,

--- a/souther-compiler/src/test/java/souther/compiler/query/ABehaviorWithNoBoundaryIsMeasuredAsOneNobodyCouldMeasureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ABehaviorWithNoBoundaryIsMeasuredAsOneNobodyCouldMeasureTest.java
@@ -220,12 +220,13 @@ class ABehaviorWithNoBoundaryIsMeasuredAsOneNobodyCouldMeasureTest {
         assertTrue(behaviorOf(report, "receipt").has("signature"),
                 "and the behavior whose boundary did work out is written in full");
 
-        // The three states apart, in the document. `issue` has no section because its positions
-        // were not derived and an empty array of them would say it takes nothing; `whole` has one
-        // saying the measure has no subject, which is true of a composition whatever else is wrong
-        // with it; `receipt` has one with numbers in it.
+        // The three states apart, in the document. `issue` has no section because nothing derived
+        // what the model divides it into — the axes come off the boundary and no declaration gives
+        // them, so an empty array would say the model divides none of its positions; `whole` has
+        // one saying the measure has no subject, which is true of a composition whatever else is
+        // wrong with it; `receipt` has one with numbers in it.
         assertFalse(behaviorOf(report, "issue").has("partition"),
-                "no section where the positions were not derived");
+                "no section where nothing derived what the model divides it into");
         assertEquals("no_subject", behaviorOf(report, "whole")
                         .get("partition").get("axesMeasure").get("reason").asString(),
                 "a composition is measured at its stages, and the document says so");

--- a/souther-compiler/src/test/java/souther/compiler/query/ABehaviorWithNoBoundaryIsMeasuredAsOneNobodyCouldMeasureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ABehaviorWithNoBoundaryIsMeasuredAsOneNobodyCouldMeasureTest.java
@@ -1,0 +1,250 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.report.AdequacyReport;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A behavior whose boundary could not be worked out is measured, and what it comes to is that
+ * nobody could measure it.
+ *
+ * <p>Three absences meet on one behavior and they are three different things. The signature is an
+ * analysis saying what it could not work out, and it is right to have no entry. The measures of
+ * that behavior are asked for and started and cannot finish, so each of them is a measurement with
+ * no number that says what it went without. And the reading of what the model divides the behavior
+ * into is never asked for, because the measure that would ask has already answered.
+ *
+ * <p>Read as one, they were: the two measures that read a boundary left the behavior out of their
+ * maps, one reader of that stopped the report and one read it as a measure nobody asked for — so a
+ * behavior nothing could be established about was held to no bar at all (issue #1044).
+ */
+class ABehaviorWithNoBoundaryIsMeasuredAsOneNobodyCouldMeasureTest {
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    /**
+     * A parameter naming a type from a module that did not resolve, and a composition over the
+     * behavior that takes it.
+     *
+     * <p>The composition is the point of the second half. A {@code >->} has no positions of its own
+     * — its partition measure answers that whatever else is wrong — so it is the one behavior whose
+     * account of the boundary can come from the signature measure and from nothing else.
+     */
+    private static final String UNRESOLVED = """
+            module probe.unresolved
+            import shared.money ( Amount )
+
+            data Invoice = { amount: Amount }
+            data Receipt = { n: Int }
+
+            behavior issue : (a: Amount) -> Invoice
+                constructs Invoice
+            let issue (a) = Invoice { amount = a }
+
+            behavior receipt : (i: Invoice) -> Receipt
+                constructs Receipt
+            let receipt (i) = Receipt { n = 1 }
+
+            behavior whole = issue >-> receipt
+            """;
+
+    private static Compilation measured() {
+        Compilation compilation = Compilation.ofSource(UNRESOLVED, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    private static JsonNode behaviorOf(AdequacyReport report, String name) {
+        JsonNode root = JSON.readTree(
+                report.json(souther.compiler.diag.SourceNameResolver.identity()));
+        for (JsonNode each : root.get("modules").get(0).get("behaviors")) {
+            if (name.equals(each.get("name").asString())) {
+                return each;
+            }
+        }
+        throw new AssertionError("no behavior `" + name + "` in the document");
+    }
+
+    private static List<String> weakeningOf(JsonNode behavior) {
+        JsonNode said = behavior.get("weakening");
+        return said == null ? List.of()
+                : said.valueStream().map(JsonNode::asString).toList();
+    }
+
+    /** The analysis has no signature to publish, and that is not a measurement. */
+    @Test
+    void theSignatureIsAbsentFromTheAnalysis() {
+        Map<String, souther.compiler.check.Sig> sigs =
+                measured().db().ask(new Bodies.Signatures("probe.unresolved")).value();
+        assertNotNull(sigs, "the signatures answered");
+        assertFalse(sigs.containsKey("issue"), "no boundary was built for `issue`");
+        assertFalse(sigs.containsKey("whole"), "nor for the composition over it");
+        assertTrue(sigs.containsKey("receipt"), "and the behavior beside them keeps its own");
+    }
+
+    /**
+     * And what the model divides it into is never asked for.
+     *
+     * <p>The stronger half of the same fact. A reading nobody asked for cannot have answered
+     * wrongly, and the measure that would have asked has an answer of its own — so the partiality
+     * of the analysis stops at the measure and does not reach past it.
+     */
+    @Test
+    void whatTheModelDividesItIntoIsNotAsked() {
+        Compilation compilation = measured();
+        assertNotNull(compilation.db().ask(new Adequacy.Coverage("probe.unresolved")).value(),
+                "the coverage answered");
+        assertEquals(null,
+                compilation.db().ask(new Adequacy.Divided("probe.unresolved", "issue")).value(),
+                "nothing derived what the model divides `issue` into");
+    }
+
+    /** Each measure of it says it could not be made, and says the same thing. */
+    @Test
+    void everyMeasureThatReadsABoundarySaysItHadNone() {
+        Compilation compilation = measured();
+        Adequacy.SignatureEvidence signature = compilation.db()
+                .ask(new Adequacy.Witnesses("probe.unresolved")).value().get("issue");
+        PartitionEvidence partition = compilation.db()
+                .ask(new Adequacy.Coverage("probe.unresolved")).value().get("issue");
+        assertNotNull(signature, "the signature measure answered for `issue`");
+        assertNotNull(partition, "and so did the partition measure");
+
+        assertEquals(BoundaryForMeasurement.NotDerived.BEHAVIOR_BOUNDARY_NOT_DERIVED,
+                signature.counted().why());
+        assertEquals(BoundaryForMeasurement.NotDerived.BEHAVIOR_BOUNDARY_NOT_DERIVED,
+                partition.partitioned().why());
+        assertEquals(BoundaryForMeasurement.NotDerived.BEHAVIOR_BOUNDARY_NOT_DERIVED,
+                partition.bounded().why());
+
+        // The arms are measured off the bodies and not off the boundary, so they say what happened
+        // to them. Two measures short of two different things is two sentences, and a behavior
+        // whose every measure gave one reason would be this deciding what the others found.
+        Adequacy.BranchEvidence branch = compilation.db()
+                .ask(new Adequacy.BranchCoverage("probe.unresolved")).value().get("issue");
+        assertEquals(Adequacy.BranchEvidence.Unelaborated.BODIES_NOT_ELABORATED,
+                branch.measured().why());
+    }
+
+    /**
+     * How many positions it has is unknown for a composition, and known for a declared behavior.
+     *
+     * <p>Which is why the positions are a measurement. Both come out with no case counted anywhere,
+     * and only one of them can say how many places there were to count at: a {@code >->} takes what
+     * its first stage takes, and that is the boundary that did not work out.
+     */
+    @Test
+    void thePositionsAreKnownOnlyWhereTheDeclarationWritesThem() {
+        Map<String, Adequacy.SignatureEvidence> witnesses =
+                measured().db().ask(new Adequacy.Witnesses("probe.unresolved")).value();
+
+        assertEquals(1, witnesses.get("issue").positions().size(),
+                "`issue` writes one parameter, whatever its type resolved to");
+        assertInstanceOf(Measurement.FailedToMeasure.class, witnesses.get("whole").inputs(),
+                "a composition's positions are its first stage's, and that is what was not read");
+    }
+
+    /**
+     * The behavior carries the fact once, and the composition carries it from the signature measure
+     * alone.
+     *
+     * <p>Which makes the composition the row that holds this. Its partition measure answers that it
+     * has no subject and goes without nothing, so a signature measure that went back to leaving the
+     * behavior out would leave nothing anywhere saying this behavior could not be measured — while
+     * the declared behavior beside it would go on carrying the fact through the partition measure
+     * and look unchanged.
+     */
+    @Test
+    void theFactIsCarriedOncePerBehavior() {
+        Compilation compilation = measured();
+        AdequacyReport report = AdequacyReport.of(compilation);
+        for (AdequacyReport.ModuleReport module : report.modules()) {
+            for (AdequacyReport.BehaviorReport behavior : module.behaviors()) {
+                long said = behavior.evidence().weakening().causes().stream()
+                        .filter(each -> each instanceof Weakening.BoundaryNotDerived)
+                        .count();
+                assertEquals("receipt".equals(behavior.name()) ? 0 : 1, said,
+                        () -> "what " + behavior.name() + " went without: "
+                                + behavior.evidence().weakening());
+            }
+        }
+
+        PartitionEvidence composed = compilation.db()
+                .ask(new Adequacy.Coverage("probe.unresolved")).value().get("whole");
+        assertEquals(PartitionEvidence.NONE, composed,
+                "a composition is measured at its stages, boundary or no boundary");
+        assertTrue(composed.weakening().isEmpty(),
+                "so its partition measure is short of nothing, and cannot be where the fact came"
+                        + " from");
+    }
+
+    /**
+     * The document says what could not be read, in the words it promises, and leaves out the
+     * sections it has nothing to fill in.
+     */
+    @Test
+    void theDocumentLeavesOutWhatItCouldNotRead() {
+        AdequacyReport report = AdequacyReport.of(measured());
+        for (String name : List.of("issue", "whole")) {
+            JsonNode behavior = behaviorOf(report, name);
+            assertFalse(behavior.has("signature"),
+                    () -> name + " has no signature to read, so the document writes none");
+            assertEquals(1, weakeningOf(behavior).stream()
+                            .filter("behavior_boundary_not_derived"::equals).count(),
+                    () -> "what " + name + " went without: " + weakeningOf(behavior));
+        }
+        assertTrue(behaviorOf(report, "receipt").has("signature"),
+                "and the behavior whose boundary did work out is written in full");
+
+        // The three states apart, in the document. `issue` has no section because its positions
+        // were not derived and an empty array of them would say it takes nothing; `whole` has one
+        // saying the measure has no subject, which is true of a composition whatever else is wrong
+        // with it; `receipt` has one with numbers in it.
+        assertFalse(behaviorOf(report, "issue").has("partition"),
+                "no section where the positions were not derived");
+        assertEquals("no_subject", behaviorOf(report, "whole")
+                        .get("partition").get("axesMeasure").get("reason").asString(),
+                "a composition is measured at its stages, and the document says so");
+        assertTrue(behaviorOf(report, "receipt").has("partition"),
+                "and a behavior that was measured carries its measurement");
+    }
+
+    /**
+     * And the line a person reads says which of the ways it has no number, rather than the words
+     * of another.
+     *
+     * <p>Both halves are held. The sentence a reason is given is worth nothing on its own — the
+     * line said {@code no row names this behavior} for every reason nobody had written a word for,
+     * which is a sentence about a state this behavior is not in — so what this fixes is fixed by
+     * the second assertion.
+     */
+    @Test
+    void theLineSaysWhichOfTheWaysItHasNoNumber() {
+        String text = AdequacyReport.of(measured())
+                .human(souther.compiler.diag.SourceNameResolver.identity());
+        assertTrue(text.contains("signature   not measured (this behavior's signature could not be"
+                        + " read)"),
+                () -> "the line names the state it is in:\n" + text);
+        assertFalse(text.contains("no row names this behavior"),
+                () -> "and not the state of a behavior nobody wrote a row for:\n" + text);
+    }
+
+    /** And no measure the bar rests on was made, so the verdict is undetermined. */
+    @Test
+    void theVerdictIsUndetermined() {
+        assertEquals(AdequacyReport.AdequacyStatus.UNDETERMINED,
+                AdequacyReport.of(measured()).adequacy());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/AFindingCarriesWhatTheMeasureThatFoundItWentWithoutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AFindingCarriesWhatTheMeasureThatFoundItWentWithoutTest.java
@@ -96,7 +96,7 @@ class AFindingCarriesWhatTheMeasureThatFoundItWentWithoutTest {
                 case About.ACaseNoRowExpects _, About.ACaseNothingWasSeenToProduce _ ->
                         signature.output().cases().weakening();
                 case About.ACaseNoRowAppliesItTo(var at, var _) ->
-                        signature.inputs().get(at.at()).cases().weakening();
+                        signature.positions().get(at.at()).cases().weakening();
                 default -> null;
             };
             if (owed == null) {

--- a/souther-compiler/src/test/java/souther/compiler/query/AnAbsentDerivationIsNotAProofAboutTheModelTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnAbsentDerivationIsNotAProofAboutTheModelTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -179,19 +180,19 @@ class AnAbsentDerivationIsNotAProofAboutTheModelTest {
     }
 
     /**
-     * The coverage answers for every behavior of the module it was asked about, bar compositions.
+     * The coverage answers for every behavior of the module it was asked about, compositions
+     * included.
      *
-     * <p>A characterization of the contract as it stands, written because a reader depends on it.
-     * {@code PartitionEvidence.NONE} says the model holds no subject for these measures, and the
-     * two readers of this map reach it by a key being missing — so what a missing key means is part
-     * of the answer, and it is written down nowhere the producer can be held to.
+     * <p>A key carried part of the answer, and the two readers of this map read it two ways: one
+     * as a composition with no subject, one as this compiler disagreeing with itself. Neither is
+     * right about a behavior whose boundary did not work out, which is a third thing a key cannot
+     * say and which the front end does produce — so the report stopped on it.
      *
-     * <p>Which is the state of it and not the intent. The map is total over what it answers for
-     * once the coverage answers for compositions itself, and this test inverts then: the reading
-     * moves into the producer and the key stops carrying it (issue #996, stage 3).
+     * <p>So a composition's answer is {@code NONE} and it is the producer that says so, from the
+     * declarations it is holding anyway. What a reader does with this map is look a name up.
      */
     @Test
-    void theCoverageOmitsOnlyCompositions() {
+    void theCoverageAnswersForEveryBehavior() {
         Compilation compilation = measured("""
                 module example.mixed
 
@@ -221,10 +222,22 @@ class AnAbsentDerivationIsNotAProofAboutTheModelTest {
 
         souther.compiler.check.Prepared module =
                 compilation.db().ask(new Shapes.Prepared("example.mixed")).value();
+        assertEquals(module.behaviors().stream()
+                        .map(souther.compiler.ast.Hir.BehaviorDef::name).toList(),
+                List.copyOf(answered.keySet()),
+                "the coverage answers for every behavior the module declares");
         for (souther.compiler.ast.Hir.BehaviorDef behavior : module.behaviors()) {
-            assertEquals(!module.isComposition(behavior), answered.containsKey(behavior.name()),
-                    () -> "a behavior is in the coverage exactly when it is not a composition: "
-                            + behavior.name() + " in " + answered.keySet());
+            PartitionEvidence found = answered.get(behavior.name());
+            assertNotNull(found, () -> "an answer for " + behavior.name());
+            // And a composition's answer is the one that says the model holds no subject here,
+            // which is what a reader used to work out for itself from the key not being there.
+            if (module.isComposition(behavior)) {
+                assertEquals(PartitionEvidence.NONE, found,
+                        () -> behavior.name() + " is measured at its stages");
+            } else {
+                assertNotEquals(PartitionEvidence.NONE, found,
+                        () -> behavior.name() + " is measured here");
+            }
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/query/AnAnsweredMeasureAnswersForEveryBehaviorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnAnsweredMeasureAnswersForEveryBehaviorTest.java
@@ -1,0 +1,138 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A measure of a module that answered answers for every behavior the module declares.
+ *
+ * <p>Whether a query answers at all is the query's own business: a compile that never reached what
+ * it reads has nothing to say, and says so by being absent. What it may not do is answer and leave
+ * a behavior out. A key that is sometimes there carries part of the answer, and the readers of
+ * these maps read a missing one three ways — a composition with no subject, a compile that did not
+ * get that far, and this compiler disagreeing with itself. Two of those are wrong about a behavior
+ * whose boundary did not work out, and the third stopped the report on it.
+ *
+ * <p>Held over every measure of a behavior and not over the one the report crashed on. Two of the
+ * four were total already and by two different arrangements — the reading of the rows through a
+ * total accessor, the arms through a loop with no way out of it — and the other two each dropped
+ * the key. One of them crashed and one went quiet, which is the same defect and one report.
+ */
+class AnAnsweredMeasureAnswersForEveryBehaviorTest {
+
+    /**
+     * A module with a behavior of every shape this has words for: one measured, a composition
+     * measured at its stages, an injected behavior with no body of its own, and one whose
+     * declaration rests on a name nothing resolved.
+     */
+    private static final String EVERY_SHAPE = """
+            module example.shapes
+            import nothing.here ( Money )
+
+            data A = { n: Int }
+            data B = { n: Int }
+            data C = { n: Int }
+
+            behavior one : (a: A) -> B
+                constructs B
+            let one (a) = B { n = a.n }
+
+            behavior two : (b: B) -> C
+                constructs C
+            let two (b) = C { n = b.n }
+
+            behavior both = one >-> two
+
+            behavior injected : (a: A) -> B
+
+            behavior priced : (m: Money) -> B
+                constructs B
+            let priced (m) = B { n = 1 }
+            """;
+
+    private static Compilation measured() {
+        Compilation compilation = Compilation.ofSource(EVERY_SHAPE, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    private static List<String> declared(Compilation compilation) {
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared("example.shapes")).value();
+        assertNotNull(prepared, "the declarations were read");
+        return prepared.behaviors().stream().map(Hir.BehaviorDef::name).toList();
+    }
+
+    /** Every measure of a behavior, under the name the report knows it by. */
+    private static Map<String, Map<String, ?>> measures(Compilation compilation) {
+        return Map.of(
+                "witnesses", compilation.db().ask(new Adequacy.Witnesses("example.shapes")).value(),
+                "coverage", compilation.db().ask(new Adequacy.Coverage("example.shapes")).value(),
+                "branch", compilation.db().ask(new Adequacy.BranchCoverage("example.shapes"))
+                        .value());
+    }
+
+    /**
+     * The key set is the behaviors, in the order they are declared, and every answer is one.
+     *
+     * <p>An equality and not a containment. A measure that answered for something the module does
+     * not declare is as wrong as one that left a behavior out, and only one of the two is what
+     * anybody was looking for when this was written.
+     */
+    @Test
+    void everyMeasureAnswersForEveryBehaviorAndNothingElse() {
+        Compilation compilation = measured();
+        List<String> behaviors = declared(compilation);
+        measures(compilation).forEach((measure, answered) -> {
+            assertNotNull(answered, () -> measure + " answered");
+            assertEquals(behaviors, List.copyOf(answered.keySet()),
+                    () -> measure + " answers for the behaviors the module declares");
+            answered.forEach((behavior, evidence) ->
+                    assertNotNull(evidence, () -> measure + " of " + behavior));
+        });
+    }
+
+    /**
+     * And the reading of the rows, which is total by an accessor rather than by a key set.
+     *
+     * <p>Asked of the thing that answers it. The reading is kept under whatever wrote a row, so its
+     * map is not keyed by the behaviors at all and an equality over its keys would be a rule about
+     * a different set. What it owes is an answer per behavior, and that is what is held here.
+     */
+    @Test
+    void theReadingOfTheRowsAnswersForEveryBehaviorToo() {
+        Compilation compilation = measured();
+        Map<String, Adequacy.RowReading> rows =
+                compilation.db().ask(new Adequacy.Rows("example.shapes")).value();
+        assertNotNull(rows, "the rows were read for or against");
+        for (String behavior : declared(compilation)) {
+            assertNotNull(Adequacy.Rows.readingFor(rows, behavior),
+                    () -> "how far the rows of " + behavior + " were read");
+        }
+    }
+
+    /**
+     * The producer has nowhere to drop one.
+     *
+     * <p>The loop is the helper's and the caller writes what one behavior comes to, so a caller
+     * that has nothing to say has to say that rather than return. What that used to be written as
+     * is a {@code continue}, and there is no longer a loop to write it in.
+     */
+    @Test
+    void aMapperThatAnswersNothingIsRefused() {
+        Prepared prepared =
+                measured().db().ask(new Shapes.Prepared("example.shapes")).value();
+        assertThrows(NullPointerException.class,
+                () -> Adequacy.answerEveryBehavior(prepared,
+                        behavior -> behavior.name().equals("one") ? null : behavior.name()),
+                "a behavior with no answer is not a behavior to leave out");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/report/WhatAWholeWentWithoutIsWhatItsPartsWentWithoutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/WhatAWholeWentWithoutIsWhatItsPartsWentWithoutTest.java
@@ -121,8 +121,10 @@ class WhatAWholeWentWithoutIsWhatItsPartsWentWithoutTest {
 
                 if (behavior.signature() != null) {
                     Adequacy.SignatureEvidence signature = behavior.signature();
-                    WeakeningSet cases = signature.output().cases().weakening();
-                    for (InputCaseEvidence each : signature.inputs()) {
+                    WeakeningSet cases = signature.output().cases().weakening()
+                            .union(signature.inputs().weakening());
+                    for (InputCaseEvidence each
+                            : signature.inputs().made().orElseGet(java.util.List::of)) {
                         cases = cases.union(each.cases().weakening());
                     }
                     holds(lost, "signature of " + behavior.name(),


### PR DESCRIPTION
Closes #1044.

## The defect

A behavior whose *parameter* type comes from a module that did not resolve ended `souther examples` in an internal compiler error. Reproduced in 0.4s and traced:

`import shared.money` unresolved → `Amount` is `Type.Erroneous` → `SignatureBoundary.of` throws `Unanswerable` at the parameter → `PipelineSigs.signatures` makes no entry → `Adequacy.Coverage`'s loop hits `sig == null` and `continue`s → the map has a hole → `PartitionEvidence.answeredFor` throws.

`Bodies.Signatures` being partial is correct — the name was reported where it was written. What was wrong is that two measures turned that into a missing key, and a missing key means three different things to the three readers of these maps: a composition with no subject, a compile that did not get that far, and this compiler disagreeing with itself.

`Adequacy.Witnesses` had the same `continue` one line apart. It does not crash; it goes quiet. A null signature contributes nothing to `BehaviorEvidence.weakening()` and is skipped by `AdequacyReport.requiredEvidence()`, so a behavior nothing could be established about was held to no bar and said nothing about it.

## The change

The invariant this fixes: **a query may be absent, but an answered per-behavior measurement is total over `Prepared.behaviors()`.** Partiality lives in the internal analyses; at the measurement boundary it becomes a value.

- `Adequacy.answerEveryBehavior` owns the key set. The caller writes what one behavior comes to, so there is no loop to write a `continue` in, and a mapper answering `null` is refused.
- `Coverage` asks whether there is a subject before asking what could be read of it. A composition answers `PartitionEvidence.NONE` and the producer says so.
- `PartitionEvidence.answeredFor` is deleted. It re-derived `isComposition` at the consumer; readers now call `partitions.get(name)`. The `Prepared` argument going away is the visible sign.
- `BoundaryForMeasurement` (new) is the one place a missing `Sig` becomes a measurement failure. Both measures ask it and answer for their own measure.
- `Weakening.BoundaryNotDerived(behavior)` is named by the behavior alone, so the fact reaching a whole by two measures arrives once.
- `SignatureEvidence.inputs` becomes `Measure<List<InputCaseEvidence>>`. A `>->` whose first stage did not work out has a position count nobody made, and an empty list is the same bytes as a behavior that takes nothing. A declared behavior keeps the positions it writes.
- The document omits `signature` and `partition` for such a behavior rather than filling them with empty arrays. The cause is the behavior's `weakening`.
- The signature text renderer's semantic fallback is removed: `default -> "not measured (no row names this behavior)"` projected every unworded reason onto a state the behavior is not in. An unknown reason now fails fast at runtime rather than being rendered as another state. It is **not** compile-checked exhaustiveness — see *Left alone*.

## Schema

One word added to `$defs.weakening` (`behavior_boundary_not_derived`). Nothing added to `signature.reason` or `partition.axesMeasure.reason`, and no property changes required-ness. Documents written before this are still version 7 documents, so no version bump.

## Before / after

```
$ souther examples invoicing/src/main/souther/*.sou
```

Before: `internal compiler error: IllegalStateException: the coverage of ... left out `issue`, which is not a composition`

After:

```
example.invoicing                                        measurement: partial
  issue                    implemented   rows not read
    signature   not measured (this behavior's signature could not be read)
    branch      not measured (this module's bodies were not elaborated)
    · no rows were read from `invoicing.sou`, so what they cover is unknown

1 behavior: 1 implemented, 0 unimplemented, 0 injected; 0 rows waiting for a `let`.
adequacy: undetermined
```

With `-cp sharedmoney/target/classes` the output is unchanged.

## Tests

Four layers:

1. `answerEveryBehavior` refuses a mapper that answers nothing.
2. `Witnesses` / `Coverage` / `BranchCoverage` each answer for exactly the declared behaviors, in order, with no null values; `Rows.readingFor` is total by its accessor.
3. `AnAbsentDerivationIsNotAProofAboutTheModelTest.theCoverageOmitsOnlyCompositions` is inverted to `theCoverageAnswersForEveryBehavior` — its own javadoc predicted this inversion.
4. A fixture separating internal absence (`Signatures`, `Divided`), measurement failure (`Witnesses`, `Coverage`), and structural non-applicability (a composition's `NONE`), plus the document, the human line, and the verdict.

The fixture puts a composition over the broken behavior. `Coverage[whole]` is `NONE` and goes without nothing, so `BoundaryNotDerived(whole)` can only reach the report through the signature measure — which makes that row the end-to-end check on `Witnesses` totality. The declared behavior beside it would keep carrying the fact through the partition measure and look unchanged.

## Mutations measured

| broken | what went red |
|---|---|
| `sig == null → continue` restored in `Witnesses` | key-set property, `whole`'s weakening (empty), document, human line — 6 assertions |
| the `BoundaryForMeasurement.NotDerived` arm removed from the text switch | `IllegalStateException: the signature measure has no word for BEHAVIOR_BOUNDARY_NOT_DERIVED` at runtime — it does not fall onto another reason's sentence |
| the arm measure returns nothing for a behavior it cannot answer for | `NullPointerException: no answer for \`one\` of \`example.shapes\`` at the producer, naming the behavior |
| `Coverage`'s gate order swapped | `Coverage[whole]` stops being `NONE` — 2 assertions |

`AMeasureIsIntroducedInOnePlaceTest` caught the three new places a measurement state is made; they are declared with their counts, and no existing entry moved.

## Verification

`mvn clean verify` — BUILD SUCCESS, on `2e112f846` (after #1053 / issue-1040 merged). The one conflict with #1040 was the `PartitionEvidence` argument it moved from `rowsFor` into `planFor`; resolved there.

## Left alone

- **The signature switch throws rather than being compile-checked.** Its selector is `MeasureReason`, a plain interface, so javac cannot prove exhaustiveness there. Sealing a reason type per measure was measured and rejected: `NothingWasAsked` is used by 4 measures across 5 sites and `BoundaryForMeasurement.NotDerived` by 6, and both are shared *by design* — nobody-asked is one fact about the run, a underivable boundary is one fact about the behavior. Per-measure sealed interfaces would make each shared reason enumerate every measure that reads it, which is the dependency the wrong way round. The comment on the `default` arm records this and the condition to revisit it: if reasons stop being shared. Runtime fail-fast is the same shape the arm measure has always used.
- `AdequacyReport.whyNoPartition` / `whyNoBoundary` still have `default -> reason.name()`. Unreachable on this path, and changing them needs a separate measurement of what currently lands there.
- `PairSpace.total` is an `int` outside the measure, so the boundary-not-derived case carries `0` for a size nobody derived. It never reaches a document; making `total` a measure is its own change.
- `SignatureBoundary` treats a parameter's `Erroneous` and a field's differently. That asymmetry is what lets the field case degrade gracefully, and symmetrising it would need a transitive validity check — a different problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review round 1 (`57757149f`, `6c1e0a95f`)

Three findings, each traced to what let it in rather than fixed where it showed.

**The positions had two introduction rules.** `boundaryNotDerived` hand-wrote a `Measurement.Partial` while every other path went through `at(...)`, so a declared behavior's positions — read off its parameters, short of nothing — carried a shortfall, and the two states the measure exists for became three. Now `at(declaredPositions(...))`.

The duplicate had already been reported and I misread it: making the measure a second way showed up in `AMeasureIsIntroducedInOnePlaceTest` as a **second introduction site**, and I declared the entry instead of taking it as the finding. Removing the duplicate rule removes the entry — that disappearance is what now says the rule is one again. The fixture pins `Complete` for `issue` and `FailedToMeasure` for `whole`, plus the reason on the position's own cases.

**`BranchCoverage` bypassed the constructor.** It was total and its property test said so, but it kept a loop with the `continue` this change exists to remove — one gate away from the same defect. Migrated. Breaking it now fails at the producer: `NullPointerException: no answer for \`one\` of \`example.shapes\``.

**The weakening word said "was made".** *Made* is what a measure nobody asked for is not; these were asked for, started, and could not be finished. I counted every place this branch says it and found **four**, all corrected — the word's javadoc, `PartitionEvidence.boundaryNotDerived`, and two test javadocs.

Also removed the four `(issue #1044)` references the new comments carried, per this repo's convention of writing the rule rather than the number.

Rebuilt on `a209004c9`; the new staged-file unused-import check passes over all 21 Java files this branch touches, and `mvn clean verify` is green.
