### PR TITLE
Owe an invariant's line once, where the invariant is written

### DIFF
--- a/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
+++ b/souther-bench/src/test/java/souther/bench/AMeasureIsIntroducedInOnePlaceTest.java
@@ -49,7 +49,7 @@ class AMeasureIsIntroducedInOnePlaceTest {
     /**
      * Every method that makes a state of a measurement, and how many it makes.
      *
-     * <p>One entry per measure's introduction rule, and nothing else. Each of the nine measures has
+     * <p>One entry per measure's introduction rule, and nothing else. Each of the ten measures has
      * one method that decides between the states from what it found and what its reading came to —
      * {@code of} where there is a choice to make, and a named factory for each answer a caller can
      * ask for outright ({@code none}, {@code noRows}, {@code noSubject}, {@code truncated}).
@@ -59,6 +59,14 @@ class AMeasureIsIntroducedInOnePlaceTest {
      * <p><b>By the method, with its parameters.</b> Counted per class, a helper beside one would
      * keep the class's total where it was and answer for nothing; counted per name, an overload
      * would be admitted without anybody deciding it should be.
+     *
+     * <p>The tenth is what an authored line came to across the readings of it
+     * ({@code Coverage#acrossTheReadings}), which is not the same measure as what one of those
+     * readings came to and arrived with issue #1062. One line is read at every position of every
+     * behavior carrying the type, and a row standing at it through any of them is evidence about the
+     * type — so the debt has an answer of its own, and it follows from what the readings found and
+     * from which of them could be hiding a row. Written by each of its readers instead, a report, a
+     * build's refusal, an editor and the generator would fold one set of readings four ways.
      *
      * <p>{@code PairSpace}'s static initialiser makes the one space that is measured in full and
      * holds nothing — a behavior with no pair of positions — and {@code ItemAssessment} makes the
@@ -105,6 +113,7 @@ class AMeasureIsIntroducedInOnePlaceTest {
             Map.entry("souther.compiler.query.PartitionEvidence$AxisCoverage#notAsked(Lsouther/compiler/partition/AxisId;Ljava/lang/String;Ljava/util/List;Lsouther/compiler/query/PartitionEvidence$AxisCoverage$Reading;)Lsouther/compiler/query/PartitionEvidence$AxisCoverage;", 1),
             Map.entry("souther.compiler.query.PartitionEvidence$PairSpace#notAsked(I)Lsouther/compiler/query/PartitionEvidence$PairSpace;", 1),
             Map.entry("souther.compiler.query.ItemAssessment#weakeningSource()Lsouther/compiler/query/Measurement;", 1),
+            Map.entry("souther.compiler.query.ItemAssessment$Coverage#acrossTheReadings(Ljava/util/List;)Lsouther/compiler/query/Measurement;", 5),
             // A behavior whose boundary could not be worked out. Every measure of it is short of
             // the same one thing, so the state is made here and each of them hands its own type
             // parameter to it — five factories and one introduction, which is what keeps them

--- a/souther-bench/src/test/java/souther/bench/OnlyAProjectionSaysHowFarAMeasurementGotTest.java
+++ b/souther-bench/src/test/java/souther/bench/OnlyAProjectionSaysHowFarAMeasurementGotTest.java
@@ -165,6 +165,11 @@ class OnlyAProjectionSaysHowFarAMeasurementGotTest {
      * <p>The factories take the measurement instead, which leaves no argument to pass the wrong
      * thing in: a caller hands over the one it is looking at. This holds the other half — that the
      * canonical constructor, which a public record cannot hide, is not how anybody makes one.
+     *
+     * <p>The two take a {@link souther.compiler.query.FindingSubject} and not a behavior's name.
+     * Still two: what a finding is about became a value rather than a word, because not every
+     * finding is about a behavior (issue #1062). The overloads that take a name hand one over and
+     * make nothing, which is why they are not here.
      */
     @Test
     void aFindingIsMadeFromTheMeasurementThatFoundIt() throws IOException {
@@ -176,12 +181,14 @@ class OnlyAProjectionSaysHowFarAMeasurementGotTest {
             }
         }
         assertEquals(Set.of(
-                        "souther.compiler.query.Adequacy$Finding#by(Ljava/lang/String;"
+                        "souther.compiler.query.Adequacy$Finding#by("
+                                + "Lsouther/compiler/query/FindingSubject;"
                                 + "Lsouther/compiler/query/Measure;"
                                 + "Lsouther/compiler/diag/Citation;"
                                 + "Lsouther/compiler/query/About;)"
                                 + "Lsouther/compiler/query/Adequacy$Finding;",
-                        "souther.compiler.query.Adequacy$Finding#noticed(Ljava/lang/String;"
+                        "souther.compiler.query.Adequacy$Finding#noticed("
+                                + "Lsouther/compiler/query/FindingSubject;"
                                 + "Lsouther/compiler/diag/Citation;"
                                 + "Lsouther/compiler/query/About;)"
                                 + "Lsouther/compiler/query/Adequacy$Finding;"),

--- a/souther-cli/src/test/java/souther/cli/ABoundaryIsAValueTheRecordCanHoldTest.java
+++ b/souther-cli/src/test/java/souther/cli/ABoundaryIsAValueTheRecordCanHoldTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -75,13 +76,48 @@ class ABoundaryIsAValueTheRecordCanHoldTest {
                 | "a" : (Band { low = Ratio(0.1m), high = Ratio(0.9m) }) -> Ok
             """;
 
+    /**
+     * Every point of every line that no row of the model stands at, said per position.
+     *
+     * <p>Read off the measure and not off the report. A line an {@code invariant} drew is owed once
+     * over every position carrying the type, and the report says it once and names it in the terms
+     * the declaration wrote (issue #1062) — so which positions reach a line is a question the report
+     * stopped answering when the debt stopped being a position's. It is answered here, where the
+     * lines are still one per position, which is what these tests are about: whether the value a
+     * record's rules leave a field at is the value the line is drawn at.
+     *
+     * <p>Written the way the report writes it, so that what the tests say is unchanged.
+     */
     private static List<String> boundariesOf(String model) throws Exception {
-        return reportOn(model).lines()
-                .map(String::trim)
-                // The sentence, whichever mark it is printed under. What a build does about a finding
-                // is said by the mark and held by the test that owns it.
-                .filter(line -> line.contains("no row is at"))
-                .toList();
+        souther.compiler.query.Compilation compilation =
+                souther.compiler.query.Compilation.ofSource(model, "Main");
+        compilation.measure(souther.compiler.query.Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        java.util.Map<String, List<souther.compiler.query.BorderAssessment>> borders =
+                // The searched reading, which is what the report is written from: whether a value
+                // at a point could be built is part of what tells a line no row stands at from one
+                // no row could stand at, and the plain measure does not compose one.
+                souther.compiler.query.Adequacy.searchedBoundariesOf(compilation.db(), module);
+        assertNotNull(borders, "the model under test compiles");
+        souther.compiler.diag.SourceNameResolver names =
+                souther.compiler.diag.SourceNameResolver.identity();
+        List<String> out = new java.util.ArrayList<>();
+        borders.forEach((behavior, lines) -> lines.forEach(line -> {
+            for (souther.compiler.query.BorderAssessment.Point point : line.points()) {
+                if (!point.item().isUnmetGap()) {
+                    continue;
+                }
+                out.add(point.role().againstTheLine()
+                        ? "no row is at the " + point.role() + " point " + behavior + "/"
+                                + line.axis() + " = " + point.against()
+                                + " (" + line.describe(names, null) + ")"
+                        : "no row is at an " + point.role() + " point of " + behavior + "/"
+                                + line.axis() + ", " + point.against()
+                                + " (" + line.describe(names, null) + ")");
+            }
+        }));
+        return List.copyOf(out);
     }
 
     /**
@@ -412,7 +448,9 @@ class ABoundaryIsAValueTheRecordCanHoldTest {
         // settled by building one. Two kinds of witness, and the projection proves neither.
         assertTrue(report.contains("border      borders 2   coverage items 2/4   excluded 4"),
                 () -> "the row at 0 is met, and 10 was built and is owed:\n" + report);
-        assertTrue(report.contains("no row is at the ON point f/r.a = 10"), () -> report);
+        // Under the declaration that drew it, in the terms it wrote: the line is owed once over
+        // every position carrying the type (issue #1062).
+        assertTrue(report.contains("no row is at the ON point value = 10"), () -> report);
     }
 
     /**

--- a/souther-cli/src/test/java/souther/cli/ABoundaryIsAValueTheRecordCanHoldTest.java
+++ b/souther-cli/src/test/java/souther/cli/ABoundaryIsAValueTheRecordCanHoldTest.java
@@ -528,8 +528,11 @@ class ABoundaryIsAValueTheRecordCanHoldTest {
 
         List<String> owed = boundariesOf(holed);
 
-        assertFalse(report.contains("f/n = 0"),
-                () -> "0 is no value of `N`, so it is no line of it: " + report);
+        // Asked of the lines the positions have and not of the report, for the reason
+        // `boundariesOf` is: the report names a declaration's line once and in the declaration's
+        // own terms, so a position's absence of one is not a sentence it can be short of.
+        assertFalse(owed.stream().anyMatch(l -> l.contains("f/n = 0")),
+                () -> "0 is no value of `N`, so it is no line of it: " + owed);
         assertTrue(owed.stream().anyMatch(l -> l.contains("f/n = 1")),
                 () -> "the line `within` placed is at the first value the rules leave: " + owed);
         assertTrue(owed.stream().anyMatch(l -> l.contains("f/n = 10")),

--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -179,7 +179,7 @@ final class AReportOfOneBorder {
         return new AdequacyReport(AdequacyReport.SCHEMA_VERSION, "test",
                 held, WeakeningSet.none(),
                 List.of(new AdequacyReport.ModuleReport("example.wide",
-                        new SourceId("wide.sou"), List.of(behavior))))
+                        new SourceId("wide.sou"), List.of(behavior), List.of())))
                 .adequacy();
     }
 }

--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -53,7 +53,7 @@ final class AReportOfOneBorder {
     static Border aBoundedBorder() {
         OriginRef origin = new OriginRef.InvariantOrigin(new RuleRef.Invariant(new Clause.Ref(
                 new Clause.Id(TypeSymbols.declared(new TypeKey("example.rate", "Amount")), 0),
-                java.util.Optional.of(new ClauseName("cap")))), true);
+                java.util.Optional.of(new ClauseName("cap")))), 0, true);
         return Border.at(
                 BoundaryTarget.at(
                         new BorderQuantity.OfACoordinate(new AxisId("weigh", "w.a"),
@@ -70,7 +70,7 @@ final class AReportOfOneBorder {
     static Border aBorderAtTheEdgeOfItsDomain() {
         OriginRef origin = new OriginRef.InvariantOrigin(new RuleRef.Invariant(new Clause.Ref(
                 new Clause.Id(TypeSymbols.declared(new TypeKey("example.rate", "Amount")), 0),
-                java.util.Optional.of(new ClauseName("cap")))), true);
+                java.util.Optional.of(new ClauseName("cap")))), 0, true);
         return Border.at(
                 BoundaryTarget.at(
                         new BorderQuantity.OfACoordinate(new AxisId("weigh", "w.a"),

--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -179,7 +179,7 @@ final class AReportOfOneBorder {
         return new AdequacyReport(AdequacyReport.SCHEMA_VERSION, "test",
                 held, WeakeningSet.none(),
                 List.of(new AdequacyReport.ModuleReport("example.wide",
-                        new SourceId("wide.sou"), List.of(behavior), List.of())))
+                        new SourceId("wide.sou"), List.of(behavior), List.of(), List.of())))
                 .adequacy();
     }
 }

--- a/souther-cli/src/test/java/souther/cli/AnEndIsWhereItsRuleStopsTest.java
+++ b/souther-cli/src/test/java/souther/cli/AnEndIsWhereItsRuleStopsTest.java
@@ -93,7 +93,7 @@ class AnEndIsWhereItsRuleStopsTest {
                 """);
 
         assertFalse(report.contains("not known to be writable: the ON point take/h.b = 10"), () -> report);
-        assertTrue(report.contains("no row is at the ON point take/h.b = 10"),
+        assertTrue(report.contains("no row is at the ON point value = 10"),
                 () -> "and the edge is one a row is owed at:\n" + report);
     }
 

--- a/souther-cli/src/test/java/souther/cli/AnEndIsWhereItsRuleStopsTest.java
+++ b/souther-cli/src/test/java/souther/cli/AnEndIsWhereItsRuleStopsTest.java
@@ -48,7 +48,7 @@ class AnEndIsWhereItsRuleStopsTest {
     void anEdgeIsNotAtAValueNoRuleNamed() throws Exception {
         String report = reportOn(MODEL);
 
-        assertFalse(report.contains("take/h.p = 1"),
+        assertFalse(report.contains("point value = 1"),
                 () -> "`value > 0m` says nothing about one:\n" + report);
     }
 

--- a/souther-cli/src/test/java/souther/cli/WhatStrictRefusesIsWhatTheRowsDoNotCoverTest.java
+++ b/souther-cli/src/test/java/souther/cli/WhatStrictRefusesIsWhatTheRowsDoNotCoverTest.java
@@ -168,7 +168,7 @@ class WhatStrictRefusesIsWhatTheRowsDoNotCoverTest {
         Run before = examples(WAITING_AND_UNCOVERED, "--generate", "--boundaries", "--strict");
 
         assertEquals(1, before.code(), before.out() + before.err());
-        assertTrue(before.out().contains("no row is at the ON point baseRate/score = 0"), before.out());
+        assertTrue(before.out().contains("no row is at the ON point value = 0"), before.out());
         assertTrue(before.out().contains("1 row waiting for a `let`."), before.out());
         // The row the block proposes, which is what the pasted model below answers.
         assertTrue(before.out().contains("| (RiskScore(0)) -> <?>"), before.out());

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBorders.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBorders.java
@@ -1,0 +1,71 @@
+package souther.compiler.check;
+
+import souther.compiler.types.TypeSymbol;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The lines one declaration draws, in the terms the declaration writes them.
+ *
+ * <p>What a report calls a line where it prints it under the declaration rather than under a
+ * behavior. {@code UserId}'s clause draws {@code String.length(value) = 1}; the behaviors carrying
+ * the type meet that line at {@code String.length(draft.owner)} and at
+ * {@code String.length(activities[*]@CallTask.owner)}, and neither of those is what the author
+ * wrote. A debt named after one of them would be named after whichever reading a report happened to
+ * reach first (issue #1062).
+ *
+ * <p><b>Asked of the declaration, rather than carried from the readings.</b> Which number a clause
+ * bounds is read from whatever value the reading started at — {@code Day}'s clause is about
+ * {@code value} read from {@code Day} and about {@code d} read from the {@code Span} holding it —
+ * so a coordinate that travelled here with a measurement would be one frame of several and nothing
+ * would say which. Read from the declaration, there is one frame and it is the author's.
+ *
+ * <p>Nothing here is an identity. What tells one authored line from another is the clause and which
+ * of its conjuncts drew the end ({@link souther.compiler.partition.BorderObligationId}), and that is
+ * what this is keyed by; what it hands back is what to call the line. Held as part of the identity,
+ * the frames above would make one line two.
+ */
+public record DeclaredBorders(Map<Key, FieldDomains.Coordinate> forms) {
+
+    /** Which authored line: the clause, and which of its conjuncts placed the end. */
+    public record Key(RuleRef.Invariant rule, int conjunct) {}
+
+    /** Nothing was written on the declaration, or it is not one this can read. */
+    public static final DeclaredBorders NONE = new DeclaredBorders(Map.of());
+
+    public DeclaredBorders {
+        forms = Map.copyOf(forms);
+    }
+
+    /**
+     * The lines {@code declaredOn} draws.
+     *
+     * <p>The declaration's own reading of its own rules, which is the reading whose frame is the
+     * author's. One of these serves every debt of one declaration, so a caller printing a report
+     * asks once per declaration rather than once per line.
+     */
+    public static DeclaredBorders of(TypeSymbol declaredOn, Symbols symbols, ReadingPolicy policy) {
+        Map<Key, FieldDomains.Coordinate> forms = new LinkedHashMap<>();
+        for (FieldDomains.Placed placed : Rules.of(declaredOn, symbols, policy).bounds().placed()) {
+            // A clause reaching this declaration through a spread is written on another one and is
+            // that one's to name, the way a line is named by the rule that drew it (ADR-0090). Its
+            // own reading answers for it.
+            if (placed.from().clause().id().declaredOn().equals(declaredOn)) {
+                forms.put(new Key(placed.from(), placed.conjunct()), placed.at());
+            }
+        }
+        return forms.isEmpty() ? NONE : new DeclaredBorders(forms);
+    }
+
+    /**
+     * What the author wrote the line on, or null where this declaration draws no such line.
+     *
+     * <p>Null is an answer about the reading and not about the line: a clause whose end this could
+     * not read is a clause with no form to print, and a caller handed one has nothing to call the
+     * line but the rule's own name.
+     */
+    public FieldDomains.Coordinate at(RuleRef.Invariant rule, int conjunct) {
+        return forms.get(new Key(rule, conjunct));
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBorders.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBorders.java
@@ -66,6 +66,12 @@ public record DeclaredBorders(Map<Key, FieldDomains.Coordinate> forms) {
      * line but the rule's own name.
      */
     public FieldDomains.Coordinate at(RuleRef.Invariant rule, int conjunct) {
-        return forms.get(new Key(rule, conjunct));
+        return at(new Key(rule, conjunct));
+    }
+
+    /** The same, for a caller holding the key the rule handed it
+     *  ({@code OriginRef.declaredLine}). */
+    public FieldDomains.Coordinate at(Key line) {
+        return forms.get(line);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBorders.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBorders.java
@@ -21,20 +21,26 @@ import java.util.Map;
  * so a coordinate that travelled here with a measurement would be one frame of several and nothing
  * would say which. Read from the declaration, there is one frame and it is the author's.
  *
+ * <p>Where the declaration is written is read here too, because a report sends a reader to it and
+ * a caller that looked it up separately would have a second way of finding one declaration — and a
+ * policy of its own for the one that came back empty, which is a null place reaching a reader as a
+ * switch over the arms a citation has.
+ *
  * <p>Nothing here is an identity. What tells one authored line from another is the clause and which
  * of its conjuncts drew the end ({@link souther.compiler.partition.BorderObligationId}), and that is
  * what this is keyed by; what it hands back is what to call the line. Held as part of the identity,
  * the frames above would make one line two.
  */
-public record DeclaredBorders(Map<Key, FieldDomains.Coordinate> forms) {
+public record DeclaredBorders(souther.compiler.diag.Citation at,
+                              Map<Key, FieldDomains.Coordinate> forms) {
 
     /** Which authored line: the clause, and which of its conjuncts placed the end. */
     public record Key(RuleRef.Invariant rule, int conjunct) {}
 
-    /** Nothing was written on the declaration, or it is not one this can read. */
-    public static final DeclaredBorders NONE = new DeclaredBorders(Map.of());
-
     public DeclaredBorders {
+        if (at == null) {
+            throw new IllegalArgumentException("a declaration is written somewhere");
+        }
         forms = Map.copyOf(forms);
     }
 
@@ -46,6 +52,15 @@ public record DeclaredBorders(Map<Key, FieldDomains.Coordinate> forms) {
      * asks once per declaration rather than once per line.
      */
     public static DeclaredBorders of(TypeSymbol declaredOn, Symbols symbols, ReadingPolicy policy) {
+        // Where the declaration is, read here with what it draws. A caller that asked one thing for
+        // the name and another for the place would have two ways of finding one declaration, and a
+        // policy of its own for the one that came back empty.
+        if (!(symbols.declarations().declaration(declaredOn) instanceof souther.compiler.ast.Hir.Data
+                data)) {
+            throw new IllegalArgumentException(
+                    "there is no declaration of " + declaredOn.name() + " to read");
+        }
+        souther.compiler.diag.Citation at = souther.compiler.diag.Citation.of(data.pos());
         Map<Key, FieldDomains.Coordinate> forms = new LinkedHashMap<>();
         for (FieldDomains.Placed placed : Rules.of(declaredOn, symbols, policy).bounds().placed()) {
             // A clause reaching this declaration through a spread is written on another one and is
@@ -55,7 +70,7 @@ public record DeclaredBorders(Map<Key, FieldDomains.Coordinate> forms) {
                 forms.put(new Key(placed.from(), placed.conjunct()), placed.at());
             }
         }
-        return forms.isEmpty() ? NONE : new DeclaredBorders(forms);
+        return new DeclaredBorders(at, forms);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBounds.java
@@ -31,6 +31,40 @@ import java.util.List;
 public final class DeclaredBounds {
 
     /**
+     * One rule that put an end here, and which number of the declaration it was written about.
+     *
+     * <p>The pair and not the rule alone. One clause can bound two numbers of one declaration —
+     * {@code invariant both = String.length(name) >= 1 && String.length(code) >= 1} places two ends
+     * at one value — and they are two lines an author drew: a row whose {@code name} is one
+     * character says nothing about {@code code}. Held as the rule, the two came out as one thing to
+     * write a row for, which is the mistake issue #1062 is about with the halves the other way round.
+     *
+     * <p><b>The conjunct and not the number it was written about.</b> Which coordinate a clause
+     * bounded is read from whatever value the reading started at — {@code Day}'s own clause is about
+     * {@code value} read from {@code Day} and about {@code d} read from the {@code Span} holding it
+     * — so two readings of one line spell the coordinate two ways, and an identity built on it calls
+     * one authored line two. The conjunct is the clause's own text: it is the same number whichever
+     * value the reading started at, and it is what tells the ends of {@code value >= 0 && value <=
+     * 10} apart.
+     *
+     * <p>Counted over every conjunct and not over the ones a line came out of, so that a reading
+     * that could make nothing of one conjunct still numbers the next the same as a reading that
+     * could.
+     */
+    public record Drawn(RuleRef.Invariant rule, int conjunct) {
+
+        public Drawn {
+            if (rule == null) {
+                throw new IllegalArgumentException("a rule put an end here, and this is which");
+            }
+            if (conjunct < 0) {
+                throw new IllegalArgumentException(
+                        "a conjunct of a clause is counted from zero: " + conjunct);
+            }
+        }
+    }
+
+    /**
      * One end of a range, and every rule that put it there.
      *
      * <p>Rules, plural. Two layers can state the same bound — a wrapper repeating what it wraps — and
@@ -46,7 +80,7 @@ public final class DeclaredBounds {
      * reference, it built the identity back for itself, which is a decision about what a rule is
      * being taken by whoever happened to consume one.
      */
-    public record End(Endpoint at, List<RuleRef.Invariant> from) {
+    public record End(Endpoint at, List<Drawn> from) {
 
         public Place value() {
             return at.at();
@@ -71,7 +105,7 @@ public final class DeclaredBounds {
             if (had.value().compareTo(one.value()) != 0) {
                 return at == had.at() ? had : one;
             }
-            List<RuleRef.Invariant> both = new ArrayList<>(had.from());
+            List<Drawn> both = new ArrayList<>(had.from());
             one.from().stream().filter(n -> !both.contains(n)).forEach(both::add);
             return new End(at, List.copyOf(both));
         }
@@ -125,7 +159,13 @@ public final class DeclaredBounds {
             for (TypeOps.Declared declared
                     : TypeOps.declaredInvariants(named, layer.data(), symbols, _ -> null)) {
                 RuleRef.Invariant rule = new RuleRef.Invariant(Clause.Ref.of(declared));
+                // Which conjunct of the clause each end came out of, counted over all of them in
+                // the order the clause was written. The other reading of these clauses counts them
+                // the same way, which is what makes an end read here and an end read through the
+                // value this type sits in one line rather than two.
+                int conjunct = -1;
                 for (Hir.Expr each : ClauseHelpers.conjunctsOf(declared.clause().expr())) {
+                    conjunct++;
                     // An end and nothing else. A rule this reads no end from narrows nothing here,
                     // and a rule stepping past the last value of the order states an end no value is
                     // at — which is a declaration with no value, answered where counts are and not
@@ -136,7 +176,7 @@ public final class DeclaredBounds {
                         continue;
                     }
                     InvariantBound read = placed.bound();
-                    End end = new End(read.end(), List.of(rule));
+                    End end = new End(read.end(), List.of(new Drawn(rule, conjunct)));
                     if (read.lower()) {
                         min = End.tighter(min, end, false);
                     } else {
@@ -170,7 +210,7 @@ public final class DeclaredBounds {
             if (!each.at().kind().equals(kind)) {
                 continue;
             }
-            End end = new End(each.end(), List.of(each.from()));
+            End end = new End(each.end(), List.of(new Drawn(each.from(), each.conjunct())));
             if (each.lower()) {
                 min = End.tighter(min, end, false);
             } else {

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -401,7 +401,8 @@ public final class FieldDomains {
      *              other kind of rule reaches this reading
      * @param lower whether this bounds the coordinate below; otherwise above
      */
-    public record Placed(Coordinate at, RuleRef.Invariant from, boolean lower, Endpoint end) {
+    public record Placed(Coordinate at, RuleRef.Invariant from, boolean lower, Endpoint end,
+                        int conjunct) {
 
         /** Where in the value the end sits. Never which number it is on: that is {@link #at}, and
          *  reading one off the other is what the pair exists to stop. */
@@ -829,7 +830,7 @@ public final class FieldDomains {
     public List<Placed> placed() {
         return directs.stream()
                 .map(each -> new Placed(each.at(), each.from(),
-                        each.bound().lower(), each.bound().end()))
+                        each.bound().lower(), each.bound().end(), each.conjunct()))
                 .toList();
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -871,7 +871,7 @@ public final class InvariantChecker {
      *                 they came back as one
      */
     record Direct(FieldDomains.Coordinate at, RuleRef.Invariant from,
-                  InvariantBound bound, Core part) {
+                  InvariantBound bound, Core part, int conjunct) {
 
         /** Where in the value the end was placed. Never which end it is: one position carries more
          *  than one number and {@link #at} is what says which of them this is. */
@@ -1123,7 +1123,7 @@ public final class InvariantChecker {
         Map<RuleRef, Required> raised = new LinkedHashMap<>();
         Map<RuleRef, Map<Core, Required>> raisedByPart = new LinkedHashMap<>();
         stated.forEach(each ->
-                direct(each.clause(), each.from(), at, byName, out, noLines, narrowers, raised,
+                direct(each.clause(), each.from(), new int[1], at, byName, out, noLines, narrowers, raised,
                         took, typeAt, parts, raisedByPart));
         // Insertion order, kept: `Map.copyOf` iterates in an order salted once per JVM run, and
         // what a report prints for a position is these in the order the declaration writes them.
@@ -1221,7 +1221,7 @@ public final class InvariantChecker {
      * asked once — read apart, the second would be a walk that had to agree with this one about which
      * comparisons it had already accounted for.
      */
-    private void direct(Core clause, RuleRef.Invariant from, Denotations at,
+    private void direct(Core clause, RuleRef.Invariant from, int[] conjunct, Denotations at,
                         Map<FactSubject, Coordinate> byName, List<Direct> out,
                         List<FieldDomains.NoLine> noLines,
                         Map<String, List<TypeSymbol>> narrowers,
@@ -1229,18 +1229,27 @@ public final class InvariantChecker {
                         Map<String, Type> typeAt,
                         PartsRead parts,
                         Map<RuleRef, Map<Core, Required>> raisedByPart) {
+        if (clause instanceof Core.Binary and && and.op() == BinOp.AND) {
+            // One rule the author wrote, so what it raises is what its conjuncts raise together.
+            // Left before right, which is the order the clause was written in and the order
+            // {@code ClauseHelpers.conjunctsOf} reads it in: the two readings of one clause number
+            // its conjuncts alike, which is what lets a line drawn here be recognised as the line
+            // the declaration's own reading drew (issue #1062).
+            direct(and.left(), from, conjunct, at, byName, out, noLines, narrowers, raised, took,
+                    typeAt, parts, raisedByPart);
+            direct(and.right(), from, conjunct, at, byName, out, noLines, narrowers, raised, took,
+                    typeAt, parts, raisedByPart);
+            return;
+        }
+        // Which conjunct of the clause this is, taken here so that every one of them is numbered —
+        // including the ones no end comes out of. Numbered only where a line was drawn, the count
+        // would depend on what this reading could make of the conjuncts before it, and two readings
+        // of one clause would disagree about which line is which.
+        int part = conjunct[0]++;
         if (!(clause instanceof Core.Binary bin)) {
             settle(clause, from, states(clause, at, byName, null),
                     new InvariantBound.Read.NoEnd(),
                     at, byName, raised, took, typeAt, parts, raisedByPart);
-            return;
-        }
-        if (bin.op() == BinOp.AND) {
-            // One rule the author wrote, so what it raises is what its conjuncts raise together.
-            direct(bin.left(), from, at, byName, out, noLines, narrowers, raised, took, typeAt,
-                    parts, raisedByPart);
-            direct(bin.right(), from, at, byName, out, noLines, narrowers, raised, took, typeAt,
-                    parts, raisedByPart);
             return;
         }
         if (!InvariantBound.ordering(bin.op()) && bin.op() != BinOp.EQ) {
@@ -1317,7 +1326,7 @@ public final class InvariantChecker {
             return;
         }
         if (end instanceof InvariantBound.Read.AnEnd placed) {
-            out.add(new Direct(found.at(), from, placed.bound(), bin));
+            out.add(new Direct(found.at(), from, placed.bound(), bin, part));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -64,6 +64,19 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
         return demands.get(role);
     }
 
+    /**
+     * What a row here is owed for, which several readings of this line share.
+     *
+     * <p>The line the author wrote, without the position it was read at. Everything that folds
+     * readings together keys on this; everything that says where a row would go reads {@link #cut}.
+     * Both are here rather than one being worked out from the other by whoever needs it, because a
+     * caller deriving a key from the parts it happened to know is how one clause's row came to be
+     * asked for once per position of every behavior carrying the type (issue #1062).
+     */
+    public BorderObligationId obligation() {
+        return new BorderObligationId(origin, cut.at());
+    }
+
     /** Where the line is, as a report names it. Not what any one of its points asks for: that is
      *  {@link #label(PointRole)}, and the two differ at three of the four. */
     public String label() {

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderObligationId.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderObligationId.java
@@ -1,0 +1,61 @@
+package souther.compiler.partition;
+
+/**
+ * What a row is owed for: one line the author wrote, wherever it is read.
+ *
+ * <p>The key evidence is interchangeable under. Two readings are one debt when a row standing at
+ * either establishes what a row standing at the other would, and that is a property of the line and
+ * not of the reading — so {@code UserId}'s clause saying a user id is a string of one character or
+ * more is one row to write, whether the position it was read at is {@code draft.owner} or
+ * {@code activities[*]@CallTask.owner}, and whether the behavior carrying it is {@code scheduleMeeting}
+ * or {@code touchCount}. Neither behavior says anything about the length of a user id, so neither
+ * can disagree with the other about a row at length 1 (issue #1062).
+ *
+ * <p><b>Not the rule.</b> One clause places two ends: {@code invariant within = value >= 1 && value
+ * <= 10} is one {@link souther.compiler.check.RuleRef.Invariant} and two lines, and a row at the
+ * bottom of the range is no evidence about the top. Keyed on the rule, the author writes one row and
+ * the other end goes quiet.
+ *
+ * <p><b>Not the level either.</b> Two rules can cut at one value on one carrier — a record stopping
+ * a {@code Minute} at 1000 and another record stopping it at the same 1000 — and each is a rule the
+ * author could change without touching the other. That is the accounting {@link OriginRef} already
+ * keeps for cuts, and it is kept here for the same reason.
+ *
+ * <p><b>And not where it was read.</b> The quantity a line was met on — which position of which
+ * behavior — is the occurrence, one per position of every behavior carrying the type. It is what
+ * {@link Border#cut()} holds, and holding it here is what asked for one clause's row 126 times over
+ * {@code crm}'s {@code UserId}.
+ *
+ * <p>Three identities and not one, the way {@link souther.compiler.coverage.CoverageSites.Obligation}
+ * and {@link souther.compiler.coverage.ControlPointId} are on the arm side. {@link OriginRef#rule()}
+ * answers which rule of the model this came from and is provenance; this answers which debt it is;
+ * {@link Border} answers where it was read. A narrowing moves the second without moving the first:
+ * {@code MinuteOfDay}'s maximum is the same rule whether or not {@code WorkInterval} moved where it
+ * lands, and the line the two settled together is not the line the bound would have drawn alone — so
+ * it comes back the same from {@code rule()} and different from here.
+ *
+ * @param origin the rule that drew the line, as the reading met it — narrowings and all, because a
+ *               narrowed end is a distinction the narrowing declarations authored and not one the
+ *               bound authored on its own
+ * @param at     where on the quantity it cut. A level and not a place: what a line is drawn on is
+ *               not always a position, and two of the three shapes count something no position holds
+ */
+public record BorderObligationId(OriginRef origin, Level at) {
+
+    public BorderObligationId {
+        if (origin == null || at == null) {
+            throw new IllegalArgumentException(
+                    "a debt is some rule's line somewhere: " + origin + " " + at);
+        }
+    }
+
+    /**
+     * Which rule of the model this came from, through however many narrowings.
+     *
+     * <p>Provenance, and never a key. Offered here so that a reader wanting to say what drew the
+     * line does not reach past this into the origin and come back holding something that groups.
+     */
+    public souther.compiler.check.RuleRef provenance() {
+        return origin.rule();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/GenerationOutcome.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GenerationOutcome.java
@@ -133,6 +133,18 @@ public sealed interface GenerationOutcome {
          */
         public enum Reason {
 
+            /**
+             * The line is owed once across every reading of it, and the search is asked of one.
+             *
+             * <p>A row at the line is composed by walking one behavior's inputs, and a line an
+             * {@code invariant} drew is owed by the declaration rather than by any of the behaviors
+             * carrying the type (issue #1062). Which reading composes the one row a debt is owed is
+             * a search over the readings and not a fold of them, and nothing does it yet.
+             */
+            NO_SEARCH_IS_ASKED_FOR_A_LINE_ACROSS_ITS_READINGS(
+                    "a row is composed by walking one behavior's inputs, and this line is owed once"
+                            + " over every behavior carrying the type"),
+
             /** The fork this arm belongs to is one no position of the inputs could be named for. */
             NO_WAY_INTO_THIS_ARM_CAN_BE_NAMED(
                     "a row is steered into an arm by the decisions that hold on the way there, and"

--- a/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
@@ -2,7 +2,6 @@ package souther.compiler.partition;
 
 import souther.compiler.check.Carrier;
 import souther.compiler.check.DeclaredBounds;
-import souther.compiler.check.RuleRef;
 import souther.compiler.check.Symbols;
 import souther.compiler.inputs.Position;
 import souther.compiler.numeric.Endpoint;
@@ -128,8 +127,10 @@ final class LocalInspection {
         // was settled where the clause was read and arrives as it was. What is added is a
         // boundary's own answer about that rule — that a reading of it drew this cut, taken in by
         // these declarations — which is nothing the rule says about itself.
-        for (RuleRef.Invariant from : end.from()) {
-            put(into, carrier, end.value(), new OriginRef.InvariantOrigin(from, end.at().inclusive()),
+        for (DeclaredBounds.Drawn from : end.from()) {
+            put(into, carrier, end.value(),
+                    new OriginRef.InvariantOrigin(from.rule(), from.conjunct(),
+                            end.at().inclusive()),
                     moved ? within : List.<TypeSymbol>of());
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
@@ -328,6 +328,28 @@ public sealed interface OriginRef {
     }
 
     /**
+     * Which authored line of a declaration this is, where it is a declaration's line.
+     *
+     * <p>The clause and the conjunct that drew the end, which together name one line the author
+     * wrote — a clause places as many as it has conjuncts with an end in them, and they are not each
+     * other's ({@link souther.compiler.check.DeclaredBorders}).
+     *
+     * <p>Here rather than at the reader that needs it, for the reason {@link #owedToTheDeclaration}
+     * is: a caller taking the clause and the conjunct apart has to know which arms have them, and a
+     * rule added later is then answered by whichever arm it was written beside. Both questions are
+     * the rule's, so both are asked of it.
+     */
+    default java.util.Optional<souther.compiler.check.DeclaredBorders.Key> declaredLine() {
+        return switch (this) {
+            case InvariantOrigin i ->
+                    java.util.Optional.of(
+                            new souther.compiler.check.DeclaredBorders.Key(i.rule(), i.conjunct()));
+            case ComparisonOrigin _, EnsuresOrigin _ -> java.util.Optional.empty();
+            case NarrowedOrigin n -> n.bound().declaredLine();
+        };
+    }
+
+    /**
      * Which comparison a row has to get an answer out of, for a rule that meeting takes more than
      * writing the value.
      *

--- a/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
@@ -300,6 +300,34 @@ public sealed interface OriginRef {
     }
 
     /**
+     * The declaration this line is owed to, where it is a declaration's line rather than a body's.
+     *
+     * <p>Whose debt a row at the line is. A clause of a {@code data} says something about the type
+     * wherever the type is carried, so a row standing at the line is evidence about the type and the
+     * behaviors carrying it have nothing to add — one line, owed once, at the declaration that wrote
+     * it. A comparison and an {@code ensures} clause are written in a body and say something about
+     * that body at that position, so they are owed per behavior, as they were.
+     *
+     * <p>Asked of the rule rather than matched on which kind it is. Read by a caller as "is this an
+     * invariant", the question would be asked again wherever a report, a build's refusal or an
+     * editor wanted it, and a rule added later would be whatever the arm it was written next to
+     * happened to say (issue #1062).
+     *
+     * <p>A narrowed end is the bound's declaration. The declarations that took it in are what
+     * {@link #describe} says beside the rule, and each of them is one where taking any away leaves
+     * the end where it is — so there is no one of them to send a reader to, and the rule that placed
+     * the end is where the line came from.
+     */
+    default java.util.Optional<TypeSymbol> owedToTheDeclaration() {
+        return switch (this) {
+            case InvariantOrigin i ->
+                    java.util.Optional.of(i.rule().clause().id().declaredOn());
+            case ComparisonOrigin _, EnsuresOrigin _ -> java.util.Optional.empty();
+            case NarrowedOrigin n -> n.bound().owedToTheDeclaration();
+        };
+    }
+
+    /**
      * Which comparison a row has to get an answer out of, for a rule that meeting takes more than
      * writing the value.
      *

--- a/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
@@ -38,6 +38,13 @@ public sealed interface OriginRef {
      * declaration bounding a position at one value came out as one origin, and the cut kept one
      * rule where ADR-0090 says it keeps every rule that drew it.
      *
+     * @param conjunct        which conjunct of the clause drew this end. What tells one line of a
+     *                        clause from another where the clause drew several: {@code
+     *                        String.length(name) >= 1 && String.length(code) >= 1} is one clause and
+     *                        two lines at one value, and a row at either says nothing about the
+     *                        other. The clause's own text and not the number it was written about,
+     *                        which is spelled differently by every reading that reaches it
+     *                        ({@link souther.compiler.check.DeclaredBounds.Drawn})
      * @param holdsAtTheValue whether the cut value is one the bound admits, which is the end's own
      *                        inclusivity and is what says whether a row at the cut is the border's
      *                        {@code ON} point or its {@code OFF} point. Carried for the same reason
@@ -51,11 +58,16 @@ public sealed interface OriginRef {
      *                        derivation gets and not one about the end, and reading the end is what
      *                        keeps the two from being confused if it ever does get further
      */
-    record InvariantOrigin(RuleRef.Invariant rule, boolean holdsAtTheValue) implements OriginRef {
+    record InvariantOrigin(RuleRef.Invariant rule, int conjunct, boolean holdsAtTheValue)
+            implements OriginRef {
 
         public InvariantOrigin {
             if (rule == null) {
                 throw new IllegalArgumentException("a bound drawn by no clause");
+            }
+            if (conjunct < 0) {
+                throw new IllegalArgumentException(
+                        "a conjunct of a clause is counted from zero: " + conjunct);
             }
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/About.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/About.java
@@ -103,6 +103,15 @@ public sealed interface About {
         public APointOfADeclaredBorder {
             java.util.Objects.requireNonNull(debt, "a finding is about something");
             java.util.Objects.requireNonNull(role, "and a border is owed a row in four roles");
+            // Two of the four. A region is not a debt's: where it stops is settled by every other
+            // rule reaching the position it is a region of, so a row well inside one reading is not
+            // a row that could stand at another — and this finding would be about a line while
+            // naming what a position asks.
+            if (!BorderObligationAssessment.AGAINST_THE_LINE.contains(role)) {
+                throw new IllegalArgumentException(
+                        "a line a declaration is owed is owed at the points against it, and "
+                                + role + " is a region of a position");
+            }
         }
 
         /** What became of this point, which is what the finding is about. */

--- a/souther-compiler/src/main/java/souther/compiler/query/About.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/About.java
@@ -84,6 +84,34 @@ public sealed interface About {
     }
 
     /**
+     * A point of a line a declaration drew, that no row anywhere in the module stands at.
+     *
+     * <p>Beside {@link APointOfABorder} rather than among its findings, and the difference is which
+     * question was answered. That one is about a line as one position of one behavior met it, and a
+     * row written for that behavior answers it. This one is about the line itself: {@code UserId}
+     * says a user id is a string of one character or more, whether the compiler believes a row
+     * standing at length 1 is a question about {@code UserId}, and the answer cannot differ between
+     * the behaviors carrying it. One row anywhere settles it.
+     *
+     * <p>Which is why it carries the debt and not one of the readings. Over {@code crm} one clause
+     * of {@code UserId} is read at 126 positions; a finding naming one of them would name whichever
+     * the walk reached first, and an author sent there would be sent to a body that says nothing
+     * about the length of a user id (issue #1062).
+     */
+    record APointOfADeclaredBorder(BorderObligationAssessment debt,
+                                   souther.compiler.partition.PointRole role) implements About {
+        public APointOfADeclaredBorder {
+            java.util.Objects.requireNonNull(debt, "a finding is about something");
+            java.util.Objects.requireNonNull(role, "and a border is owed a row in four roles");
+        }
+
+        /** What became of this point, which is what the finding is about. */
+        public ItemAssessment item() {
+            return debt.at(role);
+        }
+    }
+
+    /**
      * A finding about one rule of the model, which is what carries its identity.
      *
      * <p>Which findings these are is answered here and nowhere else. Read off a list of kinds, a

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1411,7 +1411,13 @@ public final class Adequacy {
      */
     public static GenerationOutcome whereNoRowCouldAnswer(About about) {
         return switch (about) {
-            case About.APointOfABorder _, About.ACaseNoRowAppliesItTo _, About.AClassNoRowIsIn _,
+            // A row stands at a line whoever the line is owed to, so a line a declaration is owed
+            // is answered here the way a line a body drew is. Whether anything composes that row is
+            // the other question and is the generation's ({@link #generatedForDeclarationsOf});
+            // answered here, the two would be one and a reader asking whether a row could settle
+            // this would be told what the search happens to be arranged to do.
+            case About.APointOfABorder _, About.APointOfADeclaredBorder _,
+                 About.ACaseNoRowAppliesItTo _, About.AClassNoRowIsIn _,
                  About.AnArmNoRowGoesThrough _ -> null;
             case About.ACaseNoRowExpects _ -> new GenerationOutcome.NotSupported(
                     GenerationOutcome.NotSupported.Reason.NO_STRATEGY_FOR_AN_OUTPUT_CASE);
@@ -1471,6 +1477,39 @@ public final class Adequacy {
             }
         }
         return Ordered.map(out);
+    }
+
+    /**
+     * What the generator can do about what the module's declarations are short of.
+     *
+     * <p>Beside {@link #generatedOf}, which answers per behavior. A line an {@code invariant} drew is
+     * not any behavior's, so a walk over the behaviors answers for every finding but those — and a
+     * block that printed only what it managed would read as though it had filled everything, which
+     * is the whole reason a disposition is kept beside each finding rather than dropped.
+     *
+     * <p>Every one of them, and each with the answer its own shape gets. Nothing composes a row for
+     * one of these yet: a row is composed by walking one behavior's inputs and this line is owed
+     * once over every behavior carrying the type, so which reading composes the one row it is owed
+     * is a search over the readings and not a fold of them.
+     */
+    public static List<GenerationDisposition> generatedForDeclarationsOf(Db db, String module) {
+        List<Finding> findings = db.ask(new Findings(module)).value();
+        if (findings == null) {
+            return List.of();
+        }
+        List<GenerationDisposition> out = new ArrayList<>();
+        for (Finding finding : findings) {
+            if (!(finding.subject() instanceof FindingSubject.OfADeclaration)) {
+                continue;
+            }
+            // One answer, and it is about the search rather than about the line: a row is composed
+            // by walking one behavior's inputs, and which reading composes the one row a debt is
+            // owed is a search over the readings rather than a fold of them.
+            out.add(new GenerationDisposition(finding, new GenerationOutcome.NotSupported(
+                    GenerationOutcome.NotSupported.Reason
+                            .NO_SEARCH_IS_ASKED_FOR_A_LINE_ACROSS_ITS_READINGS)));
+        }
+        return List.copyOf(out);
     }
 
     /** The same, with a value composed at every point worth one — which is a request, and costs what
@@ -2563,7 +2602,10 @@ public final class Adequacy {
                             case About.AClassNoRowIsIn(var missing) -> atClass(missing, composed);
                             case About.AnArmNoRowGoesThrough(var arm) -> atArm(arm, composed);
                             // The eight above, which is what `none` was not null for.
-                            case About.ACaseNoRowExpects _, About.ACaseNothingWasSeenToProduce _,
+                            // A line a declaration is owed is not one of this behavior's findings,
+                            // so nothing reaches here with one.
+                            case About.APointOfADeclaredBorder _,
+                                    About.ACaseNoRowExpects _, About.ACaseNothingWasSeenToProduce _,
                                     About.APositionNoLineDivides _,
                                     About.APositionThisCouldNotRead _,
                                     About.ARuleWithoutALine _,
@@ -3397,6 +3439,11 @@ public final class Adequacy {
                 case About.ACaseNothingWasSeenToProduce _ -> Kind.OUTPUT_CASE_UNVERIFIED;
                 case About.ACaseNoRowAppliesItTo _ -> Kind.INPUT_CASE_UNSPECIFIED;
                 case About.AClassNoRowIsIn _ -> Kind.AXIS_CLASS_UNCOVERED;
+                // The same two rules, asked of the role. A line owed once over its readings and a
+                // line owed at one of them are the same technique's item and are told apart under
+                // the same two codes.
+                case About.APointOfADeclaredBorder(var _, var role) -> role.againstTheLine()
+                        ? Kind.BOUNDARY_UNMET : Kind.DOMAIN_POINT_UNCOVERED;
                 case About.APointOfABorder(var point) -> point.role().againstTheLine()
                         ? Kind.BOUNDARY_UNMET : Kind.DOMAIN_POINT_UNCOVERED;
                 case About.APositionNoLineDivides _ -> Kind.PARTITION_NOT_DERIVABLE;
@@ -3493,7 +3540,132 @@ public final class Adequacy {
                 armFindings(behavior,
                         branches == null ? null : branches.get(behavior.name()), out);
             }
+            declaredFindings(db, name, partitions, out);
             return Answer.of(List.copyOf(out));
+        }
+
+        /**
+         * What the module's own declarations are short of, from every reading of every line.
+         *
+         * <p>One finding per authored line and not per reading of it. A clause of a {@code data}
+         * says something about the type wherever the type is carried, so a row standing at the line
+         * is evidence about the type and the behaviors carrying it have nothing to add: over
+         * {@code crm} one clause of {@code UserId} is read at 126 positions of 74 behaviors, and
+         * discharging what that asked for meant writing 126 rows that each stand at the same point
+         * (issue #1062).
+         *
+         * <p>After the behaviors and over all of them at once, because that is the reach: a row
+         * written for any behavior carrying the type settles the line for every one of them, and a
+         * walk that answered per behavior could not see the row beside it.
+         *
+         * <p>The line is named in the terms the declaration wrote
+         * ({@link souther.compiler.check.DeclaredBorders}) and not in the terms of whichever reading
+         * this reached first, which is the same mistake one step along.
+         */
+        private static void declaredFindings(Db db, String module,
+                                             Map<String, PartitionEvidence> partitions,
+                                             List<Finding> out) {
+            if (partitions == null) {
+                return;
+            }
+            Map<String, List<BorderAssessment>> readings = new LinkedHashMap<>();
+            partitions.forEach((behavior, evidence) -> {
+                for (BorderAssessment line : evidence.boundaries()) {
+                    if (line.border().origin().owedToTheDeclaration().isPresent()) {
+                        readings.computeIfAbsent(behavior, _ -> new ArrayList<>()).add(line);
+                    }
+                }
+            });
+            if (readings.isEmpty()) {
+                return;
+            }
+            Symbols symbols = Names.derivedSymbols(db, module).value();
+            souther.compiler.check.ReadingPolicy policy = db.ask(new Front.Reading()).value();
+            if (symbols == null || policy == null) {
+                return;
+            }
+            Map<TypeSymbol, souther.compiler.check.DeclaredBorders> declared = new LinkedHashMap<>();
+            for (BorderObligationAssessment debt : BorderObligationAssessment.across(readings,
+                    id -> axisOf(id, declared, symbols, policy))) {
+                TypeSymbol declaredOn = debt.origin().owedToTheDeclaration().orElseThrow();
+                Citation at = citationOf(symbols, declaredOn);
+                for (souther.compiler.partition.PointRole role
+                        : BorderObligationAssessment.AGAINST_THE_LINE) {
+                    ItemAssessment item = debt.at(role);
+                    if (!item.isUnmetGap()) {
+                        continue;
+                    }
+                    out.add(Finding.by(new FindingSubject.OfADeclaration(declaredOn),
+                            item.weakeningSource(), at,
+                            new About.APointOfADeclaredBorder(debt, role)));
+                }
+            }
+        }
+
+        /**
+         * What a debt's line is on, as the declaration wrote it.
+         *
+         * <p>One reading of each declaration, kept, because a declaration draws as many lines as its
+         * clauses have ends and each of them would otherwise read the declaration again.
+         *
+         * <p>The value a newtype wraps is written {@code value}, which is what the author writes in
+         * the clause. A coordinate spells an empty path as "the value", which is what it is called
+         * where a sentence says it rather than where a line is named.
+         */
+        private static String axisOf(souther.compiler.partition.BorderObligationId id,
+                                     Map<TypeSymbol, souther.compiler.check.DeclaredBorders> read,
+                                     Symbols symbols, souther.compiler.check.ReadingPolicy policy) {
+            TypeSymbol declaredOn = id.origin().owedToTheDeclaration().orElse(null);
+            if (declaredOn == null) {
+                return id.origin().named();
+            }
+            souther.compiler.check.FieldDomains.Coordinate at =
+                    read.computeIfAbsent(declaredOn,
+                            each -> souther.compiler.check.DeclaredBorders.of(each, symbols, policy))
+                            .at(ruleOf(id), conjunctOf(id));
+            // A clause whose end this could not read from the declaration has no form to print, and
+            // the rule's own name is the whole of what there is to call the line.
+            return at == null ? id.origin().named() : written(at);
+        }
+
+        /** The coordinate as a line is named by, which spells the value a newtype wraps the way the
+         *  clause does. */
+        private static String written(souther.compiler.check.FieldDomains.Coordinate at) {
+            String where = at.path().isEmpty() ? "value" : at.path();
+            return at.kind() instanceof souther.compiler.check.FieldDomains
+                    .CoordinateKind.OfWhatAnOperationAnswers taken
+                    ? taken.operation() + "(" + where + ")" : where;
+        }
+
+        /** Which clause of which declaration drew the line, and which of its conjuncts. */
+        private static souther.compiler.check.RuleRef.Invariant ruleOf(
+                souther.compiler.partition.BorderObligationId id) {
+            return ((souther.compiler.check.RuleRef.Invariant) id.origin().rule());
+        }
+
+        private static int conjunctOf(souther.compiler.partition.BorderObligationId id) {
+            return conjunctOf(id.origin());
+        }
+
+        private static int conjunctOf(souther.compiler.partition.OriginRef origin) {
+            return switch (origin) {
+                case souther.compiler.partition.OriginRef.InvariantOrigin it -> it.conjunct();
+                case souther.compiler.partition.OriginRef.NarrowedOrigin it ->
+                        conjunctOf(it.bound());
+                case souther.compiler.partition.OriginRef.ComparisonOrigin _,
+                     souther.compiler.partition.OriginRef.EnsuresOrigin _ ->
+                        throw new IllegalStateException(
+                                "a line owed to a declaration is a declaration's clause: " + origin);
+            };
+        }
+
+        /** Where the declaration is written, which is where a reader is sent. */
+        private static Citation citationOf(Symbols symbols, TypeSymbol declaredOn) {
+            // Asked of the declaration world rather than of this module's own list, because a type
+            // another module wrote is a declaration all the same and a reader sent to it is sent to
+            // where it is written.
+            return symbols.declarations().declaration(declaredOn) instanceof Hir.Data data
+                    ? Citation.of(data.pos()) : null;
         }
 
         /**
@@ -3594,6 +3766,19 @@ public final class Adequacy {
                 // where the model does, and a row at it may be one nobody can write. A point
                 // nobody is owed a row at is not a gap either, and it says so as its own shape.
                 if (!point.item().isUnmetGap()) {
+                    continue;
+                }
+                // A line the declaration is owed is answered once for the module, from every
+                // reading of it. Left here as well, one clause of `UserId` is 126 findings over
+                // `crm` — one per position of every behavior carrying the type — for a rule the
+                // author wrote once (issue #1062). Asked of the rule rather than matched on which
+                // kind it is: which of them are the declaration's is the rule's own answer.
+                // The two points against the line only. The two away from it are regions of this
+                // position — where a region stops is settled by every other rule reaching the
+                // position — so a row well inside one reading is not a row that could stand at
+                // another at all, and the point is this behavior's as it was.
+                if (point.role().againstTheLine()
+                        && point.border().origin().owedToTheDeclaration().isPresent()) {
                     continue;
                 }
                 // The point itself, and one finding for either kind. Which of the two a build is
@@ -3735,6 +3920,36 @@ public final class Adequacy {
         }
 
         /**
+         * What a row at one point of a border shows, as a hint.
+         *
+         * <p>Asked of the role, and in the role's own vocabulary. A hint saying which side of the
+         * line the value falls on would be keyed on the border being closed or open rather than on
+         * the role — {@code n <= 100} is at its ON point on the line and {@code n < 100} is at its
+         * OFF point there — so it would be a second reading of one finding, sitting under a sentence
+         * that just named the role.
+         *
+         * <p>One place, because two questions raise these. A line owed at one reading of it and a
+         * line owed once over all of them are the same technique's item, and what a row at the point
+         * shows is the same thing to say about either.
+         */
+        private static void hintFor(souther.compiler.partition.PointRole role,
+                                    souther.compiler.diag.Diagnostic.Builder built) {
+            switch (role) {
+                case ON -> built.hint(
+                        new ExampleMessage.ARowJustInsideShowsTheBorderIsNotFurtherIn());
+                case OFF -> built.hint(
+                        new ExampleMessage.ARowJustOutsideShowsTheBorderIsNotFurtherOut());
+                // Said only to a build held to reliable domain coverage, which is where the two
+                // kinds part. In its own words: what a row well inside shows is not what a row a
+                // step over shows, and the neighbour's hint would send an author to the wrong value.
+                case IN -> built.hint(
+                        new ExampleMessage.ARowWellInsideShowsTheBorderIsWhatDivides());
+                case OUT -> built.hint(
+                        new ExampleMessage.ARowWellOutsideShowsTheBorderIsWhatDivides());
+            }
+        }
+
+        /**
          * One finding as the warning a build reads.
          *
          * <p>The message keys are written out per kind rather than derived from the code's name, so
@@ -3768,6 +3983,19 @@ public final class Adequacy {
                         // Which of the two rules this is, is the role's answer, exactly as the kind
                         // is: a point against the line and a point away from it are owed by
                         // different criteria and are told under different codes.
+                        // A line owed once over every reading of it. The rule has a name — a
+                        // declaration's clause always does — so there is one sentence and not two,
+                        // and what the line is on is what the declaration wrote rather than the
+                        // position some behavior met it at (issue #1062).
+                        case About.APointOfADeclaredBorder(var debt, var role) ->
+                                role.againstTheLine()
+                                        ? new ExampleMessage.NoRowIsAtThePointOfTheBorderARuleDrew(
+                                                role.name(), debt.axis(), debt.against(role),
+                                                debt.origin().named())
+                                        : new ExampleMessage
+                                                .NoRowIsAtThePointAwayFromTheBorderARuleDrew(
+                                                role.name(), debt.axis(), debt.against(role),
+                                                debt.origin().named());
                         case About.APointOfABorder(var point) ->
                                 point.role().againstTheLine()
                                         ? point.border().origin().isWrittenRatherThanNamed()
@@ -3812,26 +4040,16 @@ public final class Adequacy {
             switch (said) {
                 case About.ACaseNoRowExpects(var missing) ->
                         built.hint(new ExampleMessage.WriteARowExpectingThatCase(missing.name()));
+                // The same hints, asked of the role. What a row at each point shows is a fact
+                // about the point and not about which of the two questions raised it.
+                case About.APointOfADeclaredBorder(var _, var role) -> hintFor(role, built);
                 case About.APointOfABorder(var point) -> {
                     // Asked of the point, and in the point's own vocabulary. A hint saying which
                     // side of the line the value falls on would be keyed on the border being closed
                     // or open rather than on the role — `n <= 100` is at its ON point on the line
                     // and `n < 100` is at its OFF point there — so it would be a second reading of
                     // one finding, sitting under a sentence that just named the role.
-                    switch (point.role()) {
-                        case ON -> built.hint(
-                                new ExampleMessage.ARowJustInsideShowsTheBorderIsNotFurtherIn());
-                        case OFF -> built.hint(
-                                new ExampleMessage.ARowJustOutsideShowsTheBorderIsNotFurtherOut());
-                        // Said only to a build held to reliable domain coverage, which is where
-                        // the two kinds part. In its own words: what a row well inside shows is not
-                        // what a row a step over shows, and the neighbour's hint would send an
-                        // author to the wrong value.
-                        case IN -> built.hint(
-                                new ExampleMessage.ARowWellInsideShowsTheBorderIsWhatDivides());
-                        case OUT -> built.hint(
-                                new ExampleMessage.ARowWellOutsideShowsTheBorderIsWhatDivides());
-                    }
+                    hintFor(point.role(), built);
                     // Where the rule has a place rather than a name, the place is a second region
                     // and not words in the sentence: a renderer resolves what to call its file,
                     // and a body written out of sight says so off its own coordinate.

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1499,15 +1499,25 @@ public final class Adequacy {
         }
         List<GenerationDisposition> out = new ArrayList<>();
         for (Finding finding : findings) {
-            if (!(finding.subject() instanceof FindingSubject.OfADeclaration)) {
+            if (!(finding.about()
+                    instanceof About.APointOfADeclaredBorder(var debt, var role))) {
                 continue;
             }
-            // One answer, and it is about the search rather than about the line: a row is composed
-            // by walking one behavior's inputs, and which reading composes the one row a debt is
-            // owed is a search over the readings rather than a fold of them.
-            out.add(new GenerationDisposition(finding, new GenerationOutcome.NotSupported(
-                    GenerationOutcome.NotSupported.Reason
-                            .NO_SEARCH_IS_ASKED_FOR_A_LINE_ACROSS_ITS_READINGS)));
+            // What a reading of this line already composed, where one did. A row standing at the
+            // point is a row standing at the line, and the readings of a debt ask the same of a row
+            // at the points against it — which is checked where their demands are. So this is the
+            // row the debt is offered and not one reading's standing in for the rest.
+            //
+            // Which reading composes it where none has is a search over the readings and not a fold
+            // of them, and nothing does that yet: the answer is then about the search rather than
+            // about the line. Said the second way for every debt, a block printed a row at the line
+            // and a sentence under it saying nothing offers one.
+            out.add(new GenerationDisposition(finding,
+                    debt.owedAt(role).attempt() instanceof ItemAssessment.Attempt.Built built
+                            ? new GenerationOutcome.Generated(List.of(built.row()))
+                            : new GenerationOutcome.NotSupported(
+                                    GenerationOutcome.NotSupported.Reason
+                                            .NO_SEARCH_IS_ASKED_FOR_A_LINE_ACROSS_ITS_READINGS)));
         }
         return List.copyOf(out);
     }
@@ -3491,7 +3501,127 @@ public final class Adequacy {
     }
 
     /**
-     * Everything the measures found, by behavior.
+     * One line a declaration is owed, with what became of it and where the declaration is.
+     *
+     * <p>Held together because they are asked together and by more than one reader: a verdict rests
+     * on what became of the line, a document publishes which declaration owes it, a report prints it
+     * under that declaration, and a generation answers what it can do about it. Each of those
+     * working it out from the readings is what the debt was introduced to stop.
+     *
+     * @param debt        what the readings of the line came to
+     * @param declaration whose clause drew it, which is what a finding about it is about
+     * @param at          where that declaration is written, which is where a reader is sent
+     */
+    public record DeclaredDebt(BorderObligationAssessment debt, TypeSymbol declaration,
+                               Citation at) {
+
+        public DeclaredDebt {
+            if (debt == null || declaration == null || at == null) {
+                throw new IllegalArgumentException("a debt is some declaration's, somewhere");
+            }
+        }
+    }
+
+    /**
+     * Every line this module's declarations are owed, made once.
+     *
+     * <p>The one place the readings of a line are folded into what is owed. A report, a build's
+     * refusal, a document and a generation all ask what became of a line an {@code invariant} drew,
+     * and four foldings of one set of readings are four answers about it — which is the shape
+     * issue #1062 is about, one layer up from where it was found.
+     *
+     * <p>Every debt and not only the ones something is short of. A line a row already stands at is
+     * what a verdict rests on as much as one nothing stands at: read off the findings, the debts
+     * that are covered are not there at all, and a bar would be settled by a denominator made of
+     * the gaps.
+     */
+    public record DeclaredBorders(String name) implements Key<List<DeclaredDebt>> {
+
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<List<DeclaredDebt>> compute(Db db) {
+            Map<String, PartitionEvidence> partitions = db.ask(new Coverage(name)).value();
+            if (partitions == null) {
+                return Answer.of(List.of());
+            }
+            Map<String, List<BorderAssessment>> readings = new LinkedHashMap<>();
+            partitions.forEach((behavior, evidence) -> {
+                for (BorderAssessment line : evidence.boundaries()) {
+                    if (line.border().origin().owedToTheDeclaration().isPresent()) {
+                        readings.computeIfAbsent(behavior, _ -> new ArrayList<>()).add(line);
+                    }
+                }
+            });
+            if (readings.isEmpty()) {
+                return Answer.of(List.of());
+            }
+            // What names a line and where its declaration is are read from the declaration, and
+            // neither is something a debt can go without — so they are asked here, once, and their
+            // absence is this measure having no answer rather than a debt built without them.
+            Symbols symbols = Names.derivedSymbols(db, name).value();
+            souther.compiler.check.ReadingPolicy policy = db.ask(new Front.Reading()).value();
+            if (symbols == null || policy == null) {
+                return Answer.absent();
+            }
+            Map<TypeSymbol, souther.compiler.check.DeclaredBorders> declarations =
+                    new LinkedHashMap<>();
+            List<DeclaredDebt> out = new ArrayList<>();
+            for (BorderObligationAssessment debt : BorderObligationAssessment.across(readings,
+                    id -> axisOf(id, declarations, symbols, policy))) {
+                TypeSymbol declaredOn = debt.origin().owedToTheDeclaration().orElseThrow();
+                out.add(new DeclaredDebt(debt, declaredOn,
+                        read(declarations, declaredOn, symbols, policy).at()));
+            }
+            return Answer.of(List.copyOf(out));
+        }
+
+        /**
+         * What a debt's line is on, as the declaration wrote it.
+         *
+         * <p>The value a newtype wraps is written {@code value}, which is what the author writes in
+         * the clause. A coordinate spells an empty path as "the value", which is what it is called
+         * where a sentence says it rather than where a line is named.
+         */
+        private static String axisOf(souther.compiler.partition.BorderObligationId id,
+                                     Map<TypeSymbol, souther.compiler.check.DeclaredBorders> read,
+                                     Symbols symbols, souther.compiler.check.ReadingPolicy policy) {
+            TypeSymbol declaredOn = id.origin().owedToTheDeclaration().orElseThrow();
+            souther.compiler.check.FieldDomains.Coordinate at =
+                    read(read, declaredOn, symbols, policy)
+                            // Which line of the declaration this is, asked of the rule. Taken apart
+                            // here, a reader would be deciding which rules have a clause and a
+                            // conjunct, which is the rule's own answer.
+                            .at(id.origin().declaredLine().orElseThrow());
+            // A clause whose end this could not read from the declaration has no form to print, and
+            // the rule's own name is the whole of what there is to call the line.
+            return at == null ? id.origin().named() : written(at);
+        }
+
+        /** The declaration's own reading of its own rules, kept: it draws as many lines as its
+         *  clauses have ends, and each of them would otherwise read the declaration again. */
+        private static souther.compiler.check.DeclaredBorders read(
+                Map<TypeSymbol, souther.compiler.check.DeclaredBorders> kept, TypeSymbol declaredOn,
+                Symbols symbols, souther.compiler.check.ReadingPolicy policy) {
+            return kept.computeIfAbsent(declaredOn,
+                    each -> souther.compiler.check.DeclaredBorders.of(each, symbols, policy));
+        }
+
+        /** The coordinate as a line is named by, which spells the value a newtype wraps the way the
+         *  clause does. */
+        private static String written(souther.compiler.check.FieldDomains.Coordinate at) {
+            String where = at.path().isEmpty() ? "value" : at.path();
+            return at.kind() instanceof souther.compiler.check.FieldDomains
+                    .CoordinateKind.OfWhatAnOperationAnswers taken
+                    ? taken.operation() + "(" + where + ")" : where;
+        }
+    }
+
+    /**
+     * Everything the measures found, whatever each of them is about.
      *
      * <p>The one statement of what counts as a finding. A report prints these, a build is warned about
      * the ones that are gaps, and {@code souther examples --strict} refuses on the same ones — three
@@ -3540,12 +3670,12 @@ public final class Adequacy {
                 armFindings(behavior,
                         branches == null ? null : branches.get(behavior.name()), out);
             }
-            declaredFindings(db, name, partitions, out);
+            declaredFindings(db, name, out);
             return Answer.of(List.copyOf(out));
         }
 
         /**
-         * What the module's own declarations are short of, from every reading of every line.
+         * What the module's own declarations are short of, from the debts the module holds.
          *
          * <p>One finding per authored line and not per reading of it. A clause of a {@code data}
          * says something about the type wherever the type is carried, so a row standing at the line
@@ -3554,111 +3684,28 @@ public final class Adequacy {
          * discharging what that asked for meant writing 126 rows that each stand at the same point
          * (issue #1062).
          *
-         * <p>After the behaviors and over all of them at once, because that is the reach: a row
-         * written for any behavior carrying the type settles the line for every one of them, and a
-         * walk that answered per behavior could not see the row beside it.
-         *
-         * <p>The line is named in the terms the declaration wrote
-         * ({@link souther.compiler.check.DeclaredBorders}) and not in the terms of whichever reading
-         * this reached first, which is the same mistake one step along.
+         * <p>Read off {@link DeclaredBorders} rather than folded here. The debts are what a verdict
+         * rests on, what a document publishes and what a generation answers about, and a finding is
+         * one more reading of them — worked out again here, each of those consumers would be
+         * answering from the readings and the aggregation would hold in none of them.
          */
-        private static void declaredFindings(Db db, String module,
-                                             Map<String, PartitionEvidence> partitions,
-                                             List<Finding> out) {
-            if (partitions == null) {
+        private static void declaredFindings(Db db, String module, List<Finding> out) {
+            List<DeclaredDebt> debts = db.ask(new DeclaredBorders(module)).value();
+            if (debts == null) {
                 return;
             }
-            Map<String, List<BorderAssessment>> readings = new LinkedHashMap<>();
-            partitions.forEach((behavior, evidence) -> {
-                for (BorderAssessment line : evidence.boundaries()) {
-                    if (line.border().origin().owedToTheDeclaration().isPresent()) {
-                        readings.computeIfAbsent(behavior, _ -> new ArrayList<>()).add(line);
-                    }
-                }
-            });
-            if (readings.isEmpty()) {
-                return;
-            }
-            Symbols symbols = Names.derivedSymbols(db, module).value();
-            souther.compiler.check.ReadingPolicy policy = db.ask(new Front.Reading()).value();
-            if (symbols == null || policy == null) {
-                // What names a line is what the declaration wrote, and neither of these is
-                // something a finding can go without. Answered by leaving the declarations' lines
-                // out, a module would be reported as short of only what its bodies are short of —
-                // which is the shortfall this whole change is about, arriving from the other side.
-                throw new IllegalStateException("the lines " + module
-                        + "'s declarations draw were read, and what they were read with is gone");
-            }
-            Map<TypeSymbol, souther.compiler.check.DeclaredBorders> declared = new LinkedHashMap<>();
-            for (BorderObligationAssessment debt : BorderObligationAssessment.across(readings,
-                    id -> axisOf(id, declared, symbols, policy))) {
-                TypeSymbol declaredOn = debt.origin().owedToTheDeclaration().orElseThrow();
-                Citation at = citationOf(symbols, declaredOn);
+            for (DeclaredDebt owed : debts) {
                 for (souther.compiler.partition.PointRole role
                         : BorderObligationAssessment.AGAINST_THE_LINE) {
-                    ItemAssessment item = debt.at(role);
+                    ItemAssessment item = owed.debt().at(role);
                     if (!item.isUnmetGap()) {
                         continue;
                     }
-                    out.add(Finding.by(new FindingSubject.OfADeclaration(declaredOn),
-                            item.weakeningSource(), at,
-                            new About.APointOfADeclaredBorder(debt, role)));
+                    out.add(Finding.by(new FindingSubject.OfADeclaration(owed.declaration()),
+                            item.weakeningSource(), owed.at(),
+                            new About.APointOfADeclaredBorder(owed.debt(), role)));
                 }
             }
-        }
-
-        /**
-         * What a debt's line is on, as the declaration wrote it.
-         *
-         * <p>One reading of each declaration, kept, because a declaration draws as many lines as its
-         * clauses have ends and each of them would otherwise read the declaration again.
-         *
-         * <p>The value a newtype wraps is written {@code value}, which is what the author writes in
-         * the clause. A coordinate spells an empty path as "the value", which is what it is called
-         * where a sentence says it rather than where a line is named.
-         */
-        private static String axisOf(souther.compiler.partition.BorderObligationId id,
-                                     Map<TypeSymbol, souther.compiler.check.DeclaredBorders> read,
-                                     Symbols symbols, souther.compiler.check.ReadingPolicy policy) {
-            TypeSymbol declaredOn = id.origin().owedToTheDeclaration().orElse(null);
-            if (declaredOn == null) {
-                return id.origin().named();
-            }
-            souther.compiler.check.FieldDomains.Coordinate at =
-                    read.computeIfAbsent(declaredOn,
-                            each -> souther.compiler.check.DeclaredBorders.of(each, symbols, policy))
-                            // Which line of the declaration this is, asked of the rule. Taken
-                            // apart here, a reader would be deciding which rules have a clause and
-                            // a conjunct, which is the rule's own answer.
-                            .at(id.origin().declaredLine().orElseThrow());
-            // A clause whose end this could not read from the declaration has no form to print, and
-            // the rule's own name is the whole of what there is to call the line.
-            return at == null ? id.origin().named() : written(at);
-        }
-
-        /** The coordinate as a line is named by, which spells the value a newtype wraps the way the
-         *  clause does. */
-        private static String written(souther.compiler.check.FieldDomains.Coordinate at) {
-            String where = at.path().isEmpty() ? "value" : at.path();
-            return at.kind() instanceof souther.compiler.check.FieldDomains
-                    .CoordinateKind.OfWhatAnOperationAnswers taken
-                    ? taken.operation() + "(" + where + ")" : where;
-        }
-
-        /** Where the declaration is written, which is where a reader is sent. */
-        private static Citation citationOf(Symbols symbols, TypeSymbol declaredOn) {
-            // Asked of the declaration world rather than of this module's own list, because a type
-            // another module wrote is a declaration all the same and a reader sent to it is sent to
-            // where it is written.
-            if (symbols.declarations().declaration(declaredOn) instanceof Hir.Data data) {
-                return Citation.of(data.pos());
-            }
-            // A line is owed to this declaration because a clause of it was read, so there is a
-            // declaration to point at. Said here rather than answered with nothing: a citation is
-            // built from a place, and a null one reaches a reader as a switch over the arms a
-            // citation has — which is a failure with nothing in it about the type this was for.
-            throw new IllegalStateException("a line is owed to " + declaredOn.name()
-                    + ", whose clause was read, and this compile has no declaration for it");
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1492,34 +1492,72 @@ public final class Adequacy {
      * once over every behavior carrying the type, so which reading composes the one row it is owed
      * is a search over the readings and not a fold of them.
      */
-    public static List<GenerationDisposition> generatedForDeclarationsOf(Db db, String module) {
+    public static List<GenerationDisposition> generatedForDeclarationsOf(Db db, String module,
+                                                                        String behavior) {
         List<Finding> findings = db.ask(new Findings(module)).value();
         if (findings == null) {
             return List.of();
         }
+        // What this request searched, and never what the measurement happened to have composed. The
+        // two are both called an attempt and they answer different questions: a measurement builds a
+        // value where the level asks it to, and says whether the point exists; a generation is asked
+        // afterwards and composes the row an author is offered. Read from the measurement, a build
+        // at `witness` composes nothing, and a block that had just printed a row would say nothing
+        // offers one — which is the sentence this whole answer exists to stop saying.
+        Map<String, List<BorderAssessment>> searched = behavior == null
+                ? searchedBoundariesOf(db, module)
+                : searchedFor(db, module, behavior);
         List<GenerationDisposition> out = new ArrayList<>();
         for (Finding finding : findings) {
             if (!(finding.about()
                     instanceof About.APointOfADeclaredBorder(var debt, var role))) {
                 continue;
             }
-            // What a reading of this line already composed, where one did. A row standing at the
-            // point is a row standing at the line, and the readings of a debt ask the same of a row
-            // at the points against it — which is checked where their demands are. So this is the
-            // row the debt is offered and not one reading's standing in for the rest.
-            //
             // Which reading composes it where none has is a search over the readings and not a fold
             // of them, and nothing does that yet: the answer is then about the search rather than
-            // about the line. Said the second way for every debt, a block printed a row at the line
-            // and a sentence under it saying nothing offers one.
+            // about the line.
+            Generator.GeneratedRow row = composed(searched, debt, role);
             out.add(new GenerationDisposition(finding,
-                    debt.owedAt(role).attempt() instanceof ItemAssessment.Attempt.Built built
-                            ? new GenerationOutcome.Generated(List.of(built.row()))
+                    row != null ? new GenerationOutcome.Generated(List.of(row))
                             : new GenerationOutcome.NotSupported(
                                     GenerationOutcome.NotSupported.Reason
                                             .NO_SEARCH_IS_ASKED_FOR_A_LINE_ACROSS_ITS_READINGS)));
         }
         return List.copyOf(out);
+    }
+
+    /**
+     * The row this request composed at one point of one line, or null where it composed none.
+     *
+     * <p>Found among the readings this request searched, which is what makes it the row the debt is
+     * offered: the readings of a debt ask the same of a row at the points against the line — checked
+     * where their demands are — so a row standing at one of them stands at the line.
+     *
+     * <p>Null is this request having composed none, and says nothing about whether another could.
+     * Which reading to search next is the question {@code --generate} does not ask yet.
+     */
+    private static Generator.GeneratedRow composed(Map<String, List<BorderAssessment>> searched,
+                                                   BorderObligationAssessment debt,
+                                                   souther.compiler.partition.PointRole role) {
+        for (List<BorderAssessment> lines : searched.values()) {
+            for (BorderAssessment line : lines) {
+                if (!line.border().obligation().equals(debt.id())) {
+                    continue;
+                }
+                ItemAssessment.Owed owed = line.owedAt(role);
+                if (owed != null && owed.attempt() instanceof ItemAssessment.Attempt.Built built) {
+                    return built.row();
+                }
+            }
+        }
+        return null;
+    }
+
+    /** The lines one behavior was searched at, keyed the way every behavior's are. */
+    private static Map<String, List<BorderAssessment>> searchedFor(Db db, String module,
+                                                                   String behavior) {
+        List<BorderAssessment> lines = db.ask(new BoundarySearch(module, behavior)).value();
+        return lines == null ? Map.of() : Map.of(behavior, lines);
     }
 
     /** The same, with a value composed at every point worth one — which is a request, and costs what
@@ -3813,12 +3851,9 @@ public final class Adequacy {
                 // `crm` — one per position of every behavior carrying the type — for a rule the
                 // author wrote once (issue #1062). Asked of the rule rather than matched on which
                 // kind it is: which of them are the declaration's is the rule's own answer.
-                // The two points against the line only. The two away from it are regions of this
-                // position — where a region stops is settled by every other rule reaching the
-                // position — so a row well inside one reading is not a row that could stand at
-                // another at all, and the point is this behavior's as it was.
-                if (point.role().againstTheLine()
-                        && point.border().origin().owedToTheDeclaration().isPresent()) {
+                // This behavior's own. A line a declaration is owed is answered once for the
+                // module, from every reading of it.
+                if (!point.owedHere()) {
                     continue;
                 }
                 // The point itself, and one finding for either kind. Which of the two a build is

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -2462,7 +2462,7 @@ public final class Adequacy {
             Map<String, souther.compiler.check.StatedContract> declared =
                     db.ask(new Bodies.StatedContracts(name)).value();
 
-            Map<String, List<Finding>> findings = db.ask(new Findings(name)).value();
+            List<Finding> findings = db.ask(new Findings(name)).value();
             Map<String, PartitionEvidence> partitions = coverage.value();
 
             Hir.SpecBehavior spec = specOf(prepared.value(), behavior);
@@ -2484,8 +2484,11 @@ public final class Adequacy {
                 // is a sentence about neither.
                 return Answer.absent();
             }
+            // This behavior's own, grouped here because that is what a generation is asked for.
+            // What each finding is about is the finding's; a walk that read them out of a map keyed
+            // by behavior would be reading the grouping as the answer.
             List<Finding> owed = findings == null ? List.of()
-                    : findings.getOrDefault(behavior, List.of());
+                    : findings.stream().filter(each -> each.subject().isBehavior(behavior)).toList();
             InputDomain domain = domainOf(readInputs, spec);
             // What this run is asked for, settled before the search and before anything that can
             // stop it. Every way out of the generation below holds this same list.
@@ -3294,7 +3297,18 @@ public final class Adequacy {
      * one of a body that may have been spliced in from a file nobody holds. A report reading a
      * coordinate cannot tell the two apart, and printed the second as though it were the first.
      */
-    public record Finding(String behavior, WeakeningSet weakenedBy, Citation at, About about) {
+    public record Finding(FindingSubject subject, WeakeningSet weakenedBy, Citation at,
+                          About about) {
+
+        /**
+         * What a report calls what this is about.
+         *
+         * <p>Here rather than at each reader, so that a message wanting a word for the subject does
+         * not reach past it for the one kind of subject it happens to know about.
+         */
+        public String named() {
+            return subject.named();
+        }
 
         /**
          * A finding one measurement established, carrying what <em>that</em> measurement went
@@ -3315,7 +3329,13 @@ public final class Adequacy {
          * different things.
          */
         public static Finding by(String behavior, Measure<?> found, Citation at, About about) {
-            return new Finding(behavior, found.weakening(), at, about);
+            return by(new FindingSubject.OfABehavior(behavior), found, at, about);
+        }
+
+        /** The same, about whatever the measure was of. */
+        public static Finding by(FindingSubject subject, Measure<?> found, Citation at,
+                                 About about) {
+            return new Finding(subject, found.weakening(), at, about);
         }
 
         /**
@@ -3327,7 +3347,12 @@ public final class Adequacy {
          * is its criterion's alone — every kind that reaches here is one no criterion refuses.
          */
         public static Finding noticed(String behavior, Citation at, About about) {
-            return new Finding(behavior, WeakeningSet.none(), at, about);
+            return noticed(new FindingSubject.OfABehavior(behavior), at, about);
+        }
+
+        /** The same, about whatever it was noticed of. */
+        public static Finding noticed(FindingSubject subject, Citation at, About about) {
+            return new Finding(subject, WeakeningSet.none(), at, about);
         }
 
         /**
@@ -3427,7 +3452,7 @@ public final class Adequacy {
      * asked to be warned, because a report wants them either way; what the level decides is which
      * measures were made at all.
      */
-    public record Findings(String name) implements Key<Map<String, List<Finding>>> {
+    public record Findings(String name) implements Key<List<Finding>> {
 
         @Override
         public String module() {
@@ -3435,7 +3460,7 @@ public final class Adequacy {
         }
 
         @Override
-        public Answer<Map<String, List<Finding>>> compute(Db db) {
+        public Answer<List<Finding>> compute(Db db) {
             Answer<souther.compiler.check.Prepared> prepared = db.ask(new Shapes.Prepared(name));
             if (!prepared.present()) {
                 return Answer.absent();
@@ -3449,20 +3474,26 @@ public final class Adequacy {
             Map<String, PartitionEvidence> partitions = db.ask(new Coverage(name)).value();
             Map<String, BranchEvidence> branches = db.ask(new BranchCoverage(name)).value();
 
-            Map<String, List<Finding>> out = new LinkedHashMap<>();
+            // One list and not a block per behavior. What each finding is about is its own
+            // ({@link FindingSubject}), and a map keyed by behavior has no key for a finding about
+            // a declaration — so one had to be filed under whichever behavior carrying the type a
+            // walk reached first, which is a choice nothing made and a reader cannot check
+            // (issue #1062). Whoever prints a block per behavior groups these; the model says what
+            // each is about.
+            //
+            // In the order the module declares its behaviors, because a build reads the warnings
+            // these become and a set of warnings whose order moves between runs is a diff nobody
+            // wrote.
+            List<Finding> out = new ArrayList<>();
             for (Hir.BehaviorDef behavior : prepared.value().behaviors()) {
-                List<Finding> found = new ArrayList<>();
                 signatureFindings(behavior.name(), Citation.of(behavior.pos()),
-                        signatures == null ? null : signatures.get(behavior.name()), found);
+                        signatures == null ? null : signatures.get(behavior.name()), out);
                 partitionFindings(behavior,
-                        partitions == null ? null : partitions.get(behavior.name()), found);
+                        partitions == null ? null : partitions.get(behavior.name()), out);
                 armFindings(behavior,
-                        branches == null ? null : branches.get(behavior.name()), found);
-                out.put(behavior.name(), List.copyOf(found));
+                        branches == null ? null : branches.get(behavior.name()), out);
             }
-            // Ordered, because a build reads the warnings these become and a set of warnings whose
-            // order moves between runs is a diff nobody wrote.
-            return Answer.of(Ordered.map(out));
+            return Answer.of(List.copyOf(out));
         }
 
         /**
@@ -3690,16 +3721,14 @@ public final class Adequacy {
             if (!asked.warn()) {
                 return Answer.of(true);
             }
-            Answer<Map<String, List<Finding>>> found = db.ask(new Findings(name));
+            Answer<List<Finding>> found = db.ask(new Findings(name));
             if (!found.present()) {
                 return Answer.absent();
             }
             List<Report> reports = new ArrayList<>();
-            for (List<Finding> ofBehavior : found.value().values()) {
-                for (Finding finding : ofBehavior) {
-                    if (finding.isAdequacyGap(asked.held())) {
-                        reports.add(warning(finding));
-                    }
+            for (Finding finding : found.value()) {
+                if (finding.isAdequacyGap(asked.held())) {
+                    reports.add(warning(finding));
                 }
             }
             return Answer.of(true, reports);
@@ -3719,12 +3748,12 @@ public final class Adequacy {
                     .say(switch (said) {
                         case About.ACaseNoRowExpects(var missing) ->
                                 new ExampleMessage.NoRowExpectsThatCase(
-                                        missing.name(), finding.behavior());
+                                        missing.name(), finding.named());
                         case About.ACaseNoRowAppliesItTo(var input, var missing) ->
                                 new ExampleMessage.NoRowAppliesItToThatCase(missing.name(),
                                         // How a person is told which input, which is one-based and
                                         // is this sentence's to spell.
-                                        String.valueOf(input.at() + 1), finding.behavior());
+                                        String.valueOf(input.at() + 1), finding.named());
                         // The rule named without a place. Nothing here knows what to call a
                         // source, so a line and a column written into the sentence would be read
                         // against whichever file the reader has in mind. Where a fork of a body
@@ -3768,7 +3797,7 @@ public final class Adequacy {
                         // words — which are the words the report writes for the same finding.
                         case About.AClassNoRowIsIn(var missing) ->
                                 new ExampleMessage.NoRowIsInThatClass(missing.name(),
-                                        missing.axis().path(), finding.behavior());
+                                        missing.axis().path(), finding.named());
                         // Kinds no build is told about under any code. Listed rather than
                         // defaulted, so that one added later has to be answered here rather than
                         // arriving as a warning with no sentence.

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -3582,7 +3582,12 @@ public final class Adequacy {
             Symbols symbols = Names.derivedSymbols(db, module).value();
             souther.compiler.check.ReadingPolicy policy = db.ask(new Front.Reading()).value();
             if (symbols == null || policy == null) {
-                return;
+                // What names a line is what the declaration wrote, and neither of these is
+                // something a finding can go without. Answered by leaving the declarations' lines
+                // out, a module would be reported as short of only what its bodies are short of —
+                // which is the shortfall this whole change is about, arriving from the other side.
+                throw new IllegalStateException("the lines " + module
+                        + "'s declarations draw were read, and what they were read with is gone");
             }
             Map<TypeSymbol, souther.compiler.check.DeclaredBorders> declared = new LinkedHashMap<>();
             for (BorderObligationAssessment debt : BorderObligationAssessment.across(readings,
@@ -3622,7 +3627,10 @@ public final class Adequacy {
             souther.compiler.check.FieldDomains.Coordinate at =
                     read.computeIfAbsent(declaredOn,
                             each -> souther.compiler.check.DeclaredBorders.of(each, symbols, policy))
-                            .at(ruleOf(id), conjunctOf(id));
+                            // Which line of the declaration this is, asked of the rule. Taken
+                            // apart here, a reader would be deciding which rules have a clause and
+                            // a conjunct, which is the rule's own answer.
+                            .at(id.origin().declaredLine().orElseThrow());
             // A clause whose end this could not read from the declaration has no form to print, and
             // the rule's own name is the whole of what there is to call the line.
             return at == null ? id.origin().named() : written(at);
@@ -3637,35 +3645,20 @@ public final class Adequacy {
                     ? taken.operation() + "(" + where + ")" : where;
         }
 
-        /** Which clause of which declaration drew the line, and which of its conjuncts. */
-        private static souther.compiler.check.RuleRef.Invariant ruleOf(
-                souther.compiler.partition.BorderObligationId id) {
-            return ((souther.compiler.check.RuleRef.Invariant) id.origin().rule());
-        }
-
-        private static int conjunctOf(souther.compiler.partition.BorderObligationId id) {
-            return conjunctOf(id.origin());
-        }
-
-        private static int conjunctOf(souther.compiler.partition.OriginRef origin) {
-            return switch (origin) {
-                case souther.compiler.partition.OriginRef.InvariantOrigin it -> it.conjunct();
-                case souther.compiler.partition.OriginRef.NarrowedOrigin it ->
-                        conjunctOf(it.bound());
-                case souther.compiler.partition.OriginRef.ComparisonOrigin _,
-                     souther.compiler.partition.OriginRef.EnsuresOrigin _ ->
-                        throw new IllegalStateException(
-                                "a line owed to a declaration is a declaration's clause: " + origin);
-            };
-        }
-
         /** Where the declaration is written, which is where a reader is sent. */
         private static Citation citationOf(Symbols symbols, TypeSymbol declaredOn) {
             // Asked of the declaration world rather than of this module's own list, because a type
             // another module wrote is a declaration all the same and a reader sent to it is sent to
             // where it is written.
-            return symbols.declarations().declaration(declaredOn) instanceof Hir.Data data
-                    ? Citation.of(data.pos()) : null;
+            if (symbols.declarations().declaration(declaredOn) instanceof Hir.Data data) {
+                return Citation.of(data.pos());
+            }
+            // A line is owed to this declaration because a clause of it was read, so there is a
+            // declaration to point at. Said here rather than answered with nothing: a citation is
+            // built from a place, and a null one reaches a reader as a switch over the arms a
+            // citation has — which is a failure with nothing in it about the type this was for.
+            throw new IllegalStateException("a line is owed to " + declaredOn.name()
+                    + ", whose clause was read, and this compile has no declaration for it");
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -3741,7 +3741,7 @@ public final class Adequacy {
                         // different criteria and are told under different codes.
                         case About.APointOfABorder(var point) ->
                                 point.role().againstTheLine()
-                                        ? point.border().rule().isWrittenRatherThanNamed()
+                                        ? point.border().origin().isWrittenRatherThanNamed()
                                                 ? new ExampleMessage
                                                         .NoRowIsAtThePointOfTheBorderAConstructDrew(
                                                         point.role().name(), point.border().axis(),
@@ -3750,8 +3750,8 @@ public final class Adequacy {
                                                         .NoRowIsAtThePointOfTheBorderARuleDrew(
                                                         point.role().name(), point.border().axis(),
                                                         point.against(),
-                                                        point.border().rule().named())
-                                        : point.border().rule().isWrittenRatherThanNamed()
+                                                        point.border().origin().named())
+                                        : point.border().origin().isWrittenRatherThanNamed()
                                                 ? new ExampleMessage
                                                         .NoRowIsAtThePointAwayFromTheBorderAConstructDrew(
                                                         point.role().name(), point.border().axis(),
@@ -3760,7 +3760,7 @@ public final class Adequacy {
                                                         .NoRowIsAtThePointAwayFromTheBorderARuleDrew(
                                                         point.role().name(), point.border().axis(),
                                                         point.against(),
-                                                        point.border().rule().named());
+                                                        point.border().origin().named());
                         case About.AnArmNoRowGoesThrough(var arm) ->
                                 new ExampleMessage.NoRowGoesThroughThatArm(
                                         phraseFor(arm), arm.behavior());
@@ -3812,7 +3812,7 @@ public final class Adequacy {
                     // dropped, on the grounds that a label naming no source would be read against
                     // the file the diagnostic is in; a label no longer takes its file from where it
                     // is shown, so what was left unsaid can be said.
-                    point.border().rule().citation().ifPresent(cited -> {
+                    point.border().origin().citation().ifPresent(cited -> {
                         switch (cited) {
                             case souther.compiler.diag.Citation.Written w ->
                                     built.secondary(souther.compiler.diag.Region.point(w.at()),

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderAssessment.java
@@ -202,6 +202,30 @@ public record BorderAssessment(Border border, Map<PointRole, ItemAssessment> ite
                     : border.axis() + " " + asked();
         }
 
+        /**
+         * Whether the behavior this reading belongs to is the one owed a row here.
+         *
+         * <p>Two of a border's four points can be owed to the declaration that drew the line rather
+         * than to any body carrying the type: what a row standing at the line shows is a fact about
+         * the type, and one row anywhere settles it (issue #1062). The other two are the regions
+         * either side, and where a region stops is settled by every other rule reaching this
+         * position — so they are this reading's whatever drew the line.
+         *
+         * <p>Asked here and not at each reader. Everything that measures a behavior, counts what it
+         * covers or raises a finding about it has to leave the declaration's points out, and the
+         * rule written at each of them is a rule each of them can forget: a verdict that kept them
+         * weighed one behavior's row against another behavior having no rows, and a count that keeps
+         * them says a body is short of something no row written for it is owed.
+         *
+         * <p>A reader that only describes may show them all the same. What is not this behavior's to
+         * be measured for is still a line its values are held to, and the block that says so is
+         * telling an author about the type they wrote.
+         */
+        public boolean owedHere() {
+            return !role.againstTheLine()
+                    || border.origin().owedToTheDeclaration().isEmpty();
+        }
+
         /** The measured half, or null where no row is owed here. */
         public ItemAssessment.Owed owed() {
             return item instanceof ItemAssessment.Owed owed ? owed : null;

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderAssessment.java
@@ -105,12 +105,22 @@ public record BorderAssessment(Border border, Map<PointRole, ItemAssessment> ite
     }
 
     /** The rule that drew the line, as a report about {@code sectionSource} writes it. */
-    public String origin(SourceNameResolver names, SourceId sectionSource) {
+    public String describe(SourceNameResolver names, SourceId sectionSource) {
         return border.origin().describe(names, sectionSource);
     }
 
-    /** The rule itself, for a reader that renders it rather than printing what this would. */
-    public OriginRef rule() {
+    /**
+     * The rule as this reading met it, for a reader that renders it rather than printing what
+     * {@link #describe} would.
+     *
+     * <p>An {@link OriginRef} and not a {@link souther.compiler.check.RuleRef}, which is why it is
+     * not called the rule. Which rule of the model this came from is
+     * {@link souther.compiler.partition.BorderObligationId#provenance()}, the same value however
+     * many lines the rule drew; what a row is owed for is
+     * {@link souther.compiler.partition.Border#obligation()}. Named the rule, the first two were one
+     * word, and a caller wanting either reached for whichever this happened to be.
+     */
+    public OriginRef origin() {
         return border.origin();
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderObligationAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderObligationAssessment.java
@@ -21,9 +21,23 @@ import java.util.Map;
  * Answered from an occurrence, one clause of {@code UserId} was 126 things to write a row for over
  * {@code crm} (issue #1062).
  *
- * <p><b>Total over {@link PointRole}, the way an occurrence is.</b> A line answers for every role
- * and so does this, so a reader asking what one of them came to is never answered by an entry that
- * is not there.
+ * <p><b>The two points against the line, and not the four an occurrence answers for.</b> {@code ON}
+ * and {@code OFF} are values of the quantity the rule cut: whether a row standing at length 1 is
+ * believed is a question about {@code UserId} and the same question wherever the type is carried.
+ * {@code IN} and {@code OUT} are not values but the two <em>regions</em> either side of the line,
+ * and where a region stops is settled by every other rule reaching that position — {@code Cm}'s
+ * lower end at 0 runs to 150 at a {@code parcel.length} the record caps and runs on at an
+ * {@code order.straw} nothing else bounds. A row well inside one is not a row that could stand at
+ * the other at all, so evidence there is not interchangeable and the point is owed per reading, as
+ * it was.
+ *
+ * <p>Which is the split {@link PointRole#againstTheLine} already names, and the one the two halves
+ * of this technique were counted under before they were brought together: the regions were the
+ * measure that counts the classes a position is divided into, and a class of a position is the
+ * position's.
+ *
+ * <p>Total over the roles it does answer for, so a reader asking what one of them came to is never
+ * answered by an entry that is not there.
  *
  * <p><b>What is owed is the same at every reading, and that is checked rather than folded.</b> A
  * {@link Demand} is what the line asks — a criterion over the levels of the quantity it cut, or a
@@ -33,9 +47,20 @@ import java.util.Map;
  * merged — that mistake would come out as a report asking for a row at a point some other line
  * owns.
  */
-public record BorderObligationAssessment(BorderObligationId id, Map<PointRole, Demand> demands,
+public record BorderObligationAssessment(BorderObligationId id, String axis,
+                                         Map<PointRole, Demand> demands,
                                          Map<PointRole, ItemAssessment> items,
-                                         List<BorderAssessment> readings) {
+                                         List<BorderAssessment> readings,
+                                         List<String> carriedBy) {
+
+    /**
+     * The roles a debt answers for: the two the line names a value at.
+     *
+     * <p>The other two are regions of a position rather than values of the line, so they are owed
+     * per reading and are not here ({@link PointRole#againstTheLine}).
+     */
+    public static final EnumSet<PointRole> AGAINST_THE_LINE =
+            EnumSet.of(PointRole.ON, PointRole.OFF);
 
     public BorderObligationAssessment {
         if (id == null) {
@@ -45,12 +70,17 @@ public record BorderObligationAssessment(BorderObligationId id, Map<PointRole, D
             throw new IllegalArgumentException(
                     "a debt is what its readings came to, and this is none of them: " + id);
         }
-        if (demands == null || !demands.keySet().equals(EnumSet.allOf(PointRole.class))
-                || items == null || !items.keySet().equals(EnumSet.allOf(PointRole.class))) {
+        if (demands == null || !demands.keySet().equals(AGAINST_THE_LINE)
+                || items == null || !items.keySet().equals(AGAINST_THE_LINE)) {
             throw new IllegalArgumentException(
-                    "a debt answering for some of its point roles and not others: " + id);
+                    "a debt answering for some of the points against its line and not others: "
+                            + id + " " + (demands == null ? null : demands.keySet()));
+        }
+        if (axis == null) {
+            throw new IllegalArgumentException("a line is a line on something: " + id);
         }
         readings = List.copyOf(readings);
+        carriedBy = List.copyOf(carriedBy);
         demands = java.util.Collections.unmodifiableMap(new EnumMap<>(demands));
         items = java.util.Collections.unmodifiableMap(new EnumMap<>(items));
     }
@@ -63,27 +93,43 @@ public record BorderObligationAssessment(BorderObligationId id, Map<PointRole, D
      * nothing here: a caller that grouped by anything else — the label, the rule, the position —
      * would be deciding what a debt is a second time and somewhere else.
      */
-    public static List<BorderObligationAssessment> across(List<BorderAssessment> readings) {
+    public static List<BorderObligationAssessment> across(
+            Map<String, List<BorderAssessment>> byBehavior,
+            java.util.function.Function<BorderObligationId, String> named) {
         Map<BorderObligationId, List<BorderAssessment>> byDebt = new LinkedHashMap<>();
-        for (BorderAssessment reading : readings) {
-            byDebt.computeIfAbsent(reading.border().obligation(), _ -> new ArrayList<>())
-                    .add(reading);
-        }
+        Map<BorderObligationId, java.util.LinkedHashSet<String>> carriers = new LinkedHashMap<>();
+        byBehavior.forEach((behavior, readings) -> {
+            for (BorderAssessment reading : readings) {
+                BorderObligationId id = reading.border().obligation();
+                byDebt.computeIfAbsent(id, _ -> new ArrayList<>()).add(reading);
+                carriers.computeIfAbsent(id, _ -> new java.util.LinkedHashSet<>()).add(behavior);
+            }
+        });
         List<BorderObligationAssessment> out = new ArrayList<>();
-        byDebt.forEach((id, of) -> out.add(of(id, of)));
+        byDebt.forEach((id, of) ->
+                out.add(of(id, named.apply(id), of, List.copyOf(carriers.get(id)))));
         return List.copyOf(out);
     }
 
-    /** One debt, from the readings of it. */
-    public static BorderObligationAssessment of(BorderObligationId id,
-                                                List<BorderAssessment> readings) {
+    /**
+     * One debt, from the readings of it, called {@code axis}.
+     *
+     * <p>What the line is on is handed in rather than taken from a reading, because that is the
+     * whole of what a debt is not. A reading names the position it met the line at — {@code
+     * String.length(draft.owner)} — and there are as many of those as there are positions carrying
+     * the type; what the author wrote is {@code String.length(value)}, and it is read from the
+     * declaration ({@link souther.compiler.check.DeclaredBorders}).
+     */
+    public static BorderObligationAssessment of(BorderObligationId id, String axis,
+                                                List<BorderAssessment> readings,
+                                                List<String> carriedBy) {
         Map<PointRole, Demand> demands = new EnumMap<>(PointRole.class);
         Map<PointRole, ItemAssessment> items = new EnumMap<>(PointRole.class);
-        for (PointRole role : EnumSet.allOf(PointRole.class)) {
+        for (PointRole role : AGAINST_THE_LINE) {
             demands.put(role, asked(id, role, readings));
             items.put(role, at(role, readings, demands.get(role)));
         }
-        return new BorderObligationAssessment(id, demands, items, readings);
+        return new BorderObligationAssessment(id, axis, demands, items, readings, carriedBy);
     }
 
     /**
@@ -112,16 +158,24 @@ public record BorderObligationAssessment(BorderObligationId id, Map<PointRole, D
     /**
      * What the readings came to in one role.
      *
-     * <p>The coverage is folded ({@link ItemAssessment.Coverage#acrossTheReadings}); what building a
-     * value came to is not here at all. A row offered for a point is offered once for the debt and
-     * not once per reading, and choosing which reading composes it is a search rather than a fold —
-     * so it stays where the readings are until there is something to say about it.
+     * <p>The coverage is folded ({@link ItemAssessment.Coverage#acrossTheReadings}). So is what
+     * building a value came to, and it is here for one thing: that a value at the point was built
+     * is evidence the point exists, and whether a point exists is what tells a line no row stands at
+     * from one no row could stand at ({@link ItemAssessment#isUnmetGap}). The two points a debt
+     * answers for ask the same of a row at every reading — which is checked, not assumed — so a
+     * value built at one of them is a value at this point.
+     *
+     * <p><b>Not the row a debt is offered.</b> A row is offered once for a line, and which reading
+     * composes it is a search over the readings rather than a fold of them: the row here is written
+     * in one behavior's terms and choosing it as the one to offer would be choosing a
+     * representative, which is the mistake this whole value exists to undo.
      */
     private static ItemAssessment at(PointRole role, List<BorderAssessment> readings, Demand asked) {
         if (asked instanceof Demand.NotOwed not) {
             return new ItemAssessment.NotOwed(not.reason());
         }
         List<Measurement<ItemAssessment.Coverage>> coverage = new ArrayList<>();
+        ItemAssessment.Attempt built = null;
         // Whether a value at the point exists is a fact about the line and not about the reading
         // that reached it: one reading proving it proves it. The other two states are what a reading
         // says about itself, so the weaker of them stands only where nothing proved anything.
@@ -134,6 +188,9 @@ public record BorderObligationAssessment(BorderObligationId id, Map<PointRole, D
                         "a reading owing nothing at a point its line owes one at: " + role);
             }
             coverage.add(owed.coverage());
+            if (built == null && owed.attempt() instanceof ItemAssessment.Attempt.Built) {
+                built = owed.attempt();
+            }
             if (owed.projection().proves()) {
                 projection = ItemAssessment.WritabilityProjection.PROVEN;
             } else if (projection != ItemAssessment.WritabilityProjection.PROVEN
@@ -142,7 +199,7 @@ public record BorderObligationAssessment(BorderObligationId id, Map<PointRole, D
             }
         }
         return new ItemAssessment.Owed(asked.criterion(),
-                ItemAssessment.Coverage.acrossTheReadings(coverage), projection, null);
+                ItemAssessment.Coverage.acrossTheReadings(coverage), projection, built);
     }
 
     /** What became of one role. Never null. */
@@ -155,8 +212,46 @@ public record BorderObligationAssessment(BorderObligationId id, Map<PointRole, D
         return at(role) instanceof ItemAssessment.Owed owed ? owed : null;
     }
 
+    /**
+     * Which behaviors read this line, in the order the module declares them.
+     *
+     * <p>Not part of what the debt is — a line is owed once however many behaviors carry the type —
+     * and here because an editor's offer stands beside a behavior. What a row written for that
+     * behavior settles is this debt, so an offer there has to know the debt is one of the things it
+     * would answer. Without it the offer beside a behavior went quiet as soon as the only work left
+     * was a line the declaration is owed (issue #1062).
+     */
+    public boolean carriedBy(String behavior) {
+        return carriedBy.contains(behavior);
+    }
+
     /** The rule that drew the line, as the readings met it. */
     public souther.compiler.partition.OriginRef origin() {
         return id.origin();
+    }
+
+    /**
+     * What one point of the line asks of a row, as a report writes it.
+     *
+     * <p>The same sentence a reading's point writes ({@link BorderAssessment.Point#said}), on what
+     * the declaration wrote rather than on the position a reading met it at. The two are joined by
+     * a consumer against one of a border's items, so they are spelled by one rule and not two.
+     */
+    public String said(PointRole role) {
+        return role.againstTheLine() ? axis + " = " + against(role)
+                : axis + " " + operator(role) + " " + against(role);
+    }
+
+    /** How one point relates a row's value to what it is against, or null where none is owed. */
+    public String operator(PointRole role) {
+        souther.compiler.partition.Criterion criterion = demands.get(role).criterion();
+        return criterion == null ? null : criterion.operator();
+    }
+
+    /** What a row at one point of it would have to do, as a report writes it, or null where no row
+     *  is owed there. */
+    public String against(PointRole role) {
+        souther.compiler.partition.Criterion criterion = demands.get(role).criterion();
+        return criterion == null ? null : criterion.written(readings.get(0).border().cut().of());
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderObligationAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderObligationAssessment.java
@@ -1,0 +1,162 @@
+package souther.compiler.query;
+
+import souther.compiler.partition.BorderObligationId;
+import souther.compiler.partition.Demand;
+import souther.compiler.partition.PointRole;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Everything known about one authored line: what it asks at each of its four points, and what all
+ * the readings of it came to.
+ *
+ * <p>What a report prints, what a build refuses over and what an editor offers are readings of this.
+ * A {@link BorderAssessment} beside it is one <em>occurrence</em> — the line as some position of
+ * some behavior met it — and there is one of those per position of every behavior carrying the type.
+ * Answered from an occurrence, one clause of {@code UserId} was 126 things to write a row for over
+ * {@code crm} (issue #1062).
+ *
+ * <p><b>Total over {@link PointRole}, the way an occurrence is.</b> A line answers for every role
+ * and so does this, so a reader asking what one of them came to is never answered by an entry that
+ * is not there.
+ *
+ * <p><b>What is owed is the same at every reading, and that is checked rather than folded.</b> A
+ * {@link Demand} is what the line asks — a criterion over the levels of the quantity it cut, or a
+ * reason no row is asked for — and none of it is about where the line was read. So two readings of
+ * one debt that disagree about it have not disagreed: something has called two authored lines one,
+ * and the identity is what is wrong. Joined instead — the stronger demand winning, or the two
+ * merged — that mistake would come out as a report asking for a row at a point some other line
+ * owns.
+ */
+public record BorderObligationAssessment(BorderObligationId id, Map<PointRole, Demand> demands,
+                                         Map<PointRole, ItemAssessment> items,
+                                         List<BorderAssessment> readings) {
+
+    public BorderObligationAssessment {
+        if (id == null) {
+            throw new IllegalArgumentException("a debt is some authored line's");
+        }
+        if (readings == null || readings.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "a debt is what its readings came to, and this is none of them: " + id);
+        }
+        if (demands == null || !demands.keySet().equals(EnumSet.allOf(PointRole.class))
+                || items == null || !items.keySet().equals(EnumSet.allOf(PointRole.class))) {
+            throw new IllegalArgumentException(
+                    "a debt answering for some of its point roles and not others: " + id);
+        }
+        readings = List.copyOf(readings);
+        demands = java.util.Collections.unmodifiableMap(new EnumMap<>(demands));
+        items = java.util.Collections.unmodifiableMap(new EnumMap<>(items));
+    }
+
+    /**
+     * The debts of a module, from every reading of every one of them.
+     *
+     * <p>In the order the readings were made, so that what a report prints is read against the one
+     * before it. What tells the readings apart is what {@link BorderObligationId} answers and
+     * nothing here: a caller that grouped by anything else — the label, the rule, the position —
+     * would be deciding what a debt is a second time and somewhere else.
+     */
+    public static List<BorderObligationAssessment> across(List<BorderAssessment> readings) {
+        Map<BorderObligationId, List<BorderAssessment>> byDebt = new LinkedHashMap<>();
+        for (BorderAssessment reading : readings) {
+            byDebt.computeIfAbsent(reading.border().obligation(), _ -> new ArrayList<>())
+                    .add(reading);
+        }
+        List<BorderObligationAssessment> out = new ArrayList<>();
+        byDebt.forEach((id, of) -> out.add(of(id, of)));
+        return List.copyOf(out);
+    }
+
+    /** One debt, from the readings of it. */
+    public static BorderObligationAssessment of(BorderObligationId id,
+                                                List<BorderAssessment> readings) {
+        Map<PointRole, Demand> demands = new EnumMap<>(PointRole.class);
+        Map<PointRole, ItemAssessment> items = new EnumMap<>(PointRole.class);
+        for (PointRole role : EnumSet.allOf(PointRole.class)) {
+            demands.put(role, asked(id, role, readings));
+            items.put(role, at(role, readings, demands.get(role)));
+        }
+        return new BorderObligationAssessment(id, demands, items, readings);
+    }
+
+    /**
+     * What the line asks in one role, which every reading of it says the same way.
+     *
+     * <p>Checked here, because this is where two readings of one debt first stand beside each other.
+     * A disagreement is not something to resolve: it says the two are not one line, and the identity
+     * that put them together is the defect. What it names is both readings, since which of them is
+     * the wrong one is exactly what is not known.
+     */
+    private static Demand asked(BorderObligationId id, PointRole role,
+                                List<BorderAssessment> readings) {
+        Demand asked = readings.get(0).border().demand(role);
+        for (BorderAssessment reading : readings) {
+            Demand also = reading.border().demand(role);
+            if (!asked.equals(also)) {
+                throw new IllegalStateException("two readings of one line disagree about what its "
+                        + role + " point asks for, so they are not one line: " + id
+                        + " asks " + asked + " at " + readings.get(0).border().cut().named()
+                        + " and " + also + " at " + reading.border().cut().named());
+            }
+        }
+        return asked;
+    }
+
+    /**
+     * What the readings came to in one role.
+     *
+     * <p>The coverage is folded ({@link ItemAssessment.Coverage#acrossTheReadings}); what building a
+     * value came to is not here at all. A row offered for a point is offered once for the debt and
+     * not once per reading, and choosing which reading composes it is a search rather than a fold —
+     * so it stays where the readings are until there is something to say about it.
+     */
+    private static ItemAssessment at(PointRole role, List<BorderAssessment> readings, Demand asked) {
+        if (asked instanceof Demand.NotOwed not) {
+            return new ItemAssessment.NotOwed(not.reason());
+        }
+        List<Measurement<ItemAssessment.Coverage>> coverage = new ArrayList<>();
+        // Whether a value at the point exists is a fact about the line and not about the reading
+        // that reached it: one reading proving it proves it. The other two states are what a reading
+        // says about itself, so the weaker of them stands only where nothing proved anything.
+        ItemAssessment.WritabilityProjection projection =
+                ItemAssessment.WritabilityProjection.NOT_COMPUTED;
+        for (BorderAssessment reading : readings) {
+            ItemAssessment.Owed owed = reading.owedAt(role);
+            if (owed == null) {
+                throw new IllegalStateException(
+                        "a reading owing nothing at a point its line owes one at: " + role);
+            }
+            coverage.add(owed.coverage());
+            if (owed.projection().proves()) {
+                projection = ItemAssessment.WritabilityProjection.PROVEN;
+            } else if (projection != ItemAssessment.WritabilityProjection.PROVEN
+                    && owed.projection() == ItemAssessment.WritabilityProjection.UNPROVEN) {
+                projection = ItemAssessment.WritabilityProjection.UNPROVEN;
+            }
+        }
+        return new ItemAssessment.Owed(asked.criterion(),
+                ItemAssessment.Coverage.acrossTheReadings(coverage), projection, null);
+    }
+
+    /** What became of one role. Never null. */
+    public ItemAssessment at(PointRole role) {
+        return items.get(role);
+    }
+
+    /** The measured half of one role, or null where no row is owed there. */
+    public ItemAssessment.Owed owedAt(PointRole role) {
+        return at(role) instanceof ItemAssessment.Owed owed ? owed : null;
+    }
+
+    /** The rule that drew the line, as the readings met it. */
+    public souther.compiler.partition.OriginRef origin() {
+        return id.origin();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderObligationAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderObligationAssessment.java
@@ -248,8 +248,16 @@ public record BorderObligationAssessment(BorderObligationId id, String axis,
         return criterion == null ? null : criterion.operator();
     }
 
-    /** What a row at one point of it would have to do, as a report writes it, or null where no row
-     *  is owed there. */
+    /**
+     * What a row at one point of it would have to do, as a report writes it, or null where no row
+     * is owed there.
+     *
+     * <p>Written on a reading's quantity, and any of them will do. What a criterion writes is the
+     * level in the terms of the order that level is on, and which order that is, is part of what a
+     * debt is — the readings of one debt cut one carrier at one place, which is checked where their
+     * demands are. So this is not a reading standing in for the rest; it is the one answer they all
+     * give.
+     */
     public String against(PointRole role) {
         souther.compiler.partition.Criterion criterion = demands.get(role).criterion();
         return criterion == null ? null : criterion.written(readings.get(0).border().cut().of());

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderObligationAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderObligationAssessment.java
@@ -59,8 +59,8 @@ public record BorderObligationAssessment(BorderObligationId id, String axis,
      * <p>The other two are regions of a position rather than values of the line, so they are owed
      * per reading and are not here ({@link PointRole#againstTheLine}).
      */
-    public static final EnumSet<PointRole> AGAINST_THE_LINE =
-            EnumSet.of(PointRole.ON, PointRole.OFF);
+    public static final java.util.Set<PointRole> AGAINST_THE_LINE =
+            java.util.Collections.unmodifiableSet(EnumSet.of(PointRole.ON, PointRole.OFF));
 
     public BorderObligationAssessment {
         if (id == null) {
@@ -202,12 +202,22 @@ public record BorderObligationAssessment(BorderObligationId id, String axis,
                 ItemAssessment.Coverage.acrossTheReadings(coverage), projection, built);
     }
 
-    /** What became of one role. Never null. */
+    /**
+     * What became of one of the points against the line. Never null.
+     *
+     * <p>Refused for a region, which is not something a debt answers for: where a region stops is
+     * settled by every other rule reaching a position, so a debt has no answer to give and a null
+     * would be read as one. A reader wanting a region asks the reading it is a region of.
+     */
     public ItemAssessment at(PointRole role) {
+        if (!AGAINST_THE_LINE.contains(role)) {
+            throw new IllegalArgumentException("a debt answers for the points against its line, and "
+                    + role + " is a region of a position: " + id);
+        }
         return items.get(role);
     }
 
-    /** The measured half of one role, or null where no row is owed there. */
+    /** The measured half of one of those, or null where no row is owed there. */
     public ItemAssessment.Owed owedAt(PointRole role) {
         return at(role) instanceof ItemAssessment.Owed owed ? owed : null;
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/FindingSubject.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/FindingSubject.java
@@ -1,0 +1,70 @@
+package souther.compiler.query;
+
+import souther.compiler.types.TypeSymbol;
+
+/**
+ * What a finding is about, which is not always a behavior.
+ *
+ * <p>Two things a model is short of and they are not one. A {@code match} arm nothing reaches and a
+ * case no row expects are facts about a body: they are found by reading one behavior, and the author
+ * fixes them by writing a row for that behavior. A line an {@code invariant} drew is a fact about
+ * the type: whether a row standing at the boundary of {@code UserId} is believed is a question about
+ * {@code UserId}, and the answer cannot differ between the behaviors carrying it (issue #1062).
+ *
+ * <p><b>Because there is no behavior to name.</b> Findings used to be a behavior and a list, so a
+ * finding about a declaration had to be filed under one of the behaviors that carry it — the first
+ * one a walk reached, which is a choice nothing made and a reader cannot check. An author sent to
+ * {@code scheduleMeeting} to fix what {@code UserId} says would be sent to a body that says nothing
+ * about the length of a user id.
+ *
+ * <p>Grouping is a reader's, and it is not this. A report prints a block per behavior because that
+ * is how somebody reads it; the model says what each finding is about and lets whoever is printing
+ * decide what to put beside what. Held as the key of a map, the two were one and the presentation
+ * won.
+ */
+public sealed interface FindingSubject {
+
+    /** What a report calls it, in English, the way every other word this writes is chosen. */
+    String named();
+
+    /** A body of the module: what a row written for that behavior answers. */
+    record OfABehavior(String name) implements FindingSubject {
+
+        public OfABehavior {
+            if (name == null) {
+                throw new IllegalArgumentException("a finding about a behavior says which");
+            }
+        }
+
+        @Override
+        public String named() {
+            return name;
+        }
+    }
+
+    /**
+     * A declaration of the module: what its own rules say, wherever the type is carried.
+     *
+     * <p>The declaration and not the clause. Which rule of it a finding is about is the finding's
+     * own ({@link About}), and a subject that carried the clause would be two answers about one
+     * question — what a report prints this under is the declaration either way.
+     */
+    record OfADeclaration(TypeSymbol declaration) implements FindingSubject {
+
+        public OfADeclaration {
+            if (declaration == null) {
+                throw new IllegalArgumentException("a finding about a declaration says which");
+            }
+        }
+
+        @Override
+        public String named() {
+            return declaration.name();
+        }
+    }
+
+    /** Whether this is the behavior named {@code name}, for a reader printing a block per behavior. */
+    default boolean isBehavior(String name) {
+        return this instanceof OfABehavior it && it.name().equals(name);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/ItemAssessment.java
@@ -276,14 +276,34 @@ public sealed interface ItemAssessment {
              *  which needs no arms. */
             ARMS_NOT_ASKED,
             /** No row names this behavior. */
-            NO_ROWS
+            NO_ROWS;
+
+            /**
+             * Whether a row at the point could be sitting behind this and not have been seen.
+             *
+             * <p>Asked of the reason and not of the state around it. Three of these are one
+             * {@code NotMeasured} and they do not mean one thing when the answers of several
+             * readings are put together: rows the build never looked at may be standing at the
+             * point, and rows that do not exist cannot be. Read as the state — "nothing was
+             * measured, so nothing is known" — a reading of a behavior nobody wrote a row for
+             * would hold open a line another reading had shown a row misses.
+             */
+            public boolean mayHideARow() {
+                return this != NO_ROWS;
+            }
         }
 
         /** Why the question was put and could not be answered. */
         enum CouldNotAsk implements souther.compiler.observe.FailureReason {
             /** The rows ran without instrumentation, so no row can be shown to have reached the
              *  comparison. Never a reason for an invariant's line. */
-            ARMS_UNREADABLE
+            ARMS_UNREADABLE;
+
+            /** Whether a row at the point could be sitting behind this, as {@link NotAsked} answers
+             *  it. The rows ran, so one of them may have reached the comparison unrecorded. */
+            public boolean mayHideARow() {
+                return true;
+            }
         }
 
         /**
@@ -299,6 +319,76 @@ public sealed interface ItemAssessment {
          */
         static boolean hit(Coverage coverage) {
             return coverage instanceof Hit;
+        }
+
+        /**
+         * What the readings of one authored line come to together.
+         *
+         * <p>One debt is read at every position of every behavior carrying the type, and each of
+         * those readings measures it on its own. What the debt came to is not any one of them: a row
+         * standing at the line through {@code draft.owner} is evidence about {@code UserId}, and the
+         * reading at {@code activities[*]@CallTask.owner} cannot disagree with it (issue #1062).
+         *
+         * <p><b>Here and nowhere else.</b> A report, a build's refusal, an editor and the generator
+         * all ask what became of a debt, and four foldings of the same readings would be four
+         * answers about one line — which is the shape this whole change is undoing.
+         *
+         * <p>The order is the whole of it. A row found settles the line whatever else went unread,
+         * so a hit outranks everything. Below that, a reading that could be hiding a row outranks
+         * one that ran out and found none, because the second is an answer and the first is the
+         * absence of one. And a reading with no rows to look at is neither: it hides nothing, so it
+         * cannot take back a miss another reading established, and where every reading is one there
+         * was nothing anywhere to look at.
+         */
+        static Measurement<Coverage> acrossTheReadings(
+                java.util.List<Measurement<Coverage>> readings) {
+            if (readings.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "a debt is what its readings came to, and this is none of them");
+            }
+            WeakeningSet unread = WeakeningSet.none();
+            souther.compiler.observe.NotMeasuredReason unasked = null;
+            boolean missed = false;
+            for (Measurement<Coverage> reading : readings) {
+                // Found is found. Said before anything else is looked at, so that no accounting of
+                // what went unread can weaken a row somebody wrote.
+                if (reading.made().map(Coverage::hit).orElse(false)) {
+                    return new Measurement.Complete<>(new Hit());
+                }
+                switch (reading) {
+                    // A reading of this line that did not run out. Whatever it could not read may
+                    // be holding the row.
+                    case Measurement.Partial<Coverage> in -> unread = unread.union(in.by());
+                    case Measurement.FailedToMeasure<Coverage> stopped -> {
+                        if (((CouldNotAsk) stopped.why()).mayHideARow()) {
+                            unread = unread.union(stopped.by());
+                        }
+                    }
+                    // The three reasons a question was not put are not one answer here. One that
+                    // may be hiding a row is kept as itself rather than turned into a weakening:
+                    // nothing was read, so there is no reading for a weakening to be about.
+                    case Measurement.NotMeasured<Coverage> none -> {
+                        if (((NotAsked) none.why()).mayHideARow()) {
+                            unasked = none.why();
+                        }
+                    }
+                    // Read to the end and no row is at the point, which is what a miss is.
+                    case Measurement.Complete<Coverage> _ -> missed = true;
+                }
+            }
+            if (!unread.isEmpty()) {
+                return new Measurement.Partial<>(new NoHit(), unread);
+            }
+            // Above a miss another reading established, because a reading that looked at nothing
+            // leaves the rows it would have looked at unaccounted for. Both of the reasons that
+            // reach here are settings of the build rather than facts about one behavior, so this is
+            // reached where every reading says it and not where one of them does.
+            if (unasked != null) {
+                return new Measurement.NotMeasured<>(unasked);
+            }
+            return missed ? new Measurement.Complete<>(new NoHit())
+                    // Every reading had nothing to look at, so neither has the debt.
+                    : new Measurement.NotMeasured<>(NotAsked.NO_ROWS);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -616,8 +616,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 // verdict would hold open what the aggregation had settled (issue #1062).
                 BorderAssessment.pointsOf(behavior.partition().boundaries()).stream()
                         .filter(p -> held.requires(p.role()))
-                        .filter(p -> !p.role().againstTheLine()
-                                || p.border().origin().owedToTheDeclaration().isEmpty())
+                        .filter(BorderAssessment.Point::owedHere)
                         .forEach(p -> add(measures, measurementOf(p.item())));
                 // Which of the four those are is the bar's answer and not a second reading of it
                 // here: a build refusing over a missing IN row and calling a model satisfied while

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -95,9 +95,23 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     }
 
     public record ModuleReport(String module, SourceId declaredIn,
-                               List<BehaviorReport> behaviors) {
+                               List<BehaviorReport> behaviors,
+                               List<Adequacy.Finding> declarations) {
+
+        /**
+         * What the module is short of that is not any behavior's.
+         *
+         * <p>A line an {@code invariant} drew is a fact about the type — whether a row standing at
+         * the boundary of {@code UserId} is believed is a question about {@code UserId}, and the
+         * behaviors carrying it say nothing about the length of a user id (issue #1062). Held in a
+         * behavior's list, it had to be filed under whichever of them a walk reached first.
+         *
+         * <p>Here rather than left out of the report, so that a finding whose subject is not a
+         * behavior cannot go missing between the measure and the page.
+         */
         public ModuleReport {
             behaviors = List.copyOf(behaviors);
+            declarations = List.copyOf(declarations);
         }
 
         /**
@@ -283,7 +297,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 compilation.db().ask(new souther.compiler.query.Bodies.Claimed(name)).value();
         // The lines this report prints and the warnings a build is given are the same list, asked for
         // once here. A second reading of the evidence would be a second statement of what a gap is.
-        Map<String, List<Adequacy.Finding>> findings =
+        List<Adequacy.Finding> findings =
                 compilation.db().ask(new Adequacy.Findings(name)).value();
         List<BehaviorReport> behaviors = new ArrayList<>();
         for (Hir.BehaviorDef behavior : module.behaviors()) {
@@ -311,10 +325,21 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     new BehaviorEvidence(reading, signature, partition, branch),
                     claims == null ? ClaimAnnotations.NONE
                             : claims.getOrDefault(behavior.name(), ClaimAnnotations.NONE),
-                    findings == null ? List.of()
-                            : findings.getOrDefault(behavior.name(), List.of())));
+                    ofBehavior(findings, behavior.name())));
         }
-        return new ModuleReport(name, compilation.sourceIdOf(name), behaviors);
+        return new ModuleReport(name, compilation.sourceIdOf(name), behaviors,
+                findings == null ? List.of()
+                        : findings.stream()
+                                .filter(each -> !(each.subject()
+                                        instanceof souther.compiler.query.FindingSubject.OfABehavior))
+                                .toList());
+    }
+
+    /** The findings about one behavior. Grouped here, where a block per behavior is printed, and
+     *  not by the measure: what each finding is about is its own answer. */
+    private static List<Adequacy.Finding> ofBehavior(List<Adequacy.Finding> findings, String name) {
+        return findings == null ? List.of()
+                : findings.stream().filter(each -> each.subject().isBehavior(name)).toList();
     }
 
     /** This report with only the modules and behaviors the caller asked about. A name that matches
@@ -333,7 +358,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // what only it carried and keeps what a whole source cost every one of them. That was a
             // filter over a list of the module's own, which is a second statement of who a reason
             // counts against — asked of the reason where it belongs (issue #996).
-            ModuleReport one = new ModuleReport(m.module(), m.declaredIn(), behaviors);
+            // What the module's declarations are short of is kept whichever behavior was asked
+            // about, for the reason the reasons are: it is not any behavior's, so narrowing to one
+            // of them takes nothing away from it.
+            ModuleReport one = new ModuleReport(m.module(), m.declaredIn(), behaviors,
+                    m.declarations());
             kept.add(one);
             overall = overall.union(one.weakenedBy());
         }

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -335,11 +335,63 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                                 .toList());
     }
 
+    /**
+     * The declarations' findings that one of {@code shown} carries.
+     *
+     * <p>Asked of the debt, which knows which behaviors read the line. A line no behavior in this
+     * report carries is work nobody reading it can do, and one that some behavior here carries is
+     * work a row written in front of the reader settles.
+     */
+    private static List<Adequacy.Finding> carriedBy(List<Adequacy.Finding> declarations,
+                                                    List<BehaviorReport> shown) {
+        java.util.Set<String> names = shown.stream().map(BehaviorReport::name)
+                .collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new));
+        return declarations.stream()
+                .filter(each -> !(each.about()
+                        instanceof About.APointOfADeclaredBorder(var debt, var _))
+                        || names.stream().anyMatch(debt::carriedBy))
+                .toList();
+    }
+
     /** The findings about one behavior. Grouped here, where a block per behavior is printed, and
      *  not by the measure: what each finding is about is its own answer. */
     private static List<Adequacy.Finding> ofBehavior(List<Adequacy.Finding> findings, String name) {
         return findings == null ? List.of()
                 : findings.stream().filter(each -> each.subject().isBehavior(name)).toList();
+    }
+
+    /**
+     * What the module's declarations are short of, under the declaration that wrote the rule.
+     *
+     * <p>Under the declaration and not under a behavior, because that is where an author fixes it. A
+     * line an {@code invariant} drew is a fact about the type — whether a row standing at the
+     * boundary of {@code UserId} is believed is a question about {@code UserId} — and it is met by a
+     * row written anywhere the type is carried. Printed under a behavior, it would have to be
+     * printed under whichever one a walk reached first, and an author sent there would be sent to a
+     * body that says nothing about the length of a user id (issue #1062).
+     *
+     * <p>The two points against the line and no others. What a row well inside the border shows is
+     * about the region of one position, so it stays with that position's behavior — which is why
+     * this block holds one kind of line and the block above still holds both.
+     *
+     * <p>After the behaviors, so that a reader who has just read what each body is short of reads
+     * what the model itself is short of once.
+     */
+    private void declared(StringBuilder out, ModuleReport module, SourceNameResolver names) {
+        Map<String, List<Adequacy.Finding>> byDeclaration = new java.util.LinkedHashMap<>();
+        for (Adequacy.Finding each : module.declarations()) {
+            byDeclaration.computeIfAbsent(each.named(), _ -> new ArrayList<>()).add(each);
+        }
+        byDeclaration.forEach((declaration, findings) -> {
+            out.append(String.format("  %s%n", declaration));
+            for (Adequacy.Finding f : findings) {
+                if (f.about() instanceof About.APointOfADeclaredBorder(var debt, var role)) {
+                    out.append(String.format("      %s no row is at the %s point %s = %s (%s)%n",
+                            mark(f), role, debt.axis(), debt.against(role),
+                            debt.origin().describe(names, module.declaredIn())));
+                }
+            }
+        });
     }
 
     /** This report with only the modules and behaviors the caller asked about. A name that matches
@@ -358,11 +410,13 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // what only it carried and keeps what a whole source cost every one of them. That was a
             // filter over a list of the module's own, which is a second statement of who a reason
             // counts against — asked of the reason where it belongs (issue #996).
-            // What the module's declarations are short of is kept whichever behavior was asked
-            // about, for the reason the reasons are: it is not any behavior's, so narrowing to one
-            // of them takes nothing away from it.
+            // What the module's declarations are short of, kept where a behavior that is shown
+            // carries the line. A line an `invariant` drew is not any behavior's, and it is
+            // discharged by a row written for any behavior carrying the type — so it is work the
+            // reader of this report can do, and a verdict that kept a line none of the behaviors
+            // shown carries would be a verdict about what the reader cannot see.
             ModuleReport one = new ModuleReport(m.module(), m.declaredIn(), behaviors,
-                    m.declarations());
+                    carriedBy(m.declarations(), behaviors));
             kept.add(one);
             overall = overall.union(one.weakenedBy());
         }
@@ -381,10 +435,20 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 .mapToInt(java.util.OptionalInt::getAsInt).sum();
     }
 
-    /** Everything the measures found, across everything reported. */
+    /**
+     * Everything the measures found, across everything reported.
+     *
+     * <p>What the declarations are short of as well as what the bodies are. A line an
+     * {@code invariant} drew is not any behavior's, and a walk over the behaviors alone left it out
+     * of the verdict — so a report printed a gap and said the rows met the bar under it
+     * (issue #1062).
+     */
     public List<Adequacy.Finding> findings() {
-        return modules.stream().flatMap(m -> m.behaviors().stream())
-                .flatMap(b -> b.findings().stream()).toList();
+        return java.util.stream.Stream.concat(
+                        modules.stream().flatMap(m -> m.behaviors().stream())
+                                .flatMap(b -> b.findings().stream()),
+                        modules.stream().flatMap(m -> m.declarations().stream()))
+                .toList();
     }
 
     /** The findings a build is entitled to refuse: a measure came to an answer and the answer was
@@ -625,6 +689,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                         .filter(gap -> gap.behavior().map(behavior.name()::equals).orElse(false))
                         .toList(), names);
             }
+            declared(out, module, names);
             said(out, module.incompleteness().stream()
                     .filter(gap -> gap.behavior().isEmpty()).toList(), names);
         }
@@ -1750,6 +1815,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                         gap.sourceIdentity().map(sources::written).orElseGet(gap::subject));
                 gap.at().ifPresent(where -> at(g, where, sources));
             }
+            // What the module's declarations are short of, beside what its bodies are. A line an
+            // `invariant` drew is not any behavior's, so publishing it under one would publish it
+            // under whichever a walk reached first — and left out, a consumer counting what a build
+            // refuses over would come up short of what the page shows (issue #1062).
+            findings(m.putArray("declarations"), module.declarations(), sources);
             ArrayNode behaviors = m.putArray("behaviors");
             for (BehaviorReport behavior : module.behaviors()) {
                 ObjectNode b = behaviors.addObject();
@@ -2171,8 +2241,19 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      * line or a class, that coordinate is not where the reader would go.
      */
     private void findings(ObjectNode behavior, BehaviorReport of, DocumentSources sources) {
-        ArrayNode out = behavior.putArray("findings");
-        for (Adequacy.Finding finding : of.findings()) {
+        findings(behavior.putArray("findings"), of.findings(), sources);
+    }
+
+    /**
+     * The same entries, wherever they are published.
+     *
+     * <p>One writer, because a finding about a declaration is published in the same fields as one
+     * about a behavior — what it is about is the subject's answer and not a second shape of entry.
+     * Written twice, a consumer joining on the fields would find them agreeing until one of the two
+     * was edited.
+     */
+    private void findings(ArrayNode out, List<Adequacy.Finding> written, DocumentSources sources) {
+        for (Adequacy.Finding finding : written) {
             ObjectNode f = out.addObject();
             f.put("kind", word(finding.kind()));
             f.put("disposition", word(finding.disposition(held)));
@@ -2227,7 +2308,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             case About.AnArmNoRowGoesThrough _ -> finding.at();
             case About.ACaseNoRowExpects _, About.ACaseNothingWasSeenToProduce _,
                     About.ACaseNoRowAppliesItTo _, About.AClassNoRowIsIn _,
-                    About.APointOfABorder _, About.APositionNoLineDivides _,
+                    About.APointOfABorder _, About.APointOfADeclaredBorder _,
+                    About.APositionNoLineDivides _,
                     About.APositionThisCouldNotRead _, About.ARuleWithoutALine _,
                     About.AQuestionNothingAnswered _,
                     About.APositionWhoseRulesWereNotReached _,
@@ -2283,6 +2365,10 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // What the point asks of a row, which is what joins it to one of a border's `items`.
             // Asked of the point, which is where the two readers of that name meet.
             case About.APointOfABorder(var point) -> point.said();
+            // The same sentence, on what the declaration wrote. A line owed once over every reading
+            // of it is named by the terms the author used and not by the position some behavior met
+            // it at, which is what the debt is (issue #1062).
+            case About.APointOfADeclaredBorder(var debt, var role) -> debt.said(role);
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -981,10 +981,10 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     out.append(againstTheLine
                             ? String.format("      %s no row is at the %s point %s = %s (%s)%n",
                                     mark(f), point.role(), point.border().axis(),
-                                    point.against(), point.border().origin(names, declaredIn))
+                                    point.against(), point.border().describe(names, declaredIn))
                             : String.format("      %s no row is at an %s point of %s, %s (%s)%n",
                                     mark(f), point.role(), point.border().axis(),
-                                    point.against(), point.border().origin(names, declaredIn)));
+                                    point.against(), point.border().describe(names, declaredIn)));
                 }
             }
         }
@@ -999,7 +999,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // without this line the difference reads as the tool being arbitrary.
             out.append(String.format("      · not known to be writable: the %s point %s %s (%s)%s%n",
                     p.role(), p.border().axis(), p.asked(),
-                    p.border().origin(names, declaredIn),
+                    p.border().describe(names, declaredIn),
                     whatWasTried(owed(p).attempt(), names, declaredIn)));
         }
         // And what the model itself answered, which is not a row anybody is behind on. Named by the
@@ -1008,7 +1008,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         for (BorderAssessment.Point p : BorderAssessment.pointsOf(partition.boundaries())) {
             if (p.item() instanceof ItemAssessment.NotOwed not) {
                 out.append(String.format("      · no %s point is owed at %s (%s): %s%n",
-                        p.role(), p.border().label(), p.border().origin(names, declaredIn),
+                        p.role(), p.border().label(), p.border().describe(names, declaredIn),
                         whyNotOwed(not.reason())));
             }
         }
@@ -1970,7 +1970,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // a place written without its source is a line and a column belonging to nothing —
             // and where a boundary is the only place a report points at, the `sources` table has
             // no other entry to guess from.
-            b.put("origin", boundary.origin(sources::written, null));
+            b.put("origin", boundary.describe(sources::written, null));
             // What the line is a line at, said rather than left to be inferred from the text beside
             // it. A line between two positions writes the other position where a line at a count
             // writes the count, and the two read alike.

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -22,6 +22,7 @@ import souther.compiler.query.OutputCaseEvidence;
 import souther.compiler.query.About;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.BorderObligationAssessment;
 import souther.compiler.query.ItemAssessment;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.BehaviorEvidence;
@@ -96,7 +97,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
 
     public record ModuleReport(String module, SourceId declaredIn,
                                List<BehaviorReport> behaviors,
-                               List<Adequacy.Finding> declarations) {
+                               List<Adequacy.Finding> declarations,
+                               List<Adequacy.DeclaredDebt> debts) {
 
         /**
          * What the module is short of that is not any behavior's.
@@ -112,6 +114,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         public ModuleReport {
             behaviors = List.copyOf(behaviors);
             declarations = List.copyOf(declarations);
+            debts = List.copyOf(debts);
         }
 
         /**
@@ -327,12 +330,15 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                             : claims.getOrDefault(behavior.name(), ClaimAnnotations.NONE),
                     ofBehavior(findings, behavior.name())));
         }
+        List<Adequacy.DeclaredDebt> debts =
+                compilation.db().ask(new Adequacy.DeclaredBorders(name)).value();
         return new ModuleReport(name, compilation.sourceIdOf(name), behaviors,
                 findings == null ? List.of()
                         : findings.stream()
                                 .filter(each -> !(each.subject()
                                         instanceof souther.compiler.query.FindingSubject.OfABehavior))
-                                .toList());
+                                .toList(),
+                debts == null ? List.of() : debts);
     }
 
     /**
@@ -415,8 +421,16 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // discharged by a row written for any behavior carrying the type — so it is work the
             // reader of this report can do, and a verdict that kept a line none of the behaviors
             // shown carries would be a verdict about what the reader cannot see.
+            // And the debts those behaviors carry, for the same reason and by the same question:
+            // a verdict about a line none of them carries is a verdict about what the reader
+            // cannot see.
+            java.util.Set<String> names = behaviors.stream().map(BehaviorReport::name)
+                    .collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new));
             ModuleReport one = new ModuleReport(m.module(), m.declaredIn(), behaviors,
-                    carriedBy(m.declarations(), behaviors));
+                    carriedBy(m.declarations(), behaviors),
+                    m.debts().stream()
+                            .filter(owed -> names.stream().anyMatch(owed.debt()::carriedBy))
+                            .toList());
             kept.add(one);
             overall = overall.union(one.weakenedBy());
         }
@@ -595,9 +609,15 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     add(measures, behavior.partition().partitioned());
                     behavior.partition().axes().forEach(axis -> add(measures, axis.reached()));
                 }
-                // And of a border's four points, the ones the bar asks for.
+                // And of a border's four points, the ones the bar asks for — of the lines this
+                // behavior is owed. A line a declaration is owed is answered once for the module
+                // below, from every reading of it: read here as well, a row standing at it in one
+                // behavior would be weighed against another behavior having no rows, and the
+                // verdict would hold open what the aggregation had settled (issue #1062).
                 BorderAssessment.pointsOf(behavior.partition().boundaries()).stream()
                         .filter(p -> held.requires(p.role()))
+                        .filter(p -> !p.role().againstTheLine()
+                                || p.border().origin().owedToTheDeclaration().isEmpty())
                         .forEach(p -> add(measures, measurementOf(p.item())));
                 // Which of the four those are is the bar's answer and not a second reading of it
                 // here: a build refusing over a missing IN row and calling a model satisfied while
@@ -609,6 +629,19 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 // question stands for it, which is a fact about the measure's reading — so it
                 // leaves the measure's own answer short of complete, and reading it back off the
                 // list of what was dropped would be this report deciding a measure's status again.
+            }
+            // And what the module's declarations are owed, once each and from every reading.
+            //
+            // The debts and not their findings. A line a row already stands at has no finding, so a
+            // denominator made of the findings is a denominator made of the gaps — which is
+            // satisfied by whatever it does not contain.
+            for (Adequacy.DeclaredDebt owed : module.debts()) {
+                for (souther.compiler.partition.PointRole role
+                        : BorderObligationAssessment.AGAINST_THE_LINE) {
+                    if (held.requires(role)) {
+                        add(measures, measurementOf(owed.debt().at(role)));
+                    }
+                }
             }
         }
         return measures;
@@ -1819,7 +1852,14 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             // `invariant` drew is not any behavior's, so publishing it under one would publish it
             // under whichever a walk reached first — and left out, a consumer counting what a build
             // refuses over would come up short of what the page shows (issue #1062).
-            findings(m.putArray("declarations"), module.declarations(), sources);
+            //
+            // Under the declaration that owes it, the way a behavior's findings are under the
+            // behavior. What a finding says of itself is what the line asks of a row, and two
+            // declarations bounding a string's length at one say it the same way — so published as
+            // one flat list they are two identical objects, and which declaration a reader is being
+            // sent to is exactly what {@link souther.compiler.query.FindingSubject} was introduced
+            // to keep.
+            declarations(m.putArray("declarations"), module.declarations(), sources);
             ArrayNode behaviors = m.putArray("behaviors");
             for (BehaviorReport behavior : module.behaviors()) {
                 ObjectNode b = behaviors.addObject();
@@ -2242,6 +2282,27 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      */
     private void findings(ObjectNode behavior, BehaviorReport of, DocumentSources sources) {
         findings(behavior.putArray("findings"), of.findings(), sources);
+    }
+
+    /**
+     * What each declaration of the module is short of, under the declaration.
+     *
+     * <p>The grouping a human report prints, published. A finding carries which declaration it is
+     * about, so this is a rendering of that and not a second answer: read off the entries alone, the
+     * subject a finding writes is what the line asks of a row, and the declaration it belongs to
+     * would be gone.
+     */
+    private void declarations(ArrayNode out, List<Adequacy.Finding> written,
+                              DocumentSources sources) {
+        Map<String, List<Adequacy.Finding>> byDeclaration = new LinkedHashMap<>();
+        for (Adequacy.Finding each : written) {
+            byDeclaration.computeIfAbsent(each.named(), _ -> new ArrayList<>()).add(each);
+        }
+        byDeclaration.forEach((declaration, findings) -> {
+            ObjectNode one = out.addObject();
+            one.put("name", declaration);
+            findings(one.putArray("findings"), findings, sources);
+        });
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -104,7 +104,7 @@ public final class GeneratedRows {
             // would be left with a model that still fails and nothing would have said which part
             // was never attempted (issue #1062).
             if (boundaries) {
-                declarations(out, compilation, name);
+                declarations(out, compilation, name, behavior);
             }
         }
         return new Block(out.toString(), rows);
@@ -122,10 +122,22 @@ public final class GeneratedRows {
      * <p>Only where the caller asked for the edges, as the lines about them are: a caller that asked
      * for no boundary rows is not asking about these either.
      */
-    private static void declarations(StringBuilder out, Compilation compilation, String module) {
+    private static void declarations(StringBuilder out, Compilation compilation, String module,
+                                     String behavior) {
         java.util.Set<String> said = new java.util.LinkedHashSet<>();
         for (Adequacy.GenerationDisposition each
                 : Adequacy.generatedForDeclarationsOf(compilation.db(), module)) {
+            // A line the behavior asked about does not carry is not work this block is about, the
+            // way a report narrowed to one behavior keeps the lines that behavior carries and drops
+            // the rest.
+            if (behavior != null && each.finding().about()
+                    instanceof About.APointOfADeclaredBorder(var debt, var _)
+                    && !debt.carriedBy(behavior)) {
+                continue;
+            }
+            // Only where nothing composed one. Where a reading of the line did, the row is already
+            // above — it was composed for that reading's own point — and a sentence saying nothing
+            // offers a row would be printed under it.
             if (each.outcome() instanceof GenerationOutcome.NotSupported none) {
                 say(out, said, String.format("// nothing offers a row for `%s` in `%s`: %s%n",
                         about(each.finding()), each.finding().named(), none.reason().said()));

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -99,8 +99,38 @@ public final class GeneratedRows {
                     boundaries, names);
             out.append(one.text());
             rows += one.rows();
+            // And what the module's own declarations are short of, which is no behavior's and so
+            // is in none of the fillings above. Left out, an author who took every row this offers
+            // would be left with a model that still fails and nothing would have said which part
+            // was never attempted (issue #1062).
+            if (boundaries) {
+                declarations(out, compilation, name);
+            }
         }
         return new Block(out.toString(), rows);
+    }
+
+    /**
+     * What nothing offers a row for among the module's declarations.
+     *
+     * <p>A line an {@code invariant} drew is owed once over every behavior carrying the type, and a
+     * row is composed by walking one behavior's inputs — so which reading composes the one row a
+     * line is owed is a search over the readings, and nothing does it yet. Said rather than left
+     * out, for the reason every other disposition is said: a block that printed only what it managed
+     * reads as though it filled everything.
+     *
+     * <p>Only where the caller asked for the edges, as the lines about them are: a caller that asked
+     * for no boundary rows is not asking about these either.
+     */
+    private static void declarations(StringBuilder out, Compilation compilation, String module) {
+        java.util.Set<String> said = new java.util.LinkedHashSet<>();
+        for (Adequacy.GenerationDisposition each
+                : Adequacy.generatedForDeclarationsOf(compilation.db(), module)) {
+            if (each.outcome() instanceof GenerationOutcome.NotSupported none) {
+                say(out, said, String.format("// nothing offers a row for `%s` in `%s`: %s%n",
+                        about(each.finding()), each.finding().named(), none.reason().said()));
+            }
+        }
     }
 
     /**
@@ -601,6 +631,10 @@ public final class GeneratedRows {
             // the role: a point away from the line was written as the value the line is at, which
             // is the one place in reach that such a point is not.
             case About.APointOfABorder(var point) -> point.said();
+            // The same words on what the declaration wrote. Nothing composes a row for one of
+            // these yet — the search walks one behavior's inputs and this line is owed once over
+            // all of them — so what is printed beside it is that, in its own sentence.
+            case About.APointOfADeclaredBorder(var debt, var role) -> debt.said(role);
             // The arm's own short name, which is what the report writes and what the document's
             // `subject` joins on. The finding carries the arm rather than words about it, so that
             // the sentence a diagnostic says in the reader's language and the words written here

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -126,7 +126,7 @@ public final class GeneratedRows {
                                      String behavior) {
         java.util.Set<String> said = new java.util.LinkedHashSet<>();
         for (Adequacy.GenerationDisposition each
-                : Adequacy.generatedForDeclarationsOf(compilation.db(), module)) {
+                : Adequacy.generatedForDeclarationsOf(compilation.db(), module, behavior)) {
             // A line the behavior asked about does not carry is not work this block is about, the
             // way a report narrowed to one behavior keeps the lines that behavior carries and drops
             // the rest.

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-7.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-7.json
@@ -100,8 +100,17 @@
           "items": { "$ref": "#/$defs/behavior" }
         },
         "declarations": {
-          "$ref": "#/$defs/findings",
-          "description": "Everything the measures found about the module's own declarations and nothing filled. A line an `invariant` drew is a fact about the type wherever the type is carried, so it is owed once and is not any behavior's: published under one of them it would be published under whichever a walk reached first. The entries are shaped as a behavior's are, because what a finding is about is its subject's answer and not a second shape of entry. Not in `required`: a document written before this array existed is still a document of this version."
+          "type": "array",
+          "description": "What each of the module's own declarations is short of. A line an `invariant` drew is a fact about the type wherever the type is carried, so it is owed once and is not any behavior's: published under one of them it would be published under whichever a walk reached first. Under the declaration and not in one flat list, because what a finding says of itself is what the line asks of a row — two declarations bounding a string's length at one say it the same way, and which declaration a reader is being sent to would be gone. Not in `required`: a document written before this array existed is still a document of this version.",
+          "items": {
+            "type": "object",
+            "required": ["name", "findings"],
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string", "description": "The declaration whose clause drew the lines below." },
+              "findings": { "$ref": "#/$defs/findings" }
+            }
+          }
         }
       }
     },

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-7.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-7.json
@@ -98,6 +98,10 @@
         "behaviors": {
           "type": "array",
           "items": { "$ref": "#/$defs/behavior" }
+        },
+        "declarations": {
+          "$ref": "#/$defs/findings",
+          "description": "Everything the measures found about the module's own declarations and nothing filled. A line an `invariant` drew is a fact about the type wherever the type is carried, so it is owed once and is not any behavior's: published under one of them it would be published under whichever a walk reached first. The entries are shaped as a behavior's are, because what a finding is about is its subject's answer and not a second shape of entry. Not in `required`: a document written before this array existed is still a document of this version."
         }
       }
     },
@@ -131,7 +135,7 @@
     },
     "findings": {
       "type": "array",
-      "description": "Everything the measures found about this behavior and nothing filled, and what a build does about each. The measures above each say what they measured; this says which findings came out of them and which of those a build refuses over, which no measure's own object can say. Not in `required`: a document written before this array existed is still a document of this version.",
+      "description": "Everything the measures found about one subject and nothing filled, and what a build does about each. The measures above each say what they measured; this says which findings came out of them and which of those a build refuses over, which no measure's own object can say. Not in `required`: a document written before this array existed is still a document of this version.",
       "items": {
         "type": "object",
         "required": ["kind", "disposition", "subject"],

--- a/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
@@ -701,9 +701,9 @@ class AMeasureWithNoNumberSaysWhyTest {
 
     private static List<Adequacy.Finding> findings(String behavior, Adequacy.Kind kind) {
         Compilation compilation = compiled();
-        Map<String, List<Adequacy.Finding>> all = compilation.db()
+        List<Adequacy.Finding> all = compilation.db()
                 .ask(new Adequacy.Findings(compilation.modules().get(0))).value();
-        return all.getOrDefault(behavior, List.of()).stream()
+        return all.stream().filter(f -> f.subject().isBehavior(behavior))
                 .filter(f -> f.kind() == kind).toList();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
@@ -371,7 +371,7 @@ class AMeasureWithNoNumberSaysWhyTest {
         assertFalse(lines.isEmpty(), "the invariant draws two");
         for (BorderAssessment.Point line : lines) {
             assertEquals(ItemAssessment.Coverage.NotAsked.NO_ROWS, line.item().weakeningSource().why(),
-                    line.border().rule().named() + " at " + line.asked());
+                    line.border().origin().named() + " at " + line.asked());
         }
     }
 
@@ -467,9 +467,9 @@ class AMeasureWithNoNumberSaysWhyTest {
                 continue;   // nothing was measured there and nothing was waiting on a row
             }
             assertNotEquals(ItemAssessment.Coverage.NotAsked.NO_ROWS, line.item().weakeningSource().why(),
-                    line.border().rule().named() + " at " + line.asked());
+                    line.border().origin().named() + " at " + line.asked());
             assertEquals(MeasurementStatus.PARTIAL, AdequacyReport.statusOf(line.item().weakeningSource()),
-                    line.border().rule().named() + " at " + line.asked());
+                    line.border().origin().named() + " at " + line.asked());
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/ARuleReadToTheEndIsNotOneThisCouldNotReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleReadToTheEndIsNotOneThisCouldNotReadTest.java
@@ -108,6 +108,11 @@ class ARuleReadToTheEndIsNotOneThisCouldNotReadTest {
         behavior.path("weakening").forEach(each -> weakening.add(each.asString()));
         List<String> kinds = new ArrayList<>();
         behavior.path("findings").forEach(each -> kinds.add(each.get("kind").asString()));
+        // And what the module's declarations are short of. A line an `invariant` drew is not any
+        // behavior's, so it is published under the module — read off the behavior alone, a clause
+        // this drew a line from would look like one nothing measured (issue #1062).
+        document.get("modules").get(0).path("declarations")
+                .forEach(each -> kinds.add(each.get("kind").asString()));
         return new Measured(behavior.get("status").asString(), weakening, kinds,
                 report.human(SourceNameResolver.identity()));
     }

--- a/souther-compiler/src/test/java/souther/compiler/ARuleReadToTheEndIsNotOneThisCouldNotReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARuleReadToTheEndIsNotOneThisCouldNotReadTest.java
@@ -108,11 +108,13 @@ class ARuleReadToTheEndIsNotOneThisCouldNotReadTest {
         behavior.path("weakening").forEach(each -> weakening.add(each.asString()));
         List<String> kinds = new ArrayList<>();
         behavior.path("findings").forEach(each -> kinds.add(each.get("kind").asString()));
-        // And what the module's declarations are short of. A line an `invariant` drew is not any
-        // behavior's, so it is published under the module — read off the behavior alone, a clause
-        // this drew a line from would look like one nothing measured (issue #1062).
-        document.get("modules").get(0).path("declarations")
-                .forEach(each -> kinds.add(each.get("kind").asString()));
+        // And what the module's declarations are short of, under the declarations that owe them. A
+        // line an `invariant` drew is not any behavior's, so it is published under the module —
+        // read off the behavior alone, a clause this drew a line from would look like one nothing
+        // measured (issue #1062).
+        document.get("modules").get(0).path("declarations").forEach(declaration ->
+                declaration.get("findings")
+                        .forEach(each -> kinds.add(each.get("kind").asString())));
         return new Measured(behavior.get("status").asString(), weakening, kinds,
                 report.human(SourceNameResolver.identity()));
     }

--- a/souther-compiler/src/test/java/souther/compiler/AnEdgeIsWritableBecauseSomethingSaidSoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEdgeIsWritableBecauseSomethingSaidSoTest.java
@@ -294,7 +294,7 @@ at.coverage().made().orElseThrow());
 
         List<BorderAssessment.Point> guards =
                 BorderAssessment.pointsOf(boundaries.get("f")).stream()
-                        .filter(p -> p.border().rule().isWrittenRatherThanNamed())
+                        .filter(p -> p.border().origin().isWrittenRatherThanNamed())
                         .filter(p -> p.owed() != null).toList();
         assertFalse(guards.isEmpty(), "the comparison draws lines: " + boundaries.get("f"));
         for (BorderAssessment.Point at : guards) {

--- a/souther-compiler/src/test/java/souther/compiler/CompileAdequacyWarningTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileAdequacyWarningTest.java
@@ -113,7 +113,7 @@ class CompileAdequacyWarningTest {
     @Test
     void aBoundaryIsToldWhereItsOwnMeasureCouldBeMade() {
         assertEquals(List.of("invariant Amount #1"), bordersWarnedAbout(Adequacy.Level.WITNESS));
-        assertEquals(List.of("invariant Amount #1", "cost <= 100", "cost <= 100"),
+        assertEquals(List.of("cost <= 100", "cost <= 100", "invariant Amount #1"),
                 bordersWarnedAbout(Adequacy.Level.ALL));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleBoundaryTest.java
@@ -104,8 +104,8 @@ class CompileExampleBoundaryTest {
         BorderAssessment.Point zero = at(away, "0").get(0);
         assertFalse(zero.owed().hasRowWitness());
         assertEquals(MeasurementStatus.COMPLETE, AdequacyReport.statusOf(zero.item().weakeningSource()));
-        assertTrue(zero.border().rule().named().startsWith("invariant"),
-                zero.border().rule().named());
+        assertTrue(zero.border().origin().named().startsWith("invariant"),
+                zero.border().origin().named());
 
         PartitionEvidence edge = evidence(MODEL + """
 
@@ -129,8 +129,8 @@ class CompileExampleBoundaryTest {
         assertEquals(MeasurementStatus.COMPLETE, AdequacyReport.statusOf(hundred.item().weakeningSource()));
         assertTrue(hundred.owed().hasRowWitness(),
                 "the row wrote 100 and the guard compared it");
-        assertTrue(hundred.border().rule().isWrittenRatherThanNamed(),
-                hundred.border().rule().named());
+        assertTrue(hundred.border().origin().isWrittenRatherThanNamed(),
+                hundred.border().origin().named());
     }
 
     /**
@@ -167,7 +167,7 @@ class CompileExampleBoundaryTest {
                 """);
 
         BorderAssessment.Point first = at(evidence, "0").stream()
-                .filter(p -> p.border().rule().isWrittenRatherThanNamed()).findFirst().orElseThrow();
+                .filter(p -> p.border().origin().isWrittenRatherThanNamed()).findFirst().orElseThrow();
         BorderAssessment.Point second = at(evidence, "100").get(0);
 
         assertEquals(MeasurementStatus.COMPLETE, AdequacyReport.statusOf(second.item().weakeningSource()),

--- a/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
@@ -142,9 +142,9 @@ class EveryFindingHasAGenerationDispositionTest {
 
     @Test
     void aBoundaryARowWasComposedForIsAnsweredWithThatRow() {
-        Compilation compilation = compiled(POLICY);
+        Compilation compilation = compiled(GUARDED);
         List<Adequacy.GenerationDisposition> answered =
-                filling(compilation, "example.policy", "fee").generation().stream()
+                filling(compilation, "example.guarded", "band").generation().stream()
                         .filter(d -> d.finding().kind() == Adequacy.Kind.BOUNDARY_UNMET).toList();
 
         assertEquals(2, answered.size(), "both edges");
@@ -152,6 +152,52 @@ class EveryFindingHasAGenerationDispositionTest {
                         d -> d.outcome() instanceof GenerationOutcome.Generated),
                 "a strategy applies to a boundary and it composed a row: " + answered);
     }
+
+    /**
+     * A line the declaration is owed is answered too, and says nothing composes a row for it yet.
+     *
+     * <p>The subject the walk over the behaviors does not reach. A line an {@code invariant} drew is
+     * not any behavior's, so the fillings above answer for every finding but those — and one printed
+     * in the report and left out of this answer is one an author is told nothing about, while the
+     * rows beside it read as though they filled everything.
+     */
+    @Test
+    void aLineOwedToADeclarationIsAnsweredForToo() {
+        Compilation compilation = compiled(POLICY);
+        List<Adequacy.Finding> declared =
+                compilation.db().ask(new Adequacy.Findings("example.policy")).value().stream()
+                        .filter(each -> each.subject()
+                                instanceof souther.compiler.query.FindingSubject.OfADeclaration)
+                        .toList();
+        assertFalse(declared.isEmpty(), "the model under test has lines its declarations are owed");
+
+        List<Adequacy.GenerationDisposition> answered =
+                Adequacy.generatedForDeclarationsOf(compilation.db(), "example.policy");
+        assertEquals(declared, answered.stream()
+                        .map(Adequacy.GenerationDisposition::finding).toList(),
+                "every one of them, and each with its own answer");
+        assertTrue(answered.stream().allMatch(each ->
+                        each.outcome() instanceof GenerationOutcome.NotSupported),
+                "nothing composes a row for a line owed across its readings yet: " + answered);
+    }
+
+    /** A guard on an input, whose line is the behavior's own and is owed a row either side. */
+    private static final String GUARDED = """
+            module example.guarded
+
+            data Ok
+            data No
+            data Verdict = Ok | No
+
+            behavior band : (days: Int) -> Verdict
+            let band (days) = {
+                guard days <= 30 else No
+                Ok
+            }
+
+            example band
+                | "well inside" : (5) -> Ok
+            """;
 
     /** A body whose decisions read two positions together, so the combinations reach its arms. */
     private static final String SHIPPING = """

--- a/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
@@ -154,12 +154,17 @@ class EveryFindingHasAGenerationDispositionTest {
     }
 
     /**
-     * A line the declaration is owed is answered too, and says nothing composes a row for it yet.
+     * A line the declaration is owed is answered too, with the row a reading of it already composed.
      *
      * <p>The subject the walk over the behaviors does not reach. A line an {@code invariant} drew is
      * not any behavior's, so the fillings above answer for every finding but those — and one printed
      * in the report and left out of this answer is one an author is told nothing about, while the
      * rows beside it read as though they filled everything.
+     *
+     * <p>And answered with what is known rather than with what has not been arranged. A reading of
+     * the line composed a row standing at the point, and the readings of a debt ask the same of a
+     * row at the points against the line — so that row is the one the debt is offered. Answered
+     * "nothing offers a row" regardless, a block printed the row and then said no row was on offer.
      */
     @Test
     void aLineOwedToADeclarationIsAnsweredForToo() {
@@ -177,8 +182,8 @@ class EveryFindingHasAGenerationDispositionTest {
                         .map(Adequacy.GenerationDisposition::finding).toList(),
                 "every one of them, and each with its own answer");
         assertTrue(answered.stream().allMatch(each ->
-                        each.outcome() instanceof GenerationOutcome.NotSupported),
-                "nothing composes a row for a line owed across its readings yet: " + answered);
+                        each.outcome() instanceof GenerationOutcome.Generated),
+                "a reading of each of these composed a row at the point: " + answered);
     }
 
     /** A guard on an input, whose line is the behavior's own and is owed a row either side. */

--- a/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
@@ -87,10 +87,10 @@ class EveryFindingHasAGenerationDispositionTest {
      */
     private static List<Adequacy.Finding> findings(Compilation compilation, String module,
                                                    String behavior) {
-        Map<String, List<Adequacy.Finding>> found =
+        List<Adequacy.Finding> found =
                 compilation.db().ask(new Adequacy.Findings(module)).value();
         assertNotNull(found, "the model under test compiles");
-        return found.get(behavior);
+        return found.stream().filter(each -> each.subject().isBehavior(behavior)).toList();
     }
 
     private static Adequacy.Filling filling(Compilation compilation, String module,

--- a/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
@@ -177,7 +177,7 @@ class EveryFindingHasAGenerationDispositionTest {
         assertFalse(declared.isEmpty(), "the model under test has lines its declarations are owed");
 
         List<Adequacy.GenerationDisposition> answered =
-                Adequacy.generatedForDeclarationsOf(compilation.db(), "example.policy");
+                Adequacy.generatedForDeclarationsOf(compilation.db(), "example.policy", null);
         assertEquals(declared, answered.stream()
                         .map(Adequacy.GenerationDisposition::finding).toList(),
                 "every one of them, and each with its own answer");
@@ -185,6 +185,63 @@ class EveryFindingHasAGenerationDispositionTest {
                         each.outcome() instanceof GenerationOutcome.Generated),
                 "a reading of each of these composed a row at the point: " + answered);
     }
+
+    /**
+     * A generation narrowed to one behavior answers from what that behavior's search composed.
+     *
+     * <p>A line is owed once over every behavior carrying the type, and a row for it may be
+     * composable at one of them and not at another — {@code held} holds the field to a single
+     * value the line is not at, and {@code anywhere} does not. Answered from the module's readings, a
+     * request that searched only {@code held} would say a row is on offer because {@code anywhere}
+     * had one, and print no row beside it (issue #1062).
+     *
+     * <p>Which reading to search when the one asked about composes nothing is the question
+     * {@code --generate} does not ask yet, and the answer says that rather than borrowing another
+     * reading's row.
+     */
+    @Test
+    void aGenerationNarrowedToOneBehaviorAnswersFromWhatThatBehaviorSearched() {
+        Compilation compilation = compiled(NARROWED);
+        assertFalse(Adequacy.generatedForDeclarationsOf(compilation.db(), "example.narrowed",
+                        "held").isEmpty(),
+                "the line is owed at both, so both are asked about");
+
+        assertTrue(Adequacy.generatedForDeclarationsOf(compilation.db(), "example.narrowed", "anywhere")
+                        .stream().allMatch(each ->
+                                each.outcome() instanceof GenerationOutcome.Generated),
+                "the search of `anywhere` composed a row at the line");
+        assertTrue(Adequacy.generatedForDeclarationsOf(compilation.db(), "example.narrowed",
+                        "held").stream().allMatch(each ->
+                                each.outcome() instanceof GenerationOutcome.NotSupported),
+                "and the search of `held` composed none, whatever `anywhere` did");
+    }
+
+    /** One line, at a position one behavior can hold a row at and the other cannot. */
+    private static final String NARROWED = """
+            module example.narrowed
+
+            data Code = String
+                invariant nonempty = String.length(value) >= 1
+
+            data Wide = { c: Code }
+
+            data Narrow = { c: Code }
+                invariant fixed = String.length(c.value) >= 4
+
+            data Ok
+
+            behavior anywhere : (w: Wide) -> Ok
+            let anywhere (w) = Ok
+
+            behavior held : (n: Narrow) -> Ok
+            let held (n) = Ok
+
+            example anywhere
+                | "a" : (Wide { c = Code("abc") }) -> Ok
+
+            example held
+                | "a" : (Narrow { c = Code("abcd") }) -> Ok
+            """;
 
     /** A guard on an input, whose line is the behavior's own and is owed a row either side. */
     private static final String GUARDED = """

--- a/souther-compiler/src/test/java/souther/compiler/FindingDispositionFollowsTheBarTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/FindingDispositionFollowsTheBarTest.java
@@ -155,13 +155,22 @@ class FindingDispositionFollowsTheBarTest {
     @Test
     void theJsonCarriesEveryFindingAndWhatABuildDoesAboutIt() {
         AdequacyReport report = report();
-        JsonNode ship = JSON.readTree(report.json(SourceNameResolver.identity()))
-                .get("modules").get(0).get("behaviors").get(0);
+        JsonNode module = JSON.readTree(report.json(SourceNameResolver.identity()))
+                .get("modules").get(0);
+        JsonNode ship = module.get("behaviors").get(0);
         JsonNode findings = ship.get("findings");
+        // What the declarations are short of, beside what the bodies are. A line an `invariant`
+        // drew is not any behavior's, so it is published under the module and not under one of
+        // them — and counted only over the behaviors, this said the document carried every finding
+        // while one of them was missing from it (issue #1062).
+        JsonNode declared = module.get("declarations");
 
         assertNotNull(findings, "the behavior's findings are published");
-        assertEquals(report.findings().size(), findings.size());
-        assertEquals(report.adequacyGaps().size(), refused(findings).size(), findings.toString());
+        assertNotNull(declared, "and so are the declarations'");
+        assertEquals(report.findings().size(), findings.size() + declared.size());
+        assertEquals(report.adequacyGaps().size(),
+                refused(findings).size() + refused(declared).size(),
+                findings.toString() + declared.toString());
 
         // The pair the issue is about, in the document. The position is written with the class
         // because two parameters of one type produce two findings a class name alone cannot tell

--- a/souther-compiler/src/test/java/souther/compiler/FindingDispositionFollowsTheBarTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/FindingDispositionFollowsTheBarTest.java
@@ -163,14 +163,19 @@ class FindingDispositionFollowsTheBarTest {
         // drew is not any behavior's, so it is published under the module and not under one of
         // them — and counted only over the behaviors, this said the document carried every finding
         // while one of them was missing from it (issue #1062).
-        JsonNode declared = module.get("declarations");
+        // Under the declaration that owes them, the way a behavior's are under the behavior: what a
+        // finding says of itself is what the line asks of a row, and two declarations bounding a
+        // string's length at one say it the same way.
+        List<JsonNode> declared = new java.util.ArrayList<>();
+        module.get("declarations").forEach(each -> each.get("findings").forEach(declared::add));
 
         assertNotNull(findings, "the behavior's findings are published");
-        assertNotNull(declared, "and so are the declarations'");
         assertEquals(report.findings().size(), findings.size() + declared.size());
         assertEquals(report.adequacyGaps().size(),
-                refused(findings).size() + refused(declared).size(),
-                findings.toString() + declared.toString());
+                refused(findings).size()
+                        + declared.stream().filter(each -> "refused"
+                                .equals(each.get("disposition").asString())).count(),
+                findings.toString() + declared);
 
         // The pair the issue is about, in the document. The position is written with the class
         // because two parameters of one type produce two findings a class name alone cannot tell

--- a/souther-compiler/src/test/java/souther/compiler/TwoLinesAboutOneClauseDoNotContradictTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/TwoLinesAboutOneClauseDoNotContradictTest.java
@@ -124,8 +124,8 @@ class TwoLinesAboutOneClauseDoNotContradictTest {
     void aClauseALineIsDrawnFromIsNotReportedAsUnread() {
         String human = humanOf(THE_ISSUE);
 
-        assertTrue(human.contains("price/length = 1 (invariant Length (min))"), human);
-        assertTrue(human.contains("price/length = 100 (invariant Length (max))"), human);
+        assertTrue(human.contains("value = 1 (invariant Length (min))"), human);
+        assertTrue(human.contains("value = 100 (invariant Length (max))"), human);
         assertFalse(human.contains("not accounted for"),
                 "every rule of this model was taken in by something: " + human);
         assertFalse(human.contains("rules not reached"), human);

--- a/souther-compiler/src/test/java/souther/compiler/WhatIsUnverifiedComesFromWhatTheRowsObservedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatIsUnverifiedComesFromWhatTheRowsObservedTest.java
@@ -8,7 +8,6 @@ import souther.compiler.query.Db;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -176,10 +175,10 @@ class WhatIsUnverifiedComesFromWhatTheRowsObservedTest {
     /** The cases one kind of finding names for one behavior, in the order the findings are held. */
     private static List<String> named(String source, String behavior, Adequacy.Kind kind) {
         Compilation compilation = compiled(source);
-        Map<String, List<Adequacy.Finding>> all = compilation.db()
+        List<Adequacy.Finding> all = compilation.db()
                 .ask(new Adequacy.Findings(compilation.modules().get(0))).value();
         return all == null ? List.of()
-                : all.getOrDefault(behavior, List.of()).stream()
+                : all.stream().filter(f -> f.subject().isBehavior(behavior))
                         .filter(f -> f.kind() == kind)
                         .map(WhatIsUnverifiedComesFromWhatTheRowsObservedTest::caseOf)
                         .toList();

--- a/souther-compiler/src/test/java/souther/compiler/check/ALineIsNamedInTheTermsItWasWrittenInTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALineIsNamedInTheTermsItWasWrittenInTest.java
@@ -1,0 +1,176 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Front;
+import souther.compiler.query.Scopes;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * A line printed under the declaration that drew it is named in the terms that declaration wrote,
+ * and not in the terms of whichever behavior a reading of it reached.
+ *
+ * <p>{@code UserId}'s clause draws one line. The behaviors carrying the type meet it at
+ * {@code draft.owner}, at {@code activities[*]@CallTask.owner} and at seventy-two other positions,
+ * and none of those is what the author wrote — so a debt named after a reading is named after
+ * whichever reading a report happened to reach first (issue #1062).
+ */
+class ALineIsNamedInTheTermsItWasWrittenInTest {
+
+    /**
+     * A newtype's clause is about the value it wraps, however many positions carry it.
+     *
+     * <p>The frame is the declaration's, so the answer says {@code value} and never a path through
+     * some record. Read from a reading instead, this is where the two frames of one line differ.
+     */
+    @Test
+    void aNewtypesClauseIsAboutTheValueItWraps() {
+        var line = lineAt("String.length(u) = 1");
+        assertEquals("String.length(the value)",
+                declaredBy("UserId").at(line.rule(), line.conjunct()).toString());
+    }
+
+    /**
+     * A clause bounding two numbers names each of them, told apart by the conjunct that drew it.
+     *
+     * <p>The pair that has to be told apart at all. Both ends are at 1, on one carrier, from one
+     * clause: nothing but which conjunct placed them says which line is which, and a report that
+     * could not say it would print one item twice and leave the author to guess.
+     */
+    @Test
+    void aClauseBoundingTwoNumbersNamesEachOfThem() {
+        DeclaredBorders lines = declaredBy("Pair");
+        var name = lineAt("String.length(p.name) = 1");
+        var code = lineAt("String.length(p.code) = 1");
+        assertEquals("String.length(name)", lines.at(name.rule(), name.conjunct()).toString());
+        assertEquals("String.length(code)", lines.at(code.rule(), code.conjunct()).toString());
+    }
+
+    /** Both ends of a range are the one number, which is what tells this from the case above. */
+    @Test
+    void bothEndsOfARangeAreTheOneNumber() {
+        DeclaredBorders lines = declaredBy("Range");
+        var bottom = lineAt("r = 1");
+        var top = lineAt("r = 10");
+        assertEquals("the value", lines.at(bottom.rule(), bottom.conjunct()).toString());
+        assertEquals("the value", lines.at(top.rule(), top.conjunct()).toString());
+        org.junit.jupiter.api.Assertions.assertNotEquals(bottom.conjunct(), top.conjunct(),
+                "the two ends are the one number and different lines");
+    }
+
+    /**
+     * A declaration answers for the clauses it wrote and not for the ones it holds.
+     *
+     * <p>A line is named by the rule that drew it (ADR-0090), so {@code Span} has nothing to say
+     * about {@code Day}'s clause even though every value of {@code Span} is held to it. Answered
+     * here, the same line would be named twice and in two frames.
+     */
+    @Test
+    void aDeclarationAnswersForTheClausesItWrote() {
+        var line = lineAt("s.d = 0");
+        assertNotNull(declaredBy("Day").at(line.rule(), line.conjunct()),
+                "Day wrote the clause, so Day names the line");
+        assertNull(declaredBy("Span").at(line.rule(), line.conjunct()),
+                "and Span holds a value that is held to it, which is not the same thing");
+    }
+
+    private static final String MODEL = """
+            module example.forms
+
+            data UserId = String
+                invariant nonempty = String.length(value) >= 1
+
+            data Pair = { name: String, code: String }
+                invariant both = String.length(name) >= 1 && String.length(code) >= 1
+
+            data Range = Int
+                invariant within = value >= 1 && value <= 10
+
+            data Day = Int
+                invariant days = value >= 0 && value <= 6
+
+            data Span = { d: Day }
+
+            data Ok
+
+            behavior f : (u: UserId) -> Ok
+            let f (u) = Ok
+
+            behavior g : (p: Pair) -> Ok
+            let g (p) = Ok
+
+            behavior h : (r: Range) -> Ok
+            let h (r) = Ok
+
+            behavior k : (s: Span) -> Ok
+            let k (s) = Ok
+
+            example f
+                | "a" : (UserId("x")) -> Ok
+
+            example g
+                | "a" : (Pair { name = "x", code = "y" }) -> Ok
+
+            example h
+                | "a" : (Range(5)) -> Ok
+
+            example k
+                | "a" : (Span { d = Day(1) }) -> Ok
+            """;
+
+    /** Every line the model draws, by what a report calls it. Read once: the whole point of the
+     *  test is that both sides of the lookup come from the one compile. */
+    private static final Map<String, souther.compiler.partition.OriginRef> LINES = linesOf();
+
+    private static Map<String, souther.compiler.partition.OriginRef> linesOf() {
+        Compilation compilation = compiled();
+        Map<String, List<souther.compiler.query.BorderAssessment>> boundaries =
+                souther.compiler.query.Adequacy.boundariesOf(compilation.db(), "example.forms");
+        assertNotNull(boundaries, "the model under test compiles");
+        Map<String, souther.compiler.partition.OriginRef> out = new java.util.LinkedHashMap<>();
+        boundaries.values().forEach(each ->
+                each.forEach(line -> out.put(line.label(), line.border().origin())));
+        return out;
+    }
+
+    private static Compilation compiled() {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.measure(souther.compiler.query.Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    /**
+     * The rule and the conjunct of the line at {@code label}, as the measurement met it.
+     *
+     * <p>Taken from the measurement rather than built here, because that is what a caller holds: a
+     * report reaches this with a debt the readings produced. Built in the test, the two sides could
+     * key their answers differently and nothing would say so — which they did, over the name the
+     * author gave the clause.
+     */
+    private static souther.compiler.partition.OriginRef.InvariantOrigin lineAt(String label) {
+        souther.compiler.partition.OriginRef origin = LINES.get(label);
+        assertNotNull(origin, () -> label + " is not a line of the model: " + LINES.keySet());
+        return (souther.compiler.partition.OriginRef.InvariantOrigin) origin;
+    }
+
+    /** The lines {@code name} draws, in its own terms. */
+    private static DeclaredBorders declaredBy(String name) {
+        Compilation compilation = compiled();
+        String module = compilation.modules().get(0);
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        ReadingPolicy policy = compilation.db().ask(new Front.Reading()).value();
+        TypeSymbol named = TypeSymbols.declared(new TypeKey("example.forms", name));
+        return DeclaredBorders.of(named, symbols, policy);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AskingForOneNumbersEndsDoesNotAnswerWithAnothersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AskingForOneNumbersEndsDoesNotAnswerWithAnothersTest.java
@@ -45,14 +45,20 @@ class AskingForOneNumbersEndsDoesNotAnswerWithAnothersTest {
         return new RuleRef.Invariant(new Clause.Ref(new Clause.Id(ON, at), Optional.empty()));
     }
 
+    /** The clauses an end names, which is what these assertions are about: which conjunct of each
+     *  drew it is beside that and is not what a reader is sent to look at. */
+    private static List<RuleRef.Invariant> rulesOf(DeclaredBounds.End end) {
+        return end.from().stream().map(DeclaredBounds.Drawn::rule).toList();
+    }
+
     /** An end above one number of `names`, placed by the clause at {@code by}. */
     private static FieldDomains.Placed upTo(FieldDomains.Coordinate on, int by, int at) {
-        return new FieldDomains.Placed(on, rule(by), false, Endpoint.inclusive(Count.of(at)));
+        return new FieldDomains.Placed(on, rule(by), false, Endpoint.inclusive(Count.of(at)), 0);
     }
 
     /** And one below it. */
     private static FieldDomains.Placed from(FieldDomains.Coordinate on, int by, int at) {
-        return new FieldDomains.Placed(on, rule(by), true, Endpoint.inclusive(Count.of(at)));
+        return new FieldDomains.Placed(on, rule(by), true, Endpoint.inclusive(Count.of(at)), 0);
     }
 
     private static final FieldDomains.Coordinate HOW_LONG =
@@ -80,9 +86,9 @@ class AskingForOneNumbersEndsDoesNotAnswerWithAnothersTest {
                 Carrier.WHOLE);
 
         assertEquals(Count.of(3), howLong.max().at().at(), "the end the rule about the length drew");
-        assertEquals(List.of(rule(0)), howLong.max().from(), "and the clause that drew it");
+        assertEquals(List.of(rule(0)), rulesOf(howLong.max()), "and the clause that drew it");
         assertEquals(Count.of(7), howMany.max().at().at(), "the end the rule about the size drew");
-        assertEquals(List.of(rule(1)), howMany.max().from(), "and the clause that drew it");
+        assertEquals(List.of(rule(1)), rulesOf(howMany.max()), "and the clause that drew it");
     }
 
     /**
@@ -117,6 +123,6 @@ class AskingForOneNumbersEndsDoesNotAnswerWithAnothersTest {
         assertEquals(Count.of(3), howLong.max().at().at(), "the length's own upper end");
         assertEquals(Count.of(1), howLong.min().at().at(),
                 "and its own lower one, which is not the floor the rule about the size put there");
-        assertEquals(List.of(rule(1)), howLong.min().from(), "named by the clause that drew it");
+        assertEquals(List.of(rule(1)), rulesOf(howLong.min()), "named by the clause that drew it");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
@@ -1,0 +1,362 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.Compilation;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * What a row is owed for is the line the author wrote, and neither the rule it came from nor the
+ * position it was read at.
+ *
+ * <p>Three identities where there used to be one. Which rule drew the line is provenance and the
+ * same value however many lines the rule drew; which line is owed a row is the debt; where that line
+ * was read is an occurrence, one per position of every behavior carrying the type. A measure keyed
+ * on the occurrence asks for one rule's row once per position — 126 times over {@code crm}'s
+ * {@code UserId} — and a measure keyed on the rule asks for one row where the author drew two lines.
+ *
+ * <p>Written before the debt exists, because the whole of what this change is worth is the answer to
+ * "why are these the same debt". Left to be read off whatever the implementation keyed on, that
+ * answer lives outside the types and the next reading takes it back.
+ */
+class ABorderDebtIsTheLineTheAuthorWroteTest {
+
+    /**
+     * One clause placing two ends is two debts, and a row at one is not a row at the other.
+     *
+     * <p>The case a debt keyed on the rule gets wrong. {@code within} is one clause and one
+     * {@link souther.compiler.check.RuleRef.Invariant}, and the lines it draws at 1 and at 10 have
+     * nothing to say about each other: a row standing at the bottom of the range is no evidence
+     * about the top. So the rule is the same value at both and the debt is not.
+     */
+    @Test
+    void aClausesTwoEndsAreTwoDebts() {
+        Map<String, BorderAssessment> lines = bordersOf(RANGE, "example.range");
+        BorderAssessment bottom = at(lines, "n = 1");
+        BorderAssessment top = at(lines, "n = 10");
+
+        assertEquals(bottom.border().obligation().provenance(),
+                top.border().obligation().provenance(),
+                "one clause drew both, which is what provenance answers");
+        assertNotEquals(bottom.border().obligation(), top.border().obligation(),
+                "and a row at the bottom of the range is no evidence about the top");
+    }
+
+    /**
+     * One invariant read at two behaviors is one debt.
+     *
+     * <p>What issue #1062 is. {@code UserId} says a user id is a string of one character or more,
+     * and whether a row standing at length 1 is believed is a question about {@code UserId} — the
+     * answer cannot differ between {@code schedule} and {@code touch}, since neither says anything
+     * about the length of a user id. Two occurrences and one debt.
+     */
+    @Test
+    void oneInvariantReadAtTwoBehaviorsIsOneDebt() {
+        Map<String, BorderAssessment> lines = bordersOf(TWO_BEHAVIORS, "example.two");
+        BorderAssessment scheduled = at(lines, "String.length(d.owner) = 1");
+        BorderAssessment touched = at(lines, "String.length(t.owner) = 1");
+
+        assertNotEquals(scheduled.border().cut(), touched.border().cut(),
+                "the two are read at different positions, which is what an occurrence is");
+        assertEquals(scheduled.border().obligation(), touched.border().obligation(),
+                "and both are the one line UserId's clause drew");
+    }
+
+    /**
+     * Two positions of one type in one behavior are one debt too.
+     *
+     * <p>The same equivalence with the behavior held still, so that nothing can satisfy the one
+     * above by keying on the behavior. A row standing at the boundary through {@code owner} is
+     * evidence about {@code UserId}, and {@code reviewer} is the same type saying the same thing.
+     */
+    @Test
+    void twoPositionsOfOneTypeInOneBehaviorAreOneDebt() {
+        Map<String, BorderAssessment> lines = bordersOf(TWO_POSITIONS, "example.both");
+
+        assertEquals(1,
+                lines.values().stream().map(each -> each.border().obligation()).distinct().count(),
+                "one clause, one line, one debt — however many positions carry the type: "
+                        + lines.keySet());
+        assertEquals(2, lines.size(), "read at both of them: " + lines.keySet());
+    }
+
+    /**
+     * Two clauses cutting at one value are two debts.
+     *
+     * <p>The other way a debt keyed too widely goes wrong, and the reason a level alone is not the
+     * key either. {@code Window} and {@code Slot} each stop a {@code Minute} at 1000, on one carrier
+     * and at one value; they are two rules an author wrote and either could be changed without the
+     * other. A row at the line one drew establishes nothing about the line the other drew.
+     *
+     * <p>Beside {@code Minute}'s own lower end, which both records carry and which is one debt. The
+     * pair is the measurement: an implementation that told the two 1000s apart by the position they
+     * were read at would pass the first half and split the second.
+     */
+    @Test
+    void twoClausesCuttingAtOneValueAreTwoDebts() {
+        Map<String, BorderAssessment> lines = bordersOf(TWO_RECORDS, "example.narrow");
+
+        assertNotEquals(at(lines, "x.stop = 1000").border().obligation(),
+                at(lines, "y.at = 1000").border().obligation(),
+                "two rules drew a line at one value, and each is owed its own row");
+        assertEquals(at(lines, "x.stop = 0").border().obligation(),
+                at(lines, "y.at = 0").border().obligation(),
+                "and one rule drew the lower end of both, which is one row to write");
+    }
+
+    /**
+     * One clause bounding two numbers of one declaration is two debts.
+     *
+     * <p>The case a debt keyed on the clause and the value gets wrong, and the reason the number the
+     * clause was written about is part of what a debt is. {@code both} places an end at 1 on
+     * {@code String.length(name)} and an end at 1 on {@code String.length(code)}: one clause, one
+     * carrier, one value, one polarity, and two lines. A row whose {@code name} is one character
+     * long says nothing about {@code code}.
+     *
+     * <p>What the two share is everything an identity read off the rule and the cut would have had
+     * to tell them apart by, which is why this is measured rather than argued: the language builds
+     * it, so a reading that folds them is a reading that reports one of them covered by the other's
+     * row.
+     */
+    @Test
+    void oneClauseBoundingTwoNumbersOfOneDeclarationIsTwoDebts() {
+        Map<String, BorderAssessment> lines = bordersOf(TWO_NUMBERS, "example.numbers");
+        BorderAssessment name = at(lines, "String.length(p.name) = 1");
+        BorderAssessment code = at(lines, "String.length(p.code) = 1");
+
+        assertEquals(name.border().obligation().provenance(),
+                code.border().obligation().provenance(), "one clause placed both ends");
+        assertEquals(name.border().cut().at(), code.border().cut().at(),
+                "at one value of one carrier, so neither the rule nor the level tells them apart");
+        assertNotEquals(name.border().obligation(), code.border().obligation(),
+                "and the number the clause was written about does");
+    }
+
+    /** One clause bounding two numbers of the declaration it is written on. */
+    private static final String TWO_NUMBERS = """
+            module example.numbers
+
+            data Pair = { name: String, code: String }
+                invariant both = String.length(name) >= 1 && String.length(code) >= 1
+
+            data Ok
+
+            behavior f : (p: Pair) -> Ok
+            let f (p) = Ok
+
+            example f
+                | "a" : (Pair { name = "x", code = "y" }) -> Ok
+            """;
+
+    /**
+     * One conjunct read through two frames is one debt.
+     *
+     * <p>The direction the case above does not fix. A clause of {@code Day} is read twice — once
+     * from {@code Day}, where it is about {@code value}, and once from the {@code Span} holding it,
+     * where it is about {@code d} — and the two readings are merged into one range
+     * ({@code DeclaredBounds.and}). What the author wrote is one line either way, so the two are one
+     * debt and each position carries two ends rather than four.
+     *
+     * <p>A second bounded field beside it, because the merge is what this is about: with one field
+     * the reading through the record contributes nothing and the model goes past the case without
+     * touching it.
+     *
+     * <p>Measured as the count of borders rather than by comparing two of them, because the way this
+     * goes wrong is a border appearing twice: an identity read off the number the clause was written
+     * about spells it {@code value} in one reading and {@code d} in the other, and both survive into
+     * the cut. Counting is what notices that; asking two borders whether they agree finds one of the
+     * pair and never the pair.
+     */
+    @Test
+    void oneConjunctReadThroughTwoFramesIsOneDebt() {
+        List<Border> lines = bordersOfThePosition(TWO_FRAMES, "classify", "s.d");
+
+        assertEquals(2, lines.size(),
+                () -> "the clause states two ends, so the position has two borders: "
+                        + lines.stream().map(Border::label).toList());
+        assertEquals(2, lines.stream().map(Border::obligation).distinct().count(),
+                "and neither of them is two debts");
+    }
+
+    /**
+     * Every border of one position, as the partition makes them.
+     *
+     * <p>Below the report, because that is where a line read twice shows as two. What reaches a
+     * report is the assessment, and a border read through two frames arrives there as one entry
+     * whichever answer this gives — so a test asking the report would have said the identity was
+     * right whatever it was.
+     */
+    private static List<Border> bordersOfThePosition(String model, String behavior, String path) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        souther.compiler.check.Prepared prepared =
+                compilation.db().ask(new souther.compiler.query.Shapes.Prepared(module)).value();
+        souther.compiler.check.Symbols symbols =
+                souther.compiler.query.Scopes.derived(compilation.db(), module).value();
+        Map<String, souther.compiler.check.Sig> sigs = compilation.db()
+                .ask(new souther.compiler.query.Bodies.Signatures(module)).value();
+        souther.compiler.ast.Hir.SpecBehavior spec =
+                (souther.compiler.ast.Hir.SpecBehavior) prepared.behaviors().stream()
+                        .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
+        assertNotNull(sigs.get(behavior), "the model under test compiles");
+        souther.compiler.inputs.InputDomain domain =
+                souther.compiler.inputs.InputDomain.of(spec, sigs.get(behavior), symbols,
+                        souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+        Partitions.Partitioning partitioning = Partitions.of(spec.name(), domain, symbols,
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+        Axis axis = partitioning.axes().stream()
+                .filter(a -> a.path().toString().equals(path)).findFirst().orElseThrow();
+        return Partitions.bordersOf(axis, symbols,
+                domain.quantities(symbols).runsBetween(axis.term()));
+    }
+
+    /** A newtype's own clause, reached through the record that holds it. */
+    private static final String TWO_FRAMES = """
+            module example.frames
+
+            data Slot = Int
+                invariant value >= 0 && value <= 10
+
+            data Day = Date
+                invariant value >= Date("2020-01-01") && value <= Date("2020-01-02")
+
+            data Span = { a: Slot, d: Day }
+
+            data Ok
+
+            behavior classify : (s: Span) -> Ok
+            let classify (s) = Ok
+
+            example classify
+                | "a" : (Span { a = Slot(1), d = Day(Date("2020-01-01")) }) -> Ok
+            """;
+
+    /** One clause placing both ends of a range. */
+    private static final String RANGE = """
+            module example.range
+
+            data N = Int
+                invariant within = value >= 1 && value <= 10
+
+            data Ok
+
+            behavior f : (n: N) -> Ok
+            let f (n) = Ok
+
+            example f
+                | "x" : (N(3)) -> Ok
+            """;
+
+    /** One type's invariant carried by two behaviors, at a position apiece. */
+    private static final String TWO_BEHAVIORS = """
+            module example.two
+
+            data UserId = String
+                invariant nonempty = String.length(value) >= 1
+
+            data Draft = { owner: UserId }
+            data Task = { owner: UserId }
+
+            data Ok
+
+            behavior schedule : (d: Draft) -> Ok
+            let schedule (d) = Ok
+
+            behavior touch : (t: Task) -> Ok
+            let touch (t) = Ok
+
+            example schedule
+                | "a" : (Draft { owner = UserId("x") }) -> Ok
+
+            example touch
+                | "a" : (Task { owner = UserId("x") }) -> Ok
+            """;
+
+    /** One type's invariant carried twice by one behavior. */
+    private static final String TWO_POSITIONS = """
+            module example.both
+
+            data UserId = String
+                invariant nonempty = String.length(value) >= 1
+
+            data Draft = { owner: UserId, reviewer: UserId }
+
+            data Ok
+
+            behavior schedule : (d: Draft) -> Ok
+            let schedule (d) = Ok
+
+            example schedule
+                | "a" : (Draft { owner = UserId("x"), reviewer = UserId("y") }) -> Ok
+            """;
+
+    /** Two records stopping one type at one value, each by a clause of its own. */
+    private static final String TWO_RECORDS = """
+            module example.narrow
+
+            data Minute = Int
+                invariant range = value >= 0 && value <= 1439
+
+            data Window = { stop: Minute }
+                invariant fits = stop.value <= 1000
+
+            data Slot = { at: Minute }
+                invariant fits = at.value <= 1000
+
+            data Ok
+
+            behavior w : (x: Window) -> Ok
+            let w (x) = Ok
+
+            behavior s : (y: Slot) -> Ok
+            let s (y) = Ok
+
+            example w
+                | "a" : (Window { stop = Minute(5) }) -> Ok
+
+            example s
+                | "a" : (Slot { at = Minute(5) }) -> Ok
+            """;
+
+    private static BorderAssessment at(Map<String, BorderAssessment> lines, String label) {
+        BorderAssessment line = lines.get(label);
+        assertNotNull(line, () -> label + " is not a line of this model: " + lines.keySet());
+        return line;
+    }
+
+    /** Every border of {@code module}, as the measure holds them: per behavior, and one entry per
+     *  occurrence. For a caller counting them rather than looking one up. */
+    private static Map<String, List<BorderAssessment>> boundariesOf(String model, String module) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, List<BorderAssessment>> boundaries =
+                Adequacy.boundariesOf(compilation.db(), module);
+        assertNotNull(boundaries, "the model under test compiles");
+        return boundaries;
+    }
+
+    /** Every border of {@code module}, by the line it is at. Each label names one position, so the
+     *  map holds one entry per occurrence and not one per debt. */
+    private static Map<String, BorderAssessment> bordersOf(String model, String module) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, List<BorderAssessment>> boundaries =
+                Adequacy.boundariesOf(compilation.db(), module);
+        assertNotNull(boundaries, "the model under test compiles");
+        Map<String, BorderAssessment> out = new LinkedHashMap<>();
+        boundaries.values().forEach(each -> each.forEach(b -> out.put(b.label(), b)));
+        return out;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderIsALineOnWhateverTheRuleCutsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderIsALineOnWhateverTheRuleCutsTest.java
@@ -98,7 +98,7 @@ class ABorderIsALineOnWhateverTheRuleCutsTest {
     void aPositionAgainstAValueIsALineAtThatPosition() {
         String report = report(guarded("a.value <= 10"));
 
-        assertTrue(report.contains("point f/a = 10"), report);
+        assertTrue(report.contains("point value = 10"), report);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
@@ -177,7 +177,11 @@ class ABorderSaysWhichOfItsTwoPointsALineIsTest {
             assertTrue(report.contains("excluded — the rules leave no value there"), report);
             assertFalse(report.contains("no row is at the OFF point"), report);
         }
-        assertFalse(strict.contains("take/h.a = 5"), strict);
+        // Asked of the value the line is named by, which is how a bound is written now: a line a
+        // declaration is owed is named in the terms it wrote and never by the position a behavior
+        // met it at (issue #1062). Left as `take/h.a = 5`, this refused a string the report has no
+        // way of printing and said nothing about where the line is.
+        assertFalse(strict.contains("point value = 5"), strict);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
@@ -143,8 +143,8 @@ class ABorderSaysWhichOfItsTwoPointsALineIsTest {
     void aBoundsPointComesFromItsEndAndNotFromItsOperator() {
         String report = report(bounded("Int", "> 5"));
 
-        assertTrue(report.contains("the ON point take/h.a = 6"), report);
-        assertFalse(report.contains("take/h.a = 5"), report);
+        assertTrue(report.contains("the ON point value = 6"), report);
+        assertFalse(report.contains("value = 5"), report);
     }
 
     /**
@@ -164,8 +164,8 @@ class ABorderSaysWhichOfItsTwoPointsALineIsTest {
         String closed = report(bounded("Int", ">= 5"));
         String strict = report(bounded("Int", "> 5"));
 
-        assertTrue(closed.contains("the ON point take/h.a = 5"), closed);
-        assertTrue(strict.contains("the ON point take/h.a = 6"), strict);
+        assertTrue(closed.contains("the ON point value = 5"), closed);
+        assertTrue(strict.contains("the ON point value = 6"), strict);
         // And neither owes a row over the line. A bound leaves nothing outside itself, so the two
         // points out there are excluded — said in those words rather than left out, because a border
         // showing two of four items and nothing beside them reads as this compiler being short.

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
@@ -43,6 +43,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class ABorderSaysWhichOfItsTwoPointsALineIsTest {
 
+    /** The clause here states one thing, so the end it places comes out of its first conjunct. */
+    private static final int THE_ONLY_CONJUNCT = 0;
+
+
     /** {@code <=}: the line's own values satisfy the rule, so 100 is inside and 101 is the step out. */
     private static final String CLOSED = model("<=");
 
@@ -189,13 +193,13 @@ class ABorderSaysWhichOfItsTwoPointsALineIsTest {
     @Test
     void aBoundThatStopsShortOfItsValueDrawsNoBorderAtIt() {
         assertEquals(Criterion.AtTheLevel.class,
-                borderOf(new OriginRef.InvariantOrigin(invariant(), true))
+                borderOf(new OriginRef.InvariantOrigin(invariant(), THE_ONLY_CONJUNCT, true))
                         .demand(PointRole.ON).criterion().getClass(),
                 "a bound that admits its own end is at that end's ON point");
         // And where it does not admit it, the position does not reach the line: the value is outside
         // what the rules leave, so there is no border here and no point of one either. Read as a
         // border, it would owe an ON point one step in that no carrier here names.
-        assertEquals(null, borderOf(new OriginRef.InvariantOrigin(invariant(), false)),
+        assertEquals(null, borderOf(new OriginRef.InvariantOrigin(invariant(), THE_ONLY_CONJUNCT, false)),
                 "a bound whose own end its position refuses draws no line at it");
     }
 
@@ -239,7 +243,7 @@ class ABorderSaysWhichOfItsTwoPointsALineIsTest {
                 border.demand(PointRole.OUT).criterion().asked(border.cut().of()));
 
         // A bound owes nothing outside itself, and says which of the three answers settled it.
-        Border bound = borderOf(new OriginRef.InvariantOrigin(invariant(), true));
+        Border bound = borderOf(new OriginRef.InvariantOrigin(invariant(), THE_ONLY_CONJUNCT, true));
         assertEquals(new Demand.NotOwed(NotOwedReason.THE_RULES_REFUSE_IT),
                 bound.demand(PointRole.OFF));
         assertEquals(new Demand.NotOwed(NotOwedReason.THE_RULES_REFUSE_IT),

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClauseReachingOneCoordinatePlacesAnEdgeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClauseReachingOneCoordinatePlacesAnEdgeTest.java
@@ -153,7 +153,7 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
     void aRecordsBoundOnItsOwnNumberPlacesAnEdge() {
         String report = report(MODEL);
 
-        assertTrue(report.contains("no row is at the ON point onTally/v.n = 1 (invariant Tally #1)"), report);
+        assertTrue(report.contains("  Tally\n      ! no row is at the ON point n = 1 (invariant Tally #1)"), report);
     }
 
     /**
@@ -167,7 +167,7 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
         String report = report(MODEL);
 
         assertTrue(report.contains(
-                "no row is at the ON point onBag/List.length(v.xs) = 1 (invariant Bag #1)"), report);
+                "point List.length(xs) = 1 (invariant Bag #1)"), report);
     }
 
     /** Both ends, so that this is read as the rules being met and not as a floor being special. */
@@ -175,8 +175,8 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
     void bothEndsOfARecordsOwnBoundAreEdges() {
         String report = report(MODEL);
 
-        assertTrue(report.contains("no row is at the ON point onBoth/v.n = 1 (invariant Both #1)"), report);
-        assertTrue(report.contains("no row is at the ON point onBoth/v.n = 10 (invariant Both #2)"), report);
+        assertTrue(report.contains("  Both\n      ! no row is at the ON point n = 1 (invariant Both #1)"), report);
+        assertTrue(report.contains("      ! no row is at the ON point n = 10 (invariant Both #2)"), report);
     }
 
     /** A clause governing the position from the declaration it sits inside reaches it, and names
@@ -186,7 +186,7 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
         String report = report(MODEL);
 
         assertTrue(report.contains(
-                "no row is at the ON point onOuter/v.inner.n = 1 (invariant Inner #1)"), report);
+                "  Inner\n      ! no row is at the ON point n = 1 (invariant Inner #1)"), report);
     }
 
     /** And the outer record's own clause where it is the tighter of the two. */
@@ -195,7 +195,7 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
         String report = report(MODEL);
 
         assertTrue(report.contains(
-                "no row is at the ON point onTight/v.inner.n = 5 (invariant Tight #1)"), report);
+                "no row is at the ON point inner.n = 5 (invariant Tight #1)"), report);
     }
 
     /**
@@ -346,7 +346,7 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
     void aRangeNarrowedByAnotherPositionsBoundIsNotAnEdge() {
         String report = report(MODEL);
 
-        assertTrue(report.contains("no row is at the ON point onR/v.b = 10 (invariant R #2)"), report);
+        assertTrue(report.contains("no row is at the ON point b = 10 (invariant R #2)"), report);
         assertFalse(report.contains("point onR/v.a"), report);
     }
 
@@ -362,7 +362,7 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
     void aRangeNarrowedThroughAnotherPositionsTypeIsNotAnEdgeEither() {
         String report = report(MODEL);
 
-        assertTrue(report.contains("no row is at the ON point onUnder/v.b = 10 (invariant B #1)"), report);
+        assertTrue(report.contains("no row is at the ON point value = 10 (invariant B #1)"), report);
         assertFalse(report.contains("point onUnder/v.a"), report);
     }
 
@@ -373,10 +373,10 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
         String report = report(ON_NEWTYPES);
 
         assertTrue(report.contains(
-                "no row is at the ON point onName/String.length(v) = 1 (invariant Name #1)"), report);
+                "no row is at the ON point String.length(value) = 1 (invariant Name #1)"), report);
         assertTrue(report.contains(
-                "no row is at the ON point onCart/List.length(c) = 1 (invariant Cart #1)"), report);
-        assertTrue(report.contains("no row is at the ON point onHop/v.n = 1 (invariant Count #1)"), report);
+                "no row is at the ON point List.length(value) = 1 (invariant Cart #1)"), report);
+        assertTrue(report.contains("no row is at the ON point value = 1 (invariant Count #1)"), report);
     }
 
     /**
@@ -390,7 +390,7 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
     void aTighterRecordClauseOwnsTheLineRatherThanNarrowingIt() {
         String report = report(ON_NEWTYPES);
 
-        assertTrue(report.contains("no row is at the ON point onMoved/v.n = 5 (invariant Moved #1)"), report);
+        assertTrue(report.contains("no row is at the ON point n = 5 (invariant Moved #1)"), report);
         assertFalse(report.contains("within Moved"), report);
     }
 
@@ -437,7 +437,7 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
     void aRuleFromOutsideDoesNotChooseWhichCoordinateAPositionIsMeasuredAt() {
         String report = report(TWO_WAYS);
 
-        assertTrue(report.contains("no row is at the ON point onPerson/v.name = m (invariant Name #1)"),
+        assertTrue(report.contains("no row is at the ON point value = m (invariant Name #1)"),
                 report);
         assertFalse(report.contains("String.length(v.name"),
                 "the record's clause states an end on a coordinate this position is not measured at:\n"

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClauseReachingOneCoordinatePlacesAnEdgeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClauseReachingOneCoordinatePlacesAnEdgeTest.java
@@ -259,9 +259,9 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
     void aWrappersRuleReachesAPositionInsideARecord() {
         Map<String, BorderAssessment> lines = linesOf(WRAPPERS, "wrappers");
 
-        assertEquals("invariant Wrapped #1", lines.get("onHeld/v.w.n = 1").rule().named());
+        assertEquals("invariant Wrapped #1", lines.get("onHeld/v.w.n = 1").origin().named());
         assertEquals("invariant NonEmptyBag #1",
-                lines.get("onHeldBag/List.length(v.b.xs) = 1").rule().named());
+                lines.get("onHeldBag/List.length(v.b.xs) = 1").origin().named());
     }
 
     /** And through as many names as are worn, since a name wrapped round a value is not a step. */
@@ -269,7 +269,7 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
     void aWrappersRuleReachesThroughAStackOfNames() {
         Map<String, BorderAssessment> lines = linesOf(WRAPPERS, "wrappers");
 
-        assertEquals("invariant W2 #1", lines.get("onStacked/v.w.n = 2").rule().named());
+        assertEquals("invariant W2 #1", lines.get("onStacked/v.w.n = 2").origin().named());
     }
 
     /**
@@ -288,9 +288,9 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
     void aNameWrappedRoundARecordReachesItsPositions() {
         Map<String, BorderAssessment> lines = linesOf(WRAPPERS, "wrappers");
 
-        assertEquals("invariant Wrapped #1", lines.get("onWrapped/v.n = 1").rule().named());
+        assertEquals("invariant Wrapped #1", lines.get("onWrapped/v.n = 1").origin().named());
         assertEquals("invariant NonEmptyBag #1",
-                lines.get("onNonEmpty/List.length(v.xs) = 1").rule().named());
+                lines.get("onNonEmpty/List.length(v.xs) = 1").origin().named());
     }
 
     /**
@@ -635,7 +635,7 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
         assertTrue(lines.containsKey("onWrapped/v.a = 9"),
                 "and one step lower under the wrapper's clause: " + lines.keySet());
         assertEquals("invariant A #1 within Wrapped",
-                lines.get("onWrapped/v.a = 9").rule().named(),
+                lines.get("onWrapped/v.a = 9").origin().named(),
                 "the wrapper moved the edge `A` drew and did not draw one");
     }
 
@@ -653,7 +653,7 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
         Map<String, BorderAssessment> lines = linesOf(WRAPPED_RELATION, "wrappedrelation");
 
         assertEquals("invariant A #1 within Wrapped",
-                lines.get("onHeld/v.w.a = 9").rule().named(),
+                lines.get("onHeld/v.w.a = 9").origin().named(),
                 "the clause is `Wrapped`'s wherever a `Wrapped` is held: " + lines.keySet());
     }
 
@@ -716,7 +716,7 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
     void aRelationThatMovedNoEndDoesNotNameOne() {
         Map<String, BorderAssessment> lines = linesOf(WHO_HELD_IT, "whoheldit");
 
-        assertEquals("invariant A #1 within Inner", lines.get("onOuter/v.a = 7").rule().named(),
+        assertEquals("invariant A #1 within Inner", lines.get("onOuter/v.a = 7").origin().named(),
                 "`Outer`'s clause reaches nothing `a` had not already passed");
     }
 
@@ -736,7 +736,7 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
         Map<String, BorderAssessment> lines = linesOf(WHO_HELD_IT, "whoheldit");
 
         assertEquals("invariant A #1 within Again or Twice",
-                lines.get("onIdle/v.a = 7").rule().named(),
+                lines.get("onIdle/v.a = 7").origin().named(),
                 "`Idle`'s clause moves this end nowhere");
     }
 
@@ -745,8 +745,8 @@ class AClauseReachingOneCoordinatePlacesAnEdgeTest {
     void eachEndIsHeldByWhicheverDeclarationHoldsIt() {
         Map<String, BorderAssessment> lines = linesOf(WHO_HELD_IT, "whoheldit");
 
-        assertEquals("invariant N #1 within Both", lines.get("onBoth/v.n = 3").rule().named());
-        assertEquals("invariant N #2 within Upper", lines.get("onBoth/v.n = 7").rule().named());
+        assertEquals("invariant N #1 within Both", lines.get("onBoth/v.n = 3").origin().named());
+        assertEquals("invariant N #2 within Upper", lines.get("onBoth/v.n = 7").origin().named());
     }
 
     /** A length floor over an element type nothing inhabits. Its own module, since a declaration that

--- a/souther-compiler/src/test/java/souther/compiler/partition/ALineIsNamedByTheClauseThatDrewItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ALineIsNamedByTheClauseThatDrewItTest.java
@@ -101,9 +101,11 @@ class ALineIsNamedByTheClauseThatDrewItTest {
                 at1.origins().stream().map(OriginRef::named).toList(),
                 "one cut, two rules that drew it");
 
+        // Under the declaration that drew them, and named in the terms it wrote: the line is owed
+        // once over every behavior carrying the type (issue #1062).
         String human = humanOf(TWO_CLAUSES_AT_ONE_VALUE);
-        assertTrue(human.contains("price/length = 1 (invariant Length (floorA))"), human);
-        assertTrue(human.contains("price/length = 1 (invariant Length (floorB))"), human);
+        assertTrue(human.contains("value = 1 (invariant Length (floorA))"), human);
+        assertTrue(human.contains("value = 1 (invariant Length (floorB))"), human);
     }
 
     /**
@@ -118,8 +120,8 @@ class ALineIsNamedByTheClauseThatDrewItTest {
     void aLineNamesTheClauseTheAuthorWrote() {
         String human = humanOf(NAMED_CLAUSES);
 
-        assertTrue(human.contains("price/length = 1 (invariant Length (floor))"), human);
-        assertTrue(human.contains("price/length = 100 (invariant Length (ceiling))"), human);
+        assertTrue(human.contains("value = 1 (invariant Length (floor))"), human);
+        assertTrue(human.contains("value = 100 (invariant Length (ceiling))"), human);
     }
 
     /**
@@ -134,8 +136,8 @@ class ALineIsNamedByTheClauseThatDrewItTest {
     void oneClauseIsOneRuleAndAnUnnamedOneIsNamedByItsDeclaration() {
         String human = humanOf(ONE_UNNAMED_CLAUSE);
 
-        assertTrue(human.contains("price/length = 1 (invariant Length #1)"), human);
-        assertTrue(human.contains("price/length = 100 (invariant Length #1)"), human);
+        assertTrue(human.contains("value = 1 (invariant Length #1)"), human);
+        assertTrue(human.contains("value = 100 (invariant Length #1)"), human);
 
         Axis length = axis(ONE_UNNAMED_CLAUSE);
         assertEquals(1, cutAt(length, 1L).origins().size(),

--- a/souther-compiler/src/test/java/souther/compiler/query/AFindingCarriesWhatTheMeasureThatFoundItWentWithoutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AFindingCarriesWhatTheMeasureThatFoundItWentWithoutTest.java
@@ -66,7 +66,8 @@ class AFindingCarriesWhatTheMeasureThatFoundItWentWithoutTest {
         Compilation compilation = Compilation.ofSource(MODEL, "Main");
         compilation.measure(Adequacy.Asked.fullReport());
         compilation.answerEverything();
-        return compilation.db().ask(new Adequacy.Findings("demo")).value().get(behavior);
+        return compilation.db().ask(new Adequacy.Findings("demo")).value().stream()
+                .filter(each -> each.subject().isBehavior(behavior)).toList();
     }
 
     private static Adequacy.SignatureEvidence signature(String behavior) {

--- a/souther-compiler/src/test/java/souther/compiler/query/OneAuthoredLineIsOneDebtHoweverManyBehaviorsCarryItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/OneAuthoredLineIsOneDebtHoweverManyBehaviorsCarryItTest.java
@@ -228,6 +228,105 @@ class OneAuthoredLineIsOneDebtHoweverManyBehaviorsCarryItTest {
                 "and what the page shows is what the verdict rests on");
     }
 
+    /**
+     * A behavior with no rows does not hold open a line another behavior's row settles.
+     *
+     * <p>The verdict and not the findings. A row at the line makes the debt covered, so there is no
+     * finding to be short of — and a verdict assembled from the readings still had one behavior's
+     * {@code NO_ROWS} in it and came out undetermined about a line something had already settled.
+     * The two answers came from one set of readings folded two ways, which is what a debt is for.
+     *
+     * <p>{@code touch} carries {@code UserId} and is written no rows at all; {@code schedule} is
+     * written one at the boundary. The debt is what they come to together.
+     */
+    @Test
+    void aBehaviorWithNoRowsDoesNotHoldOpenALineAnotherSettles() {
+        Compilation compilation = Compilation.ofSource(ONE_WRITES_ROWS, "Main");
+        // Held to the rows against a line and not to the regions either side, so that what is
+        // measured here is the line and not a region `touch` has no rows in. The regions stay with
+        // the reading whatever the bar, which is the other half of this change.
+        compilation.measure(Adequacy.Asked.fullReport(Adequacy.AdequacyBar.SIMPLIFIED_DOMAIN));
+        compilation.answerEverything();
+        AdequacyReport report = AdequacyReport.of(compilation);
+
+        assertEquals(List.of(), report.adequacyGaps().stream()
+                        .map(each -> each.about().toString()).toList(),
+                () -> "nothing is short of the line: "
+                        + report.human(SourceNameResolver.identity()));
+        assertEquals(AdequacyReport.AdequacyStatus.SATISFIED, report.adequacy(),
+                () -> "and the verdict says so: " + report.human(SourceNameResolver.identity()));
+    }
+
+    /** Two behaviors carrying one type, one of them written a row at the boundary and the other
+     *  written none. */
+    private static final String ONE_WRITES_ROWS = """
+            module example.onewrites
+
+            data UserId = String
+                invariant nonempty = String.length(value) >= 1
+
+            data Draft = { owner: UserId }
+            data Task = { owner: UserId }
+
+            data Ok
+
+            behavior schedule : (d: Draft) -> Ok
+            let schedule (d) = Ok
+
+            behavior touch : (t: Task) -> Ok
+            let touch (t) = Ok
+
+            example schedule
+                | "at the boundary" : (Draft { owner = UserId("x") }) -> Ok
+            """;
+
+    /**
+     * The document says which declaration is short of a line, and not only what the line asks.
+     *
+     * <p>Two declarations bounding a string's length at one ask a row the same thing, so what a
+     * finding says of itself is the same words for both. Published in one flat list they are two
+     * identical objects and a consumer cannot tell which declaration it is being sent to — which is
+     * what a subject was introduced to keep (issue #1062).
+     */
+    @Test
+    void theDocumentSaysWhichDeclarationIsShortOfALine() {
+        Compilation compilation = Compilation.ofSource(TWO_DECLARATIONS, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        String json = AdequacyReport.of(compilation).json(SourceNameResolver.identity());
+        tools.jackson.databind.JsonNode declarations =
+                tools.jackson.databind.json.JsonMapper.builder().build().readTree(json)
+                        .get("modules").get(0).get("declarations");
+
+        List<String> named = new java.util.ArrayList<>();
+        declarations.forEach(each -> named.add(each.get("name").asString()));
+        assertEquals(List.of("UserId", "OrderId"), named,
+                () -> "each line is under the declaration that owes it: " + declarations);
+        declarations.forEach(each -> assertEquals(1, each.get("findings").size(),
+                () -> "and one line apiece: " + declarations));
+    }
+
+    /** Two declarations whose clauses ask a row the same thing. */
+    private static final String TWO_DECLARATIONS = """
+            module example.two
+
+            data UserId = String
+                invariant nonempty = String.length(value) >= 1
+
+            data OrderId = String
+                invariant nonempty = String.length(value) >= 1
+
+            data Draft = { owner: UserId, order: OrderId }
+
+            data Ok
+
+            behavior schedule : (d: Draft) -> Ok
+            let schedule (d) = Ok
+
+            example schedule
+                | "a" : (Draft { owner = UserId("abc"), order = OrderId("def") }) -> Ok
+            """;
+
     /** Every reading of every line of {@code module}, as the measure holds them. */
     private static List<BorderAssessment> readingsOf(String model, String module) {
         Compilation compilation = Compilation.ofSource(model, "Main");

--- a/souther-compiler/src/test/java/souther/compiler/query/OneAuthoredLineIsOneDebtHoweverManyBehaviorsCarryItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/OneAuthoredLineIsOneDebtHoweverManyBehaviorsCarryItTest.java
@@ -2,12 +2,15 @@ package souther.compiler.query;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.diag.SourceNameResolver;
 import souther.compiler.partition.PointRole;
+import souther.compiler.report.AdequacyReport;
 
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -37,10 +40,12 @@ class OneAuthoredLineIsOneDebtHoweverManyBehaviorsCarryItTest {
                 () -> "the clause is read at every position carrying the type: "
                         + readings.stream().map(BorderAssessment::label).toList());
 
-        List<BorderObligationAssessment> debts = BorderObligationAssessment.across(readings);
-        assertEquals(1, debts.size(),
-                () -> "and all of them are the one line UserId's clause drew: "
-                        + debts.stream().map(each -> each.origin().named()).toList());
+        // What a report and a build are handed. A debt is one item however many readings there
+        // are, so the ON point of this clause is asked for once or not at all.
+        List<Adequacy.Finding> declared = declaredFindings(CARRIED, "example.carried");
+        assertEquals(List.of(), declared,
+                () -> "one row is written at the boundary, so the line is not owed another: "
+                        + declared.stream().map(each -> each.about().toString()).toList());
     }
 
     /**
@@ -53,20 +58,48 @@ class OneAuthoredLineIsOneDebtHoweverManyBehaviorsCarryItTest {
      */
     @Test
     void aRowAtOnePositionDischargesTheDebtAtAllOfThem() {
-        List<BorderObligationAssessment> debts =
-                BorderObligationAssessment.across(readingsOf(CARRIED, "example.carried"));
-        BorderObligationAssessment debt = debts.get(0);
-
-        assertTrue(debt.owedAt(PointRole.ON).hasRowWitness(),
-                "one behavior's row stands at the ON point, which settles the line");
-
         Map<String, BorderAssessment> byPosition = new java.util.LinkedHashMap<>();
         readingsOf(CARRIED, "example.carried").forEach(r -> byPosition.put(r.label(), r));
         assertEquals(List.of(true, false, false, false),
                 byPosition.values().stream()
                         .map(each -> each.owedAt(PointRole.ON).hasRowWitness()).toList(),
-                () -> "and the readings on their own say what they always said: "
-                        + byPosition.keySet());
+                () -> "only one reading has a row at the point: " + byPosition.keySet());
+
+        assertEquals(List.of(), declaredFindings(CARRIED, "example.carried"),
+                "and the line is settled, because whether a row standing at length 1 is believed is"
+                        + " a question about UserId");
+    }
+
+    /**
+     * Take the one row away and the line is owed once, not once per position.
+     *
+     * <p>The other half of the measurement. Without it, an implementation that produced no declared
+     * finding at all would pass both of the assertions above.
+     */
+    @Test
+    void aLineNoRowStandsAtIsOwedOnce() {
+        List<Adequacy.Finding> declared = declaredFindings(WELL_INSIDE, "example.carried");
+        assertEquals(1, declared.size(),
+                () -> "four readings and one row to write: "
+                        + declared.stream().map(each -> each.about().toString()).toList());
+        assertEquals(new FindingSubject.OfADeclaration(
+                        souther.compiler.types.TypeSymbols.declared(
+                                new souther.compiler.types.TypeKey("example.carried", "UserId"))),
+                declared.get(0).subject(),
+                "and it is asked of the declaration that wrote the rule");
+    }
+
+    /** Every finding the module's declarations are short of. */
+    private static List<Adequacy.Finding> declaredFindings(String model, String module) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        List<Adequacy.Finding> findings =
+                compilation.db().ask(new Adequacy.Findings(module)).value();
+        assertNotNull(findings, "the model under test compiles");
+        return findings.stream()
+                .filter(each -> each.about() instanceof About.APointOfADeclaredBorder)
+                .toList();
     }
 
     /**
@@ -103,6 +136,97 @@ class OneAuthoredLineIsOneDebtHoweverManyBehaviorsCarryItTest {
             example review
                 | "well inside" : (Note { by = UserId("abcd") }) -> Ok
             """;
+
+    /** The same three behaviors with no row at the boundary anywhere. */
+    private static final String WELL_INSIDE =
+            CARRIED.replace("UserId(\"x\")", "UserId(\"abc\")");
+
+    /**
+     * The points against the line agree across its readings; the points away from it do not.
+     *
+     * <p>Where the two halves of a border part. {@code ON} and {@code OFF} are values of the
+     * quantity the rule cut, so what they ask is the same wherever the line is read — which is what
+     * makes one row anywhere evidence for all of them. {@code IN} and {@code OUT} are the regions
+     * either side, and where a region stops is settled by every other rule reaching that position:
+     * {@code Cm}'s lower end runs to 150 at a length the record caps and runs on where nothing else
+     * bounds it. A row well inside the second is not a row the first could hold at all.
+     *
+     * <p>Fixed here because the pull is to undo it. A border is one construct with four points, and
+     * bringing all four under one debt reads as tidying — it would report a region covered on the
+     * strength of a row that could not stand in it.
+     */
+    @Test
+    void thePointsAgainstTheLineAgreeAcrossItsReadingsAndTheRegionsDoNot() {
+        Map<String, BorderAssessment> byPosition = new java.util.LinkedHashMap<>();
+        readingsOf(TWO_REGIONS, "example.regions").forEach(r -> byPosition.put(r.label(), r));
+        BorderAssessment capped = byPosition.get("p.length = 0");
+        BorderAssessment open = byPosition.get("o.straw = 0");
+        assertNotNull(capped, byPosition.keySet().toString());
+        assertNotNull(open, byPosition.keySet().toString());
+        assertEquals(capped.border().obligation(), open.border().obligation(),
+                "one clause of Cm drew the line both readings met");
+
+        assertEquals(capped.border().demand(PointRole.ON), open.border().demand(PointRole.ON),
+                "what a row at the line has to do is the same question about Cm");
+        assertNotEquals(capped.border().demand(PointRole.IN), open.border().demand(PointRole.IN),
+                "and what a row well inside has to do is a question about the position");
+    }
+
+    /** One newtype's lower end, read at a position a record caps and at one nothing else bounds. */
+    private static final String TWO_REGIONS = """
+            module example.regions
+
+            data Cm = Int
+                invariant nonneg = value >= 0
+
+            data Parcel = { length: Cm }
+                invariant fits = length.value <= 150
+
+            data Order = { straw: Cm }
+
+            data Ok
+
+            behavior quote : (p: Parcel) -> Ok
+            let quote (p) = Ok
+
+            behavior mix : (o: Order) -> Ok
+            let mix (o) = Ok
+
+            example quote
+                | "a" : (Parcel { length = Cm(10) }) -> Ok
+
+            example mix
+                | "a" : (Order { straw = Cm(10) }) -> Ok
+            """;
+
+    /**
+     * A report prints the line under the declaration that drew it, once, and refuses over it.
+     *
+     * <p>Both halves, because they came apart. What the report shows and what the verdict rests on
+     * are the same list read twice, and a walk over the behaviors alone left a declaration's line
+     * out of the second — so a page printed a gap and said the rows met the bar underneath it.
+     *
+     * <p>Under the declaration, because that is where the author fixes it. Printed under a behavior
+     * it would be printed under whichever one a walk reached first, and the reader sent there would
+     * find a body that says nothing about the length of a user id.
+     */
+    @Test
+    void aReportPrintsTheLineUnderItsDeclarationAndRefusesOverIt() {
+        Compilation compilation = Compilation.ofSource(WELL_INSIDE, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        AdequacyReport report = AdequacyReport.of(compilation);
+        String page = report.human(SourceNameResolver.identity());
+
+        assertEquals(1, page.lines().filter(each -> each.contains("no row is at the ON point"))
+                        .count(),
+                () -> "four readings of one line and one item to read: " + page);
+        assertTrue(page.contains("  UserId\n"
+                        + "      ! no row is at the ON point String.length(value) = 1"),
+                () -> "under the declaration that drew it, in the terms it was written in: " + page);
+        assertEquals(AdequacyReport.AdequacyStatus.NOT_SATISFIED, report.adequacy(),
+                "and what the page shows is what the verdict rests on");
+    }
 
     /** Every reading of every line of {@code module}, as the measure holds them. */
     private static List<BorderAssessment> readingsOf(String model, String module) {

--- a/souther-compiler/src/test/java/souther/compiler/query/OneAuthoredLineIsOneDebtHoweverManyBehaviorsCarryItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/OneAuthoredLineIsOneDebtHoweverManyBehaviorsCarryItTest.java
@@ -1,0 +1,117 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.partition.PointRole;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a report asks an author for is one row per authored line, and not one per position of every
+ * behavior carrying the type.
+ *
+ * <p>Issue #1062 measured what the second costs. Over the fourteen modules of {@code
+ * souther-examples}, 969 of the 1504 items a report marks are borders an {@code invariant} drew, and
+ * they come from 75 clauses; in {@code crm} alone one clause of {@code UserId} is named 126 times,
+ * at 74 behaviors. Discharging what that asks for means writing 126 rows that each stand at the same
+ * point, for a rule the author wrote once — and no module can turn {@code --strict} on.
+ */
+class OneAuthoredLineIsOneDebtHoweverManyBehaviorsCarryItTest {
+
+    /**
+     * One clause carried by many behaviors is one debt, whatever the readings.
+     *
+     * <p>Counted rather than compared, because the failure is a debt appearing again: three
+     * behaviors carry {@code UserId} at four positions between them, so a measure keyed on the
+     * reading asks for the same row four times.
+     */
+    @Test
+    void oneClauseCarriedByThreeBehaviorsIsOneDebt() {
+        List<BorderAssessment> readings = readingsOf(CARRIED, "example.carried");
+        assertEquals(4, readings.size(),
+                () -> "the clause is read at every position carrying the type: "
+                        + readings.stream().map(BorderAssessment::label).toList());
+
+        List<BorderObligationAssessment> debts = BorderObligationAssessment.across(readings);
+        assertEquals(1, debts.size(),
+                () -> "and all of them are the one line UserId's clause drew: "
+                        + debts.stream().map(each -> each.origin().named()).toList());
+    }
+
+    /**
+     * A row at one of the positions discharges the debt at all of them.
+     *
+     * <p>The whole of what the collapse is worth, and what the count above does not say. Only
+     * {@code schedule} is written a row at length 1; the debt is covered, because whether a row
+     * standing at length 1 is believed is a question about {@code UserId} and neither
+     * {@code touch} nor {@code review} says anything about the length of a user id.
+     */
+    @Test
+    void aRowAtOnePositionDischargesTheDebtAtAllOfThem() {
+        List<BorderObligationAssessment> debts =
+                BorderObligationAssessment.across(readingsOf(CARRIED, "example.carried"));
+        BorderObligationAssessment debt = debts.get(0);
+
+        assertTrue(debt.owedAt(PointRole.ON).hasRowWitness(),
+                "one behavior's row stands at the ON point, which settles the line");
+
+        Map<String, BorderAssessment> byPosition = new java.util.LinkedHashMap<>();
+        readingsOf(CARRIED, "example.carried").forEach(r -> byPosition.put(r.label(), r));
+        assertEquals(List.of(true, false, false, false),
+                byPosition.values().stream()
+                        .map(each -> each.owedAt(PointRole.ON).hasRowWitness()).toList(),
+                () -> "and the readings on their own say what they always said: "
+                        + byPosition.keySet());
+    }
+
+    /**
+     * Three behaviors carrying one type, one of them at two positions, and a row at the boundary
+     * written for one of them.
+     */
+    private static final String CARRIED = """
+            module example.carried
+
+            data UserId = String
+                invariant nonempty = String.length(value) >= 1
+
+            data Draft = { owner: UserId, reviewer: UserId }
+            data Task = { owner: UserId }
+            data Note = { by: UserId }
+
+            data Ok
+
+            behavior schedule : (d: Draft) -> Ok
+            let schedule (d) = Ok
+
+            behavior touch : (t: Task) -> Ok
+            let touch (t) = Ok
+
+            behavior review : (n: Note) -> Ok
+            let review (n) = Ok
+
+            example schedule
+                | "at the boundary" : (Draft { owner = UserId("x"), reviewer = UserId("yy") }) -> Ok
+
+            example touch
+                | "well inside" : (Task { owner = UserId("abcd") }) -> Ok
+
+            example review
+                | "well inside" : (Note { by = UserId("abcd") }) -> Ok
+            """;
+
+    /** Every reading of every line of {@code module}, as the measure holds them. */
+    private static List<BorderAssessment> readingsOf(String model, String module) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, List<BorderAssessment>> boundaries =
+                Adequacy.boundariesOf(compilation.db(), module);
+        assertNotNull(boundaries, "the model under test compiles");
+        return boundaries.values().stream().flatMap(List::stream).toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/OneOfTwoRulesAtOneValueCanBeAGapTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/OneOfTwoRulesAtOneValueCanBeAGapTest.java
@@ -57,8 +57,8 @@ class OneOfTwoRulesAtOneValueCanBeAGapTest {
 
         // Both halves. That the gap exists is what makes the lookup happen at all, and a model
         // whose lines were all met would pass this without the reading under test having run.
-        assertTrue(compilation.db().ask(new Adequacy.Findings(module)).value()
-                        .getOrDefault("charge", java.util.List.of()).stream()
+        assertTrue(compilation.db().ask(new Adequacy.Findings(module)).value().stream()
+                        .filter(each -> each.subject().isBehavior("charge"))
                         .anyMatch(each -> each.kind() == Adequacy.Kind.BOUNDARY_UNMET),
                 "the guard's line at a hundred is the gap this is about");
         assertDoesNotThrow(() -> Adequacy.generatedOf(compilation.db(), module),

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatTheReadingsOfOneDebtComeToTogetherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatTheReadingsOfOneDebtComeToTogetherTest.java
@@ -1,0 +1,131 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.ItemAssessment.Coverage;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * One authored line is read at every position of every behavior carrying the type, and what the debt
+ * came to is not any one of those readings.
+ *
+ * <p>Written against the fold rather than through a model, because what decides the answer is which
+ * readings there are and a model reaches only the combinations it happens to produce. The case this
+ * is for — a behavior nobody wrote a row for beside one whose rows were read to the end — is one no
+ * model of a few lines puts together, and it is the one an implementation gets wrong.
+ *
+ * <p>The mistake it is against is reading the state and not the reason. Three of these readings are
+ * one {@code NotMeasured} and they do not mean one thing: rows the build never looked at may be
+ * standing at the point, and rows that do not exist cannot be.
+ */
+class WhatTheReadingsOfOneDebtComeToTogetherTest {
+
+    /**
+     * A row found anywhere settles the line, whatever the readings beside it went without.
+     *
+     * <p>First, and before anything is counted. A debt is discharged by evidence from any of its
+     * readings — that is what makes the readings of one line one debt — so an accounting of what
+     * went unread may not take back a row somebody wrote.
+     */
+    @Test
+    void aRowFoundAtOneReadingSettlesTheDebt() {
+        assertEquals(new Measurement.Complete<>(new Coverage.Hit()),
+                Coverage.acrossTheReadings(List.of(
+                        missed(), found(), unread())),
+                "one reading is at the point, which is what the line asked for");
+    }
+
+    /**
+     * A reading that may be hiding a row leaves the debt unsettled, however many read to the end.
+     *
+     * <p>The row could be at the position that went unread, so nothing here has shown there is none.
+     * What the other readings established is kept beside it as the value — no row was seen — and the
+     * measurement says the reading was not whole.
+     */
+    @Test
+    void aReadingThatMayBeHidingARowLeavesTheDebtUnsettled() {
+        Measurement<Coverage> across = Coverage.acrossTheReadings(List.of(missed(), unread()));
+
+        assertInstanceOf(Measurement.Partial.class, across,
+                "the reading was not whole, so neither is the answer");
+        assertEquals(new Measurement.Partial<>(new Coverage.NoHit(), WEAKENED), across,
+                "no row was seen at any of them, and this is what the reading went without");
+    }
+
+    /**
+     * A reading with no rows to look at does not take back a miss another reading established.
+     *
+     * <p>The case the reasons are told apart for. A behavior nobody wrote a row for is not a place a
+     * row could be hiding, so it says nothing about the line and the reading that read its rows to
+     * the end still answers. Read as the state — nothing was measured, so nothing is known — a debt
+     * carried by two behaviors went undecided as soon as one of them had no rows, and a build
+     * stopped refusing a gap it had established.
+     */
+    @Test
+    void aReadingWithNoRowsDoesNotUnsettleAMissBesideIt() {
+        assertEquals(new Measurement.Complete<>(new Coverage.NoHit()),
+                Coverage.acrossTheReadings(List.of(noRows(), missed())),
+                "the rows that exist were read and none is at the point");
+    }
+
+    /**
+     * A build that asked for no measurement does take it back.
+     *
+     * <p>Beside the case above, which is the whole of what telling the reasons apart buys. Both are
+     * a {@code NotMeasured} and only one of them could be holding the row: rows the build never
+     * looked at exist and were not read, and rows nobody wrote do not exist.
+     */
+    @Test
+    void aBuildThatLookedAtNothingDoesUnsettleAMissBesideIt() {
+        assertEquals(new Measurement.NotMeasured<>(Coverage.NotAsked.NOT_ASKED),
+                Coverage.acrossTheReadings(List.of(notAsked(), missed())),
+                "the rows of the reading that was never made may be at the point");
+    }
+
+    /** Where every reading had nothing to look at, neither has the debt. */
+    @Test
+    void aDebtNoRowAnywhereCouldHaveAnsweredIsNotAMiss() {
+        assertEquals(new Measurement.NotMeasured<>(Coverage.NotAsked.NO_ROWS),
+                Coverage.acrossTheReadings(List.of(noRows(), noRows())));
+    }
+
+    /** A debt is what its readings came to, so there is no answer where there are none. */
+    @Test
+    void aDebtWithNoReadingsIsNotAnAnswer() {
+        assertThrows(IllegalArgumentException.class,
+                () -> Coverage.acrossTheReadings(List.of()));
+    }
+
+    /** A reading that found the row. */
+    private static Measurement<Coverage> found() {
+        return new Measurement.Complete<>(new Coverage.Hit());
+    }
+
+    /** A reading that read its rows to the end and found none at the point. */
+    private static Measurement<Coverage> missed() {
+        return new Measurement.Complete<>(new Coverage.NoHit());
+    }
+
+    /** A reading that did not run out, so the row may be behind what it could not read. */
+    private static Measurement<Coverage> unread() {
+        return new Measurement.Partial<>(new Coverage.NoHit(), WEAKENED);
+    }
+
+    /** A reading of a behavior nobody wrote a row for. */
+    private static Measurement<Coverage> noRows() {
+        return new Measurement.NotMeasured<>(Coverage.NotAsked.NO_ROWS);
+    }
+
+    /** A reading the build never asked for. */
+    private static Measurement<Coverage> notAsked() {
+        return new Measurement.NotMeasured<>(Coverage.NotAsked.NOT_ASKED);
+    }
+
+    private static final WeakeningSet WEAKENED =
+            WeakeningSet.of(new Weakening.BodiesNotElaborated("example"));
+}

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.generated.txt
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.generated.txt
@@ -70,3 +70,4 @@
 //         }
 //     )
 //         -> <?>
+// nothing offers a row for `String.length(value) = 1` in `Sku`: a row is composed by walking one behavior's inputs, and this line is owed once over every behavior carrying the type

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.generated.txt
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.generated.txt
@@ -70,4 +70,3 @@
 //         }
 //     )
 //         -> <?>
-// nothing offers a row for `String.length(value) = 1` in `Sku`: a row is composed by walking one behavior's inputs, and this line is owed once over every behavior carrying the type

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
@@ -223,10 +223,13 @@
     "weakening" : [ "rules_not_reached", "rule_unread" ],
     "incompleteness" : [ ],
     "declarations" : [ {
-      "kind" : "boundary_unmet",
-      "disposition" : "refused",
-      "subject" : "String.length(value) = 1",
-      "code" : "E1916"
+      "name" : "Sku",
+      "findings" : [ {
+        "kind" : "boundary_unmet",
+        "disposition" : "refused",
+        "subject" : "String.length(value) = 1",
+        "code" : "E1916"
+      } ]
     } ],
     "behaviors" : [ {
       "name" : "台帳へ書く",

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
@@ -9,6 +9,7 @@
     "status" : "partial",
     "weakening" : [ "rule_unread" ],
     "incompleteness" : [ ],
+    "declarations" : [ ],
     "behaviors" : [ {
       "name" : "discount",
       "implementation" : "implemented",
@@ -221,6 +222,12 @@
     "status" : "partial",
     "weakening" : [ "rules_not_reached", "rule_unread" ],
     "incompleteness" : [ ],
+    "declarations" : [ {
+      "kind" : "boundary_unmet",
+      "disposition" : "refused",
+      "subject" : "String.length(value) = 1",
+      "code" : "E1916"
+    } ],
     "behaviors" : [ {
       "name" : "台帳へ書く",
       "implementation" : "injected",
@@ -372,11 +379,6 @@
         "reason" : "no_body"
       },
       "findings" : [ {
-        "kind" : "boundary_unmet",
-        "disposition" : "refused",
-        "subject" : "台帳へ書く/String.length(指示.品目[*]) = 1",
-        "code" : "E1916"
-      }, {
         "kind" : "partition_not_derivable",
         "disposition" : "reported",
         "subject" : "指示.受付日"
@@ -674,11 +676,6 @@
         "unreached" : [ ]
       },
       "findings" : [ {
-        "kind" : "boundary_unmet",
-        "disposition" : "refused",
-        "subject" : "出荷する/String.length(指示.品目[*]) = 1",
-        "code" : "E1916"
-      }, {
         "kind" : "domain_point_uncovered",
         "disposition" : "refused",
         "subject" : "出荷する/指示.重量 in 30001 < 指示.重量",

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -775,30 +775,23 @@ public final class Analyzer {
         if (findings == null) {
             return false;
         }
-        // This behavior's own, and the lines its type declarations are owed that a row written
-        // here would settle. A line an `invariant` drew is not this behavior's — what `UserId` says
-        // is the same wherever the type is carried — but a row written for a behavior carrying the
-        // type is what discharges it, so an offer standing beside that behavior is an offer to do
-        // this work (issue #1062). Read as the behavior's own alone, the offer went quiet as soon
-        // as the only work left was a line a declaration is owed.
+        // This behavior's own, and the lines its type declarations are owed that a row written here
+        // would settle. A line an `invariant` drew is not this behavior's finding — what `UserId`
+        // says is the same wherever the type is carried — and a row written for a behavior carrying
+        // the type is what discharges it, so an offer standing beside that behavior is an offer to
+        // do that work (issue #1062). Read as the behavior's own alone, the offer went quiet as
+        // soon as the only work left was a line a declaration is owed.
+        //
+        // Asked of the finding and never of what a search has composed. Whether a value has been
+        // built turns on how much the build was measuring, and an offer that read it would appear
+        // at one level and not at another for work that is there either way.
         for (souther.compiler.query.Adequacy.Finding each : findings) {
-            if (each.subject().isBehavior(behavior)
-                    && souther.compiler.query.Adequacy.whereNoRowCouldAnswer(each.about()) == null) {
-                return true;
+            if (souther.compiler.query.Adequacy.whereNoRowCouldAnswer(each.about()) != null) {
+                continue;
             }
-            // A line a declaration is owed that this behavior carries. It is not this behavior's
-            // finding — what `UserId` says is the same wherever the type is carried — and a row
-            // written here is what discharges it, so an offer standing beside this behavior is an
-            // offer to do that work (issue #1062). Read as the behavior's own alone, the offer went
-            // quiet as soon as the only work left was a line a declaration is owed.
-            //
-            // Asked of the finding and never of what a search has composed. Whether a value has
-            // been built turns on how much the build was measuring, and an offer that read it would
-            // appear at one level and not at another for work that is there either way.
-            if (each.about() instanceof souther.compiler.query.About
-                    .APointOfADeclaredBorder(var debt, var _)
-                    && debt.carriedBy(behavior)
-                    && souther.compiler.query.Adequacy.whereNoRowCouldAnswer(each.about()) == null) {
+            if (each.subject().isBehavior(behavior)
+                    || each.about() instanceof souther.compiler.query.About
+                            .APointOfADeclaredBorder(var debt, var _) && debt.carriedBy(behavior)) {
                 return true;
             }
         }

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -770,12 +770,15 @@ public final class Analyzer {
     /** Whether anything this behavior is short of is a thing writing a row could answer. */
     private static boolean anythingARowCouldAnswer(Compilation compilation, String module,
                                                    String behavior) {
-        Map<String, List<souther.compiler.query.Adequacy.Finding>> findings =
+        List<souther.compiler.query.Adequacy.Finding> findings =
                 compilation.db().ask(new souther.compiler.query.Adequacy.Findings(module)).value();
         if (findings == null) {
             return false;
         }
-        return findings.getOrDefault(behavior, List.of()).stream()
+        // This behavior's own. A finding about a declaration is not one writing a row for this
+        // behavior answers — what {@code UserId} says is the same wherever the type is carried —
+        // so the offer beside a behavior is about the behavior's own (issue #1062).
+        return findings.stream().filter(each -> each.subject().isBehavior(behavior))
                 .anyMatch(each -> souther.compiler.query.Adequacy
                         .whereNoRowCouldAnswer(each.about()) == null);
     }

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -775,12 +775,34 @@ public final class Analyzer {
         if (findings == null) {
             return false;
         }
-        // This behavior's own. A finding about a declaration is not one writing a row for this
-        // behavior answers — what {@code UserId} says is the same wherever the type is carried —
-        // so the offer beside a behavior is about the behavior's own (issue #1062).
-        return findings.stream().filter(each -> each.subject().isBehavior(behavior))
-                .anyMatch(each -> souther.compiler.query.Adequacy
-                        .whereNoRowCouldAnswer(each.about()) == null);
+        // This behavior's own, and the lines its type declarations are owed that a row written
+        // here would settle. A line an `invariant` drew is not this behavior's — what `UserId` says
+        // is the same wherever the type is carried — but a row written for a behavior carrying the
+        // type is what discharges it, so an offer standing beside that behavior is an offer to do
+        // this work (issue #1062). Read as the behavior's own alone, the offer went quiet as soon
+        // as the only work left was a line a declaration is owed.
+        for (souther.compiler.query.Adequacy.Finding each : findings) {
+            if (each.subject().isBehavior(behavior)
+                    && souther.compiler.query.Adequacy.whereNoRowCouldAnswer(each.about()) == null) {
+                return true;
+            }
+            // A line a declaration is owed that this behavior carries. It is not this behavior's
+            // finding — what `UserId` says is the same wherever the type is carried — and a row
+            // written here is what discharges it, so an offer standing beside this behavior is an
+            // offer to do that work (issue #1062). Read as the behavior's own alone, the offer went
+            // quiet as soon as the only work left was a line a declaration is owed.
+            //
+            // Asked of the finding and never of what a search has composed. Whether a value has
+            // been built turns on how much the build was measuring, and an offer that read it would
+            // appear at one level and not at another for work that is there either way.
+            if (each.about() instanceof souther.compiler.query.About
+                    .APointOfADeclaredBorder(var debt, var _)
+                    && debt.carriedBy(behavior)
+                    && souther.compiler.query.Adequacy.whereNoRowCouldAnswer(each.about()) == null) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/souther-lsp/src/test/java/souther/lsp/AdequacyLensTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/AdequacyLensTest.java
@@ -269,6 +269,32 @@ class AdequacyLensTest {
                 "and at `witness` they are the same rows: taking the action is what asks for them");
     }
 
+    /**
+     * The rows the action writes are not printed under a sentence saying nothing offers them.
+     *
+     * <p>Both are answers about the same request, and they were read from different places. A line
+     * an {@code invariant} drew is owed to the declaration, and what a generation can do about it is
+     * what this request's search composed — read from the measurement instead, a build at
+     * {@code witness} composes nothing while it measures, so the block printed the rows the action
+     * had just composed and then said no row was on offer (issue #1062).
+     *
+     * <p>At {@code witness} because that is where the two come apart. At {@code all} the measurement
+     * composes values of its own and the two answers agree by accident.
+     */
+    @Test
+    void theRowsTheActionWritesAreNotPrintedUnderASentenceSayingNothingOffersThem() {
+        Analyzer analyzer = measuring(Adequacy.Level.WITNESS);
+        ModuleGraph graph = graphOf(Map.of(EDGES, ONLY_EDGES));
+        CodeAction.Deferred offered = assertInstanceOf(CodeAction.Deferred.class,
+                analyzer.codeActions(EDGES, ONLY_EDGES, on(7), graph).get(0),
+                "there is work to offer");
+
+        CodeAction.Edit taken = analyzer.resolve(offered, ONLY_EDGES, graph);
+        assertNotNull(taken, "and taking it writes rows");
+        assertFalse(taken.newText().contains("nothing offers a row"),
+                () -> "the rows are right there: " + taken.newText());
+    }
+
     /** With one document there is nothing to offer: the values a row writes are built through the
      * module's derived decoders, and its imports are part of that. */
     @Test


### PR DESCRIPTION
Closes #1062.

A border carried one identity and answered two questions with it: what the author wrote, and where a reading met it. So a line a `data`'s clause draws was owed at every position of every behavior carrying the type. Over `crm`, one clause of `UserId` was 126 items at 74 behaviors, and two thirds of what `--strict` would refuse over was one rule asked for again.

## What a row is owed for

`BorderObligationId` is the authored line: the rule as the reading met it — narrowings and all — and the level it cut. It does not hold the quantity, which is where the line was read.

Which conjunct of the clause drew the end is part of the rule, because neither the clause nor the value is enough. One clause places two ends, and `String.length(name) >= 1 && String.length(code) >= 1` places both of them at 1: a row whose `name` is one character says nothing about `code`. The conjunct and not the number the clause was written about — a clause of `Day` is about `value` read from `Day` and about `d` read from the `Span` holding it, so an identity spelled that way calls one authored line two.

Which lines are a declaration's is asked of the rule (`OriginRef.owedToTheDeclaration`) and never matched on which kind it is, so a rule added later is answered where rules are read rather than wherever a reader happened to write an `instanceof`.

## Two of the four points, and the reason

`ON` and `OFF` are values of the quantity the rule cut, so what they ask is the same wherever the line is read — which is what makes one row anywhere evidence for all of them.

`IN` and `OUT` are not values but the regions either side, and where a region stops is settled by every other rule reaching that position: `Cm`'s lower end runs to 150 at a `parcel.length` a record caps and runs on at an `order.straw` nothing else bounds. A row well inside the second is not a row the first could hold at all, so evidence there is not interchangeable and the point stays with the reading.

The issue proposed that an invariant-derived border be owed once. That is right for the points against the line and wrong for the regions, and the implementation is what said so: the check that two readings of one debt must agree about what each point asks for is what refused to fold them.

## What each layer answers

- **Aggregation** is one total function over `Measurement<Coverage>`, in one place, so a report, a build's refusal, an editor and the generator do not fold one set of readings four ways. It reads the reason and not the state: `Coverage.NotAsked` holds three reasons and only `NO_ROWS` cannot be hiding a row, so a line carried by two behaviors no longer goes undecided as soon as one of them has no rows.
- **Demand** is checked across the readings and never folded. Two readings that disagree have not disagreed about anything: something has called two authored lines one.
- **Subject.** `FindingSubject` says what a finding is about. `Findings` answers with one list, because grouping by behavior is a reader's and there is no key in it for a finding about a declaration.
- **Naming.** A line printed under its declaration is named in the terms that declaration wrote, read from the declaration itself (`DeclaredBorders`) rather than carried from a reading — a coordinate that travelled with a measurement is one frame of several with nothing to say which.

## What a reader sees

```
  UserId
      ! no row is at the ON point String.length(value) = 1 (invariant UserId (nonempty))
```

The document publishes it under `modules[].declarations`, shaped as a behavior's findings are; the schema gains the key additively. Narrowing a report to one behavior keeps the lines that behavior carries and drops the rest, so a verdict is never about what the reader cannot see.

## Measured

Over `souther-examples` `fc68e53`, thirteen of the fourteen modules (`invoicing` needs `-cp`):

| | before | after |
|---|---|---|
| `crm`, all `!` | 719 | 415 |
| `crm`, invariant-derived | 569 | 265 |
| `crm`, `invariant UserId #1` | 126 items / 74 behaviors | 5 ON + 41 IN/OUT |

`crm`'s 265 are 50 points against a line and 215 regions. The 50 come from 25 clauses, which is two ends apiece. `UserId #1`'s five are one line reported once per module that carries the type — a consumer owing a line another module's declaration wrote, which is the follow-up below.

## Non-goals

Left alone deliberately, each because including it would make the count above unreadable or is a different question:

- **Foreign obligation ownership.** A line another module's declaration wrote is still owed by every module carrying the type. Changing it moves the count for a reason that is not identity.
- **`BoundaryEvidence` as its own field of `Adequacy.Of`.** Storage topology, not identity.
- **Obligation-driven generation.** A row is composed by walking one behavior's inputs, and which reading composes the one row a line is owed is a search over the readings rather than a fold of them. The disposition says so outright. What is here is only that the existing per-reading search is projected onto the debt, so the editor's offer still stands beside a behavior that carries the line.