### PR TITLE
Answer what a type is where it is owned, and require it by name

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Accumulations.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Accumulations.java
@@ -163,9 +163,8 @@ final class Accumulations {
             Stdlib.Signature signature = stdlib.entry(operation.toString()).signature();
             int found = -1;
             for (int i = 0; i < signature.params().size(); i++) {
-                Type param = signature.params().get(i);
-                if (!Question.holdsElements(param)
-                        || !signature.result().equals(Terms.elementType(param))) {
+                Type element = Type.elementOfAContainer(signature.params().get(i));
+                if (element == null || !element.equals(signature.result())) {
                     continue;
                 }
                 if (found >= 0) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Carrier.java
@@ -157,6 +157,25 @@ public sealed interface Carrier {
     }
 
     /**
+     * Whether values of {@code type} count to a number.
+     *
+     * <p>Wider than {@link NumericAnswers#isANumber} and asked where the arithmetic is over counts
+     * rather than over numbers a model wrote: a date is not a number and counts days, so a
+     * difference of two of them is a number of days. Answered here because this is the one table
+     * saying which types have an order with counts under it. Answered beside a reader instead, the
+     * reader owns a classification it also consumes, and the next reader either borrows from it or
+     * writes a second table — and a type that is a carrier to one of them and not to the other is
+     * what that costs.
+     *
+     * <p>Asked without the declarations, as {@link #ofPrimitive} is: the type settles it and a name
+     * comes back unanswered. What that leaves out is measured there.
+     */
+    static boolean countsToANumber(Type type) {
+        Carrier carrier = ofPrimitive(type);
+        return carrier != null && carrier.counts();
+    }
+
+    /**
      * The carrier a location's own content is counted on, or null where nothing here orders it.
      *
      * <p>Asked of what the names wrap, so a newtype answers as the value it carries — which is what

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -244,7 +244,7 @@ final class DischargeRules {
      * result it cannot is a form it cannot carry.
      *
      * <p>Asked with {@link NumericAnswers#isANumber} where the binding asks
-     * {@link Question#countsToANumber}. That is the difference between what is true of the
+     * {@link Carrier#countsToANumber}. That is the difference between what is true of the
      * operation and what this check can do with it — a date counts and is no number, so
      * {@code Date.daysBetween} is declared and is not carried here.
      *
@@ -864,10 +864,10 @@ final class DischargeRules {
      */
     static void holdAFormOfItsArguments(Stdlib stdlib, ValueName operation,
             souther.compiler.numeric.NumericDomain.LinearForm<ArgumentRef> form) {
-        holdTheResultToTheDeclaration(stdlib, operation, Question::countsToANumber,
+        holdTheResultToTheDeclaration(stdlib, operation, Carrier::countsToANumber,
                 "a value with a count for a form of its arguments to be about");
         for (ArgumentRef argument : form.coefs().keySet()) {
-            holdToTheDeclaration(stdlib, operation, argument, null, Question::countsToANumber,
+            holdToTheDeclaration(stdlib, operation, argument, null, Carrier::countsToANumber,
                     "an argument the result is a form of");
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -24,10 +24,8 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 /**
  * What the language's own operations do to the properties the invariant-discharge check tracks
@@ -522,8 +520,8 @@ final class DischargeRules {
     }
 
     /**
-     * As {@link #bind}, for the arithmetic an operation computes: it takes as many arguments as the
-     * row hands over, and it answers its number where the row says it does.
+     * As {@link #holdToTheDeclaration}, for the arithmetic an operation computes: it takes as many
+     * arguments as the row hands over, and it answers its number where the row says it does.
      *
      * <p>The result position is the half a signature can disagree with silently. A row saying the
      * number arrives in the case carrying {@code Int} is read at an arm, and an arm that never
@@ -548,8 +546,8 @@ final class DischargeRules {
         }
         switch (rule.at()) {
             case NumericResult.Answered.Directly ignored ->
-                    holdTheResultToTheDeclaration(stdlib, operation, NumericAnswers::isANumber,
-                            "a number for the arithmetic it computes to be answered at");
+                    holdTheResultToTheDeclaration(stdlib, operation, TypeRequirement.NUMBER,
+                            "where the arithmetic it computes is answered");
             case NumericResult.Answered.InTheCaseCarrying(Type carried) -> {
                 if (!(signature.result() instanceof Type.Union(Set<TypeSymbol> members))) {
                     throw new IllegalStateException(operation + " answers "
@@ -581,19 +579,19 @@ final class DischargeRules {
         }
         if (rule.unless() != null) {
             holdToTheDeclaration(stdlib, operation, rule.unless().argument(), null,
-                    NumericAnswers::isANumber, "the argument a failure is decided by");
+                    TypeRequirement.NUMBER, "the argument a failure is decided by");
         }
     }
 
     /**
-     * As {@link #bind}, for a rule stating a shift through a measure: the amount is a number, the
-     * value shifted is of the type the measure counts, and the measure counts two of what the
-     * operation answers. A rule pairing an operation with a measure of something else would state a
-     * relation between two values that have none.
+     * As {@link #holdToTheDeclaration}, for a rule stating a shift through a measure: the amount is
+     * a number, the value shifted is of the type the measure counts, and the measure counts two of
+     * what the operation answers. A rule pairing an operation with a measure of something else
+     * would state a relation between two values that have none.
      */
     static void holdShift(Stdlib stdlib, ValueName operation, OperationFact.ShiftsBy
             shift) {
-        holdToTheDeclaration(stdlib, operation, shift.amount(), null, NumericAnswers::isANumber,
+        holdToTheDeclaration(stdlib, operation, shift.amount(), null, TypeRequirement.NUMBER,
                 "the amount a shift moves by");
         Stdlib.Entry counts = stdlib.entry(shift.measure().qualified());
         if (counts == null) {
@@ -608,30 +606,41 @@ final class DischargeRules {
             throw new IllegalStateException(shift.measure().qualified()
                     + " does not count two of what " + operation + " answers apart as a number");
         }
-        holdToTheDeclaration(stdlib, operation, shift.of(), null,
-                t -> t.equals(shifted.signature().result()), "the value a shift moves from");
+        Type moved = holdToTheDeclaration(stdlib, operation, shift.of(), null,
+                TypeRequirement.ANY, "the value a shift moves from");
+        // Not a requirement on the type, which is why it is stated here rather than passed as one.
+        // What this asks is that two positions of one signature stand at the same type, and nothing
+        // about a type on its own answers that — a requirement able to say it would be one carrying
+        // the signature it was written for.
+        if (!moved.equals(shifted.signature().result())) {
+            throw new IllegalStateException("the value " + ((ValueName.Stdlib) operation).qualified()
+                    + " shifts is " + Type.show(moved) + " and what it answers is "
+                    + Type.show(shifted.signature().result())
+                    + ", so what it moves is not what the measure counts");
+        }
     }
 
-    /** As {@link #bind}, for the arguments a case names: the one it answers, and the two sides of
-     * each condition it is reached under. */
+    /** As {@link #holdToTheDeclaration}, for the arguments a case names: the one it answers, and
+     * the two sides of each condition it is reached under. */
     static void holdCase(Stdlib stdlib, ValueName operation, OperationFact.Case one) {
-        holdTheResultToTheDeclaration(stdlib, operation, NumericAnswers::isANumber,
-                "a number for a case of the definition to answer");
+        holdTheResultToTheDeclaration(stdlib, operation, TypeRequirement.NUMBER,
+                "what a case of the definition answers");
         List<ArgumentRef> named = new ArrayList<>();
         named.add(one.answers());
         one.given().forEach(stands -> {
             named.add(stands.left());
             named.add(stands.right());
         });
-        named.forEach(each -> holdToTheDeclaration(stdlib, operation, each, null, NumericAnswers::isANumber,
-                "an argument a case of the definition names"));
+        named.forEach(each -> holdToTheDeclaration(stdlib, operation, each, null,
+                TypeRequirement.NUMBER, "an argument a case of the definition names"));
     }
 
-    /** As {@link #bind}, for the arguments a bound names: the one the result is bounded against, and
-     * the one a condition on the rule reads. Each is a separate claim about a separate argument. */
+    /** As {@link #holdToTheDeclaration}, for the arguments a bound names: the one the result is
+     * bounded against, and the one a condition on the rule reads. Each is a separate claim about a
+     * separate argument. */
     static void holdBound(Stdlib stdlib, ValueName operation, ResultBound bound) {
-        holdTheResultToTheDeclaration(stdlib, operation, NumericAnswers::isANumber,
-                "a number for a bound on the result to hold of");
+        holdTheResultToTheDeclaration(stdlib, operation, TypeRequirement.NUMBER,
+                "what a bound on the result holds of");
         List<ArgumentRef> named = new ArrayList<>();
         if (bound.against() != null) {
             named.add(bound.against());
@@ -641,34 +650,8 @@ final class DischargeRules {
                 constant) {
             named.add(constant.argument());
         }
-        named.forEach(one -> holdToTheDeclaration(stdlib, operation, one, null, NumericAnswers::isANumber,
-                "an argument a bound on the result names"));
-    }
-
-    /** As {@link #bind}, for a rule that names more than one argument: each is held to the
-     * declaration on its own, since each is a separate claim about a separate argument. */
-    static Map<ValueName, List<ArgumentRef>> bindEach(Stdlib stdlib,
-                                                Map<ValueName, List<ArgumentRef>> rules,
-                                                ArgumentRef derived,
-                                                Predicate<Type> required, String what) {
-        rules.forEach((operation, reads) -> reads.forEach(one ->
-                bind(stdlib, Map.of(operation, one), Function.identity(), derived, required, what)));
-        return rules;
-    }
-
-    /**
-     * {@code rules}, once every row has been held to the operation it is about: the operation is one
-     * the library declares, the argument it names is one that declaration has, and what stands there
-     * is what the rule is about. A row naming a part of something the signature says the operation
-     * does not hand is caught by {@link ArgumentRef}; one that writes a position the signature already
-     * answers is caught here, since two answers to one question are what come apart later.
-     */
-    static <T> Map<ValueName, T> bind(Stdlib stdlib, Map<ValueName, T> rules,
-                                      Function<T, ArgumentRef> reads, ArgumentRef derived,
-                                      Predicate<Type> required, String what) {
-        rules.forEach((operation, rule) ->
-                holdToTheDeclaration(stdlib, operation, reads.apply(rule), derived, required, what));
-        return rules;
+        named.forEach(one -> holdToTheDeclaration(stdlib, operation, one, null,
+                TypeRequirement.NUMBER, "an argument a bound on the result names"));
     }
 
     /**
@@ -766,17 +749,18 @@ final class DischargeRules {
      * Improvising a check per kind defaults to omitting it, which is how a fact naming no argument
      * once went through an empty arm ({@link #holdTheOperationToTheLibrary}).
      *
-     * <p>What is required is the caller's, since what a fact says of the result is the fact's. A
+     * <p>Which requirement is the caller's, since what a fact says of the result is the fact's. A
      * form is about a count and a bound about a number, and the difference between those two is a
-     * difference between the propositions and not between two ways of holding one.
+     * difference between the propositions and not between two ways of holding one. Which it may
+     * choose from is not the caller's ({@link TypeRequirement}).
      */
     static void holdTheResultToTheDeclaration(Stdlib stdlib, ValueName operation,
-            Predicate<Type> required, String what) {
+            TypeRequirement required, String role) {
         Type result = holdTheOperationToTheLibrary(stdlib, operation).signature().result();
-        if (result == null || !required.test(result)) {
+        if (result == null || !required.admits(result)) {
             throw new IllegalStateException("what " + ((ValueName.Stdlib) operation).qualified()
                     + " answers is " + (result == null ? "left to its body" : Type.show(result))
-                    + ", which is not " + what);
+                    + ", not " + required + "; it is named as " + role);
         }
     }
 
@@ -824,8 +808,8 @@ final class DischargeRules {
         // answers at that path is the union — which case it is in is a question this account has no
         // room for. Narrower than the range of whatever asks for such an account, and deliberately:
         // what may be declared and what is asked about are two ranges.
-        holdTheResultToTheDeclaration(stdlib, operation, NumericAnswers::isANumber,
-                "a number for a term of what it answers to be about");
+        holdTheResultToTheDeclaration(stdlib, operation, TypeRequirement.NUMBER,
+                "what a term of its answer is about");
         // Before the shape below, because it is the operation that is being asked about and not
         // this fact. An account that does not fit the operation is still an account of a number
         // some other representation may already read, and asked the other way round the exclusivity
@@ -864,38 +848,57 @@ final class DischargeRules {
      */
     static void holdAFormOfItsArguments(Stdlib stdlib, ValueName operation,
             souther.compiler.numeric.NumericDomain.LinearForm<ArgumentRef> form) {
-        holdTheResultToTheDeclaration(stdlib, operation, Carrier::countsToANumber,
-                "a value with a count for a form of its arguments to be about");
+        holdTheResultToTheDeclaration(stdlib, operation, TypeRequirement.COUNTED,
+                "what a form of its arguments is about");
         for (ArgumentRef argument : form.coefs().keySet()) {
-            holdToTheDeclaration(stdlib, operation, argument, null, Carrier::countsToANumber,
+            holdToTheDeclaration(stdlib, operation, argument, null, TypeRequirement.COUNTED,
                     "an argument the result is a form of");
         }
     }
 
-    /** The same, for one rule. Asked per rule so that whatever holds a whole declaration source can
-     *  walk it and hold each of them, rather than reaching for a table of its own. */
-    static void holdToTheDeclaration(Stdlib stdlib, ValueName operation, ArgumentRef at,
-                                     ArgumentRef derived, Predicate<Type> required, String what) {
+    /**
+     * Holds one rule to the operation it is about: the operation is one the library declares, the
+     * argument it names is one that declaration has, and what stands there is what the rule
+     * requires. A rule naming a part of something the signature says the operation does not hand is
+     * caught by {@link ArgumentRef}; one that writes a position the signature already answers is
+     * caught here, since two answers to one question are what come apart later.
+     *
+     * <p>Asked per rule so that whatever holds a whole declaration source can walk it and hold each
+     * of them, rather than reaching for a table of its own. Holding a table at a time was two
+     * wrappers over this, and neither was reached: what walks the declarations walks them one rule
+     * at a time, so an entry point taking a map of them said there was a way of binding that
+     * nothing binds.
+     *
+     * <p>Answers what stands at the position it held. A caller with something to state that a
+     * requirement cannot — that two positions of one signature stand at one type — then says it
+     * without reading the position over again, and two readings of where an argument is are two
+     * answers to it.
+     */
+    static Type holdToTheDeclaration(Stdlib stdlib, ValueName operation, ArgumentRef at,
+                                     ArgumentRef derived, TypeRequirement required, String role) {
         Stdlib.Entry entry = holdTheOperationToTheLibrary(stdlib, operation);
         ValueName.Stdlib library = (ValueName.Stdlib) operation;
         List<Type> params = entry.signature().params();
         int position = CallArguments.positionIn(at, operation);
         if (position < 0 || position >= params.size()) {
             throw new IllegalStateException(library.qualified() + " takes " + params.size()
-                    + " argument(s), and the rule about " + what + " reads argument "
+                    + " argument(s), and the rule about " + role + " reads argument "
                     + (position + 1));
         }
-        if (!required.test(params.get(position))) {
+        Type stands = params.get(position);
+        if (!required.admits(stands)) {
             throw new IllegalStateException("argument " + (position + 1) + " of "
-                    + library.qualified() + " is not " + what);
+                    + library.qualified() + " is " + Type.show(stands) + ", not " + required
+                    + "; it is named as " + role);
         }
         if (at instanceof ArgumentRef.At && derived != null && Combinators.of(operation) != null
                 && CallArguments.positionIn(derived, operation) == position) {
-            throw new IllegalStateException("the rule about " + what + " for "
+            throw new IllegalStateException("the rule about " + role + " for "
                     + library.qualified()
                     + " writes the argument its signature already answers — say which part it is"
                     + " rather than where, so the two cannot come apart");
         }
+        return stands;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/OperationFactBinder.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OperationFactBinder.java
@@ -4,7 +4,6 @@ import souther.compiler.stdlib.Stdlib;
 import souther.compiler.semantics.ArgumentRef;
 import souther.compiler.semantics.OperationFact;
 import souther.compiler.semantics.OperationFacts;
-import souther.compiler.types.Type;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -67,9 +66,11 @@ final class OperationFactBinder {
                 // statement and a signature could disagree with either half.
                 case OperationFact.StatesTheOrderOfItsArguments states -> {
                     DischargeRules.holdToTheDeclaration(stdlib, each.operation(), states.order().greater(),
-                            null, type -> true, "the argument a positive answer names as greater");
+                            null, TypeRequirement.ANY,
+                            "the argument a positive answer names as greater");
                     DischargeRules.holdToTheDeclaration(stdlib, each.operation(), states.order().lesser(),
-                            null, type -> true, "the argument a positive answer names as lesser");
+                            null, TypeRequirement.ANY,
+                            "the argument a positive answer names as lesser");
                 }
                 case OperationFact.ShiftsBy shifts -> DischargeRules.holdShift(stdlib, each.operation(),
                         shifts);
@@ -79,22 +80,22 @@ final class OperationFactBinder {
                         DischargeRules.holdToTheDeclaration(stdlib, each.operation(),
                                 builds.built().from(),
                                 new ArgumentRef.TheContainer(),
-                                t -> Type.elementOfAContainer(t) != null,
+                                TypeRequirement.CONTAINER,
                                 "the container something is built from");
                 case OperationFact.ResultIsNoSmallerThan bounded ->
                         DischargeRules.holdToTheDeclaration(stdlib, each.operation(), bounded.container(),
                                 new ArgumentRef.TheContainer(),
-                                t -> Type.elementOfAContainer(t) != null,
+                                TypeRequirement.CONTAINER,
                                 "a container the result is no smaller than");
                 case OperationFact.ReadsItsContainer reads ->
                         DischargeRules.holdToTheDeclaration(stdlib, each.operation(), reads.container(),
                                 new ArgumentRef.TheContainer(),
-                                t -> Type.elementOfAContainer(t) != null,
+                                TypeRequirement.CONTAINER,
                                 "the container a predicate reads");
                 case OperationFact.IsStatedOverAProjection over ->
                         DischargeRules.holdToTheDeclaration(stdlib, each.operation(), over.projection(),
                                 new ArgumentRef.TheClosure(),
-                                type -> type instanceof Type.FnOf,
+                                TypeRequirement.CLOSURE,
                                 "the projection a predicate is stated over");
                 // None of these names an argument — a silence names none by definition — so there
                 // is nothing about one to hold to a signature. Their operation is held above with
@@ -109,8 +110,8 @@ final class OperationFactBinder {
                 // wrong here (#1027).
                 case OperationFact.EveryAnswerItCanGiveHasASourceValue _ ->
                         DischargeRules.holdTheResultToTheDeclaration(stdlib, each.operation(),
-                                NumericAnswers::isANumber,
-                                "a number for every answer of it to have a value");
+                                TypeRequirement.NUMBER,
+                                "what every answer of it has a value for");
                 case OperationFact.AnswersANumberTakenOfTheOneValueItIsGiven taken ->
                         DischargeRules.holdTakenOf(stdlib, declared, each.operation(), taken.how());
                 case OperationFact.ComputesANumber computes ->

--- a/souther-compiler/src/main/java/souther/compiler/check/OperationFactBinder.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/OperationFactBinder.java
@@ -79,17 +79,17 @@ final class OperationFactBinder {
                         DischargeRules.holdToTheDeclaration(stdlib, each.operation(),
                                 builds.built().from(),
                                 new ArgumentRef.TheContainer(),
-                                Question::holdsElements,
+                                t -> Type.elementOfAContainer(t) != null,
                                 "the container something is built from");
                 case OperationFact.ResultIsNoSmallerThan bounded ->
                         DischargeRules.holdToTheDeclaration(stdlib, each.operation(), bounded.container(),
                                 new ArgumentRef.TheContainer(),
-                                Question::holdsElements,
+                                t -> Type.elementOfAContainer(t) != null,
                                 "a container the result is no smaller than");
                 case OperationFact.ReadsItsContainer reads ->
                         DischargeRules.holdToTheDeclaration(stdlib, each.operation(), reads.container(),
                                 new ArgumentRef.TheContainer(),
-                                Question::holdsElements,
+                                t -> Type.elementOfAContainer(t) != null,
                                 "the container a predicate reads");
                 case OperationFact.IsStatedOverAProjection over ->
                         DischargeRules.holdToTheDeclaration(stdlib, each.operation(), over.projection(),

--- a/souther-compiler/src/main/java/souther/compiler/check/Question.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Question.java
@@ -84,7 +84,8 @@ enum Question {
         @Override
         boolean asksOf(Stdlib stdlib, Stdlib.Signature signature) {
             Type result = signature.result();
-            if (result == null || signature.params().stream().noneMatch(Question::holdsElements)) {
+            if (result == null || signature.params().stream().noneMatch(
+                    t -> Type.elementOfAContainer(t) != null)) {
                 return false;
             }
             boolean carriesItBack = signature.params().stream().anyMatch(
@@ -133,7 +134,7 @@ enum Question {
         boolean asksOf(Stdlib stdlib, Stdlib.Signature signature) {
             Type result = signature.result();
             return result != null && signature.params().stream().anyMatch(
-                    t -> holdsElements(t) && result.equals(Terms.elementType(t)));
+                    t -> result.equals(Type.elementOfAContainer(t)));
         }
 
         @Override
@@ -158,8 +159,9 @@ enum Question {
     BUILT("what it keeps of the container it is built from") {
         @Override
         boolean asksOf(Stdlib stdlib, Stdlib.Signature signature) {
-            return holdsElements(signature.result())
-                    && signature.params().stream().anyMatch(Question::holdsElements);
+            return Type.elementOfAContainer(signature.result()) != null
+                    && signature.params().stream().anyMatch(
+                            t -> Type.elementOfAContainer(t) != null);
         }
 
         @Override
@@ -602,13 +604,6 @@ enum Question {
         return entry != null && asksOf(stdlib, entry.signature());
     }
 
-    /** Whether a construction over {@code t} is one whose elements a shape can speak of. Read where
-     * the rules are bound as well: what a rule about a container may be written over is the same
-     * question as what puts an operation in range of one. */
-    static boolean holdsElements(Type t) {
-        return t instanceof Type.ListOf || t instanceof Type.SetOf || t instanceof Type.MapOf;
-    }
-
     /**
      * Whether the library counts two values of {@code t} apart as a number.
      *
@@ -626,9 +621,19 @@ enum Question {
         });
     }
 
-    /** Whether {@code t} is something the check can name the size of — a container, or a string. */
+    /**
+     * Whether {@code t} is something these questions can name the size of — a container, or a
+     * string.
+     *
+     * <p>A policy of this range and not a classification of the type. Nothing here says a string is
+     * a container or that either is intrinsically sized: it says which types a question about a size
+     * call is asked of, which is this enum's own business and is why it is answered here. Should a
+     * reader outside these ranges need the same set for a reason of its own, whether that is one
+     * proposition or two sets that happen to agree is the question to settle then — the same set is
+     * not the same statement.
+     */
     private static boolean hasASize(Type t) {
-        return holdsElements(t) || t == Type.Prim.STRING;
+        return Type.elementOfAContainer(t) != null || t == Type.Prim.STRING;
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/check/Question.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Question.java
@@ -451,8 +451,8 @@ enum Question {
     FORM("what it answers, counted, in what its arguments are counted as") {
         @Override
         boolean asksOf(Stdlib stdlib, Stdlib.Signature signature) {
-            return countsToANumber(signature.result())
-                    && signature.params().stream().anyMatch(Question::countsToANumber);
+            return Carrier.countsToANumber(signature.result())
+                    && signature.params().stream().anyMatch(Carrier::countsToANumber);
         }
 
         @Override
@@ -624,26 +624,6 @@ enum Question {
             return NumericAnswers.isANumber(entry.signature().result()) && counted.size() == 2
                     && counted.get(0).equals(t) && counted.get(1).equals(t);
         });
-    }
-
-    /**
-     * Whether values of {@code t} count to a number.
-     *
-     * <p>Wider than {@link NumericAnswers#isANumber} and asked where the arithmetic is over counts
-     * rather than over numbers a model wrote: a date is not a number and counts days, so a
-     * difference of two of them is a number of days. Asked of {@link Carrier}, which is the one
-     * table saying which types have an order with counts under it — a second answer here would be a
-     * second table, and a type that is a carrier to one of them and not to the other is what that
-     * costs.
-     *
-     * <p>Asked without the declarations, which is what a reading of the library's own signatures
-     * has: {@link Carrier#ofPrimitive} answers where the type settles it and leaves a name
-     * unanswered. The names in those signatures are the error unions and {@code RoundingMode}, and
-     * a form is written over none of them.
-     */
-    static boolean countsToANumber(Type t) {
-        Carrier carrier = Carrier.ofPrimitive(t);
-        return carrier != null && carrier.counts();
     }
 
     /** Whether {@code t} is something the check can name the size of — a container, or a string. */

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeRequirement.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeRequirement.java
@@ -1,0 +1,80 @@
+package souther.compiler.check;
+
+import souther.compiler.types.Type;
+
+/**
+ * What a declared fact requires of a position in the signature it names.
+ *
+ * <p>A closed vocabulary, so that requiring something of a position is choosing from it. Written as
+ * a {@code Predicate<Type>} the caller handed over, the condition and its name came from the caller
+ * too: {@link OperationFactBinder} named a projection's closure by writing
+ * {@code type -> type instanceof Type.FnOf} where the call was made, said "no requirement" as
+ * {@code type -> true}, and borrowed the two classifications that had been written inside
+ * {@link Question} for the rest. Each of those is a classification answered inside a consumer of the
+ * answer, which is the defect #1056 removed twice over and this closes the route to (#1059).
+ *
+ * <p><b>A requirement names a condition; it does not own the answer to one.</b> Each constant below
+ * delegates to whatever owns the classification it names, and a constant added is a constant whose
+ * owner has been decided. A requirement may read a {@link Type} constructor itself only where the
+ * constructor is the whole of the condition, which is why {@link #CLOSURE} stands out: there is no
+ * table behind {@code FnOf} to disagree with, and a second answer to what one is cannot be written.
+ * The day a requirement wants a condition assembled here out of several, what it wants is an owner.
+ *
+ * <p>What is asked of a type, and not what is asked of a signature. That two positions stand at one
+ * type is a condition no constant here could answer, because nothing about a type on its own decides
+ * it; {@link DischargeRules#holdShift} states that one where both ends are known, and holds the
+ * position itself to {@link #ANY}.
+ *
+ * <p>Not read by {@link Question}, which reads the owners directly. The two sides ask the same
+ * things of a type, but this is the vocabulary of one of them — what a fact requires of a
+ * declaration — and a range is not a requirement. Read by both, the names here would stop meaning
+ * what a fact demands and become somewhere to put a type predicate, which is the shape of the
+ * defect rather than the fix.
+ */
+enum TypeRequirement {
+
+    /** A kind of number the domain relates arithmetically ({@link NumericAnswers#isANumber}). */
+    NUMBER("a number"),
+
+    /** A type whose values count to a number, which is wider than being one ({@link Carrier}). */
+    COUNTED("something that counts to a number"),
+
+    /** A construction holding elements a rule can speak of ({@link Type#elementOfAContainer}). */
+    CONTAINER("a container"),
+
+    /** A function, which is what a rule about a projection or a step is written over. */
+    CLOSURE("a closure"),
+
+    /**
+     * Nothing about what stands there.
+     *
+     * <p>A statement and not a gap: the fact names an argument, so the argument has to be one the
+     * operation takes, and the rest of the holding says so. What the fact says of it — which of two
+     * a positive answer calls the greater — is true of values of any type, so there is nothing about
+     * the type to require. {@code admits} answers true for every type, today and after: a
+     * requirement that came to answer false for some of them would be a different requirement.
+     */
+    ANY("any type");
+
+    private final String required;
+
+    TypeRequirement(String required) {
+        this.required = required;
+    }
+
+    /** Whether {@code type} is what this requires. */
+    boolean admits(Type type) {
+        return switch (this) {
+            case NUMBER -> NumericAnswers.isANumber(type);
+            case COUNTED -> Carrier.countsToANumber(type);
+            case CONTAINER -> Type.elementOfAContainer(type) != null;
+            case CLOSURE -> type instanceof Type.FnOf;
+            case ANY -> true;
+        };
+    }
+
+    @Override
+    public String toString() {
+        return required;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/types/Type.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/Type.java
@@ -197,6 +197,28 @@ public sealed interface Type permits Type.Leaf, Type.Compound {
         };
     }
 
+    /**
+     * What a container of this type holds many of, or null where it is no container: a list's or a
+     * set's element, and a map's value.
+     *
+     * <p>Beside {@link #elementOf} and narrower than it. That one answers what is handed out one at
+     * a time, which an option's payload and a closure's first parameter also are; this one answers
+     * what a construction holds many of, which neither of them is. A reader that asks the wider
+     * question where it means this one is told an {@code Option<Int>} has elements, and goes on to
+     * say what became of them.
+     *
+     * <p>The element and not a yes. Whether a type is a container and what it holds are wanted
+     * together wherever either is wanted at all, and asking them separately is two answers that can
+     * come apart — which is what a check testing for the constructor here and reading the element
+     * over there had.
+     */
+    static Type elementOfAContainer(Type t) {
+        return switch (t) {
+            case ListOf _, SetOf _, MapOf _ -> elementOf(t);
+            case null, default -> null;
+        };
+    }
+
     /** A homogeneous list of {@code element}. */
     record ListOf(Type element) implements Compound {}
 

--- a/souther-compiler/src/test/java/souther/compiler/check/ARuleIsHeldToTheDeclarationItIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARuleIsHeldToTheDeclarationItIsAboutTest.java
@@ -5,13 +5,9 @@ import souther.compiler.semantics.ArgumentRef;
 import souther.compiler.semantics.BuiltFrom;
 import souther.compiler.semantics.ElementLineage;
 import souther.compiler.semantics.SizeAgainstItsSource;
-import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
-
-import java.util.Map;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -37,7 +33,7 @@ class ARuleIsHeldToTheDeclarationItIsAboutTest {
 
     private static void bindCarried(String operation, ArgumentRef container) {
         DischargeRules.holdToTheDeclaration(DefaultStdlib.get(), op(operation), container,
-                new ArgumentRef.TheContainer(), t -> Type.elementOfAContainer(t) != null,
+                new ArgumentRef.TheContainer(), TypeRequirement.CONTAINER,
                 "the container a predicate reads");
     }
 
@@ -45,7 +41,7 @@ class ARuleIsHeldToTheDeclarationItIsAboutTest {
         DischargeRules.holdToTheDeclaration(DefaultStdlib.get(), op(operation),
                 new BuiltFrom(new ElementLineage.SameAs(new ElementLineage.Source(from, 1)),
                         SizeAgainstItsSource.AT_MOST).from(),
-                new ArgumentRef.TheContainer(), t -> Type.elementOfAContainer(t) != null,
+                new ArgumentRef.TheContainer(), TypeRequirement.CONTAINER,
                 "the container something is built from");
     }
 
@@ -62,7 +58,9 @@ class ARuleIsHeldToTheDeclarationItIsAboutTest {
         // container's elements — of a string this names only its length.
         IllegalStateException e = assertThrows(IllegalStateException.class,
                 () -> bindCarried("String.contains", new ArgumentRef.At(1)));
-        assertTrue(e.getMessage().contains("is not the container a predicate reads"), e.getMessage());
+        assertTrue(e.getMessage().contains("is String, not a container"), e.getMessage());
+        assertTrue(e.getMessage().contains("named as the container a predicate reads"),
+                e.getMessage());
     }
 
     @Test
@@ -103,13 +101,11 @@ class ARuleIsHeldToTheDeclarationItIsAboutTest {
         });
     }
 
-    /** The binding reads what the declaration says, so a table it agrees with binds. */
+    /** The binding reads what the declaration says, so a rule it agrees with binds. */
     @Test
     void aRuleThatAgreesWithTheDeclaration() {
-        assertDoesNotThrow(() -> DischargeRules.bind(DefaultStdlib.get(), 
-                Map.of(op("List.reverse"), new ArgumentRef.At(0)),
-                Function.identity(), new ArgumentRef.TheContainer(),
-                (Type t) -> Type.elementOfAContainer(t) != null,
-                "the container something is built from"));
+        assertDoesNotThrow(() -> DischargeRules.holdToTheDeclaration(DefaultStdlib.get(),
+                op("List.reverse"), new ArgumentRef.At(0), new ArgumentRef.TheContainer(),
+                TypeRequirement.CONTAINER, "the container something is built from"));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/ARuleIsHeldToTheDeclarationItIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARuleIsHeldToTheDeclarationItIsAboutTest.java
@@ -37,7 +37,7 @@ class ARuleIsHeldToTheDeclarationItIsAboutTest {
 
     private static void bindCarried(String operation, ArgumentRef container) {
         DischargeRules.holdToTheDeclaration(DefaultStdlib.get(), op(operation), container,
-                new ArgumentRef.TheContainer(), Question::holdsElements,
+                new ArgumentRef.TheContainer(), t -> Type.elementOfAContainer(t) != null,
                 "the container a predicate reads");
     }
 
@@ -45,7 +45,7 @@ class ARuleIsHeldToTheDeclarationItIsAboutTest {
         DischargeRules.holdToTheDeclaration(DefaultStdlib.get(), op(operation),
                 new BuiltFrom(new ElementLineage.SameAs(new ElementLineage.Source(from, 1)),
                         SizeAgainstItsSource.AT_MOST).from(),
-                new ArgumentRef.TheContainer(), Question::holdsElements,
+                new ArgumentRef.TheContainer(), t -> Type.elementOfAContainer(t) != null,
                 "the container something is built from");
     }
 
@@ -109,6 +109,7 @@ class ARuleIsHeldToTheDeclarationItIsAboutTest {
         assertDoesNotThrow(() -> DischargeRules.bind(DefaultStdlib.get(), 
                 Map.of(op("List.reverse"), new ArgumentRef.At(0)),
                 Function.identity(), new ArgumentRef.TheContainer(),
-                (Type t) -> Question.holdsElements(t), "the container something is built from"));
+                (Type t) -> Type.elementOfAContainer(t) != null,
+                "the container something is built from"));
     }
 }


### PR DESCRIPTION
Closes #1059.

`Question` held two classifications of what kind of thing a type is, and both
were read from outside it — `countsToANumber` by `DischargeRules` at two sites,
`holdsElements` by `OperationFactBinder` at three, by `Accumulations` at one and
by a test at three. #1056 moved two classifications of this kind out of the same
place; these were left because one is about containers and had no numeric home.

## What left them there

The route, not the two functions. `holdToTheDeclaration`, its result-side
sibling and `bind` took a `Predicate<Type>` from the caller, so the condition a
fact requires of a position and the words for it were the caller's to write. The
binder had every shape that produces at once: two borrowed from `Question`,
`type -> type instanceof Type.FnOf` written at the call, and `type -> true`
twice for "nothing required". Moving the two and leaving the parameter removes
what was found and keeps what finds it.

## Three commits

1. **`Carrier.countsToANumber`.** The body was already
   `Carrier.ofPrimitive(t).counts()`, so the answer was owned and the question
   was spelling it for a second reader.

2. **`Type.elementOfAContainer`.** `Type.elementOf` already says that a fact
   about a type is answered there; this is narrower and beside it, since an
   option's payload and a closure's first parameter are handed out one at a time
   and are not elements of a container. It answers the element rather than a
   yes, which closes a pair: `Question.ACCUMULATION` and
   `Accumulations.containers` asked whether an argument was a container and then
   asked a wider second reading what it held. `hasASize` stays in `Question` and
   now says why — it is a policy of those ranges, not a classification of the
   type.

3. **`TypeRequirement`.** A closed vocabulary — `NUMBER`, `COUNTED`,
   `CONTAINER`, `CLOSURE`, `ANY` — that owns no answer and delegates each to
   whoever does. `Question` does not read it: the two sides ask the same things
   of a type, but a range is not a demand, and a vocabulary read by both would
   become somewhere to put a type predicate.

## A property of a type, not of a signature

`holdShift` turned out to be passing a fourth shape through the same parameter:

```java
t -> t.equals(shifted.signature().result())
```

Every constant of `TypeRequirement` is a unary property of one type. This is a
relation between two positions of one signature, and nothing about a type on its
own decides it. Admitted as a `SAME_AS_RESULT` beside the rest, the enum would
have stopped being a vocabulary of what a type is and become somewhere to put
any condition a declaration check wants. So it is stated in `holdShift`, where
both ends are known, and the holding answers the type it held so that saying it
reads the position once rather than resolving it again.

## `bind` and `bindEach` are gone

They took a rule table and applied the holding to each row, and nothing called
them — `bindEach` had no caller at all, and `bind` was reached only from
`bindEach` and from one test. Converted to the new parameter and left in place,
they would have gone on saying there is a way of binding a table of rules that
nothing binds. What their javadoc said about the two ways a rule can disagree
with a declaration moves onto `holdToTheDeclaration`, which is where that check
is, and the test that showed an agreeing rule binds now says so of it directly.

Errors say the requirement and the role apart: `argument 2 of String.contains is
String, not a container; it is named as the container a predicate reads`.

`mvn -o test` is green.