### PR TITLE
Close ADR-0114's refinement chain through construction, and take the optional

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/inputs/BlockReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/BlockReason.java
@@ -362,14 +362,12 @@ public sealed interface BlockReason {
      * What a derivation would have to be able to reach into.
      *
      * <p>What it can reach into is not here. The elements of a {@code List} or a {@code Set} were,
-     * and are positions of the input now — a word for a reaching that is made says a reader can
-     * still meet it, and the next one to read this would take its presence for evidence that a
-     * sequence is where the walk stops.
+     * and are positions of the input now; so was the value an {@code Option} holds, which is a
+     * branch of the position under the narrowing that it holds one. A word for a reaching that is
+     * made says a reader can still meet it, and the next one to read this would take its presence
+     * for evidence that a sequence, or an optional, is where the walk stops.
      */
     enum Traversal {
-
-        /** The value an {@code Option} holds when it holds one. */
-        OPTIONAL_VALUE,
 
         /**
          * What a {@code Map} holds. One case and not two, because which of a key and a value a rule

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputReads.java
@@ -109,7 +109,7 @@ public record InputReads(InputDomain read, Map<BindingId, TermPath> roots,
         if (scrutinee == null) {
             return this;
         }
-        TermPath narrowed = scrutinee.refine(new Refinement.SumCase(arm.caseTypes().get(0)));
+        TermPath narrowed = scrutinee.refine(Refinement.sumCase(arm.caseTypes().get(0)));
         // Only where the reading of the input has such a position. A narrowing of something that is
         // not a sum of the input's, or of a case the rules refuse, is a place no row is read at and
         // no class is drawn at — and a line drawn there would be owed by nothing.

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Refinement.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Refinement.java
@@ -37,22 +37,72 @@ public sealed interface Refinement {
      */
     static Refinement of(Case one) {
         return switch (one) {
-            case Case.SumCase sum -> new SumCase(sum.leaf());
+            case Case.SumCase sum -> sumCase(sum.leaf());
             case Case.Presence presence -> new Presence(presence.present());
             case Case.Truth _, Case.Named _ -> null;
         };
     }
 
     /**
+     * The narrowing to {@code leaf}, for a caller that already has the case and not the distinction.
+     *
+     * <p>Not a second correspondence. {@link #of} relates two vocabularies — what a position divides
+     * into, and what a position under it stands beneath — and a caller holding a {@code match} arm's
+     * case has not asked that question: which case the arm selected was settled where the arm was
+     * read. Sent back through {@link Distinctions} to be turned into a {@link Case} first, it would
+     * be a reader re-deriving what it was already told, which is the arrangement this vocabulary
+     * exists to stop.
+     *
+     * <p>Here rather than at a constructor, so that what a narrowing is stays this type's to say.
+     */
+    static Refinement sumCase(TypeSymbol leaf) {
+        return new SumCase(leaf);
+    }
+
+    /**
      * The value turned out to be this case of the sum standing at the position.
      *
-     * @param leaf the case, folded to a leaf as {@link Distinctions} folds the cases it reads
+     * <p>A class and not a record so that the canonical way in can be closed: nothing outside this
+     * declaration may spell a narrowing, because a narrowing spelled somewhere else is a second
+     * reading of which distinctions narrow a position. Compared by what it narrows to all the same —
+     * every reader that decides whether two requirements hold together does it by equality
+     * ({@link Requirements#merge}), and an identity comparison here would have no two narrowings
+     * ever agree.
      */
-    record SumCase(TypeSymbol leaf) implements Refinement {
+    final class SumCase implements Refinement {
+
+        /** The case, folded to a leaf as {@link Distinctions} folds the cases it reads. */
+        private final TypeSymbol leaf;
+
+        private SumCase(TypeSymbol leaf) {
+            if (leaf == null) {
+                throw new IllegalArgumentException("a narrowing to no case is not one");
+            }
+            this.leaf = leaf;
+        }
+
+        public TypeSymbol leaf() {
+            return leaf;
+        }
 
         @Override
         public String spelled() {
             return leaf.name();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof SumCase that && leaf.equals(that.leaf);
+        }
+
+        @Override
+        public int hashCode() {
+            return leaf.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "SumCase[leaf=" + leaf + "]";
         }
     }
 
@@ -64,12 +114,39 @@ public sealed interface Refinement {
      * ({@link TermPath}). So the position under it is {@code x@Some} and never {@code x@Some.value}
      * — the second would be a location this compiler invented, spelled by nothing else that reads
      * the same value.
+     *
+     * <p>A class for the reason {@link SumCase} is, and compared the same way.
      */
-    record Presence(boolean present) implements Refinement {
+    final class Presence implements Refinement {
+
+        private final boolean present;
+
+        private Presence(boolean present) {
+            this.present = present;
+        }
+
+        public boolean present() {
+            return present;
+        }
 
         @Override
         public String spelled() {
             return present ? "Some" : "None";
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof Presence that && present == that.present;
+        }
+
+        @Override
+        public int hashCode() {
+            return Boolean.hashCode(present);
+        }
+
+        @Override
+        public String toString() {
+            return "Presence[present=" + present + "]";
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/StructuralInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/StructuralInspection.java
@@ -196,11 +196,12 @@ public sealed interface StructuralInspection {
             // what a case declares is under the case and not under the sum, which is why this is a
             // continuation rather than a decomposition, and why the sum keeps the classes it has.
             case Shape.Sum _ -> new Retained(new Continuation.Branches(branchesOf(shape, declared)));
-            // Still held inside something nothing here reaches into. A branch under one is exactly
-            // what would lift it — whether the optional holds anything is a narrowing like any
-            // other — and it is not taken here.
-            case Shape.Optional _ -> stopped(new BlockReason.UnsupportedTraversal(
-                    BlockReason.Traversal.OPTIONAL_VALUE));
+            // Whether an optional holds anything is a narrowing like any other, so it is branches
+            // like a sum's cases: `Some` leaves what the optional holds at this same position and
+            // the absence leaves nothing. Not a decomposition, and not a step inward — what an
+            // optional holds is at no name of its own, so the position under it is `x@Some`.
+            case Shape.Optional _ ->
+                    new Retained(new Continuation.Branches(branchesOf(shape, declared)));
             case Shape.Mapping _ -> stopped(new BlockReason.UnsupportedTraversal(
                     BlockReason.Traversal.MAPPING_CONTENT));
             // Nothing was interpreted, so there is nothing to be made of. A model carrying one

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
@@ -240,6 +240,21 @@ final class ConstructionPlan {
                         { return new Result.Conflict(against.at(), against.one(), against.other()); }
             }
         }
+        // A position said twice. A caller that fixed a value at a position and also requires a
+        // narrowing there has stated the narrowing and fixed a value at it, which ADR-0114 keeps
+        // apart -- the value stands at the narrowed position and is chosen there, so one location is
+        // never decided twice under two names. Nothing a model writes reaches this: the classes that
+        // narrow offer no value to fix, and the ones that offer a value narrow nothing. It is the
+        // arrangement an optional's classes had before they said which narrowing they were, and it
+        // is refused rather than answered by preferring one of the two.
+        for (TermPath fixed : decided) {
+            if (required.at(fixed) != null) {
+                throw new IllegalStateException("`" + fixed + "` is fixed at a value and required to"
+                        + " be " + required.at(fixed).spelled() + "; a narrowing states the"
+                        + " narrowing and does not also fix a value there, so this is the caller"
+                        + " keeping two accounts of one position");
+            }
+        }
         return new Result.Planned(
                 new ConstructionPlan(node(declared, at, symbols, 0, decided, required, least)));
     }
@@ -285,37 +300,28 @@ final class ConstructionPlan {
     private static Node node(Type declared, TermPath at, Symbols symbols, int depth,
                              Set<TermPath> decided, Requirements required,
                              java.util.function.ToIntBiFunction<TermPath, Type> least) {
-        // Before the narrowing, because a position the caller fixed takes the value it was given
-        // whatever a class would have built there.
-        if (decided.contains(at)) {
-            return new Slot(at, declared, List.of(), true);
+        // What the requirements leave standing here, worked out before anything is decided about
+        // the position. Read once and in full: what is built, whether the search chooses it, and
+        // where every path below it hangs all follow from it.
+        Settled settled = settle(declared, at, symbols, required);
+        if (settled.exact() != null) {
+            return new Exact(settled.at(), settled.exact(), settled.outer());
         }
-        Refinement refinement = required.at(at);
-        // The position as the narrowing leaves it, which is where every path below it hangs. A
-        // refinement is not a step into the value and takes no level of the plan; what it changes is
-        // the name of this one position and what may be built at it. Written without it, two cases
-        // spreading one record would put two different positions at one name.
-        TermPath here = refinement == null ? at : at.refine(refinement);
-        // The names the position wore before the narrowing, which are what a value chosen at it is
-        // still missing.
-        List<TypeOps.Layer> outer =
-                refinement == null ? List.of() : TypeView.of(declared, symbols).wrappers();
-        Type building = refined(declared, refinement, symbols);
-        // The absence of an optional settles the value rather than narrowing to something to be
-        // built: `None` is a branch that puts no position anywhere (ADR-0114), so the search has
-        // nothing to look at here. Under the names the position wore, since the value arrives bare.
-        if (building == null) {
-            return new Exact(here, FixtureTemplate.none(), outer);
+        // A position the caller fixed takes the value it was given whatever would have been built
+        // there. Asked at the position as the narrowings leave it, which is the name the caller
+        // wrote it under: a value fixed under a case is fixed at the case.
+        if (decided.contains(settled.at())) {
+            return new Slot(settled.at(), settled.building(), settled.outer(), true);
         }
+        TermPath here = settled.at();
+        Type building = settled.building();
         TypeView view = TypeView.of(building, symbols);
-        // And those with the narrowed type's own after them, which is what a value composed here
-        // bare needs. Both are what the position declares, kept: a value written under the narrowed
-        // type's names alone is of a type the parameter does not declare.
-        List<TypeOps.Layer> worn = refinement == null ? view.wrappers()
-                : outside(outer, view.wrappers());
-        if (refinement != null && decided.contains(here)) {
-            return new Slot(here, building, outer, true);
-        }
+        // The names the position wore before the narrowings, and those with the narrowed type's own
+        // after them — which is what a value composed here bare needs. Both are what the position
+        // declares, kept: a value written under the narrowed type's names alone is of a type the
+        // parameter does not declare.
+        List<TypeOps.Layer> worn = settled.outer().isEmpty() ? view.wrappers()
+                : outside(settled.outer(), view.wrappers());
         // A sequence with something to be placed inside it. Built out of its element rather than
         // chosen whole, since what is being asked for is a list holding a value in a class and no
         // proposal of a whole list can be asked to hold one.
@@ -332,12 +338,75 @@ final class ConstructionPlan {
         // A record with no fields composes nothing out of anything, so it is a value to be chosen
         // like any other and not a position made of positions.
         if (depth >= MAX_DEPTH || children == null || children.under().isEmpty()) {
-            return new Slot(here, building, outer, false);
+            return new Slot(here, building, settled.outer(), false);
         }
         Map<String, Node> under = new LinkedHashMap<>();
         children.under().forEach((field, type) -> under.put(field,
                 node(type, here.then(field), symbols, depth + 1, decided, required, least)));
         return new Built(here, building, children.of(), worn, under);
+    }
+
+    /**
+     * A position with every requirement standing at it applied.
+     *
+     * <p><b>Every one, because a narrowing takes no level.</b> A refinement does not move to another
+     * position (ADR-0114), so a second may stand at the position the first left — an optional
+     * holding a sum is narrowed to what it holds and then to the case that turned out to be there,
+     * and `query.tag@Some@Tag` is one position with two narrowings at it. Read one at a time, the
+     * plan built the sum and the case went missing, which is a value chosen from the wrong type
+     * however carefully the first narrowing was applied.
+     *
+     * @param at       the position as the narrowings leave it, which is the name every path below it
+     *                 hangs from and the name a caller that fixed a value here wrote it under
+     * @param building what is to be built there, or null where {@code exact} settled it instead
+     * @param exact    the value the narrowings settled, or null where they left something to build.
+     *                 Exactly one of the two is null: a narrowing either says which values may stand
+     *                 here or says which value does
+     * @param outer    the names the position wore before the narrowings, which are what a value
+     *                 arriving under the narrowed type is still missing
+     */
+    private record Settled(TermPath at, Type building, FixtureTemplate exact,
+                           List<TypeOps.Layer> outer) {
+
+        Settled {
+            if ((building == null) == (exact == null)) {
+                throw new IllegalArgumentException(
+                        "a settled position either has something to build or is a value: "
+                                + building + " / " + exact);
+            }
+            outer = List.copyOf(outer);
+        }
+    }
+
+    /**
+     * {@code declared} at {@code at}, with the requirements standing there applied in turn.
+     *
+     * <p>Stops where the requirements say nothing more, and where one of them settles the value —
+     * nothing narrows what is not there, so a requirement under an absence would be a caller asking
+     * about a position no value reaches, which {@link Requirements} has already refused by merging.
+     */
+    private static Settled settle(Type declared, TermPath at, Symbols symbols,
+                                  Requirements required) {
+        List<TypeOps.Layer> outer = List.of();
+        Type building = declared;
+        TermPath here = at;
+        for (Refinement refinement = required.at(here); refinement != null;
+                refinement = required.at(here)) {
+            // The names worn before the first narrowing, which is where a value chosen at the
+            // narrowed position is still missing them. Taken once: a narrowing of a narrowing wears
+            // nothing new, since it is the same position read again.
+            if (outer.isEmpty()) {
+                outer = TypeView.of(declared, symbols).wrappers();
+            }
+            here = here.refine(refinement);
+            if (refinement instanceof Refinement.Presence presence && !presence.present()) {
+                // The absence of an optional settles the value rather than narrowing to something to
+                // be built: `None` is a branch that puts no position anywhere.
+                return new Settled(here, null, FixtureTemplate.none(), outer);
+            }
+            building = narrowed(building, refinement, symbols);
+        }
+        return new Settled(here, building, null, outer);
     }
 
     /** {@code outer} and then {@code inner}, which is the order names are put back on a value. */
@@ -380,8 +449,7 @@ final class ConstructionPlan {
     }
 
     /**
-     * The type a value is built at: the declared one, unless a refinement narrowed the position, and
-     * null where the narrowing leaves nothing to build.
+     * The type a value is built at once {@code refinement} has narrowed the position.
      *
      * <p>A narrowing of what stands at the position and not a rereading of the declaration. The
      * position's declared type is still the sum, and the axis still says so — a class of it saying
@@ -389,20 +457,30 @@ final class ConstructionPlan {
      * would have a later reader believe the model declares something it does not. What moves is what
      * is being built.
      *
-     * <p>Null is the one narrowing that settles the value instead of narrowing the type, and it is
-     * read as that by {@link #node} and nowhere else. Answered with the declared type, the position
-     * would be built as the optional and the search would be free to put a value in it; answered
-     * with what the optional holds, it would be built as the value the narrowing says is not there.
+     * <p><b>Only the narrowings that leave something to build reach here.</b> The absence of an
+     * optional is not one of them and is answered by {@link #settle}, where the position is settled
+     * at a value instead. Answered here, it would have to come back as a type — the declared
+     * optional, or what the optional holds — and either is a position built as something the
+     * narrowing said is not there. So this returns a type and never null, and a narrowing that
+     * settles a value is a case {@link #settle} has to name rather than one this can express.
      */
-    private static Type refined(Type declared, Refinement refinement, Symbols symbols) {
+    private static Type narrowed(Type declared, Refinement refinement, Symbols symbols) {
         return switch (refinement) {
-            case null -> declared;
             case Refinement.SumCase one -> Type.ref(one.leaf());
             // What a `Some` leaves at the position is what the optional was declared to hold, which
             // is the same reading the branches under a position are made from
-            // (`StructuralInspection.carried`). And the absence leaves nothing.
-            case Refinement.Presence presence -> presence.present() ? held(declared, symbols) : null;
+            // (`StructuralInspection.carried`).
+            case Refinement.Presence presence -> presence.present() ? held(declared, symbols)
+                    : illegal(declared);
         };
+    }
+
+    /** The absence reaching the one place that cannot express it, which is this compiler
+     *  contradicting itself rather than anything a model can write. */
+    private static Type illegal(Type declared) {
+        throw new IllegalStateException("`" + Type.show(declared) + "` is asked for the type an"
+                + " absence narrows it to; an absence settles the value and narrows no type, so this"
+                + " is the plan reading a settled position as one still to be built");
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
@@ -381,32 +381,71 @@ final class ConstructionPlan {
     /**
      * {@code declared} at {@code at}, with the requirements standing there applied in turn.
      *
-     * <p>Stops where the requirements say nothing more, and where one of them settles the value —
-     * nothing narrows what is not there, so a requirement under an absence would be a caller asking
-     * about a position no value reaches, which {@link Requirements} has already refused by merging.
+     * <p>A fold and not a walk with a running total beside it. What one narrowing does is two
+     * things at once — it changes what stands at the position, and it takes a name off that a value
+     * chosen under the narrowed type is then missing — and they are one step. Kept as two locals
+     * updated on their own, the second stopped after the first narrowing while the first went on:
+     * a case that is a newtype over an optional narrowed to what the optional holds and the case's
+     * own name was never put back, so the row carried a value of a type the parameter does not
+     * declare. The state is a {@link Settled}, so a step cannot move one half and leave the other.
      */
     private static Settled settle(Type declared, TermPath at, Symbols symbols,
                                   Requirements required) {
-        List<TypeOps.Layer> outer = List.of();
-        Type building = declared;
-        TermPath here = at;
-        for (Refinement refinement = required.at(here); refinement != null;
-                refinement = required.at(here)) {
-            // The names worn before the first narrowing, which is where a value chosen at the
-            // narrowed position is still missing them. Taken once: a narrowing of a narrowing wears
-            // nothing new, since it is the same position read again.
-            if (outer.isEmpty()) {
-                outer = TypeView.of(declared, symbols).wrappers();
+        Settled settled = new Settled(at, declared, null, List.of());
+        for (Refinement refinement = required.at(settled.at()); refinement != null;
+                refinement = required.at(settled.at())) {
+            settled = applying(settled, refinement, symbols, required);
+            // Nothing narrows what is not there, so a narrowing that settled the value is the end
+            // of the chain whatever else was written.
+            if (settled.exact() != null) {
+                return settled;
             }
-            here = here.refine(refinement);
-            if (refinement instanceof Refinement.Presence presence && !presence.present()) {
-                // The absence of an optional settles the value rather than narrowing to something to
-                // be built: `None` is a branch that puts no position anywhere.
-                return new Settled(here, null, FixtureTemplate.none(), outer);
-            }
-            building = narrowed(building, refinement, symbols);
         }
-        return new Settled(here, building, null, outer);
+        return settled;
+    }
+
+    /**
+     * One narrowing applied to a settled position: what stands there afterwards, and the name it
+     * took off.
+     *
+     * <p>Both, here, because they are one step. What the position wears now is what a value chosen
+     * under the narrowed type will be missing, and it is read from what stands here rather than
+     * from the declaration — a narrowing may leave a position wearing a name the next one takes off
+     * in turn, and the declaration wore neither.
+     */
+    private static Settled applying(Settled settled, Refinement refinement, Symbols symbols,
+                                    Requirements required) {
+        List<TypeOps.Layer> outer = outside(settled.outer(),
+                TypeView.of(settled.building(), symbols).wrappers());
+        TermPath here = settled.at().refine(refinement);
+        if (refinement instanceof Refinement.Presence presence && !presence.present()) {
+            // The absence of an optional settles the value rather than narrowing to something to be
+            // built: `None` is a branch that puts no position anywhere (ADR-0114).
+            refuseWhatWouldStandUnder(here, required);
+            return new Settled(here, null, FixtureTemplate.none(), outer);
+        }
+        return new Settled(here, narrowed(settled.building(), refinement, symbols), null, outer);
+    }
+
+    /**
+     * That nothing is required below a position an absence settled.
+     *
+     * <p>A requirement under one names a position no value reaches, which is a caller asking about
+     * somewhere inside a value it has just said is not there. Refused here rather than left to
+     * {@link Requirements#merge}: that answers whether one position is asked to be two things, and
+     * {@code x} being absent and {@code x@None.y} being narrowed are two keys it has no quarrel
+     * with. Nothing a model writes reaches it — the absence puts no position anywhere, so nothing
+     * derives one to require — and a claim that somebody else refuses it is a guarantee this is not
+     * in a position to make.
+     */
+    private static void refuseWhatWouldStandUnder(TermPath absent, Requirements required) {
+        for (TermPath each : required.refinements().keySet()) {
+            if (!each.equals(absent) && each.isAtOrUnder(absent)) {
+                throw new IllegalStateException("`" + each + "` is required to be "
+                        + required.at(each).spelled() + " under `" + absent + "`, which holds no"
+                        + " value; nothing stands under an absence for a requirement to be about");
+            }
+        }
     }
 
     /** {@code outer} and then {@code inner}, which is the order names are put back on a value. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
@@ -305,6 +305,7 @@ final class ConstructionPlan {
         // where every path below it hangs all follow from it.
         Settled settled = settle(declared, at, symbols, required);
         if (settled.exact() != null) {
+            refuseWhatWouldStandUnder(settled.at(), decided, required);
             return new Exact(settled.at(), settled.exact(), settled.outer());
         }
         // A position the caller fixed takes the value it was given whatever would have been built
@@ -420,30 +421,48 @@ final class ConstructionPlan {
         TermPath here = settled.at().refine(refinement);
         if (refinement instanceof Refinement.Presence presence && !presence.present()) {
             // The absence of an optional settles the value rather than narrowing to something to be
-            // built: `None` is a branch that puts no position anywhere (ADR-0114).
-            refuseWhatWouldStandUnder(here, required);
+            // built: `None` is a branch that puts no position anywhere (ADR-0114). Whether anything
+            // was asked for under it is not this reading's question — what stands at a position and
+            // what a caller demanded of it are two, and only the caller's side knows both halves of
+            // the second.
             return new Settled(here, null, FixtureTemplate.none(), outer);
         }
         return new Settled(here, narrowed(settled.building(), refinement, symbols), null, outer);
     }
 
     /**
-     * That nothing is required below a position an absence settled.
+     * That nothing is asked for at or under a position an absence settled.
      *
-     * <p>A requirement under one names a position no value reaches, which is a caller asking about
-     * somewhere inside a value it has just said is not there. Refused here rather than left to
-     * {@link Requirements#merge}: that answers whether one position is asked to be two things, and
-     * {@code x} being absent and {@code x@None.y} being narrowed are two keys it has no quarrel
-     * with. Nothing a model writes reaches it — the absence puts no position anywhere, so nothing
-     * derives one to require — and a claim that somebody else refuses it is a guarantee this is not
-     * in a position to make.
+     * <p>Asked of the whole demand and not of half of it. What a caller asks for is the paths it
+     * fixed a value at and the requirements it stated, put together where the plan is made — so a
+     * check that read only the requirements would pass a value fixed at {@code x@None.foo}, which a
+     * field step adds no requirement for, and drop it in silence.
+     *
+     * <p>And at the position as well as under it. A refinement does not move to another position,
+     * so a second narrowing of one an absence settled is written at that same path: leaving it out
+     * as "not below" reads a rule about steps into a value as one about narrowings, which take
+     * none. That is what {@link Result.Conflict} is about at a position two narrowings disagree
+     * over, and this is the other half of it — the narrowings agree, and there is nothing there for
+     * the second to be about.
+     *
+     * <p>Nothing a model writes reaches either. The absence puts no position anywhere, so nothing
+     * derives one to require or to fix. It is refused so that {@link Exact} means what it says: the
+     * value is settled here, and there is nothing left below for anything to have asked of.
      */
-    private static void refuseWhatWouldStandUnder(TermPath absent, Requirements required) {
+    private static void refuseWhatWouldStandUnder(TermPath absent, Set<TermPath> decided,
+                                                  Requirements required) {
         for (TermPath each : required.refinements().keySet()) {
-            if (!each.equals(absent) && each.isAtOrUnder(absent)) {
+            if (each.isAtOrUnder(absent)) {
                 throw new IllegalStateException("`" + each + "` is required to be "
-                        + required.at(each).spelled() + " under `" + absent + "`, which holds no"
-                        + " value; nothing stands under an absence for a requirement to be about");
+                        + required.at(each).spelled() + " at or under `" + absent + "`, which holds"
+                        + " no value; nothing stands there for a requirement to be about");
+            }
+        }
+        for (TermPath each : decided) {
+            if (each.isAtOrUnder(absent)) {
+                throw new IllegalStateException("a value is fixed at `" + each + "`, at or under `"
+                        + absent + "`, which holds no value; nothing stands there for a value to be"
+                        + " written at");
             }
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
@@ -67,15 +67,21 @@ final class ConstructionPlan {
      *  a record four levels down still has to be constructed. */
     private static final int MAX_DEPTH = 8;
 
-    /** One position of the value being built. */
-    sealed interface Node permits Slot, Built, Held {
+    /**
+     * One position of the value being built.
+     *
+     * <p><b>Where it is, and no more.</b> What is built at a position is a question three of these
+     * answer and the fourth does not have: a requirement that settles the value itself leaves
+     * nothing to build there, and a type answered for it would be a type nothing is built at. Asked
+     * of all four, the one that has no answer has to invent one — the declared type, or the absence
+     * dressed as a type — which is the shortfall this vocabulary exists to state going back in under
+     * another name. So {@code type()} is each builder's own, and every reader of one already knows
+     * which it is holding.
+     */
+    sealed interface Node permits Slot, Built, Held, Exact {
 
         /** Where it is. */
         TermPath at();
-
-        /** What is built there — the declared type, unless a requirement narrowed the position, or
-         *  the caller settled it before this was worked out. */
-        Type type();
 
         /**
          * The newtype names still to put on what this node produces, outermost first.
@@ -162,6 +168,34 @@ final class ConstructionPlan {
     }
 
     /**
+     * A position the requirement itself settles the value of.
+     *
+     * <p>The absence of an optional is the one of these there is. {@code None} is not a narrowed
+     * type with something to be chosen inside it — it is a branch that "puts no position anywhere"
+     * (ADR-0114) — so there is nothing here for the search to look at and nothing for it to be
+     * refused at.
+     *
+     * <p><b>Beside the value being fixed by the caller and not the same thing.</b> A caller that
+     * fixed a value has one to hand over; here nobody handed anything over and the requirement
+     * decides, so writing it as a fixed {@link Slot} would mean putting the value into the caller's
+     * table as well — a class stating a narrowing and fixing a value at the same position, which is
+     * the two accounts ADR-0114 keeps apart.
+     *
+     * @param exact the value, which is what the requirement came to
+     * @param worn  {@link Node#worn}: every name the position wears, since the value arrives bare.
+     *              A {@code data MaybeTagN = Tag?} carries {@code MaybeTagN(None)}
+     */
+    record Exact(TermPath at, FixtureTemplate exact, List<TypeOps.Layer> worn) implements Node {
+
+        Exact {
+            if (exact == null) {
+                throw new IllegalArgumentException("a position settled at no value is not settled");
+            }
+            worn = List.copyOf(worn);
+        }
+    }
+
+    /**
      * A plan, or the position that would have to be two things for there to be one.
      *
      * <p>Two answers because both are ordinary. A caller asking for a class under one case of a sum
@@ -219,7 +253,9 @@ final class ConstructionPlan {
 
     private static void collectHeld(Node node, List<Held> out) {
         switch (node) {
-            case Slot _ -> { }
+            // Nothing is built under either: one holds a value the search chooses and the other a
+            // value the requirement settled, and a collection is neither.
+            case Slot _, Exact _ -> { }
             case Built built -> built.under().values().forEach(each -> collectHeld(each, out));
             case Held held -> {
                 out.add(held);
@@ -240,6 +276,9 @@ final class ConstructionPlan {
             case Slot slot -> out.add(slot);
             case Built built -> built.under().values().forEach(each -> collect(each, out));
             case Held held -> collect(held.under(), out);
+            // Not a position a value is chosen at: the requirement settled it, so there is nothing
+            // here for the search to offer and nothing for it to be refused at.
+            case Exact _ -> { }
         }
     }
 
@@ -252,19 +291,26 @@ final class ConstructionPlan {
             return new Slot(at, declared, List.of(), true);
         }
         Refinement refinement = required.at(at);
-        Type building = refined(declared, refinement, symbols);
-        TypeView view = TypeView.of(building, symbols);
         // The position as the narrowing leaves it, which is where every path below it hangs. A
         // refinement is not a step into the value and takes no level of the plan; what it changes is
         // the name of this one position and what may be built at it. Written without it, two cases
         // spreading one record would put two different positions at one name.
         TermPath here = refinement == null ? at : at.refine(refinement);
         // The names the position wore before the narrowing, which are what a value chosen at it is
-        // still missing; and those with the narrowed type's own after them, which is what a value
-        // composed here bare needs. Both are what the position declares, kept: a value written
-        // under the narrowed type's names alone is of a type the parameter does not declare.
+        // still missing.
         List<TypeOps.Layer> outer =
                 refinement == null ? List.of() : TypeView.of(declared, symbols).wrappers();
+        Type building = refined(declared, refinement, symbols);
+        // The absence of an optional settles the value rather than narrowing to something to be
+        // built: `None` is a branch that puts no position anywhere (ADR-0114), so the search has
+        // nothing to look at here. Under the names the position wore, since the value arrives bare.
+        if (building == null) {
+            return new Exact(here, FixtureTemplate.none(), outer);
+        }
+        TypeView view = TypeView.of(building, symbols);
+        // And those with the narrowed type's own after them, which is what a value composed here
+        // bare needs. Both are what the position declares, kept: a value written under the narrowed
+        // type's names alone is of a type the parameter does not declare.
         List<TypeOps.Layer> worn = refinement == null ? view.wrappers()
                 : outside(outer, view.wrappers());
         if (refinement != null && decided.contains(here)) {
@@ -325,31 +371,55 @@ final class ConstructionPlan {
             case Built built -> built.under().values().stream()
                     .anyMatch(ConstructionPlan::holdsAFixedPosition);
             case Held held -> holdsAFixedPosition(held.under());
+            // A value the requirement settled is as much something asked of the position as one the
+            // caller fixed: a list asked to hold a `None` is a list built around it. Reached where
+            // the path above it does not narrow, which is a requirement stated at this position
+            // rather than at one the path passed through.
+            case Exact _ -> true;
         };
     }
 
     /**
-     * The type a value is built at: the declared one, unless a refinement narrowed the position.
+     * The type a value is built at: the declared one, unless a refinement narrowed the position, and
+     * null where the narrowing leaves nothing to build.
      *
      * <p>A narrowing of what stands at the position and not a rereading of the declaration. The
      * position's declared type is still the sum, and the axis still says so — a class of it saying
      * which case a witness takes is not the position becoming that case, and reading the two as one
      * would have a later reader believe the model declares something it does not. What moves is what
      * is being built.
+     *
+     * <p>Null is the one narrowing that settles the value instead of narrowing the type, and it is
+     * read as that by {@link #node} and nowhere else. Answered with the declared type, the position
+     * would be built as the optional and the search would be free to put a value in it; answered
+     * with what the optional holds, it would be built as the value the narrowing says is not there.
      */
     private static Type refined(Type declared, Refinement refinement, Symbols symbols) {
         return switch (refinement) {
             case null -> declared;
             case Refinement.SumCase one -> Type.ref(one.leaf());
-            // Nothing builds through one yet. An optional's classes are values a row writes —
-            // a value of what it holds, or nothing — and neither is composed field by field, so
-            // no requirement of this kind reaches a plan. The day one does, what is built here is
-            // what it holds, and that is a decision to make with the row that asks for it rather
-            // than one to leave standing as a guess.
-            case Refinement.Presence _ -> throw new IllegalStateException(
-                    "a value is asked to be built through the presence of an optional at `" + declared
-                            + "`; nothing states such a requirement, so this is the generator and"
-                            + " the classes disagreeing about what a class asks for");
+            // What a `Some` leaves at the position is what the optional was declared to hold, which
+            // is the same reading the branches under a position are made from
+            // (`StructuralInspection.carried`). And the absence leaves nothing.
+            case Refinement.Presence presence -> presence.present() ? held(declared, symbols) : null;
         };
+    }
+
+    /**
+     * What the optional at this position holds.
+     *
+     * <p>Asked of the shape rather than of the written type, since the position may wear names: a
+     * {@code data MaybeTagN = Tag?} is an optional and holds a {@code Tag}.
+     */
+    private static Type held(Type declared, Symbols symbols) {
+        if (TypeView.of(declared, symbols).shape()
+                instanceof souther.compiler.check.Shape.Optional optional) {
+            return optional.element();
+        }
+        // The requirement and the declaration disagreeing about the position's shape, which is this
+        // compiler contradicting itself rather than anything a model can write.
+        throw new IllegalStateException("`" + Type.show(declared) + "` is asked for what it holds,"
+                + " and it is not an optional; the reading of a position and the plan built from it"
+                + " disagree about its shape");
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
@@ -37,8 +37,27 @@ import java.util.Set;
  * where the walk that collected the choices and this one disagree". Holding the positions and the
  * shape they compose back into as one value is what makes that disagreement unsayable rather than
  * something a test has to go looking for.
+ *
+ * <p><b>Made only by {@link #of}, which is where the requirements are put together.</b> A path the
+ * caller fixed a value at states what has to hold for that position to exist, and a caller that also
+ * hands over requirements of its own is handing over the second half of one fact rather than a
+ * second fact (ADR-0114: coverage and construction use one merge, and neither keeps an account of
+ * its own). A constructor a caller could reach is that merge being optional, and one caller took the
+ * option: a line at {@code query.tag@Tag} was planned against no requirement at all, and the row
+ * offered for it put a {@code NoTag} there.
  */
-record ConstructionPlan(Node root) {
+final class ConstructionPlan {
+
+    private final Node root;
+
+    private ConstructionPlan(Node root) {
+        this.root = root;
+    }
+
+    /** The position the parameter's own value is built at. */
+    Node root() {
+        return root;
+    }
 
     /** How deep a record is built. Past this a value stops being anything an author recognises as
      *  one input, and a type that refers to itself would not stop at all.
@@ -143,17 +162,52 @@ record ConstructionPlan(Node root) {
     }
 
     /**
-     * The plan for one parameter.
+     * A plan, or the position that would have to be two things for there to be one.
      *
-     * @param decided the paths the caller has already fixed a value at, which are positions this
-     *                search does not choose at and does not look under. Not a depth and not a fact
-     *                about the type: the caller has what goes there, so what the field of a record
-     *                three levels inside it would have offered is nothing this row asks
+     * <p>Two answers because both are ordinary. A caller asking for a class under one case of a sum
+     * beside a class under another has asked for a row no value is, which the model settles and this
+     * reports; nothing here fell short.
      */
-    static ConstructionPlan of(Type declared, TermPath at, Symbols symbols, Set<TermPath> decided,
-                               Requirements required,
-                               java.util.function.ToIntBiFunction<TermPath, Type> least) {
-        return new ConstructionPlan(node(declared, at, symbols, 0, decided, required, least));
+    sealed interface Result {
+
+        /** The plan, which is what a caller that got one goes on with. */
+        record Planned(ConstructionPlan plan) implements Result {}
+
+        /** No value is at both, and this is the position and the two it would have to be. */
+        record Conflict(TermPath at, Refinement one, Refinement other) implements Result {}
+    }
+
+    /**
+     * The plan for one parameter, against everything that has to hold of it.
+     *
+     * <p><b>The requirements are put together here and nowhere else.</b> A path states what has to
+     * hold for the position it names to exist ({@link TermPath#requirements}), and a caller may have
+     * requirements besides that — a class selects a refinement at its own position, which no path
+     * says. Both are read here, so a caller cannot hand over a fixed path under a case and no
+     * requirement that the case was taken: the two would be one location decided twice, and the
+     * plan would build the position as the sum rather than as the case.
+     *
+     * @param decided    the paths the caller has already fixed a value at, which are positions this
+     *                   search does not choose at and does not look under. Not a depth and not a
+     *                   fact about the type: the caller has what goes there, so what the field of a
+     *                   record three levels inside it would have offered is nothing this row asks
+     * @param additional what has to hold besides whatever {@code decided} already states. Named for
+     *                   that, because a caller handing over the whole of it is the arrangement this
+     *                   exists to stop
+     */
+    static Result of(Type declared, TermPath at, Symbols symbols, Set<TermPath> decided,
+                     Requirements additional,
+                     java.util.function.ToIntBiFunction<TermPath, Type> least) {
+        Requirements required = additional;
+        for (TermPath fixed : decided) {
+            switch (required.merge(fixed.requirements())) {
+                case Requirements.Merge.Merged both -> required = both.requirements();
+                case Requirements.Merge.Conflict against ->
+                        { return new Result.Conflict(against.at(), against.one(), against.other()); }
+            }
+        }
+        return new Result.Planned(
+                new ConstructionPlan(node(declared, at, symbols, 0, decided, required, least)));
     }
 
     /** The collections this plan builds out of what stands at their element. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -3039,11 +3039,18 @@ public final class Generator {
         return out;
     }
 
-    /** One parameter's value, with the positions the caller fixed already decided. */
+    /**
+     * One parameter's value, with the positions the caller fixed already decided.
+     *
+     * <p>{@code additional} is what has to hold besides whatever the fixed paths already state.
+     * What a path under a refinement requires is read from the path, where it is written, and the
+     * plan puts the two together — so a caller with nothing of its own to add hands over nothing
+     * and loses none of it.
+     */
     private static Outcome valueAt(Subject subject, int p,
                                    Map<TermPath, List<FixtureTemplate>> decided,
                                    Map<TermPath, Place> settled,
-                                   Requirements required, CandidateCheck check) {
+                                   Requirements additional, CandidateCheck check) {
         // Where a value has to be built under this parameter, worked out once. What each position
         // may take, the search that chooses them one at a time, and the composing of what was chosen
         // all read this, so there is no second reading of the declarations for one of them to
@@ -3055,9 +3062,18 @@ public final class Generator {
         // how many the list holds is not a row.
         FieldDomains under = rulesOf(subject.types().get(p), subject.symbols(),
                 subject.inputs().policy(), under(root, settled));
-        ConstructionPlan plan = ConstructionPlan.of(subject.types().get(p), root, subject.symbols(),
-                decided.keySet(), required, (at, building) -> leastHeld(under, at, building,
-                        subject.symbols()));
+        ConstructionPlan.Result planned = ConstructionPlan.of(subject.types().get(p), root,
+                subject.symbols(), decided.keySet(), additional,
+                (at, building) -> leastHeld(under, at, building, subject.symbols()));
+        // A row that would have to be two things at one position, which is what the model settles
+        // and not something this fell short of — the same answer the class search gives when two
+        // classes select different refinements of one position.
+        if (planned instanceof ConstructionPlan.Result.Conflict against) {
+            return new Outcome(null, UnresolvedCombination.Reason.ONE_POSITION_CANNOT_BE_BOTH,
+                    "`" + against.at() + "` would have to be both " + against.one().spelled()
+                            + " and " + against.other().spelled());
+        }
+        ConstructionPlan plan = ((ConstructionPlan.Result.Planned) planned).plan();
         Choices choices = choicesOf(subject, p, plan, decided, settled);
         if (choices.missingAt() != null) {
             return new Outcome(null, UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -2324,6 +2324,10 @@ public final class Generator {
             heldBack.put(at, edge.refused());
         }
         List<FixtureTemplate> inputs = new ArrayList<>();
+        // Whether a candidate was turned away for standing somewhere else, which is what tells a
+        // search that ran out of candidates from one that certified none of the ones it had.
+        boolean[] uncertified = {false};
+        CandidateCheck certified = certifying(check, subject, fixing, on, uncertified);
         for (int p = 0; p < subject.parameters().size() && p < subject.types().size(); p++) {
             String head = subject.parameters().get(p);
             Map<TermPath, List<FixtureTemplate>> here = new LinkedHashMap<>();
@@ -2332,7 +2336,7 @@ public final class Generator {
                     here.put(term.path(), decided.get(term.path()));
                 }
             }
-            Outcome tried = valueAt(subject, p, here, settled, Requirements.NONE, check);
+            Outcome tried = valueAt(subject, p, here, settled, Requirements.NONE, certified);
             if (tried.value() == null) {
                 // Where the refusal is of the values one edge offered, what that edge held back
                 // outranks it: values that were never built were not among the ones refused. Only
@@ -2341,6 +2345,13 @@ public final class Generator {
                 // something this knows. Taken from whichever came first, the reason named the wrong
                 // position's search.
                 UnresolvedCombination.Reason why = tried.reason();
+                // A search that offered candidates and certified none of them has not shown that
+                // every value the rules allow was refused: what it found out is that what it built
+                // did not stand where it was built for, which is its own answer.
+                if (uncertified[0]
+                        && why == UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED) {
+                    why = UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS;
+                }
                 if (here.size() == 1
                         && why == UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED) {
                     why = heldBack.getOrDefault(here.keySet().iterator().next(), why);
@@ -2352,6 +2363,108 @@ public final class Generator {
         }
         return new BoundaryAttempt.Built(
                 new GeneratedRow(new Purpose.ForAPoint(label), inputs));
+    }
+
+    /**
+     * {@code check}, refusing any candidate at this parameter that does not read back at the place
+     * it is being built for.
+     *
+     * <p><b>An acceptance condition and not an assertion.</b> A candidate that reads back somewhere
+     * else is one candidate the search has tried, and the search goes on to the next — the same
+     * shape a class's witness is certified with. Written as a throw, or as a refusal of the whole
+     * point, one candidate landing elsewhere would be reported as a point no row can be written at.
+     *
+     * <p>What it asks is the property {@code TermRealizations} states of itself: every value built
+     * there reads back as the number it was built for, and the way that would break is "a row
+     * offered at an edge it does not stand on". Asked through the reading a row's own values are
+     * read by, so nothing here is a second account of where a value stands.
+     *
+     * @param refused set where a candidate was turned away for this and nothing else, which is what
+     *                tells a search that ran out of candidates from one that certified none
+     */
+    private static CandidateCheck certifying(CandidateCheck check, Subject subject,
+                                             Map<NumericTerm, Place> fixing,
+                                             java.util.function.Function<NumericTerm, Carrier> on,
+                                             boolean[] refused) {
+        return (parameter, candidate) -> {
+            CandidateCheck.Built built = check.build(parameter, candidate);
+            // Nothing built it, so nothing here can say where it went, and the row is offered as it
+            // was composed.
+            if (!(built instanceof CandidateCheck.Built.Value(var observed))) {
+                return built;
+            }
+            List<souther.compiler.observe.ObservedValue> row = new ArrayList<>(
+                    java.util.Collections.nCopies(subject.parameters().size(), null));
+            row.set(parameter, observed);
+            for (Map.Entry<NumericTerm, Place> each : fixing.entrySet()) {
+                if (!subject.parameters().get(parameter).equals(each.getKey().path().head())) {
+                    continue;
+                }
+                String elsewhere = readsElsewhere(subject, row, each.getKey(), each.getValue(),
+                        on.apply(each.getKey()));
+                if (elsewhere != null) {
+                    refused[0] = true;
+                    return new CandidateCheck.Built.Refused(elsewhere);
+                }
+            }
+            return built;
+        };
+    }
+
+    /**
+     * Where the row reads at the term's position, said only where that is not {@code at}.
+     *
+     * <p>Null where nothing here can say. A term this cannot read the orders of, a position the row
+     * wrote no value at, a walk the value and the type disagree about — none of them is the row
+     * standing somewhere else, and refusing a candidate for one would turn what this compiler cannot
+     * see into a row the model does not have.
+     *
+     * <p>One occurrence is enough, as it is for a row that was written: a row stands at a point
+     * where one of its readings does.
+     */
+    private static String readsElsewhere(Subject subject,
+                                         List<souther.compiler.observe.ObservedValue> row,
+                                         NumericTerm term, Place at, Carrier answered) {
+        souther.compiler.inputs.TermOrders orders = ordersOf(subject, term, answered);
+        if (orders == null) {
+            return null;
+        }
+        List<souther.compiler.observe.ObservedValue> values =
+                subject.inputs().valuesAt(row, term.path());
+        if (values == null || values.isEmpty()) {
+            return null;
+        }
+        for (souther.compiler.observe.ObservedValue value : values) {
+            if (term.read(value, orders) instanceof NumericTerm.Reading.Number number
+                    && number.value().compareTo(at) == 0) {
+                return null;
+            }
+        }
+        return "it was composed to put " + term + " at " + at + " and does not stand there";
+    }
+
+    /**
+     * How the term at this position is read: the order its values are written on, and the order the
+     * number it answers is measured on.
+     *
+     * <p>Off the axis where the subject has one, and off the declared type where it has none, which
+     * is the same pair {@link #edgeAt} builds the value against. Null where neither answers, since a
+     * term nothing here reads is one nothing here can say the value stands away from.
+     */
+    private static souther.compiler.inputs.TermOrders ordersOf(Subject subject, NumericTerm term,
+                                                               Carrier answered) {
+        if (answered == null) {
+            return null;
+        }
+        for (Axis axis : subject.axes()) {
+            if (axis.term().equals(term)) {
+                return new souther.compiler.inputs.TermOrders(
+                        term.observedOn(axis.type(), subject.symbols()), answered);
+            }
+        }
+        Type declared = declaredAt(subject, term.path());
+        return declared == null ? null : new souther.compiler.inputs.TermOrders(
+                term.observedOn(declared, subject.symbols()), answered);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -3680,6 +3680,9 @@ public final class Generator {
             case ConstructionPlan.Slot slot -> worn(slot.worn(), chosen.get(slot.at()), symbols);
             case ConstructionPlan.Built built -> composed(built, chosen, symbols, policy);
             case ConstructionPlan.Held held -> held(held, chosen, symbols, policy);
+            // The requirement settled this one, so nothing was chosen for it and there is nothing to
+            // look up. Under every name the position wears, since the value arrives bare.
+            case ConstructionPlan.Exact exact -> worn(exact.worn(), exact.exact(), symbols);
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -2294,6 +2294,9 @@ public final class Generator {
         // came back as one every value tried was refused at.
         Map<TermPath, Place> settled = new LinkedHashMap<>();
         Map<TermPath, UnresolvedCombination.Reason> heldBack = new LinkedHashMap<>();
+        // Per term, because a fixing names one order pair per position and a row is certified
+        // against the one its own value was built on.
+        Map<NumericTerm, souther.compiler.inputs.TermOrders> builtOn = new LinkedHashMap<>();
         for (Map.Entry<NumericTerm, Place> each : fixing.entrySet()) {
             // The order this position is written back on, which is the position's own. Handed one
             // order for the whole fixing, a form over positions written back differently wrote each
@@ -2318,18 +2321,24 @@ public final class Generator {
                         UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE));
             }
             decided.put(at, edge.values());
+            // The orders the value was built against, kept so that reading it back asks the
+            // question building it asked rather than a second reading of the same position.
+            builtOn.put(each.getKey(), edge.on());
             if (edge.settledAt() != null) {
                 settled.put(at, edge.settledAt());
             }
             heldBack.put(at, edge.refused());
         }
         List<FixtureTemplate> inputs = new ArrayList<>();
-        // Whether a candidate was turned away for standing somewhere else, which is what tells a
-        // search that ran out of candidates from one that certified none of the ones it had.
-        boolean[] uncertified = {false};
-        CandidateCheck certified = certifying(check, subject, fixing, on, uncertified);
         for (int p = 0; p < subject.parameters().size() && p < subject.types().size(); p++) {
             String head = subject.parameters().get(p);
+            // Whether a candidate was turned away for standing somewhere else, which is what tells
+            // a search that ran out of candidates from one that certified none of the ones it had.
+            // Per parameter, since it is this parameter's search the answer is about: shared, a
+            // candidate turned away under one parameter would name the reason another failed for.
+            boolean[] uncertified = {false};
+            CandidateCheck certified =
+                    certifying(check, subject, p, fixing, builtOn, uncertified);
             Map<TermPath, List<FixtureTemplate>> here = new LinkedHashMap<>();
             for (NumericTerm term : fixing.keySet()) {
                 if (term.path().head().equals(head)) {
@@ -2382,26 +2391,23 @@ public final class Generator {
      * @param refused set where a candidate was turned away for this and nothing else, which is what
      *                tells a search that ran out of candidates from one that certified none
      */
-    private static CandidateCheck certifying(CandidateCheck check, Subject subject,
+    private static CandidateCheck certifying(CandidateCheck check, Subject subject, int parameter,
                                              Map<NumericTerm, Place> fixing,
-                                             java.util.function.Function<NumericTerm, Carrier> on,
+                                             Map<NumericTerm, souther.compiler.inputs.TermOrders> builtOn,
                                              boolean[] refused) {
-        return (parameter, candidate) -> {
-            CandidateCheck.Built built = check.build(parameter, candidate);
+        return (at, candidate) -> {
+            CandidateCheck.Built built = check.build(at, candidate);
             // Nothing built it, so nothing here can say where it went, and the row is offered as it
             // was composed.
-            if (!(built instanceof CandidateCheck.Built.Value(var observed))) {
+            if (at != parameter || !(built instanceof CandidateCheck.Built.Value(var observed))) {
                 return built;
             }
-            List<souther.compiler.observe.ObservedValue> row = new ArrayList<>(
-                    java.util.Collections.nCopies(subject.parameters().size(), null));
-            row.set(parameter, observed);
             for (Map.Entry<NumericTerm, Place> each : fixing.entrySet()) {
                 if (!subject.parameters().get(parameter).equals(each.getKey().path().head())) {
                     continue;
                 }
-                String elsewhere = readsElsewhere(subject, row, each.getKey(), each.getValue(),
-                        on.apply(each.getKey()));
+                String elsewhere = readsElsewhere(subject, parameter, observed, each.getKey(),
+                        each.getValue(), builtOn.get(each.getKey()));
                 if (elsewhere != null) {
                     refused[0] = true;
                     return new CandidateCheck.Built.Refused(elsewhere);
@@ -2414,57 +2420,41 @@ public final class Generator {
     /**
      * Where the row reads at the term's position, said only where that is not {@code at}.
      *
-     * <p>Null where nothing here can say. A term this cannot read the orders of, a position the row
+     * <p>Null where nothing here can say. A fixing whose edge kept no orders, a position the row
      * wrote no value at, a walk the value and the type disagree about — none of them is the row
-     * standing somewhere else, and refusing a candidate for one would turn what this compiler cannot
-     * see into a row the model does not have.
+     * standing somewhere else, and refusing a candidate for one would turn what this compiler
+     * cannot see into a row the model does not have.
      *
      * <p>One occurrence is enough, as it is for a row that was written: a row stands at a point
      * where one of its readings does.
+     *
+     * @param on the orders the value was built against, carried from the edge that built it. Read
+     *           back on anything else, this would be a second reading of the position free to
+     *           disagree with the one the value came from
      */
-    private static String readsElsewhere(Subject subject,
-                                         List<souther.compiler.observe.ObservedValue> row,
-                                         NumericTerm term, Place at, Carrier answered) {
-        souther.compiler.inputs.TermOrders orders = ordersOf(subject, term, answered);
-        if (orders == null) {
+    private static String readsElsewhere(Subject subject, int parameter,
+                                         souther.compiler.observe.ObservedValue observed,
+                                         NumericTerm term, Place at, souther.compiler.inputs.TermOrders on) {
+        if (on == null) {
             return null;
         }
+        // Only this parameter's value is filled in: the walk reads the one the path names, and the
+        // others are not this candidate's to say anything about.
+        List<souther.compiler.observe.ObservedValue> row = new ArrayList<>(
+                java.util.Collections.nCopies(subject.parameters().size(), null));
+        row.set(parameter, observed);
         List<souther.compiler.observe.ObservedValue> values =
                 subject.inputs().valuesAt(row, term.path());
         if (values == null || values.isEmpty()) {
             return null;
         }
         for (souther.compiler.observe.ObservedValue value : values) {
-            if (term.read(value, orders) instanceof NumericTerm.Reading.Number number
+            if (term.read(value, on) instanceof NumericTerm.Reading.Number number
                     && number.value().compareTo(at) == 0) {
                 return null;
             }
         }
         return "it was composed to put " + term + " at " + at + " and does not stand there";
-    }
-
-    /**
-     * How the term at this position is read: the order its values are written on, and the order the
-     * number it answers is measured on.
-     *
-     * <p>Off the axis where the subject has one, and off the declared type where it has none, which
-     * is the same pair {@link #edgeAt} builds the value against. Null where neither answers, since a
-     * term nothing here reads is one nothing here can say the value stands away from.
-     */
-    private static souther.compiler.inputs.TermOrders ordersOf(Subject subject, NumericTerm term,
-                                                               Carrier answered) {
-        if (answered == null) {
-            return null;
-        }
-        for (Axis axis : subject.axes()) {
-            if (axis.term().equals(term)) {
-                return new souther.compiler.inputs.TermOrders(
-                        term.observedOn(axis.type(), subject.symbols()), answered);
-            }
-        }
-        Type declared = declaredAt(subject, term.path());
-        return declared == null ? null : new souther.compiler.inputs.TermOrders(
-                term.observedOn(declared, subject.symbols()), answered);
     }
 
     /**
@@ -2508,10 +2498,10 @@ public final class Generator {
         if (declared == null) {
             return Edge.none(UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         }
-        return edgeFrom(TermRealizations.at(term, declared,
-                new souther.compiler.inputs.TermOrders(
-                        term.observedOn(declared, subject.symbols()), carrier),
-                at, subject.symbols(), subject.inputs().policy()), term, at);
+        souther.compiler.inputs.TermOrders on = new souther.compiler.inputs.TermOrders(
+                term.observedOn(declared, subject.symbols()), carrier);
+        return edgeFrom(TermRealizations.at(term, declared, on, at, subject.symbols(),
+                subject.inputs().policy()), term, at, on);
     }
 
     /** The type declared at a position this subject has no axis for, which is a bare parameter and
@@ -3902,16 +3892,23 @@ public final class Generator {
      * location at it, and what the rest of the record may hold is read from the rules relating them;
      * a line on a count taken of a location settles no number inside it, and saying it did would tell
      * the rest of the row that a string's length is the number the string holds.
+     *
+     * @param on the pair of orders the values here were built against: the one a value at the
+     *           position is written on, and the one the number it answers is measured on. Carried
+     *           rather than worked out again by whoever wants it — reading a value back is asking
+     *           the same question building it asked, and a second answer to it is two readings of
+     *           one position free to disagree about which order the number is on
      */
     private record Edge(List<FixtureTemplate> values, UnresolvedCombination.Reason reason,
-                        Place settledAt, UnresolvedCombination.Reason heldBack) {
+                        Place settledAt, UnresolvedCombination.Reason heldBack,
+                        souther.compiler.inputs.TermOrders on) {
 
         Edge {
             values = List.copyOf(values);
         }
 
         static Edge none(UnresolvedCombination.Reason why) {
-            return new Edge(List.of(), why, null, null);
+            return new Edge(List.of(), why, null, null, null);
         }
 
         /**
@@ -3939,12 +3936,10 @@ public final class Generator {
         // The order the line was drawn on is the caller's — a cut carries the one the rule was read
         // on — and the order the value at the position is written on is the position's. Both, so
         // neither stands in for the other.
-        return edgeFrom(
-                TermRealizations.at(axis.term(), axis.type(),
-                        new souther.compiler.inputs.TermOrders(
-                                axis.term().observedOn(axis.type(), symbols), carrier),
-                        at, symbols, policy),
-                axis.term(), at);
+        souther.compiler.inputs.TermOrders on = new souther.compiler.inputs.TermOrders(
+                axis.term().observedOn(axis.type(), symbols), carrier);
+        return edgeFrom(TermRealizations.at(axis.term(), axis.type(), on, at, symbols, policy),
+                axis.term(), at, on);
     }
 
     /**
@@ -3956,7 +3951,8 @@ public final class Generator {
      * the search records as settled is the one and not the other. The one question here the variant
      * genuinely settles, and asked of the variant.
      */
-    private static Edge edgeFrom(TermRealizations.Realization made, NumericTerm term, Place at) {
+    private static Edge edgeFrom(TermRealizations.Realization made, NumericTerm term, Place at,
+                                 souther.compiler.inputs.TermOrders on) {
         Place settled = switch (term) {
             case NumericTerm.ValueOf _ -> at;
             case NumericTerm.TakenOf _ -> null;
@@ -3964,7 +3960,7 @@ public final class Generator {
         return switch (made) {
             case TermRealizations.Realization.BuiltNone none -> Edge.none(none.why());
             case TermRealizations.Realization.Built built ->
-                    new Edge(built.values(), null, settled, built.heldBack());
+                    new Edge(built.values(), null, settled, built.heldBack(), on);
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
@@ -110,20 +110,29 @@ final class PartitionClasses {
     }
 
     /**
-     * The class one distinction gets.
+     * The class one distinction gets, and the narrowing a row in it meets.
      *
      * <p>Exhaustive over {@link Case}, with no {@code default}: a distinction the reading learns to
      * make later stops this compiling rather than arriving as a class nothing can name.
+     *
+     * <p><b>Which narrowing it is is asked once, here, of the one reading that relates the two
+     * vocabularies.</b> What a position divides into and what a position under it stands beneath are
+     * the same statement read twice, and each arm below deciding for itself is how they came apart:
+     * the arm for a sum's case spelled the narrowing again and the arm for an optional spelled none,
+     * so an optional's classes narrowed nothing — a row could be asked to be `None` here and to hold
+     * a class under `Some` at the same time, and nothing could say the two do not go together.
      */
     private static PartitionClass classOf(Case one, TypeView view, List<TypeSymbol> worn,
                                           ReadingPolicy policy,
                                           List<TypeReachName.Written> writes, Symbols symbols) {
-        return switch (one) {
+        PartitionClass built = switch (one) {
             case Case.Truth truth -> eitherWay(truth.value(), worn, writes);
             case Case.Presence presence -> heldOrNot(presence.present(), view, worn, policy, writes, symbols);
             case Case.SumCase sum -> caseClass(sum, worn, policy, writes, symbols);
             case Case.Named named -> ValueClasses.classAt(named.value(), view, worn, symbols);
         };
+        Refinement narrowing = Refinement.of(one);
+        return narrowing == null ? built : built.selecting(narrowing);
     }
 
     /** One of the two values of a {@code Bool}, under the names the position writes it under. */
@@ -171,13 +180,7 @@ final class PartitionClasses {
     private static PartitionClass caseClass(Case.SumCase one, List<TypeSymbol> worn,
                                             ReadingPolicy policy,
                                             List<TypeReachName.Written> writes, Symbols symbols) {
-        // The narrowing a row in this class meets, asked of the one reading that relates the two
-        // vocabularies. A row whose value here is an `Approved` is a row at every position the
-        // `Approved` case declares, and that is the same fact read from the other end — read here a
-        // second time, this class and the branch under the position would be free to disagree about
-        // which narrowing they are.
-        return holdingWhatItIs(one, writableCase(one.leaf(), worn, policy, writes, symbols))
-                .selecting(Refinement.of(one));
+        return holdingWhatItIs(one, writableCase(one.leaf(), worn, policy, writes, symbols));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
@@ -171,11 +171,13 @@ final class PartitionClasses {
     private static PartitionClass caseClass(Case.SumCase one, List<TypeSymbol> worn,
                                             ReadingPolicy policy,
                                             List<TypeReachName.Written> writes, Symbols symbols) {
-        // The narrowing a row in this class meets, carried from the distinction it was made from. A
-        // row whose value here is an `Approved` is a row at every position the `Approved` case
-        // declares, and that is the same fact read from the other end.
+        // The narrowing a row in this class meets, asked of the one reading that relates the two
+        // vocabularies. A row whose value here is an `Approved` is a row at every position the
+        // `Approved` case declares, and that is the same fact read from the other end — read here a
+        // second time, this class and the branch under the position would be free to disagree about
+        // which narrowing they are.
         return holdingWhatItIs(one, writableCase(one.leaf(), worn, policy, writes, symbols))
-                .selecting(new Refinement.SumCase(one.leaf()));
+                .selecting(Refinement.of(one));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/inputs/ALeafIsNotAnAbsenceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/ALeafIsNotAnAbsenceTest.java
@@ -68,7 +68,7 @@ class ALeafIsNotAnAbsenceTest {
 
     private StructuralInspection.Branch unitCase(String name) {
         return new StructuralInspection.Branch(
-                new Refinement.SumCase(((Type.Ref) named(name)).name()), null);
+                Refinement.sumCase(((Type.Ref) named(name)).name()), null);
     }
 
     private Type named(String name) {

--- a/souther-compiler/src/test/java/souther/compiler/inputs/ALeafIsNotAnAbsenceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/ALeafIsNotAnAbsenceTest.java
@@ -173,15 +173,37 @@ class ALeafIsNotAnAbsenceTest {
         assertEquals(blocked(new BlockReason.DepthLimit()), under(Type.list(named("Slot")), false));
     }
 
-    /** Each of the three is its own reaching, so implementing one does not read as all three. */
+    /**
+     * The one reaching still not made is its own, so making another does not read as making it.
+     *
+     * <p>Two of the three are made now: a sequence holds a position, and what an optional holds
+     * stands under the branch that says it holds something. What a mapping holds is not reached,
+     * and is stopped as that rather than as a shape nothing was read at.
+     */
     @Test
-    void theOtherTwoReachingsAreToldApartFromIt() {
-        assertEquals(blocked(new BlockReason.UnsupportedTraversal(
-                        BlockReason.Traversal.OPTIONAL_VALUE)),
-                under(Type.option(Type.INT)));
+    void theReachingStillNotMadeIsToldApartFromIt() {
         assertEquals(blocked(new BlockReason.UnsupportedTraversal(
                         BlockReason.Traversal.MAPPING_CONTENT)),
                 under(Type.map(Type.STRING, Type.INT)));
+    }
+
+    /**
+     * And whether an optional holds anything is a narrowing, so it answers with branches.
+     *
+     * <p>Beside the mapping rather than instead of it. The two were one word until the optional's
+     * branches were taken, and what says they were never one question is that each answers
+     * differently now.
+     */
+    @Test
+    void whatAnOptionalHoldsStandsUnderTheBranchThatSaysItDoes() {
+        StructuralInspection.Retained retained =
+                assertInstanceOf(StructuralInspection.Retained.class, under(Type.option(Type.INT)));
+        assertEquals(new StructuralInspection.Continuation.Branches(List.of(
+                        new StructuralInspection.Branch(Refinement.of(new Case.Presence(false)), null),
+                        new StructuralInspection.Branch(Refinement.of(new Case.Presence(true)),
+                                Type.INT))),
+                retained.continuation(),
+                "the absence puts no position anywhere, and `Some` leaves the element here");
     }
 
     /** A declaration reachable from itself: interpreted as far as it goes, which is not far enough. */

--- a/souther-compiler/src/test/java/souther/compiler/inputs/ANarrowingIsSpelledByTheOneThatOwnsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/ANarrowingIsSpelledByTheOneThatOwnsItTest.java
@@ -1,0 +1,88 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.types.TypeSymbol;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A narrowing is spelled where narrowings are owned, and nowhere else.
+ *
+ * <p>Measured against the shape of the API rather than against an answer. {@link Refinement#of} says
+ * it is "the one place the two vocabularies are related", and {@code TermPath.requirements} says a
+ * requirement is read from the path "here and nowhere else" — both sentences, and both were kept by
+ * whoever happened to read them. The classes of a position spelled a sum's narrowing a second time
+ * and never spelled an optional's, so an optional's classes narrowed nothing and two of them could
+ * sit in one row; and the boundary search planned a value against no requirement at all, so a row
+ * offered for a line under a case carried another case. A sentence is kept by whoever reads it; a
+ * signature is kept by everyone (ADR-0114).
+ *
+ * <p>The scan below is a tripwire under that, not the other way round — what holds it is that the
+ * variants have no constructor a caller can reach.
+ */
+class ANarrowingIsSpelledByTheOneThatOwnsItTest {
+
+    @Test
+    void aNarrowingHasNoConstructorAReaderCanReach() {
+        for (Class<?> variant : new Class<?>[] {Refinement.SumCase.class, Refinement.Presence.class}) {
+            for (Constructor<?> each : variant.getDeclaredConstructors()) {
+                assertTrue(Modifier.isPrivate(each.getModifiers()),
+                        "a reader could spell a narrowing of its own: " + each);
+            }
+            assertEquals(0, variant.getConstructors().length,
+                    () -> "and none of " + variant.getSimpleName()
+                            + " is reachable by reflection either");
+        }
+    }
+
+    /**
+     * And the two ways in take what they are named for.
+     *
+     * <p>Written out rather than counted. {@link Refinement#of} answers which narrowing a
+     * distinction is, and {@link Refinement#sumCase} builds one for a caller that already has the
+     * case — two questions, and a third entry arriving is a decision somebody made here.
+     */
+    @Test
+    void everyWayInTakesWhatTheNarrowingIsReadFrom() {
+        assertEquals(Refinement.sumCase(TypeSymbol.primitive("Int")),
+                Refinement.of(new Case.SumCase(TypeSymbol.primitive("Int"), false)),
+                "one case read two ways is one narrowing");
+        assertEquals(2, java.util.Arrays.stream(Refinement.class.getDeclaredMethods())
+                        .filter(each -> Modifier.isStatic(each.getModifiers()))
+                        .count(),
+                "a third way to spell a narrowing is a decision, not an accident: "
+                        + java.util.Arrays.toString(Refinement.class.getDeclaredMethods()));
+    }
+
+    /**
+     * A narrowing is what it narrows to, and not which object it is.
+     *
+     * <p>Load-bearing rather than tidy. Every reader deciding whether two requirements hold together
+     * does it by equality ({@link Requirements#merge}), and every branch of a position is found by
+     * comparing the narrowing it carries — so an identity comparison would have no two narrowings
+     * ever agree, which reads as a model whose cases are all incompatible.
+     */
+    @Test
+    void twoNarrowingsToTheSameThingAreOne() {
+        assertEquals(Refinement.sumCase(TypeSymbol.primitive("Int")),
+                Refinement.sumCase(TypeSymbol.primitive("Int")));
+        assertEquals(Refinement.sumCase(TypeSymbol.primitive("Int")).hashCode(),
+                Refinement.sumCase(TypeSymbol.primitive("Int")).hashCode());
+        assertNotEquals(Refinement.sumCase(TypeSymbol.primitive("Int")),
+                Refinement.sumCase(TypeSymbol.primitive("Bool")));
+
+        assertEquals(Refinement.of(new Case.Presence(true)), Refinement.of(new Case.Presence(true)));
+        assertNotEquals(Refinement.of(new Case.Presence(true)),
+                Refinement.of(new Case.Presence(false)));
+        assertFalse(Refinement.of(new Case.Presence(true))
+                        .equals(Refinement.sumCase(TypeSymbol.primitive("Int"))),
+                "and a presence is not a case of a sum");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/ANarrowingIsSpelledByTheOneThatOwnsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/ANarrowingIsSpelledByTheOneThatOwnsItTest.java
@@ -54,11 +54,16 @@ class ANarrowingIsSpelledByTheOneThatOwnsItTest {
         assertEquals(Refinement.sumCase(TypeSymbol.primitive("Int")),
                 Refinement.of(new Case.SumCase(TypeSymbol.primitive("Int"), false)),
                 "one case read two ways is one narrowing");
-        assertEquals(2, java.util.Arrays.stream(Refinement.class.getDeclaredMethods())
-                        .filter(each -> Modifier.isStatic(each.getModifiers()))
-                        .count(),
-                "a third way to spell a narrowing is a decision, not an accident: "
-                        + java.util.Arrays.toString(Refinement.class.getDeclaredMethods()));
+        // Named rather than counted. A count is tripped by a private helper, which is nobody's way
+        // in, and the reading of it that fits is to raise the number — which lets a way in be added
+        // later with nothing having said so.
+        assertEquals(java.util.Set.of("of", "sumCase"),
+                java.util.Arrays.stream(Refinement.class.getDeclaredMethods())
+                        .filter(each -> Modifier.isStatic(each.getModifiers())
+                                && !Modifier.isPrivate(each.getModifiers()))
+                        .map(java.lang.reflect.Method::getName)
+                        .collect(java.util.stream.Collectors.toSet()),
+                "a third way to spell a narrowing is a decision, not an accident");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/inputs/APositionUnderACaseIsAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/APositionUnderACaseIsAPositionTest.java
@@ -170,7 +170,7 @@ class APositionUnderACaseIsAPositionTest {
                 behavior open : (b: Box) -> Ack
                 """, "open");
         Position least = read.at(TermPath.of("b").refine(
-                new Refinement.SumCase(caseNamed(read, "Held"))).then("least"));
+                Refinement.sumCase(caseNamed(read, "Held"))).then("least"));
         assertNotNull(least, "a field of the case is a position");
         assertFalse(least.rulesNotReached(),
                 "and the clause relating it to the field beside it was reached");

--- a/souther-compiler/src/test/java/souther/compiler/inputs/APositionUnderACaseIsAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/APositionUnderACaseIsAPositionTest.java
@@ -66,12 +66,21 @@ class APositionUnderACaseIsAPositionTest {
                 .map(each -> each.path().toString()).toList();
     }
 
-    /** Every case's fields, each under the narrowing it stands beneath. */
+    /**
+     * Every case's fields, each under the narrowing it stands beneath.
+     *
+     * <p>And what an optional field holds is one of them. {@code tag} is a position of its own —
+     * the model divides it into holding something and holding nothing — and {@code tag@Some} is
+     * where what it holds stands, which is where that type's rules are read and where its border is
+     * owed. A narrowing takes no level either way, so both are at the same distance from the
+     * parameter as a plain field would be.
+     */
     @Test
     void theFieldsOfEveryCaseArePositionsOfTheInput() {
         assertEquals(List.of("query",
                         "query@GlobalQuery", "query@GlobalQuery.limit", "query@GlobalQuery.tag",
-                        "query@GlobalQuery.author",
+                        "query@GlobalQuery.tag@Some",
+                        "query@GlobalQuery.author", "query@GlobalQuery.author@Some",
                         "query@FeedQuery", "query@FeedQuery.limit", "query@FeedQuery.followees",
                         "query@FeedQuery.followees[*]"),
                 positionsOf(QUERIES, "readArticles"));

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClassUnderACaseIsOfferedARowAtThatCaseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClassUnderACaseIsOfferedARowAtThatCaseTest.java
@@ -77,7 +77,7 @@ class AClassUnderACaseIsOfferedARowAtThatCaseTest {
     }
 
     private static TermPath under(String leaf) {
-        return TermPath.of("query").refine(new Refinement.SumCase(
+        return TermPath.of("query").refine(Refinement.sumCase(
                 TypeSymbols.declared(new TypeKey("example.q", leaf))));
     }
 
@@ -131,7 +131,7 @@ class AClassUnderACaseIsOfferedARowAtThatCaseTest {
         assertFalse(tag.requirements().compatibleWith(sum.requiring(classOf(sum, "FeedQuery"))),
                 "and a row that is a FeedQuery is at none of them");
         assertEquals(Requirements.NONE.and(TermPath.of("query"),
-                        new Refinement.SumCase(
+                        Refinement.sumCase(
                                 TypeSymbols.declared(new TypeKey("example.q", "GlobalQuery")))),
                 tag.requirements(),
                 "which the path says on its own, with nothing kept beside it");

--- a/souther-compiler/src/test/java/souther/compiler/partition/AConstructionPositionIsNotAnInputPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AConstructionPositionIsNotAnInputPositionTest.java
@@ -248,7 +248,9 @@ class AConstructionPositionIsNotAnInputPositionTest {
         ConstructionPlan built = plan(read, throughApproved(read));
         assertEquals(declared, reading(read).at(TermPath.of("d")).view().declared(),
                 "the position is still declared to hold a Decision");
-        assertEquals("Approved", Type.show(built.root().type()),
+        ConstructionPlan.Built root = assertInstanceOf(ConstructionPlan.Built.class, built.root(),
+                "an `Approved` is composed out of its fields");
+        assertEquals("Approved", Type.show(root.type()),
                 "and what is built there is the case the class named");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AConstructionPositionIsNotAnInputPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AConstructionPositionIsNotAnInputPositionTest.java
@@ -85,9 +85,11 @@ class AConstructionPositionIsNotAnInputPositionTest {
     /** The plan for the behavior's one parameter, with nothing decided and the given
      *  requirements. */
     private static ConstructionPlan plan(Read read, Requirements required) {
-        return ConstructionPlan.of(read.sig().inputTypes().get(0),
+        ConstructionPlan.Result planned = ConstructionPlan.of(read.sig().inputTypes().get(0),
                 TermPath.of(read.spec().params().get(0).name()), read.symbols(), Set.of(), required,
                 (_, _) -> 0);
+        return assertInstanceOf(ConstructionPlan.Result.Planned.class, planned,
+                "nothing here asks one position to be two things").plan();
     }
 
     private static List<String> slots(ConstructionPlan plan) {
@@ -226,7 +228,7 @@ class AConstructionPositionIsNotAnInputPositionTest {
     /** The requirement a class of {@code d} states by being the {@code Approved} case of it. */
     private static Requirements throughApproved(Read read) {
         return Requirements.NONE.and(TermPath.of(read.spec().params().get(0).name()),
-                new Refinement.SumCase(caseNamed(SUM, "probe")));
+                Refinement.sumCase(caseNamed(SUM, "probe")));
     }
 
     /** The name of the case to build through, taken off a behavior that is declared to take one. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/AMeasureIsShortOfWhateverItsReadingDidNotReachTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AMeasureIsShortOfWhateverItsReadingDidNotReachTest.java
@@ -30,17 +30,27 @@ class AMeasureIsShortOfWhateverItsReadingDidNotReachTest {
     /**
      * A position the walk could not reach into, which is a fact no question carries.
      *
-     * <p>Nothing was read there and so nothing was found wanting: an {@code Option} holds its value
+     * <p>Nothing was read there and so nothing was found wanting: a {@code Map} holds its values
      * inside something this does not enter, and a rule about what is inside raises no question this
      * could be short of. Both measures are short of it, because what is not known about the
      * position is not known for either.
+     *
+     * <p><b>Written on a mapping because that is what is left.</b> This was an {@code Amount?}, and
+     * an optional is entered now — what it holds stands at the narrowing that says it holds
+     * something, where the rules of that type are read and its border is owed. So the model that
+     * used to be short of both is short of one, and a fixture kept for its numbers would have gone
+     * on being called a position nothing reached into.
+     *
+     * <p>The {@code Bool} beside it is what the partition measures. Without it nothing here divides
+     * at all and that measure says so instead, which is the other way of having no number and not
+     * the one this is about.
      */
     private static final String RULES_NOT_REACHED = """
             module example.notreached
 
             data Amount = Int
                 invariant value >= 0 && value <= 100
-            data Req = { cost: Amount? }
+            data Req = { cost: Map<String, Amount>, flag: Bool }
             data Res = { n: Int }
 
             behavior f : (r: Req) -> Res
@@ -48,7 +58,7 @@ class AMeasureIsShortOfWhateverItsReadingDidNotReachTest {
             let f (r) = Res { n = 0 }
 
             example f
-                | "one" : (Req { cost = 1 }) -> Res { n = 0 }
+                | "one" : (Req { cost = [ ("a", Amount(1)) ], flag = true }) -> Res { n = 0 }
             """;
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/AMeasureIsShortOfWhateverItsReadingDidNotReachTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AMeasureIsShortOfWhateverItsReadingDidNotReachTest.java
@@ -9,6 +9,7 @@ import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.PartitionEvidence;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,9 +42,12 @@ class AMeasureIsShortOfWhateverItsReadingDidNotReachTest {
      * used to be short of both is short of one, and a fixture kept for its numbers would have gone
      * on being called a position nothing reached into.
      *
-     * <p>The {@code Bool} beside it is what the partition measures. Without it nothing here divides
-     * at all and that measure says so instead, which is the other way of having no number and not
-     * the one this is about.
+     * <p><b>The {@code Bool} is what makes the model say two things.</b> This is about the two
+     * measures answering apart, and a position has to be measured for one of them to be the answer
+     * it is: the optional divided into holding something and holding nothing and was that position
+     * itself, and a mapping divides nothing. Without it both measures say the same word for
+     * different reasons, and the test would pass over the two being merged. So the field is part of
+     * what is being said and is asserted below rather than left standing as scenery.
      */
     private static final String RULES_NOT_REACHED = """
             module example.notreached
@@ -94,6 +98,14 @@ class AMeasureIsShortOfWhateverItsReadingDidNotReachTest {
     @Test
     void aPositionTheWalkDidNotReachIntoLeavesBothMeasuresShort() {
         PartitionEvidence evidence = evidenceFor(RULES_NOT_REACHED, "f");
+
+        // What the partition did measure, so that the two answers below are one model saying two
+        // things rather than one measure with nothing in it. A fixture whose every position is out
+        // of reach says `NOT_MEASURED` on both sides for two different reasons, and reading that as
+        // this would be the merge this exists to catch.
+        assertEquals(List.of("r.flag"),
+                evidence.axes().stream().map(PartitionEvidence.AxisCoverage::path).toList(),
+                () -> "the mapping divides nothing, so the `Bool` is the position measured here");
 
         assertEquals(MeasurementStatus.PARTIAL, AdequacyReport.statusOf(evidence.partitioned()),
                 () -> "partition: " + evidence.partitioned());

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANameTakenOffByOneNarrowingGoesBackOnAfterTheNextTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANameTakenOffByOneNarrowingGoesBackOnAfterTheNextTest.java
@@ -1,0 +1,156 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeOps;
+import souther.compiler.inputs.InputDomain;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * A name one narrowing takes off goes back on after the next one.
+ *
+ * <p>Every name a position wears is put back on the value chosen there — a row that dropped one
+ * carries a value of a type the parameter does not declare, which is what
+ * {@code ANameGoesBackOnTheWayItCameOff} holds. A narrowing takes one off, and a narrowing may
+ * stand where another left the position (ADR-0114), so the name the first one uncovered is taken
+ * off by the second and is owed all the same.
+ *
+ * <p>The settling read the names once, off the declaration, and went on narrowing — so a case that
+ * is a newtype over an optional lost the case's own name at the step that reached what the optional
+ * holds. Written on the model rather than on the loop: what a value has to wear is a fact about the
+ * declarations, and a test on how far a variable was carried would pass over the same value coming
+ * out wrong for another reason.
+ */
+class ANameTakenOffByOneNarrowingGoesBackOnAfterTheNextTest {
+
+    /** A case of a sum that is a newtype over an optional: the name is uncovered by the case and
+     *  taken off again by the presence. */
+    private static final String A_CASE_THAT_WRAPS_AN_OPTIONAL = """
+            module example.wrapping
+
+            data Tag = String
+                invariant String.length(value) >= 1
+
+            data MaybeTag = Tag?
+            data Rejected
+            data Decision = Rejected | MaybeTag
+            data Page = { count: Int }
+
+            behavior look : (d: Decision) -> Page
+            """;
+
+    /** And the other way round: an optional over a newtype of a sum. */
+    private static final String AN_OPTIONAL_OVER_A_WRAPPED_SUM = """
+            module example.wrapped
+
+            data Tag = String
+                invariant String.length(value) >= 1
+
+            data NoTag
+            data Filter = NoTag | Tag
+            data FilterN = Filter
+            data Query = { tag: FilterN? }
+            data Page = { count: Int }
+
+            behavior look : (query: Query) -> Page
+            """;
+
+    @Test
+    void aCaseThatWrapsAnOptionalKeepsItsOwnName() {
+        assertEquals(List.of("MaybeTag"),
+                wornAt(A_CASE_THAT_WRAPS_AN_OPTIONAL, "d@MaybeTag", "Some"),
+                "a value chosen under the presence is still missing the case's own name");
+        assertEquals(List.of("MaybeTag"),
+                wornAt(A_CASE_THAT_WRAPS_AN_OPTIONAL, "d@MaybeTag", "None"),
+                "and so is the absence the presence settled");
+    }
+
+    @Test
+    void anOptionalOverAWrappedSumKeepsTheNameThePresenceUncovered() {
+        assertEquals(List.of("FilterN"),
+                wornAt(AN_OPTIONAL_OVER_A_WRAPPED_SUM, "query.tag@Some", "Tag"),
+                "the name the presence uncovered is taken off by the case and owed all the same");
+    }
+
+    /** The one narrowing that uncovers no name owes none, so nothing is worn twice. */
+    @Test
+    void aNarrowingThatUncoversNoNameOwesNone() {
+        assertEquals(List.of(),
+                wornAt(AN_OPTIONAL_OVER_A_WRAPPED_SUM, "query.tag", "Some"),
+                "a `FilterN?` wears no name of its own at the field");
+    }
+
+    /** The names a value chosen for {@code classId} at {@code path} is still missing. */
+    private static List<String> wornAt(String source, String path, String classId) {
+        Read read = read(source);
+        Partitions.Partitioning partitioning =
+                Partitions.of("look", read.domain(), read.symbols(), ReadAs.THE_COMPILATION_DOES);
+        Axis axis = partitioning.axes().stream()
+                .filter(each -> each.path().toString().equals(path)).findFirst()
+                .orElseThrow(() -> new AssertionError("no axis at " + path + ": "
+                        + partitioning.axes().stream().map(a -> a.path().toString()).toList()));
+        PartitionClass cls = axis.classes().stream()
+                .filter(each -> each.id().equals(classId)).findFirst()
+                .orElseThrow(() -> new AssertionError("no class " + classId + " at " + path));
+
+        ConstructionPlan plan = assertInstanceOf(ConstructionPlan.Result.Planned.class,
+                ConstructionPlan.of(read.sig().inputTypes().get(0),
+                        TermPath.of(read.parameter()), read.symbols(), Set.of(),
+                        axis.requiring(cls), (_, _) -> 1),
+                "nothing here asks one position to be two things").plan();
+
+        return names(under(plan.root(), axis.path().refine(cls.selects())));
+    }
+
+    /** What the plan built at {@code at}, wherever it stands under the root. */
+    private static ConstructionPlan.Node under(ConstructionPlan.Node node, TermPath at) {
+        return switch (node) {
+            case ConstructionPlan.Slot slot -> slot.at().equals(at) ? slot : null;
+            case ConstructionPlan.Exact exact -> exact.at().equals(at) ? exact : null;
+            case ConstructionPlan.Held held -> under(held.under(), at);
+            case ConstructionPlan.Built built -> built.under().values().stream()
+                    .map(each -> under(each, at)).filter(each -> each != null).findFirst()
+                    .orElse(null);
+        };
+    }
+
+    private static List<String> names(ConstructionPlan.Node node) {
+        List<TypeOps.Layer> worn = switch (node) {
+            case ConstructionPlan.Slot slot -> slot.worn();
+            case ConstructionPlan.Exact exact -> exact.worn();
+            case null -> throw new AssertionError("the plan builds nothing at that position");
+            default -> throw new AssertionError("not a position a value is put at: " + node);
+        };
+        return worn.stream().map(each -> each.named().name()).toList();
+    }
+
+    private record Read(String parameter, Sig sig, Symbols symbols, InputDomain domain) {}
+
+    private static Read read(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().get(0);
+        return new Read(spec.params().get(0).name(), sigs.get("look"), symbols,
+                InputDomain.of(spec, sigs.get("look"), symbols, ReadAs.THE_COMPILATION_DOES));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANarrowingMayStandWhereAnotherLeftThePositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANarrowingMayStandWhereAnotherLeftThePositionTest.java
@@ -1,0 +1,118 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A narrowing may stand where another left the position, and what is built there is what both of
+ * them left.
+ *
+ * <p>A refinement does not move to another position and takes no level (ADR-0114), so two of them
+ * can stand at one: an optional holding a sum is narrowed to what it holds and then to the case that
+ * turned out to be there, and {@code query.tag@Some@Tag} is one position with two narrowings at it.
+ * {@code TermPath.requirements} writes both, each against the position it was taken at.
+ *
+ * <p>The plan read one and went on to the shape, so it built the sum and chose whatever the sum's
+ * candidates offered first — which is the defect at {@code query.tag@Tag} (#1070) reappearing one
+ * narrowing deeper, and reached by a model that writes `Filter?` rather than by anything unusual.
+ * Held end to end, because a plan that stops early and a row that stands at the point are the two
+ * ends of the same statement.
+ */
+class ANarrowingMayStandWhereAnotherLeftThePositionTest {
+
+    /** An optional holding a sum, one of whose cases carries the rules. */
+    private static final String OPTIONAL_OF_SUM = """
+            module example.chain
+
+            data Tag = String
+                invariant String.length(value) >= 1
+
+            data NoTag
+            data Filter = NoTag | Tag
+
+            data Query = { tag: Filter? }
+            data Page = { count: Int }
+
+            behavior look : (query: Query) -> Page
+
+            example look
+                | "none" : (Query { }) -> Page { count = 0 }
+            """;
+
+    /**
+     * The line the case's own type draws is owed under both narrowings, and the row offered for it
+     * carries the case.
+     *
+     * <p>{@code NoTag} is written first on purpose. The narrowing being dropped is invisible where
+     * the case carrying a value is the first the search reaches, so a model that hid it would pass
+     * over the plan reading no narrowing at all.
+     */
+    @Test
+    void aRowForALineTwoNarrowingsDeepCarriesBoth() {
+        List<String> offered =
+                offeredFor("String.length(query.tag@Some@Tag) = 1", OPTIONAL_OF_SUM);
+
+        assertFalse(offered.isEmpty(), "a row is offered for the line under `Some` and then `Tag`");
+        for (String row : offered) {
+            assertTrue(row.contains("tag = Tag("),
+                    "a row for a line under `Some@Tag` puts a `Tag` there: " + row);
+            assertFalse(row.contains("tag = NoTag"),
+                    "the second narrowing is not the first one read twice: " + row);
+            assertFalse(row.contains("tag = None"),
+                    "nor is the first one dropped: " + row);
+        }
+    }
+
+    /** And a narrowing under a field of a case still works, which is one at each of two positions
+     *  rather than two at one. */
+    private static final String OPTIONAL_UNDER_A_CASE = """
+            module example.undercase
+
+            data Tag = String
+                invariant String.length(value) >= 1
+
+            data Rejected = { why: Int }
+            data Approved = { note: Tag? }
+            data Decision = Approved | Rejected
+            data Page = { count: Int }
+
+            behavior look : (d: Decision) -> Page
+
+            example look
+                | "no" : (Rejected { why = 1 }) -> Page { count = 0 }
+            """;
+
+    @Test
+    void aNarrowingUnderAFieldOfACaseIsUnaffected() {
+        List<String> offered =
+                offeredFor("String.length(d@Approved.note@Some) = 1", OPTIONAL_UNDER_A_CASE);
+
+        assertFalse(offered.isEmpty(), "a row is offered for the line under the case's own field");
+        for (String row : offered) {
+            assertTrue(row.contains("note = Tag("),
+                    "and it puts a value at the field the line is under: " + row);
+        }
+    }
+
+    private static List<String> offeredFor(String point, String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, Adequacy.Filling> all =
+                Adequacy.generatedOf(compilation.db(), compilation.modules().get(0));
+        assertNotNull(all, "the model under test compiles");
+        return all.get("look").boundaries().rows().stream()
+                .filter(row -> row.purposes().stream().anyMatch(p -> p.toString().contains(point)))
+                .map(row -> String.join(", ", row.inputs().stream().map(i -> i.text()).toList()))
+                .toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/APlanIsMadeWhereItsRequirementsArePutTogetherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APlanIsMadeWhereItsRequirementsArePutTogetherTest.java
@@ -1,0 +1,153 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.inputs.Refinement;
+import souther.compiler.inputs.Requirements;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+import souther.compiler.types.TypeSymbols;
+import souther.compiler.types.TypeKey;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A plan is made where the requirements of the positions it builds at are put together.
+ *
+ * <p>A path states what has to hold for the position it names to exist, and a caller may have
+ * requirements besides — a class selects a refinement at its own position, which no path says. Both
+ * go into one plan (ADR-0114: coverage and construction use one merge and neither keeps an account
+ * of its own), and the defect this exists over is a caller that handed over the first and left the
+ * second empty: the boundary search fixed a value at {@code query.tag@Tag} and planned against
+ * {@code Requirements.NONE}, so the plan built the position as the sum and the row offered for a
+ * line under {@code Tag} carried a {@code NoTag}.
+ *
+ * <p>What holds it is that a plan is only ever made by {@link ConstructionPlan#of}, which is where
+ * the two are merged. The scan below is a tripwire under that.
+ */
+class APlanIsMadeWhereItsRequirementsArePutTogetherTest {
+
+    private static final String FILTER = """
+            module g
+
+            data Tag = String
+            data NoTag
+            data Filter = Tag | NoTag
+
+            data Query = { tag: Filter, other: Tag }
+            data Page = { count: Int }
+
+            behavior readArticles : (query: Query) -> Page
+            """;
+
+    @Test
+    void aPlanHasNoConstructorAReaderCanReach() {
+        for (Constructor<?> each : ConstructionPlan.class.getDeclaredConstructors()) {
+            assertTrue(Modifier.isPrivate(each.getModifiers()),
+                    "a caller could hold a plan its requirements were never put together for: "
+                            + each);
+        }
+        assertEquals(0, ConstructionPlan.class.getConstructors().length,
+                "and none is reachable by reflection either");
+    }
+
+    /**
+     * A path fixed under a case carries the case into the plan, with nothing added by the caller.
+     *
+     * <p>The invariant itself. {@code query.tag@Tag} says the position had to be a {@code Tag} for
+     * there to be a value at it, and a caller that says no more than that has still said it — so the
+     * plan builds a {@code Tag} at the refined position rather than a {@code Filter} at the
+     * unrefined one.
+     */
+    @Test
+    void aFixedPathUnderACaseIsPlannedAsThatCase() {
+        TermPath under = TermPath.of("query").then("tag").refine(caseOf("Tag"));
+
+        ConstructionPlan plan = planned(Set.of(under), Requirements.NONE);
+
+        List<String> slots = plan.slots().stream().map(each -> each.at().toString()).toList();
+        assertTrue(slots.contains(under.toString()),
+                "the position the value was fixed at is the position the plan builds at: " + slots);
+        assertFalse(slots.contains("query.tag"),
+                "and the unrefined position is not a second name for it: " + slots);
+        ConstructionPlan.Slot fixed = plan.slots().stream()
+                .filter(each -> each.at().equals(under)).findFirst().orElseThrow();
+        assertTrue(fixed.fixed(), "it is the caller's value that goes there");
+        assertEquals("Tag", souther.compiler.types.Type.show(fixed.type()),
+                "built as the case and not as the sum");
+    }
+
+    /**
+     * And two requirements at one position that disagree are a row no value is.
+     *
+     * <p>Which is an answer about the model and not a fall-short of this search, so it comes back
+     * said rather than thrown: a caller asking for a {@code NoTag} at a position it also fixed a
+     * {@code Tag} value under has asked for something no row is.
+     */
+    @Test
+    void twoNarrowingsOfOnePositionAreNoRow() {
+        TermPath tag = TermPath.of("query").then("tag");
+
+        ConstructionPlan.Result asked = ConstructionPlan.of(typeOf(), TermPath.of("query"),
+                symbols(), Set.of(tag.refine(caseOf("Tag"))),
+                Requirements.NONE.and(tag, caseOf("NoTag")), (_, _) -> 0);
+
+        ConstructionPlan.Result.Conflict against =
+                assertInstanceOf(ConstructionPlan.Result.Conflict.class, asked,
+                        "no value at `query.tag` is both a `Tag` and a `NoTag`");
+        assertEquals(tag, against.at());
+        assertEquals(Set.of("Tag", "NoTag"),
+                Set.of(against.one().spelled(), against.other().spelled()),
+                "and the answer says which two it would have to be");
+    }
+
+    private static ConstructionPlan planned(Set<TermPath> decided, Requirements additional) {
+        return assertInstanceOf(ConstructionPlan.Result.Planned.class,
+                ConstructionPlan.of(typeOf(), TermPath.of("query"), symbols(), decided, additional,
+                        (_, _) -> 0),
+                "nothing here asks one position to be two things").plan();
+    }
+
+    private static Refinement caseOf(String leaf) {
+        return Refinement.sumCase(TypeSymbols.declared(new TypeKey("g", leaf)));
+    }
+
+    /** The behavior's one parameter type, and the names it is read against. */
+    private static souther.compiler.types.Type typeOf() {
+        return read().sig().inputTypes().get(0);
+    }
+
+    private static Symbols symbols() {
+        return read().symbols();
+    }
+
+    private record Read(Sig sig, Symbols symbols) {}
+
+    private static Read read() {
+        Compilation compilation =
+                Compilation.ofSources(List.of(FILTER), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals("readArticles")).findFirst().orElseThrow();
+        return new Read(sigs.get(spec.name()), Scopes.derived(compilation.db(), module).value());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/APlanIsMadeWhereItsRequirementsArePutTogetherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APlanIsMadeWhereItsRequirementsArePutTogetherTest.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -115,6 +116,30 @@ class APlanIsMadeWhereItsRequirementsArePutTogetherTest {
         assertEquals(Set.of("Tag", "NoTag"),
                 Set.of(against.one().spelled(), against.other().spelled()),
                 "and the answer says which two it would have to be");
+    }
+
+    /**
+     * A value fixed at a position that is also required to be narrowed is two accounts of one
+     * location, and is refused.
+     *
+     * <p>What ADR-0114 keeps apart, said as a contract rather than answered by preferring one of
+     * the two: a class that narrows states the narrowing and does not also fix a value there,
+     * because the value stands at the narrowed position and is chosen there. Nothing a model writes
+     * reaches it — the classes that narrow offer no value to fix and the ones that offer a value
+     * narrow nothing — and it is exactly the arrangement an optional's classes had before they said
+     * which narrowing they were, so leaving the API able to express it leaves the next producer able
+     * to write it.
+     */
+    @Test
+    void aValueFixedWhereANarrowingIsRequiredIsTwoAccountsOfOnePosition() {
+        TermPath tag = TermPath.of("query").then("tag");
+
+        IllegalStateException said = assertThrows(IllegalStateException.class,
+                () -> ConstructionPlan.of(typeOf(), TermPath.of("query"), symbols(), Set.of(tag),
+                        Requirements.NONE.and(tag, caseOf("Tag")), (_, _) -> 0));
+
+        assertTrue(said.getMessage().contains("query.tag") && said.getMessage().contains("Tag"),
+                "the answer names the position said twice: " + said.getMessage());
     }
 
     private static ConstructionPlan planned(Set<TermPath> decided, Requirements additional) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/APlanIsMadeWhereItsRequirementsArePutTogetherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APlanIsMadeWhereItsRequirementsArePutTogetherTest.java
@@ -6,6 +6,7 @@ import souther.compiler.ast.Hir;
 import souther.compiler.check.Prepared;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
+import souther.compiler.inputs.Case;
 import souther.compiler.inputs.Refinement;
 import souther.compiler.inputs.Requirements;
 import souther.compiler.inputs.TermPath;
@@ -142,6 +143,72 @@ class APlanIsMadeWhereItsRequirementsArePutTogetherTest {
                 "the answer names the position said twice: " + said.getMessage());
     }
 
+    private static final String HELD = """
+            module g
+
+            data Tag = String
+            data NoTag
+            data Filter = NoTag | Tag
+
+            data Query = { tag: Filter?, other: Tag }
+            data Page = { count: Int }
+
+            behavior readArticles : (query: Query) -> Page
+            """;
+
+    /**
+     * A second narrowing of a position an absence settled is asked about nothing.
+     *
+     * <p>A refinement does not move to another position, so it is written at the same path the
+     * absence left — `x@None` and not something below it. Read as "not below", it would be let
+     * through, and the plan would answer `None` for a caller that asked for a `Tag`.
+     */
+    @Test
+    void aNarrowingUnderAnAbsenceIsAskedAboutNothing() {
+        TermPath tag = TermPath.of("query").then("tag");
+        TermPath absent = tag.refine(Refinement.of(new Case.Presence(false)));
+
+        IllegalStateException said = assertThrows(IllegalStateException.class,
+                () -> ConstructionPlan.of(heldType(), TermPath.of("query"), heldSymbols(),
+                        Set.of(),
+                        Requirements.NONE.and(tag, Refinement.of(new Case.Presence(false)))
+                                .and(absent, caseOf("Tag")),
+                        (_, _) -> 0));
+
+        assertTrue(said.getMessage().contains("query.tag@None"),
+                "the answer names the position that holds no value: " + said.getMessage());
+    }
+
+    /**
+     * And a value fixed under one is too, which no requirement would have shown.
+     *
+     * <p>A field step adds no requirement, so `x@None.foo` appears nowhere in what the caller
+     * stated — only in what it fixed. Read off the requirements alone the value is dropped in
+     * silence, which is the half of a demand this check exists to stop being read on its own.
+     */
+    @Test
+    void aValueFixedUnderAnAbsenceIsAskedAboutNothing() {
+        TermPath tag = TermPath.of("query").then("tag");
+        TermPath absent = tag.refine(Refinement.of(new Case.Presence(false)));
+
+        IllegalStateException said = assertThrows(IllegalStateException.class,
+                () -> ConstructionPlan.of(heldType(), TermPath.of("query"), heldSymbols(),
+                        Set.of(absent.then("value")),
+                        Requirements.NONE.and(tag, Refinement.of(new Case.Presence(false))),
+                        (_, _) -> 0));
+
+        assertTrue(said.getMessage().contains("query.tag@None.value"),
+                "the answer names the value fixed where nothing stands: " + said.getMessage());
+    }
+
+    private static souther.compiler.types.Type heldType() {
+        return readOf(HELD).sig().inputTypes().get(0);
+    }
+
+    private static Symbols heldSymbols() {
+        return readOf(HELD).symbols();
+    }
+
     private static ConstructionPlan planned(Set<TermPath> decided, Requirements additional) {
         return assertInstanceOf(ConstructionPlan.Result.Planned.class,
                 ConstructionPlan.of(typeOf(), TermPath.of("query"), symbols(), decided, additional,
@@ -165,8 +232,12 @@ class APlanIsMadeWhereItsRequirementsArePutTogetherTest {
     private record Read(Sig sig, Symbols symbols) {}
 
     private static Read read() {
+        return readOf(FILTER);
+    }
+
+    private static Read readOf(String source) {
         Compilation compilation =
-                Compilation.ofSources(List.of(FILTER), souther.compiler.meta.ModulePath.EMPTY);
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowAtAnotherCaseStandsNowhereBelowItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowAtAnotherCaseStandsNowhereBelowItTest.java
@@ -91,7 +91,7 @@ class ARowAtAnotherCaseStandsNowhereBelowItTest {
 
     private static TermPath under(String module, String leaf, String field) {
         return TermPath.of("query")
-                .refine(new Refinement.SumCase(TypeSymbols.declared(new TypeKey(module, leaf))))
+                .refine(Refinement.sumCase(TypeSymbols.declared(new TypeKey(module, leaf))))
                 .then(field);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowIsOfferedForAPointOnlyWhereItStandsThereTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowIsOfferedForAPointOnlyWhereItStandsThereTest.java
@@ -96,13 +96,63 @@ class ARowIsOfferedForAPointOnlyWhereItStandsThereTest {
                 "nothing ran the candidate, so nothing says it stands anywhere else");
     }
 
+    /** Two parameters, and a second position under the first so its search has more than one
+     *  candidate to offer — which is what lets a parameter refuse one and still succeed. */
+    private static final String TWO = """
+            module example.bounded
+
+            data Amount = Int
+                invariant value >= 0 && value <= 100
+            data Req = { cost: Amount, note: String }
+            data Other = { n: Int }
+            data Res = { n: Int }
+
+            behavior g : (r: Req, o: Other) -> Res
+            """;
+
+    /**
+     * What one parameter's search found out is not said of another's.
+     *
+     * <p>A candidate turned away for standing elsewhere is news about the parameter it was built
+     * for. Kept for the whole row, the first parameter certifying its second candidate would name
+     * the reason a later parameter failed for — and the later one was refused by the model, which is
+     * the opposite answer: one says every value the rules allow was turned away, and the other says
+     * what was built did not stand where it was built for.
+     */
+    @Test
+    void whatOneParametersSearchFoundOutIsNotSaidOfAnothers() {
+        int[] tried = {0};
+        Generator.BoundaryAttempt attempt = attemptOver(TWO, "g", Count.of(100),
+                (parameter, _) -> {
+                    if (parameter != 0) {
+                        return new Generator.CandidateCheck.Built.Refused("the model refuses it");
+                    }
+                    // The first candidate stands away from the point and the next stands on it, so
+                    // this parameter refuses one and succeeds all the same.
+                    return new Generator.CandidateCheck.Built.Value(
+                            reqWith(++tried[0] == 1 ? 7 : 100));
+                });
+
+        Generator.BoundaryAttempt.Unresolved no = assertInstanceOf(
+                Generator.BoundaryAttempt.Unresolved.class, attempt,
+                "no value of `o` was allowed, so no row builds");
+        assertEquals(Generator.UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED,
+                no.why().reason(),
+                "the second parameter's every candidate was refused by the model, which the first"
+                        + " parameter's uncertified candidate says nothing about");
+    }
+
     /** A check answering every candidate with a {@code Req} whose cost is {@code n}, whatever was
      *  asked for — a construction that does not answer with what it was given. */
     private static Generator.CandidateCheck always(int n) {
-        ObservedValue amount = new ObservedValue.Constructed(declared("Amount"),
-                Map.of("value", new ObservedValue.Integer(n)));
-        return (_, _) -> new Generator.CandidateCheck.Built.Value(
-                new ObservedValue.Constructed(declared("Req"), Map.of("cost", amount)));
+        return (_, _) -> new Generator.CandidateCheck.Built.Value(reqWith(n));
+    }
+
+    private static ObservedValue reqWith(int n) {
+        return new ObservedValue.Constructed(declared("Req"), Map.of("cost",
+                new ObservedValue.Constructed(declared("Amount"),
+                        Map.of("value", new ObservedValue.Integer(n))),
+                "note", new ObservedValue.Text("")));
     }
 
     private static souther.compiler.types.TypeSymbol declared(String name) {
@@ -112,13 +162,20 @@ class ARowIsOfferedForAPointOnlyWhereItStandsThereTest {
 
     private static Generator.BoundaryAttempt attemptAt(souther.compiler.numeric.Place at,
                                                        Generator.CandidateCheck check) {
-        Compilation compilation = Compilation.ofSource(BOUNDED, "Main");
+        return attemptOver(BOUNDED, "f", at, check);
+    }
+
+    private static Generator.BoundaryAttempt attemptOver(String source, String behavior,
+                                                         souther.compiler.numeric.Place at,
+                                                         Generator.CandidateCheck check) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         String module = compilation.modules().get(0);
         Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
         Symbols symbols = Scopes.derived(compilation.db(), module).value();
         Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
-        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().get(0);
+        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                .filter(each -> each.name().equals(behavior)).findFirst().orElseThrow();
         InputDomain domain = compilation.db()
                 .ask(new souther.compiler.query.Adequacy.Inputs(module)).value().get(spec.name());
         assertNotNull(domain, "the model under test compiles");

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowIsOfferedForAPointOnlyWhereItStandsThereTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowIsOfferedForAPointOnlyWhereItStandsThereTest.java
@@ -1,0 +1,141 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.inputs.InputDomain;
+import souther.compiler.numeric.Count;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * A row is offered for a point only where the value that was built stands there.
+ *
+ * <p>What was asked for and what was built are two things, and the generator answered with the
+ * first. A row composed to put a term at a number went out labelled for that number whatever the
+ * value came to — so a row that reached the point and a row that did not were reported alike, as
+ * {@code Generated}, and an author reading the report was told a shortfall had been answered when
+ * it had not (issue #1063).
+ *
+ * <p><b>Held against a construction that answers with something else, because that is the case the
+ * check is for.</b> {@code TermRealizations} states of itself that every value built there reads
+ * back as the number it was built for, and names the way it would break: "a row offered at an edge
+ * it does not stand on". The generator's own arithmetic meeting that is what the other tests here
+ * are about; this one is about what happens when something between the candidate and the value does
+ * not — a decoder that narrows, a construction that clamps — which is exactly what nothing was
+ * asking.
+ */
+class ARowIsOfferedForAPointOnlyWhereItStandsThereTest {
+
+    private static final String BOUNDED = """
+            module example.bounded
+
+            data Amount = Int
+                invariant value >= 0 && value <= 100
+            data Req = { cost: Amount }
+            data Res = { n: Int }
+
+            behavior f : (r: Req) -> Res
+            """;
+
+    /**
+     * A construction that answers with a value away from the point offers no row for it.
+     *
+     * <p>And says which of the two it is: nothing was refused by the model, so reporting it as a
+     * value the rules turned away would send an author looking at their invariant.
+     */
+    @Test
+    void aValueThatLandsElsewhereIsNoWitness() {
+        Generator.BoundaryAttempt attempt = attemptAt(Count.of(100), always(7));
+
+        Generator.BoundaryAttempt.Unresolved no = assertInstanceOf(
+                Generator.BoundaryAttempt.Unresolved.class, attempt,
+                "a value that reads back at 7 is no row for the point at 100");
+        assertEquals(Generator.UnresolvedCombination.Reason.NO_CERTIFIED_WITNESS,
+                no.why().reason());
+    }
+
+    /** And one that answers with the value it was built for is the row. */
+    @Test
+    void aValueThatLandsOnThePointIsTheWitness() {
+        Generator.BoundaryAttempt attempt = attemptAt(Count.of(100), always(100));
+
+        Generator.BoundaryAttempt.Built built = assertInstanceOf(
+                Generator.BoundaryAttempt.Built.class, attempt,
+                "a value that reads back at 100 stands at the point");
+        assertEquals(List.of("Req { cost = Amount(100) }"),
+                built.row().inputs().stream().map(FixtureTemplate::text).toList());
+    }
+
+    /**
+     * And where nothing built the candidate, the row is offered as it was composed.
+     *
+     * <p>The fail-open half, and the reason it is one: there is no runtime to put a candidate
+     * through, so nothing here can say where it went — and refusing every row wherever a build is
+     * unavailable would answer a question nobody asked with the worst of the two answers.
+     */
+    @Test
+    void whereNothingBuiltItTheRowIsOfferedAsComposed() {
+        assertInstanceOf(Generator.BoundaryAttempt.Built.class,
+                attemptAt(Count.of(100), Generator.CandidateCheck.ANY),
+                "nothing ran the candidate, so nothing says it stands anywhere else");
+    }
+
+    /** A check answering every candidate with a {@code Req} whose cost is {@code n}, whatever was
+     *  asked for — a construction that does not answer with what it was given. */
+    private static Generator.CandidateCheck always(int n) {
+        ObservedValue amount = new ObservedValue.Constructed(declared("Amount"),
+                Map.of("value", new ObservedValue.Integer(n)));
+        return (_, _) -> new Generator.CandidateCheck.Built.Value(
+                new ObservedValue.Constructed(declared("Req"), Map.of("cost", amount)));
+    }
+
+    private static souther.compiler.types.TypeSymbol declared(String name) {
+        return souther.compiler.types.TypeSymbols.declared(
+                new souther.compiler.types.TypeKey("example.bounded", name));
+    }
+
+    private static Generator.BoundaryAttempt attemptAt(souther.compiler.numeric.Place at,
+                                                       Generator.CandidateCheck check) {
+        Compilation compilation = Compilation.ofSource(BOUNDED, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().get(0);
+        InputDomain domain = compilation.db()
+                .ask(new souther.compiler.query.Adequacy.Inputs(module)).value().get(spec.name());
+        assertNotNull(domain, "the model under test compiles");
+        Partitions.Partitioning partitioning =
+                Partitions.of(spec.name(), domain, symbols, ReadAs.THE_COMPILATION_DOES);
+
+        List<String> names = new ArrayList<>();
+        spec.params().forEach(each -> names.add(each.name()));
+        Generator.Subject subject = new Generator.Subject(spec.name(),
+                new BehaviorInputs(names, sigs.get(spec.name()).inputTypes(), symbols,
+                        ReadAs.THE_COMPILATION_DOES),
+                partitioning.axes(), HeldCounts.of(domain, symbols));
+
+        Axis axis = partitioning.axes().stream()
+                .filter(each -> each.path().toString().equals("r.cost")).findFirst().orElseThrow();
+        return Generator.probeFixing(subject, "r.cost = " + at,
+                _ -> axis.term().answeredOn(axis.type(), symbols),
+                Map.of(axis.term(), at), check);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ARowOfferedForALineUnderACaseStandsUnderThatCaseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ARowOfferedForALineUnderACaseStandsUnderThatCaseTest.java
@@ -1,0 +1,82 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A row offered for a line under a case is a row at that case.
+ *
+ * <p>What a line is written about and what a row offered for it has to be are one statement
+ * (ADR-0114): a boundary at {@code query.tag@Tag} is a line about the values a {@code Tag} standing
+ * at {@code tag} takes, and a row whose {@code tag} is a {@code NoTag} stands nowhere near it. The
+ * requirement saying so is written in the path the line is at and is read from there and nowhere
+ * else, so a caller composing a row for the line has it already.
+ *
+ * <p><b>Written as two orders of one sum, because the order is what made the defect visible rather
+ * than what caused it.</b> The requirement was dropped either way; where the case carrying a value
+ * is declared first, the search happened to reach that case's values before the unit case's and the
+ * row came out right. So a test written on one order alone passes over a generator that reads no
+ * requirement at all — which is what it did — and the two together say the answer does not depend
+ * on the order a sum's cases were written in.
+ */
+class ARowOfferedForALineUnderACaseStandsUnderThatCaseTest {
+
+    /** A `Tag` behind a case of a sum, with the length invariant that draws the line. */
+    private static String filteredBy(String cases) {
+        return """
+                module example.filter
+
+                data Tag = String
+                    invariant String.length(value) >= 1
+
+                data NoTag
+                data Filter = %s
+
+                data Query = { tag: Filter, other: Tag }
+                data Page = { count: Int }
+
+                behavior readArticles : (query: Query) -> Page
+
+                example readArticles
+                    | "no filter" : (Query { tag = NoTag, other = Tag("x") }) -> Page { count = 0 }
+                    | "a tag"     : (Query { tag = Tag("dragons"), other = Tag("x") }) -> Page { count = 1 }
+                """.formatted(cases);
+    }
+
+    @Test
+    void aRowForTheLineUnderTheCaseCarriesThatCase() {
+        for (String cases : List.of("Tag | NoTag", "NoTag | Tag")) {
+            List<String> offered = offeredFor("String.length(query.tag@Tag) = 1",
+                    filteredBy(cases));
+            assertTrue(!offered.isEmpty(),
+                    "a row is offered for the line under `Tag` where `Filter` is `" + cases + "`");
+            for (String row : offered) {
+                assertTrue(row.contains("tag = Tag("),
+                        "a row offered for a line under `Tag` puts a `Tag` there, and `" + cases
+                                + "` offered: " + row);
+            }
+        }
+    }
+
+    /** The rows the generator composed for the point labelled {@code point}, as they are written. */
+    private static List<String> offeredFor(String point, String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, Adequacy.Filling> all =
+                Adequacy.generatedOf(compilation.db(), compilation.modules().get(0));
+        assertNotNull(all, "the model under test compiles");
+        return all.get("readArticles").boundaries().rows().stream()
+                .filter(row -> row.purposes().stream().anyMatch(p -> p.toString().contains(point)))
+                .map(row -> String.join(", ", row.inputs().stream().map(i -> i.text()).toList()))
+                .toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -225,7 +225,7 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
     @Test
     void aReadingThatStoppedOutranksWhatTheRulesCameTo() {
         PendingPosition blocked = new PendingPosition.Blocked(AT,
-                new BlockReason.UnsupportedTraversal(BlockReason.Traversal.OPTIONAL_VALUE));
+                new BlockReason.UnsupportedTraversal(BlockReason.Traversal.MAPPING_CONTENT));
         UndividedPosition.Why expected = new UndividedPosition.Why.CannotDerive();
 
         assertEquals(expected, blocked.complete(new BodyCutInspection.Exhausted()).why());
@@ -235,7 +235,7 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
         // position the walk could not enter describes that same stop from the other end.
         assertEquals(new souther.compiler.inputs.PositionReadingBlocked(AT,
                         new BlockReason.UnsupportedTraversal(
-                                BlockReason.Traversal.OPTIONAL_VALUE)),
+                                BlockReason.Traversal.MAPPING_CONTENT)),
                 blocked.reportable());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnOptionalsClassesStateWhichNarrowingTheyAreTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnOptionalsClassesStateWhichNarrowingTheyAreTest.java
@@ -1,0 +1,171 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.inputs.Case;
+import souther.compiler.inputs.Refinement;
+import souther.compiler.inputs.Requirements;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An optional's classes state which narrowing they are, and what the absence narrows to is a value.
+ *
+ * <p>A class that narrows a position states the narrowing and does not also fix a value there
+ * (ADR-0114). The classes of an optional stated neither: they were built with no narrowing at all,
+ * so their values went into the caller's table like any unnarrowed class's. Nothing said the two
+ * did not go together — a row could be asked to hold nothing at a position and to hold a value in a
+ * class beneath it at the same time, and no reader could see that no value is both.
+ */
+class AnOptionalsClassesStateWhichNarrowingTheyAreTest {
+
+    private static final String FLAGGED = """
+            module example.flagged
+
+            data On
+            data Off
+            data Flag = On | Off
+
+            data Query = { f: Flag?, n: Int }
+            data Page = { count: Int }
+
+            behavior look : (query: Query) -> Page
+            """;
+
+    /**
+     * Holding nothing here and holding a class under {@code Some} is no row.
+     *
+     * <p>The requirement the second states is written in its own path, and the first is what the
+     * class selects — so the two meet in one merge and it says which position could not be both.
+     */
+    @Test
+    void holdingNothingAndHoldingAClassBeneathItAreNoRow() {
+        Partitions.Partitioning partitioning = partitioningOf();
+        Axis optional = axisAt(partitioning, "query.f");
+        Axis beneath = axisAt(partitioning, "query.f@Some");
+
+        Requirements none = optional.requiring(classNamed(optional, "None"));
+        Requirements under = beneath.requiring(beneath.classes().get(0));
+
+        assertFalse(none.compatibleWith(under),
+                "no value at `query.f` holds nothing and is an `On` as well");
+        Requirements.Merge.Conflict against = assertInstanceOf(Requirements.Merge.Conflict.class,
+                none.merge(under), "and the answer says which position it is");
+        assertEquals(TermPath.of("query").then("f"), against.at());
+        assertEquals(Set.of("None", "Some"),
+                Set.of(against.one().spelled(), against.other().spelled()));
+    }
+
+    /** And holding something here goes with a class beneath it, which is the row the model has. */
+    @Test
+    void holdingSomethingGoesWithAClassBeneathIt() {
+        Partitions.Partitioning partitioning = partitioningOf();
+        Axis optional = axisAt(partitioning, "query.f");
+        Axis beneath = axisAt(partitioning, "query.f@Some");
+
+        assertTrue(optional.requiring(classNamed(optional, "Some"))
+                        .compatibleWith(beneath.requiring(beneath.classes().get(0))),
+                "a `Some` holding an `On` is a row the model has");
+    }
+
+    /**
+     * The absence inside a collection is built there, and the collection is built around it.
+     *
+     * <p>The narrowing settles the value rather than narrowing to something to be chosen, so the
+     * position under it is an {@link ConstructionPlan.Exact} and no slot; what the list holds is
+     * still something asked of the list, so the list is composed around it rather than proposed
+     * whole. Read off the plan rather than off the paths: whether one position is under another is
+     * a fact about the steps between them.
+     *
+     * <p>Written {@code List<Option<Tag>>}, because a {@code ?} is where an optional is made and no
+     * position inside a type is one — {@code List<Tag?>} is refused (E1403).
+     */
+    @Test
+    void anAbsenceInsideACollectionIsBuiltThereAndTheCollectionAroundIt() {
+        TermPath element = TermPath.of("query").then("many").element();
+
+        ConstructionPlan plan = planFor(Requirements.NONE.and(element,
+                Refinement.of(new Case.Presence(false))));
+
+        ConstructionPlan.Built root =
+                assertInstanceOf(ConstructionPlan.Built.class, plan.root(), "a `Held` is composed");
+        ConstructionPlan.Held many = assertInstanceOf(ConstructionPlan.Held.class,
+                root.under().get("many"),
+                "the list is built around what it was asked to hold, and not proposed whole");
+        ConstructionPlan.Exact exact = assertInstanceOf(ConstructionPlan.Exact.class, many.under(),
+                "and what it holds is the value the narrowing settled");
+        assertEquals(element.refine(Refinement.of(new Case.Presence(false))), exact.at());
+        assertEquals("None", exact.exact().text());
+        assertTrue(plan.slots().stream().noneMatch(each -> each.at().isAtOrUnder(element)),
+                "nothing under the element is searched for: " + plan.slots());
+    }
+
+    private static final String HOLDING = """
+            module example.holding
+
+            data Tag = String
+
+            data Query = { many: List<Option<Tag>> }
+            data Page = { count: Int }
+
+            behavior look : (query: Query) -> Page
+            """;
+
+    private static ConstructionPlan planFor(Requirements required) {
+        Read read = read(HOLDING);
+        return assertInstanceOf(ConstructionPlan.Result.Planned.class,
+                ConstructionPlan.of(read.sig().inputTypes().get(0), TermPath.of("query"),
+                        read.symbols(), Set.of(), required, (_, _) -> 1),
+                "nothing here asks one position to be two things").plan();
+    }
+
+    private static Axis axisAt(Partitions.Partitioning partitioning, String path) {
+        return partitioning.axes().stream()
+                .filter(each -> each.path().toString().equals(path)).findFirst()
+                .orElseThrow(() -> new AssertionError("no axis at " + path + ": "
+                        + partitioning.axes().stream().map(a -> a.path().toString()).toList()));
+    }
+
+    private static PartitionClass classNamed(Axis axis, String id) {
+        return axis.classes().stream().filter(each -> each.id().equals(id)).findFirst()
+                .orElseThrow(() -> new AssertionError("no class " + id + " at " + axis.path()));
+    }
+
+    private static Partitions.Partitioning partitioningOf() {
+        Read read = read(FLAGGED);
+        return Partitions.of(read.spec().name(),
+                souther.compiler.inputs.InputDomain.of(read.spec(), read.sig(), read.symbols(),
+                        souther.compiler.query.ReadAs.THE_COMPILATION_DOES),
+                read.symbols(), souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+    }
+
+    private record Read(Hir.SpecBehavior spec, Sig sig, Symbols symbols) {}
+
+    private static Read read(String source) {
+        Compilation compilation =
+                Compilation.ofSources(List.of(source), souther.compiler.meta.ModulePath.EMPTY);
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals("look")).findFirst().orElseThrow();
+        return new Read(spec, sigs.get("look"), Scopes.derived(compilation.db(), module).value());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneProjectionWritesTheWordADocumentReadsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneProjectionWritesTheWordADocumentReadsTest.java
@@ -60,7 +60,6 @@ class OneProjectionWritesTheWordADocumentReadsTest {
         List<BlockReason> all = List.of(
                 new BlockReason.TypeUnresolved(),
                 new BlockReason.DepthLimit(),
-                new BlockReason.UnsupportedTraversal(BlockReason.Traversal.OPTIONAL_VALUE),
                 new BlockReason.UnsupportedTraversal(BlockReason.Traversal.MAPPING_CONTENT),
                 new BlockReason.UnreadComparisonForm(),
                 new BlockReason.UnreadComparisonDomain(),

--- a/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
@@ -236,15 +236,23 @@ class PartitionsTest {
         assertEquals("Amount", invariant.rule().clause().id().declaredOn().name());
     }
 
-    /** A record is taken apart, and only so far: two levels reach a field of a record a parameter
-     * holds, which is where rules are written. */
+    /**
+     * A record is taken apart, and only so far: two levels reach a field of a record a parameter
+     * holds, which is where rules are written.
+     *
+     * <p>{@code memo@Some} is beside {@code memo} rather than instead of it, and is not a third
+     * level. The optional divides into holding something and holding nothing, which is what
+     * {@code memo} is measured on; what it holds stands at the narrowing, which is where anything
+     * written about that type is read. A narrowing is not a step into the value, so the field is
+     * where it was.
+     */
     @Test
     void aProductIsTakenApartFieldByField() {
         List<String> paths = partitioningOf(KINDS, "submit").axes().stream()
                 .map(a -> a.path().toString()).toList();
 
         assertEquals(List.of("request.kind", "request.cost", "request.urgent", "request.memo",
-                "request.note"), paths);
+                "request.memo@Some", "request.note"), paths);
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatAnOptionalHoldsIsOwedAndOfferedARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatAnOptionalHoldsIsOwedAndOfferedARowTest.java
@@ -1,0 +1,104 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What an optional holds is a position, so what its type says about it is owed and a row is offered
+ * for it.
+ *
+ * <p>Whether an optional holds anything is a narrowing like a sum's case (ADR-0114), so the position
+ * under it is {@code tag@Some} and the rules of what it holds are read there. Before that it was
+ * nowhere: `Tag?` and `Tag` held the same type, the second was measured against the invariant and
+ * the first was reported as rules the walk never reached, and nothing an author could write
+ * discharged it — the same boundary was insisted on at one field and owed at neither end of the
+ * other (issue #1063).
+ *
+ * <p><b>Both ends, because each was wrong on its own.</b> The measure has to owe the line, and the
+ * generator has to offer a row that stands on it: with the line owed and the requirement dropped on
+ * the way to the plan, the row offered for {@code String.length(query.tag@Some) = 1} was
+ * {@code tag = None}, which is a row at no point under {@code Some} at all.
+ */
+class WhatAnOptionalHoldsIsOwedAndOfferedARowTest {
+
+    private static final String TAGGED = """
+            module example.tagged
+
+            data Tag = String
+                invariant String.length(value) >= 1
+
+            data Query = { tag: Tag?, other: Tag }
+            data Page = { count: Int }
+
+            behavior readArticles : (query: Query) -> Page
+
+            example readArticles
+                | "no filter" : (Query { other = Tag("x") }) -> Page { count = 0 }
+                | "a tag"     : (Query { tag = Tag("dragons"), other = Tag("x") }) -> Page { count = 1 }
+            """;
+
+    /** The line the type behind the `?` draws is owed where the optional holds a value. */
+    @Test
+    void theLineBehindTheQuestionMarkIsOwed() {
+        String report = human(TAGGED);
+
+        assertTrue(report.contains("String.length(query.tag@Some) = 1"),
+                "the invariant of what the optional holds draws its line at the narrowing: "
+                        + report);
+        assertTrue(report.contains("String.length(query.other) = 1"),
+                "as it does at the field holding the same type outright: " + report);
+    }
+
+    /**
+     * And the row offered for it holds a value there.
+     *
+     * <p>Read off what was composed and not off the label it was composed under. What went wrong
+     * was exactly a row that carried the label and not the value, so a test that read the label
+     * back would have passed over it.
+     */
+    @Test
+    void theRowOfferedForItHoldsAValueThere() {
+        List<String> offered = offeredFor("String.length(query.tag@Some) = 1", TAGGED);
+
+        assertFalse(offered.isEmpty(), "a row is offered for the line under `Some`");
+        for (String row : offered) {
+            assertTrue(row.contains("tag = Tag("),
+                    "a row offered for a line under `Some` puts a value there: " + row);
+            assertFalse(row.contains("tag = None"),
+                    "and a row with nothing at the position stands at no point under it: " + row);
+        }
+    }
+
+    private static Compilation measured(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    private static String human(String source) {
+        return AdequacyReport.of(measured(source)).human(SourceNameResolver.identity());
+    }
+
+    private static List<String> offeredFor(String point, String source) {
+        Compilation compilation = measured(source);
+        Map<String, Adequacy.Filling> all =
+                Adequacy.generatedOf(compilation.db(), compilation.modules().get(0));
+        assertNotNull(all, "the model under test compiles");
+        return all.get("readArticles").boundaries().rows().stream()
+                .filter(row -> row.purposes().stream().anyMatch(p -> p.toString().contains(point)))
+                .map(row -> String.join(", ", row.inputs().stream().map(i -> i.text()).toList()))
+                .toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhyADerivationStoppedIsNotWhatAReportPromisesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhyADerivationStoppedIsNotWhatAReportPromisesTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class WhyADerivationStoppedIsNotWhatAReportPromisesTest {
 
     /**
-     * The collapse, written down where it can be reviewed. Three missing traversals are one word a
+     * The collapse, written down where it can be reviewed. Every missing traversal is one word a
      * report writes, because a reader of the report cannot act on which of them it was — the model
      * is the same either way.
      */
@@ -43,15 +43,15 @@ class WhyADerivationStoppedIsNotWhatAReportPromisesTest {
     }
 
     /**
-     * Which traversals are told apart here is a claim about what would lift each: choosing among a
-     * sequence's elements, choosing whether an optional holds one, and deciding what part of a
-     * mapping a rule is about are three pieces of work. Written out so that collapsing two of them
-     * is a change to this test rather than a quiet edit.
+     * Which traversals are named here is a claim about what is still not reached, and it shrinks as
+     * the reachings are made: a sequence's elements are positions of the input, and so is what an
+     * optional holds — a branch under the narrowing that it holds one. What is left is deciding
+     * what part of a mapping a rule is about, which nothing has decided. Written out so that a
+     * reaching leaving this list is a change to this test rather than a quiet edit.
      */
     @Test
-    void theTraversalsToldApartAreTheOnesLiftedByDifferentWork() {
-        assertEquals(Set.of(BlockReason.Traversal.OPTIONAL_VALUE,
-                        BlockReason.Traversal.MAPPING_CONTENT),
+    void theTraversalsNamedAreTheOnesStillNotMade() {
+        assertEquals(Set.of(BlockReason.Traversal.MAPPING_CONTENT),
                 Set.of(BlockReason.Traversal.values()));
     }
 
@@ -62,7 +62,7 @@ class WhyADerivationStoppedIsNotWhatAReportPromisesTest {
         for (BlockReason reason : new BlockReason[] {
                 new BlockReason.TypeUnresolved(),
                 new BlockReason.DepthLimit(),
-                new BlockReason.UnsupportedTraversal(BlockReason.Traversal.OPTIONAL_VALUE)}) {
+                new BlockReason.UnsupportedTraversal(BlockReason.Traversal.MAPPING_CONTENT)}) {
             assertNotNull(ReportedReason.of(reason), reason + " is reported as something");
         }
     }

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
@@ -154,7 +154,7 @@
           "provenInfeasible" : 0,
           "unknown" : 0
         },
-        "notDerivable" : [ ],
+        "notDerivable" : [ "item.note@Some" ],
         "notRead" : [ {
           "position" : "item.price",
           "reason" : "unsupported_syntax",
@@ -187,6 +187,10 @@
         "unreached" : [ ]
       },
       "findings" : [ {
+        "kind" : "partition_not_derivable",
+        "disposition" : "reported",
+        "subject" : "item.note@Some"
+      }, {
         "kind" : "partition_not_read",
         "disposition" : "reported",
         "subject" : "item.price",


### PR DESCRIPTION
Closes #1070. Closes #1063.

ADR-0114 established one ownership chain for refinements: a path spells the narrowing, `Requirements`
owns whether two of them hold together, and coverage and construction use that one merge with
neither keeping an account of its own. Two generation paths still went round it. This makes those
bypasses unrepresentable, then takes the optional continuation the ADR deliberately deferred.

The order matters: the generator defect is on `develop` today with no optional in it, and taking the
optional is what makes every row go through the part that was broken.

## 1. Put a plan's requirements together where the plan is made (#1070)

`Generator.probeFixing` fixed a boundary value at `query.tag@Tag` and planned against
`Requirements.NONE`, so the plan built the position as the sum and the search took whatever the
sum's candidates offered first. `data Filter = Tag | NoTag` is right by luck; `NoTag | Tag` offers
`Query { tag = NoTag }` for the point `String.length(query.tag@Tag) = 1`.

`ConstructionPlan.of` now merges every fixed path's own requirements with whatever the caller adds,
and answers `Planned` or `Conflict` — the model settling that no value is at both, the same answer
the class search already gives. The parameter is `additional`. The constructor is private, so there
is no plan whose requirements were never put together.

`Refinement`'s variants close the same way. Its javadoc calls `of(Case)` "the one place the two
vocabularies are related" and `PartitionClasses` spelled a sum's narrowing again anyway; a sentence
is kept by whoever reads it. The variants are final classes with private constructors, keeping value
equality — every reader deciding whether two requirements hold together does it by equality.
`PartitionClasses` asks `of`; `InputReads` holds an arm's case rather than a distinction, so it asks
`sumCase`, which is construction from an identity already settled and not a second correspondence.

## 2. Let an optional take the branches ADR-0114 left it (#1063)

The ADR said the optional stays unrefined "for now" and named what taking it would be. The rules
behind a `?` were never reached until then: `Tag?` and `Tag` hold one type, the second was measured
against `invariant Tag #1` and the first reported `rules not reached`, and no row an author could
write discharged it.

`Shape.Optional` answers with branches. `classOf` asks `Refinement.of(one)` for every distinction, so
the sum's arm no longer spells a narrowing and the optional's arm no longer spells none — which is
what left an optional's classes narrowing nothing, so a row could be asked to hold nothing at a
position and to hold a class beneath it at once.

`Presence(false)` reaches construction the moment those classes narrow, and there is no type to build
through it. The plan has an `Exact` node, and `Node.type()` is gone from the interface: answering it
for a position where nothing is built is the shortfall coming back as a value. Nothing read it
polymorphically.

`Traversal.OPTIONAL_VALUE` goes — its own javadoc says a word for a reaching that is made would have
the next reader take its presence for evidence that the walk stops there.

## 3. Offer a boundary row only where the value built stands at the point

`TermRealizations` says of itself that every value built there reads back as the number it was built
for, and names the way that breaks: "a row offered at an edge it does not stand on". Nothing asked.
Boundary candidates are now certified the way a class's witness already is — read back through
`NumericTerm.read` and the walk a row's own values are read by, nothing reimplemented here.

An acceptance condition and not an assertion: a refused candidate is one the search has tried and it
goes on to the next, and a search that runs out having certified none answers `NO_CERTIFIED_WITNESS`
rather than every value being refused. Fail-open where nothing built the candidate.

## What the probe from #1063 says now

```
border      borders 2   coverage items 2/4   excluded 4
  ! no row is at the ON point readArticles/String.length(query.tag@Some) = 1 (invariant Tag #1)

BOUNDARY_UNMET -> Generated[ purposes=[String.length(query.tag@Some) = 1],
                             inputs=[Query { tag = Tag("x"), other = Tag("x") }] ]
```

## Left out

`rules not reached: query.tag` stays, and is not about optionals: `PathEngine.declining` derives
`missed` at a position from `anyRuleUnder(type)`, so a sum or a list whose descendants carry rules
says the same thing while the border below it is measured. That is reachability accounting rather
than refinement propagation, and it is #1072 — the half of #1063 this does not close, split out so
that closing #1063 here does not drop it.

`item.note@Some` in the catalog corpus is a `String` nothing is written about, so it is reported as a
position the model divides in no way, as a plain `String` field is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
