### PR TITLE
Hold a rounding policy to the operation that declares one, not to its name

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -541,7 +541,7 @@ final class DischargeRules {
                     + " argument(s), and the arithmetic written for it reads " + reads.size());
         }
         for (int i = 0; i < reads.size(); i++) {
-            if (!reads.get(i).heldBy(signature.params().get(i), answers)) {
+            if (!heldBy(stdlib, reads.get(i), signature.params().get(i), answers)) {
                 throw new IllegalStateException("argument " + (i + 1) + " of " + operation
                         + " is " + Type.show(signature.params().get(i))
                         + ", which the arithmetic written for it reads as " + reads.get(i));
@@ -670,6 +670,62 @@ final class DischargeRules {
         rules.forEach((operation, rule) ->
                 holdToTheDeclaration(stdlib, operation, reads.apply(rule), derived, required, what));
         return rules;
+    }
+
+    /**
+     * Whether the argument declared {@code at} is what the row says that position reads, for an
+     * operation answering {@code answered}.
+     *
+     * <p>Here and not on {@link Arithmetic.Reads}, which says what a position is and stops there.
+     * Holding one of those to a declaration is a question about the library, and this is the reader
+     * that has the library — the same reader that holds the operation's arity and its result to it.
+     *
+     * <p>Two of them are answered from the row itself: the number the operation answers is the one
+     * its result carries, and a scale is a count. The third is answered from a declaration, because
+     * there is nothing about a rounding policy that a type says of itself — and reading it off a
+     * name written here would be a second answer to which type it is, which is what ADR-0087 ends.
+     */
+    private static boolean heldBy(Stdlib stdlib, Arithmetic.Reads reads, Type at, Type answered) {
+        return switch (reads) {
+            case THE_NUMBER_IT_ANSWERS -> at.equals(answered);
+            case A_SCALE -> at == Type.Prim.INT;
+            case A_ROUNDING_MODE -> at.equals(theRoundingPolicyTheLibraryDeclares(stdlib));
+        };
+    }
+
+    /** Which library operation the rounding policy is read off, and where in its arguments. */
+    private static final ValueName.Stdlib ROUNDING_POLICY_ANCHOR =
+            new ValueName.Stdlib("Decimal", "round");
+
+    /** {@code round(scale, mode, d)} — the second of them. */
+    private static final int ROUNDING_POLICY_ARGUMENT = 1;
+
+    /**
+     * The type the library declares for a rounding policy, taken from the operation that declares
+     * one and read as whatever that operation declares there.
+     *
+     * <p>Whatever it declares there, and never a type this checks against. A rule that said the
+     * anchor's argument must be {@code RoundingMode} would be the spelling back again, one operation
+     * further along. What is held is that two declarations agree: {@code Decimal.divide} takes at
+     * its policy position the type {@code Decimal.round} takes at its own, and either of them
+     * drifting alone fails this. Both moving to a new policy type together passes, and should —
+     * that is the library being redesigned rather than the table and the library disagreeing.
+     *
+     * <p>The anchor is a choice and is written down as one. What it is not is a second definition
+     * of which type the policy is: the library's declaration remains the only one.
+     *
+     * @throws IllegalStateException where the anchor no longer declares the argument it is read off
+     */
+    private static Type theRoundingPolicyTheLibraryDeclares(Stdlib stdlib) {
+        List<Type> params = holdTheOperationToTheLibrary(stdlib, ROUNDING_POLICY_ANCHOR)
+                .signature().params();
+        if (params.size() <= ROUNDING_POLICY_ARGUMENT) {
+            throw new IllegalStateException(ROUNDING_POLICY_ANCHOR.qualified() + " takes "
+                    + params.size() + " argument(s), and the rounding policy every arithmetic over"
+                    + " one is held to is read off argument " + (ROUNDING_POLICY_ARGUMENT + 1)
+                    + " of it");
+        }
+        return params.get(ROUNDING_POLICY_ARGUMENT);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/semantics/Arithmetic.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/Arithmetic.java
@@ -1,7 +1,6 @@
 package souther.compiler.semantics;
 
 import souther.compiler.types.BinOp;
-import souther.compiler.types.Type;
 
 import java.util.List;
 
@@ -82,7 +81,16 @@ public sealed interface Arithmetic {
         }
     }
 
-    /** What one argument of a numeric operation is, as far as a fact about it needs to know. */
+    /**
+     * What one argument of a numeric operation is, as far as a fact about it needs to know.
+     *
+     * <p>What each of these <em>is</em>, said once. Which declaration answers to one, and whether
+     * the library's signature agrees, is a question about the library and is asked where the
+     * library is — {@code check.DischargeRules}, which holds every one of these facts to what the
+     * library declares before a call is read. It used to be asked here, by comparing the argument's
+     * type against a name written down beside it, which is a second answer to which type that is
+     * (ADR-0087) and a backend's spelling in a package that is neutral about all of them (#1039).
+     */
     enum Reads {
 
         /** A number of the kind the operation answers. */
@@ -92,24 +100,6 @@ public sealed interface Arithmetic {
         A_SCALE,
 
         /** Which way it rounds there. */
-        A_ROUNDING_MODE;
-
-        /** The declaration that rule is about, by the address the library declares it under. Still
-         *  a spelling this reads, which is the debt #1039 names; what has moved is that it is the
-         *  address the library writes and no longer the package a backend ships it in. */
-        private static final souther.compiler.types.TypeKey ROUNDING_MODE =
-                new souther.compiler.types.TypeKey("souther.decimal", "RoundingMode");
-
-        /** Whether an argument declared {@code at} is this, for an operation answering
-         *  {@code answered}. */
-        public boolean heldBy(Type at, Type answered) {
-            return switch (this) {
-                case THE_NUMBER_IT_ANSWERS -> at.equals(answered);
-                case A_SCALE -> at == Type.Prim.INT;
-                case A_ROUNDING_MODE ->
-                        at instanceof Type.Ref(souther.compiler.types.TypeSymbol.AtModule name)
-                                && name.key().equals(ROUNDING_MODE);
-            };
-        }
+        A_ROUNDING_MODE
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/TheRoundingPolicyIsOneTypeTwoOperationsShareTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TheRoundingPolicyIsOneTypeTwoOperationsShareTest.java
@@ -1,0 +1,61 @@
+package souther.compiler.check;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.stdlib.Stdlib;
+import souther.compiler.types.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * {@code Decimal.round} and {@code Decimal.divide} take one rounding policy between them.
+ *
+ * <p>The invariant the check rests on, said where a reader can find it. Nothing in this compiler
+ * names the policy type: a rule says a position of {@code Decimal.divide} reads one, and which type
+ * that is comes from the argument {@code Decimal.round} declares for the same job
+ * ({@code DischargeRules}). Two declarations held to each other, which is a check only while they
+ * really are two declarations of one thing.
+ *
+ * <p>So this is the sentence that reading assumes. Either operation moving to a policy of its own
+ * fails the build where the facts are registered, which is a class initializer and says nothing
+ * about an anchor; this fails first and says what the anchor is.
+ *
+ * <p>Both moving together passes here and there, and should: that is the library choosing a new
+ * policy type, not the hand-written arithmetic and the library disagreeing.
+ */
+class TheRoundingPolicyIsOneTypeTwoOperationsShareTest {
+
+    /** {@code divide(dividend, divisor, scale, mode)}. */
+    private static final int MODE_OF_DIVIDE = 3;
+
+    /** {@code round(scale, mode, d)}. */
+    private static final int MODE_OF_ROUND = 1;
+
+    @Test
+    void theTypeEachTakesForItIsTheSameType() {
+        assertEquals(argumentOf("Decimal.round", MODE_OF_ROUND),
+                argumentOf("Decimal.divide", MODE_OF_DIVIDE),
+                "the arithmetic over a rounded quotient is held to the policy `Decimal.round`"
+                        + " declares, so a policy of its own would hold `Decimal.divide` to nothing");
+    }
+
+    /** And it is a declaration, rather than a number or a scalar that happens to sit there. */
+    @Test
+    void andItIsATypeSomethingDeclares() {
+        assertEquals(Type.Ref.class, argumentOf("Decimal.round", MODE_OF_ROUND).getClass(),
+                "a policy is a declared type; a scale is the count beside it");
+        assertEquals(Type.INT, argumentOf("Decimal.round", 0),
+                "and the scale is that count");
+    }
+
+    private static Type argumentOf(String operation, int at) {
+        Stdlib.Entry entry = DefaultStdlib.get().entry(operation);
+        assertNotNull(entry, () -> "the library declares no `" + operation + "`");
+        assertEquals(true, entry.signature().params().size() > at,
+                () -> "`" + operation + "` takes " + entry.signature().params().size()
+                        + " argument(s), and this reads " + (at + 1));
+        return entry.signature().params().get(at);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/semantics/OnlyTheAbiSpellsATypeTheLibraryDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/semantics/OnlyTheAbiSpellsATypeTheLibraryDeclaresTest.java
@@ -1,0 +1,94 @@
+package souther.compiler.semantics;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.Reserved;
+import souther.compiler.ast.Hir;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The library declares its types, and nothing else in this compiler says their names.
+ *
+ * <p>ADR-0087 puts it as a rule: the declaration is where a runtime-backed type is settled, and no
+ * other place may branch on its name. A conditional that asks whether a type is called
+ * {@code RoundingMode} is a second answer to which type that is — one the library does not know it
+ * has given, and one that goes on answering after the library has changed its mind.
+ *
+ * <p>{@code semantics/Arithmetic} had one, and it is what #1039 was. A rule there says a position
+ * of {@code Decimal.divide} reads a rounding policy; which type answers to that is a question about
+ * the library and is asked where the library is, by taking the type {@code Decimal.round} declares
+ * at its own policy position. Two declarations held to each other, and no name written down.
+ *
+ * <p>One place spells them, and has to: {@code jvm.SoutherJvmAbi} says what each is called on this
+ * backend, and a table from a declaration to a class name is names on both sides. That is the seam
+ * #1038 built, and it is the only exception here.
+ *
+ * <p>Read off the library rather than listed, so a type the library gains is covered the day it is
+ * declared.
+ */
+class OnlyTheAbiSpellsATypeTheLibraryDeclaresTest {
+
+    /** Where a declaration may be named, because naming it is the answer being given. */
+    private static final Set<String> THE_ABI = Set.of("jvm/SoutherJvmAbi.java");
+
+    @Test
+    void nothingButTheAbiWritesOneOfTheirNames() throws IOException {
+        Set<String> declared = everyTypeTheLibraryDeclares();
+        assertTrue(declared.contains("RoundingMode"),
+                () -> "the library declares RoundingMode; this found " + declared);
+
+        Set<String> spelling = new TreeSet<>();
+        for (Path source : sources()) {
+            String text = Files.readString(source);
+            for (String name : declared) {
+                if (text.contains('"' + name + '"') && !THE_ABI.contains(relative(source))) {
+                    spelling.add(relative(source) + ": \"" + name + '"');
+                }
+            }
+        }
+
+        assertEquals(List.of(), List.copyOf(spelling),
+                "which type answers to a rule is the library's to say (ADR-0087); what one is called"
+                        + " on a machine is `jvm.SoutherJvmAbi`'s, and is the only name written out");
+    }
+
+    /** Every type name the standard library declares, from the library itself. */
+    private static Set<String> everyTypeTheLibraryDeclares() {
+        Set<String> names = new LinkedHashSet<>();
+        for (Reserved.StdlibModule module : Reserved.MODULES) {
+            for (Hir.Def def : DefaultStdlib.get()
+                    .languageDeclarationsIn(module.moduleName()).values()) {
+                names.add(def.name());
+            }
+        }
+        return names;
+    }
+
+    private static String relative(Path source) {
+        String path = source.toString().replace('\\', '/');
+        return path.substring(path.indexOf("souther/compiler/") + "souther/compiler/".length());
+    }
+
+    private static List<Path> sources() throws IOException {
+        Path main = Path.of("src/main/java/souther/compiler");
+        assertTrue(Files.isDirectory(main), () -> "no " + main.toAbsolutePath());
+        try (Stream<Path> walk = Files.walk(main)) {
+            List<Path> found = walk.filter(each -> each.toString().endsWith(".java")).sorted()
+                    .toList();
+            assertTrue(found.size() > 100, () -> "that is not the compiler: " + found.size());
+            return found;
+        }
+    }
+}


### PR DESCRIPTION
Closes #1039.

`Arithmetic.Reads.A_ROUNDING_MODE` asked whether an argument's type was called `RoundingMode`. Two things wrong with that, and ADR-0087 names the first: the declaration is where a runtime-backed type is settled, and a conditional elsewhere that branches on its name is a second answer to which type it is. The second is where it sat — `semantics`, whose rule is that a fact there is about the operation and about no reader.

## What moved

`Reads` says what a position is and stops there. Holding one of those to a declaration is a question about the library, and `check.DischargeRules` is the reader that has the library — it already holds the operation's arity and its result to what the library declares, and this is the third of the same.

`heldBy` moved there whole. It was never used for anything else: it has one caller, `holdNumericResult`, which runs before any call is read and exists to catch the hand-written table and `decimal.sou` drifting apart.

## What answers "which type is a rounding policy"

`Decimal.round`, at the argument it declares for the job, read as **whatever it declares there**.

Never checked against a name. A rule saying the anchor's argument must be `RoundingMode` would be the spelling back again, one operation further along. What is held is that two declarations agree:

| | |
|---|---|
| `Decimal.round`'s policy argument changes | fails |
| `Decimal.divide`'s policy argument changes | fails |
| scale and mode swap places | fails — a scale is an `Int` |
| both move to a new policy type together | passes |

The last one passes and should. Two declarations moving to a new policy type is the library being redesigned, not the table and the library disagreeing.

The anchor is a choice and is written down as one, with the position it reads. If `Decimal.round` stops declaring that argument, the failure says the anchor lost it rather than throwing out of a list.

## Held

`OnlyTheAbiSpellsATypeTheLibraryDeclaresTest` reads the library for every type name it declares — `RoundingMode` and the seven cases today, whatever it gains tomorrow — and holds the whole compiler to writing none of them.

One place does and must: `jvm.SoutherJvmAbi` says what each is called on this backend, and a table from a declaration to a class name is names on both sides. That is the seam #1038 built, and it is the only exception.

Checked by breaking it: putting `"RoundingMode"` back into `Arithmetic` fails the test with that file and that string.

`TheRoundingPolicyIsOneTypeTwoOperationsShareTest` says the invariant the anchor rests on out loud. Either operation drifting alone already fails the build, but it fails in a class initializer that says nothing about an anchor; this fails first and names it.

Full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)