### PR TITLE
Say which bindings a checked behavior's inputs arrive in

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/SpecImplementation.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecImplementation.java
@@ -58,20 +58,23 @@ public final class SpecImplementation {
     }
 
     /**
-     * The definition implementing a behavior, with its parameters divided the way {@link
-     * #parameters} says they arrive.
+     * The definition implementing a behavior, and which of its parameters are the declared inputs.
      *
-     * <p>Both halves so that no reader slices the list again. {@code inputs} are the behavior's
-     * declared inputs, positionally the signature's; {@code dependencies} are the behaviors it was
-     * declared to depend on, which arrive as the trailing parameters and are injected rather than
-     * passed at a call.
+     * <p>A value rather than the list alone, so that having found a definition and having found one
+     * that takes nothing stay two answers. A behavior of no inputs is implemented by a {@code let}
+     * of no parameters, and a caller handed an empty list for both would have to decide which it
+     * was looking at.
+     *
+     * <p>The inputs and not also the trailing parameters the {@code depends on} clause is answered
+     * by. Nothing reads those as a list: {@link SpecChecker#dependencyBindings} walks them against
+     * the clause, and it runs while E1614 is still being decided — where this refuses a list too
+     * short to divide, that one carries on and lets the diagnostic be the report. Divided here as
+     * well, the two would be one rule with two strictnesses.
      */
-    public record Implemented(Hir.FnDef definition, List<Hir.FnParam> inputs,
-                              List<Hir.FnParam> dependencies) {
+    public record Implemented(Hir.FnDef definition, List<Hir.FnParam> inputs) {
 
         public Implemented {
             inputs = List.copyOf(inputs);
-            dependencies = List.copyOf(dependencies);
         }
     }
 
@@ -88,7 +91,8 @@ public final class SpecImplementation {
      * <p>How many parameters the definition is required to have is {@link SpecChecker}'s, reported
      * as E1614 where it disagrees. Nothing is restated here: what this refuses is the state where
      * the division cannot be made at all, which is not a program being wrong but that check not
-     * having run.
+     * having run. So this is for a reader standing after the check — the emitter, the snapshot — and
+     * not for the checker deciding it.
      */
     public static Implemented implementedBy(Hir.Module module, Hir.SpecBehavior spec) {
         Hir.FnDef definition = null;
@@ -106,8 +110,7 @@ public final class SpecImplementation {
                     + inputs + " and its implementation has " + definition.params().size()
                     + " parameters to divide");
         }
-        return new Implemented(definition, definition.params().subList(0, inputs),
-                definition.params().subList(inputs, definition.params().size()));
+        return new Implemented(definition, definition.params().subList(0, inputs));
     }
 
     /** What an implementation of {@code spec} is required to take, in order. */

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecImplementation.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecImplementation.java
@@ -15,6 +15,10 @@ import java.util.List;
  * to know the shape — the checker that refuses one, an editor offering to write one — asks rather
  * than works it out again from the signature. Two readings of one rule agree until either moves.
  *
+ * <p>Which definition implements a behavior is answered here as well ({@link #implementedBy}), and
+ * for the same reason: a caller that found the definition itself would then divide its parameters
+ * itself, and the division is this rule.
+ *
  * <p>Nothing here is about how a parameter is written. Where it goes in a line, and whether the line
  * breaks, is the formatter's.
  */
@@ -51,6 +55,59 @@ public final class SpecImplementation {
          * says it again.
          */
         record Unanswered() implements Parameter {}
+    }
+
+    /**
+     * The definition implementing a behavior, with its parameters divided the way {@link
+     * #parameters} says they arrive.
+     *
+     * <p>Both halves so that no reader slices the list again. {@code inputs} are the behavior's
+     * declared inputs, positionally the signature's; {@code dependencies} are the behaviors it was
+     * declared to depend on, which arrive as the trailing parameters and are injected rather than
+     * passed at a call.
+     */
+    public record Implemented(Hir.FnDef definition, List<Hir.FnParam> inputs,
+                              List<Hir.FnParam> dependencies) {
+
+        public Implemented {
+            inputs = List.copyOf(inputs);
+            dependencies = List.copyOf(dependencies);
+        }
+    }
+
+    /**
+     * The {@code let} of {@code module} implementing {@code spec}, or null where the module has
+     * none — an injected behavior and an unwritten one both reach this and neither has a definition.
+     *
+     * <p>Among what the module declared, and not among what it took on to emit. What a module emits
+     * without declaring is a recursion another module wrote and a method minted for a row's operand
+     * ({@code Hir.Module#takenOn}); a behavior's implementation is a {@code let} of its name and is
+     * always a declaration. {@link Requirements#implementationOf} decides whether a behavior has one
+     * by looking in the same place, so a name found here is a name that reading called implemented.
+     *
+     * <p>How many parameters the definition is required to have is {@link SpecChecker}'s, reported
+     * as E1614 where it disagrees. Nothing is restated here: what this refuses is the state where
+     * the division cannot be made at all, which is not a program being wrong but that check not
+     * having run.
+     */
+    public static Implemented implementedBy(Hir.Module module, Hir.SpecBehavior spec) {
+        Hir.FnDef definition = null;
+        for (Hir.FnDef fn : module.fns()) {
+            if (fn.name().equals(spec.name())) {
+                definition = fn;   // the last, as every reader keying these by name keeps
+            }
+        }
+        if (definition == null) {
+            return null;
+        }
+        int inputs = spec.params().size();
+        if (definition.params().size() < inputs) {
+            throw new IllegalStateException("`" + module.name() + "." + spec.name() + "` takes "
+                    + inputs + " and its implementation has " + definition.params().size()
+                    + " parameters to divide");
+        }
+        return new Implemented(definition, definition.params().subList(0, inputs),
+                definition.params().subList(inputs, definition.params().size()));
     }
 
     /** What an implementation of {@code spec} is required to take, in order. */

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -16,6 +16,7 @@ import souther.compiler.check.ReqSig;
 import souther.compiler.check.Requirements;
 import souther.compiler.check.BehaviorContract;
 import souther.compiler.check.Sig;
+import souther.compiler.check.SpecImplementation;
 import souther.compiler.check.EnsuresEnforcement;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
@@ -314,11 +315,13 @@ public final class Backend {
             });
         }
         // Behavior fn bodies arrive with their helper calls already inlined (the Lower stage,
-        // ADR-0021); the backend emits them as-is and never lowers a helper on its own.
-        Map<String, Hir.FnDef> fns = new HashMap<>();
-        for (Hir.FnDef fn : emitted(module)) {
-            fns.put(fn.name(), fn);
-        }
+        // ADR-0021); the backend emits them as-is and never lowers a helper on its own. Which
+        // definition implements a behavior, and which of its parameters are the declared inputs, is
+        // asked of `SpecImplementation` rather than worked out here: the snapshot's assembler reads
+        // the same binders, and two readings of one behavior's parameter list agree until either
+        // moves. Asked of what the module declared, which is where `Requirements` looks for one —
+        // a map keyed over `emitted(module)` let a method this module only took on to emit displace
+        // the `let` of the same name.
         // Injection targets (spec §injected-behavior): a SpecBehavior with no matching fn. Each becomes an
         // abstract base class a Java implementation extends (§java-base-class). Imported injection targets
         // (their base lives in the declaring module) are requirements too, so a composition here
@@ -446,12 +449,13 @@ public final class Backend {
                 }
                 switch (bd) {
                     case Hir.SpecBehavior spec -> {
-                        Hir.FnDef fn = fns.get(spec.name());
-                        if (fn != null) {
+                        SpecImplementation.Implemented implemented =
+                                SpecImplementation.implementedBy(module, spec);
+                        if (implemented != null) {
                             // a fn-implemented behavior: the $Impl holds the logic, the public interface
                             // (behaviorClass) is what Java code declares (spec §jvm-anonymous-union).
                             out.put(new GeneratedClass.BehaviorImpl(module.name(), spec.name()),
-                                    b.generateSpecFn(spec, fn, requiredNames, requiredSuccess, requiredParam));
+                                    b.generateSpecFn(spec, implemented, requiredNames, requiredSuccess, requiredParam));
                             List<Type> pts = new ArrayList<>();
                             for (Hir.Param p : spec.params()) {
                                 pts.add(b.successType(p.type()));
@@ -1249,7 +1253,7 @@ public final class Backend {
      * leading parameters name the inputs (their types come from the behavior); the trailing ones
      * name the injected behaviors and are resolved as inline calls, not bound as locals.
      */
-    private byte[] generateSpecFn(Hir.SpecBehavior spec, Hir.FnDef fn,
+    private byte[] generateSpecFn(Hir.SpecBehavior spec, SpecImplementation.Implemented implemented,
                                   Set<ValueName.Behavior> requiredNames,
                                   Map<ValueName.Behavior, Type> requiredSuccess,
                                   Map<ValueName.Behavior, List<Type>> requiredParam) {
@@ -1286,17 +1290,17 @@ public final class Backend {
                 gen.injectsInto(successType(spec.ret()));
                 gen.requireds(requiredNames, requiredSuccess, requiredParam, injected);
                 for (int i = 0; i < n; i++) {
-                    // the fn's leading param names the input; its type comes from the behavior
+                    // the definition's input names the binding; its type comes from the behavior
                     Type pt = successType(spec.params().get(i).type());
                     code.aload(i + 1);
                     int slot = gen.slot(pt);
                     unbox(code, pt, slot);
-                    gen.bind(fn.params().get(i).binder().binding(), fn.params().get(i).binder().name(),
-                            slot, pt);
+                    Hir.Binder binder = implemented.inputs().get(i).binder();
+                    gen.bind(binder.binding(), binder.name(), slot, pt);
                 }
                 // thread the behavior's declared output so a tail-position fold over an empty seed
                 // materialises its step at the output type, not a bottom (issue #70)
-                gen.emitTail(elaborated(checked.behaviorBodies(), fn.name()),
+                gen.emitTail(elaborated(checked.behaviorBodies(), implemented.definition().name()),
                         cdB, requiredNames, requiredSuccess, successType(spec.ret()));
             });
             if (n != 1) {

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -314,14 +314,6 @@ public final class Backend {
                 }
             });
         }
-        // Behavior fn bodies arrive with their helper calls already inlined (the Lower stage,
-        // ADR-0021); the backend emits them as-is and never lowers a helper on its own. Which
-        // definition implements a behavior, and which of its parameters are the declared inputs, is
-        // asked of `SpecImplementation` rather than worked out here: the snapshot's assembler reads
-        // the same binders, and two readings of one behavior's parameter list agree until either
-        // moves. Asked of what the module declared, which is where `Requirements` looks for one —
-        // a map keyed over `emitted(module)` let a method this module only took on to emit displace
-        // the `let` of the same name.
         // Injection targets (spec §injected-behavior): a SpecBehavior with no matching fn. Each becomes an
         // abstract base class a Java implementation extends (§java-base-class). Imported injection targets
         // (their base lives in the declaring module) are requirements too, so a composition here
@@ -449,6 +441,12 @@ public final class Backend {
                 }
                 switch (bd) {
                     case Hir.SpecBehavior spec -> {
+                        // Which definition implements it, and which of that definition's parameters
+                        // are the declared inputs, is asked rather than worked out here: the
+                        // snapshot's assembler reads its binders from the same answer, so which
+                        // local an input arrives in cannot be one thing there and another here.
+                        // Bodies arrive with their helper calls already inlined (the Lower stage,
+                        // ADR-0021), and are emitted as-is.
                         SpecImplementation.Implemented implemented =
                                 SpecImplementation.implementedBy(module, spec);
                         if (implemented != null) {

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedBehavior.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedBehavior.java
@@ -19,6 +19,15 @@ public final class CheckedBehavior {
 
     CheckedBehavior(ValueName.Behavior name, CheckedSignature signature,
                     CheckedImplementation implementation) {
+        // The one place the two readings of what a behavior takes meet, and so the one place they
+        // are held to each other. A signature says the inputs as types and a body says the bindings
+        // they arrive in; a reader is offered them as one parameter at each index, and lists of
+        // different lengths would make that reading wrong at some index rather than refused.
+        if (implementation instanceof CheckedImplementation.Body body
+                && body.parameters().size() != signature.takes().size()) {
+            throw new IllegalArgumentException("`" + name.module() + "." + name.name() + "` takes "
+                    + signature.takes().size() + " and its body binds " + body.parameters().size());
+        }
         this.name = name;
         this.signature = signature;
         this.implementation = implementation;

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedImplementation.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedImplementation.java
@@ -3,6 +3,8 @@ package souther.compiler.program;
 import souther.compiler.core.Composition;
 import souther.compiler.core.Core;
 
+import java.util.List;
+
 /**
  * Where a behavior's implementation comes from, in the four states a checked module has them in.
  *
@@ -13,10 +15,34 @@ import souther.compiler.core.Core;
  */
 public sealed interface CheckedImplementation {
 
-    /** Written here, as a {@code let} of the behavior's name: the checker's Core for it. */
-    record Body(Core body) implements CheckedImplementation {
+    /**
+     * Written here, as a {@code let} of the behavior's name: the checker's Core for it, and the
+     * bindings its inputs arrive in.
+     *
+     * <p>{@code parameters} holds the binders of the behavior's declared inputs, in the order
+     * {@link CheckedSignature#takes()} is in — so the {@code i}th input is
+     * {@code parameters().get(i)} and {@code signature().takes().get(i)}, and a read of that
+     * binding in {@code body} is a read of that input. A behavior's injected dependencies are not
+     * among them: they are not passed at a call, and a body reaches one by its name rather than by
+     * reading a binding.
+     *
+     * <p>The binders and not the types. A type here would be a second reading of what
+     * {@link CheckedSignature} already answers, and the two would agree until either moved.
+     * {@link CheckedBehavior} is where they are held to the same length, which is what makes
+     * reading them as one parameter safe.
+     *
+     * <p>Here and not on {@link CheckedBehavior}, because a binder exists exactly where a body
+     * does. An injected behavior takes inputs and has no body to bind them in, an unwritten one has
+     * none either, and a composition applies its first stage to what it was given. Answering this
+     * for any of them would be answering a question that has no answer.
+     */
+    record Body(List<Core.Binder> parameters, Core body) implements CheckedImplementation {
 
         public Body {
+            // Copied and not held: a caller that kept its list could change what the snapshot says
+            // a body's inputs are. `List.copyOf` refuses a null among them, and a parameter's
+            // binder is never the absent one a `match` arm binding nothing has.
+            parameters = List.copyOf(parameters);
             if (body == null) {
                 throw new IllegalArgumentException("an implemented behavior has a body");
             }

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
@@ -5,8 +5,10 @@ import souther.compiler.check.BehaviorImplementation;
 import souther.compiler.check.CoreBinders;
 import souther.compiler.check.Lower;
 import souther.compiler.check.Sig;
+import souther.compiler.check.SpecImplementation;
 import souther.compiler.check.TypeOps;
 import souther.compiler.core.Composition;
+import souther.compiler.core.Core;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.query.Acceptance;
 import souther.compiler.query.Bodies;
@@ -71,7 +73,7 @@ final class CheckedProgramAssembler {
         for (Hir.BehaviorDef declared : lowered.behaviors()) {
             ValueName.Behavior named = new ValueName.Behavior(module, declared.name());
             behaviors.add(new CheckedBehavior(named, signatureOf(signatures.get(declared.name())),
-                    implementationOf(named, declared.name(), implementations, checked,
+                    implementationOf(named, declared, lowered, implementations, checked,
                             compositions)));
         }
         return new CheckedModule(module, behaviors, helpersOf(module, lowered, checked));
@@ -98,9 +100,10 @@ final class CheckedProgramAssembler {
      * not something to infer from an absence.
      */
     private static CheckedImplementation implementationOf(
-            ValueName.Behavior named, String name,
+            ValueName.Behavior named, Hir.BehaviorDef declared, Hir.Module lowered,
             Map<String, BehaviorImplementation> implementations, Bodies.Elaborated checked,
             Map<ValueName.Behavior, Composition> compositions) {
+        String name = declared.name();
         BehaviorImplementation state = implementations.get(name);
         if (state == null || state == BehaviorImplementation.UNIMPLEMENTED) {
             return new CheckedImplementation.Unwritten();
@@ -112,7 +115,43 @@ final class CheckedProgramAssembler {
         if (composed != null) {
             return new CheckedImplementation.Composed(composed);
         }
-        return new CheckedImplementation.Body(checked.behaviorBodies().get(name));
+        return new CheckedImplementation.Body(inputBindersOf(named, declared, lowered),
+                checked.behaviorBodies().get(name));
+    }
+
+    /**
+     * The bindings this behavior's body reads its declared inputs through.
+     *
+     * <p>Read off the definition that implements it, and divided from what that definition takes by
+     * {@link SpecImplementation} — which is the same reading the JVM emitter binds its parameters
+     * from, so the snapshot and the emitted program cannot come to disagree about which local an
+     * input arrives in. The division is that rule's and not this one's: a definition's trailing
+     * parameters are the behaviors it depends on, and an assembler slicing the list itself would be
+     * a second place that knew so.
+     *
+     * <p>Sliced by what the behavior declares and not by how long its signature is. Sliced by the
+     * signature the two lengths would be equal by construction, and {@link CheckedBehavior}'s check
+     * of them would be comparing an answer with itself — the disagreement it is there to refuse
+     * would arrive instead as a dependency's binder handed over as an input's.
+     */
+    private static List<Core.Binder> inputBindersOf(ValueName.Behavior named,
+                                                    Hir.BehaviorDef declared, Hir.Module lowered) {
+        SpecImplementation.Implemented implemented =
+                declared instanceof Hir.SpecBehavior spec
+                        ? SpecImplementation.implementedBy(lowered, spec)
+                        : null;
+        if (implemented == null) {
+            // This behavior was taken as implemented here and by a body of its own, and the module
+            // has no definition to read one from. Nothing here can put that right, and letting it
+            // through would hand an output a body whose reads resolve to nothing it was given.
+            throw new IllegalStateException("`" + named.module() + "." + named.name()
+                    + "` was taken as having a body and has no definition to read it from");
+        }
+        List<Core.Binder> binders = new ArrayList<>();
+        for (Hir.FnParam input : implemented.inputs()) {
+            binders.add(CoreBinders.of(input.binder()));
+        }
+        return binders;
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/program/ACheckedBehaviorHoldsItsTwoReadingsOfWhatItTakesTogetherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/program/ACheckedBehaviorHoldsItsTwoReadingsOfWhatItTakesTogetherTest.java
@@ -1,0 +1,84 @@
+package souther.compiler.program;
+
+import souther.compiler.core.Core;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A behavior says what it takes twice — as types on its signature, and as the bindings its body
+ * reads them through — and a {@link CheckedBehavior} holding the two at different lengths is not
+ * one that can be made.
+ *
+ * <p>Written against the model and not through a compile. What the assembler produces is held to
+ * this by every module {@code AnOutputOutsideTheCompilerReadsACheckedProgramTest} compiles, and a
+ * check only reached that way is a check that has never been asked its own question: it would go on
+ * passing after the constructor stopped making it, because a correct assembler never offers it a
+ * mismatch. Here the mismatch is offered.
+ */
+class ACheckedBehaviorHoldsItsTwoReadingsOfWhatItTakesTogetherTest {
+
+    private static final Type INT = Type.INT;
+
+    @Test
+    void aBodyBindingFewerThanTheSignatureTakesIsRefused() {
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> behavior(List.of(INT, INT), body(binder("only"))));
+
+        assertEquals("`demo.combine` takes 2 and its body binds 1", refused.getMessage());
+    }
+
+    @Test
+    void andSoIsOneBindingMore() {
+        assertThrows(IllegalArgumentException.class,
+                () -> behavior(List.of(INT), body(binder("input"), binder("dependency"))),
+                "a definition's trailing parameters are what it depends on, and are not inputs");
+    }
+
+    /**
+     * And the invariant is one a behavior can satisfy.
+     *
+     * <p>A constructor that refused every argument would pass both tests above.
+     */
+    @Test
+    void aBodyBindingWhatTheSignatureTakesIsMade() {
+        CheckedBehavior made = behavior(List.of(INT, INT), body(binder("first"), binder("second")));
+
+        assertEquals(List.of("first", "second"),
+                ((CheckedImplementation.Body) made.implementation()).parameters().stream()
+                        .map(Core.Binder::name).toList());
+    }
+
+    /** The states with no body of their own are not held to it, having no binders to be held by. */
+    @Test
+    void anImplementationWithNoBodyIsNotAskedWhichBindingsItsInputsArriveIn() {
+        assertEquals(2, behavior(List.of(INT, INT), new CheckedImplementation.Injected())
+                .signature().takes().size());
+        assertEquals(2, behavior(List.of(INT, INT), new CheckedImplementation.Unwritten())
+                .signature().takes().size());
+    }
+
+    private static CheckedBehavior behavior(List<Type> takes, CheckedImplementation implementation) {
+        return new CheckedBehavior(new ValueName.Behavior("demo", "combine"),
+                new CheckedSignature(takes, INT), implementation);
+    }
+
+    private static CheckedImplementation.Body body(Core.Binder... parameters) {
+        return new CheckedImplementation.Body(List.of(parameters), new Core.Int(1, INT, null));
+    }
+
+    private static final BindingOwner OWNER = new BindingOwner.OfValue("demo", "combine");
+    private static int next;
+
+    private static Core.Binder binder(String name) {
+        return new Core.Binder(name, new BindingId(OWNER, next++));
+    }
+}

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputOutsideTheCompilerReadsACheckedProgramTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputOutsideTheCompilerReadsACheckedProgramTest.java
@@ -9,6 +9,7 @@ import souther.compiler.program.CheckedHelper;
 import souther.compiler.program.CheckedImplementation;
 import souther.compiler.program.CheckedModule;
 import souther.compiler.program.CheckedProgram;
+import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
@@ -19,6 +20,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -264,6 +266,123 @@ class AnOutputOutsideTheCompilerReadsACheckedProgramTest {
         Type answers = composed.answers();
         assertInstanceOf(Type.Union.class, answers, "a composition that drops a case answers a sum");
         return ((Type.Union) answers).members().stream().map(TypeSymbol::name).sorted().toList();
+    }
+
+    /**
+     * A body's parameter reads resolve to the parameters the snapshot says it has.
+     *
+     * <p>What a helper's body already allowed. A read carries the binding it was answered with, and
+     * until now nothing said which parameter that binding was: an output emitting {@code $sum}
+     * could see the read and not know which of its locals it names.
+     *
+     * <p>An equality and not the absence of an unresolved read. {@code combine}'s body binds
+     * nothing of its own, so every read in it is a parameter read, and a body whose reads all
+     * resolved because it had none would answer the same as this one.
+     */
+    @Test
+    void everyParameterReadInABodyResolvesToAParameter() {
+        CheckedModule demo = CheckedProgram.of(List.of(TAKES_TWO)).module("demo");
+        CheckedBehavior combine = named(demo, "combine");
+        CheckedImplementation.Body body =
+                (CheckedImplementation.Body) combine.implementation();
+
+        assertEquals(2, body.parameters().size(), "as many bindings as it takes");
+        assertEquals(combine.signature().takes().size(), body.parameters().size(),
+                "so the ith input is parameters().get(i) and takes().get(i)");
+        assertEquals(body.parameters().stream().map(Core.Binder::binding)
+                        .collect(Collectors.toSet()),
+                readsIn(body.body()),
+                "every read in this body is a read of one of them");
+        assertFalse(readsIn(body.body()).isEmpty(), "and it reads them");
+    }
+
+    /**
+     * And in the order the signature is in.
+     *
+     * <p>A set would answer the same for a list assembled backwards, and the two inputs of
+     * {@code combine} are both {@code Int}s — so a reader zipping the binders with
+     * {@code takes()} would be handed the wrong local with nothing to say so.
+     */
+    @Test
+    void theBindersAreInTheOrderTheInputsWereDeclared() {
+        CheckedBehavior combine =
+                named(CheckedProgram.of(List.of(TAKES_TWO)).module("demo"), "combine");
+        CheckedImplementation.Body body = (CheckedImplementation.Body) combine.implementation();
+
+        assertEquals(List.of("first", "second"),
+                body.parameters().stream().map(Core.Binder::name).toList(),
+                "the definition's parameters, in the order it wrote them");
+        // and the body's first read is the first parameter: `first.value - second.value`
+        assertEquals(body.parameters().get(0).binding(), firstReadIn(body.body()).binding());
+    }
+
+    private static final String TAKES_TWO = """
+            module demo
+
+            data Amount = Int
+            data Gap    = { gap: Int }
+
+            behavior combine : (first: Amount, second: Amount) -> Gap constructs Gap
+
+            let combine (first, second) = Gap { gap = first.value - second.value }
+            """;
+
+    /**
+     * An injected dependency is not one of these.
+     *
+     * <p>The definition implementing a behavior takes its declared inputs and then the behaviors it
+     * depends on, and only the first are what a call supplies. A snapshot handing over the whole
+     * parameter list would put a dependency at an index the signature has no type for, and
+     * {@code takes()} would go on saying the behavior takes one.
+     */
+    @Test
+    void aBehaviorsInjectedDependenciesAreNotAmongItsParameters() {
+        CheckedModule demo = CheckedProgram.of(List.of(DEPENDS_ON)).module("demo");
+        CheckedBehavior report = named(demo, "report");
+        CheckedImplementation.Body body = (CheckedImplementation.Body) report.implementation();
+
+        assertEquals(1, report.signature().takes().size(), "one input, as it was declared");
+        assertEquals(List.of("amount"), body.parameters().stream().map(Core.Binder::name).toList(),
+                "the input, and not the behavior it depends on");
+        assertEquals(body.parameters().stream().map(Core.Binder::binding)
+                        .collect(Collectors.toSet()),
+                readsIn(body.body()),
+                "the dependency is reached by name, so nothing in the body reads it as a binding");
+    }
+
+    private static final String DEPENDS_ON = """
+            module demo
+
+            data Amount = Int
+            data Line   = { line: String }
+
+            behavior render : (a: Amount) -> Line constructs Line
+
+            behavior report : (amount: Amount) -> Line
+                depends on render
+
+            let report (amount, render) = render(amount)
+            """;
+
+    /** The binding of every {@code Core.Read} in {@code body}. */
+    private static Set<BindingId> readsIn(Core body) {
+        Set<BindingId> read = new LinkedHashSet<>();
+        for (Core node : everyNodeOf(body)) {
+            if (node instanceof Core.Read r) {
+                read.add(r.binding());
+            }
+        }
+        return read;
+    }
+
+    /** The first read the walk reaches, which for a body of one expression is its leftmost. */
+    private static Core.Read firstReadIn(Core body) {
+        for (Core node : everyNodeOf(body)) {
+            if (node instanceof Core.Read r) {
+                return r;
+            }
+        }
+        throw new AssertionError("this body reads a parameter");
     }
 
     /**


### PR DESCRIPTION
A body read a parameter as a `Core.Read` carrying a `BindingId`, and the snapshot held nothing that said which parameter that binding was. An output emitting a behavior could see the read and not know which of its locals it names. A helper's body has never had that problem.

`CheckedImplementation.Body` now carries the binders of the behavior's declared inputs, in the order `CheckedSignature.takes()` is in — so the `i`th input is `parameters().get(i)` and `takes().get(i)`. The binders and not the types: a type here would be a second reading of what the signature answers.

Three readings, each held where it can be:

- `CheckedBehavior` refuses a body whose binder count and signature disagree. It is the one place both are in hand, and its constructor is the only way one of these is made, so no path into the model can produce a pair that cannot be read as parameters.
- `SpecImplementation` answers which definition implements a behavior and which of its parameters are the declared inputs rather than the behaviors it depends on. It already said what shape such a definition must have; the assembler and the JVM emitter now both read it there, so the local an input arrives in cannot be one thing in the snapshot and another in the emitted program.
- The assembler divides by what the behavior declares, not by how long its signature is. Sliced by the signature the two lengths would agree by construction and the check above would compare an answer with itself.

The emitter used to resolve a behavior's implementation over a map keyed across `emitted(module)`, where a method the module only took on to emit — a recursion another module wrote, a method minted for a row's operand — displaced the `let` of the same name. A behavior's implementation is always a declaration, and `Requirements` looks for one in `fns()` alone; the emitter now agrees.

## Tests

Outside `souther-compiler`, on bodies chosen so the assertions are equalities rather than absences: every read in a body that binds nothing of its own is a read of one of its parameters, the binders are in declaration order, and a behavior's injected dependencies are not among them. Both were checked by mutation — reversing the list and handing over the whole parameter list each fail.

Inside, on the model alone: a mismatch offered directly to `CheckedBehavior` is refused. Reached only through a correct assembler, that constructor would never be asked its own question.

Closes #1068