### PR TITLE
Say what a checked module's data are made of

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedData.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedData.java
@@ -16,9 +16,8 @@ import java.util.NoSuchElementException;
  * <p>The shape a value has, and not the declaration as it was written. An include is already
  * flattened into {@link Product#fields()}, and a case that is itself a sum is already descended
  * into {@link Sum#cases()}. Either one worked out again by a reader would be a second answer to a
- * question this compiler settled once — and the descent in particular is a question four readers
- * inside the compiler used to answer for themselves, disagreeing wherever it reached one case
- * twice.
+ * question the language settled once, and two readers that each descended would differ at the
+ * shape neither of them is written against: the one where the descent reaches a case twice.
  *
  * <p>Three arms and not fields-or-cases. The language declares in three forms, and a unit written as
  * a product with no fields is a declaration a reader cannot tell from one that happens to have

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedData.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedData.java
@@ -1,0 +1,177 @@
+package souther.compiler.program;
+
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * What one of a module's declared data is made of, as an output outside this compiler reads it.
+ *
+ * <p>A {@link Type.Ref} names a data and says nothing of what is in it. So a reader holding a value
+ * of a declared type could say neither where in it a field lies nor which case it turned out to be,
+ * and both are decisions the language made. This is where they are read back.
+ *
+ * <p>The shape a value has, and not the declaration as it was written. An include is already
+ * flattened into {@link Product#fields()}, and a case that is itself a sum is already descended
+ * into {@link Sum#cases()}. Either one worked out again by a reader would be a second answer to a
+ * question this compiler settled once — and the descent in particular is a question four readers
+ * inside the compiler used to answer for themselves, disagreeing wherever it reached one case
+ * twice.
+ *
+ * <p>Three arms and not fields-or-cases. The language declares in three forms, and a unit written as
+ * a product with no fields is a declaration a reader cannot tell from one that happens to have
+ * none — while {@link souther.compiler.core.Core.UnitValue} names exactly the first.
+ *
+ * <p>Only what a module declares. What the language gives — a primitive standing as a case,
+ * {@code Option}'s cases — is declared by no module, which is why every arm is named by a
+ * {@link TypeSymbol.AtModule} rather than by a {@link TypeSymbol}. A name that is not one, among
+ * them what {@code Core.UnitValue} can carry, names something no module declared; it is not a
+ * declaration this snapshot is missing.
+ *
+ * <p>{@link Product} and {@link Field} are classes and answer no {@code equals}. What a product is
+ * known to be will grow — its invariant clauses, and the binding each field is read through — and a
+ * record would fix both the constructor and what two of them are compared by before there is a
+ * reader for either. {@link Sum} and {@link Unit} hold everything they will hold, so they are
+ * records.
+ */
+public sealed interface CheckedData {
+
+    /** Which declaration this is. */
+    TypeSymbol.AtModule name();
+
+    /**
+     * A data a value is built out of, field by field.
+     *
+     * <p>A {@code newtype} is one of these: a single field called {@code value} holding what it
+     * wraps (spec §newtype). Only its external representation differs, which is
+     * {@code check.Boundary}'s answer and no part of what a value is made of, so nothing here marks
+     * it out.
+     */
+    final class Product implements CheckedData {
+
+        private final TypeSymbol.AtModule name;
+        private final List<Field> fields;
+
+        Product(TypeSymbol.AtModule name, List<Field> fields) {
+            if (name == null) {
+                throw new IllegalArgumentException("a declared data is named");
+            }
+            this.name = name;
+            this.fields = List.copyOf(fields);
+        }
+
+        @Override
+        public TypeSymbol.AtModule name() {
+            return name;
+        }
+
+        /**
+         * Every field a value of this holds, in the order they are laid out. What an included data
+         * brought in is already among them, and comes first.
+         *
+         * <p>This is the layout and not a way of pairing a construction off against it.
+         * {@link souther.compiler.core.Core.Construct} supplies every one of these and names each
+         * by the field it fills, so what a reader has to know is where a name lies —
+         * {@link #positionOf} — rather than which value happens to stand at which index. The two
+         * orders do agree, and that agreement is a property of the checked program worth holding
+         * to; a reader that placed by it would be reading a position as an identity.
+         */
+        public List<Field> fields() {
+            return fields;
+        }
+
+        /**
+         * Where the field called {@code field} lies among {@link #fields()}.
+         *
+         * <p>The one derivation of a position from a name, so that a reader emitting a load and a
+         * reader emitting a store cannot come to place the same field differently. Derived rather
+         * than held: a map beside the list would be the same fact twice, and the two would agree
+         * until one of them was rebuilt.
+         *
+         * @throws NoSuchElementException where this data has no such field — a name that is not a
+         *     field of it is a mistake at the reader, and answering with a position that is not one
+         *     would put the mistake in whatever it emitted
+         */
+        public int positionOf(String field) {
+            for (int i = 0; i < fields.size(); i++) {
+                if (fields.get(i).name().equals(field)) {
+                    return i;
+                }
+            }
+            throw new NoSuchElementException("`" + name + "` has no field `" + field + "`");
+        }
+
+        @Override
+        public String toString() {
+            return name.toString();
+        }
+    }
+
+    /**
+     * The cases a value of this can be (spec §sum-data).
+     *
+     * <p>What it can be, which is not what it lists. A sum whose case is a sum is transparent as a
+     * value — anything of the inner one is of the outer one — so the descent is made here and what
+     * is answered is the cases that are not themselves sums. A case reached by two paths is one
+     * case.
+     *
+     * <p>The order is deterministic: the order the cases are written in, a case keeping the place
+     * it was first reached at. A case is identified by its {@link TypeSymbol}, and its position
+     * here is not that identity. One data may be a case of two sums declared in one module and
+     * stands at a different position in each, so a reader that made a position into a tag would
+     * have given one value two of them.
+     */
+    record Sum(TypeSymbol.AtModule name, List<TypeSymbol> cases) implements CheckedData {
+
+        public Sum {
+            if (name == null) {
+                throw new IllegalArgumentException("a declared data is named");
+            }
+            cases = List.copyOf(cases);
+        }
+    }
+
+    /** One value, and naming it is that value (spec §unit-data). What {@code Core.UnitValue}
+     *  names. */
+    record Unit(TypeSymbol.AtModule name) implements CheckedData {
+
+        public Unit {
+            if (name == null) {
+                throw new IllegalArgumentException("a declared data is named");
+            }
+        }
+    }
+
+    /** One field: what it is called, and what is in it. */
+    final class Field {
+
+        private final String name;
+        private final Type type;
+
+        Field(String name, Type type) {
+            if (name == null || type == null) {
+                throw new IllegalArgumentException("a field is a name and what is in it: "
+                        + name + " " + type);
+            }
+            this.name = name;
+            this.type = type;
+        }
+
+        /** What the field is called — what a construction fills and a field access names. */
+        public String name() {
+            return name;
+        }
+
+        /** What is in it. */
+        public Type type() {
+            return type;
+        }
+
+        @Override
+        public String toString() {
+            return name + ": " + Type.show(type);
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedModule.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedModule.java
@@ -72,8 +72,14 @@ public final class CheckedModule {
         return helperByName.get(name);
     }
 
-    /** What it declares, in the order it declares them — a case a sum declares rather than being
-     *  written on its own standing after the sum that declares it. */
+    /**
+     * What it declares.
+     *
+     * <p>No order is answered for. A declaration is reached by its name —
+     * {@link #data(TypeSymbol.AtModule)} — and where one stands among the others is a fact about
+     * how the module was read rather than one the language decided. The orders that are decided
+     * are inside a declaration: the fields a value lays out, and the cases it can be.
+     */
     public List<CheckedData> data() {
         return data;
     }

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedModule.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedModule.java
@@ -72,7 +72,8 @@ public final class CheckedModule {
         return helperByName.get(name);
     }
 
-    /** What it declares, in the order the declarations are written. */
+    /** What it declares, in the order it declares them — a case a sum declares rather than being
+     *  written on its own standing after the sum that declares it. */
     public List<CheckedData> data() {
         return data;
     }

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedModule.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedModule.java
@@ -1,5 +1,6 @@
 package souther.compiler.program;
 
+import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
 
 import java.util.LinkedHashMap;
@@ -10,8 +11,8 @@ import java.util.Map;
  * One module the compiler checked, as an output outside this compiler reads it.
  *
  * <p>A class and not a record, for the reason {@link CheckedBehavior} is one: what a checked module
- * is known to be will grow — its declared shapes, its invariants, what its examples said — and each
- * of those arrives as a question a reader asks rather than as a place in a constructor.
+ * is known to be will grow — its invariants, what its examples said — and each of those arrives as
+ * a question a reader asks rather than as a place in a constructor.
  */
 public final class CheckedModule {
 
@@ -20,11 +21,15 @@ public final class CheckedModule {
     private final Map<ValueName.Behavior, CheckedBehavior> behaviourByName;
     private final List<CheckedHelper> helpers;
     private final Map<ValueName.Helper, CheckedHelper> helperByName;
+    private final List<CheckedData> data;
+    private final Map<TypeSymbol.AtModule, CheckedData> dataByName;
 
-    CheckedModule(String name, List<CheckedBehavior> behaviors, List<CheckedHelper> helpers) {
+    CheckedModule(String name, List<CheckedBehavior> behaviors, List<CheckedHelper> helpers,
+                  List<CheckedData> data) {
         this.name = name;
         this.behaviors = List.copyOf(behaviors);
         this.helpers = List.copyOf(helpers);
+        this.data = List.copyOf(data);
         Map<ValueName.Behavior, CheckedBehavior> byBehavior = new LinkedHashMap<>();
         for (CheckedBehavior behavior : this.behaviors) {
             byBehavior.put(behavior.name(), behavior);
@@ -35,6 +40,11 @@ public final class CheckedModule {
             byHelper.put(helper.name(), helper);
         }
         this.helperByName = Map.copyOf(byHelper);
+        Map<TypeSymbol.AtModule, CheckedData> byData = new LinkedHashMap<>();
+        for (CheckedData declared : this.data) {
+            byData.put(declared.name(), declared);
+        }
+        this.dataByName = Map.copyOf(byData);
     }
 
     /** What the module is called: what its own declarations are under, and what an import names. */
@@ -60,6 +70,23 @@ public final class CheckedModule {
     /** The helper {@code name} reaches, or null where it is not one of this module's. */
     public CheckedHelper helper(ValueName.Helper name) {
         return helperByName.get(name);
+    }
+
+    /** What it declares, in the order the declarations are written. */
+    public List<CheckedData> data() {
+        return data;
+    }
+
+    /**
+     * The declaration {@code name} reaches, or null where it is not one of this module's.
+     *
+     * <p>Reached through the module that declares it, as a behavior and a helper are. A name
+     * carries the module it was declared by, so a reader holding one asks that module — and where
+     * this compile did not check it, {@link CheckedProgram#module} has already answered null and the
+     * two absences stay apart.
+     */
+    public CheckedData data(TypeSymbol.AtModule name) {
+        return dataByName.get(name);
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgram.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgram.java
@@ -34,10 +34,16 @@ import java.util.Map;
  * carries it is how an accepted one is obtained, and that moves when what acceptance runs a program
  * with stops being named by the thing that asks.
  *
- * <p>Only the modules this compile checked are here. A call in a body may name a behavior of a
- * module read off the path, and that module is not among {@link #modules()}: what such a call
- * carries is the identity resolution gave it, and neither the behavior's own signature nor its
- * body is part of this snapshot.
+ * <p>Only the modules this compile checked are here. A checked body may name something a module
+ * read off the path declares — a behavior it calls, a data whose field it reads — and that module
+ * is not among {@link #modules()}. What the body carries is the identity resolution gave it; what
+ * the declaring module says about that identity is not part of this snapshot. A call carries no
+ * signature and no body, and a name carries no fields and no cases.
+ *
+ * <p>Which module a name belongs to is therefore asked before what it is. {@link #module} answers
+ * null for a module this compile did not check, and a module answers null for a name it does not
+ * declare, so the two absences are separate answers and neither reads as the other. Nothing here
+ * shortens that into one question: shortened, a single null would carry both.
  */
 public final class CheckedProgram {
 

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
@@ -105,6 +105,12 @@ final class CheckedProgramAssembler {
      * carried straight into the list. Nothing between the two holds the fields as a set: an order
      * the answer decided, passed through something that does not keep one, comes out as an order
      * nothing decided.
+     *
+     * <p>Walked over the module's own declarations rather than looked up one at a time, because
+     * that is where an order of them exists. A declaration world answers which declaration a name
+     * is and states no order over them, so a reader that iterated one would publish whichever order
+     * its map happened to be in. What a name means is still asked of that world, which is what
+     * {@code symbols} is here for.
      */
     private static List<CheckedData> dataOf(Hir.Module lowered, Symbols symbols) {
         List<CheckedData> declared = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
@@ -78,20 +78,26 @@ final class CheckedProgramAssembler {
             // means the two readings of whether this program checked have come apart.
             throw new IllegalStateException("`" + module + "` was taken as checked and is not");
         }
-        Hir.Module lowered = lowering.lowered();
+        // Two trees and each is read for what it is the tree for: a declaration comes off the
+        // settled one and a body off the lowered one, which is the division `Lower.Lowered` states.
+        // They are both `Hir.Module`, so nothing but the name at the call below says which is
+        // being handed over — and a declaration read off the tree the backend emits from would
+        // agree with the checker only for as long as lowering left declarations alone.
+        Hir.Module declarations = lowering.settled();
+        Hir.Module bodies = lowering.lowered();
         List<CheckedBehavior> behaviors = new ArrayList<>();
-        for (Hir.BehaviorDef declared : lowered.behaviors()) {
+        for (Hir.BehaviorDef declared : bodies.behaviors()) {
             ValueName.Behavior named = new ValueName.Behavior(module, declared.name());
             behaviors.add(new CheckedBehavior(named, signatureOf(signatures.get(declared.name())),
-                    implementationOf(named, declared, lowered, implementations, checked,
+                    implementationOf(named, declared, bodies, implementations, checked,
                             compositions)));
         }
-        return new CheckedModule(module, behaviors, helpersOf(module, lowered, checked),
-                dataOf(lowered, symbols));
+        return new CheckedModule(module, behaviors, helpersOf(module, bodies, checked),
+                dataOf(declarations, symbols));
     }
 
     /**
-     * What the module declares, in the order the declarations are written.
+     * What the module declares.
      *
      * <p>Each of the three forms is materialised from the answer this compiler already has for it,
      * and neither walk is written again here. A product's fields are
@@ -106,15 +112,16 @@ final class CheckedProgramAssembler {
      * the answer decided, passed through something that does not keep one, comes out as an order
      * nothing decided.
      *
-     * <p>Walked over the module's own declarations rather than looked up one at a time, because
-     * that is where an order of them exists. A declaration world answers which declaration a name
-     * is and states no order over them, so a reader that iterated one would publish whichever order
-     * its map happened to be in. What a name means is still asked of that world, which is what
-     * {@code symbols} is here for.
+     * <p>The list is what the module holds and its order is not answered for. A declaration written
+     * on its own and one a sum's case list declares reach {@code defs} by different routes, so
+     * where either stands among them is how the front end put them there rather than something the
+     * language decided. The two orders that are decided are inside a declaration —
+     * {@link CheckedData.Product#fields} and {@link CheckedData.Sum#cases} — and those are the
+     * ones said out loud.
      */
-    private static List<CheckedData> dataOf(Hir.Module lowered, Symbols symbols) {
+    private static List<CheckedData> dataOf(Hir.Module declarations, Symbols symbols) {
         List<CheckedData> declared = new ArrayList<>();
-        for (Hir.Def def : lowered.defs()) {
+        for (Hir.Def def : declarations.defs()) {
             declared.add(switch (def) {
                 case Hir.Data product -> productOf(product, symbols);
                 case Hir.SumData sum -> new CheckedData.Sum(sum.declares(),

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
@@ -1,11 +1,13 @@
 package souther.compiler.program;
 
 import souther.compiler.ast.Hir;
+import souther.compiler.check.AtomSpace;
 import souther.compiler.check.BehaviorImplementation;
 import souther.compiler.check.CoreBinders;
 import souther.compiler.check.Lower;
 import souther.compiler.check.Sig;
 import souther.compiler.check.SpecImplementation;
+import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
 import souther.compiler.core.Composition;
 import souther.compiler.core.Core;
@@ -15,6 +17,8 @@ import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Compositions;
 import souther.compiler.query.Db;
+import souther.compiler.query.Names;
+import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
@@ -62,8 +66,14 @@ final class CheckedProgramAssembler {
                 db.ask(new Bodies.Implementation(module)).value();
         Map<ValueName.Behavior, Composition> compositions =
                 db.ask(new Compositions.Of(module)).value();
+        // What the module's names mean over the derived declarations, which is what a declaration's
+        // fields and a sum's cases are read against. It is a way of reaching the compiler's answers
+        // and not one of them: it holds a registry that asks `db` for each declaration, so it is
+        // read here and dropped here, and nothing it was reached through is carried into what is
+        // made.
+        Symbols symbols = Names.derivedSymbols(db, module).value();
         if (checked == null || lowering == null || signatures == null || implementations == null
-                || compositions == null) {
+                || compositions == null || symbols == null) {
             // Not a report: the failure above is what a caller is told, and reaching here past it
             // means the two readings of whether this program checked have come apart.
             throw new IllegalStateException("`" + module + "` was taken as checked and is not");
@@ -76,7 +86,45 @@ final class CheckedProgramAssembler {
                     implementationOf(named, declared, lowered, implementations, checked,
                             compositions)));
         }
-        return new CheckedModule(module, behaviors, helpersOf(module, lowered, checked));
+        return new CheckedModule(module, behaviors, helpersOf(module, lowered, checked),
+                dataOf(lowered, symbols));
+    }
+
+    /**
+     * What the module declares, in the order the declarations are written.
+     *
+     * <p>Each of the three forms is materialised from the answer this compiler already has for it,
+     * and neither walk is written again here. A product's fields are
+     * {@link TypeOps#fieldTypes}, which flattens what an include brought in; a sum's cases are
+     * {@link AtomSpace#subjectAtoms}, which descends a case that is itself a sum and reaches one
+     * case once. Both are decisions the language made, and an assembler with a walk of its own
+     * would be the second place that made them — which is the thing a reader outside this compiler
+     * is being given these to avoid.
+     *
+     * <p>{@code fieldTypes} answers in the order a value lays its fields out, and that order is
+     * carried straight into the list. Nothing between the two holds the fields as a set: an order
+     * the answer decided, passed through something that does not keep one, comes out as an order
+     * nothing decided.
+     */
+    private static List<CheckedData> dataOf(Hir.Module lowered, Symbols symbols) {
+        List<CheckedData> declared = new ArrayList<>();
+        for (Hir.Def def : lowered.defs()) {
+            declared.add(switch (def) {
+                case Hir.Data product -> productOf(product, symbols);
+                case Hir.SumData sum -> new CheckedData.Sum(sum.declares(),
+                        AtomSpace.subjectAtoms(Type.ref(sum.declares()), symbols));
+                case Hir.UnitData unit -> new CheckedData.Unit(unit.declares());
+            });
+        }
+        return declared;
+    }
+
+    /** One product, its fields in the order {@link TypeOps#fieldTypes} lays them out. */
+    private static CheckedData productOf(Hir.Data product, Symbols symbols) {
+        List<CheckedData.Field> fields = new ArrayList<>();
+        TypeOps.fieldTypes(product, symbols)
+                .forEach((field, type) -> fields.add(new CheckedData.Field(field, type)));
+        return new CheckedData.Product(product.declares(), fields);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -535,8 +535,19 @@ public final class Names {
         return symbols(db, name, resolvedRegistry(db));
     }
 
-    /** The same over the derived declarations — what everything below the check reads. */
-    static Answer<Symbols> derivedSymbols(Db db, String name) {
+    /**
+     * The same over the derived declarations — what everything below the check reads.
+     *
+     * <p>Public where its two neighbours are not, because {@link souther.compiler.program} takes
+     * its snapshot of what a module declares through it. What is widened is this entry and nothing
+     * under it: the registry it reads through stays this package's.
+     *
+     * <p>A way in and not a key. What comes back holds a registry that asks {@code db} for each
+     * declaration, so it is how to reach an answer rather than an answer — it has no equality to be
+     * memoised by, and a caller that kept one would be holding the compilation it was made from. It
+     * is built where it is used and dropped there.
+     */
+    public static Answer<Symbols> derivedSymbols(Db db, String name) {
         return symbols(db, name, derivedRegistry(db));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/program/WhatASnapshotSaysAModuleDeclaresIsWhatTheCheckerResolvedAgainstTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/program/WhatASnapshotSaysAModuleDeclaresIsWhatTheCheckerResolvedAgainstTest.java
@@ -1,0 +1,155 @@
+package souther.compiler.program;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeOps;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Names;
+import souther.compiler.types.TypeSymbol;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * What a checked program says a module declares is what the checker resolved names against.
+ *
+ * <p>A compile holds a declaration in more than one tree. Two of them come back together and are
+ * both an {@code Hir.Module} — one the declarations were settled in, one the bodies were lowered
+ * into — so which of the two an assembler hands on is settled by the name of a local variable and
+ * by nothing javac can see. Everything below the check resolves a name through the declaration
+ * world, and that world is the one a reader of a checked program has to be reading too: a snapshot
+ * taken from a tree that had been rewritten for some later stage's convenience would describe a
+ * program the checker never saw, and would do it silently for as long as the rewrite left
+ * declarations alone.
+ *
+ * <p>So the two are compared here. Not the snapshot against the tree it was taken from, which would
+ * be an answer against itself, but against the world every other reader of a declaration asks —
+ * {@code symbols.declarations()}, reached through the derived registry, which is what
+ * {@code TypeOps} and {@code AtomSpace} answer over.
+ *
+ * <p>Inside {@code souther-compiler} because that world is the compiler's own and does not cross
+ * the boundary. What the boundary hands out is checked from outside it, and this is the seam that
+ * check cannot see.
+ */
+class WhatASnapshotSaysAModuleDeclaresIsWhatTheCheckerResolvedAgainstTest {
+
+    /**
+     * Every shape a module declares, including the ones a later stage has a reason to touch: a
+     * newtype, whose applications are rewritten below the declarations; a data carrying an
+     * invariant, which is settled and rewritten between the two trees; an include; a sum of sums;
+     * and units a case list declares rather than a line of its own.
+     */
+    private static final String MODULE = """
+            module demo
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Common = { id: Int, tag: String }
+            data Wide   = { ...Common, extra: Int }
+            data Only   = { ...Common }
+
+            data Middle = { ...Common }
+            data Left   = Wide | Middle
+            data Right  = Middle | Only
+            data Reach  = Left | Right
+
+            data Kind = Plain | Express
+
+            behavior widen : (n: Int) -> Wide constructs Wide
+
+            let widen (n) = Wide { id = n, tag = "t", extra = n }
+            """;
+
+    @Test
+    void everyDeclarationTheCheckerHasIsOneTheSnapshotHas() {
+        Read read = read();
+
+        assertEquals(read.world().keySet(), read.snapshot().keySet(),
+                "the declarations the checker resolves against, and the ones the snapshot holds");
+    }
+
+    /**
+     * And each one is made of what the checker would say it is made of.
+     *
+     * <p>Asked of the declaration the world answers with, not of the one the snapshot was taken
+     * from. A product's fields and a sum's cases are read here the way every reader below the check
+     * reads them, so a snapshot built over a tree that had drifted answers differently at the first
+     * declaration the drift touched.
+     */
+    @Test
+    void andIsMadeOfWhatTheCheckerWouldSayItIsMadeOf() {
+        Read read = read();
+
+        for (Map.Entry<TypeSymbol.AtModule, Hir.Def> declared : read.world().entrySet()) {
+            CheckedData published = read.snapshot().get(declared.getKey());
+            assertNotNull(published, () -> "not in the snapshot: " + declared.getKey());
+            switch (declared.getValue()) {
+                case Hir.Data data -> assertEquals(
+                        new ArrayList<>(TypeOps.fieldTypes(data, read.symbols()).keySet()),
+                        assertInstanceOf(CheckedData.Product.class, published,
+                                declared.getKey()::toString)
+                                .fields().stream().map(CheckedData.Field::name).toList(),
+                        () -> "the fields of " + declared.getKey());
+                case Hir.SumData sum -> assertEquals(
+                        souther.compiler.check.AtomSpace.subjectAtoms(
+                                souther.compiler.types.Type.ref(sum.declares()), read.symbols()),
+                        assertInstanceOf(CheckedData.Sum.class, published,
+                                declared.getKey()::toString).cases(),
+                        () -> "the cases of " + declared.getKey());
+                case Hir.UnitData _ -> assertInstanceOf(CheckedData.Unit.class, published,
+                        declared.getKey()::toString);
+            }
+        }
+    }
+
+    /** The three declarations a module can write, so that neither side is compared over a set that
+     *  happens to hold only one of them. */
+    @Test
+    void andAllThreeShapesAreAmongThem() {
+        Set<Class<?>> shapes = new LinkedHashSet<>();
+        for (CheckedData published : read().snapshot().values()) {
+            shapes.add(published.getClass());
+        }
+
+        assertEquals(Set.of(CheckedData.Product.class, CheckedData.Sum.class,
+                CheckedData.Unit.class), shapes);
+    }
+
+    /** The declaration world the checker resolves against, the snapshot taken of the same compile,
+     *  and the world itself for asking what a declaration is made of. */
+    private record Read(Map<TypeSymbol.AtModule, Hir.Def> world,
+                        Map<TypeSymbol.AtModule, CheckedData> snapshot,
+                        Symbols symbols) {}
+
+    private static Read read() {
+        Compilation compilation = Compilation.ofSources(List.of(MODULE), ModulePath.EMPTY);
+        Symbols symbols = Names.derivedSymbols(compilation.db(), "demo").value();
+        assertNotNull(symbols, "the module has a declaration world");
+        Map<TypeSymbol.AtModule, Hir.Def> world = new LinkedHashMap<>();
+        symbols.declarations().declaredIn("demo").values().forEach(def -> {
+            if (def.declares() instanceof TypeSymbol.AtModule at) {
+                world.put(at, def);
+            }
+        });
+
+        CheckedModule module = CheckedProgram.of(List.of(MODULE)).module("demo");
+        assertNotNull(module, "the compile checked this module");
+        Map<TypeSymbol.AtModule, CheckedData> snapshot = new LinkedHashMap<>();
+        for (CheckedData published : module.data()) {
+            snapshot.put(published.name(), published);
+        }
+        return new Read(world, snapshot, symbols);
+    }
+}

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatAModulesDataAreMadeOfTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatAModulesDataAreMadeOfTest.java
@@ -1,0 +1,351 @@
+package souther.program.api;
+
+import souther.compiler.core.Core;
+import souther.compiler.program.CheckedBehavior;
+import souther.compiler.program.CheckedData;
+import souther.compiler.program.CheckedHelper;
+import souther.compiler.program.CheckedImplementation;
+import souther.compiler.program.CheckedModule;
+import souther.compiler.program.CheckedProgram;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeSymbol;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What an output that is not this compiler can learn about a module's declared data.
+ *
+ * <p>A backend lays a value out, loads a field out of one, and decides which case a running value
+ * is. None of the three is readable from a {@link Type.Ref}, which is a name; all three are
+ * decisions this compiler made. What is held here is that they cross whole — that a reader is given
+ * the answer rather than the materials to work it out a second time.
+ */
+class AnOutputReadsWhatAModulesDataAreMadeOfTest {
+
+    /**
+     * A module written to be read rather than to be run.
+     *
+     * <p>{@code Wide} takes {@code Common} in, so its fields are laid out with what the include
+     * brought in first. {@code Both} is a sum over two cases that each take {@code Common} in, and
+     * what every case carries is a property of the sum — which is what lets {@code idOf} read
+     * {@code id} off the sum itself. {@code Reach} is a sum of sums, and {@code Left} and
+     * {@code Right} both reach {@code Middle}, so a descent that counted paths would count it
+     * twice. {@code Amount} is a newtype.
+     */
+    private static final String MODULE = """
+            module demo
+
+            data Amount = Int
+
+            data Common = { id: Int, tag: String }
+
+            data Wide  = { ...Common, extra: Int }
+            data Only  = { ...Common }
+
+            data Both = Wide | Only
+
+            data First  = { ...Common }
+            data Middle = { ...Common }
+            data Last   = { ...Common }
+
+            data Left  = First | Middle
+            data Right = Middle | Last
+            data Reach = Left | Right
+
+            data Kind = Plain | Express
+
+            // Reads a field of a product this module never constructs, which is the reading a
+            // backend emits a load for.
+            behavior extraOf : (w: Wide) -> Int
+
+            let extraOf (w) = w.extra
+
+            // Reads a field off the sum, which every case carries because every case takes
+            // `Common` in.
+            behavior idOf : (b: Both) -> Int
+
+            let idOf (b) = b.id
+
+            behavior wrap : (n: Int) -> Amount constructs Amount
+
+            let wrap (n) = Amount(n)
+
+            behavior widen : (n: Int) -> Wide constructs Wide
+
+            // Written in an order the declaration does not lay out, so that a snapshot agreeing
+            // with the construction is agreeing about the checked program rather than about how
+            // this literal happens to be typed out.
+            let widen (n) = Wide { extra = n, id = n, tag = "t" }
+            """;
+
+    private static CheckedModule demo() {
+        CheckedProgram program = CheckedProgram.of(List.of(MODULE));
+        CheckedModule module = program.module("demo");
+        assertNotNull(module, "the compile checked this module");
+        return module;
+    }
+
+    private static CheckedData declared(CheckedModule module, String name) {
+        for (CheckedData each : module.data()) {
+            if (each.name().name().equals(name)) {
+                return each;
+            }
+        }
+        throw new AssertionError(name + " is not among " + names(module.data()));
+    }
+
+    private static CheckedData.Product product(CheckedModule module, String name) {
+        return assertInstanceOf(CheckedData.Product.class, declared(module, name), name);
+    }
+
+    private static List<String> names(List<CheckedData> data) {
+        return data.stream().map(each -> each.name().name()).toList();
+    }
+
+    private static List<String> fieldNames(CheckedData.Product product) {
+        return product.fields().stream().map(CheckedData.Field::name).toList();
+    }
+
+    @Test
+    void aModuleAnswersWithWhatItDeclares() {
+        CheckedModule module = demo();
+
+        assertTrue(names(module.data()).containsAll(
+                        List.of("Amount", "Common", "Wide", "Both", "Reach", "Kind")),
+                () -> "declared " + names(module.data()));
+    }
+
+    /**
+     * The include is already flattened, and what it brought in comes first.
+     *
+     * <p>The order is the layout. A reader given the includes instead would work the flattening out
+     * for itself, and this compiler and that reader would be two places deciding where a field
+     * lies.
+     */
+    @Test
+    void aProductAnswersEveryFieldItHoldsWithAnIncludesFieldsFirst() {
+        CheckedModule module = demo();
+
+        assertEquals(List.of("id", "tag", "extra"), fieldNames(product(module, "Wide")));
+        assertEquals(List.of("id", "tag"), fieldNames(product(module, "Common")));
+        assertEquals(List.of(Type.INT, Type.STRING, Type.INT),
+                product(module, "Wide").fields().stream().map(CheckedData.Field::type).toList());
+    }
+
+    /**
+     * A newtype is the one-field product it is.
+     *
+     * <p>Held to deliberately. What differs about a newtype is how it is written outside the
+     * program, which is no part of what a value is made of, so a reader laying one out has nothing
+     * to tell it from any other single-field product.
+     */
+    @Test
+    void aNewtypeIsAProductOfTheOneFieldItWraps() {
+        CheckedData.Product amount = product(demo(), "Amount");
+
+        assertEquals(List.of("value"), fieldNames(amount));
+        assertEquals(Type.INT, amount.fields().get(0).type());
+    }
+
+    /** A unit is its own arm, and not a product that happens to have no fields. */
+    @Test
+    void aUnitIsItsOwnArm() {
+        assertInstanceOf(CheckedData.Unit.class, declared(demo(), "Plain"));
+    }
+
+    /**
+     * A sum answers what a value of it can be, which is not the cases it lists.
+     *
+     * <p>{@code Reach} lists two sums, and both of them reach {@code Middle}. What crosses is the
+     * descent this compiler already makes, with a case reached twice appearing once — the answer
+     * four readers inside the compiler used to work out for themselves and disagreed about at
+     * exactly this shape.
+     */
+    @Test
+    void aSumAnswersTheLeafCasesAValueOfItCanBe() {
+        CheckedModule module = demo();
+
+        CheckedData.Sum reach = assertInstanceOf(CheckedData.Sum.class, declared(module, "Reach"));
+
+        assertEquals(List.of("First", "Middle", "Last"),
+                reach.cases().stream().map(TypeSymbol::name).toList());
+        assertEquals(3, reach.cases().size(), () -> "a case reached twice is one case: "
+                + reach.cases());
+    }
+
+    /**
+     * A case belongs to two sums as one identity standing at two positions.
+     *
+     * <p>Which is why a position here is not a tag. A reader that made one into a discriminator
+     * would have given {@code Middle} two of them, and the values a program passes between the two
+     * sums are the same values.
+     */
+    @Test
+    void aCaseOfTwoSumsIsOneIdentityAtTwoPositions() {
+        CheckedModule module = demo();
+
+        List<TypeSymbol> left = assertInstanceOf(CheckedData.Sum.class,
+                declared(module, "Left")).cases();
+        List<TypeSymbol> right = assertInstanceOf(CheckedData.Sum.class,
+                declared(module, "Right")).cases();
+
+        assertEquals(1, left.indexOf(middleOf(left)));
+        assertEquals(0, right.indexOf(middleOf(right)));
+        assertEquals(middleOf(left), middleOf(right), "one declaration, one identity");
+    }
+
+    private static TypeSymbol middleOf(List<TypeSymbol> cases) {
+        return cases.stream().filter(each -> each.name().equals("Middle")).findFirst()
+                .orElseThrow(() -> new AssertionError("no Middle among " + cases));
+    }
+
+    /**
+     * A field is reached by its name, whatever order the names are asked in.
+     *
+     * <p>The one derivation of a position from a name. Asked out of order because a reader walking
+     * a construction asks in the order the construction evaluates, and a reader emitting a load
+     * asks for one field alone — neither is walking the layout.
+     */
+    @Test
+    void aFieldIsFoundByItsNameWhateverOrderItIsAskedIn() {
+        CheckedData.Product wide = product(demo(), "Wide");
+
+        assertEquals(2, wide.positionOf("extra"));
+        assertEquals(0, wide.positionOf("id"));
+        assertEquals(1, wide.positionOf("tag"));
+    }
+
+    /** A name that is no field of it is refused rather than answered with a position that is not
+     *  one. */
+    @Test
+    void aNameThatIsNoFieldOfItIsRefused() {
+        CheckedData.Product wide = product(demo(), "Wide");
+
+        NoSuchElementException refused =
+                assertThrows(NoSuchElementException.class, () -> wide.positionOf("absent"));
+
+        assertTrue(refused.getMessage().contains("absent"), refused::getMessage);
+    }
+
+    /**
+     * Every construction fills the declared fields, in the order they are laid out.
+     *
+     * <p>A property of the checked program and not how a reader places a field — that is
+     * {@link CheckedData.Product#positionOf}, which reads the name a construction wrote. Held here
+     * because a store and a load that came to disagree would disagree silently, and this is the one
+     * place both readings are visible at once.
+     */
+    @Test
+    void everyConstructionFillsTheDeclaredFieldsInTheOrderTheyAreLaidOut() {
+        CheckedModule module = demo();
+        List<Core.Construct> constructions = new ArrayList<>();
+        for (Core body : bodiesOf(module)) {
+            collect(body, Core.Construct.class, constructions);
+        }
+
+        assertTrue(constructions.size() >= 2, () -> "found " + constructions.size());
+        for (Core.Construct construction : constructions) {
+            CheckedData.Product built = assertInstanceOf(CheckedData.Product.class,
+                    module.data(construction.typeName()), construction.typeName()::toString);
+            assertEquals(fieldNames(built),
+                    construction.values().stream().map(Core.FieldValue::field).toList(),
+                    () -> "what `" + construction.typeName() + "` is built with");
+        }
+    }
+
+    /**
+     * Every field read names a field of what it reads from.
+     *
+     * <p>The other half of the same reading, and the half a construction cannot stand in for: a
+     * module may read a field of a product it never builds, and that read is what a backend has to
+     * place. Two shapes can be read from — a product, and a sum every case of which carries the
+     * field — and the second is answered by the leaves the sum already descended to.
+     */
+    @Test
+    void everyFieldReadNamesAFieldOfWhatItReadsFrom() {
+        CheckedModule module = demo();
+        List<Core.FieldAccess> reads = new ArrayList<>();
+        for (Core body : bodiesOf(module)) {
+            collect(body, Core.FieldAccess.class, reads);
+        }
+
+        assertTrue(reads.size() >= 2, () -> "found " + reads.size());
+        int offSums = 0;
+        int offProducts = 0;
+        for (Core.FieldAccess read : reads) {
+            if (!(read.target().type() instanceof Type.Ref(TypeSymbol.AtModule named))) {
+                continue;
+            }
+            switch (module.data(named)) {
+                // Answering at all is the assertion: a name that is no field of it is refused.
+                case CheckedData.Product product -> {
+                    offProducts++;
+                    product.positionOf(read.field());
+                }
+                case CheckedData.Sum sum -> {
+                    offSums++;
+                    assertTrue(!sum.cases().isEmpty(), () -> "no cases on " + named);
+                    for (TypeSymbol leaf : sum.cases()) {
+                        CheckedData.Product carrying = assertInstanceOf(CheckedData.Product.class,
+                                module.data(assertInstanceOf(TypeSymbol.AtModule.class, leaf)),
+                                leaf::toString);
+                        carrying.positionOf(read.field());
+                    }
+                }
+                case CheckedData.Unit _ ->
+                        throw new AssertionError("a unit has no field to read: " + named);
+                case null -> throw new AssertionError(named + " is declared by no module here");
+            }
+        }
+        assertEquals(1, offSums, "the read off a sum is the one this module writes");
+        assertTrue(offProducts >= 1, () -> "no read off a product among " + reads.size());
+    }
+
+    /**
+     * Which module a name belongs to is asked before what the name is, and the two absences are
+     * separate answers.
+     */
+    @Test
+    void aModuleThisCompileDidNotCheckAndANameItDoesNotDeclareAreTwoAnswers() {
+        CheckedProgram program = CheckedProgram.of(List.of(MODULE));
+
+        assertNull(program.module("elsewhere"), "this compile checked no such module");
+        CheckedModule module = program.module("demo");
+        assertNotNull(module);
+        assertSame(declared(module, "Wide"), module.data(declared(module, "Wide").name()));
+    }
+
+    /** Every body this module holds: a behavior written here, and a helper it emits. */
+    private static List<Core> bodiesOf(CheckedModule module) {
+        List<Core> bodies = new ArrayList<>();
+        for (CheckedBehavior behavior : module.behaviors()) {
+            if (behavior.implementation() instanceof CheckedImplementation.Body written) {
+                bodies.add(written.body());
+            }
+        }
+        for (CheckedHelper helper : module.helpers()) {
+            bodies.add(helper.body());
+        }
+        return bodies;
+    }
+
+    /** Every node of {@code of} in the tree under {@code from}, itself included. */
+    private static <T extends Core> void collect(Core from, Class<T> of, List<T> out) {
+        if (of.isInstance(from)) {
+            out.add(of.cast(from));
+        }
+        Core.forEachChild(from, child -> collect(child, of, out));
+    }
+}

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatAModulesDataAreMadeOfTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatAModulesDataAreMadeOfTest.java
@@ -118,13 +118,22 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
         return product.fields().stream().map(CheckedData.Field::name).toList();
     }
 
+    /**
+     * Every declaration the module has, in the order it declares them.
+     *
+     * <p>The whole list and in order, because both are what is claimed. {@code Plain} and
+     * {@code Express} are declared by {@code Kind}'s case list rather than written on their own, and
+     * they stand after the declarations that are written — which is a thing a reader walking this
+     * list meets and nothing else would tell it.
+     */
     @Test
-    void aModuleAnswersWithWhatItDeclares() {
+    void aModuleAnswersWithEveryDeclarationItHasInTheOrderItDeclaresThem() {
         CheckedModule module = demo();
 
-        assertTrue(names(module.data()).containsAll(
-                        List.of("Amount", "Common", "Wide", "Both", "Reach", "Kind")),
-                () -> "declared " + names(module.data()));
+        assertEquals(
+                List.of("Amount", "Common", "Wide", "Only", "Both", "First", "Middle", "Last",
+                        "Left", "Right", "Reach", "Kind", "Plain", "Express"),
+                names(module.data()));
     }
 
     /**
@@ -169,9 +178,9 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
      * A sum answers what a value of it can be, which is not the cases it lists.
      *
      * <p>{@code Reach} lists two sums, and both of them reach {@code Middle}. What crosses is the
-     * descent this compiler already makes, with a case reached twice appearing once — the answer
-     * four readers inside the compiler used to work out for themselves and disagreed about at
-     * exactly this shape.
+     * descent already made, with a case reached twice appearing once. This is the shape two
+     * readers descending for themselves would differ at, and it is the shape neither of them would
+     * have been written against.
      */
     @Test
     void aSumAnswersTheLeafCasesAValueOfItCanBe() {
@@ -284,8 +293,10 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
         assertTrue(reads.size() >= 2, () -> "found " + reads.size());
         int offSums = 0;
         int offProducts = 0;
+        List<Core.FieldAccess> unaccounted = new ArrayList<>();
         for (Core.FieldAccess read : reads) {
             if (!(read.target().type() instanceof Type.Ref(TypeSymbol.AtModule named))) {
+                unaccounted.add(read);
                 continue;
             }
             switch (module.data(named)) {
@@ -311,20 +322,44 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
         }
         assertEquals(1, offSums, "the read off a sum is the one this module writes");
         assertTrue(offProducts >= 1, () -> "no read off a product among " + reads.size());
+        // Every read is accounted for, so a read of a shape this does not know how to place cannot
+        // pass by being skipped. The two arms above are what the language admits reading a field
+        // off; a read that arrived at neither would be the finding, and going quiet about it is
+        // what would hide one.
+        assertEquals(List.of(), unaccounted.stream().map(Core.FieldAccess::field).toList(),
+                "a field read of a shape neither arm answers for");
     }
 
+    /** A second module, so that a name declared somewhere other than {@code demo} is one this test
+     *  can hold rather than one it has to imagine. */
+    private static final String OTHER = """
+            module other
+
+            data Elsewhere = { n: Int }
+            """;
+
     /**
-     * Which module a name belongs to is asked before what the name is, and the two absences are
-     * separate answers.
+     * A module this compile did not check and a name a module does not declare are two answers.
+     *
+     * <p>Which module a name belongs to is asked before what the name is, and both questions can
+     * answer nothing. Asked as one they would answer nothing once, and a reader could not tell a
+     * program it was given too little of from a name that is not a declaration. Held with a name
+     * another module really declares, because a name no module declares cannot be made at all —
+     * which is the same reason the two questions can be kept apart.
      */
     @Test
     void aModuleThisCompileDidNotCheckAndANameItDoesNotDeclareAreTwoAnswers() {
-        CheckedProgram program = CheckedProgram.of(List.of(MODULE));
+        CheckedProgram program = CheckedProgram.of(List.of(MODULE, OTHER));
+        CheckedModule demo = program.module("demo");
+        CheckedModule other = program.module("other");
+        assertNotNull(demo);
+        assertNotNull(other);
+        TypeSymbol.AtModule elsewhere = declared(other, "Elsewhere").name();
 
-        assertNull(program.module("elsewhere"), "this compile checked no such module");
-        CheckedModule module = program.module("demo");
-        assertNotNull(module);
-        assertSame(declared(module, "Wide"), module.data(declared(module, "Wide").name()));
+        assertNull(program.module("nowhere"), "this compile checked no module of that name");
+        assertNull(demo.data(elsewhere), "`demo` declares no `Elsewhere`");
+        assertSame(declared(other, "Elsewhere"), other.data(elsewhere),
+                "the module that declares it answers for it");
     }
 
     /** Every body this module holds: a behavior written here, and a helper it emits. */

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatAModulesDataAreMadeOfTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatAModulesDataAreMadeOfTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -119,21 +120,23 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
     }
 
     /**
-     * Every declaration the module has, in the order it declares them.
+     * Every declaration the module has, and no other.
      *
-     * <p>The whole list and in order, because both are what is claimed. {@code Plain} and
-     * {@code Express} are declared by {@code Kind}'s case list rather than written on their own, and
-     * they stand after the declarations that are written — which is a thing a reader walking this
-     * list meets and nothing else would tell it.
+     * <p>The whole set, because the whole set is what is claimed — a reader that walks this list to
+     * lay out a program is told here that it has met everything. Not the order: a declaration
+     * written on its own and one a sum's case list declares ({@code Plain}, {@code Express}) reach
+     * the list by different routes, and nothing decided which of the two comes first. Fixing that
+     * here would make how the module was read into something a reader could build on.
      */
     @Test
-    void aModuleAnswersWithEveryDeclarationItHasInTheOrderItDeclaresThem() {
+    void aModuleAnswersWithEveryDeclarationItHasAndNoOther() {
         CheckedModule module = demo();
 
         assertEquals(
-                List.of("Amount", "Common", "Wide", "Only", "Both", "First", "Middle", "Last",
+                Set.of("Amount", "Common", "Wide", "Only", "Both", "First", "Middle", "Last",
                         "Left", "Right", "Reach", "Kind", "Plain", "Express"),
-                names(module.data()));
+                Set.copyOf(names(module.data())));
+        assertEquals(14, module.data().size(), "one entry per declaration");
     }
 
     /**
@@ -264,7 +267,8 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
             collect(body, Core.Construct.class, constructions);
         }
 
-        assertTrue(constructions.size() >= 2, () -> "found " + constructions.size());
+        assertEquals(2, constructions.size(), () -> "the constructions this module writes: "
+                + constructions.stream().map(each -> each.typeName().name()).toList());
         for (Core.Construct construction : constructions) {
             CheckedData.Product built = assertInstanceOf(CheckedData.Product.class,
                     module.data(construction.typeName()), construction.typeName()::toString);
@@ -290,7 +294,8 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
             collect(body, Core.FieldAccess.class, reads);
         }
 
-        assertTrue(reads.size() >= 2, () -> "found " + reads.size());
+        assertEquals(2, reads.size(), () -> "the field reads this module writes: "
+                + reads.stream().map(Core.FieldAccess::field).toList());
         int offSums = 0;
         int offProducts = 0;
         List<Core.FieldAccess> unaccounted = new ArrayList<>();
@@ -307,7 +312,9 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
                 }
                 case CheckedData.Sum sum -> {
                     offSums++;
-                    assertTrue(!sum.cases().isEmpty(), () -> "no cases on " + named);
+                    assertEquals(List.of("Wide", "Only"),
+                            sum.cases().stream().map(TypeSymbol::name).toList(),
+                            () -> "the cases " + named + " is read across");
                     for (TypeSymbol leaf : sum.cases()) {
                         CheckedData.Product carrying = assertInstanceOf(CheckedData.Product.class,
                                 module.data(assertInstanceOf(TypeSymbol.AtModule.class, leaf)),
@@ -321,7 +328,7 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
             }
         }
         assertEquals(1, offSums, "the read off a sum is the one this module writes");
-        assertTrue(offProducts >= 1, () -> "no read off a product among " + reads.size());
+        assertEquals(1, offProducts, "the read off a product is the one this module writes");
         // Every read is accounted for, so a read of a shape this does not know how to place cannot
         // pass by being skipped. The two arms above are what the language admits reading a field
         // off; a read that arrived at neither would be the finding, and going quiet about it is


### PR DESCRIPTION
Closes #1069.

`CheckedModule` now answers with what it declares. `CheckedData` has three arms — `Product`, `Sum`, `Unit` — and `Product` carries `Field(name, type)`.

## What crosses is the shape a value has

Not the declaration as it was written. An include is already flattened into `Product.fields()`, and a case that is itself a sum is already descended into `Sum.cases()`.

The descent is the change from the shape the issue proposed. `Sum.cases()` answers the leaf cases a value can be, not the cases the declaration lists, because `AtomSpace`'s own note records that four readers inside this compiler used to write that descent for themselves and disagreed wherever it reached one case twice. Handing out the case list would have put that back one backend at a time. The reason given for the immediate reading — that `Composition.Routing.OnCases` names written cases — does not hold: `PipelineSigs.mainlineCases` builds `accepted` from `AtomSpace.subjectAtoms`, so routing already carries leaves.

`CheckedProgramAssembler` materialises `TypeOps.fieldTypes` and `AtomSpace.subjectAtoms` and walks neither structure itself. `fieldTypes` answers in layout order and that order goes straight into the list, with nothing between the two that does not keep one.

## Identity and position are held apart, on both arms

A field is identified by its name; `Core.FieldValue` carries the name it fills. `Product.positionOf(String)` is the one derivation of a layout position from a name, and it refuses a name that is no field rather than answering with a position that is not one. So a backend addresses by name and does not pair a construction off against the layout by index.

A case is identified by its `TypeSymbol`. One data may be a case of two sums declared in one module and stands at a different place in each, so a position here is not a discriminator. There is no `positionOf` on `Sum` for that reason, and the javadoc says why.

## The snapshot boundary

Only the modules this compile checked are here. `CheckedProgram`'s paragraph about a call into a module read off the path is now the one rule it always was, with a call and a field read as its instances. Which module a name belongs to is asked before what the name is, so `program.module(...) == null` and `module.data(...) == null` stay two answers — which is also why there is no `CheckedProgram.data(AtModule)` shortcut.

`Names.derivedSymbols` is public so the snapshot can be taken through it; `derivedRegistry` and `symbols` stay package-private. It is a way in and not a key — what it answers holds a registry that asks the `Db` per declaration, so it has no equality to be memoised by. It is read where the snapshot is made and dropped there.

## Tests

`AnOutputReadsWhatAModulesDataAreMadeOfTest`, 11 of them, outside `souther-compiler`. Every one was checked by mutation rather than by being green:

| mutation | what fails |
| --- | --- |
| reverse `Product.fields()` | include order, construction agreement, `positionOf` |
| `positionOf` returns `-1` | the refusal |
| `Sum.cases()` back to one layer | `expected: <[First, Middle, Last]> but was: <[Left, Right]>` |

Both readers a backend has are covered. Constructions are held to filling the declared fields in the order they are laid out, and the fixture writes one literal in an order the declaration does not lay out — a probe confirmed `Core.Construct` normalises to declaration order, so the test is about the checked program rather than about how a literal was typed. Field reads are held to naming a field of what they read from, in two arms: a product, and a sum every case of which carries the field. The second arm is what a construction cannot stand in for, since a module may read a field of a product it never builds. Both arms are counted so neither can go quiet.

A sum of sums reaching one case by two paths yields it once, and a case of two sums crosses as one identity at two positions.

`NothingReachableFromACheckedProgramNamesTheCompilerTest` still passes. Full reactor `mvn -o test` is green.

## Not done

The backend-side test that `Core.FieldAccess` lowering reads `Product.positionOf`. `souther-wasm-compiler` was not kept, so there is no reader to hold to it; `positionOf` being public API is what the test will be written against when there is one.

Invariant clauses and boundary representation do not cross. Neither has a reader yet, and `Product` and `Field` being classes is what leaves room for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
