### PR TITLE
Count the readings of the number an operation answers

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -783,20 +783,20 @@ final class DischargeRules {
     /**
      * Holds a declared account of what an operation takes of the one value it is given.
      *
-     * <p>Two different things, and they are kept apart. The first three are the declaration and the
-     * signature agreeing: the operation takes exactly one value, since what such a term is read off
-     * is one location and a term names one path; it answers a number, since a boundary is drawn on
-     * one; and what it takes it of is the shape the account is written for — a count is taken of
-     * something that holds things, a part of a time of a time. None of the three is checked
-     * anywhere else, and each is about this fact and this declaration.
+     * <p>Two different things, and they are kept apart. Three of these hold the declaration and the
+     * signature to each other: the operation takes exactly one value, since what such a term is read
+     * off is one location and a term names one path; it answers a number, since a boundary is drawn
+     * on one; and what it takes it of is the shape the account is written for — a count is taken of
+     * something that holds things, a magnitude of the operation's own kind of number. None of the
+     * three is checked anywhere else, and each is about this fact and this declaration.
      *
-     * <p>The last is not about this fact at all. It is that the number the operation answers is read
-     * by one representation, which is a property of the operation and holds whichever of the
-     * accounts was declared last. Asked as "is there already a form, an arithmetic, a body" it was
-     * three conditions naming the three representations there were, so a fourth would have had to be
-     * named in each of them and in whatever the next such procedure turned out to be. Asked as how
-     * many readings the operation has ({@link NumericReadings}), a representation added is refused
-     * against every existing one without being paired with any of them.
+     * <p>The one that is not about this fact at all is that the number the operation answers is read
+     * by one representation. That is a property of the operation and holds whichever of the accounts
+     * was declared last. Asked as "is there already a form, an arithmetic, a body", it is one
+     * condition per representation there is, so a fourth has to be named in each of them and in
+     * whatever the next such procedure turns out to be. Asked as how many readings the operation has
+     * ({@link NumericReadings}), a representation added is refused against every existing one
+     * without being paired with any of them.
      *
      * <p>Counted over the declarations being held and not over a table read from elsewhere, so the
      * answer does not depend on the order the facts were declared in or on whether they have

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -243,7 +243,7 @@ final class DischargeRules {
      * counted, and what it was given, counted. A form whose arguments this can carry and whose
      * result it cannot is a form it cannot carry.
      *
-     * <p>Asked with {@link Question#isANumber} where the binding asks
+     * <p>Asked with {@link NumericAnswers#isANumber} where the binding asks
      * {@link Question#countsToANumber}. That is the difference between what is true of the
      * operation and what this check can do with it — a date counts and is no number, so
      * {@code Date.daysBetween} is declared and is not carried here.
@@ -255,12 +255,12 @@ final class DischargeRules {
     private static boolean everyPartIsANumber(Stdlib stdlib, ValueName operation) {
         Stdlib.Signature signature =
                 stdlib.entry(((ValueName.Stdlib) operation).qualified()).signature();
-        if (!Question.isANumber(signature.result())) {
+        if (!NumericAnswers.isANumber(signature.result())) {
             return false;
         }
         List<Type> params = signature.params();
         return answersAFormOf(operation).coefs().keySet().stream().allMatch(argument ->
-                Question.isANumber(params.get(CallArguments.positionIn(argument, operation))));
+                NumericAnswers.isANumber(params.get(CallArguments.positionIn(argument, operation))));
     }
 
     /** Those of them the read-through table has, by name, for the test that holds each to a
@@ -533,7 +533,7 @@ final class DischargeRules {
      */
     static void holdNumericResult(Stdlib stdlib, ValueName operation, NumericResult rule) {
         Stdlib.Signature signature = holdTheOperationToTheLibrary(stdlib, operation).signature();
-        Type answers = Question.numberAnsweredBy(signature.result());
+        Type answers = NumericAnswers.in(signature.result());
         List<Arithmetic.Reads> reads = rule.computes().reads();
         if (signature.params().size() != reads.size()) {
             throw new IllegalStateException(operation + " takes " + signature.params().size()
@@ -548,7 +548,7 @@ final class DischargeRules {
         }
         switch (rule.at()) {
             case NumericResult.Answered.Directly ignored ->
-                    holdTheResultToTheDeclaration(stdlib, operation, Question::isANumber,
+                    holdTheResultToTheDeclaration(stdlib, operation, NumericAnswers::isANumber,
                             "a number for the arithmetic it computes to be answered at");
             case NumericResult.Answered.InTheCaseCarrying(Type carried) -> {
                 if (!(signature.result() instanceof Type.Union(Set<TypeSymbol> members))) {
@@ -581,7 +581,7 @@ final class DischargeRules {
         }
         if (rule.unless() != null) {
             holdToTheDeclaration(stdlib, operation, rule.unless().argument(), null,
-                    Question::isANumber, "the argument a failure is decided by");
+                    NumericAnswers::isANumber, "the argument a failure is decided by");
         }
     }
 
@@ -593,7 +593,7 @@ final class DischargeRules {
      */
     static void holdShift(Stdlib stdlib, ValueName operation, OperationFact.ShiftsBy
             shift) {
-        holdToTheDeclaration(stdlib, operation, shift.amount(), null, Question::isANumber,
+        holdToTheDeclaration(stdlib, operation, shift.amount(), null, NumericAnswers::isANumber,
                 "the amount a shift moves by");
         Stdlib.Entry counts = stdlib.entry(shift.measure().qualified());
         if (counts == null) {
@@ -602,7 +602,7 @@ final class DischargeRules {
         }
         Stdlib.Entry shifted = holdTheOperationToTheLibrary(stdlib, operation);
         List<Type> counted = counts.signature().params();
-        if (counted.size() != 2 || !Question.isANumber(counts.signature().result())
+        if (counted.size() != 2 || !NumericAnswers.isANumber(counts.signature().result())
                 || !counted.get(0).equals(shifted.signature().result())
                 || !counted.get(1).equals(shifted.signature().result())) {
             throw new IllegalStateException(shift.measure().qualified()
@@ -615,7 +615,7 @@ final class DischargeRules {
     /** As {@link #bind}, for the arguments a case names: the one it answers, and the two sides of
      * each condition it is reached under. */
     static void holdCase(Stdlib stdlib, ValueName operation, OperationFact.Case one) {
-        holdTheResultToTheDeclaration(stdlib, operation, Question::isANumber,
+        holdTheResultToTheDeclaration(stdlib, operation, NumericAnswers::isANumber,
                 "a number for a case of the definition to answer");
         List<ArgumentRef> named = new ArrayList<>();
         named.add(one.answers());
@@ -623,14 +623,14 @@ final class DischargeRules {
             named.add(stands.left());
             named.add(stands.right());
         });
-        named.forEach(each -> holdToTheDeclaration(stdlib, operation, each, null, Question::isANumber,
+        named.forEach(each -> holdToTheDeclaration(stdlib, operation, each, null, NumericAnswers::isANumber,
                 "an argument a case of the definition names"));
     }
 
     /** As {@link #bind}, for the arguments a bound names: the one the result is bounded against, and
      * the one a condition on the rule reads. Each is a separate claim about a separate argument. */
     static void holdBound(Stdlib stdlib, ValueName operation, ResultBound bound) {
-        holdTheResultToTheDeclaration(stdlib, operation, Question::isANumber,
+        holdTheResultToTheDeclaration(stdlib, operation, NumericAnswers::isANumber,
                 "a number for a bound on the result to hold of");
         List<ArgumentRef> named = new ArrayList<>();
         if (bound.against() != null) {
@@ -641,7 +641,7 @@ final class DischargeRules {
                 constant) {
             named.add(constant.argument());
         }
-        named.forEach(one -> holdToTheDeclaration(stdlib, operation, one, null, Question::isANumber,
+        named.forEach(one -> holdToTheDeclaration(stdlib, operation, one, null, NumericAnswers::isANumber,
                 "an argument a bound on the result names"));
     }
 
@@ -824,7 +824,7 @@ final class DischargeRules {
         // answers at that path is the union — which case it is in is a question this account has no
         // room for. Narrower than the range of whatever asks for such an account, and deliberately:
         // what may be declared and what is asked about are two ranges.
-        holdTheResultToTheDeclaration(stdlib, operation, Question::isANumber,
+        holdTheResultToTheDeclaration(stdlib, operation, NumericAnswers::isANumber,
                 "a number for a term of what it answers to be about");
         // Before the shape below, because it is the operation that is being asked about and not
         // this fact. An account that does not fit the operation is still an account of a number

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -10,7 +10,6 @@ import souther.compiler.semantics.ElementLineage;
 import souther.compiler.semantics.ElementShape;
 import souther.compiler.semantics.NumericResult;
 import souther.compiler.semantics.OperationFact;
-import souther.compiler.ast.Hir;
 import souther.compiler.semantics.OperationFacts;
 import souther.compiler.semantics.PositiveOrder;
 import souther.compiler.semantics.ResultBound;
@@ -784,52 +783,62 @@ final class DischargeRules {
     /**
      * Holds a declared account of what an operation takes of the one value it is given.
      *
-     * <p>Three things at once, because a term of this kind rests on all three and none of them is
-     * checked anywhere else. The operation takes exactly one value, since what such a term is read
-     * off is one location and a term names one path. It answers a number, since a boundary is drawn
-     * on one. And what it takes it of is the shape the account is written for — a count is taken of
-     * something that holds things, a magnitude of the operation's own kind of number.
+     * <p>Two different things, and they are kept apart. The first three are the declaration and the
+     * signature agreeing: the operation takes exactly one value, since what such a term is read off
+     * is one location and a term names one path; it answers a number, since a boundary is drawn on
+     * one; and what it takes it of is the shape the account is written for — a count is taken of
+     * something that holds things, a part of a time of a time. None of the three is checked
+     * anywhere else, and each is about this fact and this declaration.
+     *
+     * <p>The last is not about this fact at all. It is that the number the operation answers is read
+     * by one representation, which is a property of the operation and holds whichever of the
+     * accounts was declared last. Asked as "is there already a form, an arithmetic, a body" it was
+     * three conditions naming the three representations there were, so a fourth would have had to be
+     * named in each of them and in whatever the next such procedure turned out to be. Asked as how
+     * many readings the operation has ({@link NumericReadings}), a representation added is refused
+     * against every existing one without being paired with any of them.
+     *
+     * <p>Counted over the declarations being held and not over a table read from elsewhere, so the
+     * answer does not depend on the order the facts were declared in or on whether they have
+     * reached a table yet. What is required is that the count comes to one and that the one is this
+     * account — a term found beside a form fails the same way whether the term or the form was
+     * written first.
      *
      * <p>Held here rather than trusted at the reader. The reader applies the account to whatever
      * observation stands at the path, so an account declared of an operation it is not the shape of
      * is a row read as a number nobody named, with nothing about it looking like a failure (#1027).
      * Refused where the declaration is written, that reading cannot be reached.
      */
-    static void holdTakenOf(Stdlib stdlib, ValueName operation,
-            souther.compiler.semantics.TakenAs how) {
+    static void holdTakenOf(Stdlib stdlib, List<OperationFacts.Declared> declared,
+            ValueName operation, souther.compiler.semantics.TakenAs how) {
         Stdlib.Entry entry = holdTheOperationToTheLibrary(stdlib, operation);
         Stdlib.Signature signature = entry.signature();
         String named = ((ValueName.Stdlib) operation).qualified();
-        // A call the reading expands is a call the reading already understands. `Int.abs` is an
-        // ordinary `let` over `<` and `-`, so a body reading takes the comparison inside it and
-        // draws the line the definition draws; a term standing for the call would be a second
-        // reading of the same call, and which of the two a report showed would be whichever reader
-        // arrived. Refused here, so the exclusivity is a property of what can be declared rather
-        // than of which operations somebody thought to leave out (#1027).
-        if (!(entry.declaration().body() instanceof Hir.FnBody.Intrinsic)) {
-            throw new IllegalStateException(named + " is written in the language, so its body is"
-                    + " read where it is called and a term of what it answers would be a second"
-                    + " reading of the same call");
-        }
-        // And a call some other representation already reads is one this must not read too. A form
-        // says what the result is in the arguments' own counts, which is more than a term standing
-        // for it can say; declared as both, `Decimal.fromInt(n)` would be `n` to one reader and an
-        // opaque number to another.
-        if (OperationFacts.answersAFormOfItsArguments(operation) != null) {
-            throw new IllegalStateException(named + " already answers a form of its arguments, which"
-                    + " says more about what it answers than a term standing for it can");
-        }
-        if (OperationFacts.computesANumber(operation) != null) {
-            throw new IllegalStateException(named + " already computes an arithmetic this reads,"
-                    + " which says more about what it answers than a term standing for it can");
-        }
         if (signature.params().size() != 1) {
             throw new IllegalStateException(named + " takes " + signature.params().size()
                     + " arguments, and a number taken of the one value an operation is given is"
                     + " taken of one");
         }
+        // A number and not a number at one case of a union. A term names one path and stands for
+        // what the operation answered there, and what an operation answering `Int | NotANumber`
+        // answers at that path is the union — which case it is in is a question this account has no
+        // room for. Narrower than the range of whatever asks for such an account, and deliberately:
+        // what may be declared and what is asked about are two ranges.
         holdTheResultToTheDeclaration(stdlib, operation, Question::isANumber,
                 "a number for a term of what it answers to be about");
+        // Before the shape below, because it is the operation that is being asked about and not
+        // this fact. An account that does not fit the operation is still an account of a number
+        // some other representation may already read, and asked the other way round the exclusivity
+        // would be reachable only through arms that happen to fit.
+        NumericReadings.Resolution read = NumericReadings.resolve(stdlib, declared, operation);
+        if (!(read instanceof NumericReadings.Resolution.One(
+                NumericReading.AsATermTakenOfItsArgument(souther.compiler.semantics.TakenAs held)))
+                || !held.equals(how)) {
+            throw new IllegalStateException("the number " + named + " answers is read as "
+                    + NumericReadings.describe(read) + ", and one numeric call is read by one"
+                    + " representation — which of them a report showed would be whichever reader"
+                    + " arrived");
+        }
         Type source = signature.params().get(0);
         Type answered = signature.result();
         if (!how.takenOf(source, answered)) {

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericAnswers.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericAnswers.java
@@ -16,9 +16,9 @@ import souther.compiler.types.ValueName;
  * <p>Read by three kinds of reader and owned by none of them: what puts an operation in range of a
  * question ({@link Question}), what holds a declared fact to the signature it is about
  * ({@link DischargeRules}), and what lists the representations reading a number
- * ({@link NumericReadings}). Answered inside any one of them, the other two would be borrowing a
- * consumer's answer — which is what a resolver of facts reading a question's range was, and what
- * left the same question with two answers that part on a union.
+ * ({@link NumericReadings}). Answered inside any one of them, the other two borrow a consumer's
+ * answer, and a reader that would rather not borrow writes a second answer — which agrees with the
+ * first everywhere except a union, where nothing brings the two together to disagree.
  *
  * <p>What this is for is the carrier of a term standing for such an answer. What a number is
  * measured by follows from what the number <em>is</em>, and what it is is declared by the operation:

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericAnswers.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericAnswers.java
@@ -1,7 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.semantics.NumericResult;
-import souther.compiler.semantics.OperationFacts;
 import souther.compiler.stdlib.Stdlib;
 import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
@@ -9,11 +8,17 @@ import souther.compiler.types.ValueName;
 /**
  * The type of the number one of the language's operations answers.
  *
- * <p><b>The one entry, so that a caller never assembles this itself.</b> Three things have a say —
- * the library's signature, whether the number stands in the result or in one case of it
- * ({@link NumericResult.Answered}), and nothing else — and a caller that read the signature alone
- * would be right for every operation until the first that answers its number inside a union, and
- * wrong there without saying so.
+ * <p><b>The one entry, so that a caller never assembles this itself.</b> Two things have a say — the
+ * library's signature and the shape of what it answers — and a caller that took the result type as
+ * it stands would be right for every operation until the first that answers its number inside a
+ * union, and wrong there without saying so.
+ *
+ * <p>Read by three kinds of reader and owned by none of them: what puts an operation in range of a
+ * question ({@link Question}), what holds a declared fact to the signature it is about
+ * ({@link DischargeRules}), and what lists the representations reading a number
+ * ({@link NumericReadings}). Answered inside any one of them, the other two would be borrowing a
+ * consumer's answer — which is what a resolver of facts reading a question's range was, and what
+ * left the same question with two answers that part on a union.
  *
  * <p>What this is for is the carrier of a term standing for such an answer. What a number is
  * measured by follows from what the number <em>is</em>, and what it is is declared by the operation:
@@ -45,12 +50,52 @@ public final class NumericAnswers {
         if (entry == null || entry.signature() == null) {
             return null;
         }
-        NumericResult computed = OperationFacts.computesANumber(operation);
-        if (computed != null
-                && computed.at() instanceof NumericResult.Answered.InTheCaseCarrying carrying) {
-            return carrying.carried();
+        return in(entry.signature().result());
+    }
+
+    /**
+     * The number a result of {@code t} answers — {@code t} itself where it is one, and the number a
+     * union carries where exactly one of its cases is a number.
+     *
+     * <p>Exactly one, and not the first found. A union carrying two numbers would answer its number
+     * at two cases, and which of them a statement about the operation was written for is a question
+     * nothing here has a column for — so it answers none, and goes on answering none until something
+     * says which.
+     *
+     * <p>Read off the result and not off what is declared of the operation. What arithmetic an
+     * operation computes says where <em>that</em> arithmetic is answered
+     * ({@link NumericResult.Answered.InTheCaseCarrying}), which is a different sentence: an
+     * operation answering {@code Int | Decimal | SomeError} carries two numbers whatever its
+     * arithmetic names, and taking the arithmetic's case for the number the operation answers would
+     * make a proposition about one representation into the answer for all of them. The two are held
+     * to each other where the arithmetic is declared, so a case naming a number this does not find
+     * is refused rather than believed.
+     */
+    static Type in(Type t) {
+        if (isANumber(t)) {
+            return t;
         }
-        return entry.signature().result();
+        if (!(t instanceof Type.Union union)) {
+            return null;
+        }
+        Type found = null;
+        for (souther.compiler.types.TypeSymbol member : union.members()) {
+            Type.Prim prim = member.primitiveKind();
+            if (prim != null && isANumber(prim)) {
+                if (found != null) {
+                    return null;
+                }
+                found = prim;
+            }
+        }
+        return found;
+    }
+
+    /** Whether {@code t} is one of the kinds of number the domain relates arithmetically. Read where
+     * the numeric rules are bound as well: what such a rule may be written about is the same question
+     * as what puts an operation in range of one. */
+    static boolean isANumber(Type t) {
+        return t == Type.Prim.INT || t == Type.Prim.DECIMAL;
     }
 
     /** The same, for a reader already holding the symbols its module was compiled against. */

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericReading.java
@@ -1,0 +1,96 @@
+package souther.compiler.check;
+
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.semantics.ArgumentRef;
+import souther.compiler.semantics.NumericResult;
+import souther.compiler.semantics.TakenAs;
+
+/**
+ * A representation that reads the number an operation answers.
+ *
+ * <p>What is read and not who reads it. Each of these stands for an account under which the number
+ * a call answers is understood, and the account is what a reader of any kind takes: a partition
+ * drawing a boundary and a discharge procedure keying an atom take the same one, which is what
+ * makes two of them at one call a disagreement rather than two opinions.
+ *
+ * <p>Sealed, and the arms are the accounts there are. A fifth is added here, and the exclusivity
+ * between it and each of the four is then stated nowhere — {@link NumericReadings} counts what it
+ * finds, so an operation carrying the new account beside an old one is two readings without anybody
+ * writing the pair down. That is the whole of why this is a sum and not four predicates asked in
+ * turn.
+ */
+sealed interface NumericReading {
+
+    /** What this reads the number as, for a message naming the readings an operation has. */
+    String describes();
+
+    /**
+     * The number is taken of the one value the operation is given, and {@code how} is the account of
+     * what is taken.
+     *
+     * <p>Carried whole rather than as the fact that there is one. What holds a declaration of this
+     * kind has to say that the account it is holding is the account that was found, and an arm that
+     * said only "a term" could not: the two would be compared by there being one of each.
+     */
+    record AsATermTakenOfItsArgument(TakenAs how) implements NumericReading {
+
+        public AsATermTakenOfItsArgument {
+            java.util.Objects.requireNonNull(how, "this one says what the number is taken as");
+        }
+
+        @Override
+        public String describes() {
+            return "a term of what it answers";
+        }
+    }
+
+    /** The number is arithmetic over what the arguments are counted as, and {@code form} is that
+     *  arithmetic. */
+    record AsAFormOfItsArguments(NumericDomain.LinearForm<ArgumentRef> form)
+            implements NumericReading {
+
+        public AsAFormOfItsArguments {
+            java.util.Objects.requireNonNull(form, "this one says what it answers");
+        }
+
+        @Override
+        public String describes() {
+            return "a form of its arguments";
+        }
+    }
+
+    /** The number is the arithmetic the operation computes, and {@code result} says which and where
+     *  it is answered. */
+    record AsTheArithmeticItComputes(NumericResult result) implements NumericReading {
+
+        public AsTheArithmeticItComputes {
+            java.util.Objects.requireNonNull(result, "this one says what it computes");
+        }
+
+        @Override
+        public String describes() {
+            return "the arithmetic it computes";
+        }
+    }
+
+    /**
+     * The operation is written in the language, so what it answers is read by reading its body.
+     *
+     * <p>Nothing to carry: the body is the library's and is read where the call is. What this says
+     * is that reading it is already an account of the number, so a second one written beside it
+     * would be two readings of one call — {@code Int.abs} is an ordinary {@code let} over
+     * {@code <} and {@code -}, and a term standing for the call would draw a line the definition
+     * already draws.
+     *
+     * <p>Derived and not declared, which is what keeps it from going stale. An operation rewritten
+     * from a {@code let} into an intrinsic loses this reading in the same commit that rewrites it,
+     * rather than when somebody remembers a table.
+     */
+    record ByTheBodyTheLanguageWritesOut() implements NumericReading {
+
+        @Override
+        public String describes() {
+            return "the body the language writes out";
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericReadings.java
@@ -39,12 +39,12 @@ import java.util.List;
  * exclusivity would hold as far as that question's range and no further, and would move when the
  * range moved.
  *
- * <p><b>Why this exists at all.</b> The exclusivity was three conditions inside the procedure that
- * holds a declared term ({@link DischargeRules#holdTakenOf}), one per representation it knew of.
- * Written that way, a representation added is a representation every existing one has to be told
- * about, and the pair that nobody wrote down is the pair that goes unchecked. Counted here,
- * an account added is one arm added to {@link NumericReading} and one line here, and every pair it
- * makes with an existing arm is refused without being named.
+ * <p><b>Counted, and not asked one representation at a time.</b> Written as a condition per
+ * representation inside whatever holds a declaration ({@link DischargeRules#holdTakenOf}), a
+ * representation added is one every existing representation has to be told about, and the pair
+ * nobody writes down is the pair that goes unchecked. Counted here, an account added is one arm on
+ * {@link NumericReading} and one line here, and every pair it makes with an existing arm is refused
+ * without being named.
  */
 final class NumericReadings {
 
@@ -141,7 +141,7 @@ final class NumericReadings {
                 // The cases a definition is written in name which argument is answered under which
                 // relation between the arguments. A reader still reads the argument, so what the
                 // call answers has no account of its own here — and every operation carrying one
-                // today is written in the language as well, so the two have never had to be told
+                // today is written in the language as well, so nothing here has to tell the two
                 // apart.
                 case OperationFact.IsDefinedByCases _,
                      // The rest say something else about the operation: where a number runs, what

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericReadings.java
@@ -116,7 +116,7 @@ final class NumericReadings {
     private static List<NumericReading> readingsOf(Stdlib stdlib,
             List<OperationFacts.Declared> declared, ValueName operation) {
         Stdlib.Entry entry = DischargeRules.holdTheOperationToTheLibrary(stdlib, operation);
-        if (Question.numberAnsweredBy(entry.signature().result()) == null) {
+        if (NumericAnswers.in(entry.signature().result()) == null) {
             return List.of();
         }
         List<NumericReading> terms = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericReadings.java
@@ -1,0 +1,184 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.semantics.ArgumentRef;
+import souther.compiler.semantics.NumericResult;
+import souther.compiler.semantics.OperationFact;
+import souther.compiler.semantics.OperationFacts;
+import souther.compiler.semantics.TakenAs;
+import souther.compiler.stdlib.Stdlib;
+import souther.compiler.types.ValueName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Which representations read the number an operation answers, and how many of them there are.
+ *
+ * <p>Three sentences say what this is for, and each of them is a decision somebody will want to
+ * undo:
+ *
+ * <ul>
+ *   <li>This describes facts, not precedence. There is no first arm and no fallback: an operation
+ *       carrying two accounts of its number gets two, and choosing between them here would be a
+ *       fifth account nobody declared.
+ *   <li>{@link Resolution.Multiple} is an invalid library definition, not a choice to resolve. What
+ *       it means is that two representations would each read one call and which of them a report
+ *       showed would be whichever reader arrived. Nothing recovers from it.
+ *   <li>{@link Resolution.None} is valid globally; a question may make it invalid within its range.
+ *       Most of the library answers numbers nothing reads, and that is ordinary. Where a check
+ *       needs a reading, it is that check's range that says so and its silence
+ *       ({@code OperationFact.SaysNothingOf}) that is the other answer.
+ * </ul>
+ *
+ * <p>The third is the one worth keeping. Made to answer {@code One} wherever a number is answered,
+ * this would start carrying the deliberate silences — {@code String.toInt} answers a number at one
+ * case of a union and no representation reads it there — and finding out what is declared would be
+ * deciding what ought to be. Made to refuse {@code Multiple} only where some question asks, the
+ * exclusivity would hold as far as that question's range and no further, and would move when the
+ * range moved.
+ *
+ * <p><b>Why this exists at all.</b> The exclusivity was three conditions inside the procedure that
+ * holds a declared term ({@link DischargeRules#holdTakenOf}), one per representation it knew of.
+ * Written that way, a representation added is a representation every existing one has to be told
+ * about, and the pair that nobody wrote down is the pair that goes unchecked. Counted here,
+ * an account added is one arm added to {@link NumericReading} and one line here, and every pair it
+ * makes with an existing arm is refused without being named.
+ */
+final class NumericReadings {
+
+    /** How many representations read one operation's number. */
+    sealed interface Resolution {
+
+        /** Nothing reads it. */
+        record None() implements Resolution {}
+
+        /** Exactly one does, and this is it. */
+        record One(NumericReading reading) implements Resolution {
+
+            public One {
+                java.util.Objects.requireNonNull(reading, "there is one, so it is named");
+            }
+        }
+
+        /** More than one does, which the library must not declare. */
+        record Multiple(List<NumericReading> readings) implements Resolution {
+
+            public Multiple {
+                readings = List.copyOf(readings);
+                if (readings.size() < 2) {
+                    throw new IllegalArgumentException(
+                            "more than one is more than one: " + readings.size() + " named");
+                }
+            }
+        }
+    }
+
+    /**
+     * The representations that read the number {@code operation} answers, counted, over the
+     * declarations in {@code declared}.
+     *
+     * <p>Over a source that is handed in and not over the table the process happens to hold. What
+     * holds the declarations to the library is given its source for the same reason
+     * ({@code OperationFactBinder#bindAll}): a fact reaches it before it reaches any table, so a
+     * check reading the table instead would be blind to exactly the declaration being held. It
+     * would also be asking that table to finish building while it was being built.
+     *
+     * @throws IllegalStateException where the library declares no such operation
+     */
+    static Resolution resolve(Stdlib stdlib, List<OperationFacts.Declared> declared,
+            ValueName operation) {
+        List<NumericReading> found = readingsOf(stdlib, declared, operation);
+        return switch (found.size()) {
+            case 0 -> new Resolution.None();
+            case 1 -> new Resolution.One(found.get(0));
+            default -> new Resolution.Multiple(found);
+        };
+    }
+
+    /**
+     * The same, listed.
+     *
+     * <p>The subject is the number, so an operation that answers none has no reading of one — a
+     * date shifted by an amount is declared as a form of what its arguments are counted as, and
+     * that form is about the date and not about a number the operation answered. Read without this,
+     * every such operation would carry a reading of a number that is not there, and a proposition
+     * with no subject is one nothing can be false of.
+     *
+     * <p>Answered at one case of a union counts, for the reason {@code Question.NUMERIC_RESULT}
+     * counts it: what the shape of a result says is which inputs an operation declines, not what
+     * it answers where it answers anything.
+     *
+     * <p>In the order the arms are written and not in the order the facts were declared, so a
+     * message naming two readings names them the same way whichever of them was written first.
+     */
+    private static List<NumericReading> readingsOf(Stdlib stdlib,
+            List<OperationFacts.Declared> declared, ValueName operation) {
+        Stdlib.Entry entry = DischargeRules.holdTheOperationToTheLibrary(stdlib, operation);
+        if (Question.numberAnsweredBy(entry.signature().result()) == null) {
+            return List.of();
+        }
+        List<NumericReading> terms = new ArrayList<>();
+        List<NumericReading> forms = new ArrayList<>();
+        List<NumericReading> arithmetic = new ArrayList<>();
+        for (OperationFacts.Declared each : declared) {
+            if (!operation.equals(each.operation())) {
+                continue;
+            }
+            // No default. A kind of fact added is a kind this has to answer for — whether it is an
+            // account of the number an operation answers is a question about the fact, and one
+            // nobody would think to come here and ask. Answered by falling through a default, the
+            // fifth representation would be exclusive with nothing.
+            switch (each.fact()) {
+                case OperationFact.AnswersANumberTakenOfTheOneValueItIsGiven(TakenAs how) ->
+                        terms.add(new NumericReading.AsATermTakenOfItsArgument(how));
+                case OperationFact.AnswersAFormOfItsArguments(
+                        NumericDomain.LinearForm<ArgumentRef> form) ->
+                        forms.add(new NumericReading.AsAFormOfItsArguments(form));
+                case OperationFact.ComputesANumber(NumericResult result) ->
+                        arithmetic.add(new NumericReading.AsTheArithmeticItComputes(result));
+                // The cases a definition is written in name which argument is answered under which
+                // relation between the arguments. A reader still reads the argument, so what the
+                // call answers has no account of its own here — and every operation carrying one
+                // today is written in the language as well, so the two have never had to be told
+                // apart.
+                case OperationFact.IsDefinedByCases _,
+                     // The rest say something else about the operation: where a number runs, what
+                     // an operation keeps of a container, what a predicate travels through, what a
+                     // shift is stated through, whether every answer has a value that gives it.
+                     // None of them is a way of reading the number a call answered.
+                     OperationFact.BoundsItsResult _,
+                     OperationFact.StatesTheOrderOfItsArguments _,
+                     OperationFact.ShiftsBy _,
+                     OperationFact.BuildsItsResultFrom _,
+                     OperationFact.ResultIsNoSmallerThan _,
+                     OperationFact.ReadsItsContainer _,
+                     OperationFact.IsStatedOverAProjection _,
+                     OperationFact.StatesItsPredicateOfEveryElement _,
+                     OperationFact.MeansTheSameAsASizeOfNought _,
+                     OperationFact.EveryAnswerItCanGiveHasASourceValue _,
+                     OperationFact.SaysNothingOf _ -> { }
+            }
+        }
+        List<NumericReading> found = new ArrayList<>(terms);
+        found.addAll(forms);
+        found.addAll(arithmetic);
+        if (!(entry.declaration().body() instanceof Hir.FnBody.Intrinsic)) {
+            found.add(new NumericReading.ByTheBodyTheLanguageWritesOut());
+        }
+        return List.copyOf(found);
+    }
+
+    /** What reads it, for a message that names the readings there are. */
+    static String describe(Resolution resolution) {
+        return switch (resolution) {
+            case Resolution.None _ -> "nothing";
+            case Resolution.One(NumericReading one) -> one.describes();
+            case Resolution.Multiple(List<NumericReading> readings) -> String.join(" and ",
+                    readings.stream().map(NumericReading::describes).toList());
+        };
+    }
+
+    private NumericReadings() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/OperationFactBinder.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OperationFactBinder.java
@@ -112,7 +112,7 @@ final class OperationFactBinder {
                                 Question::isANumber,
                                 "a number for every answer of it to have a value");
                 case OperationFact.AnswersANumberTakenOfTheOneValueItIsGiven taken ->
-                        DischargeRules.holdTakenOf(stdlib, each.operation(), taken.how());
+                        DischargeRules.holdTakenOf(stdlib, declared, each.operation(), taken.how());
                 case OperationFact.ComputesANumber computes ->
                         DischargeRules.holdNumericResult(stdlib, each.operation(), computes.result());
                 case OperationFact.IsDefinedByCases defined ->

--- a/souther-compiler/src/main/java/souther/compiler/check/OperationFactBinder.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OperationFactBinder.java
@@ -109,7 +109,7 @@ final class OperationFactBinder {
                 // wrong here (#1027).
                 case OperationFact.EveryAnswerItCanGiveHasASourceValue _ ->
                         DischargeRules.holdTheResultToTheDeclaration(stdlib, each.operation(),
-                                Question::isANumber,
+                                NumericAnswers::isANumber,
                                 "a number for every answer of it to have a value");
                 case OperationFact.AnswersANumberTakenOfTheOneValueItIsGiven taken ->
                         DischargeRules.holdTakenOf(stdlib, declared, each.operation(), taken.how());

--- a/souther-compiler/src/main/java/souther/compiler/check/Question.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Question.java
@@ -360,7 +360,7 @@ enum Question {
     BOUNDS("what bounds the number it answers") {
         @Override
         boolean asksOf(Stdlib stdlib, Stdlib.Signature signature) {
-            return isANumber(signature.result());
+            return NumericAnswers.isANumber(signature.result());
         }
 
         @Override
@@ -387,9 +387,9 @@ enum Question {
     MEASURE("what it states through the measure counting the two apart") {
         @Override
         boolean asksOf(Stdlib stdlib, Stdlib.Signature signature) {
-            return signature.result() != null && !isANumber(signature.result())
+            return signature.result() != null && !NumericAnswers.isANumber(signature.result())
                     && signature.params().contains(signature.result())
-                    && signature.params().stream().anyMatch(Question::isANumber)
+                    && signature.params().stream().anyMatch(NumericAnswers::isANumber)
                     && hasAMeasureCountingTwoApart(stdlib, signature.result());
         }
 
@@ -417,8 +417,8 @@ enum Question {
     CHOICE("whether it answers one of its arguments, and in which cases") {
         @Override
         boolean asksOf(Stdlib stdlib, Stdlib.Signature signature) {
-            return isANumber(signature.result())
-                    && signature.params().stream().anyMatch(Question::isANumber);
+            return NumericAnswers.isANumber(signature.result())
+                    && signature.params().stream().anyMatch(NumericAnswers::isANumber);
         }
 
         @Override
@@ -486,7 +486,7 @@ enum Question {
     NUMERIC_RESULT("what number it computes, and where it answers it") {
         @Override
         boolean asksOf(Stdlib stdlib, Stdlib.Signature signature) {
-            Type number = numberAnsweredBy(signature.result());
+            Type number = NumericAnswers.in(signature.result());
             return number != null && signature.params().size() >= 2
                     && number.equals(signature.params().get(0))
                     && number.equals(signature.params().get(1));
@@ -568,26 +568,20 @@ enum Question {
     private static boolean hasAMeasureCountingTwoApart(Stdlib stdlib, Type t) {
         return stdlib.entries().values().stream().anyMatch(entry -> {
             List<Type> counted = entry.signature().params();
-            return isANumber(entry.signature().result()) && counted.size() == 2
+            return NumericAnswers.isANumber(entry.signature().result()) && counted.size() == 2
                     && counted.get(0).equals(t) && counted.get(1).equals(t);
         });
-    }
-
-    /** Whether {@code t} is one of the kinds of number the domain relates arithmetically. Read where
-     * the numeric rules are bound as well: what such a rule may be written about is the same question
-     * as what puts an operation in range of one. */
-    static boolean isANumber(Type t) {
-        return t == Type.Prim.INT || t == Type.Prim.DECIMAL;
     }
 
     /**
      * Whether values of {@code t} count to a number.
      *
-     * <p>Wider than {@link #isANumber} and asked where the arithmetic is over counts rather than
-     * over numbers a model wrote: a date is not a number and counts days, so a difference of two of
-     * them is a number of days. Asked of {@link Carrier}, which is the one table saying which types
-     * have an order with counts under it — a second answer here would be a second table, and a type
-     * that is a carrier to one of them and not to the other is what that costs.
+     * <p>Wider than {@link NumericAnswers#isANumber} and asked where the arithmetic is over counts
+     * rather than over numbers a model wrote: a date is not a number and counts days, so a
+     * difference of two of them is a number of days. Asked of {@link Carrier}, which is the one
+     * table saying which types have an order with counts under it — a second answer here would be a
+     * second table, and a type that is a carrier to one of them and not to the other is what that
+     * costs.
      *
      * <p>Asked without the declarations, which is what a reading of the library's own signatures
      * has: {@link Carrier#ofPrimitive} answers where the type settles it and leaves a name
@@ -597,34 +591,6 @@ enum Question {
     static boolean countsToANumber(Type t) {
         Carrier carrier = Carrier.ofPrimitive(t);
         return carrier != null && carrier.counts();
-    }
-
-    /**
-     * The number a result of {@code t} answers — {@code t} itself where it is one, and the number a
-     * union carries where exactly one of its cases is a number.
-     *
-     * <p>Exactly one, and not the first found. A union carrying two numbers would answer its number
-     * at two cases, and which of them a rule about the operation was written for is a question the
-     * table has no column for — so it is out of range, and stays out until something says which.
-     */
-    static Type numberAnsweredBy(Type t) {
-        if (isANumber(t)) {
-            return t;
-        }
-        if (!(t instanceof Type.Union union)) {
-            return null;
-        }
-        Type found = null;
-        for (souther.compiler.types.TypeSymbol member : union.members()) {
-            Type.Prim prim = member.primitiveKind();
-            if (prim != null && isANumber(prim)) {
-                if (found != null) {
-                    return null;
-                }
-                found = prim;
-            }
-        }
-        return found;
     }
 
     /** Whether {@code t} is something the check can name the size of — a container, or a string. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Question.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Question.java
@@ -22,6 +22,11 @@ import java.util.Set;
  * reason. So the library gaining an operation is the library asking these questions, and each is
  * unanswered until someone answers it.
  *
+ * <p>One of the two and not either. A silence says that nothing is true under the subject, so it is
+ * the denial of a rule rather than a spare row beside one, and an operation carrying both is one
+ * where one of the two is wrong. Read as "a rule or a silence", a silence that had become false was
+ * only ever a filler and stayed where it was.
+ *
  * <p>A range is read off the declaration and nothing else, so it holds an operation nobody thought
  * of. Where the answer too is read off the declaration the rule is derived rather than written
  * ({@link Combinators}), and the range is still stated here: a signature the derivation gets nothing

--- a/souther-compiler/src/main/java/souther/compiler/check/Question.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Question.java
@@ -24,8 +24,8 @@ import java.util.Set;
  *
  * <p>One of the two and not either. A silence says that nothing is true under the subject, so it is
  * the denial of a rule rather than a spare row beside one, and an operation carrying both is one
- * where one of the two is wrong. Read as "a rule or a silence", a silence that had become false was
- * only ever a filler and stayed where it was.
+ * where one of the two is wrong. Read as "a rule or a silence", a silence is only ever a filler, and
+ * one that has become false covers the range as well as anything and stays where it is.
  *
  * <p>A range is read off the declaration and nothing else, so it holds an operation nobody thought
  * of. Where the answer too is read off the declaration the rule is derived rather than written

--- a/souther-compiler/src/test/java/souther/compiler/check/ANumberIsReadByAtMostOneRepresentationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ANumberIsReadByAtMostOneRepresentationTest.java
@@ -46,11 +46,12 @@ class ANumberIsReadByAtMostOneRepresentationTest {
         List<String> twice = new ArrayList<>();
         for (Map.Entry<String, Stdlib.Entry> e : DefaultStdlib.get().entries().entrySet()) {
             ValueName operation = DefaultStdlib.get().operation(e.getKey());
-            if (NumericReadings.resolve(DefaultStdlib.get(), OperationFacts.declarations(),
-                    operation) instanceof NumericReadings.Resolution.Multiple(
-                            List<NumericReading> readings)) {
-                twice.add(e.getKey() + " — " + String.join(" and ",
-                        readings.stream().map(NumericReading::describes).toList()));
+            NumericReadings.Resolution read = NumericReadings.resolve(
+                    DefaultStdlib.get(), OperationFacts.declarations(), operation);
+            if (read instanceof NumericReadings.Resolution.Multiple) {
+                // Named by whatever names them in a refusal, so what a reader is told here and what
+                // the library is refused with are one sentence rather than two that drift.
+                twice.add(e.getKey() + " — " + NumericReadings.describe(read));
             }
         }
         assertEquals(List.of(), twice,

--- a/souther-compiler/src/test/java/souther/compiler/check/ANumberIsReadByAtMostOneRepresentationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ANumberIsReadByAtMostOneRepresentationTest.java
@@ -14,7 +14,14 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * The number an operation answers is read by one representation.
+ * The number an operation answers is read by at most one representation.
+ *
+ * <p>At most, and the name says so. Nothing read is ordinary — most of what the library answers is
+ * read by nothing at all — and where a reading is owed it is a range that says so, which is a
+ * different proposition asked in {@link AnOperationTheLibraryGainsIsAnsweredForTest}. Named for one
+ * rather than for at most one, this would read as the stronger claim with an exception in it, and
+ * the way to make the name true would be to pull the obligation in here, where it would hold as far
+ * as nothing in particular.
  *
  * <p>A term standing for a call, the form its result is of its arguments, the arithmetic it
  * computes, the body the language writes out — each is an account of the same number, and two of
@@ -27,11 +34,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * with it — and the operations no question asks about today are exactly the ones nobody would think
  * to check by hand.
  *
- * <p>{@code None} is not a failure here. Most of what the library answers is read by nothing, which
- * is ordinary; where a reading is owed it is a question's range that says so, and that is asked in
- * {@code AnOperationTheLibraryGainsIsAnsweredForTest}.
+ * <p>That each account is found where it is declared is not asked here either. This is a negative
+ * property and stays one: an arm the resolver stopped reading would leave the operations that carry
+ * it read by nothing, which is a state this is written to allow. What holds the accounts to being
+ * found is {@link NumericReadingsFindTheAccountsTheLibraryDeclaresTest}.
  */
-class OneNumericAnswerIsReadByOneRepresentationTest {
+class ANumberIsReadByAtMostOneRepresentationTest {
 
     @Test
     void noOperationsNumberIsReadByTwoRepresentations() {
@@ -39,7 +47,8 @@ class OneNumericAnswerIsReadByOneRepresentationTest {
         for (Map.Entry<String, Stdlib.Entry> e : DefaultStdlib.get().entries().entrySet()) {
             ValueName operation = DefaultStdlib.get().operation(e.getKey());
             if (NumericReadings.resolve(DefaultStdlib.get(), OperationFacts.declarations(),
-                    operation) instanceof NumericReadings.Resolution.Multiple(List<NumericReading> readings)) {
+                    operation) instanceof NumericReadings.Resolution.Multiple(
+                            List<NumericReading> readings)) {
                 twice.add(e.getKey() + " — " + String.join(" and ",
                         readings.stream().map(NumericReading::describes).toList()));
             }
@@ -47,23 +56,5 @@ class OneNumericAnswerIsReadByOneRepresentationTest {
         assertEquals(List.of(), twice,
                 "the number each of these answers is read by more than one representation, so which"
                         + " reading a report shows is whichever reader arrived");
-    }
-
-    /**
-     * An operation that answers no number has no reading of one.
-     *
-     * <p>{@code Date.addDays} declares a form and answers a date. The form is about what its
-     * arguments are counted as, which is what lets a date take part in one at all; it is not an
-     * account of a number the operation answered, because it answered none. Counted as one, every
-     * such operation would carry a reading whose subject is missing — and a proposition with no
-     * subject cannot come out false, so the count would look right for the wrong reason.
-     */
-    @Test
-    void anOperationThatAnswersNoNumberIsReadByNothing() {
-        assertEquals(new NumericReadings.Resolution.None(),
-                NumericReadings.resolve(DefaultStdlib.get(), OperationFacts.declarations(),
-                        DefaultStdlib.get().operation("Date.addDays")),
-                "a form over what its arguments are counted as is not a reading of a number this"
-                        + " operation answers, since it answers a date");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperationTheLibraryGainsIsAnsweredForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperationTheLibraryGainsIsAnsweredForTest.java
@@ -21,10 +21,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * {@code List.distinctBy} came to be in neither of the two combinator tables it belonged in.
  *
  * <p>Here every question is held to its range, both ways round. An operation the library declares is
- * in range of a question by what it is declared to be, and one in range has an answer — a rule, or
- * its name among the ones there is nothing to say of. Adding an operation to the library therefore
- * fails this until someone decides which, and the decision is written where the next reader will
- * find it.
+ * in range of a question by what it is declared to be, and one in range has exactly one answer — a
+ * rule, or its name among the ones there is nothing to say of, and never both. Adding an operation
+ * to the library therefore fails this until someone decides which, and the decision is written where
+ * the next reader will find it.
+ *
+ * <p>What is <em>not</em> asked here is whether the number an operation answers is read by more than
+ * one representation. That is a property of the declarations and holds of every operation, in range
+ * of a question or not, so it is held over the declarations themselves
+ * ({@link OneNumericAnswerIsReadByOneRepresentationTest}). Asked here, how far the exclusivity
+ * reached would be whatever a range happened to cover that week.
  *
  * <p>A question whose answer is read off the declaration ({@link Question#COMBINATOR}) is held the
  * same way and for the same reason: the derivation answering for most of its range does not make a
@@ -32,22 +38,43 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class AnOperationTheLibraryGainsIsAnsweredForTest {
 
+    /**
+     * One of the two, and not one or the other.
+     *
+     * <p>A rule and a silence are not two ways of covering a range. A silence says that nothing is
+     * true of the operation under the subject, so beside a rule saying what is, it is the denial of
+     * what the rule says and one of the two is wrong. Asked as "a rule <em>or</em> a silence", a
+     * silence that had become false stayed where it was — {@code Int.add} was declared to say
+     * nothing of what it answers in what it was given, next to the arithmetic the language reads it
+     * as, and nothing fell over, because covering the range was all that was asked.
+     *
+     * <p>A rule may be one another proposition already gives. What answers a question is what
+     * {@link Question#answeredFor} says, which for some of them is derived from a fact declared
+     * under a different subject; what is written down <em>for</em> a question is
+     * {@link Question#answeredOperations}, and the two are kept apart on purpose. So the
+     * contradiction between a rule and a silence is read here, over the range, rather than off the
+     * rows — read off the rows, an operation answered by another proposition and silenced here would
+     * be in neither list and would go unseen.
+     */
     @Test
-    void everyOperationInAQuestionsRangeAnswersIt() {
-        List<String> unanswered = new ArrayList<>();
+    void everyOperationInAQuestionsRangeAnswersItOneWayAndNotBoth() {
+        List<String> unsettled = new ArrayList<>();
         for (Map.Entry<String, Stdlib.Entry> e : DefaultStdlib.get().entries().entrySet()) {
             ValueName operation = DefaultStdlib.get().operation(e.getKey());
             for (Question question : Question.askedOf(DefaultStdlib.get(), e.getValue().signature())) {
-                if (question.answeredFor(operation)
-                        || question.nothingSaidOf().contains(operation)) {
+                boolean answered = question.answeredFor(operation);
+                boolean silent = question.nothingSaidOf().contains(operation);
+                if (answered != silent) {
                     continue;
                 }
-                unanswered.add(e.getKey() + " — " + question);
+                unsettled.add(e.getKey() + " — " + question
+                        + (answered ? " (a rule and a silence beside it)" : " (neither)"));
             }
         }
-        assertEquals(List.of(), unanswered,
-                "these operations are in range of a question and answer it neither with a rule nor by"
-                        + " being named as one there is nothing to say of");
+        assertEquals(List.of(), unsettled,
+                "these operations are in range of a question and do not answer it exactly once —"
+                        + " with neither a rule nor a name among the ones there is nothing to say"
+                        + " of, or with both, where the silence denies the rule");
     }
 
     /**
@@ -75,35 +102,6 @@ class AnOperationTheLibraryGainsIsAnsweredForTest {
         }
         assertEquals(List.of(), unasked,
                 "these are written down against a question they are not asked");
-    }
-
-    /**
-     * And no operation is on both sides of a question at once. A silence is a decision that nothing
-     * is true under the subject, so beside a rule saying what is it is not a spare row — it is the
-     * denial of what the rule says, and the two cannot both be read without one of them being
-     * wrong.
-     *
-     * <p>The direction the other two cannot see. Both of them read the union: a range covered is a
-     * range where every operation has a rule <em>or</em> a silence, and a name written down is a
-     * name the question asks of either way. So a silence was only ever tested as a filler, and one
-     * that had become false stayed where it was — {@code Int.add} was declared to say nothing of
-     * what it answers in what it was given, next to the arithmetic the language reads it as, for as
-     * long as no rule for it reached this question. Nothing here fell over, because covering a
-     * range is all either of them asks.
-     */
-    @Test
-    void noOperationBothAnswersAQuestionAndIsSilentUnderIt() {
-        List<String> saidBothWays = new ArrayList<>();
-        for (Question question : Question.values()) {
-            for (ValueName operation : question.answeredOperations()) {
-                if (question.nothingSaidOf().contains(operation)) {
-                    saidBothWays.add(operation + " — " + question);
-                }
-            }
-        }
-        assertEquals(List.of(), saidBothWays,
-                "these answer a question with a rule and are also declared to say nothing under it,"
-                        + " so the silence beside the rule denies it");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperationTheLibraryGainsIsAnsweredForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperationTheLibraryGainsIsAnsweredForTest.java
@@ -44,9 +44,9 @@ class AnOperationTheLibraryGainsIsAnsweredForTest {
      * <p>A rule and a silence are not two ways of covering a range. A silence says that nothing is
      * true of the operation under the subject, so beside a rule saying what is, it is the denial of
      * what the rule says and one of the two is wrong. Asked as "a rule <em>or</em> a silence", a
-     * silence that had become false stayed where it was — {@code Int.add} was declared to say
-     * nothing of what it answers in what it was given, next to the arithmetic the language reads it
-     * as, and nothing fell over, because covering the range was all that was asked.
+     * silence that has become false stays where it is: {@code Int.add} declared to say nothing of
+     * what it answers in what it was given, beside the arithmetic the language reads it as, covers
+     * the range as well as anything, and covering the range is all that such a question asks.
      *
      * <p>A rule may be one another proposition already gives. What answers a question is what
      * {@link Question#answeredFor} says, which for some of them is derived from a fact declared

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperationTheLibraryGainsIsAnsweredForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperationTheLibraryGainsIsAnsweredForTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * <p>What is <em>not</em> asked here is whether the number an operation answers is read by more than
  * one representation. That is a property of the declarations and holds of every operation, in range
  * of a question or not, so it is held over the declarations themselves
- * ({@link OneNumericAnswerIsReadByOneRepresentationTest}). Asked here, how far the exclusivity
+ * ({@link ANumberIsReadByAtMostOneRepresentationTest}). Asked here, how far the exclusivity
  * reached would be whatever a range happened to cover that week.
  *
  * <p>A question whose answer is read off the declaration ({@link Question#COMBINATOR}) is held the

--- a/souther-compiler/src/test/java/souther/compiler/check/EverySemanticDeclarationIsHeldToTheLibraryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EverySemanticDeclarationIsHeldToTheLibraryTest.java
@@ -174,6 +174,11 @@ class EverySemanticDeclarationIsHeldToTheLibraryTest {
      * <p>Refused where the declaration is written and not by a list of operations to leave out. A
      * list would be a second account of which operations the language writes out, kept in step by
      * whoever remembered; the declaration itself already says.
+     *
+     * <p>What refuses it is the count and not a condition naming the body. The readings the
+     * operation has are listed and there are two of them, so this and the form below are one check
+     * seen at two pairs rather than one condition each — which is what makes a representation added
+     * exclusive with all four without being paired with any.
      */
     @Test
     void anOperationWrittenInTheLanguageCannotBeGivenATermOfWhatItAnswers() {
@@ -188,20 +193,22 @@ class EverySemanticDeclarationIsHeldToTheLibraryTest {
                 () -> OperationFactBinder.bindAll(DefaultStdlib.get(), gained));
 
         assertTrue(refused.getMessage().contains("Int.abs"), refused.getMessage());
-        assertTrue(refused.getMessage().contains("written in the language"),
-                "and says why, which is that its body is read where it is called: "
+        assertTrue(refused.getMessage().contains("the body the language writes out"),
+                "and names the reading that was already there, which is its body: "
                         + refused.getMessage());
     }
 
     /**
      * Nor can one whose result some other representation already reads.
      *
-     * <p>The other half of the same invariant, and the one a check on how the operation is written
-     * cannot make. {@code Decimal.fromInt} is an intrinsic and takes one number, so nothing about
-     * how it is declared keeps it out; what keeps it out is that a form already says what it answers
-     * in its argument's own count, which is more than a term standing for it can say. Read as both,
-     * a rule about {@code n} would settle a clause about {@code Decimal.fromInt(n)} for one reader
-     * and not for the other.
+     * <p>The same invariant at the other pair. {@code Decimal.fromInt} is an intrinsic and takes one
+     * number, so nothing about how it is written keeps it out; what keeps it out is that a form
+     * already says what it answers in its argument's own count, which is more than a term standing
+     * for it can say. Read as both, a rule about {@code n} would settle a clause about
+     * {@code Decimal.fromInt(n)} for one reader and not for the other.
+     *
+     * <p>Here because the pairs are what a reader wants to see and not because the check has two
+     * halves. Nothing between this and the one above names either representation.
      */
     @Test
     void anOperationWhoseResultAFormAlreadyReadsCannotBeGivenOneEither() {

--- a/souther-compiler/src/test/java/souther/compiler/check/NumericReadingsFindTheAccountsTheLibraryDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/NumericReadingsFindTheAccountsTheLibraryDeclaresTest.java
@@ -1,0 +1,87 @@
+package souther.compiler.check;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.semantics.OperationFacts;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Each account of a number is found where the library declares it.
+ *
+ * <p>What the invariant beside this cannot say. That one refuses a second reading, so it is asked of
+ * an operation by counting to more than one — and an arm the resolver stopped reading takes its
+ * operations from one reading to none, which is a state that invariant exists to allow. Measured:
+ * with the arm for the arithmetic an operation computes removed, the whole suite stayed green.
+ *
+ * <p>So an account nobody reads and an account nobody looked for were the same observation, which is
+ * the defect the questions exist against, one level up. Here each arm is named at an operation that
+ * carries it, so a reading that stops being found is a failure rather than an operation that turns
+ * out to have none.
+ *
+ * <p>One operation per arm and no more. This is a characterization of the resolver and not a table
+ * of the library: what every operation answers is asked of the declarations themselves, and a list
+ * kept here would be a second copy of them, wrong one turn later.
+ */
+class NumericReadingsFindTheAccountsTheLibraryDeclaresTest {
+
+    @Test
+    void aTermIsFoundWhereOneIsDeclared() {
+        assertInstanceOf(NumericReading.AsATermTakenOfItsArgument.class,
+                readingOf("List.length"),
+                "List.length is declared to answer a number taken of the one value it is given");
+    }
+
+    @Test
+    void aFormIsFoundWhereOneIsDeclared() {
+        assertInstanceOf(NumericReading.AsAFormOfItsArguments.class,
+                readingOf("Decimal.fromInt"),
+                "Decimal.fromInt is declared to answer the count of its argument");
+    }
+
+    @Test
+    void theArithmeticAnOperationComputesIsFound() {
+        assertInstanceOf(NumericReading.AsTheArithmeticItComputes.class,
+                readingOf("Int.add"),
+                "Int.add is declared to compute the arithmetic the operator stands for");
+    }
+
+    @Test
+    void aBodyTheLanguageWritesOutIsFound() {
+        assertInstanceOf(NumericReading.ByTheBodyTheLanguageWritesOut.class,
+                readingOf("Int.abs"),
+                "Int.abs is an ordinary let, so what it answers is read by reading it");
+    }
+
+    /**
+     * And an operation answering no number carries no account of one.
+     *
+     * <p>{@code Date.addDays} declares a form and answers a date. The form is about what its
+     * arguments are counted as, which is what lets a date take part in one at all; it is not an
+     * account of a number the operation answered, because it answered none. Counted as one, every
+     * such operation would carry a reading whose subject is missing — and a proposition with no
+     * subject cannot come out false, so the count would look right for the wrong reason.
+     */
+    @Test
+    void anOperationThatAnswersNoNumberCarriesNoAccountOfOne() {
+        assertEquals(new NumericReadings.Resolution.None(), resolutionOf("Date.addDays"),
+                "a form over what its arguments are counted as is not a reading of a number this"
+                        + " operation answers, since it answers a date");
+    }
+
+    private static NumericReading readingOf(String qualified) {
+        NumericReadings.Resolution resolved = resolutionOf(qualified);
+        return assertInstanceOf(NumericReadings.Resolution.One.class, resolved,
+                qualified + " carries one account of the number it answers, and this is what was"
+                        + " found instead").reading();
+    }
+
+    private static NumericReadings.Resolution resolutionOf(String qualified) {
+        ValueName operation = DefaultStdlib.get().operation(qualified);
+        return NumericReadings.resolve(
+                DefaultStdlib.get(), OperationFacts.declarations(), operation);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/NumericReadingsFindTheAccountsTheLibraryDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/NumericReadingsFindTheAccountsTheLibraryDeclaresTest.java
@@ -13,14 +13,13 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
  * Each account of a number is found where the library declares it.
  *
  * <p>What the invariant beside this cannot say. That one refuses a second reading, so it is asked of
- * an operation by counting to more than one — and an arm the resolver stopped reading takes its
- * operations from one reading to none, which is a state that invariant exists to allow. Measured:
- * with the arm for the arithmetic an operation computes removed, the whole suite stayed green.
+ * an operation by counting to more than one — and an arm the resolver stops reading takes its
+ * operations from one reading to none, which is a state that invariant exists to allow. Left to it,
+ * an account nobody reads and an account nobody looked for are the same observation, which is the
+ * defect the questions exist against, one level up.
  *
- * <p>So an account nobody reads and an account nobody looked for were the same observation, which is
- * the defect the questions exist against, one level up. Here each arm is named at an operation that
- * carries it, so a reading that stops being found is a failure rather than an operation that turns
- * out to have none.
+ * <p>So each arm is named at an operation that carries it, and a reading that stops being found is a
+ * failure rather than an operation that turns out to have none.
  *
  * <p>One operation per arm and no more. This is a characterization of the resolver and not a table
  * of the library: what every operation answers is asked of the declarations themselves, and a list

--- a/souther-compiler/src/test/java/souther/compiler/check/OneNumericAnswerIsReadByOneRepresentationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneNumericAnswerIsReadByOneRepresentationTest.java
@@ -1,0 +1,69 @@
+package souther.compiler.check;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.semantics.OperationFacts;
+import souther.compiler.stdlib.Stdlib;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The number an operation answers is read by one representation.
+ *
+ * <p>A term standing for a call, the form its result is of its arguments, the arithmetic it
+ * computes, the body the language writes out — each is an account of the same number, and two of
+ * them at one call is not two opinions but a report whose content depends on which reader arrived.
+ * {@code Decimal.fromInt(n)} declared as a term as well as a form would be {@code n} to a check
+ * reading forms and an opaque number to a check reading terms.
+ *
+ * <p>Held of every operation the library declares and not of the ones some question asks about. The
+ * exclusivity is a property of the declarations, so a range that moved would move what is exclusive
+ * with it — and the operations no question asks about today are exactly the ones nobody would think
+ * to check by hand.
+ *
+ * <p>{@code None} is not a failure here. Most of what the library answers is read by nothing, which
+ * is ordinary; where a reading is owed it is a question's range that says so, and that is asked in
+ * {@code AnOperationTheLibraryGainsIsAnsweredForTest}.
+ */
+class OneNumericAnswerIsReadByOneRepresentationTest {
+
+    @Test
+    void noOperationsNumberIsReadByTwoRepresentations() {
+        List<String> twice = new ArrayList<>();
+        for (Map.Entry<String, Stdlib.Entry> e : DefaultStdlib.get().entries().entrySet()) {
+            ValueName operation = DefaultStdlib.get().operation(e.getKey());
+            if (NumericReadings.resolve(DefaultStdlib.get(), OperationFacts.declarations(),
+                    operation) instanceof NumericReadings.Resolution.Multiple(List<NumericReading> readings)) {
+                twice.add(e.getKey() + " — " + String.join(" and ",
+                        readings.stream().map(NumericReading::describes).toList()));
+            }
+        }
+        assertEquals(List.of(), twice,
+                "the number each of these answers is read by more than one representation, so which"
+                        + " reading a report shows is whichever reader arrived");
+    }
+
+    /**
+     * An operation that answers no number has no reading of one.
+     *
+     * <p>{@code Date.addDays} declares a form and answers a date. The form is about what its
+     * arguments are counted as, which is what lets a date take part in one at all; it is not an
+     * account of a number the operation answered, because it answered none. Counted as one, every
+     * such operation would carry a reading whose subject is missing — and a proposition with no
+     * subject cannot come out false, so the count would look right for the wrong reason.
+     */
+    @Test
+    void anOperationThatAnswersNoNumberIsReadByNothing() {
+        assertEquals(new NumericReadings.Resolution.None(),
+                NumericReadings.resolve(DefaultStdlib.get(), OperationFacts.declarations(),
+                        DefaultStdlib.get().operation("Date.addDays")),
+                "a form over what its arguments are counted as is not a reading of a number this"
+                        + " operation answers, since it answers a date");
+    }
+}


### PR DESCRIPTION
The first half of #1045. It adds no question and answers none: what it
establishes is the invariant the question will rest on, which is that the
number an operation answers is read by one representation.

## What was wrong

`DischargeRules.holdTakenOf` refused a declared term where a form, an
arithmetic or a body reading already read the same call. Three conditions,
one per representation it knew of, and nothing anywhere counted. A fourth
account of a number would have had to be named inside each of them, and
inside whatever the next such procedure turned out to be, and the pair that
nobody wrote down would be the pair that goes unchecked.

The exclusivity was also only ever asked where a term was being declared.
Two representations meeting any other way -- a form beside an arithmetic --
were refused by nothing.

## What is here

`NumericReading` is the four accounts: a term taken of the one argument, a
form of the arguments, the arithmetic the operation computes, and the body
the language writes out where the operation is not an intrinsic. It is
sealed, and the switch that reads the declarations into it is exhaustive
over `OperationFact` with no default, so a kind of fact added has to say
whether it is an account of a number.

`NumericReadings.resolve` answers `None | One | Multiple`. Three sentences
in its javadoc are the design and are meant to stay:

    NumericReadings describes facts, not precedence.
    Multiple is an invalid library definition, not a choice to resolve.
    None is valid globally; a Question may make it invalid within its range.

The third is the one worth keeping. Made to answer `One` wherever a number
is answered, this would start carrying the deliberate silences, and finding
out what is declared would become deciding what ought to be.

`holdTakenOf` now asks the count. The other three things it holds -- one
argument, a result that is a bare number, an account the operation is the
shape of -- stay, because those are this fact and this declaration agreeing
and are not about how many readings there are. The count comes before the
shape, so the exclusivity is reachable for an operation no existing arm fits.

`OneNumericAnswerIsReadByOneRepresentationTest` refuses `Multiple` for every
operation the library declares, in range of a question or not.

`AnOperationTheLibraryGainsIsAnsweredForTest` asks for exactly one of a rule
and a silence instead of at least one of the two. A silence denies a rule
rather than standing beside it, and read as an `or` a silence that had become
false was only ever a filler. The separate check on the two sides goes: over
the range the strengthened question sees what it saw, and it could not see an
operation answered by another proposition and silenced here.

## Measured

Each tripwire was broken and the failure read.

| break | what stopped |
| --- | --- |
| a form declared for `Time.hour`, beside its term | the uniqueness test, naming the pair |
| a term declared for `Int.abs` | the binder: read as a term and as the body the language writes out |
| `SaysNothingOf(SIZE)` for `String.length`, beside its rule | the strengthened question: a rule and a silence beside it |
| a new arm on `OperationFact` | `NumericReadings` does not compile |

`mvn -o test` green over the reactor, 10,178 tests.

## Not here

`Question.READING` and the operations that owe an answer to it. That is the
completeness half and lands with the date parts, so that the range and every
answer in it arrive together rather than leaving `Date.year` in range and
unanswered.


## Review, second round

Two findings, and the cause under the first one turned out to be wider than
where it showed.

**One question with two answers.** The resolver read `Question.numberAnsweredBy`,
so a resolver of facts depended on the range that demands them. Underneath
that, `Question.numberAnsweredBy` and `NumericAnswers.typeOf` were two answers
to one question, each living inside a consumer -- what asks the questions, and
what a term's carrier is taken from. They agree wherever an arithmetic declares
the case it answers at, and part where a union carries a number and none is
declared: `String.toInt` is `Int` to the first and `Int | NotANumber` to the
second. Unreachable today, and in range of the question the next PR adds.

So the classification is now `NumericAnswers`, which already declared itself
the one entry, and the range, the holds and the readings read it.
`isANumber` moved with it, since left behind it would have had the
classification reading the questions to answer what a number is.

`NumericAnswers.typeOf` no longer consults the case an arithmetic names. What
an arithmetic answers where is a proposition about one representation; an
operation answering `Int | Decimal | SomeError` carries two numbers whatever
its arithmetic names. Behaviour-preserving today: the three operations
declaring a case (`Int.divide`, `Int.truncatingRemainder`, `Decimal.divide`)
each name the number the shape already carries, and `holdNumericResult` holds
the two to each other, so that agreement is now checked rather than assumed.

**An invariant named for a stronger claim, and a negative property.** The test
asserted that nothing is read twice while its name said every number is read
once, with the exception in its own javadoc -- an argument, later, for pulling
completeness back into the invariant this PR exists to keep it away from. It is
now `ANumberIsReadByAtMostOneRepresentationTest` and holds that and nothing
else.

And because it is negative, every account the resolver reads was observed only
where some other test built a conflict needing it. Measured: with the arm for
the arithmetic an operation computes removed, the whole suite stayed green --
an account nobody reads and an account nobody looked for were one observation.
`NumericReadingsFindTheAccountsTheLibraryDeclaresTest` names one operation per
arm (`List.length`, `Decimal.fromInt`, `Int.add`, `Int.abs`) beside
`Date.addDays`, which answers no number and carries no account of one. Measured
again with the arm removed: it fails at `Int.add`.

`mvn -o test` green over the reactor.


## Self-check

Four things, three of them mine and fixed here.

The refusal names the readings an operation has, and the test finding the same
fault built that sentence again out of the arms — one caller of the naming and
a hand copy beside it. The test asks for the sentence now.

The clause saying what an account is written for named two examples and lost
the rule they were examples of, and one of them came out broken. The rule is
back.

The grouping of what `holdTakenOf` holds read "the first three" and "the last",
written before the count moved ahead of the shape check. They are named for
what each is about instead.

And the prose reporting what had happened — a suite that stayed green under a
mutation, conditions the code used to have — says what would happen under the
alternative instead. A rule holds without a date on it.

The fourth is not from this branch and is filed as #1059: `countsToANumber` and
`holdsElements` are classifications of a type living inside `Question` and read
from `DischargeRules`, `OperationFactBinder` and `Accumulations`. Same shape as
the one this PR moved, no dependency added by anything here, and `holdsElements`
has nothing to do with numbers — so moving it would put a second proposition in
this change.
