### PR TITLE
A rule read to the end is not one this could not read

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseStates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseStates.java
@@ -60,6 +60,27 @@ sealed interface ClauseStates {
     record ARelation() implements ClauseStates {}
 
     /**
+     * The clause restricts no value of anything.
+     *
+     * <p>{@code lo - lo >= 0} holds of every row there is. The quantity it cuts is empty — the
+     * position cancels against itself — so there is no value of any position it admits or refuses,
+     * and nothing a measure of coverage could go and check.
+     *
+     * <p><b>Read off what the rule cuts and not off what the spelling names.</b> The position is
+     * written twice in that clause, so counted off the sides it is a rule about the position and
+     * raises the questions a rule about a position raises: which values may stand there, and where
+     * they stop. Nothing can answer either, because the rule states neither — so a clause this
+     * compiler read from end to end and understood completely came out as a question nobody had
+     * answered, and took the measurement to partial with it.
+     *
+     * <p>Its own state and not {@link SomethingElse} with an empty set of positions. That one is a
+     * clause about a position written in a shape this classification does not take further, and it
+     * carries the positions so that whatever reads the clause can be asked about them. This is a
+     * conclusion about the clause: it was read, and there is nothing in it to ask anybody about.
+     */
+    record NoRestriction() implements ClauseStates {}
+
+    /**
      * Something else: the values a rule names, a call, a pattern, an expression the terms do not
      * name.
      *
@@ -97,6 +118,9 @@ sealed interface ClauseStates {
             // A rule about a pair costs neither of them: what it says is not a set of one
             // position's values, so there is nothing about one for anything to have read.
             case ARelation _ -> Set.of();
+            // And a rule that restricts nothing costs nothing anywhere. Not the same as naming no
+            // position — this one names one and says nothing about it.
+            case NoRestriction _ -> Set.of();
         };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -76,7 +76,7 @@ public final class FieldDomains {
     private final List<InvariantChecker.Direct> directs;
     /** The rules saying where a coordinate's values stop that no end came out of — see
      * {@link #noLineAt}. */
-    private final List<NoLine> unread;
+    private final List<NoLine> noLines;
     /** What each clause reaching this value raises, keyed on the rule it is. */
     private final Map<RuleRef, Required> raised;
     /** The same per part of each clause. A reader that found one conjunct wanting names what that
@@ -143,7 +143,7 @@ public final class FieldDomains {
                          Map<String, ValueSet> admittedByField,
                          Map<String, UnreadReason> unreadByField,
                          Set<String> notSeparatedByField,
-                         List<InvariantChecker.Direct> directs, List<NoLine> unread,
+                         List<InvariantChecker.Direct> directs, List<NoLine> noLines,
                          Map<RuleRef, Required> raised,
                          Map<RuleRef, Map<Core, Required>> raisedByPart, ReadingEvidence took,
                          Map<String, List<TypeSymbol>> narrowers,
@@ -162,7 +162,7 @@ public final class FieldDomains {
         this.unreadByField = unreadByField;
         this.notSeparatedByField = notSeparatedByField;
         this.directs = directs;
-        this.unread = unread;
+        this.noLines = noLines;
         this.raised = raised;
         this.raisedByPart = raisedByPart;
         this.took = took;
@@ -770,7 +770,7 @@ public final class FieldDomains {
      */
     private RuleAccounting.Outcome unreadAnswerFor(RuleRef rule, Core part,
                                                    Owed.Subject.OfAPosition where) {
-        for (NoLine said : unread) {
+        for (NoLine said : noLines) {
             if (said.from().equals(rule) && said.part() == part
                     && said.path().equals(where.path())
                     && said.measured() == where.measured()
@@ -849,7 +849,7 @@ public final class FieldDomains {
      * silenced the record's clause about the same field.
      */
     public List<NoLine> noLineAt(String path) {
-        return unread.stream().filter(each -> each.path().equals(path)).toList();
+        return noLines.stream().filter(each -> each.path().equals(path)).toList();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -754,15 +754,30 @@ public final class FieldDomains {
         return new RuleAccounting.Outcome.Accounted(RuleAccounting.Reader.THE_END_READING);
     }
 
-    /** What the reading of ends said about the rule at this position, where it said anything. */
+    /**
+     * What the reading of ends said about the rule at this position, where it said anything.
+     *
+     * <p>Unanswered only where that reading stopped. A rule it read from end to end and drew no
+     * line from has answered the question that reading answers: the rule places no line, so there
+     * is none to be owed at, and a reader sent after it would be looking for a limit of this
+     * compiler that is not there.
+     *
+     * <p>Which is the second of two places that has to hold. A rule read to the end raises no such
+     * question in the first place ({@link ClauseStates.NoRestriction},
+     * {@link ClauseStates.ARelation}), so nothing reaches here to be answered this way — and the
+     * question being unaskable is what makes the answer unreachable rather than the other way
+     * about. Both are written, because the day one of them slips the other is what is left.
+     */
     private RuleAccounting.Outcome unreadAnswerFor(RuleRef rule, Core part,
                                                    Owed.Subject.OfAPosition where) {
         for (Unread said : unread) {
             if (said.from().equals(rule) && said.part() == part
                     && said.path().equals(where.path())
-                    && said.measured() == where.measured()) {
+                    && said.measured() == where.measured()
+                    && said.why() instanceof souther.compiler.inputs.BlockReason
+                            .RuleReadingStopped stopped) {
                 return new RuleAccounting.Outcome.Unaccounted(
-                        new RuleAccounting.Why.TheEndReadingSays(said.why()));
+                        new RuleAccounting.Why.TheEndReadingSays(stopped));
             }
         }
         return new RuleAccounting.Outcome.Accounted(RuleAccounting.Reader.THE_END_READING);

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -75,8 +75,8 @@ public final class FieldDomains {
      * leave — see {@link #placedAt}. */
     private final List<InvariantChecker.Direct> directs;
     /** The rules saying where a coordinate's values stop that no end came out of — see
-     * {@link #unreadAt}. */
-    private final List<Unread> unread;
+     * {@link #noLineAt}. */
+    private final List<NoLine> unread;
     /** What each clause reaching this value raises, keyed on the rule it is. */
     private final Map<RuleRef, Required> raised;
     /** The same per part of each clause. A reader that found one conjunct wanting names what that
@@ -143,7 +143,7 @@ public final class FieldDomains {
                          Map<String, ValueSet> admittedByField,
                          Map<String, UnreadReason> unreadByField,
                          Set<String> notSeparatedByField,
-                         List<InvariantChecker.Direct> directs, List<Unread> unread,
+                         List<InvariantChecker.Direct> directs, List<NoLine> unread,
                          Map<RuleRef, Required> raised,
                          Map<RuleRef, Map<Core, Required>> raisedByPart, ReadingEvidence took,
                          Map<String, List<TypeSymbol>> narrowers,
@@ -438,7 +438,7 @@ public final class FieldDomains {
      * @param why  what would have to change before this rule could be a line, in this compiler's
      *             own terms
      */
-    public record Unread(String path, ValueName by, RuleRef.Invariant from,
+    public record NoLine(String path, ValueName by, RuleRef.Invariant from,
                          Core part, souther.compiler.inputs.BlockReason.RuleWithoutLineReason why) {
 
         /** Whether it is a number taken of the position rather than its own values, derived for the
@@ -720,7 +720,7 @@ public final class FieldDomains {
      * What answered "where does the line fall" for one rule at one position.
      *
      * <p>The reading that turns a clause into an end, asked for its own account. It keeps one where
-     * a rule says where the values stop and no end came of it ({@link Unread}), so the absence of
+     * a rule says where the values stop and no end came of it ({@link NoLine}), so the absence of
      * one is the reading having got there: either it placed the end, or it read the rule to the end
      * and found the order stops past where the rule points. The second is the line understood and
      * not a reading that fell short — whether a value can be written at it is a question about
@@ -770,7 +770,7 @@ public final class FieldDomains {
      */
     private RuleAccounting.Outcome unreadAnswerFor(RuleRef rule, Core part,
                                                    Owed.Subject.OfAPosition where) {
-        for (Unread said : unread) {
+        for (NoLine said : unread) {
             if (said.from().equals(rule) && said.part() == part
                     && said.path().equals(where.path())
                     && said.measured() == where.measured()
@@ -848,7 +848,7 @@ public final class FieldDomains {
      * and an end there says nothing about this — read as one answer, a bound on a field's own type
      * silenced the record's clause about the same field.
      */
-    public List<Unread> unreadAt(String path) {
+    public List<NoLine> noLineAt(String path) {
         return unread.stream().filter(each -> each.path().equals(path)).toList();
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -374,7 +374,7 @@ public final class FieldDomains {
         positions.forEach(field ->
                 named(seeded, field).forEach(term -> placeOf.putIfAbsent(term, field)));
         return new FieldDomains(Map.copyOf(out), Map.copyOf(holds), Map.copyOf(admitted),
-                Map.copyOf(unread), Set.copyOf(notSeparated), seeded.reading().directs(), seeded.reading().unread(),
+                Map.copyOf(unread), Set.copyOf(notSeparated), seeded.reading().directs(), seeded.reading().noLines(),
                 seeded.reading().raised(), seeded.reading().raisedByPart(), seeded.took(),
                 seeded.reading().narrowers(),
                 seeded.notGathered(), placeOf,

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -439,7 +439,7 @@ public final class FieldDomains {
      *             own terms
      */
     public record Unread(String path, ValueName by, RuleRef.Invariant from,
-                         Core part, souther.compiler.inputs.BlockReason.AboutARule why) {
+                         Core part, souther.compiler.inputs.BlockReason.RuleWithoutLineReason why) {
 
         /** Whether it is a number taken of the position rather than its own values, derived for the
          *  reason {@link Placed#measured} gives. */

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1230,7 +1230,8 @@ public final class InvariantChecker {
                         PartsRead parts,
                         Map<RuleRef, Map<Core, Required>> raisedByPart) {
         if (!(clause instanceof Core.Binary bin)) {
-            settle(clause, from, states(clause, at, byName), new InvariantBound.Read.NoEnd(),
+            settle(clause, from, states(clause, at, byName, null),
+                    new InvariantBound.Read.NoEnd(),
                     at, byName, raised, took, typeAt, parts, raisedByPart);
             return;
         }
@@ -1243,7 +1244,8 @@ public final class InvariantChecker {
             return;
         }
         if (!InvariantBound.ordering(bin.op()) && bin.op() != BinOp.EQ) {
-            settle(bin, from, states(bin, at, byName), new InvariantBound.Read.NoEnd(),
+            settle(bin, from, states(bin, at, byName, arithmeticOf(bin, at, byName)),
+                    new InvariantBound.Read.NoEnd(),
                     at, byName, raised, took, typeAt, parts, raisedByPart);
             return;
         }
@@ -1272,7 +1274,10 @@ public final class InvariantChecker {
         // What the clause is about, asked of the comparison and not of what `end` came to. A
         // coordinate compared for order against something naming no other coordinate states where
         // the values stop, whether or not the number on the other side is one this could fold.
-        ClauseStates shape = states(bin, at, byName);
+        // Read once for this comparison and handed to both of the questions asked of it: what the
+        // clause states, and what a reader is left with where no end came of it.
+        Arithmetic read = arithmeticOf(bin, at, byName);
+        ClauseStates shape = states(bin, at, byName, read);
         // And nothing of this value on the other side. `ARelation` is only what
         // `Relates.twoPositions` recognises, which wants each whole side to be a position — so
         // `width <= height + 1` is not one, and read as a bound it raised a question about where
@@ -1304,7 +1309,7 @@ public final class InvariantChecker {
             // §example-partition). A position carries more than one statement, and an end read at
             // it says nothing about the rule beside it: kept as what the position was left with,
             // a bound on a field's own type swallowed the record's clause about the same field.
-            noLineDrawn(bin, from, at, byName, unread);
+            noLineDrawn(bin, from, at, byName, unread, read);
             // The declaration and not the clause. Which declaration took an edge in is what ADR-0090
             // names beside a line, and what a reader is sent to look at is the declaration holding
             // the relation.
@@ -1340,7 +1345,7 @@ public final class InvariantChecker {
      * raises, and is answered or not by whichever reading could take it in.
      */
     private ClauseStates states(Core clause, Denotations at,
-                                Map<FactSubject, Coordinate> byName) {
+                                Map<FactSubject, Coordinate> byName, Arithmetic read) {
         List<String> found = new ArrayList<>();
         namedIn(clause, at, byName, found);
         // What the rule cuts, ahead of what it looks like. Which values a rule restricts is settled
@@ -1360,7 +1365,8 @@ public final class InvariantChecker {
         // And only where the clause names a position at all. `1 >= 0` cuts nothing either, and it
         // is not a rule that restricts no value of this position — it is a rule about nowhere, said
         // by the one authority for that question, which is whether the value is mentioned.
-        if (!found.isEmpty() && clause instanceof Core.Binary bin && holdsOfEveryRow(bin, at, byName)) {
+        if (!found.isEmpty() && read != null && clause instanceof Core.Binary bin
+                && read.holdsOfEveryRow(bin.op())) {
             return new ClauseStates.NoRestriction();
         }
         if (Relates.twoPositions(clause, e -> {
@@ -1494,14 +1500,15 @@ public final class InvariantChecker {
      * came to, which is this reader's own way of looking a coordinate up.
      */
     private void noLineDrawn(Core.Binary comparison, RuleRef.Invariant from, Denotations at,
-                            Map<FactSubject, Coordinate> byName, List<FieldDomains.NoLine> out) {
+                            Map<FactSubject, Coordinate> byName, List<FieldDomains.NoLine> out,
+                            Arithmetic read) {
         if (!InvariantBound.ordering(comparison.op())) {
             return;
         }
         Places left = placesIn(comparison.left(), at, byName);
         Places right = placesIn(comparison.right(), at, byName);
         BlockReason.RuleWithoutLineReason why = UnreadComparison.why(left.origin(), right.origin(),
-                quantityOf(comparison, at, byName),
+                read.quantity(),
                 place -> carrierAt(place, left, right) != null);
         for (Coordinate each : coordinatesIn(comparison, at, byName)) {
             FieldDomains.NoLine said =
@@ -1513,64 +1520,67 @@ public final class InvariantChecker {
     }
 
     /**
-     * Whether this comparison holds of every row there is.
+     * What this reader's arithmetic made of one comparison, read once and projected twice.
      *
-     * <p>Two halves and both are needed. The positions have to cancel — what the canonical form
-     * cuts is empty, so no value of anything is either side of anything — and what is left of the
-     * comparison when they have cancelled has to be true. {@code lo - lo >= 0} is {@code 0 >= 0},
-     * which every row satisfies; {@code lo - lo >= 1} is {@code 0 >= 1}, which no row satisfies,
-     * and a rule that admits nothing is the opposite of one that restricts nothing. Read off the
-     * empty quantity alone, the two came out alike.
+     * <p>Two questions come off one reading. Which coordinates the quantity is over is what says
+     * whether a rule relates two positions or bounds one, and what is left when they cancel is what
+     * says whether the rule holds of every row. Read separately, each reader called the same
+     * arithmetic on the same two sides and the answers agreed only because the calls were the same
+     * — which is the shape this branch removed from {@link ComparisonAssessment} at the other
+     * producer, and put back here.
      *
-     * <p>Every comparison and not the orderings alone. Which operator is written is no part of
-     * whether a rule states anything: {@code lo - lo == 0} holds of every row exactly as the first
-     * one does, and an author who wrote it would have been told that which values may stand at
-     * {@code lo} is a question nothing answered. What the operator decides is what the residue has
-     * to be for the rule to hold, which is the switch below and nothing else.
-     *
-     * <p>The form read once, here, rather than through {@link #quantityOf}. That one answers which
-     * coordinates a quantity is over and throws the residue away, and the residue is half of this.
+     * @param quantity what the canonical form cuts, in the words {@link UnreadComparison} reads
+     * @param residue  what is left of {@code left - right} once the positions have cancelled, or
+     *                 null where the arithmetic stopped or a position is still in it
      */
-    private boolean holdsOfEveryRow(Core.Binary comparison, Denotations at,
-                                    Map<FactSubject, Coordinate> byName) {
-        if (!comparison.op().compares()) {
-            return false;
+    private record Arithmetic(UnreadComparison.Quantity<String> quantity,
+                              java.math.BigDecimal residue) {
+
+        /**
+         * Whether the comparison holds of every row there is.
+         *
+         * <p>Two halves and both are needed. The positions have to cancel — the quantity is empty,
+         * so no value of anything is either side of anything — and what is left has to be true.
+         * {@code lo - lo >= 0} is {@code 0 >= 0}, which every row satisfies; {@code lo - lo >= 1}
+         * is {@code 0 >= 1}, which no row satisfies, and a rule that admits nothing is the opposite
+         * of one that restricts nothing. Read off the empty quantity alone, the two came out alike.
+         *
+         * <p>Every comparison and not the orderings alone. Which operator is written is no part of
+         * whether a rule states anything: {@code lo - lo == 0} holds of every row exactly as the
+         * first one does, and an author who wrote it would have been told that which values may
+         * stand at {@code lo} is a question nothing answered. What the operator decides is what the
+         * residue has to be, which is the switch here and nothing else.
+         */
+        boolean holdsOfEveryRow(BinOp op) {
+            if (residue == null) {
+                return false;
+            }
+            int sign = residue.signum();
+            return switch (op) {
+                case GE -> sign >= 0;
+                case GT -> sign > 0;
+                case LE -> sign <= 0;
+                case LT -> sign < 0;
+                case EQ -> sign == 0;
+                case NE -> sign != 0;
+                case AND, OR, ADD, SUB, MUL, DIV, CONCAT -> false;
+            };
         }
-        AffineForms.Outcome<FactSubject, Denotations> left =
-                terms.outcomeOf(comparison.left(), at, byName::containsKey);
-        AffineForms.Outcome<FactSubject, Denotations> right =
-                terms.outcomeOf(comparison.right(), at, byName::containsKey);
-        if (!(left instanceof AffineForms.Outcome.Composed<FactSubject, Denotations> l)
-                || !(right instanceof AffineForms.Outcome.Composed<FactSubject, Denotations> r)) {
-            return false;   // the arithmetic stopped, so there is no residue to be sure about
-        }
-        NumericDomain.LinearForm<FactSubject> whole = l.form().minus(r.form());
-        if (!whole.coefs().isEmpty()) {
-            return false;
-        }
-        int residue = whole.constant().signum();
-        return switch (comparison.op()) {
-            case GE -> residue >= 0;
-            case GT -> residue > 0;
-            case LE -> residue <= 0;
-            case LT -> residue < 0;
-            case EQ -> residue == 0;
-            case NE -> residue != 0;
-            case AND, OR, ADD, SUB, MUL, DIV, CONCAT -> false;
-        };
     }
 
     /**
-     * The coordinates the quantity this clause cuts is over, or null where the arithmetic read no
-     * form at all.
+     * That reading, made once for a comparison, or null where the operator is not one.
      *
      * <p>This reader's own, because the atoms are: a clause names a coordinate of the value it is
      * written about. What is done with the answer is {@link UnreadComparison}'s, so a {@code guard}
      * of the same shape in a body two declarations away is described in the same words — which is
      * what {@code invariant Int.add(length.value, width.value) <= 150} and the guard beside it are.
      */
-    private UnreadComparison.Quantity<String> quantityOf(Core.Binary comparison, Denotations at,
-                                                         Map<FactSubject, Coordinate> byName) {
+    private Arithmetic arithmeticOf(Core.Binary comparison, Denotations at,
+                                    Map<FactSubject, Coordinate> byName) {
+        if (!comparison.op().compares()) {
+            return null;
+        }
         // Named against this reader's own coordinates rather than against every number the
         // discharge procedure can identify. A value that is a number and is no coordinate of the
         // subject is one the walk stops at, so the expression and its environment come back
@@ -1581,8 +1591,8 @@ public final class InvariantChecker {
                 terms.outcomeOf(comparison.right(), at, byName::containsKey);
         for (AffineForms.Outcome<FactSubject, Denotations> side : java.util.List.of(left, right)) {
             if (side instanceof AffineForms.Outcome.StoppedAt<FactSubject, Denotations> stopped) {
-                return new UnreadComparison.Quantity.NotRead<>(
-                        placesIn(stopped.node(), stopped.at(), byName).origin());
+                return new Arithmetic(new UnreadComparison.Quantity.NotRead<>(
+                        placesIn(stopped.node(), stopped.at(), byName).origin()), null);
             }
         }
         NumericDomain.LinearForm<FactSubject> whole =
@@ -1593,8 +1603,9 @@ public final class InvariantChecker {
         for (FactSubject atom : whole.coefs().keySet()) {
             over.add(byName.get(atom).path());
         }
-        return over.isEmpty() ? new UnreadComparison.Quantity.CutsNothing<>()
-                : new UnreadComparison.Quantity.Over<>(over);
+        return over.isEmpty()
+                ? new Arithmetic(new UnreadComparison.Quantity.CutsNothing<>(), whole.constant())
+                : new Arithmetic(new UnreadComparison.Quantity.Over<>(over), null);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1118,16 +1118,16 @@ public final class InvariantChecker {
                 new Coordinate(FieldDomains.Coordinate.takenBy(path, counted.by()),
                         Carrier.WHOLE)));
         List<Direct> out = new ArrayList<>();
-        List<FieldDomains.NoLine> unread = new ArrayList<>();
+        List<FieldDomains.NoLine> noLines = new ArrayList<>();
         Map<String, List<TypeSymbol>> narrowers = new LinkedHashMap<>();
         Map<RuleRef, Required> raised = new LinkedHashMap<>();
         Map<RuleRef, Map<Core, Required>> raisedByPart = new LinkedHashMap<>();
         stated.forEach(each ->
-                direct(each.clause(), each.from(), at, byName, out, unread, narrowers, raised,
+                direct(each.clause(), each.from(), at, byName, out, noLines, narrowers, raised,
                         took, typeAt, parts, raisedByPart));
         // Insertion order, kept: `Map.copyOf` iterates in an order salted once per JVM run, and
         // what a report prints for a position is these in the order the declaration writes them.
-        return new Reading(List.copyOf(out), List.copyOf(unread), Map.copyOf(narrowers),
+        return new Reading(List.copyOf(out), List.copyOf(noLines), Map.copyOf(narrowers),
                 java.util.Collections.unmodifiableMap(new LinkedHashMap<>(raised)),
                 java.util.Collections.unmodifiableMap(new LinkedHashMap<>(raisedByPart)));
     }
@@ -1223,7 +1223,7 @@ public final class InvariantChecker {
      */
     private void direct(Core clause, RuleRef.Invariant from, Denotations at,
                         Map<FactSubject, Coordinate> byName, List<Direct> out,
-                        List<FieldDomains.NoLine> unread,
+                        List<FieldDomains.NoLine> noLines,
                         Map<String, List<TypeSymbol>> narrowers,
                         Map<RuleRef, Required> raised, ReadingEvidence took,
                         Map<String, Type> typeAt,
@@ -1237,9 +1237,9 @@ public final class InvariantChecker {
         }
         if (bin.op() == BinOp.AND) {
             // One rule the author wrote, so what it raises is what its conjuncts raise together.
-            direct(bin.left(), from, at, byName, out, unread, narrowers, raised, took, typeAt,
+            direct(bin.left(), from, at, byName, out, noLines, narrowers, raised, took, typeAt,
                     parts, raisedByPart);
-            direct(bin.right(), from, at, byName, out, unread, narrowers, raised, took, typeAt,
+            direct(bin.right(), from, at, byName, out, noLines, narrowers, raised, took, typeAt,
                     parts, raisedByPart);
             return;
         }
@@ -1309,7 +1309,7 @@ public final class InvariantChecker {
             // §example-partition). A position carries more than one statement, and an end read at
             // it says nothing about the rule beside it: kept as what the position was left with,
             // a bound on a field's own type swallowed the record's clause about the same field.
-            noLineDrawn(bin, from, at, byName, unread, read);
+            noLineDrawn(bin, from, at, byName, noLines, read);
             // The declaration and not the clause. Which declaration took an edge in is what ADR-0090
             // names beside a line, and what a reader is sent to look at is the declaration holding
             // the relation.

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1089,7 +1089,7 @@ public final class InvariantChecker {
      *                  that found one conjunct wanting and reached for the rule's questions would
      *                  name the positions of the conjunct written beside it as well
      */
-    record Reading(List<Direct> directs, List<FieldDomains.NoLine> unread,
+    record Reading(List<Direct> directs, List<FieldDomains.NoLine> noLines,
                    Map<String, List<TypeSymbol>> narrowers,
                    Map<RuleRef, Required> raised,
                    Map<RuleRef, Map<Core, Required>> raisedByPart) {}

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1089,7 +1089,7 @@ public final class InvariantChecker {
      *                  that found one conjunct wanting and reached for the rule's questions would
      *                  name the positions of the conjunct written beside it as well
      */
-    record Reading(List<Direct> directs, List<FieldDomains.Unread> unread,
+    record Reading(List<Direct> directs, List<FieldDomains.NoLine> unread,
                    Map<String, List<TypeSymbol>> narrowers,
                    Map<RuleRef, Required> raised,
                    Map<RuleRef, Map<Core, Required>> raisedByPart) {}
@@ -1115,7 +1115,7 @@ public final class InvariantChecker {
         held.forEach((path, counted) -> byName.put(counted.atom(),
                 new Coordinate(path, counted.by(), Carrier.WHOLE)));
         List<Direct> out = new ArrayList<>();
-        List<FieldDomains.Unread> unread = new ArrayList<>();
+        List<FieldDomains.NoLine> unread = new ArrayList<>();
         Map<String, List<TypeSymbol>> narrowers = new LinkedHashMap<>();
         Map<RuleRef, Required> raised = new LinkedHashMap<>();
         Map<RuleRef, Map<Core, Required>> raisedByPart = new LinkedHashMap<>();
@@ -1220,7 +1220,7 @@ public final class InvariantChecker {
      */
     private void direct(Core clause, RuleRef.Invariant from, Denotations at,
                         Map<FactSubject, Coordinate> byName, List<Direct> out,
-                        List<FieldDomains.Unread> unread,
+                        List<FieldDomains.NoLine> unread,
                         Map<String, List<TypeSymbol>> narrowers,
                         Map<RuleRef, Required> raised, ReadingEvidence took,
                         Map<String, Type> typeAt,
@@ -1299,7 +1299,7 @@ public final class InvariantChecker {
             // §example-partition). A position carries more than one statement, and an end read at
             // it says nothing about the rule beside it: kept as what the position was left with,
             // a bound on a field's own type swallowed the record's clause about the same field.
-            unreadEnds(bin, from, at, byName, unread);
+            noLineDrawn(bin, from, at, byName, unread);
             // The declaration and not the clause. Which declaration took an edge in is what ADR-0090
             // names beside a line, and what a reader is sent to look at is the declaration holding
             // the relation.
@@ -1491,8 +1491,8 @@ public final class InvariantChecker {
      * cannot come to a different answer. What is read here is only what each side of the comparison
      * came to, which is this reader's own way of looking a coordinate up.
      */
-    private void unreadEnds(Core.Binary comparison, RuleRef.Invariant from, Denotations at,
-                            Map<FactSubject, Coordinate> byName, List<FieldDomains.Unread> out) {
+    private void noLineDrawn(Core.Binary comparison, RuleRef.Invariant from, Denotations at,
+                            Map<FactSubject, Coordinate> byName, List<FieldDomains.NoLine> out) {
         if (!InvariantBound.ordering(comparison.op())) {
             return;
         }
@@ -1502,8 +1502,8 @@ public final class InvariantChecker {
                 quantityOf(comparison, at, byName),
                 place -> carrierAt(place, left, right) != null);
         for (Coordinate each : coordinatesIn(comparison, at, byName)) {
-            FieldDomains.Unread said =
-                    new FieldDomains.Unread(each.path(), each.by(), from, comparison, why);
+            FieldDomains.NoLine said =
+                    new FieldDomains.NoLine(each.path(), each.by(), from, comparison, why);
             if (!out.contains(said)) {
                 out.add(said);
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1476,7 +1476,7 @@ public final class InvariantChecker {
         }
         Places left = placesIn(comparison.left(), at, byName);
         Places right = placesIn(comparison.right(), at, byName);
-        BlockReason.AboutARule why = UnreadComparison.why(left.origin(), right.origin(),
+        BlockReason.RuleWithoutLineReason why = UnreadComparison.why(left.origin(), right.origin(),
                 quantityOf(comparison, at, byName),
                 place -> carrierAt(place, left, right) != null);
         for (Coordinate each : coordinatesIn(comparison, at, byName)) {

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1355,9 +1355,7 @@ public final class InvariantChecker {
         // And only where the clause names a position at all. `1 >= 0` cuts nothing either, and it
         // is not a rule that restricts no value of this position — it is a rule about nowhere, said
         // by the one authority for that question, which is whether the value is mentioned.
-        if (!found.isEmpty() && clause instanceof Core.Binary bin
-                && InvariantBound.ordering(bin.op())
-                && quantityOf(bin, at, byName) instanceof UnreadComparison.Quantity.CutsNothing<?>) {
+        if (!found.isEmpty() && clause instanceof Core.Binary bin && holdsOfEveryRow(bin, at, byName)) {
             return new ClauseStates.NoRestriction();
         }
         if (Relates.twoPositions(clause, e -> {
@@ -1508,6 +1506,54 @@ public final class InvariantChecker {
                 out.add(said);
             }
         }
+    }
+
+    /**
+     * Whether this comparison holds of every row there is.
+     *
+     * <p>Two halves and both are needed. The positions have to cancel — what the canonical form
+     * cuts is empty, so no value of anything is either side of anything — and what is left of the
+     * comparison when they have cancelled has to be true. {@code lo - lo >= 0} is {@code 0 >= 0},
+     * which every row satisfies; {@code lo - lo >= 1} is {@code 0 >= 1}, which no row satisfies,
+     * and a rule that admits nothing is the opposite of one that restricts nothing. Read off the
+     * empty quantity alone, the two came out alike.
+     *
+     * <p>Every comparison and not the orderings alone. Which operator is written is no part of
+     * whether a rule states anything: {@code lo - lo == 0} holds of every row exactly as the first
+     * one does, and an author who wrote it would have been told that which values may stand at
+     * {@code lo} is a question nothing answered. What the operator decides is what the residue has
+     * to be for the rule to hold, which is the switch below and nothing else.
+     *
+     * <p>The form read once, here, rather than through {@link #quantityOf}. That one answers which
+     * coordinates a quantity is over and throws the residue away, and the residue is half of this.
+     */
+    private boolean holdsOfEveryRow(Core.Binary comparison, Denotations at,
+                                    Map<FactSubject, Coordinate> byName) {
+        if (!comparison.op().compares()) {
+            return false;
+        }
+        AffineForms.Outcome<FactSubject, Denotations> left =
+                terms.outcomeOf(comparison.left(), at, byName::containsKey);
+        AffineForms.Outcome<FactSubject, Denotations> right =
+                terms.outcomeOf(comparison.right(), at, byName::containsKey);
+        if (!(left instanceof AffineForms.Outcome.Composed<FactSubject, Denotations> l)
+                || !(right instanceof AffineForms.Outcome.Composed<FactSubject, Denotations> r)) {
+            return false;   // the arithmetic stopped, so there is no residue to be sure about
+        }
+        NumericDomain.LinearForm<FactSubject> whole = l.form().minus(r.form());
+        if (!whole.coefs().isEmpty()) {
+            return false;
+        }
+        int residue = whole.constant().signum();
+        return switch (comparison.op()) {
+            case GE -> residue >= 0;
+            case GT -> residue > 0;
+            case LE -> residue <= 0;
+            case LT -> residue < 0;
+            case EQ -> residue == 0;
+            case NE -> residue != 0;
+            case AND, OR, ADD, SUB, MUL, DIV, CONCAT -> false;
+        };
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1336,14 +1336,36 @@ public final class InvariantChecker {
      */
     private ClauseStates states(Core clause, Denotations at,
                                 Map<FactSubject, Coordinate> byName) {
+        List<Owed.Subject> found = new ArrayList<>();
+        namedIn(clause, at, byName, found);
+        // What the rule cuts, ahead of what it looks like. Which values a rule restricts is settled
+        // by the quantity its canonical form cuts, and that is the rule `UnreadComparison.why` is
+        // written around one layer down — asked of what the rule cuts, and of the sides only where
+        // that is unreadable. This reader was still asking the sides, so `lo - lo >= 0` came out as
+        // a rule about `lo` and raised the questions a rule about a position raises: which values
+        // may stand there, and where they stop. It states neither, so nothing could answer either.
+        //
+        // Only the empty quantity is read off here. A quantity over positions leaves which of them
+        // the rule is about to the walk, which reads the same clause with the same coordinates, and
+        // where the arithmetic read no quantity there is no fact to outrank a spelling with. The
+        // order is what matters: a semantic answer, wherever this reader has one, comes first — so
+        // the arithmetic growing able to read more moves this classification with it and nothing
+        // below has to be touched.
+        //
+        // And only where the clause names a position at all. `1 >= 0` cuts nothing either, and it
+        // is not a rule that restricts no value of this position — it is a rule about nowhere, said
+        // by the one authority for that question, which is whether the value is mentioned.
+        if (!found.isEmpty() && clause instanceof Core.Binary bin
+                && InvariantBound.ordering(bin.op())
+                && quantityOf(bin, at, byName) instanceof UnreadComparison.Quantity.CutsNothing<?>) {
+            return new ClauseStates.NoRestriction();
+        }
         if (Relates.twoPositions(clause, e -> {
             FactSubject named = nameOf(e, at);
             return named != null && byName.containsKey(named) ? named : null;
         })) {
             return new ClauseStates.ARelation();
         }
-        List<Owed.Subject> found = new ArrayList<>();
-        namedIn(clause, at, byName, found);
         return ClauseStates.SomethingElse.naming(found);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Required.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Required.java
@@ -145,7 +145,20 @@ public sealed interface Required {
          * position for anything to have read. A rule cannot cost a position it does not name, which
          * is what the reading of values says of its own failures for the same reason.
          */
-        IT_NAMES_NO_POSITION
+        IT_NAMES_NO_POSITION,
+
+        /**
+         * The rule names a position and restricts no value of it.
+         *
+         * <p>{@code lo - lo >= 0} holds of every row: the quantity it cuts is empty, so there is no
+         * value it admits or refuses anywhere and no question a measure of coverage could answer.
+         *
+         * <p>Its own word beside {@link #IT_NAMES_NO_POSITION}, which is a rule about nothing here
+         * at all. This one is written about a position — an author looking for why it costs the
+         * measurement nothing would not find it under a word saying their clause mentions no field
+         * of the value it is declared on.
+         */
+        IT_CONSTRAINS_NO_VALUE
     }
 
     /** What every invariant clause raises about a position it is written about. */
@@ -195,6 +208,8 @@ public sealed interface Required {
                             .map(Required::admittedValues).collect(java.util.stream.Collectors
                                     .toCollection(LinkedHashSet::new)));
             case ClauseStates.ARelation _ -> new Irrelevant(Set.of(Because.IT_RELATES_TWO_POSITIONS));
+            case ClauseStates.NoRestriction _ ->
+                    new Irrelevant(Set.of(Because.IT_CONSTRAINS_NO_VALUE));
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
@@ -197,8 +197,16 @@ public final class RuleAccounting {
             }
         }
 
-        /** The reading that turns a clause into an end a line can be drawn at. */
-        record TheEndReadingSays(souther.compiler.inputs.BlockReason.RuleWithoutLineReason why)
+        /**
+         * The reading that turns a clause into an end a line can be drawn at.
+         *
+         * <p>Only a reason that says that reading stopped. A rule it took in from end to end
+         * answered the question by being read — where it places no line, there is no line to be
+         * owed, and where it restricts no value there is nothing to be admitted. Held as either
+         * half, a rule this compiler understood completely was one nobody had accounted for, and
+         * the measurement went to partial on the strength of it.
+         */
+        record TheEndReadingSays(souther.compiler.inputs.BlockReason.RuleReadingStopped why)
                 implements Why {
 
             public TheEndReadingSays {

--- a/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RuleAccounting.java
@@ -198,7 +198,7 @@ public final class RuleAccounting {
         }
 
         /** The reading that turns a clause into an end a line can be drawn at. */
-        record TheEndReadingSays(souther.compiler.inputs.BlockReason.AboutARule why)
+        record TheEndReadingSays(souther.compiler.inputs.BlockReason.RuleWithoutLineReason why)
                 implements Why {
 
             public TheEndReadingSays {

--- a/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UnreadComparison.java
@@ -128,7 +128,7 @@ public final class UnreadComparison {
      *                Asked of the reader because a position is looked up there, and asked at all
      *                only about a side that is one
      */
-    public static <K> BlockReason.AboutARule why(ValueOrigin<K> left, ValueOrigin<K> right,
+    public static <K> BlockReason.RuleWithoutLineReason why(ValueOrigin<K> left, ValueOrigin<K> right,
                                                  Quantity<K> quantity, Predicate<K> ordered) {
         // What the rule cuts, where the arithmetic could be read at all. A quantity over
         // more than one position divides none of them — which values of one are on which
@@ -157,7 +157,7 @@ public final class UnreadComparison {
      * <p>Only here. Where the canonical form was read it has already said what the rule cuts, and a
      * spelling saying otherwise is the spelling being wrong about the rule.
      */
-    private static <K> BlockReason.AboutARule whatTheSidesSay(ValueOrigin<K> left,
+    private static <K> BlockReason.RuleWithoutLineReason whatTheSidesSay(ValueOrigin<K> left,
                                                               ValueOrigin<K> right,
                                                               Quantity.NotRead<K> notRead,
                                                               Predicate<K> ordered) {
@@ -201,7 +201,7 @@ public final class UnreadComparison {
     }
 
     /** What one side leaves to say. */
-    private static <K> BlockReason.AboutARule whatThisSideSays(ValueOrigin<K> side,
+    private static <K> BlockReason.RuleWithoutLineReason whatThisSideSays(ValueOrigin<K> side,
                                                                Predicate<K> ordered) {
         return switch (side) {
             // The position itself against something no end came out of. The carrier, asked of the

--- a/souther-compiler/src/main/java/souther/compiler/inputs/BlockReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/BlockReason.java
@@ -24,14 +24,41 @@ import souther.compiler.check.CoverageObligation;
 public sealed interface BlockReason {
 
     /**
-     * A rule this read and could not use, which is a reason there is always a rule to name.
+     * This compiler fell short of something, whatever it was short of.
+     *
+     * <p>Two questions and not one tree. "Is there a rule to name?" and "did this compiler get to
+     * the end of what it was reading?" are asked by different callers about the same set of
+     * reasons, and the answers cut across each other: a rule this got partway through is both a
+     * rule with no line and a shortfall, a rule read from end to end that divides nothing is the
+     * first and not the second, and a position whose rules were never reached is the second and not
+     * the first. Written as one hierarchy, whichever question the tree was shaped by, the other one
+     * has to be asked by reading the reason and deciding — and a caller that decides wrong cannot
+     * be stopped by anything.
+     *
+     * <p>So the two are capabilities and a reason implements what is true of it. A parameter typed
+     * here takes exactly the reasons a reading that stopped can produce, and
+     * {@link RuleWithoutLineReason} takes exactly the ones that leave a rule without a line. What
+     * used to be a comment saying which reasons a caller must not be handed is now the parameter
+     * type.
+     */
+    sealed interface ReadingStopReason extends BlockReason {}
+
+    /**
+     * A rule of the model that is no line at a position it is about, however that came about.
      *
      * <p>Whose rule it is, is the producer's to carry. What this says is that there is one: a
-     * comparison was written, a reader took it apart as far as it goes, and what stopped it is a
-     * fact about that rule and this compiler. So a finding built on one of these owes an identity
-     * for the rule, and the type is what makes owing it unavoidable.
+     * comparison was written, a reader took it apart, and what came of it is a fact about that rule
+     * — either about how far this compiler got with it, or about what the rule itself places. So a
+     * finding built on one of these owes an identity for the rule, and the type is what makes owing
+     * it unavoidable.
+     *
+     * <p><b>Named for what is true of every one of them, and not for either cause.</b> The two
+     * halves under this are opposite sentences about this compiler, and a name taken from one of
+     * them made the other unsayable: carried as rules this could not read, a rule read from end to
+     * end went out under a word meaning nobody had managed to read it. What they share is the
+     * observable predicate — this rule has no line here — and that is what the name says.
      */
-    sealed interface AboutARule extends BlockReason {
+    sealed interface RuleWithoutLineReason extends BlockReason {
 
         /**
          * Whether {@code measure} is thereby short of something.
@@ -46,8 +73,8 @@ public sealed interface BlockReason {
     }
 
     /**
-     * A rule a reading stopped on, which is the half of {@link AboutARule} that says this compiler
-     * fell short.
+     * A rule a reading stopped on, which is the half of {@link RuleWithoutLineReason} that says
+     * this compiler fell short.
      *
      * <p>Told apart by the type because the two halves are opposite sentences and were one set. A
      * reading that stopped leaves whatever the rule states unknown; a rule read to the end that
@@ -59,8 +86,13 @@ public sealed interface BlockReason {
      * a rule would have raised is exactly the part that was not read, so an obligation cannot be
      * built from it; that the model is thereby short of something is what {@link #leavesShort} says
      * instead.
+     *
+     * <p><b>The one reason in both capabilities.</b> A rule this got partway through is a rule with
+     * no line here, and it is also this compiler having fallen short — so it is the only member of
+     * {@link ReadingStopReason} that names a rule, and the only member of
+     * {@link RuleWithoutLineReason} a caller asking about a stop may be handed.
      */
-    sealed interface ReadingStopped extends AboutARule {
+    sealed interface RuleReadingStopped extends RuleWithoutLineReason, ReadingStopReason {
 
         /**
          * <p><b>Two switches and no {@code default} on either.</b> Asked per measure rather than
@@ -99,8 +131,14 @@ public sealed interface BlockReason {
      * <p>No measure is short of anything here, and that is what makes them one half rather than
      * three reasons that happen to agree. A rule that was read has had whatever it places placed by
      * the reading that placed it, and where it places none there is none to be owed.
+     *
+     * <p><b>Not a {@link ReadingStopReason}, and that is the whole of what the type is for.</b>
+     * Nothing here is a stop, so nothing here may reach a caller asking what stopped a reading —
+     * an accounting that calls such a rule unanswered, a claim that calls it unread, a value
+     * reading that reports itself partial on its account. Each of those was reachable while one
+     * type stood for both halves.
      */
-    sealed interface ReadButDidNotDivideAPosition extends AboutARule {
+    sealed interface ReadToEndWithoutLine extends RuleWithoutLineReason {
 
         @Override
         default boolean leavesShort(CoverageObligation.Measure measure) {
@@ -116,8 +154,12 @@ public sealed interface BlockReason {
      * author wrote, and a finding built on one names the position and nothing else. Told apart from
      * the above by the type, because the two used to be one set and a report could name a rule for
      * some of them and not the rest with nothing saying which was which.
+     *
+     * <p>Every one of these is a stop. There is no reading that arrives at the end of a position's
+     * rules and reports one of these, so this whole half sits inside {@link ReadingStopReason} and
+     * the two questions meet only at {@link RuleReadingStopped}.
      */
-    sealed interface AboutThePosition extends BlockReason {}
+    sealed interface AboutThePosition extends ReadingStopReason {}
 
     /**
      * What a value reading's account of a rule it could not use comes to here.
@@ -134,7 +176,7 @@ public sealed interface BlockReason {
      * about, so a caller here would be naming one it does not have — which is the whole of what
      * {@link AboutThePosition} is beside this for.
      */
-    static AboutARule ofARuleTheValueReadingLeft(souther.compiler.values.UnreadReason why) {
+    static RuleWithoutLineReason ofARuleTheValueReadingLeft(souther.compiler.values.UnreadReason why) {
         return switch (why) {
             case RELATES_TWO_POSITIONS -> new ComparisonBetweenPositions();
             case FORM_NOT_READ, ALTERNATIVE_NOT_READ -> new UnreadValueRule();
@@ -187,11 +229,11 @@ public sealed interface BlockReason {
      * producers of one kind of evidence (spec §example-partition), and what stopped each of them is
      * the same fact about this compiler.
      */
-    record UnreadComparisonForm() implements ReadingStopped {}
+    record UnreadComparisonForm() implements RuleReadingStopped {}
 
     /** A comparison naming the position is against values no line is drawn on here — the carrier,
      *  asked of the carrier. */
-    record UnreadComparisonDomain() implements ReadingStopped {}
+    record UnreadComparisonDomain() implements RuleReadingStopped {}
 
     /**
      * A rule is written about a value that came from the position rather than about the position.
@@ -206,7 +248,7 @@ public sealed interface BlockReason {
      * is not the difficulty. It is here at all so that such a rule is not silent: read as nothing,
      * a model whose predicate this cannot follow is one that states no rule.
      */
-    record RuleAboutADerivedValue() implements ReadingStopped {}
+    record RuleAboutADerivedValue() implements RuleReadingStopped {}
 
     /**
      * A rule naming which values the position may hold is written in a form no reader here takes
@@ -218,7 +260,7 @@ public sealed interface BlockReason {
      * different work — one wants a wider fragment of comparison forms, and one wants a reading of
      * values that follows a rule into a shape it does not enter today.
      */
-    record UnreadValueRule() implements ReadingStopped {}
+    record UnreadValueRule() implements RuleReadingStopped {}
 
     /**
      * The reading of what the position may hold never reached the rules about it.
@@ -245,7 +287,7 @@ public sealed interface BlockReason {
      * not a reader for an expression but a rule for which coordinate wins, and an author told the
      * first would go looking for a syntax this compiler handles perfectly well.
      */
-    record CompetingCoordinates() implements ReadingStopped {}
+    record CompetingCoordinates() implements RuleReadingStopped {}
 
     /**
      * The comparison was read to the end and cuts no quantity at all.
@@ -258,7 +300,7 @@ public sealed interface BlockReason {
      * not read. The two were one absence and so one word, and a rule this compiler had read from
      * end to end was reported as one whose spelling defeated it.
      */
-    record ComparisonCuttingNothing() implements ReadButDidNotDivideAPosition {}
+    record ComparisonCuttingNothing() implements ReadToEndWithoutLine {}
 
     /**
      * The comparison was read to the end, the quantity it cuts was found, and the line it draws
@@ -272,7 +314,7 @@ public sealed interface BlockReason {
      * quantity to cut, and here it has one and cuts outside it. Read as a rule this compiler could
      * not take in, an author was sent after a limit that is not there.
      */
-    record ComparisonCuttingOutsideDomain() implements ReadButDidNotDivideAPosition {}
+    record ComparisonCuttingOutsideDomain() implements ReadToEndWithoutLine {}
 
     /**
      * The comparison relates two positions rather than dividing one.
@@ -282,7 +324,7 @@ public sealed interface BlockReason {
      * partition of one is not — so a line like this is settled beside the partition rather than in
      * it, and the position it names is left with no class of its own from this rule.
      */
-    record ComparisonBetweenPositions() implements ReadButDidNotDivideAPosition {}
+    record ComparisonBetweenPositions() implements ReadToEndWithoutLine {}
 
     /**
      * What a derivation would have to be able to reach into.

--- a/souther-compiler/src/main/java/souther/compiler/inputs/BlockReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/BlockReason.java
@@ -109,11 +109,13 @@ public sealed interface BlockReason {
                 // bounded it, and nothing knows which — so both.
                 case PARTITION -> switch (this) {
                     case UnreadComparisonForm _, UnreadComparisonDomain _, RuleAboutADerivedValue _,
-                         UnreadValueRule _, CompetingCoordinates _ -> true;
+                         UnreadValueRule _, ValueRuleRelatingTwoPositions _,
+                         CompetingCoordinates _ -> true;
                 };
                 case BOUNDARY -> switch (this) {
                     case UnreadComparisonForm _, UnreadComparisonDomain _, RuleAboutADerivedValue _,
-                         UnreadValueRule _, CompetingCoordinates _ -> true;
+                         UnreadValueRule _, ValueRuleRelatingTwoPositions _,
+                         CompetingCoordinates _ -> true;
                 };
             };
         }
@@ -164,21 +166,29 @@ public sealed interface BlockReason {
     /**
      * What a value reading's account of a rule it could not use comes to here.
      *
-     * <p>The one place the two vocabularies meet, so a reader holding a reading's completeness and
-     * one holding a block reason cannot come to different words for one stop. A relation between
-     * two positions is what {@link ComparisonBetweenPositions} already says, whichever rule wrote
-     * it: a {@code guard} comparing two inputs and an {@code invariant} relating two fields leave a
-     * reader the same thing to know. The other is its own, because what would lift it is different
-     * work — a reader for a form rather than a gathering that reaches further.
+     * <p><b>Every one of them is a stop, and that is a fact about this reading rather than about
+     * the rule.</b> What is held at a position is a set of its own values, and every arm of
+     * {@link souther.compiler.values.UnreadReason} widens it — a position carrying one of them
+     * admits what the reading arrived at and may admit fewer. So a caller here is being told this
+     * compiler fell short, whichever rule shape it fell short on.
+     *
+     * <p>Which is why a relation between two positions is {@link ValueRuleRelatingTwoPositions}
+     * here and {@link ComparisonBetweenPositions} where a line is drawn. One rule, two readings,
+     * two answers, and both are true: the reading of ends took {@code a < b} in completely and
+     * placed no line, and the reading of values could not turn it into a set of one position's
+     * values at all. Written as one reason, the second was reported in the words of the first —
+     * that nothing fell short — over a position whose values are an upper bound. A word out there
+     * is not what splits: {@link ReportedReason} sends both to the one the document has, so a
+     * reader holding either still meets one vocabulary.
      *
      * <p>{@link souther.compiler.values.UnreadReason#NOT_REACHED} is refused rather than answered.
      * A reading that never arrived at the rules of a position is holding no rule for this to be
      * about, so a caller here would be naming one it does not have — which is the whole of what
      * {@link AboutThePosition} is beside this for.
      */
-    static RuleWithoutLineReason ofARuleTheValueReadingLeft(souther.compiler.values.UnreadReason why) {
+    static RuleReadingStopped ofARuleTheValueReadingLeft(souther.compiler.values.UnreadReason why) {
         return switch (why) {
-            case RELATES_TWO_POSITIONS -> new ComparisonBetweenPositions();
+            case RELATES_TWO_POSITIONS -> new ValueRuleRelatingTwoPositions();
             case FORM_NOT_READ, ALTERNATIVE_NOT_READ -> new UnreadValueRule();
             case NOT_REACHED -> throw new IllegalArgumentException(
                     "a reading that did not reach the rules of a position holds no rule to say"
@@ -193,8 +203,12 @@ public sealed interface BlockReason {
      * to "why is there nothing here", and which of them it is decides what a report may go on to
      * say rather than whether the reading stopped. Written in terms of the one above, so the
      * classification is stated once.
+     *
+     * <p>A stop either way, which the type says. A value reading has no way of finishing and
+     * leaving a rule without a line — that is the reading of ends' answer to give — so nothing this
+     * returns may reach a caller as a rule read from end to end.
      */
-    static BlockReason of(souther.compiler.values.UnreadReason why) {
+    static ReadingStopReason of(souther.compiler.values.UnreadReason why) {
         return why == souther.compiler.values.UnreadReason.NOT_REACHED
                 ? new ValueRulesNotReached() : ofARuleTheValueReadingLeft(why);
     }
@@ -261,6 +275,24 @@ public sealed interface BlockReason {
      * values that follows a rule into a shape it does not enter today.
      */
     record UnreadValueRule() implements RuleReadingStopped {}
+
+    /**
+     * A rule about the position says how it stands against another position, and what is held here
+     * is a set of this position's own values.
+     *
+     * <p>The reading of values could not turn the rule into one, so what it arrived at is an upper
+     * bound: a value it holds may be one no row can take, and a value it does not hold is still
+     * one no rule admits. That is a stop, and every arm of
+     * {@link souther.compiler.values.UnreadReason} is one for the same reason.
+     *
+     * <p><b>Its own case and not {@link ComparisonBetweenPositions}, which is the other reading's
+     * answer for the same rule.</b> Nothing about {@code a < b} was beyond the reading of ends: it
+     * took the rule in whole and placed no line, and no measure is short of anything on its
+     * account. The reading of values met the same rule and got nothing it could hold. One reason
+     * for both said the second in the words of the first — that the rule was read and nothing is
+     * missing — over a position whose values this compiler cannot state.
+     */
+    record ValueRuleRelatingTwoPositions() implements RuleReadingStopped {}
 
     /**
      * The reading of what the position may hold never reached the rules about it.

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Crossing.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Crossing.java
@@ -70,13 +70,13 @@ final class Crossing {
     /**
      * What stopped the values reading, in the vocabulary a report is projected from.
      *
-     * <p>A relation between two positions is what {@link BlockReason.ComparisonBetweenPositions}
-     * already says, whichever rule wrote it: a {@code guard} comparing two inputs and an
-     * {@code invariant} relating two fields leave a reader the same thing to know. The other two
-     * are their own, because what would lift each is different work — one wants a reader for a form,
-     * and one wants the gathering to reach further.
+     * <p>A stop, and the type says so. Every arm of {@link souther.compiler.values.UnreadReason}
+     * leaves the values here an upper bound, including the one for a rule the reading of ends took
+     * in whole — {@code a < b} places no line and is no shortfall there, and here it is a rule this
+     * could not turn into a set of one position's values at all. What each of them would take to
+     * lift is different work, which is why they stay apart rather than becoming one word.
      */
-    static BlockReason stopped(souther.compiler.values.UnreadReason why) {
+    static BlockReason.ReadingStopReason stopped(souther.compiler.values.UnreadReason why) {
         return BlockReason.of(why);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Crossing.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Crossing.java
@@ -42,7 +42,7 @@ final class Crossing {
      *
      * @param within   what the rules leave the position's numbers, or null where nothing bounds them
      * @param admitted which values the position may hold, and how much of its rules was read
-     * @param unread   a rule about this position that this compiler got partway through, or null
+     * @param stopped  a rule about this position that this compiler got partway through, or null
      *                 where there is none. A rule that went unread can refuse a distinction as
      *                 readily as one that was read, so it is what keeps an admission from being
      *                 claimed here — and a rule read from end to end cannot be that, which is why
@@ -52,12 +52,12 @@ final class Crossing {
      */
     static ReadingResult of(List<Case> declared, TypeView view, NumericDomain.Bounds within,
                             AdmissibleSet admitted, Symbols symbols,
-                            BlockReason.RuleReadingStopped unread) {
+                            BlockReason.RuleReadingStopped stopped) {
         List<Case> kept = admits(constructibleWithin(declared, view, within, symbols), admitted);
         List<Case> refused = new ArrayList<>(declared);
         refused.removeAll(kept);
         BlockReason.ReadingStopReason why =
-                admitted.whyPartial() != null ? stopped(admitted.whyPartial()) : unread;
+                admitted.whyPartial() != null ? stopped(admitted.whyPartial()) : stopped;
         if (why != null) {
             // A rule left standing is said ahead of what the reading could not hold together, and
             // both may be true of one position. What a caller does about them is the same — the

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Crossing.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Crossing.java
@@ -42,17 +42,22 @@ final class Crossing {
      *
      * @param within   what the rules leave the position's numbers, or null where nothing bounds them
      * @param admitted which values the position may hold, and how much of its rules was read
-     * @param unread   a rule about this position's own values that this reading could not turn into
-     *                 an end, or null where there is none. A rule that went unread can refuse a
-     *                 distinction as readily as one that was read, so it is what keeps an admission
-     *                 from being claimed here
+     * @param unread   a rule about this position that this compiler got partway through, or null
+     *                 where there is none. A rule that went unread can refuse a distinction as
+     *                 readily as one that was read, so it is what keeps an admission from being
+     *                 claimed here — and a rule read from end to end cannot be that, which is why
+     *                 the type takes only the stops. Handed a rule that placed no line because it
+     *                 relates two positions, this called the reading partial over a position
+     *                 nothing had been short of
      */
     static ReadingResult of(List<Case> declared, TypeView view, NumericDomain.Bounds within,
-                            AdmissibleSet admitted, Symbols symbols, BlockReason unread) {
+                            AdmissibleSet admitted, Symbols symbols,
+                            BlockReason.RuleReadingStopped unread) {
         List<Case> kept = admits(constructibleWithin(declared, view, within, symbols), admitted);
         List<Case> refused = new ArrayList<>(declared);
         refused.removeAll(kept);
-        BlockReason why = admitted.whyPartial() != null ? stopped(admitted.whyPartial()) : unread;
+        BlockReason.ReadingStopReason why =
+                admitted.whyPartial() != null ? stopped(admitted.whyPartial()) : unread;
         if (why != null) {
             // A rule left standing is said ahead of what the reading could not hold together, and
             // both may be true of one position. What a caller does about them is the same — the

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -634,11 +634,11 @@ public final class InputDomain {
                                          NumericDomain.Bounds admissible, AdmissibleSet admitted,
                                          Symbols symbols, List<UnreadRule> unread,
                                          boolean nothingExists, Type type) {
-        BlockReason unreadable = Distinctions.unreadableAt(view);
+        BlockReason.AboutThePosition unreadable = Distinctions.unreadableAt(view);
         if (unreadable != null) {
             return new ReadingResult.Unsupported(unreadable);
         }
-        BlockReason here = unread.isEmpty() ? null : unread.get(0).why();
+        BlockReason.RuleReadingStopped here = stoppedOn(unread);
         if (!declared.isEmpty()) {
             return Crossing.of(declared, view, admissible, admitted, symbols, here);
         }
@@ -648,14 +648,38 @@ public final class InputDomain {
         // value of it for a rule to have named.
         List<Case> named = nothingExists ? List.of()
                 : Distinctions.ofValues(admitted.approximation(), type, symbols);
-        BlockReason why = admitted.whyPartial() != null ? Crossing.stopped(admitted.whyPartial())
-                : here;
+        BlockReason.ReadingStopReason why = admitted.whyPartial() != null
+                ? Crossing.stopped(admitted.whyPartial()) : here;
         if (why != null) {
             return new ReadingResult.Partial(named, List.of(), why);
         }
         return admitted.alternativesNotSeparated()
                 ? new ReadingResult.NotSeparated(named, List.of())
                 : new ReadingResult.Complete(named, List.of());
+    }
+
+    /**
+     * A rule at this position that this compiler got partway through, or null where there is none.
+     *
+     * <p>What such a rule costs the reading is everything it would have said, so a position holding
+     * one has values this cannot claim are what the rules leave. That is what a caller does with
+     * this, and it is why the rules read from end to end are not here: a rule that placed no line
+     * because it relates two positions, or because its quantity is empty, was taken in whole and
+     * takes nothing back. Handed one of those, the reading called itself partial over a position
+     * nothing had been short of, and every claim about its cases came back unsettled because a rule
+     * went unread.
+     *
+     * <p>The first, and the rest say the same thing. Any one of them costs the reading the same —
+     * the values are an upper bound and there is no more or less of that — and which rule to go and
+     * look at is the finding's to say, one per rule, where they are all named.
+     */
+    private static BlockReason.RuleReadingStopped stoppedOn(List<UnreadRule> unread) {
+        for (UnreadRule each : unread) {
+            if (each.why() instanceof BlockReason.RuleReadingStopped stopped) {
+                return stopped;
+            }
+        }
+        return null;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -599,9 +599,11 @@ public final class InputDomain {
         // own type draws a line, because a clause relating two fields is not a partition of one.
         NumericDomain.Bounds admissible = nothingExists ? null
                 : TypeBounds.admissible(own, projected, term);
-        List<RuleWithoutALine> unread = rulesWithoutALineAt(placed, path, type, symbols, competing);
+        List<RuleWithoutALine> withoutALine =
+                rulesWithoutALineAt(placed, path, type, symbols, competing);
 
-        ReadingResult reading = crossed(declared, view, admissible, admitted, symbols, unread,
+        ReadingResult reading = crossed(declared, view, admissible, admitted, symbols,
+                withoutALine,
                 nothingExists, type);
         return new ReadPosition(path, view, term, admissible, own, projected,
                 // Where the position actually stops, which the ends as written do not say: a clause
@@ -612,7 +614,7 @@ public final class InputDomain {
                 placed.projection(), declared, reading,
                 ObligationDomain.of(reading, declared), admitted.completeness(),
                 admitted.whyPartial() == null ? null : Crossing.stopped(admitted.whyPartial()),
-                unread,
+                withoutALine,
                 // What the rules of this position raise that nothing answered. Asked of the
                 // accounting rather than read off the completeness beside it: one reading being
                 // short of a position's rules is that reading's business, and a rule another
@@ -640,13 +642,14 @@ public final class InputDomain {
      */
     private static ReadingResult crossed(List<Case> declared, TypeView view,
                                          NumericDomain.Bounds admissible, AdmissibleSet admitted,
-                                         Symbols symbols, List<RuleWithoutALine> unread,
+                                         Symbols symbols,
+                                         List<RuleWithoutALine> withoutALine,
                                          boolean nothingExists, Type type) {
         BlockReason.AboutThePosition unreadable = Distinctions.unreadableAt(view);
         if (unreadable != null) {
             return new ReadingResult.Unsupported(unreadable);
         }
-        BlockReason.RuleReadingStopped here = stoppedOn(unread);
+        BlockReason.RuleReadingStopped here = stoppedOn(withoutALine);
         if (!declared.isEmpty()) {
             return Crossing.of(declared, view, admissible, admitted, symbols, here);
         }
@@ -681,8 +684,8 @@ public final class InputDomain {
      * the values are an upper bound and there is no more or less of that — and which rule to go and
      * look at is the finding's to say, one per rule, where they are all named.
      */
-    private static BlockReason.RuleReadingStopped stoppedOn(List<RuleWithoutALine> unread) {
-        for (RuleWithoutALine each : unread) {
+    private static BlockReason.RuleReadingStopped stoppedOn(List<RuleWithoutALine> rules) {
+        for (RuleWithoutALine each : rules) {
             if (each.why() instanceof BlockReason.RuleReadingStopped stopped) {
                 return stopped;
             }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -554,7 +554,7 @@ public final class InputDomain {
         // dropped and from the list that still holds them, because this is the one place that knows
         // which rules they were — recovered afterwards from a position with no axis, the finding
         // could name the position and nothing else, which is what it is for.
-        List<UnreadRule> competing = List.of();
+        List<RuleWithoutALine> competing = List.of();
         if (undecidable(ofType, valueOfType, stated, taken, carried)) {
             competing = competingCoordinates(stated, path, type, symbols);
             stated = List.of();
@@ -588,7 +588,7 @@ public final class InputDomain {
         // own type draws a line, because a clause relating two fields is not a partition of one.
         NumericDomain.Bounds admissible = nothingExists ? null
                 : TypeBounds.admissible(own, projected, term);
-        List<UnreadRule> unread = unreadRulesAt(placed, path, type, symbols, competing);
+        List<RuleWithoutALine> unread = rulesWithoutALineAt(placed, path, type, symbols, competing);
 
         ReadingResult reading = crossed(declared, view, admissible, admitted, symbols, unread,
                 nothingExists, type);
@@ -632,7 +632,7 @@ public final class InputDomain {
      */
     private static ReadingResult crossed(List<Case> declared, TypeView view,
                                          NumericDomain.Bounds admissible, AdmissibleSet admitted,
-                                         Symbols symbols, List<UnreadRule> unread,
+                                         Symbols symbols, List<RuleWithoutALine> unread,
                                          boolean nothingExists, Type type) {
         BlockReason.AboutThePosition unreadable = Distinctions.unreadableAt(view);
         if (unreadable != null) {
@@ -673,8 +673,8 @@ public final class InputDomain {
      * the values are an upper bound and there is no more or less of that — and which rule to go and
      * look at is the finding's to say, one per rule, where they are all named.
      */
-    private static BlockReason.RuleReadingStopped stoppedOn(List<UnreadRule> unread) {
-        for (UnreadRule each : unread) {
+    private static BlockReason.RuleReadingStopped stoppedOn(List<RuleWithoutALine> unread) {
+        for (RuleWithoutALine each : unread) {
             if (each.why() instanceof BlockReason.RuleReadingStopped stopped) {
                 return stopped;
             }
@@ -715,12 +715,12 @@ public final class InputDomain {
      * their clauses are in the way. A rule placing two ends is one rule and one finding, which is
      * what the key settles.
      */
-    private static List<UnreadRule> competingCoordinates(List<FieldDomains.Placed> stated,
+    private static List<RuleWithoutALine> competingCoordinates(List<FieldDomains.Placed> stated,
                                                          TermPath path, Type type,
                                                          Symbols symbols) {
-        List<UnreadRule> out = new ArrayList<>();
+        List<RuleWithoutALine> out = new ArrayList<>();
         for (FieldDomains.Placed each : stated) {
-            UnreadRule said = new UnreadRule(each.from(),
+            RuleWithoutALine said = new RuleWithoutALine(each.from(),
                     souther.compiler.check.RuleCitation.named(each.from()),
                     // Each rule at the coordinate that rule is about, which is what makes the two
                     // two. What is undecided is which of them the position is measured at, and that
@@ -805,7 +805,7 @@ public final class InputDomain {
      * saying so — a bound it dropped left the position looking like one no rule bounds, which is
      * what the declaration above it denies.
      *
-     * <p>Read off the one reading that draws lines from clauses ({@link FieldDomains#unreadAt}) and
+     * <p>Read off the one reading that draws lines from clauses ({@link FieldDomains#noLineAt}) and
      * not walked again here. A second walk over the position's own type answered for the clauses
      * written on it and knew nothing of the clauses written on the value it sits in, so a record's
      * rule about one of its fields was dropped in silence; and where both had something to say
@@ -816,17 +816,17 @@ public final class InputDomain {
      * to rewrite is what an author acts on, and a position is not it. Kept per reason, the second
      * of them was dropped as a repeat of the first.
      */
-    private static List<UnreadRule> unreadRulesAt(PlacedRules placed, TermPath path, Type type,
-                                                  Symbols symbols, List<UnreadRule> competing) {
-        List<UnreadRule> out = new ArrayList<>(competing);
-        for (FieldDomains.Unread each : placed.unreadAt(path)) {
+    private static List<RuleWithoutALine> rulesWithoutALineAt(PlacedRules placed, TermPath path, Type type,
+                                                  Symbols symbols, List<RuleWithoutALine> competing) {
+        List<RuleWithoutALine> out = new ArrayList<>(competing);
+        for (FieldDomains.NoLine each : placed.noLineAt(path)) {
             // The rule the reading of ends was holding when it gave up, carried rather than left
             // behind. It is a clause of an invariant, so it has a name and the handle is that name.
             //
             // At the number that rule is about, which the rule itself says. Nothing is missing here
             // for the position to stand in for: a clause was read far enough to be about one number
             // or the other, and it is only the line that nothing came of.
-            UnreadRule said = new UnreadRule(each.from(),
+            RuleWithoutALine said = new RuleWithoutALine(each.from(),
                     souther.compiler.check.RuleCitation.named(each.from()),
                     filedAt(path, each.by(), type, symbols),
                     each.why());

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
@@ -202,9 +202,9 @@ record PlacedRules(TermPath root, TypeSymbol value, Rules rules) {
      * answer at the root is what the type's own reading already gives. A rule nothing could read is
      * not given twice by anybody, and a newtype's own clause is where the question started.
      */
-    List<FieldDomains.Unread> unreadAt(TermPath path) {
+    List<FieldDomains.NoLine> noLineAt(TermPath path) {
         String where = keyOf(path);
-        return where == null ? List.of() : bounds().unreadAt(where);
+        return where == null ? List.of() : bounds().noLineAt(where);
     }
 
     /** Which declarations' clauses are holding the end at {@code path}, on the side asked for. */

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
@@ -171,7 +171,7 @@ public sealed interface Position permits ReadPosition {
      * is what decides whether an absence of classes may be reported as the model stating no
      * division.
      */
-    BlockReason valuesUnread();
+    BlockReason.ReadingStopReason valuesUnread();
 
     /**
      * The rules written about this position that the reading of ends could not turn into one.

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
@@ -174,7 +174,13 @@ public sealed interface Position permits ReadPosition {
     BlockReason.ReadingStopReason valuesUnread();
 
     /**
-     * The rules written about this position that the reading of ends could not turn into one.
+     * The rules written about this position that the reading of ends drew no line from.
+     *
+     * <p>Both ways of there being none. A rule that reading got partway through, and one it read
+     * from end to end that places no line — a relation between two positions, a quantity the
+     * position cancels out of. Each is worth saying at a position a report is asked about, and they
+     * are opposite sentences about this compiler; which of the two is the reason's to say and is
+     * not read back out of this list's name.
      *
      * <p>Whichever value they are written on: a clause of this position's own type and a clause of
      * the value it sits in are two ways of saying where its values stop, and both come from the one
@@ -186,7 +192,7 @@ public sealed interface Position permits ReadPosition {
      * answered for the record's clause about the same field, and the clause was dropped in silence
      * (issue #868).
      */
-    List<UnreadRule> unreadRules();
+    List<RuleWithoutALine> rulesWithoutALine();
 
     /**
      * Whether the values at this position are read from a product this reading cannot show the

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PositionReadingBlocked.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PositionReadingBlocked.java
@@ -3,7 +3,7 @@ package souther.compiler.inputs;
 /**
  * A position whose reading stopped before it got to what is written about it.
  *
- * <p>The other half of {@link UnreadRule}, and told apart from it by which authority answers. There
+ * <p>The other half of {@link RuleWithoutALine}, and told apart from it by which authority answers. There
  * a rule was read and could not be used, and the finding names it; here nothing about any one rule
  * is known â a depth, a shape this does not reach into, a type that could not be worked out, a
  * gathering that stopped â and what there is to say is the position and the limit. Carrying a rule

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PositionValuesNotSeparated.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PositionValuesNotSeparated.java
@@ -3,7 +3,7 @@ package souther.compiler.inputs;
 /**
  * A position whose values are read from a product this reading cannot show the rules admit.
  *
- * <p>Not {@link UnreadRule} and not {@link PositionReadingBlocked}. Every rule about the position
+ * <p>Not {@link RuleWithoutALine} and not {@link PositionReadingBlocked}. Every rule about the position
  * arrived and every one of them was taken in, so there is no rule to name and nothing was left
  * unreached; what happened is that a choice reaching across positions is held one position at a
  * time, and a clause met with it afterwards can leave the values wider than the rules are. Said as

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadPosition.java
@@ -34,7 +34,7 @@ record ReadPosition(TermPath path, TypeView view, NumericTerm term,
                     List<TypeSymbol> narrowedUpper, boolean nothingExists,
                     ProjectionEvidence projection, List<Case> declared, ReadingResult reading,
                     ObligationDomain obligations, AdmissibleSet.Completeness completeness,
-                    BlockReason valuesUnread, List<UnreadRule> unreadRules,
+                    BlockReason.ReadingStopReason valuesUnread, List<UnreadRule> unreadRules,
                     List<RuleAccounting.Unanswered> unansweredQuestions, boolean rulesNotReached,
                     StructuralInspection structure) implements Position {
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadPosition.java
@@ -34,7 +34,7 @@ record ReadPosition(TermPath path, TypeView view, NumericTerm term,
                     List<TypeSymbol> narrowedUpper, boolean nothingExists,
                     ProjectionEvidence projection, List<Case> declared, ReadingResult reading,
                     ObligationDomain obligations, AdmissibleSet.Completeness completeness,
-                    BlockReason.ReadingStopReason valuesUnread, List<UnreadRule> unreadRules,
+                    BlockReason.ReadingStopReason valuesUnread, List<RuleWithoutALine> rulesWithoutALine,
                     List<RuleAccounting.Unanswered> unansweredQuestions, boolean rulesNotReached,
                     StructuralInspection structure) implements Position {
 
@@ -42,7 +42,7 @@ record ReadPosition(TermPath path, TypeView view, NumericTerm term,
         narrowedLower = List.copyOf(narrowedLower);
         narrowedUpper = List.copyOf(narrowedUpper);
         declared = List.copyOf(declared);
-        unreadRules = List.copyOf(unreadRules);
+        rulesWithoutALine = List.copyOf(rulesWithoutALine);
         unansweredQuestions = List.copyOf(unansweredQuestions);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadingResult.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadingResult.java
@@ -42,7 +42,8 @@ public sealed interface ReadingResult {
      * not the same claim: {@code refused} is what the rules proved empty, and {@code kept} is what
      * this reading has no reason to remove — which a rule that went unread may yet remove.
      */
-    record Partial(List<Case> kept, List<Case> refused, BlockReason why) implements ReadingResult {
+    record Partial(List<Case> kept, List<Case> refused, BlockReason.ReadingStopReason why)
+            implements ReadingResult {
 
         public Partial {
             kept = List.copyOf(kept);
@@ -78,7 +79,7 @@ public sealed interface ReadingResult {
      * {@link Complete} with every distinction kept, and says so about the model; this says nothing
      * about the model at all.
      */
-    record Unsupported(BlockReason why) implements ReadingResult {
+    record Unsupported(BlockReason.ReadingStopReason why) implements ReadingResult {
 
         public Unsupported {
             if (why == null) {

--- a/souther-compiler/src/main/java/souther/compiler/inputs/RuleWithoutALine.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/RuleWithoutALine.java
@@ -10,8 +10,8 @@ import souther.compiler.check.RuleRef;
  * read at it says nothing about the rest — a threshold on {@code x} does not answer for the bound
  * beside it that nothing could read. Carrying only the position, the sentence written from this
  * told an author that a rule about {@code r.cost} went unread and left them to find which rule; and
- * two rules stopped by one limit at one position came out as one line, which is what a finding
- * asked of the rule may not do.
+ * two rules with no line at one position came out as one line, which is what a finding asked of the
+ * rule may not do.
  *
  * <p><b>Whichever rule drew it.</b> A {@code guard}'s comparison, a newtype's invariant and a
  * clause of an {@code ensures} are three producers of one kind of evidence (spec
@@ -26,26 +26,36 @@ import souther.compiler.check.RuleRef;
  * step wherever a rule has no name. Neither stands in for the other, and only the
  * first is part of what makes two of these one finding.
  *
+ * <p><b>Named for what is true of everything in it.</b> Two opposite things bring a rule here — one
+ * this compiler got partway through, and one it read from end to end that draws no line — and the
+ * name used to be the first of them. So a rule read completely was carried, named and published as
+ * one nobody could read, and the sentence a person was shown said the opposite of what had
+ * happened. What both have in common is the whole of what this says: at this position, this rule is
+ * no line. Which of the two it was is {@code why}, and it is asked of the type rather than read
+ * back out of a word.
+ *
  * @param rule  which rule of the model, as everything that names a rule names it
  * @param cited how a reader finds it — a name where the author gave one, a place where they did not
  * @param at    the position, spelled the way a report names it. One of these per position the rule
  *              is about: {@code a < b} leaves neither of them divided, and a reader looking up
  *              either is owed the same answer. Filed at the first alone, which position was named
  *              would turn on which side the author wrote it
- * @param why   what would have to change before this rule could be a line, in this compiler's own
- *              terms. Which word a report writes for it is {@link ReportedReason}'s, so a
- *              capability gained here need not move a published vocabulary
+ * @param why   why there is no line here, in this compiler's own terms: what would have to change
+ *              before this rule could be one, or what the rule itself places. Which word a report
+ *              writes for it is {@link ReportedReason}'s, so a capability gained here need not move
+ *              a published vocabulary
  */
-public record UnreadRule(RuleRef rule, RuleCitation cited, FilingCoordinate at,
+public record RuleWithoutALine(RuleRef rule, RuleCitation cited, FilingCoordinate at,
                          BlockReason.RuleWithoutLineReason why) {
 
-    public UnreadRule {
+    public RuleWithoutALine {
         if (rule == null || cited == null) {
             throw new IllegalArgumentException(
-                    "a rule this could not read is one a reader can be sent to look at");
+                    "a rule with no line here is one a reader can be sent to look at");
         }
         if (at == null || why == null) {
-            throw new IllegalArgumentException("a rule went unread somewhere, and for something");
+            throw new IllegalArgumentException("a rule is without a line somewhere, and for a"
+                    + " reason");
         }
     }
 
@@ -56,7 +66,7 @@ public record UnreadRule(RuleRef rule, RuleCitation cited, FilingCoordinate at,
      * handle for it are two questions, and a key holding the handle would file one rule under
      * several wherever the two come apart.
      */
-    public boolean sameAs(UnreadRule other) {
+    public boolean sameAs(RuleWithoutALine other) {
         return rule.equals(other.rule) && at.equals(other.at) && why.equals(other.why);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/UnreadRule.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/UnreadRule.java
@@ -37,7 +37,7 @@ import souther.compiler.check.RuleRef;
  *              capability gained here need not move a published vocabulary
  */
 public record UnreadRule(RuleRef rule, RuleCitation cited, FilingCoordinate at,
-                         BlockReason.AboutARule why) {
+                         BlockReason.RuleWithoutLineReason why) {
 
     public UnreadRule {
         if (rule == null || cited == null) {

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Unsettlement.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Unsettlement.java
@@ -15,7 +15,7 @@ public sealed interface Unsettlement {
 
     /** A rule about the position went unread, and it could refuse the distinction as readily as one
      *  that was read. */
-    record ReadingStopped(BlockReason why) implements Unsettlement {
+    record ReadingStopped(BlockReason.ReadingStopReason why) implements Unsettlement {
 
         public ReadingStopped {
             if (why == null) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -1,6 +1,5 @@
 package souther.compiler.partition;
 
-import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.Requirements;
 import souther.compiler.inputs.StructuralInspection;
@@ -68,16 +67,18 @@ import java.util.List;
  *                 Beside the questions and not among them: a position whose rules were never
  *                 enumerated raises no question and is not one whose rules were all accounted for,
  *                 and an empty list says the second (issue #791)
- * @param unread   a rule about this position's own values that the local reading did not take in,
- *                 or null where it read them all. Carried for the same reason {@link #pending} is,
- *                 and kept apart from it because the two are lifted by different work and one
- *                 outranks the other: where the walk could not reach into what the position holds,
- *                 a rule about what is inside describes that same stop from the other end
+ * @param leftWith what the position is left with where the local reading gave it no axis, or null
+ *                 where nothing is. Which of the two it is comes with it: a reading stopped, or a
+ *                 rule was read to the end and draws no line. Carried for the same reason
+ *                 {@link #pending} is, and kept apart from it because the two are lifted by
+ *                 different work and one outranks the other — where the walk could not reach into
+ *                 what the position holds, a rule about what is inside describes that same stop
+ *                 from the other end
  */
 public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> classes,
                    List<Cut> cuts, List<Seam> parted, List<RuleAccounting.Unanswered> unanswered,
                    boolean rulesNotReached,
-                   StructuralInspection.Continuation pending, BlockReason unread) {
+                   StructuralInspection.Continuation pending, LeftAtThePosition leftWith) {
 
     public Axis {
         classes = List.copyOf(classes);
@@ -105,9 +106,10 @@ public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> 
     public static Axis pendingAt(AxisId id, NumericTerm term, Type type,
                                  List<RuleAccounting.Unanswered> unanswered,
                                  boolean rulesNotReached,
-                                 StructuralInspection.Continuation found, BlockReason unread) {
+                                 StructuralInspection.Continuation found,
+                                 LeftAtThePosition leftWith) {
         return new Axis(id, term, type, List.of(), List.of(), List.of(), unanswered,
-                rulesNotReached, found, unread);
+                rulesNotReached, found, leftWith);
     }
 
     /**
@@ -122,13 +124,13 @@ public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> 
      */
     public Axis measuredAt(AxisId id, NumericTerm term) {
         return new Axis(id, term, type, classes, cuts, parted, unanswered, rulesNotReached, pending,
-                unread);
+                leftWith);
     }
 
     /** The same position, with what a body's rules divided it into and the lines they drew. */
     public Axis carrying(List<PartitionClass> classes, List<Cut> cuts, List<Seam> parted) {
         return new Axis(id, term, type, classes, cuts, parted, unanswered, rulesNotReached, pending,
-                unread);
+                leftWith);
     }
 
     /** Where the value this axis is about sits, which is where a row is walked to before the term is

--- a/souther-compiler/src/main/java/souther/compiler/partition/BodyCutInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BodyCutInspection.java
@@ -29,7 +29,7 @@ public sealed interface BodyCutInspection {
      * it.
      *
      * <p>What was read, and not what could be written. A rule in a form no reader here takes apart
-     * is {@link Blocked} and says so; a rule nothing looks for at all is neither, and no case of
+     * is {@link NoLine} and says so; a rule nothing looks for at all is neither, and no case of
      * this could say it. So this is a producer's answer about its own reading, which is what
      * anything reading it may say — never that no line exists at the position.
      */

--- a/souther-compiler/src/main/java/souther/compiler/partition/BodyCutInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BodyCutInspection.java
@@ -42,7 +42,7 @@ public sealed interface BodyCutInspection {
      * settles is only that this phase did not.
      *
      * <p>It carries no reason, and the reason is not lost. A rule this phase read and could not use
-     * is an {@link souther.compiler.inputs.UnreadRule} made by the reader that read it, naming
+     * is an {@link souther.compiler.inputs.RuleWithoutALine} made by the reader that read it, naming
      * which rule; carried through here as well, one limit at one position stood for however many
      * rules were stopped by it, and the first of them was the one a report printed.
      * What this phase owes the verdict is whether it drew anything, which is the whole of what

--- a/souther-compiler/src/main/java/souther/compiler/partition/BodyCutInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BodyCutInspection.java
@@ -15,8 +15,8 @@ package souther.compiler.partition;
  * front of it says.
  *
  * <p><b>Whichever rule wrote it.</b> A {@code guard}'s comparison and a newtype's invariant are two
- * producers of one kind of evidence (spec §example-partition), so {@link Blocked} is what either
- * of them was left unread as. The reader is told the same thing about both and does not have to
+ * producers of one kind of evidence (spec §example-partition), so {@link NoLine} is what either of
+ * them left the position with. The reader is told the same thing about both and does not have to
  * know which wrote it.
  */
 public sealed interface BodyCutInspection {
@@ -36,17 +36,34 @@ public sealed interface BodyCutInspection {
     record Exhausted() implements BodyCutInspection {}
 
     /**
-     * A rule was written about the position and nothing here turned it into a line.
+     * A rule was written about the position and this phase turned it into no line.
      *
      * <p>Not a verdict on the position. Something else may still answer for it, and what this
      * settles is only that this phase did not.
      *
-     * <p>It carries no reason, and the reason is not lost. A rule this phase read and could not use
-     * is an {@link souther.compiler.inputs.RuleWithoutALine} made by the reader that read it, naming
+     * <p><b>Which of the two ways that happened travels with it.</b> A reading that stopped and a
+     * rule read from end to end that draws no line are opposite sentences about this compiler, and
+     * this phase used to answer with neither — it said only that something was left, and the
+     * verdict read that as a derivation this compiler could not make. So a {@code guard} relating
+     * two positions, understood completely, came out as a position something is written at that
+     * nothing read.
+     *
+     * <p>{@link LeftAtThePosition} and not a reason, because that is the same value the reading
+     * before this one hands over: the two phases answer about one position, and a verdict has to
+     * put their answers together without either being able to say more than it knows.
+     *
+     * <p>Which rule it was is not here, and is not lost. A rule this phase could not use is a
+     * {@link souther.compiler.inputs.RuleWithoutALine} made by the reader that read it, naming
      * which rule; carried through here as well, one limit at one position stood for however many
-     * rules were stopped by it, and the first of them was the one a report printed.
-     * What this phase owes the verdict is whether it drew anything, which is the whole of what
-     * three cases say.
+     * rules were stopped by it and the first of them was the one a report printed.
      */
-    record Blocked() implements BodyCutInspection {}
+    record NoLine(LeftAtThePosition left) implements BodyCutInspection {
+
+        public NoLine {
+            if (left == null) {
+                throw new IllegalArgumentException(
+                        "a position left with nothing is what Exhausted says");
+            }
+        }
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
@@ -24,9 +24,25 @@ import souther.compiler.inputs.RuleWithoutALine;
  */
 public sealed interface ClosureGap {
 
-    /** A rule of the model that a reader set aside. The rule says which measures that costs
-     *  ({@link BlockReason.RuleWithoutLineReason#leavesShort}). */
-    record RuleUnread(RuleWithoutALine rule) implements ClosureGap {}
+    /**
+     * A rule of the model a reader stopped on. The rule says which measures that costs
+     * ({@link BlockReason.RuleWithoutLineReason#leavesShort}).
+     *
+     * <p>Only a rule this compiler got partway through. A rule read from end to end that draws no
+     * line leaves no measure short of anything — that is what its half of the reasons answers, for
+     * every one of them and not case by case — so it is not a gap in what was measured and there is
+     * nothing here for it to be counted as. `MeasureClosure` asks the reason before building one of
+     * these, and this refuses what that question would have had to let through.
+     */
+    record RuleUnread(RuleWithoutALine rule) implements ClosureGap {
+
+        public RuleUnread {
+            if (!(rule.why() instanceof BlockReason.RuleReadingStopped)) {
+                throw new IllegalArgumentException(
+                        "a rule read to the end leaves no measure short: " + rule.why());
+            }
+        }
+    }
 
     /**
      * A question the rules written about one position raise that nothing answered.

--- a/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
@@ -2,7 +2,7 @@ package souther.compiler.partition;
 
 import souther.compiler.check.RuleAccounting;
 import souther.compiler.inputs.BlockReason;
-import souther.compiler.inputs.UnreadRule;
+import souther.compiler.inputs.RuleWithoutALine;
 
 /**
  * One thing that stopped a measure's reading of the model from running out.
@@ -26,7 +26,7 @@ public sealed interface ClosureGap {
 
     /** A rule of the model that a reader set aside. The rule says which measures that costs
      *  ({@link BlockReason.RuleWithoutLineReason#leavesShort}). */
-    record RuleUnread(UnreadRule rule) implements ClosureGap {}
+    record RuleUnread(RuleWithoutALine rule) implements ClosureGap {}
 
     /**
      * A question the rules written about one position raise that nothing answered.

--- a/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
@@ -25,7 +25,7 @@ import souther.compiler.inputs.UnreadRule;
 public sealed interface ClosureGap {
 
     /** A rule of the model that a reader set aside. The rule says which measures that costs
-     *  ({@link BlockReason.AboutARule#leavesShort}). */
+     *  ({@link BlockReason.RuleWithoutLineReason#leavesShort}). */
     record RuleUnread(UnreadRule rule) implements ClosureGap {}
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
@@ -130,7 +130,7 @@ sealed interface ComparisonAssessment {
      * @param filedAt where the reading was looking, which is a diagnostic position and never the
      *                subject of a question. What such a rule is about is the part that was not read
      */
-    record Unread(BlockReason.ReadingStopped why, List<FilingCoordinate> filedAt)
+    record Unread(BlockReason.RuleReadingStopped why, List<FilingCoordinate> filedAt)
             implements ComparisonAssessment {
 
         public Unread {

--- a/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ComparisonAssessment.java
@@ -12,6 +12,7 @@ import souther.compiler.numeric.Place;
 import souther.compiler.types.BindingId;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * What one comparison comes to on the input space: one reading, and everything read off it.
@@ -256,6 +257,44 @@ sealed interface ComparisonAssessment {
             case Unread unread -> unread.filedAt();
             case CutsNothing _ -> GuardThresholds.filedAt(comparison, reads, symbols);
             case AtAPosition _, AnswerDependent _, NoInput _ -> List.of();
+        };
+    }
+
+    /**
+     * Why the reading of lines drew none from this comparison, or empty where it drew one.
+     *
+     * <p><b>Named for the reading it is the answer of, and not for the assessment it is read
+     * off.</b> What a comparison comes to is one decision; what a reading makes of it is that
+     * reading's own, and the two do not agree even about one comparison — a rule relating two
+     * positions is read here from end to end and places no line, and the reading that turns clauses
+     * into sets of values gets nothing it can hold from the same rule. A name saying only that a
+     * reason was read off an assessment would be reached for by that reader too, and the answer it
+     * would take is the one that says nothing fell short.
+     *
+     * <p>Answered once, here. Both producers of this evidence — a clause of an {@code ensures} and a
+     * {@code guard}'s comparison — worked the same table out separately, so a case added to
+     * {@link ComparisonAssessment} had to be answered twice and the two could disagree about one
+     * comparison. That is the shape this whole type was made to have none of.
+     *
+     * <p>Empty rather than null, and no {@code default} on the switch. A comparison that drew a
+     * line, one about no position of the input, and one about what the behavior answers each leave
+     * nothing for a reader to be told, and saying so with an absent value made the absence a
+     * sentinel one caller had to remember to test for. An arm added is a compile error in this
+     * method and in the value reading's own beside it, which is the point of neither having a
+     * default.
+     */
+    default Optional<BlockReason.RuleWithoutLineReason> whyTheLineReadingDrewNone() {
+        return switch (this) {
+            case AcrossPositions _ -> Optional.of(new BlockReason.ComparisonBetweenPositions());
+            case CutsNothing _ -> Optional.of(new BlockReason.ComparisonCuttingNothing());
+            case OutsideTheDomain _ ->
+                    Optional.of(new BlockReason.ComparisonCuttingOutsideDomain());
+            // Its own answer for having stopped, decided where it stopped. Worked out again from
+            // the comparison afterwards, one whose carrier stopped the reading came back as a rule
+            // that relates two positions — a sentence saying no measure is short of anything, over
+            // a model missing a border.
+            case Unread unread -> Optional.of(unread.why());
+            case AtAPosition _, NoInput _, AnswerDependent _ -> Optional.empty();
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Cutting.java
@@ -66,7 +66,7 @@ record Cutting(BorderQuantity of, Level at, ComparisonClaim claim,
         record CutsNothing() implements Read {}
 
         /** The reading stopped, and this is what it stopped on. */
-        record Stopped(souther.compiler.inputs.BlockReason.ReadingStopped why) implements Read {
+        record Stopped(souther.compiler.inputs.BlockReason.RuleReadingStopped why) implements Read {
 
             public Stopped {
                 java.util.Objects.requireNonNull(why, "a reading that stopped says why");

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -254,8 +254,9 @@ public final class EnsuresThresholds {
     }
 
     /**
-     * The positions a statement names that nothing turned into a line, where that is a limit of
-     * this compiler.
+     * The positions a statement names that it draws no line at, for whichever of the two reasons
+     * there are: this reading got partway through the rule, or it read the rule whole and there is
+     * no line in it.
      *
      * <p>Named rather than passed over, because a position left out of every answer is reported as
      * one the model draws no line through — a sentence about the model, and the model says otherwise
@@ -267,9 +268,9 @@ public final class EnsuresThresholds {
      * behavior is applied to. Reported as unread it sends an author after a limit of this compiler
      * that is not there, which is the opposite mistake to the one above and just as wrong.
      *
-     * <p>Why it could not be read is a comparison's own answer where the statement is one. Where it
-     * is not — a rule stated in some other form — what stopped this is the form, which is the one
-     * of the three reasons that does not turn on what two sides name.
+     * <p>Why there is no line is a comparison's own answer where the statement is one. Where it is
+     * not — a rule stated in some other form — this reading did not take it apart at all, and the
+     * form is what stopped it: the one reason that does not turn on what two sides name.
      */
     private static void reportRuleWithoutLine(RuleRef.Ensures rule, Core statement, BindingId answer,
                                      BlockReason.RuleWithoutLineReason why,

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -66,14 +66,14 @@ public final class EnsuresThresholds {
      *                them and so have no axis to come off. Already obligations rather than
      *                thresholds: a line between two positions divides neither, so there is no class
      *                for a partition to be told about
-     * @param unread  the positions a rule states something about that nothing here turned into a
-     *                line. Carried rather than left out: a position a clause compares is not a
+     * @param rulesWithoutALine  the positions a rule states something about that this drew no
+     *                line at. Carried rather than left out: a position a clause compares is not a
      *                position the model draws no line through, and a reading that answered with its
      *                lines alone would have that said of it — which is a sentence about the model,
      *                and the model says otherwise in its own declaration
      */
     public record Clauses(List<Threshold> thresholds, List<GuardThresholds.Guards.Singled> singled,
-                          List<LineDrawn> between, List<RuleWithoutALine> unread) {
+                          List<LineDrawn> between, List<RuleWithoutALine> rulesWithoutALine) {
 
         public static final Clauses NONE =
                 new Clauses(List.of(), List.of(), List.of(), List.of());
@@ -82,7 +82,7 @@ public final class EnsuresThresholds {
             thresholds = List.copyOf(thresholds);
             singled = List.copyOf(singled);
             between = List.copyOf(between);
-            unread = List.copyOf(unread);
+            rulesWithoutALine = List.copyOf(rulesWithoutALine);
         }
     }
 
@@ -129,14 +129,14 @@ public final class EnsuresThresholds {
                 }
             }
         }
-        return new Clauses(drawn.thresholds(), drawn.singled(), drawn.between(), drawn.unread());
+        return new Clauses(drawn.thresholds(), drawn.singled(), drawn.between(), drawn.rulesWithoutALine());
     }
 
     /** What the walk has found so far, and the behavior a line between two positions is named
      *  after. Together because they are filled together and are one answer. */
     private record Drawn(String behavior, List<Threshold> thresholds,
                          List<GuardThresholds.Guards.Singled> singled,
-                         List<LineDrawn> between, List<RuleWithoutALine> unread) {}
+                         List<LineDrawn> between, List<RuleWithoutALine> rulesWithoutALine) {}
 
     /**
      * The comparisons a rule states outright: its own, and those of both sides of every {@code &&}
@@ -180,7 +180,7 @@ public final class EnsuresThresholds {
                     new BlockReason.UnreadComparisonForm(),
                     GuardThresholds.mentionedIn(e, reads, symbols).stream()
                             .map(FilingCoordinate::at).toList(),
-                    out.unread());
+                    out.rulesWithoutALine());
             return;
         }
         // What the comparison comes to is read the same way wherever a comparison is written, which
@@ -193,7 +193,7 @@ public final class EnsuresThresholds {
         // reader, and a case added to an assessment had to be answered in both.
         assessed.whyTheLineReadingDrewNone().ifPresent(why ->
                 reportRuleWithoutLine(new RuleRef.Ensures(rule.id(), clause), comparison, rule.value(), why,
-                        assessed.filedAt(comparison, reads, symbols), out.unread()));
+                        assessed.filedAt(comparison, reads, symbols), out.rulesWithoutALine()));
         // And the geometry, which is this reader's own. Only the two arms that draw something have
         // anything to add here.
         switch (assessed) {
@@ -275,7 +275,7 @@ public final class EnsuresThresholds {
     private static void reportRuleWithoutLine(RuleRef.Ensures rule, Core statement, BindingId answer,
                                      BlockReason.RuleWithoutLineReason why,
                                      List<FilingCoordinate> at,
-                                     List<RuleWithoutALine> unread) {
+                                     List<RuleWithoutALine> withoutALine) {
         if (ComparisonAssessment.readsAnswer(statement, answer)) {
             return;
         }
@@ -283,8 +283,8 @@ public final class EnsuresThresholds {
                 souther.compiler.check.RuleCitation.named(rule);
         for (FilingCoordinate named : at) {
             RuleWithoutALine here = new RuleWithoutALine(rule, cited, named, why);
-            if (unread.stream().noneMatch(had -> had.sameAs(here))) {
-                unread.add(here);
+            if (withoutALine.stream().noneMatch(had -> had.sameAs(here))) {
+                withoutALine.add(here);
             }
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -188,6 +188,14 @@ public final class EnsuresThresholds {
         // draw one line and raise one question, and neither is worked out beside the other.
         ComparisonAssessment assessed = ComparisonAssessment.of(out.behavior(), comparison, reads,
                 symbols, quantities, rule.value());
+        // What the positions this names are left with, where the reading of lines drew none. Asked
+        // of the assessment and not worked out per arm here: the same table stood in the guard
+        // reader, and a case added to an assessment had to be answered in both.
+        assessed.whyTheLineReadingDrewNone().ifPresent(why ->
+                reportUnread(new RuleRef.Ensures(rule.id(), clause), comparison, rule.value(), why,
+                        assessed.filedAt(comparison, reads, symbols), out.unread()));
+        // And the geometry, which is this reader's own. Only the two arms that draw something have
+        // anything to add here.
         switch (assessed) {
             // A line on one position's own values. The value the classes meet at was answered by the
             // reading of the comparison; taken off the level the rule was written with, a rule that
@@ -222,11 +230,6 @@ public final class EnsuresThresholds {
             // what a border owes away from its line is a run of the arrangement every rule about
             // that quantity makes together.
             case ComparisonAssessment.AcrossPositions over -> {
-                // The positions are named as ones nothing divides, which is what a rule over a
-                // quantity that is not one position's own values leaves them.
-                reportUnread(new RuleRef.Ensures(rule.id(), clause), comparison, rule.value(),
-                        new BlockReason.ComparisonBetweenPositions(),
-                        over.filedAt(comparison, reads, symbols), out.unread());
                 // A value singled out on such a quantity has no sides, so there is nothing for a
                 // border to owe a row away from.
                 if (over.drawsABorder()) {
@@ -234,26 +237,11 @@ public final class EnsuresThresholds {
                             originOf(rule, clause, over.cutting())));
                 }
             }
-            // Nothing this reader draws. A comparison it could not read leaves the positions it
-            // names standing, in the words the reading that stopped came to — worked out again
-            // here, a comparison whose carrier stopped it would come back as one that relates two
-            // positions, which says no measure is short of anything.
-            case ComparisonAssessment.Unread unread -> reportUnread(
-                    new RuleRef.Ensures(rule.id(), clause), comparison, rule.value(), unread.why(),
-                    unread.filedAt(comparison, reads, symbols), out.unread());
-            // Read to the end, and the positions are left with no class of their own from this
-            // rule. Which of the two it was is worth saying: the quantity was empty, or the line
-            // falls where the quantity never runs. Neither leaves a measure short of anything, and
-            // both are things the model states at a position a report is asked about.
-            case ComparisonAssessment.CutsNothing nothing -> reportUnread(
-                    new RuleRef.Ensures(rule.id(), clause), comparison, rule.value(),
-                    new BlockReason.ComparisonCuttingNothing(),
-                    nothing.filedAt(comparison, reads, symbols), out.unread());
-            case ComparisonAssessment.OutsideTheDomain outside -> reportUnread(
-                    new RuleRef.Ensures(rule.id(), clause), comparison, rule.value(),
-                    new BlockReason.ComparisonCuttingOutsideDomain(),
-                    outside.filedAt(comparison, reads, symbols), out.unread());
-            case ComparisonAssessment.AnswerDependent _, ComparisonAssessment.NoInput _ -> { }
+            // Nothing this reader draws at any of them. What each leaves the positions is said
+            // above, in the one place that answers it for both readers of a comparison.
+            case ComparisonAssessment.Unread _, ComparisonAssessment.CutsNothing _,
+                 ComparisonAssessment.OutsideTheDomain _,
+                 ComparisonAssessment.AnswerDependent _, ComparisonAssessment.NoInput _ -> { }
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -10,7 +10,7 @@ import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.InputReads;
 import souther.compiler.inputs.FilingCoordinate;
-import souther.compiler.inputs.UnreadRule;
+import souther.compiler.inputs.RuleWithoutALine;
 import souther.compiler.types.BindingId;
 
 import java.util.ArrayList;
@@ -73,7 +73,7 @@ public final class EnsuresThresholds {
      *                and the model says otherwise in its own declaration
      */
     public record Clauses(List<Threshold> thresholds, List<GuardThresholds.Guards.Singled> singled,
-                          List<LineDrawn> between, List<UnreadRule> unread) {
+                          List<LineDrawn> between, List<RuleWithoutALine> unread) {
 
         public static final Clauses NONE =
                 new Clauses(List.of(), List.of(), List.of(), List.of());
@@ -136,7 +136,7 @@ public final class EnsuresThresholds {
      *  after. Together because they are filled together and are one answer. */
     private record Drawn(String behavior, List<Threshold> thresholds,
                          List<GuardThresholds.Guards.Singled> singled,
-                         List<LineDrawn> between, List<UnreadRule> unread) {}
+                         List<LineDrawn> between, List<RuleWithoutALine> unread) {}
 
     /**
      * The comparisons a rule states outright: its own, and those of both sides of every {@code &&}
@@ -176,7 +176,7 @@ public final class EnsuresThresholds {
             // A statement that is not a comparison was not assessed as one, so what stopped this
             // is the form it is written in — the one of the reasons that does not turn on what two
             // sides name — and the positions the walk met are all there is to file it at.
-            reportUnread(new RuleRef.Ensures(rule.id(), clause), e, rule.value(),
+            reportRuleWithoutLine(new RuleRef.Ensures(rule.id(), clause), e, rule.value(),
                     new BlockReason.UnreadComparisonForm(),
                     GuardThresholds.mentionedIn(e, reads, symbols).stream()
                             .map(FilingCoordinate::at).toList(),
@@ -192,7 +192,7 @@ public final class EnsuresThresholds {
         // of the assessment and not worked out per arm here: the same table stood in the guard
         // reader, and a case added to an assessment had to be answered in both.
         assessed.whyTheLineReadingDrewNone().ifPresent(why ->
-                reportUnread(new RuleRef.Ensures(rule.id(), clause), comparison, rule.value(), why,
+                reportRuleWithoutLine(new RuleRef.Ensures(rule.id(), clause), comparison, rule.value(), why,
                         assessed.filedAt(comparison, reads, symbols), out.unread()));
         // And the geometry, which is this reader's own. Only the two arms that draw something have
         // anything to add here.
@@ -271,17 +271,17 @@ public final class EnsuresThresholds {
      * is not — a rule stated in some other form — what stopped this is the form, which is the one
      * of the three reasons that does not turn on what two sides name.
      */
-    private static void reportUnread(RuleRef.Ensures rule, Core statement, BindingId answer,
+    private static void reportRuleWithoutLine(RuleRef.Ensures rule, Core statement, BindingId answer,
                                      BlockReason.RuleWithoutLineReason why,
                                      List<FilingCoordinate> at,
-                                     List<UnreadRule> unread) {
+                                     List<RuleWithoutALine> unread) {
         if (ComparisonAssessment.readsAnswer(statement, answer)) {
             return;
         }
         souther.compiler.check.RuleCitation cited =
                 souther.compiler.check.RuleCitation.named(rule);
         for (FilingCoordinate named : at) {
-            UnreadRule here = new UnreadRule(rule, cited, named, why);
+            RuleWithoutALine here = new RuleWithoutALine(rule, cited, named, why);
             if (unread.stream().noneMatch(had -> had.sameAs(here))) {
                 unread.add(here);
             }

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -284,7 +284,7 @@ public final class EnsuresThresholds {
      * of the three reasons that does not turn on what two sides name.
      */
     private static void reportUnread(RuleRef.Ensures rule, Core statement, BindingId answer,
-                                     BlockReason.AboutARule why,
+                                     BlockReason.RuleWithoutLineReason why,
                                      List<FilingCoordinate> at,
                                      List<UnreadRule> unread) {
         if (ComparisonAssessment.readsAnswer(statement, answer)) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -12,7 +12,7 @@ import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.ReadMeaning;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.inputs.FilingCoordinate;
-import souther.compiler.inputs.UnreadRule;
+import souther.compiler.inputs.RuleWithoutALine;
 import souther.compiler.numeric.Place;
 import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
@@ -64,7 +64,7 @@ public final class GuardThresholds {
      * operator is still in hand, and which values arrive is asked of the reading of the whole body.
      */
     public record Guards(List<Threshold> thresholds,
-                         List<UnreadRule> unread, List<Singled> singled,
+                         List<RuleWithoutALine> unread, List<Singled> singled,
                          List<LineDrawn> between,
                          ReachingCuts reaching) {
 
@@ -125,7 +125,7 @@ public final class GuardThresholds {
                             Symbols symbols,
                             souther.compiler.check.ElementBindings elements) {
         List<Threshold> found = new ArrayList<>();
-        List<UnreadRule> unread = new ArrayList<>();
+        List<RuleWithoutALine> unread = new ArrayList<>();
         List<Guards.Singled> singled = new ArrayList<>();
         List<LineDrawn> between = new ArrayList<>();
         // The comparisons this reader assessed, and not the positions they were about. A position
@@ -178,7 +178,7 @@ public final class GuardThresholds {
      * unread would put a statement into the report that the behavior does not make.
      */
     private static void noticed(String behavior, ComparisonReadings read, List<Core> assessed,
-                                CoverageSites.Plan plan, Symbols symbols, List<UnreadRule> out) {
+                                CoverageSites.Plan plan, Symbols symbols, List<RuleWithoutALine> out) {
         for (ComparisonReadings.Reading reading : read.all()) {
             if (reading.standing() instanceof BoundaryPolicy.Standing.DrawsNone none
                     && none.why() == NotABoundary.NOTHING_READS_IT) {
@@ -221,7 +221,7 @@ public final class GuardThresholds {
                 // well as the place. Kept by position alone, the second comparison of one condition
                 // about one position was dropped as a repeat of the first — which is the defect this
                 // finding is about, one level in.
-                UnreadRule said = new UnreadRule(rule, cited, each, why);
+                RuleWithoutALine said = new RuleWithoutALine(rule, cited, each, why);
                 if (out.stream().noneMatch(had -> had.sameAs(said))) {
                     out.add(said);
                 }
@@ -520,7 +520,7 @@ public final class GuardThresholds {
                                souther.compiler.inputs.Quantities quantities,
                                List<Threshold> out, List<Guards.Singled> singled,
                                List<LineDrawn> between,
-                               List<Core> assessed, List<UnreadRule> unread) {
+                               List<Core> assessed, List<RuleWithoutALine> unread) {
         // The plan numbered every comparison of an instrumented condition before anything read a
         // line off one, so this is here. Required rather than looked up leniently: a line whose
         // comparison has no site is this reader and the plan disagreeing about what a condition
@@ -606,7 +606,7 @@ public final class GuardThresholds {
      */
     private static void publish(String behavior, Core.Binary comparison, CoverageSites.Plan plan,
                                 InputReads reads, Symbols symbols, ComparisonAssessment read,
-                                List<UnreadRule> out) {
+                                List<RuleWithoutALine> out) {
         BlockReason.RuleWithoutLineReason why = read.whyTheLineReadingDrewNone().orElse(null);
         if (why == null) {
             return;
@@ -618,7 +618,7 @@ public final class GuardThresholds {
         // walk met.
         List<FilingCoordinate> named = read.filedAt(comparison, reads, symbols);
         for (FilingCoordinate at : named) {
-            UnreadRule said = new UnreadRule(rule, cited, at, why);
+            RuleWithoutALine said = new RuleWithoutALine(rule, cited, at, why);
             if (out.stream().noneMatch(had -> had.sameAs(said))) {
                 out.add(said);
             }

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -593,30 +593,21 @@ public final class GuardThresholds {
      * says as much. A reading that stopped leaves whatever the rule states unknown, and its own
      * reason for stopping is what says which measures are thereby short of something.
      *
-     * <p>The rest leave nothing. A line on a position divides it; a rule read to the end that cuts
-     * no quantity states that every row satisfies it; a line the quantity never reaches divides the
-     * position into nothing and was understood; and a comparison about no position of the input, or
-     * about what the behavior answers, was never about a position for anything to be left at.
+     * <p>The rest leave nothing. A line on a position divides it; and a comparison about no position
+     * of the input, or about what the behavior answers, was never about a position for anything to
+     * be left at.
      *
-     * <p>Here rather than worked out afterwards from the comparison. Read again by the walk that
-     * collects what nothing turned into a line, a comparison whose carrier stopped the reading came
-     * back described as one that relates two positions — a sentence that says no measure is short
-     * of anything, over a model missing a border.
+     * <p>Which of them it is, is {@link ComparisonAssessment#whyTheLineReadingDrewNone}'s and not
+     * this reader's. The same table stood here and in the clause reader, so a case added to an
+     * assessment had to be answered twice; and worked out from the comparison afterwards rather
+     * than where the reading stopped, one whose carrier stopped the reading came back as a rule
+     * relating two positions — a sentence saying no measure is short of anything, over a model
+     * missing a border.
      */
     private static void publish(String behavior, Core.Binary comparison, CoverageSites.Plan plan,
                                 InputReads reads, Symbols symbols, ComparisonAssessment read,
                                 List<UnreadRule> out) {
-        BlockReason.RuleWithoutLineReason why = switch (read) {
-            case ComparisonAssessment.AcrossPositions _ ->
-                    new BlockReason.ComparisonBetweenPositions();
-            case ComparisonAssessment.CutsNothing _ ->
-                    new BlockReason.ComparisonCuttingNothing();
-            case ComparisonAssessment.OutsideTheDomain _ ->
-                    new BlockReason.ComparisonCuttingOutsideDomain();
-            case ComparisonAssessment.Unread unread -> unread.why();
-            case ComparisonAssessment.AtAPosition _, ComparisonAssessment.NoInput _,
-                 ComparisonAssessment.AnswerDependent _ -> null;
-        };
+        BlockReason.RuleWithoutLineReason why = read.whyTheLineReadingDrewNone().orElse(null);
         if (why == null) {
             return;
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -64,7 +64,7 @@ public final class GuardThresholds {
      * operator is still in hand, and which values arrive is asked of the reading of the whole body.
      */
     public record Guards(List<Threshold> thresholds,
-                         List<RuleWithoutALine> unread, List<Singled> singled,
+                         List<RuleWithoutALine> rulesWithoutALine, List<Singled> singled,
                          List<LineDrawn> between,
                          ReachingCuts reaching) {
 
@@ -97,7 +97,7 @@ public final class GuardThresholds {
 
         public Guards {
             thresholds = List.copyOf(thresholds);
-            unread = List.copyOf(unread);
+            rulesWithoutALine = List.copyOf(rulesWithoutALine);
             singled = List.copyOf(singled);
             between = List.copyOf(between);
         }
@@ -125,7 +125,7 @@ public final class GuardThresholds {
                             Symbols symbols,
                             souther.compiler.check.ElementBindings elements) {
         List<Threshold> found = new ArrayList<>();
-        List<RuleWithoutALine> unread = new ArrayList<>();
+        List<RuleWithoutALine> withoutALine = new ArrayList<>();
         List<Guards.Singled> singled = new ArrayList<>();
         List<LineDrawn> between = new ArrayList<>();
         // The comparisons this reader assessed, and not the positions they were about. A position
@@ -144,11 +144,11 @@ public final class GuardThresholds {
         ComparisonReadings read = ComparisonReadings.of(body, plan, InputReads.of(inputs, elements), symbols);
         for (ComparisonReadings.Reading each : read.drawn()) {
             lineAt(behavior, each.comparison(), plan, each.reads(), symbols, quantities, found,
-                    singled, between, assessed, unread);
+                    singled, between, assessed, withoutALine);
         }
         // And every comparison the model states something by that this reader never saw.
-        noticed(behavior, read, assessed, plan, symbols, unread);
-        return new Guards(found, unread, singled, between, read.reaching(plan));
+        noticed(behavior, read, assessed, plan, symbols, withoutALine);
+        return new Guards(found, withoutALine, singled, between, read.reaching(plan));
     }
 
     /**
@@ -520,7 +520,7 @@ public final class GuardThresholds {
                                souther.compiler.inputs.Quantities quantities,
                                List<Threshold> out, List<Guards.Singled> singled,
                                List<LineDrawn> between,
-                               List<Core> assessed, List<RuleWithoutALine> unread) {
+                               List<Core> assessed, List<RuleWithoutALine> withoutALine) {
         // The plan numbered every comparison of an instrumented condition before anything read a
         // line off one, so this is here. Required rather than looked up leniently: a line whose
         // comparison has no site is this reader and the plan disagreeing about what a condition
@@ -533,7 +533,7 @@ public final class GuardThresholds {
         ComparisonAssessment read =
                 ComparisonAssessment.of(behavior, each, reads, symbols, quantities, null);
         assessed.add(each);
-        publish(behavior, each, plan, reads, symbols, read, unread);
+        publish(behavior, each, plan, reads, symbols, read, withoutALine);
         switch (read) {
             case ComparisonAssessment.AtAPosition at -> {
                 OriginRef.ComparisonOrigin origin = originOf(behavior, each, site, plan,

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -200,7 +200,7 @@ public final class GuardThresholds {
             }
             InputReads reads = reading.reads();
             List<FilingCoordinate> named = filedAt(binary, reads, symbols);
-            final BlockReason.AboutARule why = why(binary, reads, symbols);
+            final BlockReason.RuleWithoutLineReason why = why(binary, reads, symbols);
             // The rule the author wrote, read off the source. Which comparison it is is the
             // behavior and the construct the source wrote; where a reader is sent is where it is
             // written. Neither comes from the plan: a comparison in a fork both of whose arms can
@@ -366,7 +366,7 @@ public final class GuardThresholds {
      * a body's read of a parameter is what names one here, and a coordinate of a value is what
      * names one over there.
      */
-    static BlockReason.AboutARule why(Core.Binary comparison, InputReads reads,
+    static BlockReason.RuleWithoutLineReason why(Core.Binary comparison, InputReads reads,
                            Symbols symbols) {
         return said(comparison, AffineReading.read(comparison, reads, symbols), reads, symbols);
     }
@@ -378,14 +378,14 @@ public final class GuardThresholds {
      * describes. Reading it again to say why it stopped is the comparison read twice, and the
      * second read is free to answer about a shape the first one had already got past.
      */
-    static BlockReason.ReadingStopped whyItStopped(Core.Binary comparison,
+    static BlockReason.RuleReadingStopped whyItStopped(Core.Binary comparison,
                                                    AffineReading.OfAComparison canonical,
                                                    InputReads reads, Symbols symbols) {
-        BlockReason.AboutARule said = said(comparison, canonical, reads, symbols);
+        BlockReason.RuleWithoutLineReason said = said(comparison, canonical, reads, symbols);
         // What this reader is asked for is why it stopped, and the words for a rule read to the end
         // are not answers to that. Reached with one, the caller has met an absence this reading did
         // not produce — so it is refused rather than passed on as a reason nothing fell short.
-        if (said instanceof BlockReason.ReadingStopped stopped) {
+        if (said instanceof BlockReason.RuleReadingStopped stopped) {
             return stopped;
         }
         throw new IllegalStateException(
@@ -393,7 +393,7 @@ public final class GuardThresholds {
     }
 
     /** What stopped a reading of this comparison, in whatever words its own answer comes in. */
-    private static BlockReason.AboutARule said(Core.Binary comparison,
+    private static BlockReason.RuleWithoutLineReason said(Core.Binary comparison,
                                                AffineReading.OfAComparison canonical,
                                                InputReads reads, Symbols symbols) {
         Names left = namesIn(comparison.left(), reads, symbols);
@@ -606,7 +606,7 @@ public final class GuardThresholds {
     private static void publish(String behavior, Core.Binary comparison, CoverageSites.Plan plan,
                                 InputReads reads, Symbols symbols, ComparisonAssessment read,
                                 List<UnreadRule> out) {
-        BlockReason.AboutARule why = switch (read) {
+        BlockReason.RuleWithoutLineReason why = switch (read) {
             case ComparisonAssessment.AcrossPositions _ ->
                     new BlockReason.ComparisonBetweenPositions();
             case ComparisonAssessment.CutsNothing _ ->

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -607,10 +607,15 @@ public final class GuardThresholds {
     private static void publish(String behavior, Core.Binary comparison, CoverageSites.Plan plan,
                                 InputReads reads, Symbols symbols, ComparisonAssessment read,
                                 List<RuleWithoutALine> out) {
-        BlockReason.RuleWithoutLineReason why = read.whyTheLineReadingDrewNone().orElse(null);
-        if (why == null) {
-            return;
-        }
+        read.whyTheLineReadingDrewNone().ifPresent(why ->
+                publish(behavior, comparison, plan, reads, symbols, read, out, why));
+    }
+
+    /** The same, once there is something to say. */
+    private static void publish(String behavior, Core.Binary comparison, CoverageSites.Plan plan,
+                                InputReads reads, Symbols symbols, ComparisonAssessment read,
+                                List<RuleWithoutALine> out,
+                                BlockReason.RuleWithoutLineReason why) {
         RuleRef.Comparison rule = new RuleRef.Comparison(behavior, comparison.origin());
         souther.compiler.check.RuleCitation cited = citationOf(comparison, plan.comparisons());
         // Whose positions these are is the assessment's answer, not this reader's: a rule that was

--- a/souther-compiler/src/main/java/souther/compiler/partition/LeftAtThePosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LeftAtThePosition.java
@@ -1,0 +1,78 @@
+package souther.compiler.partition;
+
+import souther.compiler.inputs.BlockReason;
+
+/**
+ * What a position with no evidence is left with, told apart by whose account it is.
+ *
+ * <p>Two things keep a position from being one the model draws no line through, and they are
+ * opposite sentences. A reading stopped here, so what the model says is not known; or every reading
+ * ran to the end and a rule states something the readings turn into no line. The first is a limit
+ * somebody can lift and the second is what the model says.
+ *
+ * <p><b>Told apart here rather than downstream.</b> The distinction is one this compiler makes in
+ * four places — whether a measure could not be made or the model states this, whether a question
+ * stands or is answered, which word a claim is annotated with — and each of them used to work it
+ * out from where the evidence had come from rather than from what it says. That was sound while a
+ * position could only be left with a stop; a rule read from end to end that draws no line reaches
+ * the same slot, and every one of those derivations went on answering as though it had not.
+ *
+ * <p>So the slot is a sum and not a {@link BlockReason}. A caller holding one of these has already
+ * been told which of the two it is, and cannot spell the question a fifth way.
+ */
+public sealed interface LeftAtThePosition {
+
+    /** Why, whichever of the two it is — for a reader that wants the reason and not the account. */
+    BlockReason why();
+
+    /**
+     * A reading stopped, so what is written here is not known to have been read.
+     *
+     * <p>Whichever reading: the walk that reaches into what a position holds, the reading of which
+     * values may stand there, or the reading of ends stopping on a rule. What they leave is the
+     * same — the position may yet be divided by what nobody managed to read.
+     */
+    record AReadingStopped(BlockReason.ReadingStopReason why) implements LeftAtThePosition {
+
+        public AReadingStopped {
+            if (why == null) {
+                throw new IllegalArgumentException("a reading that stopped says why");
+            }
+        }
+    }
+
+    /**
+     * A rule was read from end to end and draws no line here.
+     *
+     * <p>Nothing is missing. The rule relates this position to another, or cuts a quantity it does
+     * not appear in, or draws its line where that quantity never runs — each of them a fact about
+     * the rule, and each of them a reason the position has no class of its own that a row could be
+     * written for.
+     *
+     * <p>Still not an absence. The model states something here, so a verdict that the model divides
+     * the position no way would be saying what the declaration two tokens away denies.
+     */
+    record ARuleWithNoLine(BlockReason.ReadToEndWithoutLine why) implements LeftAtThePosition {
+
+        public ARuleWithNoLine {
+            if (why == null) {
+                throw new IllegalArgumentException("a rule with no line here says why it has none");
+            }
+        }
+    }
+
+    /**
+     * Which of the two {@code why} is, asked once.
+     *
+     * <p>A reason a rule reading stopped on is in both capabilities — it is a stop, and it is a rule
+     * with no line — and a stop is what it is here: what such a rule would have divided the position
+     * by is exactly the part nobody read. So the stop is asked first, and the arms are the whole of
+     * {@link BlockReason} between them.
+     */
+    static LeftAtThePosition of(BlockReason why) {
+        return switch (why) {
+            case BlockReason.ReadingStopReason stopped -> new AReadingStopped(stopped);
+            case BlockReason.ReadToEndWithoutLine read -> new ARuleWithNoLine(read);
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/LeftAtThePosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LeftAtThePosition.java
@@ -62,6 +62,45 @@ public sealed interface LeftAtThePosition {
     }
 
     /**
+     * What a run of rules with no line at one position leaves it with, or null where it holds
+     * none.
+     *
+     * <p><b>A stop ahead of a rule read to the end, and never the first of the list.</b> Either
+     * keeps the position from completing as one the model draws no line through, and they are not
+     * alike in anything else: one is a limit somebody can lift and the other is what the model
+     * says. Taken in the order the rules happen to be in, which of the two a position came out
+     * under turned on which clause its author wrote first.
+     */
+    static LeftAtThePosition of(Iterable<souther.compiler.inputs.RuleWithoutALine> rules) {
+        LeftAtThePosition out = null;
+        for (souther.compiler.inputs.RuleWithoutALine rule : rules) {
+            out = outranking(out, of(rule.why()));
+        }
+        return out;
+    }
+
+    /**
+     * Of two, the one that outranks — and the first where they rank alike.
+     *
+     * <p>The one priority, written once, because more than one reading answers about a position and
+     * their answers have to be put together. A reading that stopped outranks a rule read to the
+     * end: what such a rule states is known, and what a stop leaves is not, so a position where
+     * both happened is one somebody can still do something about. Written per phase, the phases
+     * disagreed — the input reading's rule read to the end hid a stop in the body, and a stop in
+     * the input reading was hidden by nothing at all.
+     */
+    static LeftAtThePosition outranking(LeftAtThePosition first, LeftAtThePosition second) {
+        if (first == null) {
+            return second;
+        }
+        if (second == null) {
+            return first;
+        }
+        return first instanceof AReadingStopped || !(second instanceof AReadingStopped)
+                ? first : second;
+    }
+
+    /**
      * Which of the two {@code why} is, asked once.
      *
      * <p>A reason a rule reading stopped on is in both capabilities — it is a stop, and it is a rule

--- a/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
@@ -153,10 +153,10 @@ public final class MeasureClosure {
      *                and it is the rule's own reason that answers
      *                ({@link souther.compiler.inputs.BlockReason.RuleWithoutLineReason#leavesShort})
      */
-    static Both of(List<Axis> axes, List<souther.compiler.inputs.UnreadRule> refused) {
+    static Both of(List<Axis> axes, List<souther.compiler.inputs.RuleWithoutALine> refused) {
         Set<ClosureGap> partition = new LinkedHashSet<>();
         Set<ClosureGap> border = new LinkedHashSet<>();
-        for (souther.compiler.inputs.UnreadRule rule : refused) {
+        for (souther.compiler.inputs.RuleWithoutALine rule : refused) {
             if (rule.why().leavesShort(CoverageObligation.Measure.PARTITION)) {
                 partition.add(new ClosureGap.RuleUnread(rule));
             }

--- a/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
@@ -41,7 +41,7 @@ import java.util.Set;
  * <p>Which measures each of the two costs is each one's own answer, and they do not agree. A
  * position whose rules were never enumerated and one the walk could not reach into leave both short,
  * because what is not known about them is not known for either. And a rule set aside answers
- * through its own reason ({@link souther.compiler.inputs.BlockReason.AboutARule#leavesShort}),
+ * through its own reason ({@link souther.compiler.inputs.BlockReason.RuleWithoutLineReason#leavesShort}),
  * which for a comparison relating two positions is neither measure.
  *
  * <p><b>A clause's question may stand and a comparison's may not.</b> A comparison raises a question
@@ -151,7 +151,7 @@ public final class MeasureClosure {
      *                Asked which measures it leaves short rather than counted: a comparison relating
      *                two positions is set aside by what it says and not by anything missing here,
      *                and it is the rule's own reason that answers
-     *                ({@link souther.compiler.inputs.BlockReason.AboutARule#leavesShort})
+     *                ({@link souther.compiler.inputs.BlockReason.RuleWithoutLineReason#leavesShort})
      */
     static Both of(List<Axis> axes, List<souther.compiler.inputs.UnreadRule> refused) {
         Set<ClosureGap> partition = new LinkedHashSet<>();

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -68,7 +68,7 @@ public final class Partitions {
     public record Partitioning(List<Axis> axes,
                                java.util.Set<NumericTerm> uncertain,
                                List<UndividedPosition> undivided,
-                               List<RuleWithoutALine> unread,
+                               List<RuleWithoutALine> rulesWithoutALine,
                                List<souther.compiler.inputs.PositionReadingBlocked> blocked,
                                List<souther.compiler.inputs.PositionValuesNotSeparated> notSeparated,
                                List<Border> between,
@@ -80,7 +80,7 @@ public final class Partitions {
             axes = List.copyOf(axes);
             uncertain = java.util.Set.copyOf(uncertain);
             undivided = List.copyOf(undivided);
-            unread = List.copyOf(unread);
+            rulesWithoutALine = List.copyOf(rulesWithoutALine);
             blocked = List.copyOf(blocked);
             notSeparated = List.copyOf(notSeparated);
             between = List.copyOf(between);
@@ -174,7 +174,7 @@ public final class Partitions {
                                   ReadingPolicy policy) {
         List<Axis> found = new ArrayList<>();
         java.util.Set<NumericTerm> uncertain = new java.util.LinkedHashSet<>();
-        List<RuleWithoutALine> unread = new ArrayList<>();
+        List<RuleWithoutALine> rulesWithoutALine = new ArrayList<>();
         // What the reading could not hold together, asked of every position it read rather than of
         // the ones left pending. This qualifies the classes and does not stand in for them: a
         // position with classes read from a product wider than the rules admit is exactly where it
@@ -191,7 +191,7 @@ public final class Partitions {
                 notSeparated.add(
                         new souther.compiler.inputs.PositionValuesNotSeparated(position.path()));
             }
-            axisOf(behavior, position, symbols, policy, found, uncertain, unread);
+            axisOf(behavior, position, symbols, policy, found, uncertain, rulesWithoutALine);
         }
         // Every position the reading found, including the ones nothing divides: a report names what
         // it could not measure at one of those, and a body's comparison can still draw the first
@@ -206,11 +206,11 @@ public final class Partitions {
         // of them was left unread — settled beside each axis, as it is once a body has spoken.
         List<Measured> measured = new ArrayList<>();
         for (Axis axis : kept) {
-            keep(new ArrayList<>(), measured, axis, null, unread);
+            keep(new ArrayList<>(), measured, axis, null, rulesWithoutALine);
         }
-        MeasureClosure.Both closed = MeasureClosure.of(kept, unread);
+        MeasureClosure.Both closed = MeasureClosure.of(kept, rulesWithoutALine);
         return new Partitioning(kept, uncertain, undividedIn(measured),
-                List.copyOf(unread), blockedIn(measured), List.copyOf(notSeparated),
+                List.copyOf(rulesWithoutALine), blockedIn(measured), List.copyOf(notSeparated),
                 List.of(), linesAlong(kept, quantities, symbols), ReachingCuts.NONE,
                 closed.partition(), closed.border());
     }
@@ -235,7 +235,7 @@ public final class Partitions {
             measured.add(new Measured(axis, drew));
             return;
         }
-        // Whether this phase left anything at the position unread, and not which limit it was.
+        // Whether this phase left anything at the position with no line, and not which limit it was.
         // A limit belongs to the rule it stopped, and the findings carry it there; taken as the
         // position's, the first rule of however many were stopped alike was the one a report named.
         //
@@ -331,8 +331,8 @@ public final class Partitions {
                                               souther.compiler.inputs.Quantities reading,
                                               List<Threshold> thresholds,
                                               Symbols symbols, ReadingPolicy policy,
-                                              List<RuleWithoutALine> unread) {
-        return withThresholds(base, reading, thresholds, symbols, policy, unread, List.of());
+                                              List<RuleWithoutALine> rulesWithoutALine) {
+        return withThresholds(base, reading, thresholds, symbols, policy, rulesWithoutALine, List.of());
     }
 
     /**
@@ -348,9 +348,9 @@ public final class Partitions {
                                               souther.compiler.inputs.Quantities reading,
                                               List<Threshold> thresholds,
                                               Symbols symbols, ReadingPolicy policy,
-                                              List<RuleWithoutALine> unread,
+                                              List<RuleWithoutALine> rulesWithoutALine,
                                               List<GuardThresholds.Guards.Singled> singled) {
-        return withThresholds(base, reading, thresholds, symbols, policy, unread, singled, List.of());
+        return withThresholds(base, reading, thresholds, symbols, policy, rulesWithoutALine, singled, List.of());
     }
 
     /**
@@ -365,10 +365,10 @@ public final class Partitions {
                                               souther.compiler.inputs.Quantities reading,
                                               List<Threshold> thresholds,
                                               Symbols symbols, ReadingPolicy policy,
-                                              List<RuleWithoutALine> unread,
+                                              List<RuleWithoutALine> rulesWithoutALine,
                                               List<GuardThresholds.Guards.Singled> singled,
                                               List<LineDrawn> between) {
-        return withThresholds(base, reading, thresholds, symbols, policy, unread, singled, between,
+        return withThresholds(base, reading, thresholds, symbols, policy, rulesWithoutALine, singled, between,
                 souther.compiler.check.PathReachability.Answers.NONE);
     }
 
@@ -390,12 +390,12 @@ public final class Partitions {
                                               souther.compiler.inputs.Quantities reading,
                                               List<Threshold> thresholds,
                                               Symbols symbols, ReadingPolicy policy,
-                                              List<RuleWithoutALine> unread,
+                                              List<RuleWithoutALine> rulesWithoutALine,
                                               List<GuardThresholds.Guards.Singled> singled,
                                               List<LineDrawn> between,
                                               souther.compiler.check.PathReachability.Answers
                                                       arrives) {
-        return withThresholds(base, reading, thresholds, symbols, policy, unread, singled, between,
+        return withThresholds(base, reading, thresholds, symbols, policy, rulesWithoutALine, singled, between,
                 arrives, ReachingCuts.NONE);
     }
 
@@ -411,7 +411,7 @@ public final class Partitions {
                                               souther.compiler.inputs.Quantities reading,
                                               List<Threshold> thresholds,
                                               Symbols symbols, ReadingPolicy policy,
-                                              List<RuleWithoutALine> unread,
+                                              List<RuleWithoutALine> rulesWithoutALine,
                                               List<GuardThresholds.Guards.Singled> singled,
                                               List<LineDrawn> between,
                                               souther.compiler.check.PathReachability.Answers
@@ -420,8 +420,8 @@ public final class Partitions {
         // Both producers of one kind of evidence. What a body compared and what a type's own rules
         // bound are read by different readers and answer the same question, so a position either of
         // them wrote about and neither could turn into a line is named once, whichever wrote it.
-        List<RuleWithoutALine> rules = new ArrayList<>(base.unread());
-        for (RuleWithoutALine each : unread) {
+        List<RuleWithoutALine> rules = new ArrayList<>(base.rulesWithoutALine());
+        for (RuleWithoutALine each : rulesWithoutALine) {
             if (rules.stream().noneMatch(had -> had.sameAs(each))) {
                 rules.add(each);
             }
@@ -827,10 +827,10 @@ public final class Partitions {
     private static void axisOf(String behavior, Position position, Symbols symbols,
                                ReadingPolicy policy,
                                List<Axis> out, java.util.Set<NumericTerm> uncertain,
-                               List<RuleWithoutALine> unread) {
+                               List<RuleWithoutALine> rulesWithoutALine) {
         for (RuleWithoutALine each : position.rulesWithoutALine()) {
-            if (unread.stream().noneMatch(had -> had.sameAs(each))) {
-                unread.add(each);
+            if (rulesWithoutALine.stream().noneMatch(had -> had.sameAs(each))) {
+                rulesWithoutALine.add(each);
             }
         }
         NumericTerm term = position.term();

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -219,10 +219,11 @@ public final class Partitions {
         // a selection made now would be made where the least is known about what it selects
         // (see this package's documentation).
         List<Axis> kept = new ArrayList<>(found);
-        // A position undivided because a rule about it went unread says that here, without waiting
+        // A position undivided because a rule about it drew no line says that here, without waiting
         // for a body: a type bounded by a rule this cannot read is one whether or not any behavior
-        // compares it. Nothing has compared anything yet, so what the rules came to is whether one
-        // of them was left unread — settled beside each axis, as it is once a body has spoken.
+        // compares it, and so is one bounded by a rule read to the end that divides nothing. What
+        // the rules came to is whether either happened, and which of the two it was — settled
+        // beside each axis, as it is once a body has spoken.
         List<Measured> measured = new ArrayList<>();
         for (Axis axis : kept) {
             keep(new ArrayList<>(), measured, axis, null, rulesWithoutALine);
@@ -245,8 +246,8 @@ public final class Partitions {
     private record Measured(Axis axis, BodyCutInspection body) {}
 
     /** The axis, and the body's answer about it — a line it drew, nothing, or a rule about it that
-     *  went unread. Kept beside the axis rather than looked up afterwards by how its path is
-     *  spelled. */
+     *  it drew no line from, with which of the two ways that happened. Kept beside the axis rather
+     *  than looked up afterwards by how its path is spelled. */
     private static void keep(List<Axis> out, List<Measured> measured, Axis axis,
                              BodyCutInspection drew, List<RuleWithoutALine> rules) {
         out.add(axis);
@@ -520,8 +521,8 @@ public final class Partitions {
             //
             // A rule read and left outside what the position holds divided nothing, and it is not
             // a rule that went unread either: what it says was understood. So the answer there is
-            // that the rules were exhausted, which is what keeps `Blocked` meaning that a
-            // comparison could not be interpreted rather than everything that came to nothing.
+            // that the rules were exhausted, which is what keeps `NoLine` meaning that a rule was
+            // written about the position rather than everything that came to nothing.
             NumericDomain.Bounds within = domain;
             NumericTerm measuredAt = term;
             Axis read = axis;

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -867,7 +867,7 @@ public final class Partitions {
                     case StructuralInspection.Retained retained ->
                             out.add(Axis.pendingAt(id, term, position.type(),
                                     position.unansweredQuestions(), position.rulesNotReached(),
-                                    retained.continuation(), leftUnread(position)));
+                                    retained.continuation(), leftAt(position)));
                 }
             }
         }
@@ -885,16 +885,29 @@ public final class Partitions {
      * for a range at all — so it names one limit while the report's own line names another, and one
      * position came back with two causes for one clause.
      *
-     * <p>The first, as a comparison's is. Any of them keeps the position from completing as one the
-     * model draws no line through, which is the whole of what a caller here does with it: a rule
-     * this got partway through is a limit somebody can lift, and one read from end to end that
-     * draws no line is not, and neither of them leaves a position the model states nothing about.
-     * Which of the two it is stays readable in the value — {@code PendingPosition.reportable} asks
-     * the type before writing a limit down, and writes none for a rule.
+     * <p><b>A stop ahead of a rule read to the end, and not the first of the list.</b> Either keeps
+     * the position from completing as one the model draws no line through, and they are not alike
+     * in anything else: one is a limit somebody can lift and the other is what the model says. Taken
+     * in the order the rules happen to be in, which of the two a position came out under turned on
+     * which clause its author wrote first.
+     *
+     * <p>Which of the two it is travels with it, so nothing downstream works it out again. That is
+     * what {@link LeftAtThePosition} is for: the same distinction is drawn by a verdict, by a
+     * generation's account of why no row could answer, and by the words a claim is annotated with,
+     * and each of them used to read it off where the evidence had come from.
      */
-    private static BlockReason leftUnread(Position position) {
-        return position.rulesWithoutALine().isEmpty() ? position.valuesUnread()
-                : position.rulesWithoutALine().getFirst().why();
+    private static LeftAtThePosition leftAt(Position position) {
+        BlockReason stopped = position.valuesUnread();
+        for (RuleWithoutALine rule : position.rulesWithoutALine()) {
+            if (rule.why() instanceof BlockReason.RuleReadingStopped why) {
+                return new LeftAtThePosition.AReadingStopped(why);
+            }
+        }
+        if (stopped != null) {
+            return LeftAtThePosition.of(stopped);
+        }
+        return position.rulesWithoutALine().isEmpty() ? null
+                : LeftAtThePosition.of(position.rulesWithoutALine().getFirst().why());
     }
 
     // --- small helpers ----------------------------------------------------------------------------

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -9,7 +9,6 @@ import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
 import souther.compiler.check.FieldDomains;
 import souther.compiler.codegen.InvariantConstraints;
-import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.InputDomain;
 import souther.compiler.inputs.Position;
 import souther.compiler.inputs.StructuralInspection;
@@ -267,14 +266,18 @@ public final class Partitions {
         // A finding the reading did not name a number for is at the position, and answers for every
         // axis on it: what number it was about is what was not read, so an axis cannot be excused by
         // it naming another.
-        boolean anyUnread = rules.stream().anyMatch(one -> switch (one.at()) {
+        LeftAtThePosition left = LeftAtThePosition.of(rules.stream().filter(one -> switch (one.at()) {
             case souther.compiler.inputs.FilingCoordinate.OfTerm it ->
                     it.term().equals(axis.term());
             case souther.compiler.inputs.FilingCoordinate.AtPosition it ->
                     it.path().equals(axis.path());
-        });
-        measured.add(new Measured(axis, anyUnread ? new BodyCutInspection.Blocked()
-                : new BodyCutInspection.Exhausted()));
+        }).toList());
+        // Which of the two this phase was left with, and not merely that it was left with
+        // something. The verdict below tells a reading that stopped from a rule read to the end,
+        // and answered here with one word it read every rule this phase understood as one it could
+        // not read.
+        measured.add(new Measured(axis, left == null ? new BodyCutInspection.Exhausted()
+                : new BodyCutInspection.NoLine(left)));
     }
 
     /**
@@ -917,17 +920,10 @@ public final class Partitions {
      * and each of them used to read it off where the evidence had come from.
      */
     private static LeftAtThePosition leftAt(Position position) {
-        BlockReason stopped = position.valuesUnread();
-        for (RuleWithoutALine rule : position.rulesWithoutALine()) {
-            if (rule.why() instanceof BlockReason.RuleReadingStopped why) {
-                return new LeftAtThePosition.AReadingStopped(why);
-            }
-        }
-        if (stopped != null) {
-            return LeftAtThePosition.of(stopped);
-        }
-        return position.rulesWithoutALine().isEmpty() ? null
-                : LeftAtThePosition.of(position.rulesWithoutALine().getFirst().why());
+        return LeftAtThePosition.outranking(
+                LeftAtThePosition.of(position.rulesWithoutALine()),
+                position.valuesUnread() == null ? null
+                        : new LeftAtThePosition.AReadingStopped(position.valuesUnread()));
     }
 
     // --- small helpers ----------------------------------------------------------------------------

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -885,7 +885,12 @@ public final class Partitions {
      * for a range at all — so it names one limit while the report's own line names another, and one
      * position came back with two causes for one clause.
      *
-     * <p>The first, as a comparison's is. What a reader has to lift is the first limit in the way.
+     * <p>The first, as a comparison's is. Any of them keeps the position from completing as one the
+     * model draws no line through, which is the whole of what a caller here does with it: a rule
+     * this got partway through is a limit somebody can lift, and one read from end to end that
+     * draws no line is not, and neither of them leaves a position the model states nothing about.
+     * Which of the two it is stays readable in the value — {@code PendingPosition.reportable} asks
+     * the type before writing a limit down, and writes none for a rule.
      */
     private static BlockReason leftUnread(Position position) {
         return position.rulesWithoutALine().isEmpty() ? position.valuesUnread()

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -16,7 +16,7 @@ import souther.compiler.inputs.StructuralInspection;
 import souther.compiler.inputs.TypeBounds;
 import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.TermPath;
-import souther.compiler.inputs.UnreadRule;
+import souther.compiler.inputs.RuleWithoutALine;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.Granularity;
@@ -68,7 +68,7 @@ public final class Partitions {
     public record Partitioning(List<Axis> axes,
                                java.util.Set<NumericTerm> uncertain,
                                List<UndividedPosition> undivided,
-                               List<UnreadRule> unread,
+                               List<RuleWithoutALine> unread,
                                List<souther.compiler.inputs.PositionReadingBlocked> blocked,
                                List<souther.compiler.inputs.PositionValuesNotSeparated> notSeparated,
                                List<Border> between,
@@ -174,7 +174,7 @@ public final class Partitions {
                                   ReadingPolicy policy) {
         List<Axis> found = new ArrayList<>();
         java.util.Set<NumericTerm> uncertain = new java.util.LinkedHashSet<>();
-        List<UnreadRule> unread = new ArrayList<>();
+        List<RuleWithoutALine> unread = new ArrayList<>();
         // What the reading could not hold together, asked of every position it read rather than of
         // the ones left pending. This qualifies the classes and does not stand in for them: a
         // position with classes read from a product wider than the rules admit is exactly where it
@@ -229,7 +229,7 @@ public final class Partitions {
      *  went unread. Kept beside the axis rather than looked up afterwards by how its path is
      *  spelled. */
     private static void keep(List<Axis> out, List<Measured> measured, Axis axis,
-                             BodyCutInspection drew, List<UnreadRule> rules) {
+                             BodyCutInspection drew, List<RuleWithoutALine> rules) {
         out.add(axis);
         if (drew != null) {
             measured.add(new Measured(axis, drew));
@@ -331,7 +331,7 @@ public final class Partitions {
                                               souther.compiler.inputs.Quantities reading,
                                               List<Threshold> thresholds,
                                               Symbols symbols, ReadingPolicy policy,
-                                              List<UnreadRule> unread) {
+                                              List<RuleWithoutALine> unread) {
         return withThresholds(base, reading, thresholds, symbols, policy, unread, List.of());
     }
 
@@ -348,7 +348,7 @@ public final class Partitions {
                                               souther.compiler.inputs.Quantities reading,
                                               List<Threshold> thresholds,
                                               Symbols symbols, ReadingPolicy policy,
-                                              List<UnreadRule> unread,
+                                              List<RuleWithoutALine> unread,
                                               List<GuardThresholds.Guards.Singled> singled) {
         return withThresholds(base, reading, thresholds, symbols, policy, unread, singled, List.of());
     }
@@ -365,7 +365,7 @@ public final class Partitions {
                                               souther.compiler.inputs.Quantities reading,
                                               List<Threshold> thresholds,
                                               Symbols symbols, ReadingPolicy policy,
-                                              List<UnreadRule> unread,
+                                              List<RuleWithoutALine> unread,
                                               List<GuardThresholds.Guards.Singled> singled,
                                               List<LineDrawn> between) {
         return withThresholds(base, reading, thresholds, symbols, policy, unread, singled, between,
@@ -390,7 +390,7 @@ public final class Partitions {
                                               souther.compiler.inputs.Quantities reading,
                                               List<Threshold> thresholds,
                                               Symbols symbols, ReadingPolicy policy,
-                                              List<UnreadRule> unread,
+                                              List<RuleWithoutALine> unread,
                                               List<GuardThresholds.Guards.Singled> singled,
                                               List<LineDrawn> between,
                                               souther.compiler.check.PathReachability.Answers
@@ -411,7 +411,7 @@ public final class Partitions {
                                               souther.compiler.inputs.Quantities reading,
                                               List<Threshold> thresholds,
                                               Symbols symbols, ReadingPolicy policy,
-                                              List<UnreadRule> unread,
+                                              List<RuleWithoutALine> unread,
                                               List<GuardThresholds.Guards.Singled> singled,
                                               List<LineDrawn> between,
                                               souther.compiler.check.PathReachability.Answers
@@ -420,8 +420,8 @@ public final class Partitions {
         // Both producers of one kind of evidence. What a body compared and what a type's own rules
         // bound are read by different readers and answer the same question, so a position either of
         // them wrote about and neither could turn into a line is named once, whichever wrote it.
-        List<UnreadRule> rules = new ArrayList<>(base.unread());
-        for (UnreadRule each : unread) {
+        List<RuleWithoutALine> rules = new ArrayList<>(base.unread());
+        for (RuleWithoutALine each : unread) {
             if (rules.stream().noneMatch(had -> had.sameAs(each))) {
                 rules.add(each);
             }
@@ -827,8 +827,8 @@ public final class Partitions {
     private static void axisOf(String behavior, Position position, Symbols symbols,
                                ReadingPolicy policy,
                                List<Axis> out, java.util.Set<NumericTerm> uncertain,
-                               List<UnreadRule> unread) {
-        for (UnreadRule each : position.unreadRules()) {
+                               List<RuleWithoutALine> unread) {
+        for (RuleWithoutALine each : position.rulesWithoutALine()) {
             if (unread.stream().noneMatch(had -> had.sameAs(each))) {
                 unread.add(each);
             }
@@ -888,8 +888,8 @@ public final class Partitions {
      * <p>The first, as a comparison's is. What a reader has to lift is the first limit in the way.
      */
     private static BlockReason leftUnread(Position position) {
-        return position.unreadRules().isEmpty() ? position.valuesUnread()
-                : position.unreadRules().getFirst().why();
+        return position.rulesWithoutALine().isEmpty() ? position.valuesUnread()
+                : position.rulesWithoutALine().getFirst().why();
     }
 
     // --- small helpers ----------------------------------------------------------------------------

--- a/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
@@ -129,7 +129,7 @@ sealed interface PendingPosition {
             return null;
         }
         return switch (blocked.why()) {
-            case BlockReason.AboutARule _ -> null;
+            case BlockReason.RuleWithoutLineReason _ -> null;
             case BlockReason.AboutThePosition why ->
                     new souther.compiler.inputs.PositionReadingBlocked(at(), why);
         };

--- a/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
@@ -106,7 +106,7 @@ sealed interface PendingPosition {
      * did: {@link #of} refuses an axis with evidence.
      *
      * <p>Null where the surviving reason is about a rule. Such a reason is a rule this read and
-     * could not use, which is an {@link souther.compiler.inputs.UnreadRule} made by the reader that
+     * could not use, which is an {@link souther.compiler.inputs.RuleWithoutALine} made by the reader that
      * read it and carrying which rule — said again here, it would be the same fact twice, once
      * without the rule.
      *

--- a/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
@@ -41,7 +41,25 @@ sealed interface PendingPosition {
      * <p>Carried rather than reported: a rule a body writes may still draw a line on this same
      * position, and where one does the position is measured and this is never said.
      */
-    record Blocked(TermPath at, BlockReason why) implements PendingPosition {}
+    record Blocked(TermPath at, BlockReason.ReadingStopReason why) implements PendingPosition {}
+
+    /**
+     * A rule states something here and the readings turn it into no line, every one of them having
+     * run to the end.
+     *
+     * <p>Its own state beside {@link Blocked}, which is this compiler having fallen short. Nothing
+     * is missing here: the rule relates the position to another, or cuts a quantity it does not
+     * appear in, or draws its line where that quantity never runs. What the two share is that an
+     * absence may not follow from either — the model states something at this position — and what
+     * they do not share is whose work it would be to change that.
+     *
+     * <p>Held apart because the consumers of this chain each carry the same distinction and each
+     * used to read it off which state this was. A rule read from end to end arriving as
+     * {@link Blocked} came out as a position this compiler could not read, in a verdict, in a
+     * generation's account of why no row could answer, and in the words a claim is annotated with.
+     */
+    record ARuleWithNoLine(TermPath at, BlockReason.ReadToEndWithoutLine why)
+            implements PendingPosition {}
 
     /**
      * What is still to be answered for at {@code axis}, or null where the axis has evidence.
@@ -71,9 +89,7 @@ sealed interface PendingPosition {
             //
             // It outranks nothing else. This is not a division, so the position is still pending
             // whatever a body says; it is a rule the model states, so an absence may not follow.
-            case StructuralInspection.Continuation.None _ ->
-                    axis.unread() == null ? new Leaf(axis.path())
-                            : new Blocked(axis.path(), axis.unread());
+            case StructuralInspection.Continuation.None _ -> pending(axis);
             // A sequence, whose elements were reached and are a position of their own. Nothing
             // stopped here, so this is the same state a leaf is in: what the list itself divides
             // into is what its own rules say about how many it holds, and an absence may follow
@@ -83,14 +99,28 @@ sealed interface PendingPosition {
             // And a sum, whose cases were reached and stand under it. Nothing stopped here either:
             // a sum with no evidence is one whose own cases the rules left it none of, which is a
             // reading that ran to the end.
-                 StructuralInspection.Continuation.Branches _ ->
-                    axis.unread() == null ? new Leaf(axis.path())
-                            : new Blocked(axis.path(), axis.unread());
+                 StructuralInspection.Continuation.Branches _ -> pending(axis);
             // A position with no evidence that was never read. Nothing about a model follows from
             // it — an answer here would be this compiler's state written down as what the model
             // divides, which is the sentence the whole protocol is against.
             case null -> throw new IllegalStateException(
                     "nothing was read at " + axis.path() + " and it has no evidence");
+        };
+    }
+
+    /**
+     * A position nothing under it accounts for, in the state whatever is left at it puts it in.
+     *
+     * <p>Which of the two states is the evidence's answer and not this reader's. Read off whether
+     * the slot was filled at all, a rule read from end to end put the position in the state that
+     * says this compiler could not read it.
+     */
+    private static PendingPosition pending(Axis axis) {
+        return switch (axis.leftWith()) {
+            case null -> new Leaf(axis.path());
+            case LeftAtThePosition.AReadingStopped(var why) -> new Blocked(axis.path(), why);
+            case LeftAtThePosition.ARuleWithNoLine(var why) ->
+                    new ARuleWithNoLine(axis.path(), why);
         };
     }
 
@@ -129,7 +159,10 @@ sealed interface PendingPosition {
             return null;
         }
         return switch (blocked.why()) {
-            case BlockReason.RuleWithoutLineReason _ -> null;
+            // A rule this got partway through is a finding about that rule, made where the rule is
+            // known and named there. What is written here is the other one: a position whose rules
+            // this never arrived at, which names no rule because none was seen.
+            case BlockReason.RuleReadingStopped _ -> null;
             case BlockReason.AboutThePosition why ->
                     new souther.compiler.inputs.PositionReadingBlocked(at(), why);
         };
@@ -159,6 +192,10 @@ sealed interface PendingPosition {
         }
         return switch (this) {
             case Blocked _ -> UndividedPosition.cannotDerive(at());
+            // Read to the end, and what it says draws no line. Not a derivation this compiler could
+            // not make, and not an absence either: the model states something at this position, and
+            // the rule that states it is named in a finding of its own.
+            case ARuleWithNoLine _ -> UndividedPosition.statedWithoutALine(at());
             case Leaf _ -> switch (body) {
                 case BodyCutInspection.Blocked _ -> UndividedPosition.cannotDerive(at());
                 // The producers of both phases asked, none of them stopped, and none of them found

--- a/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
@@ -177,10 +177,17 @@ sealed interface PendingPosition {
      * reason beside it. What makes it the phase's answer is where it is produced, not this
      * signature: a caller inside this package can still build one out of half a reading.
      *
-     * <p>The structural reason outranks the rules'. Where the walk could not reach into what a
-     * position holds, a rule naming something inside it describes that same stop from the other end
-     * and the first is the cause (issue #626). So a {@link Blocked} completes as itself whatever
-     * the rules came to, and only a {@link Leaf} can reach an absence.
+     * <p><b>Two readings answer about one position, and the verdict is one.</b> Which of their
+     * answers outranks is {@link LeftAtThePosition#outranking}'s and is written once: a reading
+     * that stopped over a rule read to the end, and either over nothing being stated. Decided per
+     * phase instead, the phases disagreed — a rule read to the end in the declaration hid a stop
+     * in the body, and a rule read to the end in the body was reported as a stop because that is
+     * the only thing the body could say.
+     *
+     * <p>The structural reason is among what outranks, not beside it. Where the walk could not
+     * reach into what a position holds, a rule naming something inside it describes that same stop
+     * from the other end and the first is the cause (issue #626) — a stop either way, so the
+     * priority already has it.
      */
     default UndividedPosition complete(BodyCutInspection body) {
         if (body instanceof BodyCutInspection.Evidence) {
@@ -190,20 +197,37 @@ sealed interface PendingPosition {
             throw new IllegalStateException(
                     "the rules drew a line at " + at() + " and its axis has no evidence");
         }
-        return switch (this) {
-            case Blocked _ -> UndividedPosition.cannotDerive(at());
+        LeftAtThePosition left = LeftAtThePosition.outranking(leftHere(), leftBy(body));
+        return switch (left) {
+            case null -> UndividedPosition.absentAfter(this);
+            // Something is written here and this compiler did not read it, so nothing about the
+            // model follows from there being no line.
+            case LeftAtThePosition.AReadingStopped _ -> UndividedPosition.cannotDerive(at());
             // Read to the end, and what it says draws no line. Not a derivation this compiler could
             // not make, and not an absence either: the model states something at this position, and
             // the rule that states it is named in a finding of its own.
-            case ARuleWithNoLine _ -> UndividedPosition.statedWithoutALine(at());
-            case Leaf _ -> switch (body) {
-                case BodyCutInspection.Blocked _ -> UndividedPosition.cannotDerive(at());
-                // The producers of both phases asked, none of them stopped, and none of them found
-                // anything. Which is the only way to an absence, and is what one means: what those
-                // readers read, rather than a claim about what could have been written.
-                case BodyCutInspection.Exhausted _ -> UndividedPosition.absentAfter(this);
-                case BodyCutInspection.Evidence _ -> throw new IllegalStateException("unreachable");
-            };
+            case LeftAtThePosition.ARuleWithNoLine _ -> UndividedPosition.statedWithoutALine(at());
+        };
+    }
+
+    /** What the reading of this position's own declarations left it with. */
+    private LeftAtThePosition leftHere() {
+        return switch (this) {
+            case Leaf _ -> null;
+            case Blocked blocked -> new LeftAtThePosition.AReadingStopped(blocked.why());
+            case ARuleWithNoLine it -> new LeftAtThePosition.ARuleWithNoLine(it.why());
+        };
+    }
+
+    /** And what the reading of the body left it with. */
+    private static LeftAtThePosition leftBy(BodyCutInspection body) {
+        return switch (body) {
+            // The producers of this phase asked, none of them stopped, and none of them found
+            // anything. Which is one half of the way to an absence, and is what it means: what
+            // those readers read, rather than a claim about what could have been written.
+            case BodyCutInspection.Exhausted _ -> null;
+            case BodyCutInspection.NoLine(var left) -> left;
+            case BodyCutInspection.Evidence _ -> throw new IllegalStateException("unreachable");
         };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReportedReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReportedReason.java
@@ -50,6 +50,13 @@ public final class ReportedReason {
                     UndividedPosition.Reason.COMPETING_COORDINATES;
             case BlockReason.ComparisonBetweenPositions _ ->
                     UndividedPosition.Reason.UNSUPPORTED_PARTITION_SHAPE;
+            // The same word, from the other reading of the same rule. What a document promises its
+            // reader is which kind of thing stopped the derivation, and a relation between two
+            // positions is one kind of thing whether the reading that met it was drawing a line or
+            // gathering values — so the split this compiler needs between the two is a split it
+            // keeps to itself, and the two vocabularies still come to one word for one rule.
+            case BlockReason.ValueRuleRelatingTwoPositions _ ->
+                    UndividedPosition.Reason.UNSUPPORTED_PARTITION_SHAPE;
             // Its own word and not the one above. Both are rules this read to the end that divide
             // nothing, and what a reader may go on to do about them differs: one is waiting on a
             // class about two positions, and the other has nothing to wait for.

--- a/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
@@ -4,7 +4,7 @@ import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.TermPath;
 
 /**
- * A position no class came back for, and which of the two that is.
+ * A position no class came back for, and which of the three ways that happened.
  *
  * <p>The list of these used to be a list of paths, and everything downstream read a path in it as the
  * model having no distinction to draw there. A position whose rule is written in a form this does not
@@ -14,15 +14,22 @@ import souther.compiler.inputs.TermPath;
  * <p>So the absence is a value that has to be produced rather than the default reading of an empty
  * result. {@link Why.Absent} is produced by {@link PendingPosition#complete} and nowhere else, from
  * a position whose structural reading did not stop and whose rules were all read and drew nothing —
- * which is what the word means. Where the reading stopped, or where something named the position
- * and this could not turn it into a line, {@link Why.CannotDerive} says so and carries which.
+ * which is what the word means.
+ *
+ * <p>The other two are the two ways of not being that, and they are opposite sentences about this
+ * compiler. Where a reading stopped, {@link Why.CannotDerive} says something is written here that
+ * this did not read. Where every reading ran to the end and a rule states something that draws no
+ * line — a relation between two positions, a quantity the position cancels out of —
+ * {@link Why.StatedWithoutALine} says that instead: nothing is missing, and a reader sent after a
+ * limit would be looking for one that is not there. Held as one, the second went out as the first.
  *
  * @param at  the position, spelled the way a report names it
- * @param why whether the model draws nothing here or this could not read what it draws
+ * @param why whether the model draws nothing here, this could not read what it draws, or a rule
+ *            read from end to end states something that is no line
  */
 public record UndividedPosition(TermPath at, Why why) {
 
-    /** Which of the two it is. */
+    /** Which of the three it is. */
     public sealed interface Why {
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
@@ -68,6 +68,21 @@ public record UndividedPosition(TermPath at, Why why) {
          * lost.
          */
         record CannotDerive() implements Why {}
+
+        /**
+         * Every reading ran to the end, and a rule states something here that draws no line.
+         *
+         * <p>Neither of the two above. Not an absence — the model states something at this position,
+         * and a verdict saying it divides the position no way would deny the declaration two tokens
+         * away. Not a derivation this compiler could not make either: nothing was missing, and a
+         * reader sent after a limit would be looking for one that is not there.
+         *
+         * <p>What states it is named in a finding of its own, with the rule. Nothing here carries
+         * the rule, for the reason {@link CannotDerive} carries no cause: a verdict says whether
+         * anything divides the position, and reading a cause back off a verdict is where the rule
+         * was lost.
+         */
+        record StatedWithoutALine() implements Why {}
     }
 
     /**
@@ -188,6 +203,10 @@ public record UndividedPosition(TermPath at, Why why) {
      */
     static UndividedPosition absentAfter(PendingPosition proven) {
         return new UndividedPosition(proven.at(), Why.Absent.PROVEN);
+    }
+
+    static UndividedPosition statedWithoutALine(TermPath at) {
+        return new UndividedPosition(at, new Why.StatedWithoutALine());
     }
 
     static UndividedPosition cannotDerive(TermPath at) {

--- a/souther-compiler/src/main/java/souther/compiler/query/About.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/About.java
@@ -98,12 +98,17 @@ public sealed interface About {
     }
 
     /**
-     * A finding about something this reading did not read, whichever authority answered.
+     * A finding the document writes as {@code partition_not_read}, whichever authority answered.
      *
      * <p>Both shapes carry a limit, and a reader acts on it: which one is in the way is the thing
      * either finding was added to say. Asked here rather than matched against the kinds that have
      * one, for the reason {@link OfARule} is: a shape added and not listed writes no limit, and one
      * rule's findings at one position come out identical wherever it stopped for two of them.
+     *
+     * <p>Named after the kind these are written under, and it is wider than its own word — a rule
+     * read from end to end that draws no line is one of them. Which is a decision about the
+     * schema's vocabulary rather than about this grouping, and it is written down beside
+     * {@link PartitionEvidence.NotRead}, where the document's shape is.
      */
     sealed interface OfSomethingNotRead extends About {
 

--- a/souther-compiler/src/main/java/souther/compiler/query/About.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/About.java
@@ -127,9 +127,9 @@ public sealed interface About {
      * unread and left them to work out which rule — which the accounting was made to say and this
      * measure beside it was not.
      */
-    record ARuleThisCouldNotRead(PartitionEvidence.NotRead.ARule finding)
+    record ARuleWithoutALine(PartitionEvidence.NotRead.ARule finding)
             implements OfARule, OfSomethingNotRead {
-        public ARuleThisCouldNotRead {
+        public ARuleWithoutALine {
             java.util.Objects.requireNonNull(finding, "a finding is about something");
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1420,10 +1420,21 @@ public final class Adequacy {
             case About.APositionNoLineDivides _ ->
                     new GenerationOutcome.NotApplicable(GenerationOutcome.NotApplicable
                             .Reason.A_FACT_ABOUT_THE_MODEL);
-            // What this compiler could not read. A row would answer a question nothing asked, and
-            // offering one would be reporting our own shortfall as the author's work.
-            case About.APositionThisCouldNotRead _, About.ARuleWithoutALine _,
-                 About.APositionWhoseRulesWereNotReached _,
+            // <b>Asked of the finding and not read off which kind it is.</b> The two reasons here
+            // are the same distinction this compiler makes everywhere else — a shortfall of ours
+            // against something the model states — and a finding about something with no line
+            // carries both halves. Listed by kind, every rule with no line was a measure we could
+            // not make, including the ones we read from end to end and understood, and a build was
+            // told its own model's silence was our failure to read it.
+            case About.OfSomethingNotRead notRead -> new GenerationOutcome.NotApplicable(
+                    notRead.finding().readingStopped()
+                            // A row would answer a question nothing asked, and offering one would
+                            // be reporting our own shortfall as the author's work.
+                            ? GenerationOutcome.NotApplicable.Reason.NOTHING_WAS_MEASURED
+                            // The rule was read to the end and draws no line. Nothing is missing
+                            // and no row anybody writes changes what it states.
+                            : GenerationOutcome.NotApplicable.Reason.A_FACT_ABOUT_THE_MODEL);
+            case About.APositionWhoseRulesWereNotReached _,
                  About.APositionReadWiderThanItsRules _, About.AQuestionNothingAnswered _ ->
                     new GenerationOutcome.NotApplicable(GenerationOutcome.NotApplicable
                             .Reason.NOTHING_WAS_MEASURED);

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1422,7 +1422,7 @@ public final class Adequacy {
                             .Reason.A_FACT_ABOUT_THE_MODEL);
             // What this compiler could not read. A row would answer a question nothing asked, and
             // offering one would be reporting our own shortfall as the author's work.
-            case About.APositionThisCouldNotRead _, About.ARuleThisCouldNotRead _,
+            case About.APositionThisCouldNotRead _, About.ARuleWithoutALine _,
                  About.APositionWhoseRulesWereNotReached _,
                  About.APositionReadWiderThanItsRules _, About.AQuestionNothingAnswered _ ->
                     new GenerationOutcome.NotApplicable(GenerationOutcome.NotApplicable
@@ -2549,7 +2549,7 @@ public final class Adequacy {
                             case About.ACaseNoRowExpects _, About.ACaseNothingWasSeenToProduce _,
                                     About.APositionNoLineDivides _,
                                     About.APositionThisCouldNotRead _,
-                                    About.ARuleThisCouldNotRead _,
+                                    About.ARuleWithoutALine _,
                                     About.APositionWhoseRulesWereNotReached _,
                                     About.APositionReadWiderThanItsRules _,
                                     About.AQuestionNothingAnswered _ ->
@@ -3391,7 +3391,7 @@ public final class Adequacy {
                 case About.APointOfABorder(var point) -> point.role().againstTheLine()
                         ? Kind.BOUNDARY_UNMET : Kind.DOMAIN_POINT_UNCOVERED;
                 case About.APositionNoLineDivides _ -> Kind.PARTITION_NOT_DERIVABLE;
-                case About.ARuleThisCouldNotRead _ -> Kind.PARTITION_NOT_READ;
+                case About.ARuleWithoutALine _ -> Kind.PARTITION_NOT_READ;
                 // One word, whatever stopped the reading, and the reason beside it says which.
                 // PARTITION_RULES_NOT_REACHED belongs to the finding above — a position the axes
                 // did measure — and the two write nothing but the position, so sharing the word
@@ -3607,7 +3607,7 @@ public final class Adequacy {
                         Citation.of(behavior.pos()),
                         switch (each) {
                             case PartitionEvidence.NotRead.ARule rule ->
-                                    new About.ARuleThisCouldNotRead(rule);
+                                    new About.ARuleWithoutALine(rule);
                             case PartitionEvidence.NotRead.APosition position ->
                                     new About.APositionThisCouldNotRead(position);
                         }));
@@ -3789,7 +3789,7 @@ public final class Adequacy {
                         // defaulted, so that one added later has to be answered here rather than
                         // arriving as a warning with no sentence.
                         case About.ACaseNothingWasSeenToProduce _,
-                                About.APositionNoLineDivides _, About.APositionThisCouldNotRead _, About.ARuleThisCouldNotRead _,
+                                About.APositionNoLineDivides _, About.APositionThisCouldNotRead _, About.ARuleWithoutALine _,
                                 About.APositionWhoseRulesWereNotReached _,
                                 About.APositionReadWiderThanItsRules _,
                                 About.AQuestionNothingAnswered _ ->
@@ -3863,7 +3863,7 @@ public final class Adequacy {
                 // reason the switch above gives.
                 case About.ACaseNoRowAppliesItTo _, About.ACaseNothingWasSeenToProduce _,
                         About.APositionNoLineDivides _,
-                        About.APositionThisCouldNotRead _, About.ARuleThisCouldNotRead _,
+                        About.APositionThisCouldNotRead _, About.ARuleWithoutALine _,
                         About.APositionWhoseRulesWereNotReached _,
                         About.APositionReadWiderThanItsRules _,
                         About.AQuestionNothingAnswered _ -> { }

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -175,7 +175,7 @@ final class Coverages {
                 PartitionDerivation.of(axes, partitioning.partitionClosure()),
                 BoundaryDerivation.of(boundaries, partitioning.borderClosure()),
                 pairsOf(behavior.name(), divided, readings, level.readsRows(), budget),
-                partitioning.undivided(), partitioning.unread(), partitioning.blocked(),
+                partitioning.undivided(), partitioning.rulesWithoutALine(), partitioning.blocked(),
                 partitioning.notSeparated(), List.copyOf(standing),
                 whyUnclassified(readings.byRow(),
                         partitioning.axes().stream().map(Axis::id).toList()));

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -102,7 +102,7 @@ final class Coverages {
         // divide the position twice.
         return new Partitioned(Partitions.withThresholds(partitioning, quantities,
                 both(clauses.thresholds(), guards.thresholds()), symbols, policy,
-                both(clauses.unread(), guards.unread()),
+                both(clauses.rulesWithoutALine(), guards.rulesWithoutALine()),
                 both(clauses.singled(), guards.singled()),
                 both(clauses.between(), guards.between()), arrives,
                 // What a row had to satisfy to arrive at each comparison, from the walk that

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -23,7 +23,7 @@ import java.util.Set;
  * fact that costs a measure something into what weakened that measure, and the obvious next step is
  * to drop the lists and project them back out. Two of them cannot be: {@code unread} holds rules
  * that were set aside and left neither measure short — a comparison relating two positions is read,
- * says what it says, and divides nothing ({@code BlockReason.AboutARule.leavesShort}) — so the
+ * says what it says, and divides nothing ({@code BlockReason.RuleWithoutLineReason.leavesShort}) — so the
  * weakening is a strictly smaller set than what a reader is owed, and a projection would drop
  * exactly those rules from the report.
  *
@@ -208,7 +208,7 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
 
             @Override
             public boolean readingStopped() {
-                return finding.why() instanceof souther.compiler.inputs.BlockReason.ReadingStopped;
+                return finding.why() instanceof souther.compiler.inputs.BlockReason.RuleReadingStopped;
             }
 
             /** Which rule, which is what tells this finding from the one beside it. */

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -21,7 +21,7 @@ import java.util.Set;
  *                     both
  * <p><b>Why these are still here, beside the measures that went without them.</b> #953 moved every
  * fact that costs a measure something into what weakened that measure, and the obvious next step is
- * to drop the lists and project them back out. Two of them cannot be: {@code unread} holds rules
+ * to drop the lists and project them back out. Two of them cannot be: {@code rulesWithoutALine} holds rules
  * that were set aside and left neither measure short — a comparison relating two positions is read,
  * says what it says, and divides nothing ({@code BlockReason.RuleWithoutLineReason.leavesShort}) — so the
  * weakening is a strictly smaller set than what a reader is owed, and a projection would drop
@@ -42,7 +42,7 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
                                 Measure<List<BorderAssessment>> bounded,
                                 PairSpace pairs,
                                 List<souther.compiler.partition.UndividedPosition> notDerivable,
-                                List<souther.compiler.inputs.RuleWithoutALine> unread,
+                                List<souther.compiler.inputs.RuleWithoutALine> rulesWithoutALine,
                                 List<souther.compiler.inputs.PositionReadingBlocked> blocked,
                                 List<souther.compiler.inputs.PositionValuesNotSeparated> notSeparated,
                                 List<Unanswered> unanswered,
@@ -95,7 +95,7 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
 
     public PartitionEvidence {
         notDerivable = List.copyOf(notDerivable);
-        unread = List.copyOf(unread);
+        rulesWithoutALine = List.copyOf(rulesWithoutALine);
         notSeparated = List.copyOf(notSeparated);
         blocked = List.copyOf(blocked);
         unanswered = List.copyOf(unanswered);
@@ -282,7 +282,7 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
      */
     public List<NotRead> notRead() {
         List<NotRead> out = new java.util.ArrayList<>();
-        unread.forEach(each -> out.add(new NotRead.ARule(each)));
+        rulesWithoutALine.forEach(each -> out.add(new NotRead.ARule(each)));
         blocked.forEach(each -> out.add(new NotRead.APosition(each)));
         return List.copyOf(out);
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -42,7 +42,7 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
                                 Measure<List<BorderAssessment>> bounded,
                                 PairSpace pairs,
                                 List<souther.compiler.partition.UndividedPosition> notDerivable,
-                                List<souther.compiler.inputs.UnreadRule> unread,
+                                List<souther.compiler.inputs.RuleWithoutALine> unread,
                                 List<souther.compiler.inputs.PositionReadingBlocked> blocked,
                                 List<souther.compiler.inputs.PositionValuesNotSeparated> notSeparated,
                                 List<Unanswered> unanswered,
@@ -160,7 +160,7 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
     }
 
     /**
-     * One entry of what this reading could not read, as a document writes it.
+     * One entry of the document's {@code notRead}, as a document writes it.
      *
      * <p>Two shapes because two authorities answer. A rule was read and could not be used, and the
      * finding names which rule; or the reading never got to the rules of a position, and there is
@@ -171,6 +171,20 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
      * <p>The reason in the vocabulary a document promises its reader, not the one this compiler
      * records for itself: which capability was missing is this compiler's own business, and which
      * kind of thing stopped the derivation is what a reader can act on.
+     */
+    /*
+     * `NotRead` is the document's word, and it is wider than the word. A rule read from end to end
+     * that draws no line arrives here, and the array it is written to is called `notRead` in every
+     * document of schema 7. Renaming that is a version and a retired word, and the schema already
+     * tells a consumer which entries are about a limit of this compiler and which are facts about
+     * the rule — so the word stays, and the name here is the word, because this is where the
+     * document's shape is written and a type named for one thing writing a field named for another
+     * is a second place to be kept in step.
+     *
+     * Behind this projection it means what it says. Nothing in the compiler calls a rule it read to
+     * the end one it could not read: what a reading fell short of is `BlockReason.ReadingStopReason`
+     * and a rule that is no line at a position is `RuleWithoutALine`. The older word lives on this
+     * side alone.
      */
     public sealed interface NotRead {
 
@@ -194,7 +208,7 @@ public record PartitionEvidence(Measure<List<AxisCoverage>> partitioned,
         boolean readingStopped();
 
         /** A rule of the model this read and could not turn into a line. */
-        record ARule(souther.compiler.inputs.UnreadRule finding) implements NotRead {
+        record ARule(souther.compiler.inputs.RuleWithoutALine finding) implements NotRead {
 
             @Override
             public String at() {

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -1052,7 +1052,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         // given, which sent them looking for a rule the sentence never named — and two rules
         // stopped by one limit at one position came out as one line.
         for (Adequacy.Finding f : behavior.findings()) {
-            if (f.about() instanceof About.ARuleThisCouldNotRead(var it)) {
+            if (f.about() instanceof About.ARuleWithoutALine(var it)) {
                 // Two sentences, because two opposite things are being said. A form no reader takes
                 // apart is a limit of this compiler; a rule whose quantity is empty was read from
                 // end to end and says what it says. Written under one word, a line read "not read:
@@ -2217,7 +2217,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             case About.ACaseNoRowExpects _, About.ACaseNothingWasSeenToProduce _,
                     About.ACaseNoRowAppliesItTo _, About.AClassNoRowIsIn _,
                     About.APointOfABorder _, About.APositionNoLineDivides _,
-                    About.APositionThisCouldNotRead _, About.ARuleThisCouldNotRead _,
+                    About.APositionThisCouldNotRead _, About.ARuleWithoutALine _,
                     About.AQuestionNothingAnswered _,
                     About.APositionWhoseRulesWereNotReached _,
                     About.APositionReadWiderThanItsRules _ -> null;
@@ -2251,7 +2251,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     missing.name() + " (at " + missing.axis().path() + ")";
             case About.APositionNoLineDivides(var position) -> position.at().toString();
             case About.APositionThisCouldNotRead(var it) -> it.at();
-            case About.ARuleThisCouldNotRead(var it) -> it.at();
+            case About.ARuleWithoutALine(var it) -> it.at();
             case About.APositionWhoseRulesWereNotReached(var axis) -> axis.path();
             // The position, as the two above write it. What is said of it is the kind's; there is
             // no rule to name and no class this is about, so the position is the whole subject.

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -617,7 +617,7 @@ public final class GeneratedRows {
             // given words here.
             case About.ACaseNothingWasSeenToProduce _,
                     About.APositionNoLineDivides _, About.APositionThisCouldNotRead _,
-                    About.ARuleThisCouldNotRead _,
+                    About.ARuleWithoutALine _,
                     About.AQuestionNothingAnswered _,
                     About.APositionWhoseRulesWereNotReached _,
                     About.APositionReadWiderThanItsRules _ ->

--- a/souther-compiler/src/test/java/souther/compiler/ARuleReadToTheEndIsNotOneThisCouldNotReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleReadToTheEndIsNotOneThisCouldNotReadTest.java
@@ -20,12 +20,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * What a rule this read from end to end costs a measurement, which is nothing.
  *
- * <p>Four models differing by one clause, and the clause is the whole test. One draws a line; two
- * are read to the end and leave the positions no class of their own; one is written in a form
- * nothing here takes apart. The first three cost the measurement nothing and the fourth costs it
- * what a limit of this compiler costs, and the document has to say so — a rule read from end to end
- * reported as a question nobody answered tells an author to go and look at a clause that is doing
- * exactly what they wrote.
+ * <p>One model, one clause, and the clause is the whole test. It draws a line; or it is read to the
+ * end and leaves the positions no class of their own, three ways; or it is written in a form
+ * nothing here takes apart. Everything read to the end costs the measurement nothing, and only the
+ * last costs it what a limit of this compiler costs — a rule read from end to end reported as a
+ * question nobody answered tells an author to go and look at a clause that is doing exactly what
+ * they wrote.
+ *
+ * <p>And one that is read to the end and states the opposite. A comparison whose positions cancel
+ * to something no row satisfies admits nothing rather than restricting nothing, so what it raises
+ * is real — which is what keeps the reading above from being "the quantity is empty, so there is
+ * nothing to answer for".
  *
  * <p>Asked of the document and of the sentence a person reads, because the two are written by
  * different code from the same evidence and this is the seam every round of #1029 and #1047 went

--- a/souther-compiler/src/test/java/souther/compiler/ARuleReadToTheEndIsNotOneThisCouldNotReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleReadToTheEndIsNotOneThisCouldNotReadTest.java
@@ -37,7 +37,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *   <li>What a rule cuts outranks how it is spelled. Which positions a rule restricts is settled by
  *       the quantity its canonical form cuts, and the spelling answers only where there is no
  *       quantity to be had.</li>
- *   <li>A rule that cuts nothing raises no coverage obligation.</li>
+ *   <li>A comparison whose positions cancel and whose residue holds of every row raises no
+ *       coverage obligation. One whose positions cancel and whose residue holds of none admits
+ *       nothing, which is the opposite, and raises what it always did.</li>
  *   <li>A rule read to the end that draws no line is never a question nobody answered.</li>
  *   <li>Every question nobody answered is one whose reading actually stopped, which
  *       {@code RuleAccounting.Unaccounted} takes only a stop for.</li>

--- a/souther-compiler/src/test/java/souther/compiler/ARuleReadToTheEndIsNotOneThisCouldNotReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleReadToTheEndIsNotOneThisCouldNotReadTest.java
@@ -1,0 +1,164 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a rule this read from end to end costs a measurement, which is nothing.
+ *
+ * <p>Four models differing by one clause, and the clause is the whole test. One draws a line; two
+ * are read to the end and leave the positions no class of their own; one is written in a form
+ * nothing here takes apart. The first three cost the measurement nothing and the fourth costs it
+ * what a limit of this compiler costs, and the document has to say so — a rule read from end to end
+ * reported as a question nobody answered tells an author to go and look at a clause that is doing
+ * exactly what they wrote.
+ *
+ * <p>Asked of the document and of the sentence a person reads, because the two are written by
+ * different code from the same evidence and this is the seam every round of #1029 and #1047 went
+ * wrong at. The reason type told the two halves apart and the words underneath it did not.
+ */
+class ARuleReadToTheEndIsNotOneThisCouldNotReadTest {
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    /**
+     * One behavior, one record, and one clause written about a field it does not divide.
+     *
+     * <p>The behavior is deliberately about a different field. What the clause costs has to be read
+     * off the clause rather than off anything the body does with it, and a body comparing the same
+     * field would put a second reading over the first.
+     */
+    private static String model(String clause) {
+        return """
+                module m
+
+                data Auto
+                data Manual
+                data Small
+                data Large
+                data Size = Small | Large
+
+                data Box = { size: Size, name: String, lo: Int, hi: Int }
+                %s
+
+                behavior byBox : (b: Box) -> Auto | Manual
+                let byBox (b) =
+                    match b.size with
+                        | Small -> Auto
+                        | Large -> Manual
+
+                example byBox
+                    | "one" : (Box { size = Small, name = "n", lo = 1, hi = 2 }) -> Auto
+                """.formatted(clause);
+    }
+
+    /** What one of these models came to, in the words both surfaces write it in. */
+    private record Measured(String status, List<String> weakening, List<String> kinds,
+                            String human) {
+
+        boolean says(String word) {
+            return human.contains(word);
+        }
+    }
+
+    private static Measured of(String clause) {
+        Compilation compilation = Compilation.ofSource(model(clause), "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        AdequacyReport report = AdequacyReport.of(compilation);
+        JsonNode document = JSON.readTree(report.json(SourceNameResolver.identity()));
+        JsonNode behavior = document.get("modules").get(0).get("behaviors").get(0);
+        List<String> weakening = new ArrayList<>();
+        behavior.path("weakening").forEach(each -> weakening.add(each.asString()));
+        List<String> kinds = new ArrayList<>();
+        behavior.path("findings").forEach(each -> kinds.add(each.get("kind").asString()));
+        return new Measured(behavior.get("status").asString(), weakening, kinds,
+                report.human(SourceNameResolver.identity()));
+    }
+
+    /** A clause that draws a line, which is what the three below are read against. */
+    @Test
+    void aClauseThatDrawsALineIsMeasuredWhole() {
+        Measured measured = of("    invariant lo >= 0");
+
+        assertEquals("complete", measured.status());
+        assertEquals(List.of(), measured.weakening());
+        assertTrue(measured.kinds().contains("boundary_unmet"), measured.kinds().toString());
+        assertFalse(measured.kinds().contains("rule_unaccounted"), measured.kinds().toString());
+    }
+
+    /**
+     * A clause read to the end that relates two positions, which divides neither.
+     *
+     * <p>Nothing is missing: both sides were recognised, and what the clause says is not a set of
+     * one position's values. The document says the position has no class from this rule and asks
+     * nothing further of anybody.
+     */
+    @Test
+    void aClauseRelatingTwoPositionsCostsTheMeasurementNothing() {
+        Measured measured = of("    invariant lo <= hi");
+
+        assertEquals("complete", measured.status());
+        assertEquals(List.of(), measured.weakening());
+        assertTrue(measured.says("it relates two positions rather than dividing one"),
+                measured.human());
+        assertFalse(measured.kinds().contains("rule_unaccounted"), measured.kinds().toString());
+    }
+
+    /**
+     * A clause read to the end whose quantity the position does not appear in.
+     *
+     * <p>{@code lo - lo >= 0} holds of every row. It is read from end to end, and the sentence a
+     * person is shown says so; the accounting beside it raises a question about which values may
+     * stand at the position and nothing answers it, so a rule this compiler understood completely
+     * comes out as one nobody accounted for and takes the measurement down to partial with it.
+     *
+     * <p><b>This is what #1047 is about, and these three assertions are what it moves.</b> They are
+     * written against what this does today so that the change is visible as a change; the clause
+     * above raises no question at all and this one has to come to the same place.
+     */
+    @Test
+    void aClauseCuttingNothingIsStillCountedAsAQuestionNobodyAnswered() {
+        Measured measured = of("    invariant lo - lo >= 0");
+
+        assertTrue(measured.says("it was read to the end and cuts nothing this position appears in"),
+                measured.human());
+
+        assertEquals("partial", measured.status());
+        assertEquals(List.of("question_unanswered"), measured.weakening());
+        assertTrue(measured.kinds().contains("rule_unaccounted"), measured.kinds().toString());
+    }
+
+    /**
+     * And a clause nothing here takes apart, which is what a limit of this compiler looks like.
+     *
+     * <p>Here the question standing is the truth: what the clause says about the values was never
+     * read, so what the position may hold is not known to have been read either. The three above
+     * are what this one has to stay different from.
+     */
+    @Test
+    void aClauseNothingReadsIsAQuestionNobodyAnswered() {
+        Measured measured = of("    invariant String.length(name) <= 0 - 1");
+
+        assertEquals("partial", measured.status());
+        assertTrue(measured.weakening().contains("rule_unread"), measured.weakening().toString());
+        assertTrue(measured.weakening().contains("question_unanswered"),
+                measured.weakening().toString());
+        assertTrue(measured.says("written in a form this compiler does not read"), measured.human());
+        assertTrue(measured.kinds().contains("rule_unaccounted"), measured.kinds().toString());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/ARuleReadToTheEndIsNotOneThisCouldNotReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleReadToTheEndIsNotOneThisCouldNotReadTest.java
@@ -30,6 +30,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>Asked of the document and of the sentence a person reads, because the two are written by
  * different code from the same evidence and this is the seam every round of #1029 and #1047 went
  * wrong at. The reason type told the two halves apart and the words underneath it did not.
+ *
+ * <p>What these hold to, said once so that a later reader has it:
+ *
+ * <ul>
+ *   <li>What a rule cuts outranks how it is spelled. Which positions a rule restricts is settled by
+ *       the quantity its canonical form cuts, and the spelling answers only where there is no
+ *       quantity to be had.</li>
+ *   <li>A rule that cuts nothing raises no coverage obligation.</li>
+ *   <li>A rule read to the end that draws no line is never a question nobody answered.</li>
+ *   <li>Every question nobody answered is one whose reading actually stopped, which
+ *       {@code RuleAccounting.Unaccounted} takes only a stop for.</li>
+ *   <li>One comparison may come to different answers from different readings without being two
+ *       rules, and the document still writes one word for it
+ *       ({@code OneRuleReadTwoWaysIsTwoAnswersAndOneWordTest}).</li>
+ * </ul>
  */
 class ARuleReadToTheEndIsNotOneThisCouldNotReadTest {
 

--- a/souther-compiler/src/test/java/souther/compiler/ARuleReadToTheEndIsNotOneThisCouldNotReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleReadToTheEndIsNotOneThisCouldNotReadTest.java
@@ -122,25 +122,25 @@ class ARuleReadToTheEndIsNotOneThisCouldNotReadTest {
     /**
      * A clause read to the end whose quantity the position does not appear in.
      *
-     * <p>{@code lo - lo >= 0} holds of every row. It is read from end to end, and the sentence a
-     * person is shown says so; the accounting beside it raises a question about which values may
-     * stand at the position and nothing answers it, so a rule this compiler understood completely
-     * comes out as one nobody accounted for and takes the measurement down to partial with it.
+     * <p>{@code lo - lo >= 0} holds of every row, and the position it names cancels against itself.
+     * It costs the measurement what the clause above costs it, which is nothing: no value anywhere
+     * is admitted or refused, so there is no question about the values for anybody to answer.
      *
-     * <p><b>This is what #1047 is about, and these three assertions are what it moves.</b> They are
-     * written against what this does today so that the change is visible as a change; the clause
-     * above raises no question at all and this one has to come to the same place.
+     * <p>The position is written twice, so a classification counting off the sides made it a rule
+     * about {@code lo} raising the questions a rule about a position raises — which nothing could
+     * answer, because the rule states neither of them. A clause this compiler read from end to end
+     * came out as a question nobody had answered and took the measurement to partial with it.
      */
     @Test
-    void aClauseCuttingNothingIsStillCountedAsAQuestionNobodyAnswered() {
+    void aClauseCuttingNothingCostsTheMeasurementNothing() {
         Measured measured = of("    invariant lo - lo >= 0");
 
         assertTrue(measured.says("it was read to the end and cuts nothing this position appears in"),
                 measured.human());
 
-        assertEquals("partial", measured.status());
-        assertEquals(List.of("question_unanswered"), measured.weakening());
-        assertTrue(measured.kinds().contains("rule_unaccounted"), measured.kinds().toString());
+        assertEquals("complete", measured.status());
+        assertEquals(List.of(), measured.weakening());
+        assertFalse(measured.kinds().contains("rule_unaccounted"), measured.kinds().toString());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/ARuleReadToTheEndIsNotOneThisCouldNotReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleReadToTheEndIsNotOneThisCouldNotReadTest.java
@@ -159,6 +159,39 @@ class ARuleReadToTheEndIsNotOneThisCouldNotReadTest {
     }
 
     /**
+     * The same clause under a different operator, which is the same rule about the model.
+     *
+     * <p>{@code lo - lo == 0} holds of every row exactly as {@code lo - lo >= 0} does. Which
+     * operator an author wrote is no part of whether their rule states anything, so a fix that
+     * turned on the operator would have left this one telling them that which values may stand at
+     * {@code lo} is a question nothing answered.
+     */
+    @Test
+    void whichOperatorIsWrittenDoesNotDecideIt() {
+        Measured measured = of("    invariant lo - lo == 0");
+
+        assertEquals("complete", measured.status());
+        assertEquals(List.of(), measured.weakening());
+        assertFalse(measured.kinds().contains("rule_unaccounted"), measured.kinds().toString());
+    }
+
+    /**
+     * And a clause whose positions cancel to something no row satisfies, which is the opposite.
+     *
+     * <p>{@code lo - lo >= 1} is {@code 0 >= 1}. The quantity it cuts is empty, exactly as the two
+     * above, and the rule admits nothing rather than restricting nothing — so the questions it
+     * raises are real ones and the rows that cannot be built are what a reader is shown. Read off
+     * the empty quantity alone, this would have come out as a rule that states nothing.
+     */
+    @Test
+    void aClauseNoRowSatisfiesIsNotOneThatRestrictsNothing() {
+        Measured measured = of("    invariant lo - lo >= 1");
+
+        assertEquals("partial", measured.status());
+        assertTrue(measured.kinds().contains("rule_unaccounted"), measured.kinds().toString());
+    }
+
+    /**
      * And a clause nothing here takes apart, which is what a limit of this compiler looks like.
      *
      * <p>Here the question standing is the truth: what the clause says about the values was never

--- a/souther-compiler/src/test/java/souther/compiler/ARuleWithoutALineIsNamedByTheRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleWithoutALineIsNamedByTheRuleTest.java
@@ -37,7 +37,8 @@ class ARuleWithoutALineIsNamedByTheRuleTest {
 
     private static final JsonMapper JSON = JsonMapper.builder().build();
 
-    /** Two clauses of one declaration, stopped by one limit at one position. */
+    /** Two clauses of one declaration, each read to the end and each drawing no line at one
+     *  position. */
     private static final String TWO_INVARIANTS = """
             module m
 
@@ -84,11 +85,11 @@ class ARuleWithoutALineIsNamedByTheRuleTest {
      * rest. So the two clauses became one line and the line named neither.
      */
     @Test
-    void twoInvariantClausesStoppedAlikeAreTwoFindings() {
+    void twoInvariantClausesWithNoLineAreTwoFindings() {
         // Two rules about two positions, so four findings: a reader looking up either position is
         // owed both rules. What was one line is the pair at one position.
-        assertEquals(4, rulesNotRead(TWO_INVARIANTS).size(), () -> unread(TWO_INVARIANTS));
-        assertEquals(2, ruleIdsNotRead(TWO_INVARIANTS).size(), () -> unread(TWO_INVARIANTS));
+        assertEquals(4, rulesNotRead(TWO_INVARIANTS).size(), () -> withoutALine(TWO_INVARIANTS));
+        assertEquals(2, ruleIdsNotRead(TWO_INVARIANTS).size(), () -> withoutALine(TWO_INVARIANTS));
         assertTrue(namesRule(human(TWO_INVARIANTS), "invariant R (first)"),
                 human(TWO_INVARIANTS));
         assertTrue(namesRule(human(TWO_INVARIANTS), "invariant R (second)"),
@@ -110,14 +111,14 @@ class ARuleWithoutALineIsNamedByTheRuleTest {
     /** And two comparisons of one condition, which the guard producer kept one of. */
     @Test
     void twoComparisonsStoppedAlikeAreTwoFindings() {
-        assertEquals(2, rulesNotRead(TWO_COMPARISONS).size(), () -> unread(TWO_COMPARISONS));
-        assertEquals(2, ruleIdsNotRead(TWO_COMPARISONS).size(), () -> unread(TWO_COMPARISONS));
+        assertEquals(2, rulesNotRead(TWO_COMPARISONS).size(), () -> withoutALine(TWO_COMPARISONS));
+        assertEquals(2, ruleIdsNotRead(TWO_COMPARISONS).size(), () -> withoutALine(TWO_COMPARISONS));
     }
 
     /** And two clauses of an {@code ensures}. */
     @Test
-    void twoEnsuresClausesStoppedAlikeAreTwoFindings() {
-        assertEquals(2, ruleIdsNotRead(TWO_ENSURES).size(), () -> unread(TWO_ENSURES));
+    void twoEnsuresClausesWithNoLineAreTwoFindings() {
+        assertEquals(2, ruleIdsNotRead(TWO_ENSURES).size(), () -> withoutALine(TWO_ENSURES));
         assertTrue(namesRule(human(TWO_ENSURES), "ensures f (low)"), human(TWO_ENSURES));
         assertTrue(namesRule(human(TWO_ENSURES), "ensures f (high)"), human(TWO_ENSURES));
     }
@@ -135,7 +136,7 @@ class ARuleWithoutALineIsNamedByTheRuleTest {
         assertEquals(List.of("r.a", "r.b"),
                 rulesNotRead(TWO_INVARIANTS).stream()
                         .map(PartitionEvidence.NotRead::at).distinct().sorted().toList(),
-                () -> unread(TWO_INVARIANTS));
+                () -> withoutALine(TWO_INVARIANTS));
     }
 
     /**
@@ -169,7 +170,7 @@ class ARuleWithoutALineIsNamedByTheRuleTest {
 
         List<PartitionEvidence.NotRead> said = rulesNotRead(model);
 
-        assertEquals(1, said.size(), () -> unread(model));
+        assertEquals(1, said.size(), () -> withoutALine(model));
         assertTrue(human(model).contains("not read: comparison@"), human(model));
         assertTrue(human(model).lines()
                         .filter(line -> line.contains("not read:"))
@@ -357,7 +358,7 @@ class ARuleWithoutALineIsNamedByTheRuleTest {
         return AdequacyReport.of(compilation).human(SourceNameResolver.identity());
     }
 
-    private static String unread(String model) {
+    private static String withoutALine(String model) {
         JsonNode document = JSON.readTree(json(model));
         return document.get("modules").get(0).get("behaviors").get(0)
                 .get("partition").get("notRead").toString();

--- a/souther-compiler/src/test/java/souther/compiler/ARuleWithoutALineIsNamedByTheRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleWithoutALineIsNamedByTheRuleTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * (spec §example-partition). All three are here, because what each of them had in hand was a
  * different value and each dropped it at its own seam.
  */
-class ARuleThisCouldNotReadIsNamedByTheRuleTest {
+class ARuleWithoutALineIsNamedByTheRuleTest {
 
     private static final JsonMapper JSON = JsonMapper.builder().build();
 

--- a/souther-compiler/src/test/java/souther/compiler/check/ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest.java
@@ -315,7 +315,7 @@ class ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest {
                 "the rule a reader is sent to look at is the one that wrote the clause");
     }
 
-    private static List<BlockReason.AboutARule> reasonsAt(FieldDomains read, String path) {
+    private static List<BlockReason.RuleWithoutLineReason> reasonsAt(FieldDomains read, String path) {
         return read.unreadAt(path).stream().map(FieldDomains.Unread::why).toList();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest.java
@@ -126,8 +126,8 @@ class ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest {
                 """, "Parcel");
 
         assertFalse(read.placedAt("length").isEmpty());
-        assertEquals(List.of(), read.unreadAt("length"));
-        assertEquals(List.of(), read.unreadAt("width"));
+        assertEquals(List.of(), read.noLineAt("length"));
+        assertEquals(List.of(), read.noLineAt("width"));
     }
 
     /**
@@ -147,8 +147,8 @@ class ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest {
                     invariant length /= 5
                 """, "Parcel");
 
-        assertEquals(List.of(), read.unreadAt("label"));
-        assertEquals(List.of(), read.unreadAt("length"));
+        assertEquals(List.of(), read.noLineAt("label"));
+        assertEquals(List.of(), read.noLineAt("length"));
     }
 
     /**
@@ -167,7 +167,7 @@ class ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest {
                     invariant length == 5
                 """, "Parcel");
 
-        assertEquals(List.of(), read.unreadAt("length"));
+        assertEquals(List.of(), read.noLineAt("length"));
     }
 
     /**
@@ -308,7 +308,7 @@ class ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest {
                     invariant value >= 1 + 1
                 """, "Stepped");
 
-        List<FieldDomains.Unread> said = read.unreadAt(FieldDomains.THE_VALUE);
+        List<FieldDomains.NoLine> said = read.noLineAt(FieldDomains.THE_VALUE);
         assertEquals(1, said.size(), () -> "said " + said);
         assertInstanceOf(BlockReason.UnreadComparisonForm.class, said.getFirst().why());
         assertTrue(said.getFirst().from().clause().id().declaredOn().name().endsWith("Stepped"),
@@ -316,6 +316,6 @@ class ALineReadAtAPositionSaysNothingAboutTheRuleBesideItTest {
     }
 
     private static List<BlockReason.RuleWithoutLineReason> reasonsAt(FieldDomains read, String path) {
-        return read.unreadAt(path).stream().map(FieldDomains.Unread::why).toList();
+        return read.noLineAt(path).stream().map(FieldDomains.NoLine::why).toList();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatACopyOfACoordinateLeavesOutIsWrittenDownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatACopyOfACoordinateLeavesOutIsWrittenDownTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A record built by copying fields out of another says which it left behind.
  *
- * <p>{@code FieldDomains.Unread} is written from a coordinate the reading found, one field at a
+ * <p>{@code FieldDomains.NoLine} is written from a coordinate the reading found, one field at a
  * time, because the coordinate is this class's own and the record crosses into {@code inputs}. Two
  * of its fields went in one round late apiece — first whether the position is a count, then which
  * conjunct the reason came from — each after something downstream turned out to need what the
@@ -53,7 +53,7 @@ class WhatACopyOfACoordinateLeavesOutIsWrittenDownTest {
     @Test
     void theCopyCarriesEveryFieldOfTheCoordinateButTheCarrier() {
         Set<String> left = new LinkedHashSet<>(componentsOf(coordinate()));
-        left.removeAll(componentsOf(FieldDomains.Unread.class));
+        left.removeAll(componentsOf(FieldDomains.NoLine.class));
 
         assertEquals(Set.of("carrier"), left,
                 "a field of the coordinate that the copy does not carry, and nobody decided to");
@@ -62,11 +62,11 @@ class WhatACopyOfACoordinateLeavesOutIsWrittenDownTest {
     /** And what it adds is what the copy is for: whose rule it is, and which conjunct. */
     @Test
     void andWhatItAddsIsWhatTheCopyIsFor() {
-        Set<String> added = new LinkedHashSet<>(componentsOf(FieldDomains.Unread.class));
+        Set<String> added = new LinkedHashSet<>(componentsOf(FieldDomains.NoLine.class));
         added.removeAll(componentsOf(coordinate()));
 
         assertEquals(Set.of("from", "part", "why"), added);
-        assertTrue(componentsOf(FieldDomains.Unread.class).containsAll(Set.of("path", "by")),
+        assertTrue(componentsOf(FieldDomains.NoLine.class).containsAll(Set.of("path", "by")),
                 "beside the two of the coordinate that a reader downstream turned out to need:"
                         + " where it sits, and which operation takes the number if one does");
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARuleRaisesIsAskedOfTheRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARuleRaisesIsAskedOfTheRuleTest.java
@@ -146,6 +146,36 @@ class WhatARuleRaisesIsAskedOfTheRuleTest {
     }
 
     /**
+     * A rule about a position that restricts no value of it raises nothing either, under its own
+     * word.
+     *
+     * <p>{@code value - value >= 0} holds of every row: the position cancels against itself, so the
+     * quantity the rule cuts is empty and there is no value anywhere it admits or refuses. Counted
+     * off the sides it is a rule about {@code value} — the name is written twice — and it raised
+     * the questions a rule about a position raises. Neither of them is anything the rule states, so
+     * nothing could answer either, and a clause read from end to end went out as a question nobody
+     * had answered.
+     *
+     * <p>Which the quantity settles and the spelling cannot. What a rule restricts is what its
+     * canonical form cuts, which is the rule {@link UnreadComparison#why} is written around one
+     * layer down — and this classification was still counting the sides.
+     */
+    @Test
+    void aRuleRestrictingNoValueRaisesNothing() {
+        Required.Irrelevant said = assertInstanceOf(Required.Irrelevant.class,
+                only(raisedBy("""
+                        module example.rooms
+
+                        data Length = Int
+                            invariant floor = value >= 1
+                            invariant always = value - value >= 0
+                        """, "Length"), "always"));
+
+        assertEquals(Set.of(Required.Because.IT_CONSTRAINS_NO_VALUE), said.because());
+        assertEquals(Set.of(), said.obligations());
+    }
+
+    /**
      * A rule relating two positions raises nothing, and says what settled that.
      *
      * <p>The conclusion, not an empty result. Both sides were recognised, and a partition is of one

--- a/souther-compiler/src/test/java/souther/compiler/inputs/OneRuleReadTwoWaysIsTwoAnswersAndOneWordTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/OneRuleReadTwoWaysIsTwoAnswersAndOneWordTest.java
@@ -1,0 +1,102 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.CoverageObligation;
+import souther.compiler.partition.ReportedReason;
+import souther.compiler.partition.UndividedPosition;
+import souther.compiler.values.UnreadReason;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * One rule, two readings, two answers — and one word for a reader of the document.
+ *
+ * <p>{@code a < b} is where this is settled. The reading that turns clauses into lines takes it in
+ * whole and places no line, and no measure is short of anything on its account. The reading that
+ * turns clauses into sets of values gets nothing it can hold from the same rule, so what it
+ * arrived at is an upper bound over a position whose values this compiler cannot state. Both are
+ * true, and they are opposite sentences about this compiler.
+ *
+ * <p>So which half a reason is in is not a property of the rule. It is a property of the rule and
+ * the reading together, and the two readings have their own reasons for the same rule. Held as one
+ * reason on the grounds that two vocabularies must not come to different words for one stop, the
+ * value reading's account said what the line reading's says — that the rule was read and nothing is
+ * missing — over a position it had read nothing about.
+ *
+ * <p>The word is not what was ever shared. A document promises its reader which kind of thing
+ * stopped the derivation, and both of these are one kind of thing out there: the projection sends
+ * them to one word, which is asserted here beside the split so that the two cannot drift.
+ */
+class OneRuleReadTwoWaysIsTwoAnswersAndOneWordTest {
+
+    /** What the reading of lines makes of it: read to the end, and no line either side. */
+    private static final BlockReason.ComparisonBetweenPositions THE_LINE_READING =
+            new BlockReason.ComparisonBetweenPositions();
+
+    /** And what the reading of values makes of the same rule. */
+    private static final BlockReason.RuleReadingStopped THE_VALUE_READING =
+            BlockReason.ofARuleTheValueReadingLeft(UnreadReason.RELATES_TWO_POSITIONS);
+
+    /**
+     * The line reading finished, so nothing is owed on its account.
+     *
+     * <p>That it is no {@link BlockReason.ReadingStopReason} is not asserted here, and cannot be:
+     * the two are disjoint under the seal, so javac refuses an {@code instanceof} between them as
+     * one that can never hold. A test would be the weaker statement of the two — this one cannot be
+     * handed to a caller asking what stopped a reading in any program that compiles.
+     */
+    @Test
+    void theLineReadingReadItToTheEnd() {
+        assertInstanceOf(BlockReason.ReadToEndWithoutLine.class, THE_LINE_READING);
+
+        assertFalse(THE_LINE_READING.leavesShort(CoverageObligation.Measure.PARTITION));
+        assertFalse(THE_LINE_READING.leavesShort(CoverageObligation.Measure.BOUNDARY));
+    }
+
+    /**
+     * The value reading stopped, and every answer that reading gives is one.
+     *
+     * <p>What is held at a position is a set of its own values, and a rule about how it stands
+     * against another position is not one. So the values are an upper bound: this compiler fell
+     * short, whatever the reading beside it managed with the same rule.
+     *
+     * <p>And the same exclusion holds the other way, under the same seal: this answer cannot be
+     * handed to a caller asking what a rule read from end to end left, so it cannot say that
+     * nothing is missing.
+     */
+    @Test
+    void theValueReadingStoppedOnIt() {
+        assertInstanceOf(BlockReason.ReadingStopReason.class, THE_VALUE_READING);
+
+        assertTrue(THE_VALUE_READING.leavesShort(CoverageObligation.Measure.PARTITION));
+        assertTrue(THE_VALUE_READING.leavesShort(CoverageObligation.Measure.BOUNDARY));
+    }
+
+    /** And a reader of the document meets one word, which is what the two were made one for. */
+    @Test
+    void theDocumentWritesOneWordForBoth() {
+        assertEquals(UndividedPosition.Reason.UNSUPPORTED_PARTITION_SHAPE,
+                ReportedReason.of(THE_LINE_READING));
+        assertEquals(UndividedPosition.Reason.UNSUPPORTED_PARTITION_SHAPE,
+                ReportedReason.of(THE_VALUE_READING));
+    }
+
+    /**
+     * The reading that never arrived at a position's rules is refused rather than answered.
+     *
+     * <p>It is holding no rule for an answer about one to be about, which is what the reasons about
+     * a position are beside these for.
+     */
+    @Test
+    void aReadingThatReachedNoRuleNamesNone() {
+        assertInstanceOf(BlockReason.AboutThePosition.class,
+                BlockReason.of(UnreadReason.NOT_REACHED));
+        assertThrows(IllegalArgumentException.class,
+                () -> BlockReason.ofARuleTheValueReadingLeft(UnreadReason.NOT_REACHED));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACallIsAValueOnlyWhenItIsTheConstructionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACallIsAValueOnlyWhenItIsTheConstructionTest.java
@@ -9,7 +9,7 @@ import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.TermPath;
-import souther.compiler.inputs.UnreadRule;
+import souther.compiler.inputs.RuleWithoutALine;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -85,7 +85,7 @@ class ACallIsAValueOnlyWhenItIsTheConstructionTest {
                     each[0] + ": an implementation nothing here has read draws no line");
             assertEquals(1, guards.unread().size(),
                     each[0] + ": and the position says a rule about it went unread");
-            UnreadRule said = guards.unread().getFirst();
+            RuleWithoutALine said = guards.unread().getFirst();
             assertEquals(souther.compiler.inputs.FilingCoordinate.of(
                             new souther.compiler.inputs.NumericTerm.ValueOf(TermPath.of("t"))),
                     said.at(),

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACallIsAValueOnlyWhenItIsTheConstructionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACallIsAValueOnlyWhenItIsTheConstructionTest.java
@@ -83,9 +83,9 @@ class ACallIsAValueOnlyWhenItIsTheConstructionTest {
 
             assertEquals(List.of(), guards.thresholds(),
                     each[0] + ": an implementation nothing here has read draws no line");
-            assertEquals(1, guards.unread().size(),
+            assertEquals(1, guards.rulesWithoutALine().size(),
                     each[0] + ": and the position says a rule about it went unread");
-            RuleWithoutALine said = guards.unread().getFirst();
+            RuleWithoutALine said = guards.rulesWithoutALine().getFirst();
             assertEquals(souther.compiler.inputs.FilingCoordinate.of(
                             new souther.compiler.inputs.NumericTerm.ValueOf(TermPath.of("t"))),
                     said.at(),

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClassIsOneThePositionCanHoldAndNothingTakesItAwayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClassIsOneThePositionCanHoldAndNothingTakesItAwayTest.java
@@ -87,7 +87,7 @@ class AClassIsOneThePositionCanHoldAndNothingTakesItAwayTest {
                 Partitions.of(read.spec().name(), inputs, read.symbols(), souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
         return classesOf(Partitions.withThresholds(base, inputs.quantities(read.symbols()),
                 guards.thresholds(), read.symbols(), souther.compiler.query.ReadAs.THE_COMPILATION_DOES,
-                guards.unread(), guards.singled(), guards.between()));
+                guards.rulesWithoutALine(), guards.singled(), guards.between()));
     }
 
     /** The one axis, whichever phase produced it. */
@@ -415,7 +415,7 @@ class AClassIsOneThePositionCanHoldAndNothingTakesItAwayTest {
                 InputDomain.of(read.spec(), read.sig(), read.symbols(), souther.compiler.query.ReadAs.THE_COMPILATION_DOES)
                         .quantities(read.symbols()),
                 guards.thresholds(), read.symbols(), souther.compiler.query.ReadAs.THE_COMPILATION_DOES,
-                guards.unread(), guards.singled(), guards.between());
+                guards.rulesWithoutALine(), guards.singled(), guards.between());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClassThatNarrowsStatesTheNarrowingAndNotAValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClassThatNarrowsStatesTheNarrowingAndNotAValueTest.java
@@ -99,7 +99,7 @@ class AClassThatNarrowsStatesTheNarrowingAndNotAValueTest {
                             checked.supplied()),
                     compilation.db().ask(new Adequacy.Inputs(module)).value().get("use"), symbols);
             axes = Partitions.withThresholds(axes, domain.quantities(symbols), guards.thresholds(),
-                    symbols, ReadAs.THE_COMPILATION_DOES, guards.unread(), guards.singled(),
+                    symbols, ReadAs.THE_COMPILATION_DOES, guards.rulesWithoutALine(), guards.singled(),
                     guards.between());
         }
         FillResult filled = Generator.fill(

--- a/souther-compiler/src/test/java/souther/compiler/partition/AComparisonIsAccountedForWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AComparisonIsAccountedForWhereverItIsWrittenTest.java
@@ -65,6 +65,6 @@ class AComparisonIsAccountedForWhereverItIsWrittenTest {
         GuardThresholds.Guards guards = read("Int.multiply(p.x, p.x) < 10");
 
         assertEquals(List.of(), guards.thresholds());
-        assertEquals(1, guards.unread().size(), guards.unread().toString());
+        assertEquals(1, guards.rulesWithoutALine().size(), guards.rulesWithoutALine().toString());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AComparisonThisDoesNotReadIsStillNoticedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AComparisonThisDoesNotReadIsStillNoticedTest.java
@@ -12,7 +12,7 @@ import souther.compiler.inputs.BlockReason;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.check.RuleCitation;
 import souther.compiler.check.RuleRef;
-import souther.compiler.inputs.UnreadRule;
+import souther.compiler.inputs.RuleWithoutALine;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Shapes;
@@ -177,13 +177,13 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
      */
     @Test
     void twoComparisonsAboutOnePositionAreTwoFindings() {
-        List<UnreadRule> unread = read("at: Int",
+        List<RuleWithoutALine> unread = read("at: Int",
                 "Int.multiply(at, at) < 4 || Int.multiply(at, at) > 9").unread();
 
         assertEquals(List.of(new Said(TermPath.of("at"), new BlockReason.UnreadComparisonForm()),
                         new Said(TermPath.of("at"), new BlockReason.UnreadComparisonForm())),
                 said(unread));
-        assertEquals(2, unread.stream().map(UnreadRule::rule).distinct().count(),
+        assertEquals(2, unread.stream().map(RuleWithoutALine::rule).distinct().count(),
                 () -> "two comparisons are two rules: " + unread);
     }
 
@@ -198,7 +198,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
      */
     @Test
     void aFindingNamesTheComparisonThatWentUnread() {
-        UnreadRule said = read("p: Pair", "Int.multiply(p.x, p.x) < 10").unread().getFirst();
+        RuleWithoutALine said = read("p: Pair", "Int.multiply(p.x, p.x) < 10").unread().getFirst();
 
         assertInstanceOf(RuleRef.Comparison.class, said.rule());
         RuleCitation.WrittenAt cited = assertInstanceOf(RuleCitation.WrittenAt.class, said.cited());
@@ -336,7 +336,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
         }
     }
 
-    private static List<Said> said(List<UnreadRule> unread) {
+    private static List<Said> said(List<RuleWithoutALine> unread) {
         return unread.stream().map(each -> new Said(each.at(), each.why())).toList();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AComparisonThisDoesNotReadIsStillNoticedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AComparisonThisDoesNotReadIsStillNoticedTest.java
@@ -85,7 +85,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
         GuardThresholds.Guards guards = read("n.value <= 5");
 
         assertEquals(1, guards.thresholds().size());
-        assertEquals(List.of(), guards.unread());
+        assertEquals(List.of(), guards.rulesWithoutALine());
     }
 
     /** A comparison inside a conjunction is read, so it is not one this did not read. */
@@ -94,7 +94,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
         GuardThresholds.Guards guards = read("n.value >= 1 && n.value <= 5");
 
         assertEquals(2, guards.thresholds().size(), guards.thresholds().toString());
-        assertEquals(List.of(), guards.unread());
+        assertEquals(List.of(), guards.rulesWithoutALine());
     }
 
     /**
@@ -107,7 +107,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
     void anEqualityIsReadRatherThanNamed() {
         GuardThresholds.Guards guards = read("n.value == 3");
 
-        assertEquals(List.of(), guards.unread());
+        assertEquals(List.of(), guards.rulesWithoutALine());
         assertEquals(1, guards.singled().size(), guards.singled().toString());
     }
 
@@ -123,7 +123,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
     void aLineDrawnOnAStringIsRead() {
         GuardThresholds.Guards guards = read("at: String", "at < \"2026-01\"");
 
-        assertEquals(List.of(), guards.unread());
+        assertEquals(List.of(), guards.rulesWithoutALine());
         assertEquals(1, guards.thresholds().size(), guards.thresholds().toString());
     }
 
@@ -138,7 +138,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
         GuardThresholds.Guards guards =
                 read("at: DateTime", "at < DateTime(\"2026-01-01T00:00:00\")");
 
-        assertEquals(List.of(), guards.unread());
+        assertEquals(List.of(), guards.rulesWithoutALine());
         assertEquals(1, guards.thresholds().size(), guards.thresholds().toString());
     }
 
@@ -153,7 +153,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
     void aLineDrawnOnATimeIsRead() {
         GuardThresholds.Guards guards = read("at: Time", "at < Time(\"16:00:00\")");
 
-        assertEquals(List.of(), guards.unread());
+        assertEquals(List.of(), guards.rulesWithoutALine());
         assertEquals(1, guards.thresholds().size(), guards.thresholds().toString());
     }
 
@@ -163,7 +163,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
         GuardThresholds.Guards guards =
                 read("at: Instant", "at < Instant(\"2026-01-01T00:00:00Z\")");
 
-        assertEquals(List.of(), guards.unread());
+        assertEquals(List.of(), guards.rulesWithoutALine());
         assertEquals(1, guards.thresholds().size(), guards.thresholds().toString());
     }
 
@@ -178,7 +178,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
     @Test
     void twoComparisonsAboutOnePositionAreTwoFindings() {
         List<RuleWithoutALine> unread = read("at: Int",
-                "Int.multiply(at, at) < 4 || Int.multiply(at, at) > 9").unread();
+                "Int.multiply(at, at) < 4 || Int.multiply(at, at) > 9").rulesWithoutALine();
 
         assertEquals(List.of(new Said(TermPath.of("at"), new BlockReason.UnreadComparisonForm()),
                         new Said(TermPath.of("at"), new BlockReason.UnreadComparisonForm())),
@@ -198,7 +198,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
      */
     @Test
     void aFindingNamesTheComparisonThatWentUnread() {
-        RuleWithoutALine said = read("p: Pair", "Int.multiply(p.x, p.x) < 10").unread().getFirst();
+        RuleWithoutALine said = read("p: Pair", "Int.multiply(p.x, p.x) < 10").rulesWithoutALine().getFirst();
 
         assertInstanceOf(RuleRef.Comparison.class, said.rule());
         RuleCitation.WrittenAt cited = assertInstanceOf(RuleCitation.WrittenAt.class, said.cited());
@@ -229,7 +229,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
     void aPositionNamedInsideAnExpressionIsStillNoticed() {
         assertEquals(List.of(new Said(TermPath.of("p").then("x"),
                         new BlockReason.UnreadComparisonForm())),
-                said(read("p: Pair", "Int.multiply(p.x, p.x) < 10").unread()));
+                said(read("p: Pair", "Int.multiply(p.x, p.x) < 10").rulesWithoutALine()));
     }
 
     /**
@@ -247,7 +247,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
                                 new BlockReason.ComparisonBetweenPositions()),
                         Said.named(TermPath.of("p").then("y"),
                                 new BlockReason.ComparisonBetweenPositions())),
-                said(read("p: Pair", "p.x < p.y").unread()));
+                said(read("p: Pair", "p.x < p.y").rulesWithoutALine()));
     }
 
     /**
@@ -266,7 +266,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
         assertEquals(1, guards.thresholds().size(), guards.thresholds().toString());
         assertEquals(List.of(new Said(TermPath.of("p").then("x"),
                         new BlockReason.UnreadComparisonForm())),
-                said(guards.unread()));
+                said(guards.rulesWithoutALine()));
     }
 
     /**
@@ -296,7 +296,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
                                 new BlockReason.UnreadComparisonForm()),
                         new Said(TermPath.of("p").then("y"),
                                 new BlockReason.UnreadComparisonForm())),
-                said(read("p: Pair", "p.x < Int.multiply(p.y, p.y)").unread()));
+                said(read("p: Pair", "p.x < Int.multiply(p.y, p.y)").rulesWithoutALine()));
     }
 
     /**
@@ -311,7 +311,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
     void aReadableCarrierAgainstAnUnreadableSideIsNotACarrierProblem() {
         assertEquals(List.of(Said.named(TermPath.of("p").then("x"),
                         new BlockReason.UnreadComparisonForm())),
-                said(read("p: Pair", "p.x < Int.min(1, 2)").unread()));
+                said(read("p: Pair", "p.x < Int.min(1, 2)").rulesWithoutALine()));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/AMeasureIsShortOfWhateverItsReadingDidNotReachTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AMeasureIsShortOfWhateverItsReadingDidNotReachTest.java
@@ -107,7 +107,7 @@ class AMeasureIsShortOfWhateverItsReadingDidNotReachTest {
         assertInstanceOf(Measurement.NotApplicable.class, evidence.bounded());
         // And the rule is named beside them, so the two answers are about a model with a rule in it
         // and not about one with none.
-        assertEquals(2, evidence.unread().size(), () -> "unread: " + evidence.unread());
+        assertEquals(2, evidence.rulesWithoutALine().size(), () -> "unread: " + evidence.rulesWithoutALine());
     }
 
     private static PartitionEvidence evidenceFor(String source, String behavior) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -19,6 +19,7 @@ import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -62,7 +63,8 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
      *  in — which is a second way a position can be left unable to reach an absence. */
     private static Axis pending(StructuralInspection.Continuation found, BlockReason unread) {
         return Axis.pendingAt(ID, new NumericTerm.ValueOf(AT), Type.BOOL,
-                java.util.List.of(), false, found, unread);
+                java.util.List.of(), false, found,
+                unread == null ? null : LeftAtThePosition.of(unread));
     }
 
     /**
@@ -86,6 +88,26 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
         assertNull(PendingPosition.of(pending(new StructuralInspection.Continuation.None(), unread))
                         .reportable(),
                 "a rule this read and could not use is not a position nothing was reached at");
+    }
+
+    /**
+     * And a leaf carrying a rule read from end to end completes as neither of the two above.
+     *
+     * <p>Not an absence: the model states something at this position. Not a derivation this
+     * compiler could not make either — the reading ran to the end, and a reader sent after a limit
+     * would be looking for one that is not there. Held as the same state a stop puts a position in,
+     * every consumer of this chain went on saying the first of those about the second.
+     */
+    @Test
+    void aLeafCarryingARuleReadToTheEndSaysNeitherOfThose() {
+        BlockReason read = new BlockReason.ComparisonBetweenPositions();
+
+        UndividedPosition said = PendingPosition.of(
+                        pending(new StructuralInspection.Continuation.None(), read))
+                .complete(new BodyCutInspection.Exhausted());
+
+        assertFalse(said.isAbsent(), said.toString());
+        assertInstanceOf(UndividedPosition.Why.StatedWithoutALine.class, said.why(), said.toString());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -124,7 +124,8 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
         PendingPosition pending = PendingPosition.of(pending(new StructuralInspection.Continuation.None(),
                 new BlockReason.UnreadValueRule()));
 
-        assertFalse(pending.complete(new BodyCutInspection.Blocked()).isAbsent());
+        assertFalse(pending.complete(new BodyCutInspection.NoLine(new LeftAtThePosition.AReadingStopped(
+                        new BlockReason.UnreadValueRule()))).isAbsent());
         assertNull(pending.reportable(), "each rule is said with its rule, not as this position");
     }
 
@@ -170,10 +171,46 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
     /** A rule about the position that went unread is what it is left with, and not an absence. */
     @Test
     void aLeafWhoseRuleWentUnreadSaysThat() {
-        UndividedPosition done = new PendingPosition.Leaf(AT)
-                .complete(new BodyCutInspection.Blocked());
+        UndividedPosition done = new PendingPosition.Leaf(AT).complete(new BodyCutInspection.NoLine(new LeftAtThePosition.AReadingStopped(
+                        new BlockReason.UnreadValueRule())));
 
         assertFalse(done.isAbsent());
+        assertEquals(new UndividedPosition.Why.CannotDerive(), done.why());
+    }
+
+    /**
+     * And a rule the body read from end to end says the other thing, as the same rule does where
+     * the declaration wrote it.
+     *
+     * <p>The phase a rule was written in is no part of what it says. This one used to be the only
+     * answer the body could give — that something was left — and a verdict read it as the position
+     * having rules nothing looked at, over a {@code guard} this compiler understood completely.
+     */
+    @Test
+    void aLeafWhoseBodyRuleWasReadToTheEndSaysTheOtherThing() {
+        UndividedPosition done = new PendingPosition.Leaf(AT).complete(
+                new BodyCutInspection.NoLine(new LeftAtThePosition.ARuleWithNoLine(
+                        new BlockReason.ComparisonBetweenPositions())));
+
+        assertFalse(done.isAbsent());
+        assertEquals(new UndividedPosition.Why.StatedWithoutALine(), done.why());
+    }
+
+    /**
+     * A stop in the body outranks a rule the declaration read to the end.
+     *
+     * <p>Both phases answer about one position and the verdict is one. Read off the first phase
+     * alone, a rule read to the end at the declaration hid a reading that stopped two lines into
+     * the body — and a position nothing had read came back as one the model states something at.
+     */
+    @Test
+    void aStopInTheBodyOutranksARuleTheDeclarationReadToTheEnd() {
+        PendingPosition stated = new PendingPosition.ARuleWithNoLine(AT,
+                new BlockReason.ComparisonBetweenPositions());
+
+        UndividedPosition done = stated.complete(new BodyCutInspection.NoLine(
+                new LeftAtThePosition.AReadingStopped(new BlockReason.UnreadValueRule())));
+
         assertEquals(new UndividedPosition.Why.CannotDerive(), done.why());
     }
 
@@ -192,7 +229,8 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
         UndividedPosition.Why expected = new UndividedPosition.Why.CannotDerive();
 
         assertEquals(expected, blocked.complete(new BodyCutInspection.Exhausted()).why());
-        assertEquals(expected, blocked.complete(new BodyCutInspection.Blocked()).why());
+        assertEquals(expected, blocked.complete(new BodyCutInspection.NoLine(new LeftAtThePosition.AReadingStopped(
+                        new BlockReason.UnreadValueRule()))).why());
         // And the finding is the stop, whatever the rules came to: a rule naming something inside a
         // position the walk could not enter describes that same stop from the other end.
         assertEquals(new souther.compiler.inputs.PositionReadingBlocked(AT,

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnArmsBinderNamesTheNarrowedPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnArmsBinderNamesTheNarrowedPositionTest.java
@@ -78,7 +78,7 @@ class AnArmsBinderNamesTheNarrowedPositionTest {
         Partitions.Partitioning base = Partitions.of(spec.name(), read, symbols,
                 ReadAs.THE_COMPILATION_DOES);
         return Partitions.withThresholds(base, read.quantities(symbols), guards.thresholds(),
-                symbols, ReadAs.THE_COMPILATION_DOES, guards.unread(), guards.singled(),
+                symbols, ReadAs.THE_COMPILATION_DOES, guards.rulesWithoutALine(), guards.singled(),
                 guards.between()).axes();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnOpenPositionIsAReadingThatRanToTheEndTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnOpenPositionIsAReadingThatRanToTheEndTest.java
@@ -148,7 +148,7 @@ class AnOpenPositionIsAReadingThatRanToTheEndTest {
             assertNotNull(position.term(), type + " is measured at some term");
             assertNotNull(position.reading(), type + " says which values it may hold");
             assertNotNull(position.completeness(), type + " says how much of its rules was read");
-            assertNotNull(position.unreadRules(), type + " says which of its rules went unread");
+            assertNotNull(position.rulesWithoutALine(), type + " says which of its rules went unread");
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneCarrierTableAnswersForEveryOrderedTypeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneCarrierTableAnswersForEveryOrderedTypeTest.java
@@ -513,8 +513,8 @@ class OneCarrierTableAnswersForEveryOrderedTypeTest {
             assertNotNull(evidence, behavior + " was measured");
             // Through the projection a report goes through, which is what this table is of: what
             // this compiler could not do is recorded in its own words and said in the document's.
-            UndividedPosition.Reason unread = evidence.unread().isEmpty() ? null
-                    : ReportedReason.of(evidence.unread().get(0).why());
+            UndividedPosition.Reason unread = evidence.rulesWithoutALine().isEmpty() ? null
+                    : ReportedReason.of(evidence.rulesWithoutALine().get(0).why());
             // The points a row is owed at against a line, and not the borders. Which carriers name a
             // value one step over is what this table is about, and a border is one whether or not
             // its second point exists — counted as borders, every carrier answers alike.

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAClauseDrawsALineOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAClauseDrawsALineOnTest.java
@@ -213,7 +213,7 @@ class WhatAClauseDrawsALineOnTest {
                 """, "look");
 
         assertEquals(List.of(), valuesOf(clauses));
-        assertEquals(List.of(), clauses.unread(),
+        assertEquals(List.of(), clauses.rulesWithoutALine(),
                 "this read the rule; what it draws no line at is a decision and not a limit");
         assertEquals(List.of(), clauses.between(),
                 "and it is not a line between two inputs either: what it relates is the answer,"
@@ -249,7 +249,7 @@ class WhatAClauseDrawsALineOnTest {
 
         assertEquals(List.of(), valuesOf(clauses), "the line is on the answer, and a row has none");
         assertEquals(List.of(), clauses.between(), "and it is not a line between two inputs");
-        assertEquals(List.of(), clauses.unread(),
+        assertEquals(List.of(), clauses.rulesWithoutALine(),
                 "this read the rule; that it draws no line is a decision and not a limit");
 
     }
@@ -320,8 +320,8 @@ class WhatAClauseDrawsALineOnTest {
 
             assertEquals(1, clauses.thresholds().size(),
                     () -> measure + " draws a line: " + valuesOf(clauses));
-            assertEquals(List.of(), clauses.unread(),
-                    () -> measure + " was read, so nothing says otherwise: " + clauses.unread());
+            assertEquals(List.of(), clauses.rulesWithoutALine(),
+                    () -> measure + " was read, so nothing says otherwise: " + clauses.rulesWithoutALine());
             assertTrue(clauses.thresholds().get(0).term() instanceof NumericTerm.TakenOf,
                     () -> measure + " is a line on the measure: "
                             + clauses.thresholds().get(0).term());
@@ -379,7 +379,7 @@ class WhatAClauseDrawsALineOnTest {
 
         assertEquals(List.of(), valuesOf(clauses));
         assertEquals(List.of("a.n"),
-                clauses.unread().stream().map(each -> each.at().toString()).toList());
+                clauses.rulesWithoutALine().stream().map(each -> each.at().toString()).toList());
     }
 
     /**
@@ -426,7 +426,7 @@ class WhatAClauseDrawsALineOnTest {
                 line.demand(PointRole.IN).criterion().asked(line.cut().of()));
         assertEquals("in to < from", line.demand(PointRole.OUT).criterion().asked(line.cut().of()));
         assertEquals(List.of("from", "to"),
-                clauses.unread().stream().map(each -> each.at().toString()).toList());
+                clauses.rulesWithoutALine().stream().map(each -> each.at().toString()).toList());
     }
 
     /**
@@ -503,7 +503,7 @@ class WhatAClauseDrawsALineOnTest {
 
         assertEquals(List.of(), valuesOf(clauses), "nothing here reads a line out of that form");
         assertEquals(List.of("id"),
-                clauses.unread().stream().map(each -> each.at().toString()).toList(),
+                clauses.rulesWithoutALine().stream().map(each -> each.at().toString()).toList(),
                 "and the position it is about is named rather than passed over");
     }
 


### PR DESCRIPTION
Closes #1047.

`UnreadRule` held two opposite facts. A rule this compiler got partway through,
and a rule it read from end to end that draws no line — and the carrier, its
constructor message, its `why` component, its producers and the finding built on
it were all named for the first. #1029 gave the two halves types and left the
names alone, so a rule read completely was carried, named and published as one
nobody could read.

## What was measurably wrong

Four models differing by one clause on the same record:

| clause | before | after |
| --- | --- | --- |
| `invariant lo >= 0` | complete | complete |
| `invariant lo <= hi` | complete | complete |
| `invariant lo - lo >= 0` | **partial**, `question_unanswered`, `rule_unaccounted` | **complete**, nothing owed |
| `invariant lo - lo == 0` | **partial**, same | **complete**, nothing owed |
| `invariant lo - lo >= 1` | partial | partial — it admits nothing, which is the opposite |
| `invariant String.length(name) <= 0 - 1` | partial, `rule_unread` | unchanged |

`lo - lo >= 0` holds of every row. The report said so — "read to the end and
cuts nothing this position appears in" — and two lines below asked which values
may stand at `lo`, got no answer, and took the module's measurement to partial.

## The root cause, and what it took

Not the accounting. The questions should never have been raised. What a rule
restricts is settled by the quantity its canonical form cuts together with what
is left when the positions cancel, and `InvariantChecker.states` was counting
positions off the spelling — the name is written twice in that clause. One layer
down, `UnreadComparison.why` is written around exactly this: asked of what the
rule cuts, and of the sides only where that is unreadable.

Underneath that, one distinction is drawn in five vocabularies — this compiler
fell short, against the model states this — and every consumer decided which
side a piece of evidence was on from the shape of the evidence rather than from
what it says. Shape was a sound proxy while the slot could hold only a stop.
#1029 put a rule read from end to end into the same slot and all of them became
wrong at once, independently, each in its own words.

## What the commits do

- The reasons become two capabilities that cut across each other rather than one
  tree. `ReadingStopReason` is this compiler having fallen short;
  `RuleWithoutLineReason` is a rule that is no line at a position.
  `RuleReadingStopped` is the one reason in both.
- The value reading gets its own reason for a rule relating two positions. Both
  readings meet `a < b`, the reading of lines takes it in whole and the reading
  of values can hold nothing of it, and they were sharing the reason that says
  nothing fell short. `ReportedReason` still sends both to
  `unsupported_partition_shape`, which is what was ever shared.
- Every receiver that means a stop takes one: `Unsettlement.ReadingStopped`,
  `ReadingResult`, `Crossing.of`, `Position.valuesUnread`,
  `RuleAccounting.Unaccounted`.
- `ComparisonAssessment` answers once what the reading of lines drew no line
  for, instead of the same table standing in both producers, and the `null`
  sentinel is an `Optional` over a switch with no `default`.
- `ClauseStates.NoRestriction`: a comparison whose positions cancel and whose
  residue holds of every row raises no obligation, under
  `Because.IT_CONSTRAINS_NO_VALUE`. One whose residue holds of no row admits
  nothing — the opposite — and raises what it always did. `1 >= 0` stays where it
  was: whether the value is mentioned is a different question.
- `LeftAtThePosition` is what a position with no axis is left with, and it is
  carried across both phases rather than re-decided at each. The rule for putting
  two readings together — a stop outranks a rule read to the end, either outranks
  nothing stated — is written once.
- `UndividedPosition.Why.StatedWithoutALine`, neither an absence nor a
  derivation this compiler could not make. Every consumer asks `isAbsent`, so no
  document moves.
- `whereNoRowCouldAnswer` asks the finding whether the reading stopped instead of
  listing kinds: a rule read from end to end is `A_FACT_ABOUT_THE_MODEL`, not
  `NOTHING_WAS_MEASURED`.
- The carrier is `RuleWithoutALine`, and the producers and their fields say the
  same.
- One `Arithmetic` per comparison in `InvariantChecker`, projected twice, instead
  of two readings of the same two sides.

## The document does not move

`notRead`, `partition_not_read` and `notReadReason` are what every document of
schema 7 carries, and renaming them is a version and a retired word for a
distinction the schema already spells out in its `reason`. So the older words
stay, and they stay on one side of the projection: `PartitionEvidence.NotRead`
and `About.OfSomethingNotRead` are named for the document's shape and say so.
Behind them nothing calls a rule it read to the end one it could not read.

Every schema resource and the conformance report are byte-identical on this
branch.

## Checks

`mvn -o test` green across the reactor. Checkstyle clean over
`souther-compiler/src/main/java`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
