### PR TITLE
Ask which representation reads the number a unary operation answers

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Question.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Question.java
@@ -47,7 +47,7 @@ enum Question {
         }
 
         @Override
-        boolean answeredFor(ValueName operation) {
+        boolean answeredFor(Stdlib stdlib, ValueName operation) {
             return Combinators.answered().contains(operation);
         }
 
@@ -95,7 +95,7 @@ enum Question {
         }
 
         @Override
-        boolean answeredFor(ValueName operation) {
+        boolean answeredFor(Stdlib stdlib, ValueName operation) {
             return Reductions.answered().contains(operation);
         }
 
@@ -137,7 +137,7 @@ enum Question {
         }
 
         @Override
-        boolean answeredFor(ValueName operation) {
+        boolean answeredFor(Stdlib stdlib, ValueName operation) {
             return Accumulations.of(operation) != null;
         }
 
@@ -163,7 +163,7 @@ enum Question {
         }
 
         @Override
-        boolean answeredFor(ValueName operation) {
+        boolean answeredFor(Stdlib stdlib, ValueName operation) {
             return DischargeRules.builtOperations().contains(operation);
         }
 
@@ -189,7 +189,7 @@ enum Question {
         }
 
         @Override
-        boolean answeredFor(ValueName operation) {
+        boolean answeredFor(Stdlib stdlib, ValueName operation) {
             return DischargeRules.carryingOperations().contains(operation);
         }
 
@@ -215,7 +215,7 @@ enum Question {
         }
 
         @Override
-        boolean answeredFor(ValueName operation) {
+        boolean answeredFor(Stdlib stdlib, ValueName operation) {
             return DischargeRules.sizeMeantBy(operation) != null;
         }
 
@@ -243,7 +243,7 @@ enum Question {
         }
 
         @Override
-        boolean answeredFor(ValueName operation) {
+        boolean answeredFor(Stdlib stdlib, ValueName operation) {
             return DischargeRules.isQuantifier(operation);
         }
 
@@ -272,7 +272,7 @@ enum Question {
         }
 
         @Override
-        boolean answeredFor(ValueName operation) {
+        boolean answeredFor(Stdlib stdlib, ValueName operation) {
             return DischargeRules.projections().contains(operation);
         }
 
@@ -296,7 +296,7 @@ enum Question {
         }
 
         @Override
-        boolean answeredFor(ValueName operation) {
+        boolean answeredFor(Stdlib stdlib, ValueName operation) {
             return DischargeRules.isSize(operation);
         }
 
@@ -325,7 +325,7 @@ enum Question {
         }
 
         @Override
-        boolean answeredFor(ValueName operation) {
+        boolean answeredFor(Stdlib stdlib, ValueName operation) {
             return DischargeRules.decidesOrder(operation);
         }
 
@@ -364,7 +364,7 @@ enum Question {
         }
 
         @Override
-        boolean answeredFor(ValueName operation) {
+        boolean answeredFor(Stdlib stdlib, ValueName operation) {
             return DischargeRules.boundedOperations().contains(operation);
         }
 
@@ -394,7 +394,7 @@ enum Question {
         }
 
         @Override
-        boolean answeredFor(ValueName operation) {
+        boolean answeredFor(Stdlib stdlib, ValueName operation) {
             return DischargeRules.shiftingOperations().contains(operation);
         }
 
@@ -422,7 +422,7 @@ enum Question {
         }
 
         @Override
-        boolean answeredFor(ValueName operation) {
+        boolean answeredFor(Stdlib stdlib, ValueName operation) {
             return DischargeRules.choosingOperations().contains(operation);
         }
 
@@ -456,7 +456,7 @@ enum Question {
         }
 
         @Override
-        boolean answeredFor(ValueName operation) {
+        boolean answeredFor(Stdlib stdlib, ValueName operation) {
             return DischargeRules.formOperations().contains(operation);
         }
 
@@ -493,7 +493,7 @@ enum Question {
         }
 
         @Override
-        boolean answeredFor(ValueName operation) {
+        boolean answeredFor(Stdlib stdlib, ValueName operation) {
             return DischargeRules.numericResult(operation) != null;
         }
 
@@ -506,6 +506,55 @@ enum Question {
         Set<ValueName> nothingSaidOf() {
             return OperationFacts.saysNothingOf(OperationSubject.NUMERIC_RESULT);
         }
+    },
+
+    /**
+     * Which representation understands the number it answers ({@link NumericReadings}). Asked of an
+     * operation given one value and answering a number.
+     *
+     * <p>Not "is this a term". That would put the answer in the range and make the question ask
+     * itself: {@code Decimal.fromInt} meets every condition here and is answered by the form it
+     * declares, so a range drawn where the terms are would leave it out for being answered.
+     *
+     * <p>Read off the signature and no further. Whether the language writes the operation's body out
+     * is how it is answered — the body is one of the representations — so a range that required an
+     * intrinsic would be a range drawn around one of its own answers, and {@code Int.abs} would have
+     * no reader named anywhere. Every unary operation answering a number is asked, and the four
+     * accounts between them say which reads it.
+     *
+     * <p>Counted at one case of a union too, as {@link #NUMERIC_RESULT} counts it: what the shape of
+     * a result says is which inputs an operation declines, not what it answers where it answers
+     * anything. {@code String.toInt} answers a number and is asked which representation reads it,
+     * and the answer is that none does.
+     *
+     * <p>Wider than what may be declared. A term is held to a result that is a bare number
+     * ({@link DischargeRules#holdTakenOf}), because what stands at the path a term names is the
+     * union and which case it is in is not something such an account has room for. The two ranges
+     * are different on purpose: an operation may be asked a question whose only available answer is
+     * that nothing reads it.
+     */
+    READING("which representation reads the number it answers") {
+        @Override
+        boolean asksOf(Stdlib stdlib, Stdlib.Signature signature) {
+            return signature.params().size() == 1
+                    && NumericAnswers.in(signature.result()) != null;
+        }
+
+        @Override
+        boolean answeredFor(Stdlib stdlib, ValueName operation) {
+            return NumericReadings.resolve(stdlib, OperationFacts.declarations(), operation)
+                    instanceof NumericReadings.Resolution.One;
+        }
+
+        @Override
+        Set<ValueName> answeredOperations() {
+            return OperationFacts.answersANumberTakenOfItsArgument();
+        }
+
+        @Override
+        Set<ValueName> nothingSaidOf() {
+            return OperationFacts.saysNothingOf(OperationSubject.READING);
+        }
     };
 
     private final String asked;
@@ -517,8 +566,12 @@ enum Question {
     /** Whether an operation declared with {@code signature} is one this is asked of. */
     abstract boolean asksOf(Stdlib stdlib, Stdlib.Signature signature);
 
-    /** Whether {@code operation} has a rule answering this. */
-    abstract boolean answeredFor(ValueName operation);
+    /** Whether {@code operation} has a rule answering this.
+     *
+     * <p>The library comes with it, since what answers a question is not always a table keyed by the
+     * operation: it may be the declaration itself, read against what the library says the operation
+     * is. */
+    abstract boolean answeredFor(Stdlib stdlib, ValueName operation);
 
     /** The operations there is a rule about, for the check that a rule answers a question its
      * operation is asked — a rule under a name nothing asks is a rule nothing reaches. */

--- a/souther-compiler/src/main/java/souther/compiler/inputs/NumericTerm.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/NumericTerm.java
@@ -4,6 +4,7 @@ import souther.compiler.check.Carrier;
 import souther.compiler.check.NumericAnswers;
 import souther.compiler.check.Symbols;
 import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Dates;
 import souther.compiler.numeric.Place;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.observe.Incompleteness;
@@ -286,6 +287,7 @@ public sealed interface NumericTerm permits NumericTerm.ValueOf, NumericTerm.Tak
         return switch (how) {
             case TakenAs.HowManyItHolds _ -> howMany(at);
             case TakenAs.PartOfTime taken -> partOfTime(taken.part(), at, observed);
+            case TakenAs.PartOfDate taken -> partOfDate(taken.part(), at, observed);
         };
     }
 
@@ -334,6 +336,39 @@ public sealed interface NumericTerm permits NumericTerm.ValueOf, NumericTerm.Tak
         return new Reading.Number(Count.of(seconds
                 .divideToIntegralValue(java.math.BigDecimal.valueOf(part.seconds()))
                 .remainder(java.math.BigDecimal.valueOf(part.many()))));
+    }
+
+    /**
+     * Which year, month or day of its month an observed date falls in.
+     *
+     * <p>Turned into a date and asked, rather than divided. A date counts days and its parts are the
+     * calendar's: the months are of different lengths and a leap year has a day the year before it
+     * does not, so no step and modulus over the count answers any of the three. What turns a count
+     * into a date is {@link Dates}, which is also what a report and a fixture read, so the date this
+     * takes a part of is the date they would write for the same day.
+     *
+     * <p>Answered on the order the operation answers, which is a count by one, while the value is
+     * decoded on the order it is written on. The two are the same pair of orders a part of a time
+     * travels on, and for the same reason: a line at the twelfth month is not a line at the twelfth
+     * day.
+     */
+    private static Reading partOfDate(TakenAs.DatePart part, ObservedValue at, Carrier observed) {
+        if (observed == null) {
+            return new Reading.NotNumber();
+        }
+        Place read = observed.placeOf(at);
+        // A place that is not a count is not a date. No operation declaring this arm is given
+        // anything else, so this is the observation being something other than what the position
+        // declares, which is what `NotNumber` says.
+        if (!(read instanceof Count count)) {
+            return new Reading.NotNumber();
+        }
+        java.time.LocalDate date = Dates.dateAt(count);
+        return new Reading.Number(Count.of(switch (part) {
+            case YEAR -> date.getYear();
+            case MONTH -> date.getMonthValue();
+            case DAY -> date.getDayOfMonth();
+        }));
     }
 
     /** How the values beside a boundary on this term are found, which is what the number it names

--- a/souther-compiler/src/main/java/souther/compiler/numeric/Dates.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/Dates.java
@@ -28,15 +28,31 @@ public final class Dates {
             return null;   // a date-time, whose step is not a day
         }
         try {
-            return Count.of(LocalDate.parse(iso).toEpochDay());
+            return dayOf(LocalDate.parse(iso));
         } catch (DateTimeParseException _) {
             return null;
         }
     }
 
+    /** The day {@code date} counts to. */
+    public static Count dayOf(LocalDate date) {
+        return Count.of(date.toEpochDay());
+    }
+
+    /**
+     * The date {@code day} counts to.
+     *
+     * <p>The one place a count becomes a calendar again, as {@link #dayOf} is the one place a
+     * calendar becomes a count. What a date is written as and what parts it has are both read off
+     * this, so a report and a fixture cannot come to different dates from the same day.
+     */
+    public static LocalDate dateAt(Place day) {
+        return LocalDate.ofEpochDay(Count.number(day).at().longValueExact());
+    }
+
     /** The date {@code day} counts to, written the way a model writes one. */
     public static String written(Place day) {
-        return LocalDate.ofEpochDay(Count.number(day).at().longValueExact()).toString();
+        return dateAt(day).toString();
     }
 
     private Dates() {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/TermRealizations.java
@@ -8,6 +8,7 @@ import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.TermOrders;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.CountDomain;
+import souther.compiler.numeric.Dates;
 import souther.compiler.numeric.Place;
 import souther.compiler.semantics.TakenAs;
 import souther.compiler.types.Type;
@@ -82,8 +83,9 @@ final class TermRealizations {
             // The number is the value, so it is the one value there is.
             case NumericTerm.ValueOf _ -> true;
             case NumericTerm.TakenOf taken -> switch (taken.takenAs()) {
-                // Every container of that many answers it, and every time within that hour does.
-                case TakenAs.HowManyItHolds _, TakenAs.PartOfTime _ -> false;
+                // Every container of that many answers it, every time within that hour does, and
+                // every date in that year falls in it.
+                case TakenAs.HowManyItHolds _, TakenAs.PartOfTime _, TakenAs.PartOfDate _ -> false;
             };
         };
     }
@@ -138,6 +140,8 @@ final class TermRealizations {
             // travels this far and the arm takes the end (#1027).
             case TakenAs.PartOfTime taken ->
                     atThatPart(taken.part(), sourceType, orders.observed(), answer, symbols);
+            case TakenAs.PartOfDate taken ->
+                    onThatPart(taken.part(), sourceType, orders.observed(), answer, symbols);
         };
     }
 
@@ -199,6 +203,101 @@ final class TermRealizations {
                 ? new Realization.BuiltNone(
                         Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE)
                 : new Realization.Built(List.of(standing), null);
+    }
+
+    /**
+     * A date whose given part stands at that number, with the parts beside it at the first they run
+     * from.
+     *
+     * <p>One of the many, as the time above offers one of the many. Every date in the year answers
+     * the same year, and what this owes is that what it offers reads back — not that it enumerates
+     * the dates that would. The first of January is the plain choice, and it is a choice about which
+     * value to write down rather than anything the model said.
+     *
+     * <p>A day of the month is offered in the longest month there is, so every day a date can fall
+     * on is a day of the one this writes. Offered in a short month, the last days of the long ones
+     * would be days no date has, and a rule about the thirty-first would have no witness for a
+     * reason that is about this choice rather than about the calendar.
+     *
+     * <p>Whether a date can have the part at all is asked of the calendar and not of the bound the
+     * operation declares. A bound is what the model may assume of an answer; what dates there are is
+     * what a witness can be built from, and reading the second off the first would make a bound
+     * loosened by hand into dates that cannot be written.
+     */
+    private static Realization onThatPart(TakenAs.DatePart part, Type sourceType, Carrier observed,
+                                          Place answer, Symbols symbols) {
+        if (observed == null || !(answer instanceof Count count) || !count.whole()) {
+            return new Realization.BuiltNone(
+                    Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
+        }
+        java.time.LocalDate on = dateOn(part, count.at());
+        if (on == null) {
+            // Outside the parts a date has. Not this reader's to report as a refusal: a number no
+            // date answers is a number nothing composes one for.
+            return new Realization.BuiltNone(
+                    Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
+        }
+        FixtureTemplate standing = Witnesses.wrapped(sourceType,
+                FixtureTemplate.on(observed, Dates.dayOf(on), symbols.scope()::reach), symbols);
+        return standing == null
+                ? new Realization.BuiltNone(
+                        Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE)
+                : new Realization.Built(List.of(standing), null);
+    }
+
+    /**
+     * The date this offers for a part standing at {@code answer}, or null where no date has that
+     * part.
+     *
+     * <p>Asked of the calendar rather than tried and caught. What a year, a month and a day run
+     * between is something {@code java.time} answers, and building a date to find out whether one
+     * could be built is asking a question by reading the exception from the answer.
+     */
+    private static java.time.LocalDate dateOn(TakenAs.DatePart part, java.math.BigDecimal answer) {
+        return switch (part) {
+            case YEAR -> within(answer, java.time.LocalDate.MIN.getYear(),
+                    java.time.LocalDate.MAX.getYear())
+                    ? java.time.LocalDate.of(answer.intValueExact(), A_LONGEST_MONTH, FIRST_OF_THE_MONTH)
+                    : null;
+            case MONTH -> within(answer, java.time.temporal.ChronoField.MONTH_OF_YEAR)
+                    ? java.time.LocalDate.of(A_YEAR, answer.intValueExact(), FIRST_OF_THE_MONTH)
+                    : null;
+            case DAY -> dayOfTheMonthItIsOfferedIn(answer);
+        };
+    }
+
+    /**
+     * The date a day of the month is offered on, or null where that month has no such day.
+     *
+     * <p>How far the days run is asked of the month this offers them in, and not of how far a day of
+     * any month can run. The two agree only while that month is the longest there is, and a month
+     * chosen here that was not would leave the check admitting days the date cannot be built for —
+     * an answer that is refused rather than absent, at whichever value the two parted.
+     */
+    private static java.time.LocalDate dayOfTheMonthItIsOfferedIn(java.math.BigDecimal answer) {
+        java.time.YearMonth month = java.time.YearMonth.of(A_YEAR, A_LONGEST_MONTH);
+        return within(answer, 1, month.lengthOfMonth()) ? month.atDay(answer.intValueExact()) : null;
+    }
+
+    /** The year a month or a day is offered in. Every month is a month of every year, and the month
+     *  below is as long in any of them, so which year this is says nothing. */
+    private static final int A_YEAR = 2001;
+
+    /** January, which has as many days as any month has, so every day-of-month a date can fall on is
+     *  a day of this one. */
+    private static final int A_LONGEST_MONTH = 1;
+
+    /** The day a year or a month is offered on. */
+    private static final int FIRST_OF_THE_MONTH = 1;
+
+    private static boolean within(java.math.BigDecimal answer,
+                                  java.time.temporal.ChronoField field) {
+        return within(answer, field.range().getMinimum(), field.range().getMaximum());
+    }
+
+    private static boolean within(java.math.BigDecimal answer, long from, long to) {
+        return answer.compareTo(java.math.BigDecimal.valueOf(from)) >= 0
+                && answer.compareTo(java.math.BigDecimal.valueOf(to)) <= 0;
     }
 
     /** One value, wearing every name the position declares, or the reason there is none. */

--- a/souther-compiler/src/main/java/souther/compiler/semantics/OperationFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/OperationFacts.java
@@ -91,6 +91,11 @@ public final class OperationFacts {
             // standing for the call would be a second reading of the same call, which is what the
             // exclusivity below refuses.
             about("Time", "hour", takenAs(new TakenAs.PartOfTime(TakenAs.TimePart.HOUR))),
+            about("Time", "minute", takenAs(new TakenAs.PartOfTime(TakenAs.TimePart.MINUTE))),
+            about("Time", "second", takenAs(new TakenAs.PartOfTime(TakenAs.TimePart.SECOND))),
+            about("Date", "year", takenAs(new TakenAs.PartOfDate(TakenAs.DatePart.YEAR))),
+            about("Date", "month", takenAs(new TakenAs.PartOfDate(TakenAs.DatePart.MONTH))),
+            about("Date", "day", takenAs(new TakenAs.PartOfDate(TakenAs.DatePart.DAY))),
 
             // A count is never negative, and each of these says so itself. Derived from the arm
             // instead, the arm would be where a bound is really declared and every operation
@@ -109,6 +114,11 @@ public final class OperationFacts {
             about("String", "length",
                     new OperationFact.EveryAnswerItCanGiveHasASourceValue()),
             about("Time", "hour", new OperationFact.EveryAnswerItCanGiveHasASourceValue()),
+            about("Time", "minute", new OperationFact.EveryAnswerItCanGiveHasASourceValue()),
+            about("Time", "second", new OperationFact.EveryAnswerItCanGiveHasASourceValue()),
+            about("Date", "year", new OperationFact.EveryAnswerItCanGiveHasASourceValue()),
+            about("Date", "month", new OperationFact.EveryAnswerItCanGiveHasASourceValue()),
+            about("Date", "day", new OperationFact.EveryAnswerItCanGiveHasASourceValue()),
 
             // What holds of a result wherever the call is written. Each is a fact about the
             // operation, so it is stated at every call and not only where something was guarded:
@@ -405,9 +415,10 @@ public final class OperationFacts {
         // any number of them. `DateTime.minutesBetween` counts whole minutes over a carrier
         // counting seconds and drops the remainder toward zero, so it is not the difference of the
         // two counts — which is why it is the operation an author of the next such fact would reach
-        // for, and why the refusal is written down beside the ones that are accepted. A component
-        // is read out of a count by dividing or by taking a remainder: the year a day falls in, the
-        // second within a minute, the day a second falls in, the second within a day.
+        // for, and why the refusal is written down beside the ones that are accepted. A component of
+        // a value is no arithmetic over its count either, and is said as the representation that
+        // reads it rather than as a form: the parts of a day divide and take a remainder, and the
+        // parts of a date are the calendar's, which no step over a day count answers.
         out.addAll(saysNothing(OperationSubject.FORM, op("Int", "multiply"),
                 op("Decimal", "multiply"), op("Int", "compare"),
                 op("Decimal", "compare"), op("Int", "floorMod"), op("Int", "abs"), op("Decimal", "abs"), op("Decimal", "toInt"),
@@ -416,6 +427,18 @@ public final class OperationFacts {
                 op("DateTime", "minutesBetween"), op("Date", "year"), op("Date", "month"),
                 op("Date", "day"), op("Time", "hour"), op("Time", "minute"), op("Time", "second"),
                 op("DateTime", "toDate"), op("DateTime", "toTime")));
+
+        // The number each answers arrives at one case of what it answers, and the other case says
+        // the text named no number at all. So the number exists and no representation reads the
+        // call: what a reading is applied to is one location, and the value standing there is the
+        // union. Which case it is in is settled where the union is taken apart, and what stands at
+        // the arm is a value with a name of its own rather than something this operation answered.
+        //
+        // Not "no conversion is ever read". `Decimal.fromInt` is a conversion and answers a form of
+        // its argument, because what it answers is a number at every call. The difference is the
+        // union and nothing else.
+        out.addAll(saysNothing(OperationSubject.READING, op("String", "toInt"),
+                op("String", "toDecimal")));
         return List.copyOf(out);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/semantics/OperationSubject.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/OperationSubject.java
@@ -29,7 +29,8 @@ public enum OperationSubject {
     MEASURE("what it states through the measure counting the two apart"),
     CHOICE("whether it answers one of its arguments, and in which cases"),
     FORM("what it answers, counted, in what its arguments are counted as"),
-    NUMERIC_RESULT("what number it computes, and where it answers it");
+    NUMERIC_RESULT("what number it computes, and where it answers it"),
+    READING("which representation reads the number it answers");
 
     private final String asked;
 

--- a/souther-compiler/src/main/java/souther/compiler/semantics/TakenAs.java
+++ b/souther-compiler/src/main/java/souther/compiler/semantics/TakenAs.java
@@ -75,6 +75,47 @@ public sealed interface TakenAs {
         }
     }
 
+    /**
+     * Which part of a date it is: the year it falls in, the month within that year, the day within
+     * that month.
+     *
+     * <p>Beside {@link PartOfTime} and not one arm with it. Both take a component out of a value the
+     * library counts, and there the likeness stops: the parts of a day are a fixed-radix system, so
+     * a division and a remainder answer any of them and the two directions are written once for the
+     * family. The parts of a date are the calendar's, and no arithmetic over the day count answers
+     * them — a month is not a number of days. One arm covering both would carry the account of two
+     * different things, and whichever of the two was written first would be the shape the other had
+     * to be squeezed into.
+     *
+     * <p>So the part is a name and carries no arithmetic, and what a year, a month and a day are is
+     * the calendar's to say where the count is turned into a date. Given a step and a modulus here,
+     * as the parts of a day have, the numbers would be wrong for eleven months in twelve.
+     */
+    record PartOfDate(DatePart part) implements TakenAs {
+
+        public PartOfDate {
+            java.util.Objects.requireNonNull(part, "this one says which part");
+        }
+
+        @Override
+        public boolean takenOf(Type source, Type answered) {
+            return source == Type.Prim.DATE && answered == Type.Prim.INT;
+        }
+    }
+
+    /** A part of a date, in the order the parts run. */
+    enum DatePart {
+
+        /** The year it falls in. */
+        YEAR,
+
+        /** The month within that year, counted from one. */
+        MONTH,
+
+        /** The day within that month, counted from one. */
+        DAY
+    }
+
     /** A part of a time of day, in the order the parts run. */
     enum TimePart {
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperationTheLibraryGainsIsAnsweredForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperationTheLibraryGainsIsAnsweredForTest.java
@@ -62,7 +62,7 @@ class AnOperationTheLibraryGainsIsAnsweredForTest {
         for (Map.Entry<String, Stdlib.Entry> e : DefaultStdlib.get().entries().entrySet()) {
             ValueName operation = DefaultStdlib.get().operation(e.getKey());
             for (Question question : Question.askedOf(DefaultStdlib.get(), e.getValue().signature())) {
-                boolean answered = question.answeredFor(operation);
+                boolean answered = question.answeredFor(DefaultStdlib.get(), operation);
                 boolean silent = question.nothingSaidOf().contains(operation);
                 if (answered != silent) {
                     continue;

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneStatementDrawsOneBorderHoweverItIsSpelledTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneStatementDrawsOneBorderHoweverItIsSpelledTest.java
@@ -105,12 +105,25 @@ class OneStatementDrawsOneBorderHoweverItIsSpelledTest {
                 reasonsOf("a: DateTime, b: DateTime", "DateTime.minutesBetween(a, b) > 10"));
     }
 
-    /** And the same of a component, which is a count divided rather than a form of one. */
+    /**
+     * A component of a value is not a form of it, and is a line all the same.
+     *
+     * <p>The other way a rule reaches a position. A form says what a result is in the counts of what
+     * it was given, so the rule is read into the arguments and the border falls where the arithmetic
+     * puts it. A component is no such arithmetic — the months are of different lengths, so no step
+     * over the day count answers the year — and the operation says instead which representation
+     * reads the number it answers. Read that way, {@code Date.year(a) > 2020} is a border on what
+     * {@code a} may be, and the position is divided.
+     *
+     * <p>Beside the case above and not folded into it. What {@code DateTime.minutesBetween} answers
+     * is read by nothing at all, so the rule stays about a value made from the positions; the
+     * difference between the two is which representation the operation declares, and it shows here
+     * as a border against no border.
+     */
     @Test
-    void aComponentOfAValueIsARuleAboutADerivedValue() {
-        assertEquals(List.of(), bordersOf("a: Date", "Date.year(a) > 2020"));
-        assertEquals(List.of(UndividedPosition.Reason.RULE_ABOUT_A_DERIVED_VALUE),
-                reasonsOf("a: Date", "Date.year(a) > 2020"));
+    void aComponentOfAValueIsABorderOnThePositionItIsTakenOf() {
+        assertEquals(List.of("2020"), bordersOf("a: Date", "Date.year(a) > 2020"));
+        assertEquals(List.of(), reasonsOf("a: Date", "Date.year(a) > 2020"));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatIsRealizedForANumberReadsBackAsThatNumberTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatIsRealizedForANumberReadsBackAsThatNumberTest.java
@@ -65,7 +65,7 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
      */
     private static List<Long> answerable(NumericTerm term) {
         List<Long> out = new ArrayList<>();
-        for (long each : new long[] {0, 1, 3, 7, 23}) {
+        for (long each : new long[] {0, 1, 3, 7, 12, 23, 28, 31}) {
             if (term.intrinsicBounds().admits(Count.of(each))) {
                 out.add(each);
             }
@@ -247,18 +247,67 @@ class WhatIsRealizedForANumberReadsBackAsThatNumberTest {
     }
 
     /**
+     * The parts of a date, at the numbers a calendar is where the trouble is.
+     *
+     * <p>Beside the walk above and not instead of it. That one asks every account at a handful of
+     * numbers chosen to suit all of them, and the numbers a calendar goes wrong at are the calendar's
+     * own: the last day of the longest month, the day February has only every fourth year, the last
+     * month, a year either side of a leap one. A date offered for the thirty-first in a month with
+     * thirty days is not a date, and a walk that never asks for the thirty-first would not find out.
+     *
+     * <p>Read back and not compared to a date written here. Which date answers a year is the
+     * realizer's to choose, and naming one would make this a test of the choice rather than of the
+     * law it has to satisfy.
+     */
+    @Test
+    void everyPartOfADateReadsBackFromTheDateOfferedForIt() {
+        readsBackAt("Date.year", Type.Prim.DATE, 1999, 2000, 2001, 1, 0);
+        readsBackAt("Date.month", Type.Prim.DATE, 1, 2, 11, 12);
+        readsBackAt("Date.day", Type.Prim.DATE, 1, 28, 29, 30, 31);
+    }
+
+    /** Every one of those numbers has a value built for it, and it reads back as that number. */
+    private static void readsBackAt(String qualified, Type source, long... numbers) {
+        ValueName.Stdlib operation = DefaultStdlib.get().operation(qualified);
+        NumericTerm.TakenOf term = NumericTerm.TakenOf.of(operation, AT, source, SYMBOLS);
+        assertNotNull(term, qualified + " is taken of what its own signature says it takes");
+        souther.compiler.inputs.TermOrders orders = term.ordersAt(source, SYMBOLS);
+        for (long each : numbers) {
+            Place asked = Count.of(each);
+            TermRealizations.Realization made =
+                    TermRealizations.at(term, source, orders, asked, SYMBOLS, POLICY);
+            TermRealizations.Realization.Built built = assertInstanceOf(
+                    TermRealizations.Realization.Built.class, made,
+                    qualified + " answers " + each + " of some date, so there is one to offer");
+            for (FixtureTemplate value : built.values()) {
+                assertEquals(new NumericTerm.Reading.Number(asked),
+                        term.read(observed(value), orders),
+                        qualified + " built " + value.text() + " for " + each
+                                + ", and it does not read back as that");
+            }
+        }
+    }
+
+    /**
      * An operation the language gives no account of has no term.
      *
      * <p>Refused where the term is built rather than at whichever reader met it first. Every other
      * answer about such a term comes from the declaration, so one without a declaration is a term
      * read by whatever each reader's default happened to be.
+     *
+     * <p>Asked of an operation the language writes out, and not of one that has simply not been
+     * declared yet. {@code Int.abs} is an ordinary {@code let}, so a reading takes its body and a
+     * term standing for the call is refused where an account would be declared — which makes it an
+     * operation that cannot come to have one. Asked of a gap instead, this test would hold only
+     * until somebody filled the gap, and what it is about would leave with it.
      */
     @Test
     void aTermCannotBeBuiltForAnOperationThatDeclaresNoAccount() {
-        assertTrue(OperationFacts.takenAs(ValueName.Stdlib.operation("Date", "year")) == null,
-                "the premise: nothing is declared of it yet");
-        assertNull(NumericTerm.TakenOf.of(ValueName.Stdlib.operation("Date", "year"), AT,
-                        Type.Prim.DATE, SYMBOLS),
+        assertTrue(OperationFacts.takenAs(ValueName.Stdlib.operation("Int", "abs")) == null,
+                "the premise: what it answers is read by reading its body, so no account is"
+                        + " declared of it and none may be");
+        assertNull(NumericTerm.TakenOf.of(ValueName.Stdlib.operation("Int", "abs"), AT,
+                        Type.Prim.INT, SYMBOLS),
                 "so there is no term for what it answers");
     }
 


### PR DESCRIPTION
Closes #1045. The second half, on top of #1056: that one settled that a number
is read by at most one representation, this one asks which.

## The question

`OperationSubject.READING` and `Question.READING`. The range is the signature
and no more — one argument, and a number answered.

Not "and an intrinsic", which is how the issue first drew it. Whether the
language writes the body out is one of the four answers, so a range asking for
an intrinsic is drawn around its own answers, and `Int.abs` ends up with no
reader named anywhere. The issue's own argument against a narrow range is the
argument against that condition; the issue text is corrected.

A number at one case of a union counts, as the arithmetic question has counted
it since #959. Read as a bare number here, there would be two definitions of
"answers a number" in `check` — the thing #1056 spent a commit removing.

What may be **declared** stays narrower. A term is held to a bare numeric
result, because what stands at the path a term names is the union and which
case it is in is not something such an account has room for. So an operation
may be asked a question whose only available answer is that nothing reads it,
and two of them are.

## The seven that owed an answer

| | answer |
| --- | --- |
| `Time.minute`, `Time.second` | a declaration and nothing else |
| `Date.year`, `Date.month`, `Date.day` | a new account, `TakenAs.PartOfDate` |
| `String.toInt`, `String.toDecimal` | a silence, with the reason |

`Time.minute` and `Time.second` needed no code: both directions were already
written over the `TimePart` family rather than over the hour.

The silence is not "no conversion is read". `Decimal.fromInt` is a conversion
and answers a form of its argument, because what it answers is a number at
every call. What `String.toInt` answers is a number at one case and a statement
that the text named none at the other, so the value standing at the path a
reading is applied to is the union: the number exists, and no representation
reads the call.

## The parts of a date

`TakenAs.PartOfDate(DatePart)`, beside `PartOfTime` and not folded into it. The
parts of a day are a fixed-radix system, so one division and one remainder
answer any of them and neither direction has a case per part. A month is not a
number of days, so no step over the day count answers the year. An arm carrying
a step and a modulus, as the parts of a day do, would be wrong for eleven
months in twelve.

So `DatePart` is a name and carries no arithmetic, and what a year, a month and
a day are is asked of the calendar where a count becomes a date. That
conversion is `Dates`, which gains `dateAt` and `dayOf(LocalDate)` while
`written` becomes a projection of the first — one conversion each way, so a
report, a fixture and a reading come to the same date from the same day.

Writing offers one of the many, as the hour does. A day of the month is offered
in the longest month there is, so every day a date can fall on is a day of the
one that gets written; how far the days run is asked of **that month** rather
than of how far a day of any month can run. The two agree only while the month
is the longest, and a month chosen here that was not would admit days no date
could be built for.

Whether a date can have the part at all is asked of the calendar and not of the
bound the operation declares. A bound is what a model may assume of an answer;
what dates there are is what a witness can be built from, and reading the second
off the first would turn a bound loosened by hand into dates that cannot be
written.

`Generator`, `Partitions`, `HeldCounts`, `ComparisonSubjects` and
`ReadQuantities` gain nothing. That was the line #1027 set for an account added,
and it holds: what those read is `NumericTerm.TakenOf.of`, not the arm.

## Two tests stood on the gap this fills

`aTermCannotBeBuiltForAnOperationThatDeclaresNoAccount` used `Date.year` for an
operation with no account, which was a gap waiting to be filled. It asks about
`Int.abs`, whose body is the reading and which therefore cannot come to have
one.

`aComponentOfAValueIsARuleAboutADerivedValue` asserted that `Date.year(a) >
2020` draws no border. That is the thing that changed: it is a border on what
`a` may be, and the test says so.

## Measured

The existing law walk covers the new arm without a line being added, since it
walks the declarations. What it does not cover is the numbers a calendar goes
wrong at, so those are asked directly:

| break | what stopped |
| --- | --- |
| the day offered in February instead of January | the law test and the coverage test, at `Date.day` = 29 |
| the arm dropped from the reader / the realizer / `onlyOneValueAnswersIt` | each fails to compile |

The first attempt at that break threw rather than answering, which is what
showed the range check was reading the longest month's length while the date
was built in whichever month the constant named. It asks the month now.

`mvn -o test` green over the reactor, 10,209 tests.
