### PR TITLE
Name the number a coverage question is about

### DIFF
--- a/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
+++ b/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
@@ -68,7 +68,7 @@ class AMeasureIsIntroducedInOnePlaceTest {
     private static final Map<String, Integer> INTRODUCED_BY = new LinkedHashMap<>(
             Map.ofEntries(
             Map.entry("souther.compiler.query.Coverages#pairsOf(Ljava/lang/String;Ljava/util/List;Lsouther/compiler/query/Coverages$Readings;ZLsouther/compiler/partition/AdequacyPolicy$OfTheMeasures;)Lsouther/compiler/query/PartitionEvidence$PairSpace;", 2),
-            Map.entry("souther.compiler.query.Coverages#coverageOf(Lsouther/compiler/partition/Axis;Lsouther/compiler/query/Coverages$Readings;Z)Lsouther/compiler/query/PartitionEvidence$AxisCoverage;", 2),
+            Map.entry("souther.compiler.query.Coverages#coverageOf(Lsouther/compiler/partition/Axis;Lsouther/compiler/partition/Partitions$Partitioning;Lsouther/compiler/query/Coverages$Readings;Z)Lsouther/compiler/query/PartitionEvidence$AxisCoverage;", 2),
             Map.entry("souther.compiler.query.Coverages#verdictOf(Lsouther/compiler/query/Coverages$Met;ZLsouther/compiler/partition/Border;Lsouther/compiler/query/Adequacy$RowReading;)Lsouther/compiler/query/Measurement;", 3),
             Map.entry("souther.compiler.query.Coverages#whyNoGuardLine(Lsouther/compiler/query/Adequacy$RowReading;Lsouther/compiler/query/Adequacy$Level;)Lsouther/compiler/query/Measurement;", 2),
             Map.entry("souther.compiler.query.Coverages#whyNoInvariantLine(Lsouther/compiler/query/Adequacy$RowReading;Lsouther/compiler/query/Adequacy$Level;)Lsouther/compiler/query/Measurement;", 1),

--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseStates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseStates.java
@@ -23,6 +23,13 @@ import java.util.Set;
  * <p>Each carries what it is about, taken from the same reading. Worked out again where the
  * questions are raised, the subject a question is filed under and the subject the reading found
  * would be two answers about one clause.
+ *
+ * <p><b>What a clause is about, and not the questions it raises.</b> A position it names is a path
+ * and a line it draws is a {@link FieldDomains.Coordinate}, which are what a reading of a clause
+ * has; which coverage question each of them becomes is {@link Required#ofInvariant}'s and is
+ * decided there. Written in the vocabulary of the questions instead, the positions were a set of
+ * subjects every member of which was the same arm with the same flag — a set of paths wearing the
+ * type of a set of subjects, so that a lookup by path read as a comparison of subjects.
  */
 sealed interface ClauseStates {
 
@@ -34,18 +41,23 @@ sealed interface ClauseStates {
      * at the end. A rule states where the values stop by being written that way; what this compiler
      * made of the number on the other side is what answers the question, not what raises it.
      *
-     * @param line  the number the end is on, which is the position's own value or a count taken of
-     *              it
-     * @param named the positions the clause is about, which is what a rule can cost. Never empty:
-     *              a clause bounding a coordinate names it
+     * @param line      the number the end is on, which is the position's own value or a number an
+     *                  operation answers of it. The operation itself, since two operations over one
+     *                  path are two lines and a flag saying one was taken cannot tell them apart
+     * @param positions the ones the clause is about, which is what a rule can cost. Never empty:
+     *                  a clause bounding a coordinate names the position it sits at
      */
-    record ABound(Owed.Subject line, Set<Owed.Subject> named) implements ClauseStates {
+    record ABound(FieldDomains.Coordinate line, Set<String> positions) implements ClauseStates {
 
         public ABound {
-            if (named.isEmpty()) {
+            if (line == null) {
+                throw new IllegalArgumentException("a bound is a line on some number");
+            }
+            if (positions.isEmpty()) {
                 throw new IllegalArgumentException("a bound is written about a position");
             }
-            named = java.util.Collections.unmodifiableSet(new java.util.LinkedHashSet<>(named));
+            positions = java.util.Collections.unmodifiableSet(
+                    new java.util.LinkedHashSet<>(positions));
         }
     }
 
@@ -75,7 +87,7 @@ sealed interface ClauseStates {
      *                  {@link Required#ofInvariant} makes of an empty set. Filed at the value
      *                  instead, {@code invariant t = 1 >= 0} was a rule nothing had accounted for
      */
-    record SomethingElse(Set<Owed.Subject> positions) implements ClauseStates {
+    record SomethingElse(Set<String> positions) implements ClauseStates {
 
         public SomethingElse {
             // Insertion order: `Set.of` and `Set.copyOf` iterate in an order salted once per JVM
@@ -84,15 +96,15 @@ sealed interface ClauseStates {
                     new java.util.LinkedHashSet<>(positions));
         }
 
-        static SomethingElse naming(List<Owed.Subject> found) {
+        static SomethingElse naming(List<String> found) {
             return new SomethingElse(new java.util.LinkedHashSet<>(found));
         }
     }
 
     /** The positions this clause is about, by which a rule can cost one. */
-    default Set<Owed.Subject> about() {
+    default Set<String> about() {
         return switch (this) {
-            case ABound bound -> bound.named();
+            case ABound bound -> bound.positions();
             case SomethingElse other -> other.positions();
             // A rule about a pair costs neither of them: what it says is not a set of one
             // position's values, so there is nothing about one for anything to have read.

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
@@ -157,15 +157,17 @@ public final class DeclaredBounds {
      * rules a type states rather than beside the reader of them, because an end is an end whichever
      * declaration wrote it and both come out as the same {@link Bounds}.
      *
-     * @param measured which of the position's coordinates these are wanted for — the count taken of
-     *                 it, or its value
+     * @param kind which of the position's numbers these are wanted for — its own value, or what
+     *             some operation answers of it. The operation and not a flag, since a path measured
+     *             two ways by two operations has two of these and a flag brings them to one. The
+     *             path is the caller's already, which is what {@code placed} is a list of
      */
-    public static Bounds placed(List<FieldDomains.Placed> placed, boolean measured,
-                                Carrier carrier) {
+    public static Bounds placed(List<FieldDomains.Placed> placed,
+                                FieldDomains.CoordinateKind kind, Carrier carrier) {
         End min = null;
         End max = null;
         for (FieldDomains.Placed each : placed) {
-            if (each.measured() != measured) {
+            if (!each.at().kind().equals(kind)) {
                 continue;
             }
             End end = new End(each.end(), List.of(each.from()));

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -738,9 +738,13 @@ public final class FieldDomains {
         // half beside it. The parts each say what they raised, and an end says which part placed it.
         for (Map.Entry<Core, Required> part : raisedByPart
                 .getOrDefault(rule, Map.of()).entrySet()) {
+            // One arm each, so that a question added later is decided about rather than answered
+            // "not this one" by a test it also fails.
             boolean asked = part.getValue().obligations().stream()
-                    .anyMatch(owed -> owed instanceof Owed.Boundary line
-                            && line.on().equals(where));
+                    .anyMatch(owed -> switch (owed) {
+                        case Owed.Boundary line -> line.on().equals(where);
+                        case Owed.AdmittedValues _ -> false;
+                    });
             if (!asked) {
                 continue;
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -712,8 +712,6 @@ public final class FieldDomains {
         return switch (owed) {
             case Owed.AdmittedValues it -> admissionAnswered(rule, it.path());
             case Owed.Boundary it -> boundaryAnswered(rule, it.on());
-            case Owed.BoundaryBetween it -> throw new IllegalStateException(
-                    "a clause of a value asks about a position of it: " + it);
         };
     }
 
@@ -1280,9 +1278,6 @@ public final class FieldDomains {
                         switch (owed) {
                             case Owed.AdmittedValues it -> said.add(it.path());
                             case Owed.Boundary it -> said.add(it.on().path());
-                            // On neither position, so there is no position of this value to say it
-                            // of.
-                            case Owed.BoundaryBetween _ -> { }
                         }
                     });
                 }

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -441,6 +441,12 @@ public final class FieldDomains {
     public record Unread(String path, ValueName by, RuleRef.Invariant from,
                          Core part, souther.compiler.inputs.BlockReason.AboutARule why) {
 
+        /** Which number of the position the end was to have been on, which is what a question about
+         *  a line is matched against. */
+        public Coordinate coordinate() {
+            return by == null ? Coordinate.value(path) : Coordinate.takenBy(path, by);
+        }
+
         /** Whether it is a number taken of the position rather than its own values, derived for the
          *  reason {@link Placed#measured} gives. */
         public boolean measured() {
@@ -701,18 +707,21 @@ public final class FieldDomains {
         return accounting;
     }
 
-    /** What answered one question of one rule. */
+    /**
+     * What answered one question of one rule.
+     *
+     * <p>One arm each, and no arm to fence off. A clause of a `data` is written about a position of
+     * it or about a number of one, which is what the readings here answer about; a place between two
+     * numbers is a comparison's and reaches no accounting of one value's clauses. That was a throw
+     * here while the question was an obligation beside a subject and the pair admitted combinations
+     * nothing raises.
+     */
     private RuleAccounting.Outcome answered(RuleRef rule, Owed owed) {
-        // A clause of a `data` is written about a position of it, which is what the readings here
-        // answer about. A place between two numbers is a comparison's and reaches no accounting of
-        // one value's clauses.
-        if (!(owed.subject() instanceof Owed.Subject.OfAPosition where)) {
-            throw new IllegalStateException(
-                    "a clause of a value asks about a position of it: " + owed);
-        }
-        return switch (owed.obligation()) {
-            case ADMITTED_VALUES -> admissionAnswered(rule, where);
-            case BOUNDARY -> boundaryAnswered(rule, where);
+        return switch (owed) {
+            case Owed.AdmittedValues it -> admissionAnswered(rule, it.path());
+            case Owed.Boundary it -> boundaryAnswered(rule, it.on());
+            case Owed.BoundaryBetween it -> throw new IllegalStateException(
+                    "a clause of a value asks about a position of it: " + it);
         };
     }
 
@@ -730,8 +739,7 @@ public final class FieldDomains {
      * type and a clause of the record about the same field are two rules, and an end read for one
      * says nothing about the other.
      */
-    private RuleAccounting.Outcome boundaryAnswered(RuleRef rule,
-                                                   Owed.Subject.OfAPosition where) {
+    private RuleAccounting.Outcome boundaryAnswered(RuleRef rule, Coordinate where) {
         // Every conjunct that asked, and not whichever one happened to be read. A rule is read a
         // conjunct at a time and files one question about its line, so the two ways of reading the
         // record are both wrong: asked of what went unread alone, `value >= 1 && Int.abs(value) >= 2`
@@ -741,13 +749,13 @@ public final class FieldDomains {
         for (Map.Entry<Core, Required> part : raisedByPart
                 .getOrDefault(rule, Map.of()).entrySet()) {
             boolean asked = part.getValue().obligations().stream()
-                    .anyMatch(owed -> owed.obligation() == CoverageObligation.BOUNDARY
-                            && owed.subject().equals(where));
+                    .anyMatch(owed -> owed instanceof Owed.Boundary line
+                            && line.on().equals(where));
             if (!asked) {
                 continue;
             }
             if (directs.stream().noneMatch(d -> d.from().equals(rule) && d.part() == part.getKey()
-                    && d.path().equals(where.path()) && d.measured() == where.measured())) {
+                    && d.coordinate().equals(where))) {
                 return unreadAnswerFor(rule, part.getKey(), where);
             }
         }
@@ -755,12 +763,10 @@ public final class FieldDomains {
     }
 
     /** What the reading of ends said about the rule at this position, where it said anything. */
-    private RuleAccounting.Outcome unreadAnswerFor(RuleRef rule, Core part,
-                                                   Owed.Subject.OfAPosition where) {
+    private RuleAccounting.Outcome unreadAnswerFor(RuleRef rule, Core part, Coordinate where) {
         for (Unread said : unread) {
             if (said.from().equals(rule) && said.part() == part
-                    && said.path().equals(where.path())
-                    && said.measured() == where.measured()) {
+                    && said.coordinate().equals(where)) {
                 return new RuleAccounting.Outcome.Unaccounted(
                         new RuleAccounting.Why.TheEndReadingSays(said.why()));
             }
@@ -780,19 +786,18 @@ public final class FieldDomains {
      * clause beside it: {@code value >= 1} leaves the reading of values short at a position, and
      * {@code value == 7} written beside it was taken in whole.
      */
-    private RuleAccounting.Outcome admissionAnswered(RuleRef rule,
-                                                     Owed.Subject.OfAPosition where) {
-        List<FactSubject> named = named(where.path());
+    private RuleAccounting.Outcome admissionAnswered(RuleRef rule, String at) {
+        List<FactSubject> named = named(at);
         // A part of the rule nothing took in outranks everything else about it. An end placed by
         // one conjunct is not an account of the conjunct written beside it.
         if (took.anyLeftStanding(rule, named)) {
             return new RuleAccounting.Outcome.Unaccounted(
                     new RuleAccounting.Why.TheValueReadingSays(
-                            unreadByField.getOrDefault(where.path(), UnreadReason.FORM_NOT_READ)));
+                            unreadByField.getOrDefault(at, UnreadReason.FORM_NOT_READ)));
         }
         // The reading that turns this clause into where the values stop, said by the end it placed.
         if (directs.stream()
-                .anyMatch(d -> d.from().equals(rule) && d.path().equals(where.path()))) {
+                .anyMatch(d -> d.from().equals(rule) && d.path().equals(at))) {
             return new RuleAccounting.Outcome.Accounted(RuleAccounting.Reader.THE_END_READING);
         }
         // And the readings that hold what a clause says about the values themselves, each said by
@@ -800,7 +805,7 @@ public final class FieldDomains {
         if (took.tookIn(rule, named)) {
             return new RuleAccounting.Outcome.Accounted(RuleAccounting.Reader.THE_VALUE_READING);
         }
-        UnreadReason why = unreadByField.get(where.path());
+        UnreadReason why = unreadByField.get(at);
         return new RuleAccounting.Outcome.Unaccounted(new RuleAccounting.Why.TheValueReadingSays(
                 why == null ? UnreadReason.FORM_NOT_READ : why));
     }
@@ -1120,6 +1125,21 @@ public final class FieldDomains {
         public static Coordinate takenBy(String path, ValueName operation) {
             return new Coordinate(path, new CoordinateKind.OfWhatAnOperationAnswers(operation));
         }
+
+        /**
+         * The number, named. The operation and not a word for the kind of thing it is: two
+         * operations over one path are two of these, and "count of" spells them the same.
+         */
+        @Override
+        public String toString() {
+            // The value itself is at no path, which reads as nothing at all where it is printed.
+            String where = path.isEmpty() ? "the value" : path;
+            return switch (kind) {
+                case CoordinateKind.OfItsOwnValue _ -> where;
+                case CoordinateKind.OfWhatAnOperationAnswers taken ->
+                        taken.operation() + "(" + where + ")";
+            };
+        }
     }
 
     /**
@@ -1265,8 +1285,12 @@ public final class FieldDomains {
                 Required required = byPartRaised == null ? null : byPartRaised.get(part);
                 if (required != null) {
                     required.obligations().forEach(owed -> {
-                        if (owed.subject() instanceof Owed.Subject.OfAPosition at) {
-                            said.add(at.path());
+                        switch (owed) {
+                            case Owed.AdmittedValues it -> said.add(it.path());
+                            case Owed.Boundary it -> said.add(it.on().path());
+                            // On neither position, so there is no position of this value to say it
+                            // of.
+                            case Owed.BoundaryBetween _ -> { }
                         }
                     });
                 }

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -393,21 +393,20 @@ public final class FieldDomains {
      * and at nothing else (ADR-0090), so handing back the range instead would make a relational rule
      * into a partition of a position it never mentioned.
      *
-     * @param path     where the coordinate sits, read from the value these are of
-     * @param measured whether the coordinate is a count taken of the position rather than its value
-     * @param from     the rule that placed the end, which is what names the line. An invariant's,
-     *                 and said so: these are the ends the clauses of a declaration place, and no
-     *                 other kind of rule reaches this reading
-     * @param lower    whether this bounds the coordinate below; otherwise above
+     * @param at    which number of which position the end is on. The number and not a path beside
+     *              a flag: one position carries more than one, and which of them an end is on is
+     *              what the operation beside the path says
+     * @param from  the rule that placed the end, which is what names the line. An invariant's,
+     *              and said so: these are the ends the clauses of a declaration place, and no
+     *              other kind of rule reaches this reading
+     * @param lower whether this bounds the coordinate below; otherwise above
      */
-    public record Placed(String path, ValueName by, RuleRef.Invariant from,
-                         boolean lower, Endpoint end) {
+    public record Placed(Coordinate at, RuleRef.Invariant from, boolean lower, Endpoint end) {
 
-        /** Whether it is a number taken of the position rather than its own values, which is what
-         *  the readings of this value's own clauses ask each other. Derived and not stored: which
-         *  number it is, is {@link #by}, and a stored answer beside it would be a second one. */
-        public boolean measured() {
-            return by != null;
+        /** Where in the value the end sits. Never which number it is on: that is {@link #at}, and
+         *  reading one off the other is what the pair exists to stop. */
+        public String path() {
+            return at.path();
         }
     }
 
@@ -438,19 +437,12 @@ public final class FieldDomains {
      * @param why  what would have to change before this rule could be a line, in this compiler's
      *             own terms
      */
-    public record Unread(String path, ValueName by, RuleRef.Invariant from,
+    public record Unread(Coordinate at, RuleRef.Invariant from,
                          Core part, souther.compiler.inputs.BlockReason.AboutARule why) {
 
-        /** Which number of the position the end was to have been on, which is what a question about
-         *  a line is matched against. */
-        public Coordinate coordinate() {
-            return by == null ? Coordinate.value(path) : Coordinate.takenBy(path, by);
-        }
-
-        /** Whether it is a number taken of the position rather than its own values, derived for the
-         *  reason {@link Placed#measured} gives. */
-        public boolean measured() {
-            return by != null;
+        /** Where in the value the end was to have been placed. */
+        public String path() {
+            return at.path();
         }
     }
 
@@ -755,7 +747,7 @@ public final class FieldDomains {
                 continue;
             }
             if (directs.stream().noneMatch(d -> d.from().equals(rule) && d.part() == part.getKey()
-                    && d.coordinate().equals(where))) {
+                    && d.at().equals(where))) {
                 return unreadAnswerFor(rule, part.getKey(), where);
             }
         }
@@ -766,7 +758,7 @@ public final class FieldDomains {
     private RuleAccounting.Outcome unreadAnswerFor(RuleRef rule, Core part, Coordinate where) {
         for (Unread said : unread) {
             if (said.from().equals(rule) && said.part() == part
-                    && said.coordinate().equals(where)) {
+                    && said.at().equals(where)) {
                 return new RuleAccounting.Outcome.Unaccounted(
                         new RuleAccounting.Why.TheEndReadingSays(said.why()));
             }
@@ -819,7 +811,7 @@ public final class FieldDomains {
     /** Every end the rules place, wherever it is. */
     public List<Placed> placed() {
         return directs.stream()
-                .map(each -> new Placed(each.path(), each.by(), each.from(),
+                .map(each -> new Placed(each.at(), each.from(),
                         each.bound().lower(), each.bound().end()))
                 .toList();
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -873,6 +873,13 @@ public final class InvariantChecker {
     record Direct(String path, ValueName by, RuleRef.Invariant from,
                   InvariantBound bound, Core part) {
 
+        /** Which number of the position this end was placed on, which is what a question about a
+         *  line is matched against. */
+        FieldDomains.Coordinate coordinate() {
+            return by == null ? FieldDomains.Coordinate.value(path)
+                    : FieldDomains.Coordinate.takenBy(path, by);
+        }
+
         /** Whether it is a number taken of the position rather than its own values. */
         boolean measured() {
             return by != null;

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -870,19 +870,13 @@ public final class InvariantChecker {
      *                 one value are two rules a row could be owed to, and held as declarations
      *                 they came back as one
      */
-    record Direct(String path, ValueName by, RuleRef.Invariant from,
+    record Direct(FieldDomains.Coordinate at, RuleRef.Invariant from,
                   InvariantBound bound, Core part) {
 
-        /** Which number of the position this end was placed on, which is what a question about a
-         *  line is matched against. */
-        FieldDomains.Coordinate coordinate() {
-            return by == null ? FieldDomains.Coordinate.value(path)
-                    : FieldDomains.Coordinate.takenBy(path, by);
-        }
-
-        /** Whether it is a number taken of the position rather than its own values. */
-        boolean measured() {
-            return by != null;
+        /** Where in the value the end was placed. Never which end it is: one position carries more
+         *  than one number and {@link #at} is what says which of them this is. */
+        String path() {
+            return at.path();
         }
     }
 
@@ -1068,20 +1062,12 @@ public final class InvariantChecker {
      *                position no line is drawn on named nothing, and the reading that could say so
      *                had never heard of the position
      */
-    private record Coordinate(String path, ValueName by, Carrier carrier) {
+    private record Coordinate(FieldDomains.Coordinate at, Carrier carrier) {
 
-        /** Which number of the position this is, as the one type that tells two numbers at one path
-         *  apart. Built from what was recorded rather than from a flag: the operation is what makes
-         *  two of them two, and a reader handed only that one was taken has to ask somewhere else
-         *  which. */
-        FieldDomains.Coordinate coordinate() {
-            return by == null ? FieldDomains.Coordinate.value(path)
-                    : FieldDomains.Coordinate.takenBy(path, by);
-        }
-
-        /** Whether it is a number taken of the position rather than the position's own values. */
-        boolean measured() {
-            return by != null;
+        /** Where in the value it sits. Never what it is: two numbers can be taken at one path, and
+         *  {@link #at} is what tells them apart. */
+        String path() {
+            return at.path();
         }
     }
 
@@ -1118,10 +1104,10 @@ public final class InvariantChecker {
         Map<FactSubject, Coordinate> byName = new LinkedHashMap<>();
         keys.forEach((path, key) -> {
             Carrier carrier = Carrier.ofValue(typeAt.get(path), symbols);
-            byName.put(key, new Coordinate(path, null, carrier));
+            byName.put(key, new Coordinate(FieldDomains.Coordinate.value(path), carrier));
             FactSubject atom = atoms.get(path);
             if (atom != null) {
-                byName.put(atom, new Coordinate(path, null, carrier));
+                byName.put(atom, new Coordinate(FieldDomains.Coordinate.value(path), carrier));
             }
         });
         // A count is a whole number whatever it counts, so nothing about the container decides how
@@ -1129,7 +1115,8 @@ public final class InvariantChecker {
         // it: dropped here and rebuilt as "a number was taken", two operations over one path were
         // one coordinate and a report could not tell them apart.
         held.forEach((path, counted) -> byName.put(counted.atom(),
-                new Coordinate(path, counted.by(), Carrier.WHOLE)));
+                new Coordinate(FieldDomains.Coordinate.takenBy(path, counted.by()),
+                        Carrier.WHOLE)));
         List<Direct> out = new ArrayList<>();
         List<FieldDomains.Unread> unread = new ArrayList<>();
         Map<String, List<TypeSymbol>> narrowers = new LinkedHashMap<>();
@@ -1302,7 +1289,7 @@ public final class InvariantChecker {
             // And the number the line is on, which is the coordinate this reading already holds. Not
             // rebuilt from the path: which of a position's numbers a line is on is what the operation
             // beside it says, and a reader handed the path alone has to go and ask something else.
-            shape = new ClauseStates.ABound(about.coordinate(), positions);
+            shape = new ClauseStates.ABound(about.at(), positions);
         }
         settle(bin, from, shape, end, at, byName, raised, took, typeAt, parts, raisedByPart);
         if (end instanceof InvariantBound.Read.NoEnd) {
@@ -1325,7 +1312,7 @@ public final class InvariantChecker {
             return;
         }
         if (end instanceof InvariantBound.Read.AnEnd placed) {
-            out.add(new Direct(found.path(), found.by(), from, placed.bound(), bin));
+            out.add(new Direct(found.at(), from, placed.bound(), bin));
         }
     }
 
@@ -1498,7 +1485,7 @@ public final class InvariantChecker {
                 place -> carrierAt(place, left, right) != null);
         for (Coordinate each : coordinatesIn(comparison, at, byName)) {
             FieldDomains.Unread said =
-                    new FieldDomains.Unread(each.path(), each.by(), from, comparison, why);
+                    new FieldDomains.Unread(each.at(), from, comparison, why);
             if (!out.contains(said)) {
                 out.add(said);
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1063,6 +1063,15 @@ public final class InvariantChecker {
      */
     private record Coordinate(String path, ValueName by, Carrier carrier) {
 
+        /** Which number of the position this is, as the one type that tells two numbers at one path
+         *  apart. Built from what was recorded rather than from a flag: the operation is what makes
+         *  two of them two, and a reader handed only that one was taken has to ask somewhere else
+         *  which. */
+        FieldDomains.Coordinate coordinate() {
+            return by == null ? FieldDomains.Coordinate.value(path)
+                    : FieldDomains.Coordinate.takenBy(path, by);
+        }
+
         /** Whether it is a number taken of the position rather than the position's own values. */
         boolean measured() {
             return by != null;
@@ -1173,10 +1182,10 @@ public final class InvariantChecker {
         }
         // The positions this part is about, by every name each answers to, since a reading files a
         // clause under whichever name it recognised.
-        Set<Owed.Subject> named = states.about();
+        Set<String> named = states.about();
         Set<FactSubject> about = new LinkedHashSet<>();
         for (Map.Entry<FactSubject, Coordinate> each : byName.entrySet()) {
-            if (named.contains(Owed.Subject.at(each.getValue().path()))) {
+            if (named.contains(each.getValue().path())) {
                 about.add(each.getKey());
             }
         }
@@ -1279,12 +1288,14 @@ public final class InvariantChecker {
         if (about != null && InvariantBound.ordering(op)
                 && coordinatesIn(bound, at, byName).isEmpty()
                 && shape instanceof ClauseStates.SomethingElse named) {
-            Set<Owed.Subject> positions = new LinkedHashSet<>(named.positions());
-            // The coordinate the bound is on, which the walk over the comparison names anyway. Added
+            Set<String> positions = new LinkedHashSet<>(named.positions());
+            // The position the bound sits at, which the walk over the comparison names anyway. Added
             // so that the arm cannot be reached with nothing to be about.
-            positions.add(Owed.Subject.at(about.path()));
-            shape = new ClauseStates.ABound(
-                    new Owed.Subject.OfAPosition(about.path(), about.measured()), positions);
+            positions.add(about.path());
+            // And the number the line is on, which is the coordinate this reading already holds. Not
+            // rebuilt from the path: which of a position's numbers a line is on is what the operation
+            // beside it says, and a reader handed the path alone has to go and ask something else.
+            shape = new ClauseStates.ABound(about.coordinate(), positions);
         }
         settle(bin, from, shape, end, at, byName, raised, took, typeAt, parts, raisedByPart);
         if (end instanceof InvariantBound.Read.NoEnd) {
@@ -1342,7 +1353,7 @@ public final class InvariantChecker {
         })) {
             return new ClauseStates.ARelation();
         }
-        List<Owed.Subject> found = new ArrayList<>();
+        List<String> found = new ArrayList<>();
         namedIn(clause, at, byName, found);
         return ClauseStates.SomethingElse.naming(found);
     }
@@ -1356,11 +1367,10 @@ public final class InvariantChecker {
      * it is a coordinate of its own.
      */
     private void namedIn(Core e, Denotations at, Map<FactSubject, Coordinate> byName,
-                         List<Owed.Subject> out) {
+                         List<String> out) {
         for (Coordinate each : coordinatesIn(e, at, byName)) {
-            Owed.Subject where = Owed.Subject.at(each.path());
-            if (!out.contains(where)) {
-                out.add(where);
+            if (!out.contains(each.path())) {
+                out.add(each.path());
             }
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Owed.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Owed.java
@@ -3,106 +3,107 @@ package souther.compiler.check;
 /**
  * One question a rule raises, and what it is about.
  *
- * <p>The subject is here because the obligations do not share one. What values may stand somewhere
- * is about a position; where a line falls is about a number taken of one, and a {@code String}
- * bounded on its length raises both — the values are the string's and the line is on the length. A
- * report holding one subject for a rule names the wrong thing for at least one of its questions, and
- * that is how a line about a length came to be printed as a fact about which strings may stand
- * there.
+ * <p><b>The question and its subject are one thing and not two beside each other.</b> The
+ * obligations do not share a subject — what values may stand somewhere is about a position, where a
+ * line falls is about a number of one — and a rule bounding a {@code String} on its length raises
+ * both, the values being the string's and the line being on the length. Carried as an obligation
+ * beside a subject, the pair was a product every combination of which was constructible, so
+ * "which values may stand at the place a comparison drew" was a value of this type and was fenced
+ * off with a throw at the one reader that would have met it. Which subject an obligation has does
+ * not vary: it is the arm.
  *
- * <p>Which subject each obligation has follows from the obligation and is settled where the question
- * is raised, so no reader downstream chooses between a path and a term.
- *
- * @param obligation what has to be answered
- * @param subject    what it is about
+ * <p>Which arm a clause raises follows from the clause and is settled where the question is raised,
+ * so no reader downstream chooses between a path and a number.
  */
-public record Owed(CoverageObligation obligation, Subject subject) {
+public sealed interface Owed {
 
-    public Owed {
-        if (obligation == null || subject == null) {
-            throw new IllegalArgumentException("a question with no subject is not one");
+    /**
+     * Which values may stand at a position.
+     *
+     * <p>The position and never a number of it. What a rule about the length of a string admits is
+     * a set of strings; the length is where its line falls, which is the question below.
+     *
+     * @param path where in the value it sits, {@link FieldDomains#THE_VALUE} for the value itself
+     */
+    record AdmittedValues(String path) implements Owed {
+
+        public AdmittedValues {
+            if (path == null) {
+                throw new IllegalArgumentException("a subject sits somewhere in the value");
+            }
+        }
+
+        @Override
+        public String toString() {
+            // The value itself is at no path, which reads as nothing at all where it is printed.
+            return path.isEmpty() ? "the value" : path;
         }
     }
 
     /**
-     * What a question is about, as the reading that raised it names it.
+     * Where a line falls on one number of one position.
      *
-     * <p>A position of the value, a number taken of one, or the place two numbers hold one count.
-     * The first two are the same pair the reading of ends already carries, so that a question and
-     * the end that answers it are about the same thing by construction rather than by two spellings
-     * agreeing.
-     *
-     * <p>The second is not a position at all, and it is not a place written out either.
-     * {@code r.a <= r.b + 1} draws a line where the two sides meet; it is on neither of them, and
-     * filing it under either would name a place that rule never stopped. Nor is it spelled: writing
-     * the place out needs both sides in a vocabulary this compiler has, and it does not have one for
-     * {@code r.b + 1} — so a spelled subject is how far a pretty-printer got rather than what the
-     * question is about, and {@code r.b + 1} and {@code r.b + 2} come out as one place. The
-     * comparison that drew the line is what the question is about, and that this compiler can always
-     * name exactly.
+     * <p>The number itself, which is the position's own value or what an operation answers of it.
+     * Two operations over one path are two of these, and that is the whole reason the coordinate is
+     * carried rather than a flag saying that a number was taken: told apart by the flag, a rule
+     * about one operation's number was filed at another's, and every reader that wanted the name
+     * reached past the question to whatever stood beside it.
      */
-    public sealed interface Subject {
+    record Boundary(FieldDomains.Coordinate on) implements Owed {
 
-        /**
-         * A position of the value, or a number taken of one.
-         *
-         * @param path     where in the value it sits, {@link FieldDomains#THE_VALUE} for the value
-         *                 itself
-         * @param measured whether it is a count taken of the position rather than the position's
-         *                 own value
-         */
-        record OfAPosition(String path, boolean measured) implements Subject {
-
-            public OfAPosition {
-                if (path == null) {
-                    throw new IllegalArgumentException("a subject sits somewhere in the value");
-                }
-            }
-
-            @Override
-            public String toString() {
-                // The value itself is at no path, which reads as nothing at all where it is printed.
-                String where = path.isEmpty() ? "the value" : path;
-                return measured ? "count of " + where : where;
+        public Boundary {
+            if (on == null) {
+                throw new IllegalArgumentException("a line falls on some number");
             }
         }
 
-        /**
-         * The place a comparison of two moving things draws, named by that comparison.
-         *
-         * <p>Where the two sides hold one count, which is on neither of them. Named rather than
-         * written out, so that what the question is about does not move when this compiler learns to
-         * print one more shape of expression — and so that two rules drawing two lines are two
-         * subjects however little of either can be spelled.
-         *
-         * <p>Beside {@link RuleCitation} and not a copy of it. A citation is how a reader finds the
-         * rule — the place a comparison is written, the name an {@code ensures} clause was given —
-         * and this is the comparison that drew the line. For a rule that is one comparison the two
-         * point at one place and answer different questions; a clause stating two comparisons has
-         * one citation and two of these.
-         */
-        record OfComparison(souther.compiler.diag.Citation at) implements Subject {
+        @Override
+        public String toString() {
+            return on.toString();
+        }
+    }
 
-            public OfComparison {
-                if (at == null) {
-                    throw new IllegalArgumentException("a comparison is somewhere");
-                }
+    /**
+     * The place a comparison of two moving things draws, named by that comparison.
+     *
+     * <p>Where the two sides hold one count, which is on neither of them. {@code r.a <= r.b + 1}
+     * draws a line where the two sides meet; filing it under either would name a place that rule
+     * never stopped. Nor is it spelled: writing the place out needs both sides in a vocabulary this
+     * compiler has, and it does not have one for {@code r.b + 1} — so a spelled subject is how far a
+     * pretty-printer got rather than what the question is about, and {@code r.b + 1} and
+     * {@code r.b + 2} come out as one place. The comparison that drew the line is what the question
+     * is about, and that this compiler can always name exactly.
+     *
+     * <p>Beside {@link RuleCitation} and not a copy of it. A citation is how a reader finds the
+     * rule — the place a comparison is written, the name an {@code ensures} clause was given — and
+     * this is the comparison that drew the line. For a rule that is one comparison the two point at
+     * one place and answer different questions; a clause stating two comparisons has one citation
+     * and two of these.
+     */
+    record BoundaryBetween(souther.compiler.diag.Citation drawnBy) implements Owed {
+
+        public BoundaryBetween {
+            if (drawnBy == null) {
+                throw new IllegalArgumentException("a comparison is somewhere");
             }
-
-            @Override
-            public String toString() {
-                return "where the relation changes";
-            }
         }
 
-        /** The position's own value. */
-        static Subject at(String path) {
-            return new OfAPosition(path, false);
+        @Override
+        public String toString() {
+            return "where the relation changes";
         }
+    }
 
-        /** Whether this is a count taken of a position rather than a position's own value. */
-        default boolean measured() {
-            return this instanceof OfAPosition it && it.measured();
-        }
+    /**
+     * What this question asks, which is the arm and is derived rather than carried.
+     *
+     * <p>Stored beside the subject, the two could disagree — and one of the two combinations that
+     * disagreement makes was a value nothing produced and one reader threw over.
+     */
+    default CoverageObligation obligation() {
+        return switch (this) {
+            case AdmittedValues _ -> CoverageObligation.ADMITTED_VALUES;
+            case Boundary _, BoundaryBetween _ -> CoverageObligation.BOUNDARY;
+        };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Owed.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Owed.java
@@ -14,6 +14,14 @@ package souther.compiler.check;
  *
  * <p>Which arm a clause raises follows from the clause and is settled where the question is raised,
  * so no reader downstream chooses between a path and a number.
+ *
+ * <p><b>Two arms, because two are what anything raises.</b> A place a comparison of two moving
+ * things draws was a third: the line {@code r.a <= r.b + 1} draws is on neither side and is named by
+ * the comparison rather than written out. Nothing ever built one. {@link CoverageObligation} says
+ * why and always did — a comparison this compiler reads owes the rows either side of its line by
+ * having been read, so no such demand is ever outstanding, and those live where the partition's
+ * geometry does. An arm nothing raises is a question every model answers by nobody having asked it,
+ * and a completeness counted over such a set says more than it knows.
  */
 public sealed interface Owed {
 
@@ -64,37 +72,6 @@ public sealed interface Owed {
     }
 
     /**
-     * The place a comparison of two moving things draws, named by that comparison.
-     *
-     * <p>Where the two sides hold one count, which is on neither of them. {@code r.a <= r.b + 1}
-     * draws a line where the two sides meet; filing it under either would name a place that rule
-     * never stopped. Nor is it spelled: writing the place out needs both sides in a vocabulary this
-     * compiler has, and it does not have one for {@code r.b + 1} — so a spelled subject is how far a
-     * pretty-printer got rather than what the question is about, and {@code r.b + 1} and
-     * {@code r.b + 2} come out as one place. The comparison that drew the line is what the question
-     * is about, and that this compiler can always name exactly.
-     *
-     * <p>Beside {@link RuleCitation} and not a copy of it. A citation is how a reader finds the
-     * rule — the place a comparison is written, the name an {@code ensures} clause was given — and
-     * this is the comparison that drew the line. For a rule that is one comparison the two point at
-     * one place and answer different questions; a clause stating two comparisons has one citation
-     * and two of these.
-     */
-    record BoundaryBetween(souther.compiler.diag.Citation drawnBy) implements Owed {
-
-        public BoundaryBetween {
-            if (drawnBy == null) {
-                throw new IllegalArgumentException("a comparison is somewhere");
-            }
-        }
-
-        @Override
-        public String toString() {
-            return "where the relation changes";
-        }
-    }
-
-    /**
      * What this question asks, which is the arm and is derived rather than carried.
      *
      * <p>Stored beside the subject, the two could disagree — and one of the two combinations that
@@ -103,7 +80,7 @@ public sealed interface Owed {
     default CoverageObligation obligation() {
         return switch (this) {
             case AdmittedValues _ -> CoverageObligation.ADMITTED_VALUES;
-            case Boundary _, BoundaryBetween _ -> CoverageObligation.BOUNDARY;
+            case Boundary _ -> CoverageObligation.BOUNDARY;
         };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Owed.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Owed.java
@@ -6,22 +6,20 @@ package souther.compiler.check;
  * <p><b>The question and its subject are one thing and not two beside each other.</b> The
  * obligations do not share a subject — what values may stand somewhere is about a position, where a
  * line falls is about a number of one — and a rule bounding a {@code String} on its length raises
- * both, the values being the string's and the line being on the length. Carried as an obligation
- * beside a subject, the pair was a product every combination of which was constructible, so
- * "which values may stand at the place a comparison drew" was a value of this type and was fenced
- * off with a throw at the one reader that would have met it. Which subject an obligation has does
- * not vary: it is the arm.
+ * both, the values being the string's and the line being on the length. Which subject an obligation
+ * has does not vary, so it is the arm. Carried as an obligation beside a subject, the pair was a
+ * product every combination of which was a value of this type, and the reader that would have met
+ * one nothing raises fenced it off with a throw.
  *
  * <p>Which arm a clause raises follows from the clause and is settled where the question is raised,
  * so no reader downstream chooses between a path and a number.
  *
- * <p><b>Two arms, because two are what anything raises.</b> A place a comparison of two moving
- * things draws was a third: the line {@code r.a <= r.b + 1} draws is on neither side and is named by
- * the comparison rather than written out. Nothing ever built one. {@link CoverageObligation} says
- * why and always did — a comparison this compiler reads owes the rows either side of its line by
- * having been read, so no such demand is ever outstanding, and those live where the partition's
- * geometry does. An arm nothing raises is a question every model answers by nobody having asked it,
- * and a completeness counted over such a set says more than it knows.
+ * <p><b>Two arms, because two are what anything raises.</b> The place a comparison of two moving
+ * things draws was a third and nothing ever built one. {@link CoverageObligation} says why and
+ * always did: such a line owes the rows either side of it by having been read, so no demand about
+ * it is ever outstanding, and what it owes lives where the partition's geometry does. An arm
+ * nothing raises is a question every model answers by nobody having asked it, and a completeness
+ * counted over such a set says more than it knows.
  */
 public sealed interface Owed {
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Required.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Required.java
@@ -155,8 +155,20 @@ public sealed interface Required {
         return out;
     }
 
-    private static Owed admittedValues(Owed.Subject where) {
-        return new Owed(CoverageObligation.ADMITTED_VALUES, where);
+    private static Owed admittedValues(String path) {
+        return new Owed(CoverageObligation.ADMITTED_VALUES, Owed.Subject.at(path));
+    }
+
+    /**
+     * The subject a line on {@code line} is about.
+     *
+     * <p>Here and nowhere else, because this is where a coverage question is made out of what a
+     * reading found. The projection is what {@link Owed.Subject} can carry today and is undone one
+     * commit along; what matters is that the reading hands over the number and not a flag.
+     */
+    private static Owed.Subject subjectOf(FieldDomains.Coordinate line) {
+        return new Owed.Subject.OfAPosition(line.path(),
+                line.kind() instanceof FieldDomains.CoordinateKind.OfWhatAnOperationAnswers);
     }
 
     /**
@@ -182,9 +194,9 @@ public sealed interface Required {
             // A `LinkedHashSet` and not `Set.of`, which iterates in an order salted once per JVM
             // run — the questions reach a document in the order they are written here.
             case ClauseStates.ABound bound -> {
-                Set<Owed> owed = bound.named().stream().map(Required::admittedValues)
+                Set<Owed> owed = bound.positions().stream().map(Required::admittedValues)
                         .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
-                owed.add(new Owed(CoverageObligation.BOUNDARY, bound.line()));
+                owed.add(new Owed(CoverageObligation.BOUNDARY, subjectOf(bound.line())));
                 yield new Some(owed);
             }
             // A clause about no position of this value raises no question about one. Not a rule

--- a/souther-compiler/src/main/java/souther/compiler/check/Required.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Required.java
@@ -155,10 +155,6 @@ public sealed interface Required {
         return out;
     }
 
-    private static Owed admittedValues(String path) {
-        return new Owed.AdmittedValues(path);
-    }
-
     /**
      * What an invariant clause raises, from what a reader found it to state.
      *
@@ -182,7 +178,7 @@ public sealed interface Required {
             // A `LinkedHashSet` and not `Set.of`, which iterates in an order salted once per JVM
             // run — the questions reach a document in the order they are written here.
             case ClauseStates.ABound bound -> {
-                Set<Owed> owed = bound.positions().stream().map(Required::admittedValues)
+                Set<Owed> owed = bound.positions().stream().map(Owed.AdmittedValues::new)
                         .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
                 owed.add(new Owed.Boundary(bound.line()));
                 yield new Some(owed);
@@ -192,7 +188,7 @@ public sealed interface Required {
             case ClauseStates.SomethingElse other -> other.positions().isEmpty()
                     ? new Irrelevant(Set.of(Because.IT_NAMES_NO_POSITION))
                     : new Some(other.positions().stream()
-                            .map(Required::admittedValues).collect(java.util.stream.Collectors
+                            .map(Owed.AdmittedValues::new).collect(java.util.stream.Collectors
                                     .toCollection(LinkedHashSet::new)));
             case ClauseStates.ARelation _ -> new Irrelevant(Set.of(Because.IT_RELATES_TWO_POSITIONS));
         };

--- a/souther-compiler/src/main/java/souther/compiler/check/Required.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Required.java
@@ -156,19 +156,7 @@ public sealed interface Required {
     }
 
     private static Owed admittedValues(String path) {
-        return new Owed(CoverageObligation.ADMITTED_VALUES, Owed.Subject.at(path));
-    }
-
-    /**
-     * The subject a line on {@code line} is about.
-     *
-     * <p>Here and nowhere else, because this is where a coverage question is made out of what a
-     * reading found. The projection is what {@link Owed.Subject} can carry today and is undone one
-     * commit along; what matters is that the reading hands over the number and not a flag.
-     */
-    private static Owed.Subject subjectOf(FieldDomains.Coordinate line) {
-        return new Owed.Subject.OfAPosition(line.path(),
-                line.kind() instanceof FieldDomains.CoordinateKind.OfWhatAnOperationAnswers);
+        return new Owed.AdmittedValues(path);
     }
 
     /**
@@ -196,7 +184,7 @@ public sealed interface Required {
             case ClauseStates.ABound bound -> {
                 Set<Owed> owed = bound.positions().stream().map(Required::admittedValues)
                         .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
-                owed.add(new Owed(CoverageObligation.BOUNDARY, subjectOf(bound.line())));
+                owed.add(new Owed.Boundary(bound.line()));
                 yield new Some(owed);
             }
             // A clause about no position of this value raises no question about one. Not a rule

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -756,19 +756,31 @@ public final class InputDomain {
      * would be free to differ by a round of edits, and what they disagreed about would be which
      * number a rule is about.
      *
-     * <p>No falling back to the position. A coordinate with an operation on it is about that
-     * operation's number, so a term that cannot be built from the two is the reading of the clause
-     * and the reading of the position disagreeing about what stands here — which is this compiler
-     * contradicting itself rather than something the model left out.
+     * <p><b>One arm per kind of coordinate, and no falling back to the position.</b> A coordinate
+     * this does not classify is not one measured by its own values; written as a test for the
+     * operation with the position as the other answer, a kind added later would arrive here as a
+     * term about something the model never wrote, and the reading of it would be applied to
+     * whatever stood at the path.
      */
     private static NumericTerm termAt(TermPath path,
                                       souther.compiler.check.FieldDomains.Coordinate at,
                                       Type type, Symbols symbols) {
-        if (!(at.kind() instanceof souther.compiler.check.FieldDomains.CoordinateKind
-                .OfWhatAnOperationAnswers answered)) {
-            return new NumericTerm.ValueOf(path);
-        }
-        ValueName by = answered.operation();
+        return switch (at.kind()) {
+            case souther.compiler.check.FieldDomains.CoordinateKind.OfItsOwnValue _ ->
+                    new NumericTerm.ValueOf(path);
+            case souther.compiler.check.FieldDomains.CoordinateKind
+                    .OfWhatAnOperationAnswers answered -> takenBy(answered.operation(), path, type,
+                            symbols);
+        };
+    }
+
+    /**
+     * The term for what {@code by} answers of what stands at {@code path}.
+     *
+     * <p>Both refusals are this compiler contradicting itself rather than something the model left
+     * out, which is why neither is an answer a caller can act on.
+     */
+    private static NumericTerm takenBy(ValueName by, TermPath path, Type type, Symbols symbols) {
         // The operation a count is taken by is one the library declares, which is what the reading
         // that recorded the count went to. Anything else here is that reading and this one holding
         // different ideas of what an operation is.

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -617,7 +617,7 @@ public final class InputDomain {
                 // accounting rather than read off the completeness beside it: one reading being
                 // short of a position's rules is that reading's business, and a rule another
                 // reading took in is not a rule left unread.
-                placed.unanswered(path),
+                standingAt(placed, path, type, symbols),
                 // And whether the rules were reached at all, asked of the gathering that knows.
                 // No question is raised where nothing was seen, so an empty list beside it would
                 // say every rule was accounted for. Read off the reading's own reason instead, a
@@ -740,9 +740,33 @@ public final class InputDomain {
     private static FilingCoordinate filedAt(TermPath path,
                                             souther.compiler.check.FieldDomains.Coordinate at,
                                             Type type, Symbols symbols) {
+        return FilingCoordinate.of(termAt(path, at, type, symbols));
+    }
+
+    /**
+     * The number a coordinate of a declaration's own reading names, in this input's vocabulary.
+     *
+     * <p><b>The one crossing.</b> The operation comes from that reading, which recorded it against
+     * the count, and the path from this one — and neither names the term alone: a path is held over
+     * there as a key relative to the value the clauses are written on, and one parsed back out of a
+     * spelling is a path this compiler made up.
+     *
+     * <p>Shared by the two things that cross here, a finding about a rule and a question a rule
+     * raised, because it is one crossing and not a repetition. Written at each of them, the two
+     * would be free to differ by a round of edits, and what they disagreed about would be which
+     * number a rule is about.
+     *
+     * <p>No falling back to the position. A coordinate with an operation on it is about that
+     * operation's number, so a term that cannot be built from the two is the reading of the clause
+     * and the reading of the position disagreeing about what stands here — which is this compiler
+     * contradicting itself rather than something the model left out.
+     */
+    private static NumericTerm termAt(TermPath path,
+                                      souther.compiler.check.FieldDomains.Coordinate at,
+                                      Type type, Symbols symbols) {
         if (!(at.kind() instanceof souther.compiler.check.FieldDomains.CoordinateKind
                 .OfWhatAnOperationAnswers answered)) {
-            return FilingCoordinate.of(new NumericTerm.ValueOf(path));
+            return new NumericTerm.ValueOf(path);
         }
         ValueName by = answered.operation();
         // The operation a count is taken by is one the library declares, which is what the reading
@@ -757,7 +781,32 @@ public final class InputDomain {
             throw new IllegalStateException("a clause of `" + path + "` was read as a rule about `"
                     + by + "`, and that takes no number of what stands there");
         }
-        return FilingCoordinate.of(taken);
+        return taken;
+    }
+
+    /**
+     * The questions the rules of this position raise that nothing answered, crossed into this
+     * input's vocabulary.
+     *
+     * <p>Here, where the root the walk started at and the type standing at the position both are.
+     * The reading that raised them knows its positions by a key relative to the value its clauses
+     * are written on and knows a number of one by the operation beside that key; what everything
+     * past here compares is a term path and a term.
+     */
+    private static List<StandingQuestion> standingAt(PlacedRules placed, TermPath path, Type type,
+                                                     Symbols symbols) {
+        List<StandingQuestion> out = new ArrayList<>();
+        for (souther.compiler.check.RuleAccounting.Unanswered each : placed.unanswered(path)) {
+            out.add(new StandingQuestion(each.rule(), each.cited(),
+                    switch (each.owed()) {
+                        case souther.compiler.check.Owed.AdmittedValues _ ->
+                                new InputQuestion.AboutAPosition(path);
+                        case souther.compiler.check.Owed.Boundary it ->
+                                new InputQuestion.AboutANumber(
+                                        termAt(path, it.on(), type, symbols));
+                    }));
+        }
+        return List.copyOf(out);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -522,6 +522,17 @@ public final class InputDomain {
         return false;
     }
 
+    /** The position's own value, as the reading of one coordinate names it. */
+    private static final souther.compiler.check.FieldDomains.CoordinateKind ITS_OWN_VALUE =
+            new souther.compiler.check.FieldDomains.CoordinateKind.OfItsOwnValue();
+
+    /** The number {@code operation} answers of what stands at a position. */
+    private static souther.compiler.check.FieldDomains.CoordinateKind answeredBy(
+            ValueName operation) {
+        return new souther.compiler.check.FieldDomains.CoordinateKind
+                .OfWhatAnOperationAnswers(operation);
+    }
+
     /**
      * The reading of one position.
      *
@@ -568,9 +579,9 @@ public final class InputDomain {
                             + ", which is not what its type is measured by: " + Type.show(type));
         }
         DeclaredBounds.Bounds own = bySize
-                ? DeclaredBounds.and(ofType, DeclaredBounds.placed(stated, true, Carrier.WHOLE))
+                ? DeclaredBounds.and(ofType, DeclaredBounds.placed(stated, answeredBy(taken), Carrier.WHOLE))
                 : carried == null ? null
-                        : DeclaredBounds.and(valueOfType, DeclaredBounds.placed(stated, false, carried));
+                        : DeclaredBounds.and(valueOfType, DeclaredBounds.placed(stated, ITS_OWN_VALUE, carried));
         // A value whose rules contradict has no positions to cover: every edge of every field of it
         // is a row nobody can write, which is not the same answer as a field nothing bounds.
         boolean nothingExists = placed.bounds().infeasible();
@@ -596,10 +607,7 @@ public final class InputDomain {
                 // Where the position actually stops, which the ends as written do not say: a clause
                 // placing one at 0 beside a clause that takes the 0 away leaves a position whose
                 // first value is 1, and a line drawn at the 0 is drawn at no value of it.
-                placed.leftAt(path, bySize
-                        ? new souther.compiler.check.FieldDomains.CoordinateKind
-                                .OfWhatAnOperationAnswers(taken)
-                        : new souther.compiler.check.FieldDomains.CoordinateKind.OfItsOwnValue()),
+                placed.leftAt(path, bySize ? answeredBy(taken) : ITS_OWN_VALUE),
                 placed.narrowedBy(path, true), placed.narrowedBy(path, false), nothingExists,
                 placed.projection(), declared, reading,
                 ObligationDomain.of(reading, declared), admitted.completeness(),
@@ -679,7 +687,7 @@ public final class InputDomain {
         if (stated(valueOfType)) {
             return false;
         }
-        return taken != null && stated(DeclaredBounds.placed(stated, true, Carrier.WHOLE));
+        return taken != null && stated(DeclaredBounds.placed(stated, answeredBy(taken), Carrier.WHOLE));
     }
 
     /**
@@ -702,7 +710,7 @@ public final class InputDomain {
                     // two. What is undecided is which of them the position is measured at, and that
                     // is a fact about the position rather than about either rule — this reading has
                     // chosen no term for the position, and each rule chose one for itself.
-                    filedAt(path, each.by(), type, symbols),
+                    filedAt(path, each.at(), type, symbols),
                     new BlockReason.CompetingCoordinates());
             if (out.stream().noneMatch(had -> had.sameAs(said))) {
                 out.add(said);
@@ -729,11 +737,14 @@ public final class InputDomain {
      * and the reading of the position disagreeing about what stands here — which is this compiler
      * contradicting itself rather than something the model left out.
      */
-    private static FilingCoordinate filedAt(TermPath path, ValueName by, Type type,
-                                            Symbols symbols) {
-        if (by == null) {
+    private static FilingCoordinate filedAt(TermPath path,
+                                            souther.compiler.check.FieldDomains.Coordinate at,
+                                            Type type, Symbols symbols) {
+        if (!(at.kind() instanceof souther.compiler.check.FieldDomains.CoordinateKind
+                .OfWhatAnOperationAnswers answered)) {
             return FilingCoordinate.of(new NumericTerm.ValueOf(path));
         }
+        ValueName by = answered.operation();
         // The operation a count is taken by is one the library declares, which is what the reading
         // that recorded the count went to. Anything else here is that reading and this one holding
         // different ideas of what an operation is.
@@ -765,8 +776,8 @@ public final class InputDomain {
                                        Carrier carried) {
         return !stated(ofType) && !stated(valueOfType)
                 && taken != null && carried != null
-                && stated(DeclaredBounds.placed(stated, true, Carrier.WHOLE))
-                && stated(DeclaredBounds.placed(stated, false, carried));
+                && stated(DeclaredBounds.placed(stated, answeredBy(taken), Carrier.WHOLE))
+                && stated(DeclaredBounds.placed(stated, ITS_OWN_VALUE, carried));
     }
 
     private static boolean stated(DeclaredBounds.Bounds bounds) {
@@ -804,7 +815,7 @@ public final class InputDomain {
             // or the other, and it is only the line that nothing came of.
             UnreadRule said = new UnreadRule(each.from(),
                     souther.compiler.check.RuleCitation.named(each.from()),
-                    filedAt(path, each.by(), type, symbols),
+                    filedAt(path, each.at(), type, symbols),
                     each.why());
             if (out.stream().noneMatch(had -> had.sameAs(said))) {
                 out.add(said);

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputQuestion.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputQuestion.java
@@ -1,0 +1,84 @@
+package souther.compiler.inputs;
+
+import souther.compiler.check.CoverageObligation;
+
+/**
+ * What one coverage question is about, in the vocabulary of an input rather than of a declaration's
+ * own fields.
+ *
+ * <p><b>The same questions {@code check.Owed} carries, and not the same identities.</b> A reading of
+ * a declaration knows its positions by a key relative to the value the clauses are written on —
+ * {@code x}, {@code a.b}, the empty string for the value itself — and knows a number of one by the
+ * operation beside that key. What an input is walked by is a {@link TermPath} from a parameter, and
+ * what a boundary is drawn on is a {@link NumericTerm}. Neither can be read off the other without
+ * the root the walk started at and the type standing at the position, which only the boundary
+ * between the two has.
+ *
+ * <p>So the crossing is made once, where those are, and everything downstream compares these. Left
+ * in the declaration's vocabulary and compared against an axis, a field key and a term path are two
+ * spellings of one place that agree at a top-level parameter and nowhere else — and comparing them
+ * as strings is the reconstruction this whole side exists to stop.
+ *
+ * <p>The same crossing {@link UnreadRule} makes with {@link FilingCoordinate}, and for the same
+ * reason: a finding about a rule and a question about a rule are both filed at a number, and the
+ * number is named where the input's own vocabulary is.
+ */
+public sealed interface InputQuestion {
+
+    /**
+     * Which values may stand at a position of the input.
+     *
+     * <p>The position and never a number of it: what a rule about the length of a string admits is
+     * a set of strings.
+     */
+    record AboutAPosition(TermPath path) implements InputQuestion {
+
+        public AboutAPosition {
+            if (path == null) {
+                throw new IllegalArgumentException("a position sits somewhere in the input");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return path.toString();
+        }
+    }
+
+    /**
+     * Where a line falls on one number of one position.
+     *
+     * <p>The term, which names the operation for a number taken of a position and the position
+     * itself for its own values. Two operations over one path are two of these and are told apart
+     * here rather than by whatever a reader finds standing beside them.
+     */
+    record AboutANumber(NumericTerm term) implements InputQuestion {
+
+        public AboutANumber {
+            if (term == null) {
+                throw new IllegalArgumentException("a line falls on some number");
+            }
+        }
+
+        @Override
+        public String toString() {
+            return term.toString();
+        }
+    }
+
+    /** Where in the input the question sits, which both arms can always say. */
+    default TermPath path() {
+        return switch (this) {
+            case AboutAPosition it -> it.path();
+            case AboutANumber it -> it.term().path();
+        };
+    }
+
+    /** What it asks, which is the arm. */
+    default CoverageObligation obligation() {
+        return switch (this) {
+            case AboutAPosition _ -> CoverageObligation.ADMITTED_VALUES;
+            case AboutANumber _ -> CoverageObligation.BOUNDARY;
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
@@ -145,8 +145,12 @@ record PlacedRules(TermPath root, TypeSymbol value, Rules rules) {
         List<RuleAccounting.Unanswered> out = new ArrayList<>();
         bounds().accounting().values().forEach(accounting ->
                 accounting.unansweredQuestions().stream()
-                        .filter(each -> each.owed().subject() instanceof Owed.Subject.OfAPosition at
-                                && at.path().equals(where))
+                        .filter(each -> switch (each.owed()) {
+                            case Owed.AdmittedValues it -> it.path().equals(where);
+                            case Owed.Boundary it -> it.on().path().equals(where);
+                            // On neither position, so it is not at this one.
+                            case Owed.BoundaryBetween _ -> false;
+                        })
                         .forEach(out::add));
         return List.copyOf(out);
     }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
@@ -148,8 +148,6 @@ record PlacedRules(TermPath root, TypeSymbol value, Rules rules) {
                         .filter(each -> switch (each.owed()) {
                             case Owed.AdmittedValues it -> it.path().equals(where);
                             case Owed.Boundary it -> it.on().path().equals(where);
-                            // On neither position, so it is not at this one.
-                            case Owed.BoundaryBetween _ -> false;
                         })
                         .forEach(out::add));
         return List.copyOf(out);

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
@@ -2,7 +2,6 @@ package souther.compiler.inputs;
 
 import souther.compiler.check.DeclaredBounds;
 import souther.compiler.check.ProjectionEvidence;
-import souther.compiler.check.RuleAccounting;
 import souther.compiler.check.TypeView;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.types.Type;
@@ -150,7 +149,7 @@ public sealed interface Position permits ReadPosition {
      * that was. A reader deciding whether the numbers beside this position rest on a complete
      * reading of the model wants this and not a reading's own account.
      */
-    List<RuleAccounting.Unanswered> unansweredQuestions();
+    List<StandingQuestion> unansweredQuestions();
 
     /**
      * Whether the walk never reached the rules written about this position.

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadPosition.java
@@ -2,7 +2,6 @@ package souther.compiler.inputs;
 
 import souther.compiler.check.DeclaredBounds;
 import souther.compiler.check.ProjectionEvidence;
-import souther.compiler.check.RuleAccounting;
 import souther.compiler.check.TypeView;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.types.Type;
@@ -35,7 +34,7 @@ record ReadPosition(TermPath path, TypeView view, NumericTerm term,
                     ProjectionEvidence projection, List<Case> declared, ReadingResult reading,
                     ObligationDomain obligations, AdmissibleSet.Completeness completeness,
                     BlockReason valuesUnread, List<UnreadRule> unreadRules,
-                    List<RuleAccounting.Unanswered> unansweredQuestions, boolean rulesNotReached,
+                    List<StandingQuestion> unansweredQuestions, boolean rulesNotReached,
                     StructuralInspection structure) implements Position {
 
     ReadPosition {

--- a/souther-compiler/src/main/java/souther/compiler/inputs/StandingQuestion.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/StandingQuestion.java
@@ -1,0 +1,41 @@
+package souther.compiler.inputs;
+
+import souther.compiler.check.RuleCitation;
+import souther.compiler.check.RuleRef;
+
+/**
+ * One question a rule of the model raises that nothing answered, as everything past the input
+ * boundary carries it.
+ *
+ * <p>The other side of {@code check.RuleAccounting.Unanswered}, which is the same question in the
+ * vocabulary of the declaration whose clauses raised it. What crosses is what a reader out here
+ * asks: which rule, how a reader finds it, and what the question is about.
+ *
+ * <p><b>The question it came from is not carried beside it.</b> Nothing downstream reads anything
+ * of it that is not here — the rule, the citation, and what it asks, which is the arm — and holding
+ * it would leave a second identity for the same question reachable, so that every comparison
+ * downstream had two answers to choose between. That choice is what the crossing exists to take
+ * away.
+ *
+ * @param rule  which rule of the model raised it, which is what tells one question from another
+ * @param cited how a reader finds that rule, which is not what tells it from another
+ * @param asks  what it asks and what it asks it about, together
+ */
+public record StandingQuestion(RuleRef rule, RuleCitation cited, InputQuestion asks) {
+
+    public StandingQuestion {
+        if (rule == null || cited == null || asks == null) {
+            throw new IllegalArgumentException("a standing question names a rule and what it asks");
+        }
+    }
+
+    /** What it asks, which follows from what it is about. */
+    public souther.compiler.check.CoverageObligation obligation() {
+        return asks.obligation();
+    }
+
+    @Override
+    public String toString() {
+        return obligation() + " at " + asks;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -52,17 +52,6 @@ import java.util.List;
  *                 path is how a reason came to be recovered by string match. A reason travels with
  *                 the position or it is a reason about whatever the strings happened to pair it
  *                 with.
- * @param unanswered the questions the rules written about this position raise that nothing
- *                 answered, each naming the rule that raised it. Carried because it qualifies the
- *                 classes and nothing else says it: a rule nothing took in may yet refuse a value a
- *                 class holds, so {@link #classes} is the denominator the model states and not one
- *                 every class of which is known to be inhabited.
- *
- *                 <p>The questions and not a reading's account of itself. The reading that turns
- *                 clauses into sets of values has no word for a range and is short of the rules at
- *                 every numeric position an invariant bounds, while two other readings have those
- *                 rules whole — so a report written off that reading says a model was not read on
- *                 the strength of a fact about this compiler (issue #842)
  * @param rulesNotReached whether the walk reached the rules written about this position at all.
  *                 Beside the questions and not among them: a position whose rules were never
  *                 enumerated raises no question and is not one whose rules were all accounted for,
@@ -74,25 +63,18 @@ import java.util.List;
  *                 a rule about what is inside describes that same stop from the other end
  */
 public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> classes,
-                   List<Cut> cuts, List<Seam> parted,
-                   List<souther.compiler.inputs.StandingQuestion> unanswered,
-                   boolean rulesNotReached,
+                   List<Cut> cuts, List<Seam> parted, boolean rulesNotReached,
                    StructuralInspection.Continuation pending, BlockReason unread) {
 
     public Axis {
         classes = List.copyOf(classes);
         cuts = List.copyOf(cuts);
         parted = List.copyOf(parted);
-        if (unanswered == null) {
-            throw new IllegalArgumentException(
-                    "a position with no account of what its rules leave standing");
-        }
-        unanswered = List.copyOf(unanswered);
     }
 
     public Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> classes,
                 List<Cut> cuts) {
-        this(id, term, type, classes, cuts, List.of(), List.of(), false, null, null);
+        this(id, term, type, classes, cuts, List.of(), false, null, null);
     }
 
     /**
@@ -102,11 +84,9 @@ public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> 
      * and only where none does is what was found here what a report says — an absence where every
      * reading ran to the end and found nothing, and what stopped one where it did not.
      */
-    public static Axis pendingAt(AxisId id, NumericTerm term, Type type,
-                                 List<souther.compiler.inputs.StandingQuestion> unanswered,
-                                 boolean rulesNotReached,
+    public static Axis pendingAt(AxisId id, NumericTerm term, Type type, boolean rulesNotReached,
                                  StructuralInspection.Continuation found, BlockReason unread) {
-        return new Axis(id, term, type, List.of(), List.of(), List.of(), unanswered,
+        return new Axis(id, term, type, List.of(), List.of(), List.of(),
                 rulesNotReached, found, unread);
     }
 
@@ -121,14 +101,12 @@ public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> 
      * as one the model divides no way.
      */
     public Axis measuredAt(AxisId id, NumericTerm term) {
-        return new Axis(id, term, type, classes, cuts, parted, unanswered, rulesNotReached, pending,
-                unread);
+        return new Axis(id, term, type, classes, cuts, parted, rulesNotReached, pending, unread);
     }
 
     /** The same position, with what a body's rules divided it into and the lines they drew. */
     public Axis carrying(List<PartitionClass> classes, List<Cut> cuts, List<Seam> parted) {
-        return new Axis(id, term, type, classes, cuts, parted, unanswered, rulesNotReached, pending,
-                unread);
+        return new Axis(id, term, type, classes, cuts, parted, rulesNotReached, pending, unread);
     }
 
     /** Where the value this axis is about sits, which is where a row is walked to before the term is

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -6,7 +6,6 @@ import souther.compiler.inputs.Requirements;
 import souther.compiler.inputs.StructuralInspection;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.types.Type;
-import souther.compiler.check.RuleAccounting;
 
 import java.util.List;
 
@@ -75,7 +74,8 @@ import java.util.List;
  *                 a rule about what is inside describes that same stop from the other end
  */
 public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> classes,
-                   List<Cut> cuts, List<Seam> parted, List<RuleAccounting.Unanswered> unanswered,
+                   List<Cut> cuts, List<Seam> parted,
+                   List<souther.compiler.inputs.StandingQuestion> unanswered,
                    boolean rulesNotReached,
                    StructuralInspection.Continuation pending, BlockReason unread) {
 
@@ -103,7 +103,7 @@ public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> 
      * reading ran to the end and found nothing, and what stopped one where it did not.
      */
     public static Axis pendingAt(AxisId id, NumericTerm term, Type type,
-                                 List<RuleAccounting.Unanswered> unanswered,
+                                 List<souther.compiler.inputs.StandingQuestion> unanswered,
                                  boolean rulesNotReached,
                                  StructuralInspection.Continuation found, BlockReason unread) {
         return new Axis(id, term, type, List.of(), List.of(), List.of(), unanswered,

--- a/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
@@ -1,6 +1,5 @@
 package souther.compiler.partition;
 
-import souther.compiler.check.RuleAccounting;
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.UnreadRule;
 
@@ -36,7 +35,8 @@ public sealed interface ClosureGap {
      * both or yields neither and records what stopped its reading. Which is why a comparison's
      * incompleteness reaches this only as {@link RuleUnread}.
      */
-    record QuestionUnanswered(AxisId at, RuleAccounting.Unanswered question) implements ClosureGap {}
+    record QuestionUnanswered(AxisId at, souther.compiler.inputs.StandingQuestion question)
+            implements ClosureGap {}
 
     /** A position whose rules nothing enumerated. It raises no question, so it cannot be short of
      *  one — which is why it is a gap of its own and not one of the two above. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
@@ -35,7 +35,7 @@ public sealed interface ClosureGap {
      * both or yields neither and records what stopped its reading. Which is why a comparison's
      * incompleteness reaches this only as {@link RuleUnread}.
      */
-    record QuestionUnanswered(AxisId at, souther.compiler.inputs.StandingQuestion question)
+    record QuestionUnanswered(souther.compiler.inputs.StandingQuestion question)
             implements ClosureGap {}
 
     /** A position whose rules nothing enumerated. It raises no question, so it cannot be short of

--- a/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
@@ -57,7 +57,7 @@ final class LocalInspection {
         // that value can be refused, wherever in it the rule is written.
         CutEvidence drawn = cuts.isEmpty() ? new CutEvidence.None()
                 : new CutEvidence.Present(cuts, position.projection());
-        return new LocalPartition.Divided(classes, drawn, position.unansweredQuestions(),
+        return new LocalPartition.Divided(classes, drawn,
                 position.rulesNotReached());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/LocalPartition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LocalPartition.java
@@ -1,7 +1,6 @@
 package souther.compiler.partition;
 
 import souther.compiler.inputs.BlockReason;
-import souther.compiler.check.RuleAccounting;
 
 import java.util.List;
 
@@ -36,7 +35,7 @@ public sealed interface LocalPartition {
      *                   be the classes, which say nothing about what was read to get them
      */
     record Divided(List<PartitionClass> classes, CutEvidence cuts,
-                   List<RuleAccounting.Unanswered> unanswered,
+                   List<souther.compiler.inputs.StandingQuestion> unanswered,
                    boolean rulesNotReached) implements LocalPartition {
 
         public Divided {

--- a/souther-compiler/src/main/java/souther/compiler/partition/LocalPartition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LocalPartition.java
@@ -28,14 +28,8 @@ public sealed interface LocalPartition {
      * <p>Never neither. A value of this carrying no classes and no cuts would be an open position
      * dressed as a divided one, and the phase after this one would never be reached for it.
      *
-     * @param unanswered the questions the position's rules raise that nothing answered. Carried
-     *                   with the classes because it qualifies them: a rule nothing took in may yet
-     *                   refuse a value a class holds, so the classes are the model's own and are
-     *                   not known to be inhabited. Dropped here, the only thing left to read would
-     *                   be the classes, which say nothing about what was read to get them
      */
     record Divided(List<PartitionClass> classes, CutEvidence cuts,
-                   List<souther.compiler.inputs.StandingQuestion> unanswered,
                    boolean rulesNotReached) implements LocalPartition {
 
         public Divided {
@@ -44,11 +38,6 @@ public sealed interface LocalPartition {
                 throw new IllegalArgumentException(
                         "nothing divides this position, which is a different answer");
             }
-            if (unanswered == null) {
-                throw new IllegalArgumentException(
-                        "classes with no account of what their rules leave standing");
-            }
-            unanswered = List.copyOf(unanswered);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
@@ -152,7 +152,8 @@ public final class MeasureClosure {
      *                and it is the rule's own reason that answers
      *                ({@link souther.compiler.inputs.BlockReason.AboutARule#leavesShort})
      */
-    static Both of(List<Axis> axes, List<souther.compiler.inputs.UnreadRule> refused) {
+    static Both of(List<Axis> axes, List<souther.compiler.inputs.StandingQuestion> asked,
+                   List<souther.compiler.inputs.UnreadRule> refused) {
         Set<ClosureGap> partition = new LinkedHashSet<>();
         Set<ClosureGap> border = new LinkedHashSet<>();
         for (souther.compiler.inputs.UnreadRule rule : refused) {
@@ -163,32 +164,37 @@ public final class MeasureClosure {
                 border.add(new ClosureGap.RuleUnread(rule));
             }
         }
+        // The positions a gap of their own already stands for. A position whose rules nothing
+        // enumerated, and one the walk could not reach into: neither raises a question, so neither
+        // can be short of one, and what is short there is said once for the position rather than
+        // once per question it never got as far as raising.
+        Set<souther.compiler.inputs.TermPath> unreached = new LinkedHashSet<>();
         for (Axis axis : axes) {
-            // A position whose rules nothing enumerated, and one the walk could not reach into.
-            // Neither raises a question, so neither can be short of one — which is why they are
-            // asked here and not among the questions.
-            boolean unreached = false;
             if (axis.rulesNotReached()) {
                 ClosureGap gap = new ClosureGap.RulesNotReached(axis.id());
                 partition.add(gap);
                 border.add(gap);
-                unreached = true;
+                unreached.add(axis.path());
             }
             if (axis.pending() instanceof StructuralInspection.Continuation.Blocked blocked) {
                 ClosureGap gap = new ClosureGap.PositionNotReachedInto(axis.id(), blocked.why());
                 partition.add(gap);
                 border.add(gap);
-                unreached = true;
+                unreached.add(axis.path());
             }
-            if (unreached) {
+        }
+        // Asked of the question and of the position it is about, and not of whichever axis it was
+        // found beside. One position can be measured at more than one number, and an axis is
+        // re-pointed at another term as a body's rules are read — so an axis is not what a question
+        // belongs to, and a suppression written per axis decided from whichever one the loop met.
+        for (souther.compiler.inputs.StandingQuestion each : asked) {
+            if (unreached.contains(each.asks().path())) {
                 continue;
             }
-            for (souther.compiler.inputs.StandingQuestion each : axis.unanswered()) {
-                ClosureGap gap = new ClosureGap.QuestionUnanswered(axis.id(), each);
-                switch (each.obligation().answeredBy()) {
-                    case PARTITION -> partition.add(gap);
-                    case BOUNDARY -> border.add(gap);
-                }
+            ClosureGap gap = new ClosureGap.QuestionUnanswered(each);
+            switch (each.obligation().answeredBy()) {
+                case PARTITION -> partition.add(gap);
+                case BOUNDARY -> border.add(gap);
             }
         }
         return new Both(

--- a/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
@@ -1,7 +1,6 @@
 package souther.compiler.partition;
 
 import souther.compiler.check.CoverageObligation;
-import souther.compiler.check.RuleAccounting;
 import souther.compiler.inputs.StructuralInspection;
 
 import java.util.Collections;
@@ -184,9 +183,9 @@ public final class MeasureClosure {
             if (unreached) {
                 continue;
             }
-            for (RuleAccounting.Unanswered each : axis.unanswered()) {
+            for (souther.compiler.inputs.StandingQuestion each : axis.unanswered()) {
                 ClosureGap gap = new ClosureGap.QuestionUnanswered(axis.id(), each);
-                switch (each.owed().obligation().answeredBy()) {
+                switch (each.obligation().answeredBy()) {
                     case PARTITION -> partition.add(gap);
                     case BOUNDARY -> border.add(gap);
                 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -57,6 +57,12 @@ public final class Partitions {
      * reading of the declarations made where the assembling happened. Two readers therefore had two
      * chances to disagree about which lines exist, which is the thing this being one answer is for.
      *
+     * @param unanswered the questions the rules of this behavior's inputs raise that nothing
+     *                answered. Beside the axes and not inside one: the model raises them and an
+     *                axis is one reader of them, so a position no axis came back for still has
+     *                whatever was written about it — and an axis is re-pointed at another number as
+     *                a body's rules are read, which would carry a question about one number onto
+     *                another
      * @param axes    the positions this behavior is measured at, in parameter order. Every position
      *                the model divides is one of them: what a behavior is measured at is settled by
      *                what its types say and by what its body compares, and a count of positions is
@@ -66,6 +72,7 @@ public final class Partitions {
      *                has an entry, and an axis that is not measurable has no lines to have one for
      */
     public record Partitioning(List<Axis> axes,
+                               List<souther.compiler.inputs.StandingQuestion> unanswered,
                                java.util.Set<NumericTerm> uncertain,
                                List<UndividedPosition> undivided,
                                List<UnreadRule> unread,
@@ -78,6 +85,7 @@ public final class Partitions {
                                MeasureClosure.OfTheBorder borderClosure) {
         public Partitioning {
             axes = List.copyOf(axes);
+            unanswered = List.copyOf(unanswered);
             uncertain = java.util.Set.copyOf(uncertain);
             undivided = List.copyOf(undivided);
             unread = List.copyOf(unread);
@@ -180,6 +188,7 @@ public final class Partitions {
         // position with classes read from a product wider than the rules admit is exactly where it
         // has something to say, and a position with none is no more affected than any other.
         List<souther.compiler.inputs.PositionValuesNotSeparated> notSeparated = new ArrayList<>();
+        List<souther.compiler.inputs.StandingQuestion> standing = new ArrayList<>();
         for (Position position : inputs.positions()) {
             // Not at a position made of positions. Such a one is given up in favour of what is
             // under it and carries no classes of its own, so what this qualifies is not there —
@@ -192,6 +201,10 @@ public final class Partitions {
                         new souther.compiler.inputs.PositionValuesNotSeparated(position.path()));
             }
             axisOf(behavior, position, symbols, policy, found, uncertain, unread);
+            // What the rules of this position raise that nothing answered, gathered from the
+            // reading that found it. Once per position and not once per axis: a question is the
+            // model's, and which axis is standing beside it is this compiler's business.
+            standing.addAll(position.unansweredQuestions());
         }
         // Every position the reading found, including the ones nothing divides: a report names what
         // it could not measure at one of those, and a body's comparison can still draw the first
@@ -208,8 +221,8 @@ public final class Partitions {
         for (Axis axis : kept) {
             keep(new ArrayList<>(), measured, axis, null, unread);
         }
-        MeasureClosure.Both closed = MeasureClosure.of(kept, unread);
-        return new Partitioning(kept, uncertain, undividedIn(measured),
+        MeasureClosure.Both closed = MeasureClosure.of(kept, standing, unread);
+        return new Partitioning(kept, standing, uncertain, undividedIn(measured),
                 List.copyOf(unread), blockedIn(measured), List.copyOf(notSeparated),
                 List.of(), linesAlong(kept, quantities, symbols), ReachingCuts.NONE,
                 closed.partition(), closed.border());
@@ -513,8 +526,8 @@ public final class Partitions {
                     reachable.stream().map(Threshold::parts).toList()),
                     reachable.isEmpty() ? null : new BodyCutInspection.Evidence(), rules);
         }
-        MeasureClosure.Both closed = MeasureClosure.of(out, rules);
-        return new Partitioning(out, base.uncertain(),
+        MeasureClosure.Both closed = MeasureClosure.of(out, base.unanswered(), rules);
+        return new Partitioning(out, base.unanswered(), base.uncertain(),
                 undividedIn(measured), List.copyOf(rules), blockedIn(measured),
                 // Carried across: what a reading could not hold together is a fact about the
                 // declarations, and a body drawing a line on a position does not make the product
@@ -847,7 +860,7 @@ public final class Partitions {
                     uncertain.add(term);
                 }
                 out.add(new Axis(id, term, position.type(), divided.classes(),
-                        divided.cuts().cuts(), List.of(), divided.unanswered(),
+                        divided.cuts().cuts(), List.of(),
                         divided.rulesNotReached(), null, null));
             }
             // Nothing local divides the position, which is what licenses asking what it is made of.
@@ -866,7 +879,7 @@ public final class Partitions {
                     // position from completing as one the model divides no way.
                     case StructuralInspection.Retained retained ->
                             out.add(Axis.pendingAt(id, term, position.type(),
-                                    position.unansweredQuestions(), position.rulesNotReached(),
+                                    position.rulesNotReached(),
                                     retained.continuation(), leftUnread(position)));
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -204,6 +204,13 @@ public final class Partitions {
             // What the rules of this position raise that nothing answered, gathered from the
             // reading that found it. Once per position and not once per axis: a question is the
             // model's, and which axis is standing beside it is this compiler's business.
+            //
+            // At every position the reading found, including one this drew no axis at. A position
+            // given up in favour of its fields has none, and read off the axes its questions would
+            // be dropped for the position having been decomposed — which is a fact about this
+            // compiler deciding what a document says the model left standing. Nothing writes one
+            // there today; it is gathered here so that the day something does, the question is
+            // reported rather than lost.
             standing.addAll(position.unansweredQuestions());
         }
         // Every position the reading found, including the ones nothing divides: a report names what

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -403,10 +403,13 @@ final class Coverages {
     private static List<PartitionEvidence.Unanswered> unansweredAt(Axis axis) {
         return axis.unanswered().stream()
                 .map(each -> new PartitionEvidence.Unanswered(each, axis.path().toString(),
-                        // The number the line falls on, where it falls on one. Which of the two the
-                        // question is about was settled where it was raised — not here, and not by
-                        // whatever a renderer has to hand.
-                        each.owed().subject().measured() ? axis.term().toString() : null))
+                        // The number the line falls on, where it falls on one taken of the
+                        // position. Still spelled off the axis standing beside it, which is what
+                        // the translation at the input boundary takes away.
+                        each.owed() instanceof souther.compiler.check.Owed.Boundary line
+                                && line.on().kind() instanceof souther.compiler.check.FieldDomains
+                                        .CoordinateKind.OfWhatAnOperationAnswers
+                                ? axis.term().toString() : null))
                 .toList();
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -403,14 +403,25 @@ final class Coverages {
     private static List<PartitionEvidence.Unanswered> unansweredAt(Axis axis) {
         return axis.unanswered().stream()
                 .map(each -> new PartitionEvidence.Unanswered(each, axis.path().toString(),
-                        // The number the line falls on, where it falls on one taken of the
-                        // position. Still spelled off the axis standing beside it, which is what
-                        // the translation at the input boundary takes away.
-                        each.owed() instanceof souther.compiler.check.Owed.Boundary line
-                                && line.on().kind() instanceof souther.compiler.check.FieldDomains
-                                        .CoordinateKind.OfWhatAnOperationAnswers
-                                ? axis.term().toString() : null))
+                        measureOf(each)))
                 .toList();
+    }
+
+    /**
+     * The number a question's line falls on, where it falls on one taken of the position.
+     *
+     * <p>Off the question, which names it. Read off the axis standing beside it, the spelling was
+     * whatever that axis happened to be measured at — and an axis is re-pointed at a term a body's
+     * rules draw while the questions the declarations raised are carried across unchanged, so the
+     * two are not the same number and nothing said when they came apart.
+     *
+     * <p>Nothing for a line on the position's own values, which is what the field says: it is the
+     * count beside a path and not a second spelling of the path.
+     */
+    private static String measureOf(souther.compiler.inputs.StandingQuestion asked) {
+        return asked.asks() instanceof souther.compiler.inputs.InputQuestion.AboutANumber it
+                && it.term() instanceof souther.compiler.inputs.NumericTerm.TakenOf taken
+                ? taken.toString() : null;
     }
 
 
@@ -431,7 +442,7 @@ final class Coverages {
                 // falls is the border measure's question, and counting it here would put a number
                 // #869 separated back together. The questions themselves are beside the measures
                 // and are said there once.
-                axis.unanswered().stream().noneMatch(each -> each.owed().obligation()
+                axis.unanswered().stream().noneMatch(each -> each.obligation()
                         == souther.compiler.check.CoverageObligation.ADMITTED_VALUES));
         // Nothing a body claims is in scope here. What a row is owed at is counted first and on its
         // own, and what was declared about those positions is put beside it afterwards

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -149,19 +149,10 @@ final class Coverages {
         List<PartitionEvidence.AxisCoverage> axes = new ArrayList<>();
 
         List<Axis> divided = new ArrayList<>();
-        // Said once, before any axis is looked at. What the model asked and nothing answered is the
-        // model's, and whether a position could be measured is a separate answer that `undivided`
-        // below carries.
-        List<PartitionEvidence.Unanswered> standing =
-                new ArrayList<>(unansweredIn(partitioning));
         Readings readings = Readings.of(rows, where, partitioning.axes(),
                 observed.gaps().stream()
                         .filter(gap -> gap.code().leftNoRowRead()).toList());
         for (Axis axis : partitioning.axes()) {
-            // What the model asked about this position and nothing answered, said before anything
-            // here decides whether the position could be measured. The questions are the model's;
-            // `undivided` below explains why no evidence came back, which is a nothing of its own
-            // and carries no word about what was written there.
             if (!axis.measurable()) {
                 continue;   // said by `undivided`, which also says which kind of nothing it is
             }
@@ -179,7 +170,11 @@ final class Coverages {
                 BoundaryDerivation.of(boundaries, partitioning.borderClosure()),
                 pairsOf(behavior.name(), divided, readings, level.readsRows(), budget),
                 partitioning.undivided(), partitioning.unread(), partitioning.blocked(),
-                partitioning.notSeparated(), List.copyOf(standing),
+                // What the model asked and nothing answered, taken whole and not gathered as the
+                // axes are walked. The questions are the model's; whether a position could be
+                // measured is the separate answer `undivided` beside them carries, and a position
+                // no axis came back for still has whatever was written about it.
+                partitioning.notSeparated(), unansweredIn(partitioning),
                 whyUnclassified(readings.byRow(),
                         partitioning.axes().stream().map(Axis::id).toList()));
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -149,7 +149,11 @@ final class Coverages {
         List<PartitionEvidence.AxisCoverage> axes = new ArrayList<>();
 
         List<Axis> divided = new ArrayList<>();
-        List<PartitionEvidence.Unanswered> standing = new ArrayList<>();
+        // Said once, before any axis is looked at. What the model asked and nothing answered is the
+        // model's, and whether a position could be measured is a separate answer that `undivided`
+        // below carries.
+        List<PartitionEvidence.Unanswered> standing =
+                new ArrayList<>(unansweredIn(partitioning));
         Readings readings = Readings.of(rows, where, partitioning.axes(),
                 observed.gaps().stream()
                         .filter(gap -> gap.code().leftNoRowRead()).toList());
@@ -158,12 +162,11 @@ final class Coverages {
             // here decides whether the position could be measured. The questions are the model's;
             // `undivided` below explains why no evidence came back, which is a nothing of its own
             // and carries no word about what was written there.
-            standing.addAll(unansweredAt(axis));
             if (!axis.measurable()) {
                 continue;   // said by `undivided`, which also says which kind of nothing it is
             }
             if (axis.derivable()) {
-                axes.add(coverageOf(axis, readings, level.readsRows()));
+                axes.add(coverageOf(axis, partitioning, readings, level.readsRows()));
                 divided.add(axis);
             }
         }
@@ -394,17 +397,36 @@ final class Coverages {
     }
 
     /**
-     * The questions the rules about one position raise that nothing answered, as a document says
-     * them.
+     * The questions the rules of this behavior's inputs raise that nothing answered, as a document
+     * says them.
      *
-     * <p>Read off the axis because that is what carries a position's accounting here, and not
-     * because an axis owns the questions: one that could not be measured has them all the same.
+     * <p>Once, off the partitioning, and not once per axis. The model raises them and an axis is
+     * one reader of them: a position no axis came back for still has whatever was written about it,
+     * and an axis is re-pointed at another number as a body's rules are read, so a question found
+     * beside one is not thereby a question about the number that axis ended up measuring.
      */
-    private static List<PartitionEvidence.Unanswered> unansweredAt(Axis axis) {
-        return axis.unanswered().stream()
-                .map(each -> new PartitionEvidence.Unanswered(each, axis.path().toString(),
-                        measureOf(each)))
+    private static List<PartitionEvidence.Unanswered> unansweredIn(
+            souther.compiler.partition.Partitions.Partitioning partitioning) {
+        return partitioning.unanswered().stream()
+                .map(each -> new PartitionEvidence.Unanswered(each,
+                        each.asks().path().toString(), measureOf(each)))
                 .toList();
+    }
+
+    /**
+     * Whether one standing question is one this axis is a reader of.
+     *
+     * <p>Applicability and not ownership. Both sides name what they are about in the same
+     * vocabulary and the comparison is between those two names — which is a different thing from
+     * recovering the question's subject from what the axis happens to be measured at.
+     */
+    private static boolean appliesTo(souther.compiler.inputs.StandingQuestion asked, Axis axis) {
+        return switch (asked.asks()) {
+            case souther.compiler.inputs.InputQuestion.AboutAPosition it ->
+                    it.path().equals(axis.path());
+            case souther.compiler.inputs.InputQuestion.AboutANumber it ->
+                    it.term().equals(axis.term());
+        };
     }
 
     /**
@@ -425,8 +447,9 @@ final class Coverages {
     }
 
 
-    private static PartitionEvidence.AxisCoverage coverageOf(Axis axis, Readings readings,
-                                                             boolean asked) {
+    private static PartitionEvidence.AxisCoverage coverageOf(Axis axis,
+            souther.compiler.partition.Partitions.Partitioning partitioning, Readings readings,
+            boolean asked) {
         List<String> classes = axis.classes().stream().map(PartitionClass::id).toList();
         // What the axis already says about which of this position's rules nothing accounted for,
         // each named. Read off the axis rather than worked out here, and in the questions' own
@@ -442,8 +465,10 @@ final class Coverages {
                 // falls is the border measure's question, and counting it here would put a number
                 // #869 separated back together. The questions themselves are beside the measures
                 // and are said there once.
-                axis.unanswered().stream().noneMatch(each -> each.obligation()
-                        == souther.compiler.check.CoverageObligation.ADMITTED_VALUES));
+                partitioning.unanswered().stream()
+                        .filter(each -> appliesTo(each, axis))
+                        .noneMatch(each -> each.obligation()
+                                == souther.compiler.check.CoverageObligation.ADMITTED_VALUES));
         // Nothing a body claims is in scope here. What a row is owed at is counted first and on its
         // own, and what was declared about those positions is put beside it afterwards
         // ({@link ClaimReport}) — which is what keeps a claim from narrowing a denominator by being

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -403,8 +403,7 @@ final class Coverages {
     private static List<PartitionEvidence.Unanswered> unansweredIn(
             souther.compiler.partition.Partitions.Partitioning partitioning) {
         return partitioning.unanswered().stream()
-                .map(each -> new PartitionEvidence.Unanswered(each,
-                        each.asks().path().toString(), measureOf(each)))
+                .map(PartitionEvidence.Unanswered::new)
                 .toList();
     }
 
@@ -424,22 +423,6 @@ final class Coverages {
         };
     }
 
-    /**
-     * The number a question's line falls on, where it falls on one taken of the position.
-     *
-     * <p>Off the question, which names it. Read off the axis standing beside it, the spelling was
-     * whatever that axis happened to be measured at — and an axis is re-pointed at a term a body's
-     * rules draw while the questions the declarations raised are carried across unchanged, so the
-     * two are not the same number and nothing said when they came apart.
-     *
-     * <p>Nothing for a line on the position's own values, which is what the field says: it is the
-     * count beside a path and not a second spelling of the path.
-     */
-    private static String measureOf(souther.compiler.inputs.StandingQuestion asked) {
-        return asked.asks() instanceof souther.compiler.inputs.InputQuestion.AboutANumber it
-                && it.term() instanceof souther.compiler.inputs.NumericTerm.TakenOf taken
-                ? taken.toString() : null;
-    }
 
 
     private static PartitionEvidence.AxisCoverage coverageOf(Axis axis,

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -148,14 +148,14 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
         }
 
         /**
-         * And what it asks it about.
+         * The question itself, which is what it asks and what it asks it about, together.
          *
          * <p>As the reading that raised it named it, and not as words for it: a position, a number
-         * taken of one, and the comparison that drew a border between two moving terms are three
-         * things, and two of them cannot be told apart once they are one string.
+         * of one, and the comparison that drew a border between two moving terms are three things,
+         * and two of them cannot be told apart once they are one string.
          */
-        public souther.compiler.check.Owed.Subject subject() {
-            return asked.owed().subject();
+        public souther.compiler.check.Owed owed() {
+            return asked.owed();
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -129,7 +129,7 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
      *                subject because it is the reading's spelling of it and this document promises
      *                both
      */
-    public record Unanswered(souther.compiler.check.RuleAccounting.Unanswered asked, String at,
+    public record Unanswered(souther.compiler.inputs.StandingQuestion asked, String at,
                              String measure) {
 
         /** Which rule of the model raised it, which is what tells one question from another. */
@@ -144,7 +144,7 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
 
         /** What it asks. Which measure's section a reader meets it in follows from this. */
         public souther.compiler.check.CoverageObligation question() {
-            return asked.owed().obligation();
+            return asked.obligation();
         }
 
         /**
@@ -154,8 +154,8 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
          * of one, and the comparison that drew a border between two moving terms are three things,
          * and two of them cannot be told apart once they are one string.
          */
-        public souther.compiler.check.Owed owed() {
-            return asked.owed();
+        public souther.compiler.inputs.InputQuestion asks() {
+            return asked.asks();
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -122,15 +122,14 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
      *                cannot lose one. Which rule it is tells one question from another; the handle
      *                beside it is what a document shows and is not in step with that wherever a rule
      *                has no name
-     * @param at      the position it is about, spelled the way a report names it. The walk's and not
-     *                the accounting's: which position of a behavior's inputs a rule was filed at is
-     *                what the walk that found it says, and the subject is relative to it
-     * @param measure the number the position is measured by, where a border falls on one. Beside the
-     *                subject because it is the reading's spelling of it and this document promises
-     *                both
+     * <p><b>The question and nothing derived from it.</b> Everything a document writes about one of
+     * these is a projection of what the question says it is about, so it is projected here. Held
+     * beside the question as the strings a document wants, a value of this could name one position
+     * and be about another, and the two would agree only for as long as whoever wrote the one
+     * producer kept them agreeing — which is the arrangement this whole change exists to remove,
+     * left standing one layer from the document.
      */
-    public record Unanswered(souther.compiler.inputs.StandingQuestion asked, String at,
-                             String measure) {
+    public record Unanswered(souther.compiler.inputs.StandingQuestion asked) {
 
         /** Which rule of the model raised it, which is what tells one question from another. */
         public souther.compiler.check.RuleRef rule() {
@@ -156,6 +155,39 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
          */
         public souther.compiler.inputs.InputQuestion asks() {
             return asked.asks();
+        }
+
+        /**
+         * The position it is about, spelled the way a report names it.
+         *
+         * <p>The walk's and not the accounting's: which position of a behavior's inputs a rule was
+         * filed at is what the walk that found it says, which is what the question carries once it
+         * has crossed into this vocabulary.
+         */
+        public String at() {
+            return asked.asks().path().toString();
+        }
+
+        /**
+         * The number a border falls on, where it falls on one taken of the position, and null
+         * where the line is on what the position itself holds.
+         *
+         * <p>Both arms of each of the two types, and no {@code default} at either. What has no
+         * number is said by the arm that has none rather than by a test that any shape added later
+         * would also fail — which is how a question about a number nobody had classified would
+         * reach a document as one about no number at all.
+         */
+        public String measure() {
+            return switch (asked.asks()) {
+                case souther.compiler.inputs.InputQuestion.AboutAPosition _ -> null;
+                case souther.compiler.inputs.InputQuestion.AboutANumber it ->
+                        switch (it.term()) {
+                            // The position's own values, which the `path` beside this already says.
+                            case souther.compiler.inputs.NumericTerm.ValueOf _ -> null;
+                            case souther.compiler.inputs.NumericTerm.TakenOf taken ->
+                                    taken.toString();
+                        };
+            };
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1147,9 +1147,6 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      */
     private static String subjectOf(souther.compiler.query.PartitionEvidence.Unanswered asked,
                                     SourceNameResolver names, SourceId declaredIn) {
-        if (asked.owed() instanceof souther.compiler.check.Owed.BoundaryBetween it) {
-            return it.drawnBy().said(names, declaredIn);
-        }
         return asked.measure() != null ? asked.measure() : asked.at();
     }
 
@@ -1665,7 +1662,6 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         return switch (owed) {
             case souther.compiler.check.Owed.AdmittedValues _,
                  souther.compiler.check.Owed.Boundary _ -> "position";
-            case souther.compiler.check.Owed.BoundaryBetween _ -> "comparison";
         };
     }
 
@@ -1945,25 +1941,10 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 // side can be — so a consumer telling two of them apart is handed the two places
                 // rather than one sentence twice.
                 ObjectNode about = one.putObject("subject");
-                switch (each.owed()) {
-                    case souther.compiler.check.Owed.AdmittedValues _,
-                         souther.compiler.check.Owed.Boundary _ -> {
-                        about.put("kind", subjectWord(each.owed()));
-                        about.put("path", each.at());
-                        if (each.measure() != null) {
-                            about.put("measure", each.measure());
-                        }
-                    }
-                    case souther.compiler.check.Owed.BoundaryBetween it -> {
-                        about.put("kind", subjectWord(each.owed()));
-                        // Where the comparison is, for every citation this document can point at.
-                        // A comparison out of sight has no place a reader here can open, and the
-                        // rule beside it is what sends them to the declaration it is written in.
-                        if (it.drawnBy() instanceof Citation.Written
-                                || it.drawnBy() instanceof Citation.Reached) {
-                            at(about, it.drawnBy(), sources);
-                        }
-                    }
+                about.put("kind", subjectWord(each.owed()));
+                about.put("path", each.at());
+                if (each.measure() != null) {
+                    about.put("measure", each.measure());
                 }
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1147,8 +1147,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      */
     private static String subjectOf(souther.compiler.query.PartitionEvidence.Unanswered asked,
                                     SourceNameResolver names, SourceId declaredIn) {
-        if (asked.subject() instanceof souther.compiler.check.Owed.Subject.OfComparison it) {
-            return it.at().said(names, declaredIn);
+        if (asked.owed() instanceof souther.compiler.check.Owed.BoundaryBetween it) {
+            return it.drawnBy().said(names, declaredIn);
         }
         return asked.measure() != null ? asked.measure() : asked.at();
     }
@@ -1661,10 +1661,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      * an arm added and not given a word stops the compile rather than arriving in a document as one
      * that already existed.
      */
-    public static String subjectWord(souther.compiler.check.Owed.Subject subject) {
-        return switch (subject) {
-            case souther.compiler.check.Owed.Subject.OfAPosition _ -> "position";
-            case souther.compiler.check.Owed.Subject.OfComparison _ -> "comparison";
+    public static String subjectWord(souther.compiler.check.Owed owed) {
+        return switch (owed) {
+            case souther.compiler.check.Owed.AdmittedValues _,
+                 souther.compiler.check.Owed.Boundary _ -> "position";
+            case souther.compiler.check.Owed.BoundaryBetween _ -> "comparison";
         };
     }
 
@@ -1944,22 +1945,23 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 // side can be — so a consumer telling two of them apart is handed the two places
                 // rather than one sentence twice.
                 ObjectNode about = one.putObject("subject");
-                switch (each.subject()) {
-                    case souther.compiler.check.Owed.Subject.OfAPosition _ -> {
-                        about.put("kind", subjectWord(each.subject()));
+                switch (each.owed()) {
+                    case souther.compiler.check.Owed.AdmittedValues _,
+                         souther.compiler.check.Owed.Boundary _ -> {
+                        about.put("kind", subjectWord(each.owed()));
                         about.put("path", each.at());
                         if (each.measure() != null) {
                             about.put("measure", each.measure());
                         }
                     }
-                    case souther.compiler.check.Owed.Subject.OfComparison it -> {
-                        about.put("kind", subjectWord(each.subject()));
+                    case souther.compiler.check.Owed.BoundaryBetween it -> {
+                        about.put("kind", subjectWord(each.owed()));
                         // Where the comparison is, for every citation this document can point at.
                         // A comparison out of sight has no place a reader here can open, and the
                         // rule beside it is what sends them to the declaration it is written in.
-                        if (it.at() instanceof Citation.Written
-                                || it.at() instanceof Citation.Reached) {
-                            at(about, it.at(), sources);
+                        if (it.drawnBy() instanceof Citation.Written
+                                || it.drawnBy() instanceof Citation.Reached) {
+                            at(about, it.drawnBy(), sources);
                         }
                     }
                 }

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1140,10 +1140,9 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     /**
      * Which of the names a question carries a reader is shown.
      *
-     * <p>The reader's choice and not the measure's. Both surfaces of this report make it, and both
-     * of them used to overrule the one the finding arrived with: a subject that is a comparison is
-     * shown as where it is written, because the words for one are the same for every comparison
-     * there is and two of them at one position read as one.
+     * <p>The reader's choice and not the measure's. What a line falls on is shown where there is
+     * one, since that is what tells two questions at one position apart; the position is what is
+     * left.
      */
     private static String subjectOf(souther.compiler.query.PartitionEvidence.Unanswered asked,
                                     SourceNameResolver names, SourceId declaredIn) {
@@ -1658,10 +1657,10 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      * an arm added and not given a word stops the compile rather than arriving in a document as one
      * that already existed.
      */
-    public static String subjectWord(souther.compiler.check.Owed owed) {
-        return switch (owed) {
-            case souther.compiler.check.Owed.AdmittedValues _,
-                 souther.compiler.check.Owed.Boundary _ -> "position";
+    public static String subjectWord(souther.compiler.inputs.InputQuestion asks) {
+        return switch (asks) {
+            case souther.compiler.inputs.InputQuestion.AboutAPosition _,
+                 souther.compiler.inputs.InputQuestion.AboutANumber _ -> "position";
         };
     }
 
@@ -1935,13 +1934,13 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 // show a reader — which is what `rule` beside it is.
                 ruleId(one.putObject("ruleId"), each.rule());
                 one.put("question", word(each.question()));
-                // What the question is about, as what it is. A place a comparison drew between two
-                // moving terms is named by that comparison and not written out — printing it takes
-                // both sides in a vocabulary this compiler has, and it has none for every shape a
-                // side can be — so a consumer telling two of them apart is handed the two places
-                // rather than one sentence twice.
+                // What the question is about, as the question names it. The number a line falls on
+                // is beside the position rather than in place of it, because a rule about the
+                // length of a string is a rule at that string: an author looking for where it is
+                // written looks at the position, and what the line is on is the other half of the
+                // answer.
                 ObjectNode about = one.putObject("subject");
-                about.put("kind", subjectWord(each.owed()));
+                about.put("kind", subjectWord(each.asks()));
                 about.put("path", each.at());
                 if (each.measure() != null) {
                     about.put("measure", each.measure());

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-7.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-7.json
@@ -466,7 +466,7 @@
               "question": { "$ref": "#/$defs/coverageQuestion" },
               "subject": {
                 "type": "object",
-                "description": "What the question is about. The questions do not share a subject: which values may stand somewhere is about the position, a border on one position is about a number taken of it, and a border between two things that both move with the row is on neither of them. The last is named by the comparison that drew it rather than written out — printing the place takes both sides in a vocabulary this compiler has, so a written one would say how far its printer got and would give two comparisons of one rule the same subject.",
+                "description": "What the question is about. The two questions do not share a subject: which values may stand somewhere is about the position, and a border on one position is about a number of it — the position's own values, or what an operation answers of them. A border between two things that both move with the row is on neither of them, and is not here: a comparison this compiler reads owes the rows either side of its line by having been read, so no such question is ever outstanding, and what it owes is carried as the partition's own geometry.",
                 "required": ["kind"],
                 "additionalProperties": false,
                 "oneOf": [
@@ -474,10 +474,10 @@
                   { "properties": { "kind": { "const": "comparison" } }, "not": { "anyOf": [ { "required": ["path"] }, { "required": ["measure"] } ] } }
                 ],
                 "properties": {
-                  "kind": { "enum": ["position", "comparison"], "description": "`position` is a position of an input or a number taken of one; `comparison` is the place a comparison of two moving things draws, which is neither of them." },
+                  "kind": { "enum": ["position", "comparison"], "description": "`position` is a position of an input or a number taken of one. `comparison` is retired: it was to have been the place a comparison of two moving things draws, and no compiler ever wrote it — such a line owes its rows by having been read, so it never stands as a question. It is kept because this version promised it, and a reader holding the schema still meets the word." },
                   "path": { "type": "string", "description": "The position, spelled as the entry's `at` is. Written for a `position` subject." },
                   "measure": { "type": "string", "description": "The number the line falls on, where it falls on a count rather than on the position's own values — `String.length(code)` beside a `path` of `code`. Written only where the question is about a count." },
-                  "at": { "$ref": "#/$defs/at", "description": "Where the comparison is written, for a `comparison` subject this document can point at. Absent where the comparison is out of sight, and the `rule` beside it is what sends a reader to the declaration it is in." }
+                  "at": { "$ref": "#/$defs/at", "description": "Where the comparison is written, for a `comparison` subject this document can point at. Retired with the word it belongs to." }
                 }
               }
             }

--- a/souther-compiler/src/test/java/souther/compiler/AQuestionAboutANumberNamesTheNumberTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AQuestionAboutANumberNamesTheNumberTest.java
@@ -152,12 +152,16 @@ class AQuestionAboutANumberNamesTheNumberTest {
     }
 
     /**
-     * Two operations over one path are two questions, at every layer that carries one.
+     * Two operations over one path are two questions.
+     *
+     * <p>The identities and nothing that reads them, which is the half a record answers for. What
+     * reads them is asked in
+     * {@code check.AskingForOneNumbersEndsDoesNotAnswerWithAnothersTest}: these being two values is
+     * no use if the selector beside them tells them apart by whether a number was taken, and that
+     * is the reading that regressed before.
      *
      * <p>The language declares one number taken of a {@code List} today, so this is asked of the
-     * identities rather than of a model: told apart by a flag saying that a number was taken, these
-     * would be one at every layer, and the day a second operation is declared for a shape is the day
-     * a rule about one comes back filed at the other with nothing failing.
+     * identities rather than of a model.
      */
     @Test
     void twoNumbersAtOnePathStayTwo() {
@@ -175,18 +179,26 @@ class AQuestionAboutANumberNamesTheNumberTest {
                 "and a question about a number is not the question about the position");
     }
 
-    /** And the same the other side of the crossing, where a term is what names the number. */
+    /**
+     * And the other side of the crossing keeps the two questions one position raises apart.
+     *
+     * <p>Which values may stand at a position and where a line on a number of it falls are two
+     * questions at one path, and a reader matching an axis compares what each says it is about. Both
+     * say where they sit, so a reader that wanted only the path could have neither told apart —
+     * which is why what each asks is the arm rather than something carried beside it.
+     */
     @Test
-    void andTwoTermsAtOnePathStayTwoOnceTheyHaveCrossed() {
+    void thePositionsTwoQuestionsAreTwoAtOnePath() {
         TermPath at = TermPath.of("t").then("names");
+        InputQuestion aLine = new InputQuestion.AboutANumber(new NumericTerm.ValueOf(at));
+        InputQuestion itsValues = new InputQuestion.AboutAPosition(at);
 
-        assertNotEquals(new InputQuestion.AboutANumber(new NumericTerm.ValueOf(at)),
-                new InputQuestion.AboutAPosition(at),
+        assertNotEquals(aLine, itsValues,
                 "where a line falls on a position's own values is not which values may stand there");
-        assertEquals(at, new InputQuestion.AboutANumber(new NumericTerm.ValueOf(at)).path(),
+        assertEquals(at, aLine.path(),
                 "and both say where they sit, which is what an axis is matched on");
-        assertNotEquals(new InputQuestion.AboutANumber(new NumericTerm.ValueOf(at)).obligation(),
-                new InputQuestion.AboutAPosition(at).obligation(),
+        assertEquals(at, itsValues.path());
+        assertNotEquals(aLine.obligation(), itsValues.obligation(),
                 "what each asks follows from which it is, and is not carried beside it");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/AQuestionAboutANumberNamesTheNumberTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AQuestionAboutANumberNamesTheNumberTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A question about a number taken of a position names that number.
@@ -138,12 +137,17 @@ class AQuestionAboutANumberNamesTheNumberTest {
      *  position is measured by. */
     @Test
     void thePositionsOwnQuestionIsAskedOnce() {
-        assertEquals(1, standingIn(A_RULE_ABOUT_A_LENGTH).stream()
-                        .filter(each -> each.startsWith("admitted_values")).count(),
-                () -> "one rule, one question about the values: "
-                        + standingIn(A_RULE_ABOUT_A_LENGTH));
-        assertNull(partitionOf(A_RULE_ABOUT_A_LENGTH).get("unanswered").get(0).get("subject")
-                        .get("measure"),
+        List<JsonNode> admitted = new ArrayList<>();
+        for (JsonNode each : partitionOf(A_RULE_ABOUT_A_LENGTH).get("unanswered")) {
+            if (each.get("question").asString().equals("admitted_values")) {
+                admitted.add(each);
+            }
+        }
+
+        assertEquals(1, admitted.size(),
+                () -> "one rule, one question about the values, however many numbers the position"
+                        + " is measured by: " + admitted);
+        assertNull(admitted.get(0).get("subject").get("measure"),
                 "and no number beside it, because it is not about one");
     }
 
@@ -181,8 +185,8 @@ class AQuestionAboutANumberNamesTheNumberTest {
                 "where a line falls on a position's own values is not which values may stand there");
         assertEquals(at, new InputQuestion.AboutANumber(new NumericTerm.ValueOf(at)).path(),
                 "and both say where they sit, which is what an axis is matched on");
-        assertTrue(new InputQuestion.AboutANumber(new NumericTerm.ValueOf(at)).obligation()
-                        != new InputQuestion.AboutAPosition(at).obligation(),
+        assertNotEquals(new InputQuestion.AboutANumber(new NumericTerm.ValueOf(at)).obligation(),
+                new InputQuestion.AboutAPosition(at).obligation(),
                 "what each asks follows from which it is, and is not carried beside it");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/AQuestionAboutANumberNamesTheNumberTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AQuestionAboutANumberNamesTheNumberTest.java
@@ -1,0 +1,188 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import souther.compiler.check.FieldDomains;
+import souther.compiler.check.Owed;
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.inputs.InputQuestion;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+import souther.compiler.types.ValueName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A question about a number taken of a position names that number.
+ *
+ * <p>The subject of a coverage question said <em>that</em> a number was taken and not which, so
+ * every reader that wanted the name reached past the question to whatever stood beside it. The
+ * document's {@code subject.measure} is written from the question, and it was written from the axis:
+ * a position with no axis at all still has whatever was written about it, and the axis beside a
+ * question is not always measured at the number that question is about.
+ *
+ * <p>What it published is in {@link #theNumberIsNamedAndNotTheThingItWasTakenOf}: a rule about how
+ * long a list is came back with the list's own path in the field that says which count the line
+ * falls on — so a consumer reading the document was told that the line falls on a count and then
+ * handed the position as the count.
+ */
+class AQuestionAboutANumberNamesTheNumberTest {
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    /**
+     * A rule about the length of a list that no reading turns into a line.
+     *
+     * <p>{@code 10 * 2} is a number this compiler does not fold, so the rule states where the values
+     * stop and nothing placed the end — which is a boundary question standing, about the length. The
+     * position itself has no axis: nothing divides a bare {@code List<String>}, so there is no axis
+     * measured at the length for a reader to take the name from.
+     */
+    private static final String A_RULE_ABOUT_A_LENGTH = """
+            module m
+
+            data Tags = { names: List<String> }
+                invariant said = List.length(names) <= 10 * 2
+
+            behavior g : (t: Tags) -> Int
+            let g (t) = 1
+
+            example g
+                | "one" : (Tags { names = [] }) -> 1
+            """;
+
+    /** The same rules, with a body drawing a line on the length, which re-points the axis at it. */
+    private static final String THE_SAME_UNDER_A_GUARD = """
+            module m
+
+            data Tags = { names: List<String> }
+                invariant said = List.length(names) <= 10 * 2
+
+            behavior g : (t: Tags) -> Int
+            let g (t) = if List.length(t.names) > 0 then 1 else 2
+
+            example g
+                | "one" : (Tags { names = [] }) -> 2
+            """;
+
+    private static JsonNode partitionOf(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return JSON.readTree(AdequacyReport.of(compilation).json(SourceNameResolver.identity()))
+                .get("modules").get(0).get("behaviors").get(0).get("partition");
+    }
+
+    /** One question of the document, as `question at subject`, with the number where there is one. */
+    private static List<String> standingIn(String source) {
+        List<String> out = new ArrayList<>();
+        for (JsonNode each : partitionOf(source).get("unanswered")) {
+            JsonNode about = each.get("subject");
+            JsonNode measure = about.get("measure");
+            out.add(each.get("question").asString() + " at " + about.get("path").asString()
+                    + (measure == null ? "" : " on " + measure.asString()));
+        }
+        return out;
+    }
+
+    /**
+     * The number, and not the thing it was taken of.
+     *
+     * <p>What this asserted before the question carried the number was
+     * {@code boundary at t.names on t.names}: the field that says which count the line falls on
+     * held the position, because the only name to hand was the axis's and the axis is measured at
+     * the list rather than at its length.
+     */
+    @Test
+    void theNumberIsNamedAndNotTheThingItWasTakenOf() {
+        assertEquals(List.of(
+                        "admitted_values at t.names",
+                        "boundary at t.names on List.length(t.names)"),
+                standingIn(A_RULE_ABOUT_A_LENGTH),
+                "the line falls on the length, and the values it admits are the list's");
+    }
+
+    /**
+     * And it does not move when a body draws on the same position.
+     *
+     * <p>{@code Axis.measuredAt} re-points one axis at another number rather than adding a second,
+     * and it carried the questions across while doing it. A question is the model's and is about the
+     * number its own rule names, so what a body compares changes neither which questions stand nor
+     * which number each is about.
+     *
+     * <p>These two documents disagreed. One rule, one question, and
+     * {@code boundary at t.names on t.names} with no guard against
+     * {@code boundary at t.names on List.length(t.names)} with one — the published number being
+     * whatever the axis beside the question had ended up measured at.
+     */
+    @Test
+    void aBodyDrawingOnThePositionMovesNoQuestion() {
+        assertEquals(standingIn(A_RULE_ABOUT_A_LENGTH), standingIn(THE_SAME_UNDER_A_GUARD),
+                "the same rules raise the same questions about the same numbers, whatever the"
+                        + " axis beside them ended up being measured at");
+    }
+
+    /** The question about which values may stand there is asked once, however many numbers the
+     *  position is measured by. */
+    @Test
+    void thePositionsOwnQuestionIsAskedOnce() {
+        assertEquals(1, standingIn(A_RULE_ABOUT_A_LENGTH).stream()
+                        .filter(each -> each.startsWith("admitted_values")).count(),
+                () -> "one rule, one question about the values: "
+                        + standingIn(A_RULE_ABOUT_A_LENGTH));
+        assertNull(partitionOf(A_RULE_ABOUT_A_LENGTH).get("unanswered").get(0).get("subject")
+                        .get("measure"),
+                "and no number beside it, because it is not about one");
+    }
+
+    /**
+     * Two operations over one path are two questions, at every layer that carries one.
+     *
+     * <p>The language declares one number taken of a {@code List} today, so this is asked of the
+     * identities rather than of a model: told apart by a flag saying that a number was taken, these
+     * would be one at every layer, and the day a second operation is declared for a shape is the day
+     * a rule about one comes back filed at the other with nothing failing.
+     */
+    @Test
+    void twoNumbersAtOnePathStayTwo() {
+        ValueName length = ValueName.Stdlib.operation("List", "length");
+        ValueName size = ValueName.Stdlib.operation("Set", "size");
+
+        assertNotEquals(new Owed.Boundary(FieldDomains.Coordinate.takenBy("names", length)),
+                new Owed.Boundary(FieldDomains.Coordinate.takenBy("names", size)),
+                "a line on one operation's number is not a line on another's");
+        assertNotEquals(new Owed.Boundary(FieldDomains.Coordinate.takenBy("names", length)),
+                new Owed.Boundary(FieldDomains.Coordinate.value("names")),
+                "nor a line on what the position itself holds");
+        assertNotEquals(new Owed.Boundary(FieldDomains.Coordinate.takenBy("names", length)),
+                new Owed.AdmittedValues("names"),
+                "and a question about a number is not the question about the position");
+    }
+
+    /** And the same the other side of the crossing, where a term is what names the number. */
+    @Test
+    void andTwoTermsAtOnePathStayTwoOnceTheyHaveCrossed() {
+        TermPath at = TermPath.of("t").then("names");
+
+        assertNotEquals(new InputQuestion.AboutANumber(new NumericTerm.ValueOf(at)),
+                new InputQuestion.AboutAPosition(at),
+                "where a line falls on a position's own values is not which values may stand there");
+        assertEquals(at, new InputQuestion.AboutANumber(new NumericTerm.ValueOf(at)).path(),
+                "and both say where they sit, which is what an axis is matched on");
+        assertTrue(new InputQuestion.AboutANumber(new NumericTerm.ValueOf(at)).obligation()
+                        != new InputQuestion.AboutAPosition(at).obligation(),
+                "what each asks follows from which it is, and is not carried beside it");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
@@ -507,9 +507,11 @@ class EverySchemaWordIsAccountedForTest {
         // stand at a position and where a line on a number of it falls are both about the position,
         // and a document says so once.
         Set<String> written = new LinkedHashSet<>();
-        written.add(AdequacyReport.subjectWord(new souther.compiler.check.Owed.AdmittedValues("x")));
-        written.add(AdequacyReport.subjectWord(new souther.compiler.check.Owed.Boundary(
-                souther.compiler.check.FieldDomains.Coordinate.value("x"))));
+        written.add(AdequacyReport.subjectWord(new souther.compiler.inputs.InputQuestion
+                .AboutAPosition(souther.compiler.inputs.TermPath.of("x"))));
+        written.add(AdequacyReport.subjectWord(new souther.compiler.inputs.InputQuestion
+                .AboutANumber(new souther.compiler.inputs.NumericTerm.ValueOf(
+                        souther.compiler.inputs.TermPath.of("x")))));
         written.add("comparison");
 
         assertEquals(written,

--- a/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
@@ -499,9 +499,10 @@ class EverySchemaWordIsAccountedForTest {
     @Test
     void theThirdFieldWithNoEnumBehindItIsWrittenFromWhatAQuestionIsAbout() {
         assertEquals(Set.of(
-                        AdequacyReport.subjectWord(souther.compiler.check.Owed.Subject.at("x")),
-                        AdequacyReport.subjectWord(new souther.compiler.check.Owed.Subject
-                                .OfComparison(souther.compiler.diag.Citation.of(
+                        AdequacyReport.subjectWord(
+                                new souther.compiler.check.Owed.AdmittedValues("x")),
+                        AdequacyReport.subjectWord(new souther.compiler.check.Owed
+                                .BoundaryBetween(souther.compiler.diag.Citation.of(
                                         new souther.compiler.diag.SourcePos(1, 1))))),
                 allowedAt(schema(), List.of("$defs", "partition", "properties", "unanswered",
                         "items", "properties", "subject", "properties", "kind")));

--- a/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
@@ -492,18 +492,27 @@ class EverySchemaWordIsAccountedForTest {
      * And the third: which kind of thing a question is about, written from the arms of a sealed type
      * rather than from an enum.
      *
-     * <p>The arms are not interchangeable words for one thing — a position is named by where it is
-     * and a comparison by where it is written — so what a document says of each is asked of the
-     * writer rather than of a name.
+     * <p>Both arms of {@code Owed} say `position` — a position of an input, or a number of one — and
+     * they are still asked of the writer rather than assumed, so an arm added and not given a word
+     * stops the compile.
+     *
+     * <p>`comparison` is beside them and is retired. It was to have been the place a comparison of
+     * two moving things draws; nothing ever raised such a question, because a comparison this
+     * compiler reads owes its rows by having been read. The word stays because this version of the
+     * schema promised it.
      */
     @Test
     void theThirdFieldWithNoEnumBehindItIsWrittenFromWhatAQuestionIsAbout() {
-        assertEquals(Set.of(
-                        AdequacyReport.subjectWord(
-                                new souther.compiler.check.Owed.AdmittedValues("x")),
-                        AdequacyReport.subjectWord(new souther.compiler.check.Owed
-                                .BoundaryBetween(souther.compiler.diag.Citation.of(
-                                        new souther.compiler.diag.SourcePos(1, 1))))),
+        // A set built up rather than `Set.of`, because the two arms say one word: which values may
+        // stand at a position and where a line on a number of it falls are both about the position,
+        // and a document says so once.
+        Set<String> written = new LinkedHashSet<>();
+        written.add(AdequacyReport.subjectWord(new souther.compiler.check.Owed.AdmittedValues("x")));
+        written.add(AdequacyReport.subjectWord(new souther.compiler.check.Owed.Boundary(
+                souther.compiler.check.FieldDomains.Coordinate.value("x"))));
+        written.add("comparison");
+
+        assertEquals(written,
                 allowedAt(schema(), List.of("$defs", "partition", "properties", "unanswered",
                         "items", "properties", "subject", "properties", "kind")));
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest.java
@@ -179,9 +179,10 @@ class AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest {
                     invariant nonEmpty = String.length(value) >= 1
                 """, "Code"), "nonEmpty");
 
-        assertEquals(Set.of("ADMITTED_VALUES at the value", "BOUNDARY at count of the value"),
+        assertEquals(Set.of("ADMITTED_VALUES at the value",
+                        "BOUNDARY at String.length(the value)"),
                 nonEmpty.answers().keySet().stream()
-                        .map(o -> o.obligation() + " at " + o.subject())
+                        .map(o -> o.obligation() + " at " + o)
                         .collect(java.util.stream.Collectors.toSet()));
         assertEquals(Set.of(), nonEmpty.unaccounted());
     }
@@ -270,7 +271,7 @@ class AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest {
     private static Set<String> unansweredOf(String source, String type) {
         return accountingOf(source, type).values().stream()
                 .flatMap(each -> each.unaccounted().stream())
-                .map(owed -> owed.subject().toString())
+                .map(Object::toString)
                 .collect(java.util.stream.Collectors.toSet());
     }
 
@@ -283,7 +284,7 @@ class AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest {
                     invariant said = %s
                 """.formatted(clause), "Pair").values().stream()
                 .flatMap(each -> each.unaccounted().stream())
-                .map(owed -> owed.subject().toString())
+                .map(Object::toString)
                 .collect(java.util.stream.Collectors.toSet());
     }
 
@@ -333,7 +334,7 @@ class AQuestionIsAnsweredByWhicheverReadingTookTheRuleInTest {
                 rule(accountingOf(beside("value >= 1 && Int.abs(value) >= 2"), "Length"), "said")
                         .answers().entrySet().stream()
                         .filter(e -> e.getValue() instanceof RuleAccounting.Outcome.Accounted)
-                        .map(e -> e.getKey().obligation() + " at " + e.getKey().subject())
+                        .map(e -> e.getKey().obligation() + " at " + e.getKey())
                         .collect(java.util.stream.Collectors.toSet()),
                 "the line the readable half drew is answered by the reading that placed it");
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/AskingForOneNumbersEndsDoesNotAnswerWithAnothersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AskingForOneNumbersEndsDoesNotAnswerWithAnothersTest.java
@@ -1,0 +1,122 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+import souther.compiler.types.ValueName;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Ends placed on one number of a position are not answered with another number's.
+ *
+ * <p>Asked of the selector and not of the values it selects between. That two coordinates at one
+ * path are two values is the record's own business and is true the moment the operation is carried;
+ * what regressed before is the reading beside it — {@code d.path().equals(where.path()) &&
+ * d.measured() == where.measured()}, which is two projections agreeing rather than two numbers
+ * being one. A selector written that way again passes every test that only compares identities.
+ *
+ * <p>{@link DeclaredBounds#placed} is where that selector is. It took a boolean and takes a
+ * {@link FieldDomains.CoordinateKind}, and the path is the caller's already — {@code placedAt(path)}
+ * is what the list is — so the kind is the whole of what it has to tell apart.
+ *
+ * <p>Two operations over one path is not a shape the language writes today, because a shape declares
+ * one number taken of it ({@code NumericMeasures.takenOf}). That is why this is asked here rather
+ * than of a model: the day a second is declared is the day a rule about one comes back as a bound on
+ * the other, and nothing about either looks like a failure.
+ */
+class AskingForOneNumbersEndsDoesNotAnswerWithAnothersTest {
+
+    private static final TypeSymbol.AtModule ON = TypeSymbols.declared(new TypeKey("m", "R"));
+
+    private static final ValueName LENGTH = ValueName.Stdlib.operation("List", "length");
+    private static final ValueName SIZE = ValueName.Stdlib.operation("Set", "size");
+
+    /** A rule, told from another by where it sits among its declaration's clauses. */
+    private static RuleRef.Invariant rule(int at) {
+        return new RuleRef.Invariant(new Clause.Ref(new Clause.Id(ON, at), Optional.empty()));
+    }
+
+    /** An end above one number of `names`, placed by the clause at {@code by}. */
+    private static FieldDomains.Placed upTo(FieldDomains.Coordinate on, int by, int at) {
+        return new FieldDomains.Placed(on, rule(by), false, Endpoint.inclusive(Count.of(at)));
+    }
+
+    /** And one below it. */
+    private static FieldDomains.Placed from(FieldDomains.Coordinate on, int by, int at) {
+        return new FieldDomains.Placed(on, rule(by), true, Endpoint.inclusive(Count.of(at)));
+    }
+
+    private static final FieldDomains.Coordinate HOW_LONG =
+            FieldDomains.Coordinate.takenBy("names", LENGTH);
+    private static final FieldDomains.Coordinate HOW_MANY =
+            FieldDomains.Coordinate.takenBy("names", SIZE);
+    private static final FieldDomains.Coordinate ITSELF = FieldDomains.Coordinate.value("names");
+
+    /** Both, at one path, each with an end of its own and each named by a clause of its own. */
+    private static final List<FieldDomains.Placed> AT_ONE_PATH =
+            List.of(upTo(HOW_LONG, 0, 3), upTo(HOW_MANY, 1, 7));
+
+    /**
+     * Each operation's end, and its own rule beside it.
+     *
+     * <p>The rule and not only the number: an end answered from the wrong coordinate sends a reader
+     * to a clause that says nothing about what they are looking at, which is the half of this a
+     * value alone would not catch.
+     */
+    @Test
+    void eachNumbersEndIsItsOwn() {
+        DeclaredBounds.Bounds howLong = DeclaredBounds.placed(AT_ONE_PATH, HOW_LONG.kind(),
+                Carrier.WHOLE);
+        DeclaredBounds.Bounds howMany = DeclaredBounds.placed(AT_ONE_PATH, HOW_MANY.kind(),
+                Carrier.WHOLE);
+
+        assertEquals(Count.of(3), howLong.max().at().at(), "the end the rule about the length drew");
+        assertEquals(List.of(rule(0)), howLong.max().from(), "and the clause that drew it");
+        assertEquals(Count.of(7), howMany.max().at().at(), "the end the rule about the size drew");
+        assertEquals(List.of(rule(1)), howMany.max().from(), "and the clause that drew it");
+    }
+
+    /**
+     * And what the position itself holds is neither of them.
+     *
+     * <p>The arm a selector that read a flag would fall into for anything it did not recognise: both
+     * of these are numbers taken of the position, so "not taken" is the one answer that is right
+     * about neither.
+     */
+    @Test
+    void andWhatThePositionHoldsIsNeither() {
+        assertNull(DeclaredBounds.placed(AT_ONE_PATH, ITSELF.kind(), Carrier.WHOLE),
+                "no rule here says where the values of the list itself stop");
+    }
+
+    /**
+     * Both ends of one number come back, and neither side takes the other number's.
+     *
+     * <p>Asked of the two sides apart, because a selector can leak on one of them. A rule bounding
+     * the size below is not a floor under the length, and a reader handed one would report a length
+     * that cannot be short — which reads as a fact about the model rather than as the two numbers
+     * having been mixed.
+     */
+    @Test
+    void bothEndsOfOneNumberComeBackAndNeitherSideTakesTheOthers() {
+        List<FieldDomains.Placed> bothSides = List.of(
+                upTo(HOW_LONG, 0, 3), from(HOW_LONG, 1, 1), from(HOW_MANY, 2, 5));
+
+        DeclaredBounds.Bounds howLong = DeclaredBounds.placed(bothSides, HOW_LONG.kind(),
+                Carrier.WHOLE);
+
+        assertEquals(Count.of(3), howLong.max().at().at(), "the length's own upper end");
+        assertEquals(Count.of(1), howLong.min().at().at(),
+                "and its own lower one, which is not the floor the rule about the size put there");
+        assertEquals(List.of(rule(1)), howLong.min().from(), "named by the clause that drew it");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatACopyOfACoordinateLeavesOutIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatACopyOfACoordinateLeavesOutIsWrittenDownTest.java
@@ -14,9 +14,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>{@code FieldDomains.Unread} is written from a coordinate the reading found, one field at a
  * time, because the coordinate is this class's own and the record crosses into {@code inputs}. Two
- * of its fields went in one round late apiece — first whether the position is a count, then which
- * conjunct the reason came from — each after something downstream turned out to need what the
- * producer already had, and each looked like an unrelated fix.
+ * of its fields went in one round late apiece — first which number of the position it is, then
+ * which conjunct the reason came from — each after something downstream turned out to need what the
+ * producer already had, and each looked like an unrelated fix. The first arrived twice: as a flag
+ * saying a number was taken, and then as the number itself, because the flag could not tell two
+ * operations over one path apart (#1050).
  *
  * <p>So what the copy leaves out is written down rather than discovered. A field added to the
  * coordinate fails here, which is the point: the answer may well be that the copy does not want it,
@@ -66,8 +68,10 @@ class WhatACopyOfACoordinateLeavesOutIsWrittenDownTest {
         added.removeAll(componentsOf(coordinate()));
 
         assertEquals(Set.of("from", "part", "why"), added);
-        assertTrue(componentsOf(FieldDomains.Unread.class).containsAll(Set.of("path", "by")),
-                "beside the two of the coordinate that a reader downstream turned out to need:"
-                        + " where it sits, and which operation takes the number if one does");
+        assertTrue(componentsOf(FieldDomains.Unread.class).contains("at"),
+                "beside the one of the coordinate that a reader downstream turned out to need:"
+                        + " which number of which position the end was to have been on. One"
+                        + " component and not a path beside a flag — a path measured by two"
+                        + " operations has two of these, and the flag brought them to one");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleRaisesIsAskedOfTheRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleRaisesIsAskedOfTheRuleTest.java
@@ -48,7 +48,7 @@ class WhatARuleRaisesIsAskedOfTheRuleTest {
      * together. */
     private static Set<String> said(Required required) {
         return required.obligations().stream()
-                .map(o -> o.obligation() + " at " + o.subject())
+                .map(o -> o.obligation() + " at " + o)
                 .collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/inputs/APositionSaysWhichOfItsRulesWentUnansweredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/APositionSaysWhichOfItsRulesWentUnansweredTest.java
@@ -4,9 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.ast.Hir;
 import souther.compiler.check.CoverageObligation;
-import souther.compiler.check.Owed;
 import souther.compiler.check.Prepared;
-import souther.compiler.check.RuleAccounting;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.query.Bodies;
@@ -104,16 +102,16 @@ class APositionSaysWhichOfItsRulesWentUnansweredTest {
      */
     @Test
     void aClauseNothingTookInIsNamed() {
-        List<RuleAccounting.Unanswered> open = positionOf(ONE_RULE_UNANSWERED)
-                .unansweredQuestions();
+        List<StandingQuestion> open = positionOf(ONE_RULE_UNANSWERED).unansweredQuestions();
 
         assertEquals(1, open.size(), () -> "one clause, one question: " + open);
         assertEquals("invariant Length (even)", open.get(0).rule().named(),
                 "the clause the author wrote, as a report names it — and not the position it "
                         + "is about");
-        assertEquals(CoverageObligation.ADMITTED_VALUES, open.get(0).owed().obligation());
-        assertTrue(open.get(0).owed() instanceof Owed.AdmittedValues at
-                        && at.path().isEmpty(),
-                () -> "about the value the newtype wraps: " + open.get(0).owed());
+        assertEquals(CoverageObligation.ADMITTED_VALUES, open.get(0).obligation());
+        assertTrue(open.get(0).asks() instanceof InputQuestion.AboutAPosition at
+                        && at.path().equals(TermPath.of("length")),
+                () -> "about the position the newtype stands at, which is what the value its"
+                        + " clauses are written on is called out here: " + open.get(0).asks());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/inputs/APositionSaysWhichOfItsRulesWentUnansweredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/APositionSaysWhichOfItsRulesWentUnansweredTest.java
@@ -112,8 +112,8 @@ class APositionSaysWhichOfItsRulesWentUnansweredTest {
                 "the clause the author wrote, as a report names it — and not the position it "
                         + "is about");
         assertEquals(CoverageObligation.ADMITTED_VALUES, open.get(0).owed().obligation());
-        assertTrue(open.get(0).owed().subject() instanceof Owed.Subject.OfAPosition at
+        assertTrue(open.get(0).owed() instanceof Owed.AdmittedValues at
                         && at.path().isEmpty(),
-                () -> "about the value the newtype wraps: " + open.get(0).owed().subject());
+                () -> "about the value the newtype wraps: " + open.get(0).owed());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClassIsOneThePositionCanHoldAndNothingTakesItAwayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClassIsOneThePositionCanHoldAndNothingTakesItAwayTest.java
@@ -389,11 +389,14 @@ class AClassIsOneThePositionCanHoldAndNothingTakesItAwayTest {
         Partitions.Partitioning base =
                 Partitions.of(read.spec().name(), InputDomain.of(read.spec(), read.sig(), read.symbols(), souther.compiler.query.ReadAs.THE_COMPILATION_DOES), read.symbols(), souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
 
-        assertFalse(only(base).unanswered().isEmpty(),
+        assertFalse(base.unanswered().isEmpty(),
                 "a rule about this position was taken in by nothing, and the classes were made"
                         + " anyway");
-        assertEquals(only(base).unanswered(), only(withThresholdsOf(read, base)).unanswered(),
-                "what a body draws does not change which of the position's rules stand unanswered");
+        assertEquals(base.unanswered(), withThresholdsOf(read, base).unanswered(),
+                "what a body draws does not change which of the position's rules stand unanswered,"
+                        + " nor which number each of them is about — a body's rules re-point the"
+                        + " axis at another term, and a question carried on the axis would have"
+                        + " gone with it");
     }
 
     /** The same partitioning, with what the behavior's body draws taken in. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClassIsOneThePositionCanHoldAndNothingTakesItAwayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClassIsOneThePositionCanHoldAndNothingTakesItAwayTest.java
@@ -90,12 +90,6 @@ class AClassIsOneThePositionCanHoldAndNothingTakesItAwayTest {
                 guards.unread(), guards.singled(), guards.between()));
     }
 
-    /** The one axis, whichever phase produced it. */
-    private static Axis only(Partitions.Partitioning partitioning) {
-        assertEquals(1, partitioning.axes().size(), partitioning.axes().toString());
-        return partitioning.axes().get(0);
-    }
-
     /**
      * The classes of the parameter's own position, which is the first axis read.
      *

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -61,8 +61,7 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
     /** The same, with a rule about the position's own values that the local reading could not take
      *  in — which is a second way a position can be left unable to reach an absence. */
     private static Axis pending(StructuralInspection.Continuation found, BlockReason unread) {
-        return Axis.pendingAt(ID, new NumericTerm.ValueOf(AT), Type.BOOL,
-                java.util.List.of(), false, found, unread);
+        return Axis.pendingAt(ID, new NumericTerm.ValueOf(AT), Type.BOOL, false, found, unread);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnOpenPositionIsAReadingThatRanToTheEndTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnOpenPositionIsAReadingThatRanToTheEndTest.java
@@ -156,8 +156,7 @@ class AnOpenPositionIsAReadingThatRanToTheEndTest {
     @Test
     void anEmptyDivisionIsNotAnAnswer() {
         assertThrows(IllegalArgumentException.class,
-                () -> new LocalPartition.Divided(List.of(), new CutEvidence.None(),
-                        List.of(), false));
+                () -> new LocalPartition.Divided(List.of(), new CutEvidence.None(), false));
     }
 
     /**


### PR DESCRIPTION
Closes #1050.

A coverage question's subject said *that* a number was taken of a position and
not which, and the number itself was fetched from whatever stood beside the
question. This is that identity put back, from where it is lost to where it is
published.

## What it published

`invariant said = List.length(names) <= 10 * 2` raises one boundary question
about the length. On `develop`, two documents of that one model disagree about
what the question is about:

| body | `subject.measure` |
| --- | --- |
| `let g (t) = 1` | `t.names` |
| `let g (t) = if List.length(t.names) > 0 then 1 else 2` | `List.length(t.names)` |

The rule does not change between them. What changes is the axis standing beside
the question, which is where the name was taken from — and `Axis.measuredAt`
re-points one axis at a number a body's rules draw rather than adding a second.
The first row is wrong on its own: `measure` is documented as the count the line
falls on, beside a `path` of the position it is taken of, and it holds the
position.

Both are asserted in `AQuestionAboutANumberNamesTheNumberTest`, and both fail on
the commit this branch starts from.

## Where it was lost

One expression, in `InvariantChecker.direct`:

```java
new Owed.Subject.OfAPosition(about.path(), about.measured())
```

`about` is the reading's own coordinate and holds the operation; `measured()`
answers whether that operation is null. Everything after it is consequence.
`FieldDomains` matched `(path, measured)` against `Direct` and `Unread`, which
also held the operation and also projected it; `Coverages` could not spell the
number and took the spelling from the axis.

The same producer's other exit was already right. #1029 gave `UnreadRule` a
`FilingCoordinate` built by `InputDomain.filedAt` from the same `(path,
operation)` pair. Two exits, one converted.

What kept the projection from being a bug so far is that
`NumericMeasures.takenOf` returns one operation per type, so `(path, true)` has
one meaning. That is not written down anywhere and is not a property of the
language: `OperationFacts` already declares `TakenAs.PartOfTime(HOUR)`, and the
arm is `TimePart`.

## What the commits do

1. `ClauseStates` says which positions a clause names and which number its line
   is on. Its `named` and `positions` were `Set<Owed.Subject>` and every member
   was the same arm with the same flag — a set of paths wearing the type of a set
   of subjects.
2. `Owed` becomes a sum. It was `CoverageObligation × Subject`, a product every
   combination of which was constructible, and the one reader that would have met
   an impossible combination fenced it off with a throw.
3. `Placed`, `Unread`, `Direct` and the reading's coordinate carry the
   `FieldDomains.Coordinate` instead of a path beside a `ValueName` projected to
   `measured()`. `DeclaredBounds.placed` selects on a `CoordinateKind`.
4. The arm for a line between two moving things goes. Nothing ever built one —
   the only call was a test naming it so the schema word had a producer — and
   `CoverageObligation` says why and always did. `subject.kind` keeps the word
   and says it is retired.
5. A question crosses into the input's vocabulary once, at `InputDomain`, where
   the root the walk started at and the type at the position both are.
   `InputQuestion` is that vocabulary; `StandingQuestion` carries it beside the
   rule and the citation, and does not carry the question it came from.
6. `Axis` gives up the questions. They are the partitioning's, beside the axes and
   the two closures. `MeasureClosure` asks its suppression of the question and the
   position it is about rather than per axis; `ClosureGap.QuestionUnanswered`
   drops the `AxisId` nothing read; `Coverages` selects with an explicit
   `appliesTo` rather than owning.
7. The regression tests.

## What is left with no way back

No path from a question to the number it is about now goes through a boolean, a
re-derivation from the type, or an axis standing beside it. `Owed.Subject`,
`measured()` on the four records, and `Coverages.unansweredAt(Axis)` are all
gone.

## Not covered

`Time.minute` and `Time.second` declare bounds but no `TakenAs`, so the language
has no shape measured by two operations today. That two numbers at one path stay
two is asked of the identities each layer carries rather than of a model. A
source-level test wants a second operation declared for a shape, which is a
language change and not this issue's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
