### PR TITLE
Read a rule where it governs, and show that somebody took it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -992,7 +992,7 @@ public final class FieldDomains {
      * whether anything is out of sight wants this.
      */
     public boolean everyRuleReachedAt(String path) {
-        return reaches(notGathered, path) && reaches(handedOn, path);
+        return reaches(notGathered, path);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -66,7 +66,8 @@ public final class FieldDomains {
      */
     public static final FieldDomains NONE =
             new FieldDomains(Map.of(), Map.of(), Map.of(), Map.of(), Set.of(), List.of(), List.of(), Map.of(),
-                    Map.of(), new ReadingEvidence(), Map.of(), Set.of(THE_VALUE), NO_POSITIONS,
+                    Map.of(), new ReadingEvidence(), Map.of(), Set.of(THE_VALUE), Set.of(),
+                    NO_POSITIONS,
                     ConstraintState.<FactSubject>top(), null, null, null, null, Map.of(), Set.of(THE_VALUE),
                     Map.of(), Map.of(), Map.of(), Map.of());
 
@@ -107,6 +108,10 @@ public final class FieldDomains {
     /** Where a clause of this value did not reach the readings at all, as the paths the stops
      * happened at — see {@link #admits}. */
     private final Set<String> notGathered;
+    /** Where this reading ended with a declaration still to be read under the position, which is an
+     * obligation on whoever walks the positions rather than anything wrong here — see
+     * {@link #handedOn()}. */
+    private final Set<String> handedOn;
     /** And of those, the positions a construction has to make a value at. What a position admits is
      *  short wherever a rule about it went unread; whether an edge of it may be promised is about
      *  what every value of this has to satisfy, and a rule inside an optional is not that. */
@@ -147,7 +152,7 @@ public final class FieldDomains {
                          Map<RuleRef, Required> raised,
                          Map<RuleRef, Map<Core, Required>> raisedByPart, ReadingEvidence took,
                          Map<String, List<TypeSymbol>> narrowers,
-                         Set<String> notGathered,
+                         Set<String> notGathered, Set<String> handedOn,
                          SequencedMap<FactSubject, String> positions,
                          ConstraintState<FactSubject> constraints, TypeSymbol.AtModule named,
                          Hir.Data data, Symbols symbols, ReadingPolicy policy,
@@ -168,6 +173,7 @@ public final class FieldDomains {
         this.took = took;
         this.narrowers = narrowers;
         this.notGathered = notGathered;
+        this.handedOn = handedOn;
         this.positions = positions;
         this.constraints = constraints;
         this.named = named;
@@ -377,7 +383,7 @@ public final class FieldDomains {
                 Map.copyOf(unread), Set.copyOf(notSeparated), seeded.reading().directs(), seeded.reading().noLines(),
                 seeded.reading().raised(), seeded.reading().raisedByPart(), seeded.took(),
                 seeded.reading().narrowers(),
-                seeded.notGathered(), placeOf,
+                seeded.notGathered(), seeded.handedOn(), placeOf,
                 seeded.constraints(), named, data, symbols, policy, settled,
                 seeded.unreadOfEveryValue(), seeded.atoms(), seeded.held(),
                 seeded.readBy(), seeded.spacing());
@@ -986,7 +992,33 @@ public final class FieldDomains {
      * whether anything is out of sight wants this.
      */
     public boolean everyRuleReachedAt(String path) {
-        for (String stopped : notGathered) {
+        return reaches(notGathered, path) && reaches(handedOn, path);
+    }
+
+    /**
+     * The positions this reading ended at with a declaration still to be read under them.
+     *
+     * <p>Not something wrong with the reading, and not an answer about the position either. What
+     * stands at one of these is a container, an optional, or a choice between declarations, and what
+     * is written under it is written about a value one position down — so the rules pass to whatever
+     * reading is opened there, and whether one was is a fact about the walk over positions rather
+     * than about this reading of a declaration.
+     *
+     * <p>Handed over so that the walk can discharge them, one at a time and against the readings it
+     * actually opened. Answered here instead, the only thing this could say is whether the type
+     * graph has a rule somewhere below — which is what {@link #everyRuleReachedAt} used to be
+     * answering with, and it made the position above short of a rule no row could ever supply
+     * (#1072).
+     */
+    public Set<String> handedOn() {
+        return handedOn;
+    }
+
+    /** Whether {@code path} is out from under every stop in {@code stops}. A stop reaches the
+     *  position it happened at and everything under it, and a stop at {@link #THE_VALUE} is the
+     *  declaration's own clause and reaches every position of it. */
+    private static boolean reaches(Set<String> stops, String path) {
+        for (String stopped : stops) {
             if (stopped.equals(THE_VALUE) || path.equals(stopped)
                     || path.startsWith(stopped + ".")) {
                 return false;

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -900,17 +900,22 @@ public final class InvariantChecker {
     private record Written(RuleRef.Invariant from, Core clause) {}
 
     /**
-     * Whether the value a stop was taken at is one every value of what is being read has.
+     * Whether the value a stop left unread is one every value of what is being read has.
      *
-     * <p>Two questions are asked of one stop and they do not have one answer. What a position
-     * admits is short wherever a rule about it went unread, however the value it is written under is
-     * reached — a rule inside an optional narrows that value when there is one. Whether an edge may
-     * be promised is about what a construction has to satisfy, and a rule about a value the
-     * construction need not make refuses nothing at an edge of a field it must.
+     * <p>Two questions are asked of one stop and they do not have one answer. What a position admits
+     * is short wherever a rule about it went unread; whether an edge may be promised is about what a
+     * construction has to satisfy, and a rule about a value the construction need not make refuses
+     * nothing at an edge of a field it must.
      *
      * <p>Which of the two a stop was is known where the stop is taken and nowhere after it, so it is
      * said there. Read off the path instead, a reader would be deciding from a spelling what the
      * walk knew.
+     *
+     * <p><b>Asked only of the stops that leave rules unread.</b> A stop at a container, an optional
+     * or a choice between declarations hands the rules to a reading one position down and is not one
+     * of these ({@link Gathering#handedOn}); {@link PathEngine} refuses to answer for it rather than
+     * giving it a word. So nothing here decides what is handed on, and the day these two questions
+     * stop agreeing is a day nothing was resting on their agreeing (#1072).
      */
     enum Borne {
 
@@ -918,11 +923,17 @@ public final class InvariantChecker {
         BY_EVERY_VALUE,
 
         /**
-         * It may be absent or empty, or is a type already met on the way down.
+         * A type already met on the way down, read where it was met.
          *
          * <p>The same reach {@link #everyRuleRead} has, and for the same reason: a rule four records
          * down the required chain refuses the outermost construction exactly as one on its own
-         * fields does, and one inside a collection is about a value that need not be there.
+         * fields does.
+         *
+         * <p>The one stop that leaves this word, and a required field of a type already entered is
+         * borne by every value rather than by some. It is written down as it is because such a value
+         * cannot be built — a record that must hold its own kind has no values — so no construction
+         * and no edge is decided by the answer. A model that could be built here would be one this
+         * has to be told apart from the collections and optionals it used to stand for.
          */
         BY_SOME_VALUES
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -414,11 +414,14 @@ public final class InvariantChecker {
      *                 into an obligation is one another reading may have taken in whole, and
      *                 borrowing that answer would settle each reading's completeness by a fragment
      *                 that is not its own
+     * @param handedOn the positions this reading ended at with a declaration still to be read under
+     *                 them, which is an obligation on whoever walks the positions rather than
+     *                 anything wrong here — see {@link Gathering#handedOn}
      */
     record Seeded(ConstraintState<FactSubject> constraints, Map<String, FactSubject> atoms, Map<String, FactSubject> keys,
                   Map<String, FieldDomains.Counted> held, Reading reading, ReadingEvidence took,
                   boolean everyClauseRead, Set<String> notGathered,
-                  Set<String> unreadOfEveryValue,
+                  Set<String> unreadOfEveryValue, Set<String> handedOn,
                   Map<RuleRef, Map<Core, PartRead>> readBy,
                   Map<FactSubject, souther.compiler.numeric.Granularity> spacing) {
 
@@ -434,6 +437,7 @@ public final class InvariantChecker {
         public Seeded {
             notGathered = Set.copyOf(notGathered);
             unreadOfEveryValue = Set.copyOf(unreadOfEveryValue);
+            handedOn = Set.copyOf(handedOn);
             // Insertion order, which is the order the declarations write their clauses. `Map.copyOf`
             // iterates in an order salted once per JVM run, and what is read off these is a list of
             // causes a report prints.
@@ -447,7 +451,7 @@ public final class InvariantChecker {
                     new Reading(List.of(), List.of(), Map.of(), Map.of(), Map.of()),
                     new ReadingEvidence(),
                     false, Set.of(FieldDomains.THE_VALUE), Set.of(FieldDomains.THE_VALUE),
-                    Map.of(), Map.of());
+                    Set.of(), Map.of(), Map.of());
         }
 
         /** The numbers alone, for the readers that are about intervals. Whether a value exists is
@@ -540,6 +544,11 @@ public final class InvariantChecker {
         // And of those, the ones a construction cannot get out of: what a position admits and
         // whether an edge of it may be promised are two questions, and a stop answers them apart.
         Set<String> unreadOfEveryValue = new LinkedHashSet<>();
+        // The positions this reading ended at with the rules under them still to be read by
+        // somebody. Kept apart from the stops above because it is an obligation and not a finding:
+        // whether anything took the rules over is settled by whoever walks the positions, and the
+        // answer is not in this reading at all.
+        Set<String> handedOn = new LinkedHashSet<>();
         List<Written> written = new ArrayList<>();
         ReadingEvidence took = new ReadingEvidence();
         // What the bounds are able to state of each rule, as the reading that builds them says it.
@@ -563,6 +572,11 @@ public final class InvariantChecker {
                 if (borne == Borne.BY_EVERY_VALUE) {
                     unreadOfEveryValue.add(path);
                 }
+            }
+
+            @Override
+            public void handedOn(String path) {
+                handedOn.add(path);
             }
 
             @Override
@@ -725,7 +739,8 @@ public final class InvariantChecker {
                 constraints = ConstraintState.settling(constraints, atom, each.getValue(), spaced);
             }
             return new Seeded(constraints, atoms, keys, held, reading, took, read,
-                    Set.copyOf(notGathered), unreadOfEveryValue, readBy, Map.copyOf(spacing));
+                    Set.copyOf(notGathered), unreadOfEveryValue, Set.copyOf(handedOn),
+                    readBy, Map.copyOf(spacing));
         } catch (RuntimeException why) {
             gaveUp("seedFields " + named.name(), why);
             return Seeded.nothingRead();
@@ -944,6 +959,23 @@ public final class InvariantChecker {
          * either way.
          */
         void missed(String path, Borne borne);
+
+        /**
+         * A position where this reading ends and the rules under it become another reading's.
+         *
+         * <p>Not a rule missed. Nothing is declared at the position for this reading to take in —
+         * what stands there is a container, an optional, or a choice between declarations — and what
+         * is written under it is written about a value one position down, where a reading of that
+         * declaration is opened and a row meets it.
+         *
+         * <p>So this is an obligation and not a finding: something has to have taken the rules over,
+         * and whoever walks the positions is the only one who can say whether anything did. Recorded
+         * as a miss, the position above reported a rule nobody could ever discharge, because the
+         * walk had gone to the rule at the position below (#1072). Read as nothing at all, a
+         * position under which no reading was ever opened would claim to have read rules it never
+         * saw.
+         */
+        void handedOn(String path);
 
         /**
          * What the reading that builds the bounds made of one part of {@code rule}, as it read it.

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -396,10 +396,12 @@ public final class InvariantChecker {
      *                        then weaker than what the declaration actually says, and a caller
      *                        turning one into an obligation has to know that
      * @param notGathered where a clause of the value did not reach the readings at all, as the
-     *                 paths the stops happened at. A clause that could not be typed, and a walk
-     *                 that declined to go further: in both, a rule of the declaration is one no
-     *                 reading here ever saw, so no reading can say it took that part of the
-     *                 declaration in.
+     *                 paths the stops happened at. A clause that could not be typed, and a walk that
+     *                 stopped leaving rules nobody else reads ({@link PathEngine#leftBy}): in both,
+     *                 a rule of the declaration is one no reading here ever saw, so no reading can
+     *                 say it took that part of the declaration in. Not a walk that handed the rules
+     *                 on — those are {@link #handedOn()}, and they are somebody's to read rather
+     *                 than nobody's
      *
      *                 <p>Where and not whether, because a rule that narrows a position names it,
      *                 and a clause written under one field can name no position outside that field.
@@ -911,11 +913,11 @@ public final class InvariantChecker {
      * said there. Read off the path instead, a reader would be deciding from a spelling what the
      * walk knew.
      *
-     * <p><b>Asked only of the stops that leave rules unread.</b> A stop at a container, an optional
-     * or a choice between declarations hands the rules to a reading one position down and is not one
-     * of these ({@link Gathering#handedOn}); {@link PathEngine} refuses to answer for it rather than
-     * giving it a word. So nothing here decides what is handed on, and the day these two questions
-     * stop agreeing is a day nothing was resting on their agreeing (#1072).
+     * <p><b>Asked only of the stops that leave rules unread.</b> Which those are is
+     * {@link PathEngine#leftBy}'s answer and is not restated here: a stop that hands the rules to a
+     * reading one position down leaves nothing for anybody to bear ({@link Gathering#handedOn}).
+     * Nothing here decides what is handed on, so the day these two questions stop agreeing is a day
+     * nothing was resting on their agreeing (#1072).
      */
     enum Borne {
 
@@ -923,17 +925,17 @@ public final class InvariantChecker {
         BY_EVERY_VALUE,
 
         /**
-         * A type already met on the way down, read where it was met.
+         * A value the construction need not make, so a rule under it refuses no construction.
          *
          * <p>The same reach {@link #everyRuleRead} has, and for the same reason: a rule four records
          * down the required chain refuses the outermost construction exactly as one on its own
          * fields does.
          *
-         * <p>The one stop that leaves this word, and a required field of a type already entered is
-         * borne by every value rather than by some. It is written down as it is because such a value
-         * cannot be built — a record that must hold its own kind has no values — so no construction
-         * and no edge is decided by the answer. A model that could be built here would be one this
-         * has to be told apart from the collections and optionals it used to stand for.
+         * <p>Which stops leave this is {@link PathEngine#leftBy}'s answer. What is worth knowing
+         * here is that a required field of a type already entered comes back with this word and is
+         * borne by every value: such a value cannot be built — a record that must hold its own kind
+         * has no values — so no construction and no edge is decided by the answer. A model that
+         * could be built there is one this would have to be told apart from.
          */
         BY_SOME_VALUES
     }
@@ -974,10 +976,10 @@ public final class InvariantChecker {
         /**
          * A position where this reading ends and the rules under it become another reading's.
          *
-         * <p>Not a rule missed. Nothing is declared at the position for this reading to take in —
-         * what stands there is a container, an optional, or a choice between declarations — and what
-         * is written under it is written about a value one position down, where a reading of that
-         * declaration is opened and a row meets it.
+         * <p>Not a rule missed. Nothing is declared at the position for this reading to take in,
+         * and what is written under it is written about a value one position down, where a reading
+         * of that declaration is opened and a row meets it. Which stops arrive here is
+         * {@link PathEngine#leftBy}'s answer.
          *
          * <p>So this is an obligation and not a finding: something has to have taken the rules over,
          * and whoever walks the positions is the only one who can say whether anything did. Recorded

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -638,28 +638,6 @@ final class PathEngine {
     }
 
     /**
-     * What a stop leaves unread: a rule of every value that stands there, or one of only some.
-     *
-     * <p>A stop the reader asked for and a depth it could not afford both leave rules every
-     * construction has to make; the rest stop where no rule holds of every value anyway.
-     *
-     * <p>Asked only of the stops that leave something unread. A stop that hands the rules on
-     * ({@link #handsTheRulesOn}) leaves nothing here for anybody to bear, and answering for it would
-     * put a word in the hands of a reader deciding what to hand on from what a rule is borne by —
-     * which is the reading the two questions are kept apart to refuse.
-     */
-    private static InvariantChecker.Borne borne(GuaranteeWalk.Stop why) {
-        return switch (why) {
-            case PAST_THE_DEPTH, ASKED_TO_STOP, NO_VALUE_THERE ->
-                    InvariantChecker.Borne.BY_EVERY_VALUE;
-            case ALREADY_ENTERED -> InvariantChecker.Borne.BY_SOME_VALUES;
-            case NOTHING_DECLARED -> throw new IllegalArgumentException(
-                    "a stop that hands the rules on leaves nothing unread at the position it "
-                            + "happened at");
-        };
-    }
-
-    /**
      * {@code k} with what {@code guarantee} says taken as holding of the value it was read at.
      *
      * <p>The one step that turns an answer about a declaration into knowledge on this path, kept
@@ -697,36 +675,64 @@ final class PathEngine {
         if (gathering == null || type == null || !guarantees.anyRuleUnder(type)) {
             return;
         }
-        if (handsTheRulesOn(why)) {
-            gathering.handedOn(path);
-        } else {
-            gathering.missed(path, borne(why));
+        switch (leftBy(why)) {
+            case Leaves.ToAnotherReading _ -> gathering.handedOn(path);
+            case Leaves.Unread(InvariantChecker.Borne borne) -> gathering.missed(path, borne);
         }
     }
 
+    /** What a stop leaves behind. */
+    sealed interface Leaves {
+
+        /**
+         * Rules for a reading one position down, and nothing wrong here.
+         *
+         * <p>There is no declaration standing at the position for this reading to take in — a
+         * container, an optional, a choice between declarations — so what is written under it is
+         * written about a value below, where a reading of that declaration is opened and a row meets
+         * it. The rules are not lost; the responsibility for them is somebody else's, and whoever
+         * walks the positions has to show that somebody took it (#1072).
+         */
+        record ToAnotherReading() implements Leaves {}
+
+        /** Rules no reading here took in, and how much of what stands at the position they were
+         *  about. */
+        record Unread(InvariantChecker.Borne borne) implements Leaves {}
+    }
+
     /**
-     * Whether this stop passes the rules under the position to another reading rather than leaving
-     * them unread.
+     * What each way of stopping leaves behind.
      *
-     * <p>{@link GuaranteeWalk.Stop#NOTHING_DECLARED} and nothing else. It says there is no
-     * declaration standing here to be read, which is what a container, an optional and a choice
-     * between declarations all are — and what is written under one of those is written about a value
-     * one position down, where a reading of that declaration is opened and a row meets it. So the
-     * rules are not lost by this stop; the responsibility for them is somebody else's, and whoever
-     * walks the positions has to show that somebody took it (#1072).
+     * <p><b>The one statement of it.</b> Which stops hand the rules on and which leave them unread
+     * is one partition of one enum, and it used to be spelled again in the prose of every word
+     * downstream of it — {@link InvariantChecker.Borne}, {@link souther.compiler.values.UnreadReason},
+     * the account a seeding gives of itself. A partition restated is a partition that goes on being
+     * true only until somebody moves an arm, and then the code is right and the sentences are not.
+     * So it is written here once and referred to.
      *
-     * <p>Every other stop leaves them unread. {@link GuaranteeWalk.Stop#ALREADY_ENTERED} is the one
-     * worth naming: it stops where the walk could have gone on, so nothing below is opened and
-     * nobody takes the rules over. Read as a handing on, a type holding its own kind would be
-     * discharged by the reading made of it further up.
+     * <p>Exhaustive with no {@code default}, so a way of stopping added later is a compile error
+     * here rather than a stop quietly counted as a loss — or, worse, quietly counted as handed on to
+     * a reading that was never opened.
      *
-     * <p>Asked of the stop and not of {@link InvariantChecker.Borne}. What a stop leaves unread and
-     * whether the rules pass to another reading are different questions that agree today by
+     * <p>Asked of the stop and never of {@link InvariantChecker.Borne}. What a stop leaves unread
+     * and whether the rules pass to another reading are different questions that agree today by
      * coincidence: every stop that hands on is borne by some values, and one that is borne by some
      * values need not hand anything on. Read off the second, the coincidence becomes the rule.
      */
-    private static boolean handsTheRulesOn(GuaranteeWalk.Stop why) {
-        return why == GuaranteeWalk.Stop.NOTHING_DECLARED;
+    static Leaves leftBy(GuaranteeWalk.Stop why) {
+        return switch (why) {
+            case NOTHING_DECLARED -> new Leaves.ToAnotherReading();
+            // A depth this reader could not afford, a name it was told to suppose holds values, and
+            // a field it could find no value for. Each stops where a construction still has to make
+            // the value, so a rule under it can refuse the construction.
+            case PAST_THE_DEPTH, ASKED_TO_STOP, NO_VALUE_THERE ->
+                    new Leaves.Unread(InvariantChecker.Borne.BY_EVERY_VALUE);
+            // Read where the name was met, and nothing is opened here — so nobody takes the rules
+            // over. Counted as a handing on, a type holding its own kind would be discharged by the
+            // reading made of it further up.
+            case ALREADY_ENTERED ->
+                    new Leaves.Unread(InvariantChecker.Borne.BY_SOME_VALUES);
+        };
     }
 
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -622,7 +622,7 @@ final class PathEngine {
 
         @Override
         public void stopped(String path, Type type, GuaranteeWalk.Stop why) {
-            declining(type, path, gathering, borne(why));
+            stopping(type, path, gathering, why);
         }
 
         @Override
@@ -635,16 +635,28 @@ final class PathEngine {
             }
         }
 
-        /** What a stop leaves unread: a rule of every value that stands there, or one of only some.
-         * A stop the reader asked for and a depth it could not afford both leave rules every
-         * construction has to make; the rest stop where no rule holds of every value anyway. */
-        private InvariantChecker.Borne borne(GuaranteeWalk.Stop why) {
-            return switch (why) {
-                case PAST_THE_DEPTH, ASKED_TO_STOP, NO_VALUE_THERE ->
-                        InvariantChecker.Borne.BY_EVERY_VALUE;
-                case NOTHING_DECLARED, ALREADY_ENTERED -> InvariantChecker.Borne.BY_SOME_VALUES;
-            };
-        }
+    }
+
+    /**
+     * What a stop leaves unread: a rule of every value that stands there, or one of only some.
+     *
+     * <p>A stop the reader asked for and a depth it could not afford both leave rules every
+     * construction has to make; the rest stop where no rule holds of every value anyway.
+     *
+     * <p>Asked only of the stops that leave something unread. A stop that hands the rules on
+     * ({@link #handsTheRulesOn}) leaves nothing here for anybody to bear, and answering for it would
+     * put a word in the hands of a reader deciding what to hand on from what a rule is borne by —
+     * which is the reading the two questions are kept apart to refuse.
+     */
+    private static InvariantChecker.Borne borne(GuaranteeWalk.Stop why) {
+        return switch (why) {
+            case PAST_THE_DEPTH, ASKED_TO_STOP, NO_VALUE_THERE ->
+                    InvariantChecker.Borne.BY_EVERY_VALUE;
+            case ALREADY_ENTERED -> InvariantChecker.Borne.BY_SOME_VALUES;
+            case NOTHING_DECLARED -> throw new IllegalArgumentException(
+                    "a stop that hands the rules on leaves nothing unread at the position it "
+                            + "happened at");
+        };
     }
 
     /**
@@ -672,17 +684,49 @@ final class PathEngine {
     }
 
     /**
-     * Tells the reading where it is leaving rules unread.
+     * Tells the reading where it stopped, and which of the two kinds of stop it was.
      *
-     * <p>Every way the walk stops short comes here. Whether a stop costs anything is a question
-     * about the model — is any rule written under what is being left — and asking it of the walk's
-     * own reach would answer that whatever was not read had nothing in it.
+     * <p>Every way the walk stops short comes here. Whether a stop is worth saying anything about is
+     * a question about the model — is any rule written under what is being left — and asking it of
+     * the walk's own reach would answer that whatever was not read had nothing in it. That question
+     * decides whether anything is owed here; it does not decide what is owed, which is the
+     * distinction below.
      */
-    private void declining(Type type, String path, InvariantChecker.Gathering gathering,
-                           InvariantChecker.Borne borne) {
-        if (gathering != null && type != null && guarantees.anyRuleUnder(type)) {
-            gathering.missed(path, borne);
+    private void stopping(Type type, String path, InvariantChecker.Gathering gathering,
+                          GuaranteeWalk.Stop why) {
+        if (gathering == null || type == null || !guarantees.anyRuleUnder(type)) {
+            return;
         }
+        if (handsTheRulesOn(why)) {
+            gathering.handedOn(path);
+        } else {
+            gathering.missed(path, borne(why));
+        }
+    }
+
+    /**
+     * Whether this stop passes the rules under the position to another reading rather than leaving
+     * them unread.
+     *
+     * <p>{@link GuaranteeWalk.Stop#NOTHING_DECLARED} and nothing else. It says there is no
+     * declaration standing here to be read, which is what a container, an optional and a choice
+     * between declarations all are — and what is written under one of those is written about a value
+     * one position down, where a reading of that declaration is opened and a row meets it. So the
+     * rules are not lost by this stop; the responsibility for them is somebody else's, and whoever
+     * walks the positions has to show that somebody took it (#1072).
+     *
+     * <p>Every other stop leaves them unread. {@link GuaranteeWalk.Stop#ALREADY_ENTERED} is the one
+     * worth naming: it stops where the walk could have gone on, so nothing below is opened and
+     * nobody takes the rules over. Read as a handing on, a type holding its own kind would be
+     * discharged by the reading made of it further up.
+     *
+     * <p>Asked of the stop and not of {@link InvariantChecker.Borne}. What a stop leaves unread and
+     * whether the rules pass to another reading are different questions that agree today by
+     * coincidence: every stop that hands on is borne by some values, and one that is borne by some
+     * values need not hand anything on. Read off the second, the coincidence becomes the rule.
+     */
+    private static boolean handsTheRulesOn(GuaranteeWalk.Stop why) {
+        return why == GuaranteeWalk.Stop.NOTHING_DECLARED;
     }
 
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
@@ -134,6 +134,14 @@ final class TypeGuarantees {
      * <p>A question about the model and not about any walk, which is what makes it the right one to
      * ask where a reader stops: the reader's own reach is what is being decided, so reading that
      * would answer that whatever was not read had nothing in it.
+     *
+     * <p><b>Whether anything is owed here, and never what became of it.</b> A reader that stopped
+     * asks this to find out if there is anything to hand on: a field of a plain {@code Int} leaves
+     * nothing under it and owes nobody a reading. What became of what was handed on is a fact about
+     * the walk over positions and is settled there
+     * ({@link souther.compiler.inputs.RuleHandoffs}). Answered as that, a position was reported
+     * short of a rule the walk had already gone to one position down, and no row could ever
+     * discharge it (#1072).
      */
     boolean anyRuleUnder(Type type) {
         return anyRuleUnder(type, new HashSet<>());

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -510,7 +510,7 @@ public final class InputDomain {
                         policy, found, roots, java.util.Set.of(), handoffs);
             }
             case StructuralInspection.Continuation.Branches branches -> {
-                List<StructuralInspection.Branch> owed = new ArrayList<>();
+                List<StructuralInspection.Branch> standing = new ArrayList<>();
                 List<TermPath> passedTo = new ArrayList<>();
                 for (StructuralInspection.Branch branch : branches.branches()) {
                     // A branch that is the whole of a value puts no position anywhere, and one the
@@ -519,11 +519,11 @@ public final class InputDomain {
                     if (branch.under() == null || !owed(here, branch.refinement())) {
                         continue;
                     }
-                    owed.add(branch);
+                    standing.add(branch);
                     passedTo.add(path.refine(branch.refinement()));
                 }
                 handoffs.passesTo(placed.root(), path, passedTo);
-                for (StructuralInspection.Branch branch : owed) {
+                for (StructuralInspection.Branch branch : standing) {
                     walkBranch(branch, placed.root(), path, depth, symbols, policy, found, roots,
                             visited, handoffs);
                 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -157,8 +157,7 @@ public final class InputDomain {
         // rules on would have to be read after everything under it, and the order positions are
         // reported in is the order they are declared and descended into.
         List<Position> settled = found.stream()
-                .map(each -> handoffs.unresolvedAt(each.path())
-                        ? each.shortOfRulesNobodyTookOver() : each)
+                .map(each -> handoffs.unresolvedAt(each.path()) ? shortOfHandedOnRules(each) : each)
                 .toList();
         return settled.isEmpty() ? NONE
                 : new InputDomain(settled, read, parameters, roots, policy);
@@ -404,6 +403,30 @@ public final class InputDomain {
      */
     public Map<BindingId, String> parameterReads() {
         return read;
+    }
+
+    /**
+     * {@code position} with the rules it handed on counted as unread, because nothing took them.
+     *
+     * <p>Made here and not asked of the position, which does not know it. A reading of a value ends
+     * where no declaration stands to be read and the rules under the position become another
+     * reading's; whether one was opened is settled by the descent past this position, and that
+     * happens after the position has been read and reported. Answering it would be a way to write a
+     * {@link Position} down, and there being no such way is what keeps one position to one answer.
+     *
+     * <p>Read off the ledger and not off whether a reading exists somewhere under the path: an
+     * obligation discharged by whatever happens to be below it is one no descent ever had to meet
+     * ({@link RuleHandoffs}).
+     */
+    private static Position shortOfHandedOnRules(Position position) {
+        ReadPosition read = (ReadPosition) position;
+        return read.rulesNotReached() ? read
+                : new ReadPosition(read.path(), read.view(), read.term(), read.numericDomain(),
+                        read.ownEnds(), read.narrowedEnds(), read.rangeLeft(), read.narrowedLower(),
+                        read.narrowedUpper(), read.nothingExists(), read.projection(),
+                        read.declared(), read.reading(), read.obligations(), read.completeness(),
+                        read.valuesUnread(), read.rulesWithoutALine(), read.unansweredQuestions(),
+                        true, read.structure());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -137,6 +137,11 @@ public final class InputDomain {
         List<Position> found = new ArrayList<>();
         List<RuleRoot> roots = new ArrayList<>();
         Map<BindingId, String> read = new LinkedHashMap<>();
+        // Where a reading ended with the rules under a position still to be read, and what took
+        // them over. Kept across the whole walk because the two halves happen at different steps of
+        // it: the reading says it stopped as the position is read, and the descent says who took
+        // the rules as it opens the reading that did.
+        RuleHandoffs handoffs = new RuleHandoffs();
         for (Parameter parameter : parameters) {
             if (parameter.binding() != null) {
                 read.putIfAbsent(parameter.binding(), parameter.name());
@@ -145,9 +150,18 @@ public final class InputDomain {
             roots.add(new RuleRoot(at, parameter.type()));
             walk(at, parameter.type(), 0, symbols, policy,
                     PlacedRules.of(at, parameter.type(), symbols, policy), found, roots,
-                    java.util.Set.of());
+                    java.util.Set.of(), handoffs);
         }
-        return found.isEmpty() ? NONE : new InputDomain(found, read, parameters, roots, policy);
+        // And only now, because a handoff is discharged by a descent that happens after the
+        // position above it has been read. Held the other way round, every position that hands its
+        // rules on would have to be read after everything under it, and the order positions are
+        // reported in is the order they are declared and descended into.
+        List<Position> settled = found.stream()
+                .map(each -> handoffs.unresolvedAt(each.path())
+                        ? each.shortOfRulesNobodyTookOver() : each)
+                .toList();
+        return settled.isEmpty() ? NONE
+                : new InputDomain(settled, read, parameters, roots, policy);
     }
 
     /**
@@ -403,7 +417,8 @@ public final class InputDomain {
      */
     private static void walk(TermPath path, Type type, int depth, Symbols symbols,
                              ReadingPolicy policy, PlacedRules placed, List<Position> found,
-                             List<RuleRoot> roots, java.util.Set<Type> visited) {
+                             List<RuleRoot> roots, java.util.Set<Type> visited,
+                             RuleHandoffs handoffs) {
         // The proof first, and before anything is read off the position. A shape a reading is not
         // made of is this compiler disagreeing with itself about what may stand at a position, and
         // it is refused here rather than arriving further down as a position nothing divides.
@@ -416,18 +431,23 @@ public final class InputDomain {
                 StructuralInspection.of(input.shape(), depth < MAX_DEPTH, declared);
         Position here = read(input, path, symbols, placed, structure, declared);
         found.add(here);
+        // Said as the position is read and before anything under it is walked, so that a descent
+        // that never happens leaves the obligation standing rather than never making one.
+        if (placed.handsTheRulesOnAt(path)) {
+            handoffs.owes(placed.root(), path);
+        }
         switch (structure) {
             case StructuralInspection.Decomposed decomposed -> {
                 for (Map.Entry<String, Type> field : decomposed.under().entrySet()) {
                     walk(path.then(field.getKey()), field.getValue(), depth + 1, symbols, policy,
                             // A field is a value of its own, so a sum met under it is one this walk
                             // has not taken apart however many were taken apart above.
-                            placed, found, roots, java.util.Set.of());
+                            placed, found, roots, java.util.Set.of(), handoffs);
                 }
             }
             case StructuralInspection.Retained retained ->
                     under(retained.continuation(), here, path, depth, symbols, policy, placed,
-                            found, roots, visited);
+                            found, roots, visited, handoffs);
         }
     }
 
@@ -437,28 +457,6 @@ public final class InputDomain {
      * <p>Beside the position and never instead of it: what a list holds is read, and the list is
      * still a position with a length of its own that this reading has already answered for; a case
      * puts positions under the sum, and the sum still divides into its cases.
-     */
-    private static void under(StructuralInspection.Continuation continuation, Position here,
-                              TermPath path, int depth, Symbols symbols, ReadingPolicy policy,
-                              PlacedRules placed, List<Position> found, List<RuleRoot> roots,
-                              java.util.Set<Type> visited) {
-        switch (continuation) {
-            case StructuralInspection.Continuation.None _,
-                 StructuralInspection.Continuation.Blocked _ -> { }
-            case StructuralInspection.Continuation.Elements elements ->
-                    walk(path.element(), elements.element(), depth + 1, symbols, policy, placed,
-                            found, roots, java.util.Set.of());
-            case StructuralInspection.Continuation.Branches branches -> {
-                for (StructuralInspection.Branch branch : branches.branches()) {
-                    walkBranch(branch, here, path, depth, symbols, policy, found, roots,
-                            visited);
-                }
-            }
-        }
-    }
-
-    /**
-     * One branch of a position, where the reading still owes it and something stands under it.
      *
      * <p><b>Owed and not merely declared.</b> A case the rules refuse has no positions to cover —
      * every field of it is a row nobody can write — and the branches walked are the ones the
@@ -466,6 +464,77 @@ public final class InputDomain {
      * under it come from one reading of it. Which is also why the widening the obligations may have
      * applied travels with them: where the rules were set aside, they are set aside for the
      * positions under the case as much as for the case.
+     *
+     * <p>And it is where the rules the position handed on are passed to somebody. Which positions
+     * they are passed to is settled here, from the branches this position is owed at — never worked
+     * out afterwards from the readings that exist, since a reading opened under the position for
+     * some other reason is not one anybody handed anything to.
+     */
+    private static void under(StructuralInspection.Continuation continuation, Position here,
+                              TermPath path, int depth, Symbols symbols, ReadingPolicy policy,
+                              PlacedRules placed, List<Position> found, List<RuleRoot> roots,
+                              java.util.Set<Type> visited, RuleHandoffs handoffs) {
+        switch (continuation) {
+            // Nothing is opened under the position, so a handoff made there stays standing. Which
+            // is the answer whichever of the two this is: a shape this compiler does not enter and
+            // a depth this walk stops at both leave the rules under it read by nobody.
+            case StructuralInspection.Continuation.None _,
+                 StructuralInspection.Continuation.Blocked _ -> { }
+            case StructuralInspection.Continuation.Elements elements -> {
+                TermPath at = path.element();
+                handoffs.passesTo(placed.root(), path, List.of(at));
+                takeTheRulesOver(placed.root(), path, at, elements.element(), depth + 1, symbols,
+                        policy, found, roots, java.util.Set.of(), handoffs);
+            }
+            case StructuralInspection.Continuation.Branches branches -> {
+                List<StructuralInspection.Branch> owed = new ArrayList<>();
+                List<TermPath> passedTo = new ArrayList<>();
+                for (StructuralInspection.Branch branch : branches.branches()) {
+                    // A branch that is the whole of a value puts no position anywhere, and one the
+                    // rules leave nothing at has no row to be written at it. Neither is a place the
+                    // rules were passed to, so neither is owed a reading.
+                    if (branch.under() == null || !owed(here, branch.refinement())) {
+                        continue;
+                    }
+                    owed.add(branch);
+                    passedTo.add(path.refine(branch.refinement()));
+                }
+                handoffs.passesTo(placed.root(), path, passedTo);
+                for (StructuralInspection.Branch branch : owed) {
+                    walkBranch(branch, placed.root(), path, depth, symbols, policy, found, roots,
+                            visited, handoffs);
+                }
+            }
+        }
+    }
+
+    /**
+     * Open a reading at a position the rules were passed to, and say that it took them.
+     *
+     * <p>The one way a reading of a value begins under another. What a case of a sum holds and what
+     * a sequence holds are values with declarations of their own, and a clause is not written across
+     * either boundary: what {@code Tag} says about itself is written in {@code Tag}, whether the
+     * position is reached by narrowing an optional or by being one of however many a list holds. So
+     * both cross here, and a shape this compiler learns to walk later is a shape whose rules are
+     * read only if it comes through this too.
+     *
+     * <p>Taking the rules over is said here and not worked out afterwards from the readings that
+     * exist. A reading opened under a position for some other reason is not one anybody handed
+     * anything to, and letting it discharge the obligation would read the absence of a failure as
+     * evidence that something was read (#1072).
+     */
+    private static void takeTheRulesOver(TermPath by, TermPath at, TermPath opened, Type type,
+                                         int depth, Symbols symbols, ReadingPolicy policy,
+                                         List<Position> found, List<RuleRoot> roots,
+                                         java.util.Set<Type> visited, RuleHandoffs handoffs) {
+        roots.add(new RuleRoot(opened, type));
+        handoffs.accepts(by, at, opened);
+        walk(opened, type, depth, symbols, policy,
+                PlacedRules.of(opened, type, symbols, policy), found, roots, visited, handoffs);
+    }
+
+    /**
+     * One branch of a position, where the reading still owes it and something stands under it.
      *
      * <p><b>A narrowing takes no level.</b> {@code query@GlobalQuery.limit} is the same distance
      * from the parameter as {@code query.limit} is under a record parameter, because naming which
@@ -476,15 +545,10 @@ public final class InputDomain {
      * {@code GlobalQuery} says about its {@code tag} is written in {@code GlobalQuery}, so a new
      * root begins here and the reading of the sum's own value has nothing to say below it.
      */
-    private static void walkBranch(StructuralInspection.Branch branch, Position here, TermPath path,
+    private static void walkBranch(StructuralInspection.Branch branch, TermPath by, TermPath path,
                                    int depth, Symbols symbols, ReadingPolicy policy,
                                    List<Position> found, List<RuleRoot> roots,
-                                   java.util.Set<Type> visited) {
-        // Nothing stands under a branch that is the whole of a value. A unit case is one, and a
-        // position for it would be a report naming a place with nothing in it once per case.
-        if (branch.under() == null || !owed(here, branch.refinement())) {
-            return;
-        }
+                                   java.util.Set<Type> visited, RuleHandoffs handoffs) {
         // <b>A descent that costs no level stops only where it returns to a value it has already
         // been at without a step into one.</b> That is the whole of the rule, and what it is keyed
         // on is the value reached and never the narrowing taken: a narrowing is an edge and the
@@ -495,15 +559,18 @@ public final class InputDomain {
         //
         // Kept per branch of the walk and dropped at every step into a value, because a value met
         // under a field is one this walk has been nowhere near.
+        //
+        // And no reading is opened, so nothing takes the rules of this case over and the handoff
+        // above stays standing. The rules were read where the value was first met, at a position
+        // this walk already reported; saying they were read here as well would be one reading
+        // discharging an obligation raised somewhere it never went.
         if (visited.contains(branch.under())) {
             return;
         }
         java.util.Set<Type> deeper = new java.util.LinkedHashSet<>(visited);
         deeper.add(branch.under());
-        TermPath at = path.refine(branch.refinement());
-        roots.add(new RuleRoot(at, branch.under()));
-        walk(at, branch.under(), depth, symbols, policy,
-                PlacedRules.of(at, branch.under(), symbols, policy), found, roots, deeper);
+        takeTheRulesOver(by, path, path.refine(branch.refinement()), branch.under(), depth, symbols,
+                policy, found, roots, deeper, handoffs);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -72,10 +72,17 @@ public final class InputDomain {
     /**
      * The declaration a position's rules are read of, and where that value stands.
      *
-     * <p>One reading per value and not one per record met on the way down: a clause on the outer
-     * record relates positions at any depth it can name. What starts a new one is a narrowing —
-     * what a {@code GlobalQuery} says about its {@code tag} is written in {@code GlobalQuery} and
-     * cannot be written in the sum, so the rules under a case are that case's and are read of it.
+     * <p>One reading per rule-owning value and not one per record met on the way down: a clause on
+     * the outer record relates positions at any depth it can name, and rebuilding the reading at
+     * each record is how a clause stopped reaching the field it was about.
+     *
+     * <p><b>What starts a new one is a descent crossing a boundary of rule ownership</b>, which is
+     * wherever the value below is one a declaration writes its own clauses about. Narrowing into a
+     * case is one — what a {@code GlobalQuery} says about its {@code tag} is written in
+     * {@code GlobalQuery} and cannot be written in the sum — and so is entering what a sequence
+     * holds, since what {@code Tag} says about itself is written in {@code Tag} however the position
+     * is reached. Both go through {@link #takeTheRulesOver} and nothing else does, which is what a
+     * shape this compiler learns to walk later has to do to have its rules read at all (#1072).
      *
      * <p>Kept as the declarations rather than as a reading of them, for the reason the parameters
      * are: what is answered with is compared as a value by whatever decides that a compile changed
@@ -95,8 +102,8 @@ public final class InputDomain {
      * way of reading the declarations rather than a statement about them. */
     private final List<Parameter> parameters;
     /** Every declaration whose rules reach a position of this input, and where it stands. One per
-     * parameter, and one more wherever a narrowing put a value of another declaration at a
-     * position. */
+     * parameter, and one more wherever a descent crossed a boundary of rule ownership — see
+     * {@link RuleRoot}. */
     private final List<RuleRoot> roots;
     private final ReadingPolicy policy;
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/PlacedRules.java
@@ -112,19 +112,25 @@ record PlacedRules(TermPath root, TypeSymbol value, Rules rules) {
      * answer where {@link #at} is.
      */
     AdmissibleSet admits(TermPath path) {
+        return rules.admits(under(path));
+    }
+
+    /**
+     * Whether this reading ended at {@code path} with a declaration still to be read under it.
+     *
+     * <p>Not a shortfall. Nothing is declared at the position for these rules to state anything
+     * about every value of — what stands there is a container, an optional, or a choice between
+     * declarations — so what is written under it is written about a value one position down, and
+     * this reading is done here rather than short here.
+     *
+     * <p>What a caller does with it is show that something took the rules over
+     * ({@link RuleHandoffs}). Answered instead by asking whether the type graph has a rule
+     * somewhere below, the position above was short of a rule no row could reach: the walk had gone
+     * to it, one position down (#1072).
+     */
+    boolean handsTheRulesOnAt(TermPath path) {
         String where = keyOf(path);
-        if (where != null) {
-            return rules.admits(where);
-        }
-        // Inside a sequence. Where a clause of the value states something about what the container
-        // holds and nothing placed it, this reading did not reach the rules of the position — which
-        // is not the same answer as reading them and finding none. Where the container carries no
-        // such clause there was nothing to reach, and every value is admitted as it is anywhere
-        // else nothing is written.
-        return everyRuleReachedAt(path)
-                ? AdmissibleSet.complete(souther.compiler.values.ValueSet.ANY)
-                : AdmissibleSet.partial(souther.compiler.values.ValueSet.ANY,
-                        souther.compiler.values.UnreadReason.NOT_REACHED);
+        return where != null && bounds().handedOn().contains(where);
     }
 
     /**
@@ -173,21 +179,24 @@ record PlacedRules(TermPath root, TypeSymbol value, Rules rules) {
      * another reason won it.
      */
     boolean everyRuleReachedAt(TermPath path) {
+        return rules.everyRuleReachedAt(under(path));
+    }
+
+    /**
+     * What the rules of this value call {@code path}, for the questions every position answers.
+     *
+     * <p>Every position under this reading's root has a name here, the root's own included. What a
+     * sequence holds is not one of them: an element is a value with a declaration of its own and a
+     * reading is opened at it, so a path under this root never steps into one — and a position this
+     * reading is not of is not a position it may be asked about.
+     */
+    private String under(TermPath path) {
         String where = keyOf(path);
-        if (where != null) {
-            return rules.everyRuleReachedAt(where);
+        if (where == null) {
+            throw new IllegalArgumentException(
+                    path + " is not a position of the value read at " + root);
         }
-        // Inside a sequence, where no clause of the value is written and so none can go unplaced on
-        // its own account. What can is a clause written about the container: a relation stated of
-        // every element is held as a quantifier over the clause holding it, and this gathering
-        // places none of it at the position it is about.
-        //
-        // So the answer is the container's, and whether the container has a rule nothing accounted
-        // for. Said unconditionally, every element of every list came back as a position nothing
-        // had read — including in models whose lists carry no clause at all, where there is nothing
-        // for a reading to have missed.
-        return everyRuleReachedAt(path.containingSequence())
-                && unanswered(path.containingSequence()).isEmpty();
+        return where;
     }
 
     /** The ends the clauses reaching this value place on the coordinates at {@code path}, which is

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
@@ -169,21 +169,6 @@ public sealed interface Position permits ReadPosition {
     boolean rulesNotReached();
 
     /**
-     * The same position, with the rules it handed on counted as unread because nothing took them.
-     *
-     * <p>Said after the position is read, because it is not something the reading of this position
-     * knows. A reading of a value ends where no declaration stands to be read and the rules under
-     * the position become another reading's; whether one was opened is settled by the descent past
-     * this position, which happens after this position has been read and reported. So the reading
-     * answers for itself, and this is where the walk's answer is put beside it.
-     *
-     * <p>Answered here rather than by the walk consulting whether a reading exists somewhere under
-     * the path: an obligation discharged by whatever happens to be below it is one no descent ever
-     * had to meet (#1072, {@link RuleHandoffs}).
-     */
-    Position shortOfRulesNobodyTookOver();
-
-    /**
      * What stopped the reading of which values this position may hold, or null where nothing did.
      *
      * <p>{@link #completeness()} said in the vocabulary a report is projected from. Kept apart from

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
@@ -152,14 +152,36 @@ public sealed interface Position permits ReadPosition {
     List<StandingQuestion> unansweredQuestions();
 
     /**
-     * Whether the walk never reached the rules written about this position.
+     * Whether a rule this position was owed went unread.
      *
      * <p>Beside {@link #unansweredQuestions()} and not among them. A rule nothing took in is a rule
      * this compiler saw and made nothing of; here nothing was seen, so there is no rule to name and
      * no question to raise — and an empty list of questions says every rule was accounted for,
      * which is the opposite (issue #791).
+     *
+     * <p><b>Owed, which is narrower than written underneath.</b> Two things are true here and only
+     * these two: the reading that owns this position lost a clause of its own, or this position
+     * handed its rules on and no reading was opened to take them ({@link RuleHandoffs}). A rule
+     * written under a container, a case, or an optional is not one of them — it is read where it
+     * governs, one position down, and a row meets it there. Said here, the measure was short of
+     * something nobody could supply, because the walk had already gone to it (#1072).
      */
     boolean rulesNotReached();
+
+    /**
+     * The same position, with the rules it handed on counted as unread because nothing took them.
+     *
+     * <p>Said after the position is read, because it is not something the reading of this position
+     * knows. A reading of a value ends where no declaration stands to be read and the rules under
+     * the position become another reading's; whether one was opened is settled by the descent past
+     * this position, which happens after this position has been read and reported. So the reading
+     * answers for itself, and this is where the walk's answer is put beside it.
+     *
+     * <p>Answered here rather than by the walk consulting whether a reading exists somewhere under
+     * the path: an obligation discharged by whatever happens to be below it is one no descent ever
+     * had to meet (#1072, {@link RuleHandoffs}).
+     */
+    Position shortOfRulesNobodyTookOver();
 
     /**
      * What stopped the reading of which values this position may hold, or null where nothing did.

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadPosition.java
@@ -52,6 +52,15 @@ record ReadPosition(TermPath path, TypeView view, NumericTerm term,
     }
 
     @Override
+    public Position shortOfRulesNobodyTookOver() {
+        return rulesNotReached ? this
+                : new ReadPosition(path, view, term, numericDomain, ownEnds, narrowedEnds,
+                        rangeLeft, narrowedLower, narrowedUpper, nothingExists, projection,
+                        declared, reading, obligations, completeness, valuesUnread,
+                        rulesWithoutALine, unansweredQuestions, true, structure);
+    }
+
+    @Override
     public List<TypeSymbol> narrowedBy(boolean lower) {
         return lower ? narrowedLower : narrowedUpper;
     }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadPosition.java
@@ -52,15 +52,6 @@ record ReadPosition(TermPath path, TypeView view, NumericTerm term,
     }
 
     @Override
-    public Position shortOfRulesNobodyTookOver() {
-        return rulesNotReached ? this
-                : new ReadPosition(path, view, term, numericDomain, ownEnds, narrowedEnds,
-                        rangeLeft, narrowedLower, narrowedUpper, nothingExists, projection,
-                        declared, reading, obligations, completeness, valuesUnread,
-                        rulesWithoutALine, unansweredQuestions, true, structure);
-    }
-
-    @Override
     public List<TypeSymbol> narrowedBy(boolean lower) {
         return lower ? narrowedLower : narrowedUpper;
     }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/RuleHandoffs.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/RuleHandoffs.java
@@ -53,9 +53,30 @@ final class RuleHandoffs {
     /** And which of them a reading was actually opened at. */
     private final Map<Handoff, Set<TermPath>> accepted = new LinkedHashMap<>();
 
-    /** That the reading rooted at {@code by} ended at {@code at} with rules under it still to be
-     *  read. Said by the reading, which is the only thing that knows it stopped. */
+    /**
+     * That the reading rooted at {@code by} ended at {@code at} with rules under it still to be
+     * read. Said by the reading, which is the only thing that knows it stopped.
+     *
+     * <p>Refuses a second reading owing one at the same position. Which reading answers for a
+     * position is settled by where the descent last crossed an ownership boundary, so it is a
+     * function of the path and there is one of them — and {@link #unresolvedAt} leans on that,
+     * asking by position alone because a position has one owner to ask about.
+     *
+     * <p>Written down as a refusal because the projection is the whole risk. Every other step here
+     * carries the pair, and one place that drops the origin is one place where a handoff owed by a
+     * reading nobody kept could leave somebody else's position short — which is this issue's own
+     * shape, an answer taken from something other than what established it. A traversal that puts
+     * two readings under one path is this compiler contradicting itself and stops here, rather than
+     * arriving as a position quietly reported short.
+     */
     void owes(TermPath by, TermPath at) {
+        for (Handoff each : owed) {
+            if (each.at().equals(at) && !each.by().equals(by)) {
+                throw new IllegalStateException(
+                        "two readings answer for the rules at " + at + ": " + each.by()
+                                + " and " + by);
+            }
+        }
         owed.add(new Handoff(by, at));
     }
 
@@ -81,9 +102,15 @@ final class RuleHandoffs {
      * That a reading was opened at {@code child}, which is one of the positions {@code at} passed
      * the rules to.
      *
-     * <p>Refused for a position nothing said to expect. A reading opened somewhere nobody handed
-     * anything to is a reading about something else, and counting it here is what would let an
-     * unrelated root discharge an obligation.
+     * <p>Nothing happens where no handoff was made at {@code at}. A descent opens readings whether
+     * or not any rule is written under the position it came from, and a position nothing was owed at
+     * has nothing to discharge.
+     *
+     * <p>Refused where a handoff was made and {@code child} is not one of the positions it passed
+     * the rules to. That is the descent that enumerated the children and the descent that opened
+     * them disagreeing, which is one walk contradicting itself rather than a state of the model —
+     * and counting it anyway is what would let a reading nobody handed anything to discharge an
+     * obligation.
      */
     void accepts(TermPath by, TermPath at, TermPath child) {
         Handoff handoff = new Handoff(by, at);
@@ -100,11 +127,16 @@ final class RuleHandoffs {
     }
 
     /**
-     * Whether some reading ended at {@code at} with rules under it that nothing took over.
+     * Whether the reading that ended at {@code at} left rules under it that nothing took over.
      *
      * <p>Every position the rules were passed to has to have been opened, and not merely some of
      * them: a sum whose second case nothing walked has left the rules of that case unread however
      * well the first went.
+     *
+     * <p>Asked by position and not by the pair the handoffs are held under, which is safe because
+     * {@link #owes} refuses a second reading at one position. Left to be true rather than made so, a
+     * handoff owed by one reading would answer for a position another reading reports — and an
+     * answer taken from something other than what established it is what this issue was.
      */
     boolean unresolvedAt(TermPath at) {
         for (Handoff handoff : owed) {

--- a/souther-compiler/src/main/java/souther/compiler/inputs/RuleHandoffs.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/RuleHandoffs.java
@@ -1,0 +1,123 @@
+package souther.compiler.inputs;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Where a reading of a value ended with the rules under a position still to be read, and what took
+ * them over.
+ *
+ * <p>A reading of a declaration stops where no declaration stands to be read: at a container, at an
+ * optional, at a choice between declarations. What is written under one of those is written about a
+ * value one position down, so the rules are not lost there — the responsibility for them is somebody
+ * else's. Which is a claim about the walk over positions, and nothing in the reading that stopped
+ * can settle it.
+ *
+ * <p><b>Taking the rules over is an act, not a coincidence.</b> Every entry here is made by the
+ * descent that made it true: the reading that stopped says it owes one ({@link #owes}), the descent
+ * that crosses the boundary says which values are supposed to take the rules ({@link #passesTo}),
+ * and each reading actually opened says it took them ({@link #accepts}). Nothing is worked out
+ * afterwards by looking at which readings happen to exist under a path. Read that way, a reading
+ * opened under the position for some other purpose would discharge an obligation it never heard of —
+ * which is the same mistake as reading "no failure was recorded" as "everything was read", and it is
+ * the mistake this issue was (#1072).
+ *
+ * <p><b>Handing the rules over is not the same as reading them.</b> A reading that was opened and
+ * then came back short of something reports that shortfall itself, at its own position. The handoff
+ * above it is discharged all the same: the rules reached a reader, and saying so twice would report
+ * one gap at two positions. What leaves a handoff standing is that no reading was opened at all —
+ * a shape this compiler cannot enter, a depth this walk stops at, a value it has already been to.
+ */
+final class RuleHandoffs {
+
+    /**
+     * One handing over: the reading that ended, and the position it ended at.
+     *
+     * <p>The reading and not the position alone. A path says where something is, which is not the
+     * same as who was answering for the rules there — and an obligation identified by where it sits
+     * is one any reading that reaches the same place can be taken to have met.
+     *
+     * @param by the value whose rules were being read, named by where that reading is rooted
+     * @param at the position that reading stopped at
+     */
+    record Handoff(TermPath by, TermPath at) {}
+
+    /** The handoffs made, in the order the walk made them. */
+    private final Set<Handoff> owed = new LinkedHashSet<>();
+    /** Which positions are supposed to take the rules over, for the handoffs a descent has reached.
+     *  Absent for one nothing has reached, which is what leaves it standing. */
+    private final Map<Handoff, Set<TermPath>> expected = new LinkedHashMap<>();
+    /** And which of them a reading was actually opened at. */
+    private final Map<Handoff, Set<TermPath>> accepted = new LinkedHashMap<>();
+
+    /** That the reading rooted at {@code by} ended at {@code at} with rules under it still to be
+     *  read. Said by the reading, which is the only thing that knows it stopped. */
+    void owes(TermPath by, TermPath at) {
+        owed.add(new Handoff(by, at));
+    }
+
+    /**
+     * That the descent past {@code at} is supposed to open a reading at each of {@code children}.
+     *
+     * <p>Said where the children are enumerated and nowhere else. What a sum's cases are and which
+     * of them the rules leave anything at is settled once, by the descent, and the set it settled is
+     * what this handoff is measured against — worked out again from the readings that exist, a case
+     * nothing walked would be a case nobody expected.
+     *
+     * <p>Does nothing where no handoff was made at {@code at}. A descent crosses a boundary whether
+     * or not any rule is written under it, and a position nothing was owed at owes nothing.
+     */
+    void passesTo(TermPath by, TermPath at, Collection<TermPath> children) {
+        Handoff handoff = new Handoff(by, at);
+        if (owed.contains(handoff)) {
+            expected.put(handoff, new LinkedHashSet<>(children));
+        }
+    }
+
+    /**
+     * That a reading was opened at {@code child}, which is one of the positions {@code at} passed
+     * the rules to.
+     *
+     * <p>Refused for a position nothing said to expect. A reading opened somewhere nobody handed
+     * anything to is a reading about something else, and counting it here is what would let an
+     * unrelated root discharge an obligation.
+     */
+    void accepts(TermPath by, TermPath at, TermPath child) {
+        Handoff handoff = new Handoff(by, at);
+        if (!owed.contains(handoff)) {
+            return;
+        }
+        Set<TermPath> supposed = expected.get(handoff);
+        if (supposed == null || !supposed.contains(child)) {
+            throw new IllegalArgumentException(
+                    "a reading at " + child + " was not one the handoff at " + at
+                            + " passed the rules to: " + supposed);
+        }
+        accepted.computeIfAbsent(handoff, _ -> new LinkedHashSet<>()).add(child);
+    }
+
+    /**
+     * Whether some reading ended at {@code at} with rules under it that nothing took over.
+     *
+     * <p>Every position the rules were passed to has to have been opened, and not merely some of
+     * them: a sum whose second case nothing walked has left the rules of that case unread however
+     * well the first went.
+     */
+    boolean unresolvedAt(TermPath at) {
+        for (Handoff handoff : owed) {
+            if (handoff.at().equals(at) && !resolved(handoff)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean resolved(Handoff handoff) {
+        Set<TermPath> supposed = expected.get(handoff);
+        return supposed != null
+                && accepted.getOrDefault(handoff, Set.of()).containsAll(supposed);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/values/UnreadReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/UnreadReason.java
@@ -49,9 +49,14 @@ public enum UnreadReason {
      * The reading never reached the rules about this position.
      *
      * <p>A different thing from a rule it read and could not use. The walk that gathers clauses
-     * stopped — at a depth, at a type it had already been through, at one with no declaration to
-     * read — or a clause could not be typed and so never arrived. Which of those it was is not
-     * recorded: none of them is a fact about the rule, and all of them leave the same hole.
+     * stopped — at a depth, at a type it had already been through — or a clause could not be typed
+     * and so never arrived. Which of those it was is not recorded: none of them is a fact about the
+     * rule, and all of them leave the same hole.
+     *
+     * <p>Not a walk that stopped where no declaration stands to be read. What is written under a
+     * container, an optional or a choice between declarations is written about a value one position
+     * down, where a reading of that declaration is opened and a row meets it — so those rules are
+     * handed on rather than left unread, and the position above admits what it admits (#1072).
      */
     NOT_REACHED
 }

--- a/souther-compiler/src/main/java/souther/compiler/values/UnreadReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/values/UnreadReason.java
@@ -53,10 +53,10 @@ public enum UnreadReason {
      * and so never arrived. Which of those it was is not recorded: none of them is a fact about the
      * rule, and all of them leave the same hole.
      *
-     * <p>Not a walk that stopped where no declaration stands to be read. What is written under a
-     * container, an optional or a choice between declarations is written about a value one position
-     * down, where a reading of that declaration is opened and a row meets it — so those rules are
-     * handed on rather than left unread, and the position above admits what it admits (#1072).
+     * <p>Not every way a walk can stop. One of them hands the rules to a reading one position down,
+     * where a row meets them, and the position above admits what it admits (#1072). Which stops
+     * those are is settled in one place and not restated here — see {@code PathEngine.leftBy} in
+     * {@code souther.compiler.check}, which this package may not name.
      */
     NOT_REACHED
 }

--- a/souther-compiler/src/test/java/souther/compiler/AMeasuredPositionSaysHowFarItsRulesWereReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasuredPositionSaysHowFarItsRulesWereReadTest.java
@@ -134,4 +134,33 @@ class AMeasuredPositionSaysHowFarItsRulesWereReadTest {
                 && (line.contains("not read: " + position + " ")
                         || line.contains("about `" + position + "`")));
     }
+    /**
+     * And the model that leaves a rule unread at a position it measured is one this compiler
+     * refuses.
+     *
+     * <p>Said out loud, because it is what the word means now and not an accident of the fixture.
+     * A rule written under a container, a case or an optional is read where it governs, one position
+     * down (#1072); a rule this compiler cannot find a value for is a shortfall of its own. What is
+     * left is a clause the front end could not type — and a model carrying one is refused, so a
+     * document that says a measured position went short of a rule is a document about a model that
+     * did not compile.
+     *
+     * <p>A tripwire and not a preference. The day a clause can go unread in a model that compiles,
+     * this fails and whoever made it so is the one who should decide what the word means then.
+     */
+    @Test
+    void theModelThatSaysSoIsOneThisCompilerRefuses() {
+        assertTrue(isRefused(MEASURED_IN_PART),
+                "a measured position short of a rule takes a clause nothing could type");
+        assertFalse(isRefused(READ_IN_FULL), "and the control is a model that compiles");
+    }
+
+    /** Whether this compiler refuses {@code source}, which is what the fixtures above turn on. */
+    private static boolean isRefused(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        return !compilation.diagnostics().values().stream()
+                .flatMap(java.util.List::stream).toList().isEmpty();
+    }
+
 }

--- a/souther-compiler/src/test/java/souther/compiler/AMeasuredPositionSaysHowFarItsRulesWereReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasuredPositionSaysHowFarItsRulesWereReadTest.java
@@ -31,17 +31,25 @@ class AMeasuredPositionSaysHowFarItsRulesWereReadTest {
     /**
      * A position the axes measure whose rules were not read in full.
      *
-     * <p>The option divides `i.assignee` into `None` and `Some`, so the position is measured. What
-     * `Assignee` says about the value inside is behind the option, and this reading does not go
-     * there.
+     * <p>Two clauses about one value, and this reading owns both. The first names the values, so the
+     * position divides into them and is measured; the second states nothing that could be typed, so
+     * it reached no reading here and which values it would have refused is unknown. The classes are
+     * what the model was read to say and the rule that went unread may yet refuse one of them.
+     *
+     * <p><b>A rule this reading owns, and not one it handed on.</b> The fixture used to be an
+     * {@code Assignee?}, whose rules the reading below the option reads and the position above was
+     * told it had not reached — which is the defect this measure was reporting rather than a state a
+     * model can be in (#1072). What inhabits this word is a reader that got as far as deriving the
+     * classes and then lost a clause of its own.
      */
     private static final String MEASURED_IN_PART = """
             module o
 
             data Assignee = String
-                invariant String.length(value) >= 1
+                invariant named = value == "ada" || value == "bob"
+                invariant unreadable = value == 1
 
-            data Issue = { assignee: Assignee? }
+            data Issue = { assignee: Assignee }
             data Accepted = { at: Int }
 
             behavior classify : (i: Issue) -> Accepted
@@ -87,9 +95,9 @@ class AMeasuredPositionSaysHowFarItsRulesWereReadTest {
         assertEquals(2, axis.get("classes").size(), axis.toString());
         assertEquals("partial", axis.get("read").get("extent").asString(),
                 "the axis says that something about its position's rules is left standing");
-        // Which of the two it is, and not only that there is one. Nothing here reached the rules
-        // behind the option — which is not a rule this read and could not use, and saying so would
-        // publish a cause this was not observed to have.
+        // Which of the two it is, and not only that there is one. The clause that went unread
+        // reached no reading at all, so there is no rule this read and could not use, and saying so
+        // would publish a cause this was not observed to have.
         assertTrue(axis.get("read").get("rulesNotReached").asBoolean(), axis.toString());
         assertFalse(axis.get("read").has("unanswered"),
                 "there is no rule to name, because nothing was seen: " + axis);

--- a/souther-compiler/src/test/java/souther/compiler/WhatAReadingLeavesStandingIsAStateTheSchemaSaysTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatAReadingLeavesStandingIsAStateTheSchemaSaysTest.java
@@ -86,14 +86,17 @@ class WhatAReadingLeavesStandingIsAStateTheSchemaSaysTest {
                 if length.value >= 50 then 1 else 2
             """;
 
-    /** Rules the walk never reached, behind an option. */
+    /** A clause of the value this reading owns that reached no reading at all, beside one it read
+     *  to the end. What is out of sight is a rule of the very position the classes are at: a rule
+     *  handed to the reading one position down is that reading's and is read there (#1072). */
     private static final String RULES_OUT_OF_SIGHT = """
             module o
 
             data Assignee = String
-                invariant String.length(value) >= 1
+                invariant named = value == "ada" || value == "bob"
+                invariant unreadable = value == 1
 
-            data Issue = { assignee: Assignee? }
+            data Issue = { assignee: Assignee }
             data Accepted = { at: Int }
 
             behavior classify : (i: Issue) -> Accepted
@@ -105,6 +108,16 @@ class WhatAReadingLeavesStandingIsAStateTheSchemaSaysTest {
             assertNotNull(in, "adequacy-schema-7.json ships beside the compiler");
             return JSON.readTree(new String(in.readAllBytes(), StandardCharsets.UTF_8));
         }
+    }
+
+    /** The axis about {@code path}, which is what these are asked of. */
+    private static JsonNode axisAt(JsonNode partition, String path) {
+        for (JsonNode axis : partition.get("axes")) {
+            if (path.equals(axis.get("path").asString())) {
+                return axis;
+            }
+        }
+        throw new AssertionError(path + " is not among " + partition.get("axes"));
     }
 
     private static JsonNode partitionOf(String source, String behavior) {
@@ -172,9 +185,10 @@ class WhatAReadingLeavesStandingIsAStateTheSchemaSaysTest {
             module m
 
             data Inner = String
-                invariant String.length(value) >= 1
+                invariant named = value == "ada" || value == "bob"
+                invariant unreadable = value == 1
 
-            data R = { n: Int, deep: Inner? }
+            data R = { n: Int, deep: Inner }
                 invariant odd = n * n >= 4
 
             data Ok = { at: Int }
@@ -189,24 +203,32 @@ class WhatAReadingLeavesStandingIsAStateTheSchemaSaysTest {
      * The two facts are independent, and a position carries the one that is true of it.
      *
      * <p>They were arms of one type, which said they could not both be so. Nothing grounds that:
-     * what a reading could not read and what a walk never reached are different facts about
+     * what a reading could not read and what a reading never reached are different facts about
      * different rules, and here they fall at two positions of one value. Whether one position can
      * carry both is not shown by this — the model and the schema allow it, and no input is known
      * that produces it.
+     *
+     * <p><b>Both rules belong to the readings that report them.</b> {@code odd} is written on
+     * {@code R} and is short at {@code R}'s own position; {@code unreadable} is written on
+     * {@code Inner} and is short where {@code Inner} is read. A rule handed to a reading one
+     * position down is that reading's and is reported there, so neither of these is a position
+     * answering for somebody else's rule (#1072).
      */
     @Test
     void aRuleNothingTookInAndRulesOutOfSightAreIndependent() {
         JsonNode partition = partitionOf(BOTH_FACTS, "f");
-        JsonNode axes = partition.get("axes");
 
-        JsonNode number = axes.get(0).get("read");
-        assertEquals("partial", number.get("extent").asString(), number.toString());
-        assertFalse(number.has("rulesNotReached"), number.toString());
+        // The rule nothing took in, at the position it is about. Asked of the questions rather than
+        // of an axis: where a rule of the model went unread the border measure declines, and the
+        // classes at `r.n` are ones a comparison in the body draws — so the position that carries
+        // this fact has no axis in this model, and the fact is the model's either way.
         assertEquals(1, partition.get("unanswered").size(), partition.toString());
+        assertEquals("r.n", partition.get("unanswered").get(0).get("at").asString());
         assertEquals("admitted_values",
                 partition.get("unanswered").get(0).get("question").asString());
 
-        JsonNode held = axes.get(1).get("read");
+        // And the rules out of sight, at the other position, which raises no question at all.
+        JsonNode held = axisAt(partition, "r.deep").get("read");
         assertTrue(held.get("rulesNotReached").asBoolean(), held.toString());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/WhatAReadingLeavesStandingIsAStateTheSchemaSaysTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatAReadingLeavesStandingIsAStateTheSchemaSaysTest.java
@@ -219,9 +219,10 @@ class WhatAReadingLeavesStandingIsAStateTheSchemaSaysTest {
         JsonNode partition = partitionOf(BOTH_FACTS, "f");
 
         // The rule nothing took in, at the position it is about. Asked of the questions rather than
-        // of an axis: where a rule of the model went unread the border measure declines, and the
-        // classes at `r.n` are ones a comparison in the body draws — so the position that carries
-        // this fact has no axis in this model, and the fact is the model's either way.
+        // of an axis: the classes at `r.n` are ones a comparison in the body draws, and this model
+        // is refused, so its bodies are not elaborated and there is no comparison to draw them. The
+        // question the model raises about `r.n` is raised either way — it is read off the
+        // declaration, which is what makes it the thing to assert here.
         assertEquals(1, partition.get("unanswered").size(), partition.toString());
         assertEquals("r.n", partition.get("unanswered").get(0).get("at").asString());
         assertEquals("admitted_values",

--- a/souther-compiler/src/test/java/souther/compiler/WhatAReadingLeavesStandingIsAStateTheSchemaSaysTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatAReadingLeavesStandingIsAStateTheSchemaSaysTest.java
@@ -301,4 +301,33 @@ class WhatAReadingLeavesStandingIsAStateTheSchemaSaysTest {
         assertTrue(read.get("rulesNotReached").asBoolean(), read.toString());
         assertFalse(partition.has("unanswered"), partition.toString());
     }
+    /**
+     * And the model that leaves a rule unread at a position it measured is one this compiler
+     * refuses.
+     *
+     * <p>Said out loud, because it is what the word means now and not an accident of the fixture.
+     * A rule written under a container, a case or an optional is read where it governs, one position
+     * down (#1072); a rule this compiler cannot find a value for is a shortfall of its own. What is
+     * left is a clause the front end could not type — and a model carrying one is refused, so a
+     * document that says a measured position went short of a rule is a document about a model that
+     * did not compile.
+     *
+     * <p>A tripwire and not a preference. The day a clause can go unread in a model that compiles,
+     * this fails and whoever made it so is the one who should decide what the word means then.
+     */
+    @Test
+    void theModelsThatSaySoAreOnesThisCompilerRefuses() {
+        assertTrue(isRefused(RULES_OUT_OF_SIGHT), RULES_OUT_OF_SIGHT);
+        assertTrue(isRefused(BOTH_FACTS), BOTH_FACTS);
+        assertFalse(isRefused(NOTHING_STANDING), "and the control is a model that compiles");
+    }
+
+    /** Whether this compiler refuses {@code source}, which is what the fixtures above turn on. */
+    private static boolean isRefused(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        return !compilation.diagnostics().values().stream()
+                .flatMap(java.util.List::stream).toList().isEmpty();
+    }
+
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Which values a position is left, and whether that is the whole of what its rules leave it.
@@ -540,16 +541,21 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
     }
 
     /**
-     * A type the walk does not enter leaves its rules unread, and that is said too.
+     * A type the walk does not enter is a position whose own values this reading is not short of.
      *
      * <p>The walk goes through a field's own type and stops at what wraps one — an optional, a
-     * collection, a sum of records — so a rule written inside one of those reaches no reading here.
-     * A position whose values those rules narrow is not one this can speak for, however plainly the
-     * clauses it did read were read.
+     * collection, a sum of records. A rule written inside one of those is not a rule about the
+     * position holding the wrapper: it is about a value one position down, which is a value that may
+     * not be there at all. So what this reading says of the position above is the whole of what its
+     * own rules leave it, and the rules under it are handed on rather than missed (#1072).
+     *
+     * <p>Said as a widening, the position above was short of a rule no row could reach: what a
+     * {@code Some} holds is measured where the narrowing puts it, and the measure that reported the
+     * gap was the same one that had already read the rule (#1063).
      */
     @Test
-    void aRuleUnderSomethingTheWalkDoesNotEnterIsARuleUnread() {
-        asFarAsRead(ValueSet.ANY, UnreadReason.NOT_REACHED, of("""
+    void aRuleUnderSomethingTheWalkDoesNotEnterIsHandedOnAndNotMissed() {
+        handsOn(of("""
                 module demo
 
                 data Inner = String
@@ -557,7 +563,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
 
                 data Outer = { inner: Inner? }
                 """, "Outer"), "inner");
-        asFarAsRead(ValueSet.ANY, UnreadReason.NOT_REACHED, of("""
+        handsOn(of("""
                 module demo
 
                 data Inner = String
@@ -565,7 +571,7 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
 
                 data Outer = { inners: List<Inner> }
                 """, "Outer"), "inners");
-        asFarAsRead(ValueSet.ANY, UnreadReason.NOT_REACHED, of("""
+        handsOn(of("""
                 module demo
 
                 data Yes = { n: Int }
@@ -575,6 +581,18 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
 
                 data Outer = { answer: Answer }
                 """, "Outer"), "answer");
+    }
+
+    /** Every value the position holds is left to it, and the rules under it are somebody else's to
+     *  read. Both, because either alone is half the claim: a position said to be handed on and
+     *  narrowed anyway would be one this reading spoke for after all, and one read in full with no
+     *  handoff recorded would be a subtree nobody is ever asked about. */
+    private static void handsOn(FieldDomains read, String path) {
+        wholly(ValueSet.ANY, read, path);
+        assertTrue(read.handedOn().contains(path),
+                () -> path + " hands its rules on, and " + read.handedOn() + " says who does");
+        assertTrue(read.everyRuleReachedAt(path),
+                () -> path + " is short of nothing: what is under it was never addressed to it");
     }
 
     /**
@@ -591,16 +609,16 @@ class WhatAPositionMayHoldIsHandedOverWithHowMuchOfItWasReadTest {
      */
     @Test
     void aStopUnderOneFieldDoesNotSpoilTheFieldBesideIt() {
-        FieldDomains read = of("""
+        FieldDomains read = ofRefused("""
                 module demo
 
                 data Inner = String
-                    invariant only = value == "A"
+                    invariant no = value == 1
 
-                data Forecast = { inners: List<Inner>, dealCount: Int }
+                data Forecast = { inner: Inner, dealCount: Int }
                 """, "Forecast");
 
-        asFarAsRead(ValueSet.ANY, UnreadReason.NOT_REACHED, read, "inners");
+        asFarAsRead(ValueSet.ANY, UnreadReason.NOT_REACHED, read, "inner");
         wholly(ValueSet.ANY, read, "dealCount");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatEachWayOfStoppingLeavesIsWrittenDownOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatEachWayOfStoppingLeavesIsWrittenDownOnceTest.java
@@ -1,0 +1,73 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Which ways of stopping hand the rules to another reading, and which leave them unread.
+ *
+ * <p>One partition of one enum, written down here so that moving an arm is an edit somebody has to
+ * make on purpose. {@link PathEngine#leftBy} is exhaustive, so a way of stopping <em>added</em> is
+ * already a compile error; what that does not catch is an arm <em>moved</em> from one side to the
+ * other, which changes what several words downstream mean while every switch goes on compiling.
+ * That is how the prose in {@link InvariantChecker.Borne} and
+ * {@link souther.compiler.values.UnreadReason} came to describe a partition that had moved under it.
+ *
+ * <p>So the table below is a finding and not a fixture. A diff here is a claim that a stop leaves
+ * something different behind, and whoever writes it owes the reason — the words that read
+ * {@code leftBy} are what change meaning with it.
+ */
+class WhatEachWayOfStoppingLeavesIsWrittenDownOnceTest {
+
+    @Test
+    void everyWayOfStoppingLeavesWhatIsWrittenHere() {
+        Map<GuaranteeWalk.Stop, PathEngine.Leaves> expected = new LinkedHashMap<>();
+        // Nothing is declared here to read, so what is written below is written about a value one
+        // position down — where a reading of that declaration is opened and a row meets it. The one
+        // arm on this side, and the whole of what #1072 turned on.
+        expected.put(GuaranteeWalk.Stop.NOTHING_DECLARED, new PathEngine.Leaves.ToAnotherReading());
+        // A depth this reader could not afford, a name it was told to suppose holds values, and a
+        // field it could find no value for. Each stops where a construction still has to make the
+        // value, so a rule under it can refuse the construction.
+        expected.put(GuaranteeWalk.Stop.PAST_THE_DEPTH,
+                new PathEngine.Leaves.Unread(InvariantChecker.Borne.BY_EVERY_VALUE));
+        expected.put(GuaranteeWalk.Stop.ASKED_TO_STOP,
+                new PathEngine.Leaves.Unread(InvariantChecker.Borne.BY_EVERY_VALUE));
+        expected.put(GuaranteeWalk.Stop.NO_VALUE_THERE,
+                new PathEngine.Leaves.Unread(InvariantChecker.Borne.BY_EVERY_VALUE));
+        // Read where the name was met, and nothing is opened here — so nobody takes the rules over,
+        // and this is not a handing on however much it looks like one.
+        expected.put(GuaranteeWalk.Stop.ALREADY_ENTERED,
+                new PathEngine.Leaves.Unread(InvariantChecker.Borne.BY_SOME_VALUES));
+
+        Map<GuaranteeWalk.Stop, PathEngine.Leaves> answered = new LinkedHashMap<>();
+        for (GuaranteeWalk.Stop stop : GuaranteeWalk.Stop.values()) {
+            answered.put(stop, PathEngine.leftBy(stop));
+        }
+
+        assertEquals(expected, answered,
+                "what each way of stopping leaves is what the words downstream of it mean");
+    }
+
+    /**
+     * And exactly one of them hands the rules on.
+     *
+     * <p>Said apart from the table, because it is the fact the words are about rather than a second
+     * spelling of them. A second arm on that side is a second way for a position to be discharged
+     * by a reading somebody has to have opened, and whoever adds one has to say who opens it.
+     */
+    @Test
+    void oneWayOfStoppingHandsTheRulesToAnotherReading() {
+        long handing = java.util.Arrays.stream(GuaranteeWalk.Stop.values())
+                .map(PathEngine::leftBy)
+                .filter(each -> each instanceof PathEngine.Leaves.ToAnotherReading)
+                .count();
+
+        assertEquals(1, handing,
+                "each of these is a position somebody has to be shown to have read");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/TakingRulesOverIsSaidAndNotInferredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/TakingRulesOverIsSaidAndNotInferredTest.java
@@ -99,6 +99,27 @@ class TakingRulesOverIsSaidAndNotInferredTest {
         assertFalse(handoffs.unresolvedAt(HANDS_ON), "and now both of them were opened");
     }
 
+    /**
+     * One position, one reading answering for its rules.
+     *
+     * <p>Which reading that is follows from where the descent last crossed an ownership boundary, so
+     * it is a function of the path. Everything here carries the pair and one step does not:
+     * {@link RuleHandoffs#unresolvedAt} asks by position alone. That projection is safe only while
+     * this holds, so it is refused rather than assumed — a handoff owed by a reading nobody kept
+     * would otherwise leave somebody else's position short, which is this issue's own shape.
+     */
+    @Test
+    void twoReadingsCannotAnswerForTheRulesAtOnePosition() {
+        RuleHandoffs handoffs = new RuleHandoffs();
+        handoffs.owes(P, HANDS_ON);
+
+        handoffs.owes(P, HANDS_ON);
+
+        assertThrows(IllegalStateException.class,
+                () -> handoffs.owes(P.then("elsewhere"), HANDS_ON),
+                "a second reading answering for one position is this walk contradicting itself");
+    }
+
     /** A value whose own clause could not be typed, held behind an optional. What is short is the
      *  reading of that value, and the optional above it handed the rules to exactly that reading. */
     private static final String THE_READING_OPENED_IS_SHORT = """

--- a/souther-compiler/src/test/java/souther/compiler/inputs/TakingRulesOverIsSaidAndNotInferredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/TakingRulesOverIsSaidAndNotInferredTest.java
@@ -1,0 +1,156 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A reading that ends with rules under it still to be read is discharged by something saying it
+ * took them, and never by something being there.
+ *
+ * <p>The defect this is written against was the other reading of the same evidence. A position was
+ * called short of its rules because a rule stood somewhere under its type, and the walk had gone to
+ * that rule one position down — so the shortfall was worked out from the type graph rather than from
+ * what the walk did (#1072). Repaired by asking whether a reading exists under the path, it would be
+ * the same mistake pointed the other way: a reading opened under the position for some other reason
+ * would discharge an obligation it never heard of, and "no failure is visible here" would again be
+ * standing in for "everything was read".
+ *
+ * <p>So the three things below are what a discharge is. Something has to have been passed the rules,
+ * everything that was passed them has to have been opened, and opening them is the whole of it — a
+ * reading that took the rules over and then came back short of something reports that itself, at its
+ * own position, and reporting it again above would be one gap counted at two places.
+ */
+class TakingRulesOverIsSaidAndNotInferredTest {
+
+    private static final TermPath P = TermPath.of("p");
+    private static final TermPath HANDS_ON = P.then("x");
+
+    /**
+     * A reading opened somewhere nobody handed anything to discharges nothing.
+     *
+     * <p>Refused rather than ignored. A descent that opens a reading at a position the handoff never
+     * named is a descent disagreeing with the one that enumerated the children, and the two are the
+     * same walk — so this is a fault in the compiler and not a state of the model.
+     */
+    @Test
+    void aReadingNobodyPassedTheRulesToDischargesNothing() {
+        RuleHandoffs handoffs = new RuleHandoffs();
+        handoffs.owes(P, HANDS_ON);
+        handoffs.passesTo(P, HANDS_ON, List.of(HANDS_ON.element()));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> handoffs.accepts(P, HANDS_ON, P.then("y")),
+                "a reading at a position this handoff never named is not one it passed rules to");
+        assertTrue(handoffs.unresolvedAt(HANDS_ON),
+                "and the handoff is where it was");
+    }
+
+    /** And a handoff no descent ever reached stands however many readings were opened elsewhere. */
+    @Test
+    void aHandoffNoDescentReachedStandsWhateverElseWasRead() {
+        RuleHandoffs handoffs = new RuleHandoffs();
+        handoffs.owes(P, HANDS_ON);
+        TermPath elsewhere = P.then("y");
+        handoffs.owes(P, elsewhere);
+        handoffs.passesTo(P, elsewhere, List.of(elsewhere.element()));
+        handoffs.accepts(P, elsewhere, elsewhere.element());
+
+        assertFalse(handoffs.unresolvedAt(elsewhere), "that one was passed on and taken");
+        assertTrue(handoffs.unresolvedAt(HANDS_ON),
+                "and this one was never passed to anybody, whatever happened beside it");
+    }
+
+    /**
+     * Every position the rules were passed to has to have been opened, and not merely one of them.
+     *
+     * <p>A sum passes the rules of each case to that case. A case nothing walked has left the rules
+     * written on it unread however well the case beside it went, and a handoff counted as met by the
+     * first reading to arrive would say the sum had been read to the end.
+     */
+    @Test
+    void aHandoffIsMetOnlyWhenEveryPositionItPassedToWasOpened() {
+        RuleHandoffs handoffs = new RuleHandoffs();
+        handoffs.owes(P, HANDS_ON);
+        TermPath one = HANDS_ON.then("a");
+        TermPath other = HANDS_ON.then("b");
+        handoffs.passesTo(P, HANDS_ON, List.of(one, other));
+
+        handoffs.accepts(P, HANDS_ON, one);
+        assertTrue(handoffs.unresolvedAt(HANDS_ON), "the other case was passed the rules too");
+
+        handoffs.accepts(P, HANDS_ON, other);
+        assertFalse(handoffs.unresolvedAt(HANDS_ON), "and now both of them were opened");
+    }
+
+    /** A value whose own clause could not be typed, held behind an optional. What is short is the
+     *  reading of that value, and the optional above it handed the rules to exactly that reading. */
+    private static final String THE_READING_OPENED_IS_SHORT = """
+            module example.short
+
+            data Inner = String
+                invariant no = value == 1
+
+            data P = { x: Inner? }
+
+            data Taken
+
+            behavior take : (p: P) -> Taken
+            """;
+
+    /**
+     * Handing the rules over is not the same as reading them.
+     *
+     * <p>The reading opened at the narrowing is short of {@code Inner}'s own clause, which nothing
+     * could type. That is reported where it happened, and the position that passed the rules to it is
+     * short of nothing: the rules reached a reader, and saying so again above would be one gap
+     * counted at two positions and named at the one an author cannot act on.
+     */
+    @Test
+    void aReadingThatTookTheRulesOverAndCameBackShortIsShortByItself() {
+        InputDomain read = read(THE_READING_OPENED_IS_SHORT);
+
+        assertFalse(read.at(TermPath.of("p").then("x")).rulesNotReached(),
+                "the optional passed the rules on and something took them");
+        assertTrue(shortSomewhereUnder(read, TermPath.of("p").then("x")),
+                "and the reading that took them says what it could not read");
+    }
+
+    private static boolean shortSomewhereUnder(InputDomain read, TermPath above) {
+        return read.positions().stream()
+                .anyMatch(each -> !each.path().equals(above)
+                        && each.path().toString().startsWith(above.toString())
+                        && each.rulesNotReached());
+    }
+
+    private static InputDomain read(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals("take")).findFirst().orElseThrow();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        InputDomain read = InputDomain.of(spec, sigs.get("take"), symbols,
+                ReadAs.THE_COMPILATION_DOES);
+        assertNotNull(read, "the model under test compiles");
+        return read;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/WhatASequenceHoldsIsAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/WhatASequenceHoldsIsAPositionTest.java
@@ -121,14 +121,20 @@ class WhatASequenceHoldsIsAPositionTest {
     }
 
     /**
-     * Where a clause does state something of every element, that is what is short.
+     * Where a clause does state something of every element, it is the sequence that is short of it.
      *
      * <p>A relation over every element is held as a quantifier over the clause it was written in,
-     * and nothing here places one at the position it is about — so the position's rules were not
-     * reached, and an absence may not follow from finding no division at it.
+     * and nothing here places one at the position it is about. What that leaves is a question the
+     * model raised about the sequence and nothing answered — and the sequence is where the clause is
+     * written, which is what an author would edit.
+     *
+     * <p>Said at the element instead, one rule was short at two positions: the elements carry
+     * readings of their own now, and what {@code Person} states about itself is read there. So an
+     * element reported as a position nothing had read was reporting the container's clause under the
+     * element's name, and no row written at the element could ever discharge it (#1072).
      */
     @Test
-    void aClauseStatedOfEveryElementIsWhatGoesUnreached() {
+    void aClauseStatedOfEveryElementIsShortAtTheSequenceItIsWrittenAbout() {
         Compilation compilation = Compilation.ofSource("""
                 module example.roster
 
@@ -148,10 +154,12 @@ class WhatASequenceHoldsIsAPositionTest {
         InputDomain read = compilation.db().ask(new Adequacy.Inputs(MODULE)).value().get("roster");
         assertNotNull(read, "the model under test compiles");
 
-        assertTrue(read.at(pathTo("people", "[*]")).rulesNotReached(),
-                "the clause states something of every element and nothing placed it there");
+        assertFalse(read.at(pathTo("people", "[*]")).rulesNotReached(),
+                "the element is read by a reading of its own, and this clause is not its");
         assertFalse(read.positions().get(0).rulesNotReached(),
-                "while the list itself was read: the clause is written about it");
+                "and the list itself was read: the clause is written about it and arrived");
+        assertFalse(read.positions().get(0).unansweredQuestions().isEmpty(),
+                "what the clause leaves is a question about the list that nothing answered");
     }
 
     /** {@code head} with the steps spelled, for a lookup by the coordinate a report names. */

--- a/souther-compiler/src/test/java/souther/compiler/inputs/WhatRelatesTwoPositionsIsNotMovedByWhatIsReadUnderOneOfThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/WhatRelatesTwoPositionsIsNotMovedByWhatIsReadUnderOneOfThemTest.java
@@ -1,0 +1,165 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.check.Prepared;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ReadAs;
+import souther.compiler.query.Scopes;
+import souther.compiler.query.Shapes;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Where two positions of an input stand against each other is settled by the clauses relating them,
+ * and by nothing that is read underneath either one.
+ *
+ * <p>Which reading owns the rules of a value and which readings a quantity is asked over are
+ * different questions, and the second is the one this holds. A reading begun under a position — at
+ * the narrowing that says an optional holds something, at the element a sequence holds — is there to
+ * read what that value's own declaration states. It is not a party to a relation written above it:
+ * a clause relating two fields of a record is written in that record, so the reading of the record
+ * is what carries it, and a reading opened below one of the fields carries nothing of it either way.
+ *
+ * <p>So the answers below are the same whether or not such a reading exists. Held against sources
+ * and over the quantities themselves, because the thing that could go wrong is not a wrong number
+ * but a right number arrived at from a different set of readings: a relation that survived only
+ * because the readings it was collected from happened to be the roots of the walk would move the day
+ * the walk opens a root somewhere else.
+ *
+ * <p><b>What this refuses is a coincidence, not a value.</b> {@link InputDomain#quantities} takes the
+ * roots of the rule reading and uses them twice — as where the clauses come from, and as the
+ * positions a quantity may be asked about. Nothing says those two are one set. This is what says
+ * that adding to the first does not move what the second answers.
+ */
+class WhatRelatesTwoPositionsIsNotMovedByWhatIsReadUnderOneOfThemTest {
+
+    /**
+     * Two fields the record holds together, with a sequence of a rule-carrying type beside them.
+     *
+     * <p>The sequence is what makes the model say anything here. Its element is a value with a
+     * declaration of its own, which is a reading waiting to be opened under a position — and the two
+     * numbers the record relates are nowhere near it.
+     */
+    private static final String RELATED_BESIDE_A_SEQUENCE = """
+            module example.beside
+
+            data Tag = String
+                invariant nonEmpty = String.length(value) >= 1
+
+            data N = Int
+                invariant atLeastNone = value >= 0
+                invariant atMostFive  = value <= 5
+
+            data P = { x: N, y: N, tags: List<Tag> }
+                invariant together = x.value + y.value <= 5
+
+            data Taken
+
+            behavior take : (p: P) -> Taken
+            """;
+
+    /**
+     * A relation the record writes about the sequence itself.
+     *
+     * <p>The sharper of the two. What the record says here is about how many the sequence holds,
+     * which is a number at the sequence's own position — so a reading opened at the element stands
+     * between the clause and the position it is about, and a quantity collected from the readings
+     * rather than from the clauses would lose it.
+     */
+    private static final String COUNTED_AGAINST_A_FIELD = """
+            module example.counted
+
+            data Tag = String
+                invariant nonEmpty = String.length(value) >= 1
+
+            data N = Int
+                invariant atLeastNone = value >= 0
+                invariant atMostFive  = value <= 5
+
+            data P = { cap: N, tags: List<Tag> }
+                invariant capped = List.length(tags) <= cap.value
+
+            data Taken
+
+            behavior take : (p: P) -> Taken
+            """;
+
+    private static final NumericTerm X = new NumericTerm.ValueOf(TermPath.of("p").then("x"));
+    private static final NumericTerm Y = new NumericTerm.ValueOf(TermPath.of("p").then("y"));
+    private static final NumericTerm CAP = new NumericTerm.ValueOf(TermPath.of("p").then("cap"));
+
+    /** A relation between two fields is what it is, whatever stands in the field beside them. */
+    @Test
+    void aRelationBetweenTwoFieldsStandsBesideASequenceOfADeclaredType() {
+        Quantities read = read(RELATED_BESIDE_A_SEQUENCE).quantities();
+
+        assertEquals(bounds(0, 5), read.runsBetween(Y),
+                "read a position at a time, y runs the whole of what its own type allows");
+        assertEquals(bounds(0, 1), read.given(X, count(4)).runsBetween(Y),
+                "and the record's clause is what takes the rest of it away");
+    }
+
+    /** And a relation about how many a sequence holds is asked at the sequence's own position. */
+    @Test
+    void aRelationAboutHowManyASequenceHoldsIsAskedAtTheSequence() {
+        Read read = read(COUNTED_AGAINST_A_FIELD);
+        NumericTerm tags = size(read, "tags");
+
+        assertEquals(Endpoint.inclusive(count(0)), read.quantities().runsBetween(tags).min(),
+                "a sequence holds none or more");
+        assertEquals(bounds(0, 2), read.quantities().given(CAP, count(2)).runsBetween(tags),
+                "and the record's clause is what puts a ceiling on it");
+    }
+
+    /** The term for the number that counts what stands at {@code field}, built the way the compiler
+     *  builds one: through the factory that holds the operation to what is there. */
+    private static NumericTerm size(Read read, String field) {
+        TermPath at = TermPath.of("p").then(field);
+        souther.compiler.types.Type type = read.inputs().at(at).type();
+        NumericTerm.TakenOf made = NumericTerm.TakenOf.of(
+                souther.compiler.check.NumericMeasures.takenOf(type, read.symbols()),
+                at, type, read.symbols());
+        assertNotNull(made, at + " is counted by what its type is counted by");
+        return made;
+    }
+
+    private static Count count(int at) {
+        return new Count(BigDecimal.valueOf(at));
+    }
+
+    private static NumericDomain.Bounds bounds(int least, int most) {
+        return new NumericDomain.Bounds(Endpoint.inclusive(count(least)),
+                Endpoint.inclusive(count(most)));
+    }
+
+    private record Read(InputDomain inputs, Symbols symbols) {
+        Quantities quantities() {
+            return inputs.quantities(symbols);
+        }
+    }
+
+    private static Read read(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Prepared prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Hir.SpecBehavior spec = (Hir.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals("take")).findFirst().orElseThrow();
+        Symbols symbols = Scopes.derived(compilation.db(), module).value();
+        return new Read(InputDomain.of(spec, sigs.get("take"), symbols,
+                ReadAs.THE_COMPILATION_DOES), symbols);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/RulesUnderAContainerAreReachedWhereTheyGovernTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/RulesUnderAContainerAreReachedWhereTheyGovernTest.java
@@ -1,0 +1,183 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.PartitionEvidence;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A rule written under a container is read where it governs, and the position above it is short of
+ * nothing for it.
+ *
+ * <p>What a declaration states is stated about values of that declaration. An optional holds one or
+ * holds none, a sum is one of its cases, a sequence holds however many — and in none of those is the
+ * rule of the thing held a rule about every value standing at the position above. So the reading of
+ * that rule belongs one position down, where a row meets it and a border is owed against it, and the
+ * position above has read everything that was ever addressed to it.
+ *
+ * <p>Read the other way, the position above reported a rule it never reached and no row could
+ * discharge it: the walk had gone to the rule, one position down, and the accounting was working out
+ * for itself that a rule stood somewhere under the type. A measure short of something nobody can
+ * supply is short for good (#1072).
+ *
+ * <p><b>Three shapes and one claim.</b> The claim is about where a rule is read and not about
+ * containers, so it is written against each shape this compiler descends through rather than against
+ * the one the defect was found on. What each of them asserts is the same two things: the position
+ * below carries the classes the rule draws, and the measure is weakened by nothing.
+ */
+class RulesUnderAContainerAreReachedWhereTheyGovernTest {
+
+    /** A rule that names values, so that reaching it is visible as classes and not only as a word
+     *  about how far a reading got. */
+    private static final String TAG = """
+                data Tag = String
+                    invariant named = value == "a" || value == "b"
+            """;
+
+    private static final String OPTIONAL = """
+            module example.optional
+            """ + TAG + """
+            data Query = { tag: Tag?, other: Int }
+            data Page = { count: Int }
+
+            behavior read : (query: Query) -> Page
+                constructs Page
+            let read (query) = Page { count = 0 }
+
+            example read
+                | "with"    : (Query { tag = Tag("a"), other = 0 }) -> Page { count = 0 }
+                | "without" : (Query { other = 0 }) -> Page { count = 0 }
+            """;
+
+    private static final String SUM = """
+            module example.sum
+            """ + TAG + """
+            data NoTag
+            data Filter = Tag | NoTag
+            data Query = { tag: Filter, other: Int }
+            data Page = { count: Int }
+
+            behavior read : (query: Query) -> Page
+                constructs Page
+            let read (query) = Page { count = 0 }
+
+            example read
+                | "tagged"   : (Query { tag = Tag("a"), other = 0 }) -> Page { count = 0 }
+                | "untagged" : (Query { tag = NoTag, other = 0 }) -> Page { count = 0 }
+            """;
+
+    private static final String SEQUENCE = """
+            module example.sequence
+            """ + TAG + """
+            data Query = { tags: List<Tag>, other: Int }
+            data Page = { count: Int }
+
+            behavior read : (query: Query) -> Page
+                constructs Page
+            let read (query) = Page { count = 0 }
+
+            example read
+                | "one" : (Query { tags = [ Tag("a") ], other = 0 }) -> Page { count = 0 }
+            """;
+
+    /**
+     * What an optional holds is read at the narrowing that says it holds something.
+     *
+     * <p>And the optional itself divides into the two ways it can turn out, with every rule ever
+     * addressed to it read: there is no clause about a value that may not be there.
+     */
+    @Test
+    void aRuleBehindAnOptionalIsReadAtTheNarrowing() {
+        PartitionEvidence read = evidenceFor(OPTIONAL);
+
+        assertEquals(List.of("\"a\"", "\"b\""), classesAt(read, "query.tag@Some"),
+                "the rule of the type behind the `?` draws the classes at the narrowing");
+        assertReadToTheEnd(read, "query.tag");
+        assertReadToTheEnd(read, "query.tag@Some");
+        assertNothingIsOutOfSight(read);
+    }
+
+    /** A rule on one case of a sum is read at that case. */
+    @Test
+    void aRuleOnOneCaseOfASumIsReadAtTheCase() {
+        PartitionEvidence read = evidenceFor(SUM);
+
+        assertEquals(List.of("\"a\"", "\"b\""), classesAt(read, "query.tag@Tag"),
+                "the case's own rule draws the classes at the case");
+        assertReadToTheEnd(read, "query.tag");
+        assertReadToTheEnd(read, "query.tag@Tag");
+        assertNothingIsOutOfSight(read);
+    }
+
+    /**
+     * And a rule on what a sequence holds is read at the element.
+     *
+     * <p>The element is a value with a declaration of its own, exactly as what stands under a
+     * narrowing is. Read as the sequence's own business, the rule reached no position at all: the
+     * model divided nowhere and the report named two positions it had not read, one of them the
+     * element the border was nevertheless owed at.
+     */
+    @Test
+    void aRuleOnWhatASequenceHoldsIsReadAtTheElement() {
+        PartitionEvidence read = evidenceFor(SEQUENCE);
+
+        assertEquals(List.of("\"a\"", "\"b\""), classesAt(read, "query.tags[*]"),
+                "the element's own rule draws the classes at the element");
+        // And not at the sequence itself, which has no axis: nothing bounds how many it holds, so
+        // the model divides it nowhere. What is asserted of it is that nothing is out of sight
+        // there, which is the line below.
+        assertReadToTheEnd(read, "query.tags[*]");
+        assertNothingIsOutOfSight(read);
+    }
+
+    /** The classes the model divides one position into, in the order the reading answers them. */
+    private static List<String> classesAt(PartitionEvidence read, String path) {
+        return List.copyOf(axisAt(read, path).classes());
+    }
+
+    /** That the reading at one position was short of no rule, which is what no row can supply. */
+    private static void assertReadToTheEnd(PartitionEvidence read, String path) {
+        assertEquals(PartitionEvidence.AxisCoverage.Reach.EVERY_RULE, axisAt(read, path).read().reach(),
+                () -> "how far the rules at " + path + " were read");
+    }
+
+    private static PartitionEvidence.AxisCoverage axisAt(PartitionEvidence read, String path) {
+        PartitionEvidence.AxisCoverage found = read.axes().stream()
+                .filter(each -> each.path().equals(path)).findFirst().orElse(null);
+        assertNotNull(found, () -> path + " is not among "
+                + read.axes().stream().map(PartitionEvidence.AxisCoverage::path).toList());
+        return found;
+    }
+
+    /**
+     * And that the measure as a whole is weakened by nothing.
+     *
+     * <p>Beside the positions rather than instead of them. A position asserted read to the end says
+     * nothing about a second position the same walk gave up on, and what an author is told is that
+     * the measure is partial — so the claim these models make is that there is no such position
+     * anywhere in them.
+     */
+    private static void assertNothingIsOutOfSight(PartitionEvidence read) {
+        assertTrue(read.weakening().isEmpty(),
+                () -> "the measure is weakened by " + read.weakening());
+        assertEquals(List.of(), read.notRead(),
+                () -> "and nothing was left unread");
+    }
+
+    private static PartitionEvidence evidenceFor(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, PartitionEvidence> partitions = compilation.db()
+                .ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
+        return partitions.get("read");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatWasNotReadIsSaidByWhoeverKnowsWhichRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatWasNotReadIsSaidByWhoeverKnowsWhichRuleTest.java
@@ -44,21 +44,27 @@ class WhatWasNotReadIsSaidByWhoeverKnowsWhichRuleTest {
     /**
      * A position whose rules the reading never arrived at.
      *
-     * <p>The clause states a relation of every element and is held as a quantifier over the clause
-     * it was written in; nothing places one at the position it is about. So there is a rule and no
-     * reader that reached it, which is what leaves a position with no rule to name.
+     * <p>The clause states nothing that could be typed, so it is gone before any reading of the
+     * value sees it and which position it governed goes with it. So there is a rule and no reader
+     * that reached it, which is what leaves a position with no rule to name.
+     *
+     * <p>It used to be a relation stated of every element, held as a quantifier over the clause it
+     * was written in. That clause is written about the sequence and is now short where it is
+     * written, which is a question the model raised and nothing answered rather than a position
+     * nothing read (#1072).
      */
     private static final String A_POSITION = """
             module m
 
             data Ok
-            data Item = { charge: Int }
-            data Basket = List<Item>
-                invariant charged = List.all(i -> i.charge >= 1, value)
+            data Item = String
+                invariant unreadable = value == 1
 
-            behavior f : (items: Basket) -> Ok
+            data Basket = { item: Item }
+
+            behavior f : (b: Basket) -> Ok
                 constructs Ok
-            let f (items) = Ok
+            let f (b) = Ok
             """;
 
     /** A rule finding names the rule, and is told under the word for a rule. */
@@ -75,10 +81,9 @@ class WhatWasNotReadIsSaidByWhoeverKnowsWhichRuleTest {
     /**
      * And a position finding names no rule, because nothing observed one.
      *
-     * <p>The clause is stated of every element, and what holds it is the quantifier rather than
-     * the position — so what stopped this is the reading and not any one clause, and what is said
-     * is the position alone. The shape has nowhere to put a rule, which is what stops one being
-     * invented.
+     * <p>The clause reached no reading at all, so what stopped this is the reading and not any one
+     * clause it can name, and what is said is the position alone. The shape has nowhere to put a
+     * rule, which is what stops one being invented.
      */
     @Test
     void aPositionTheReadingDidNotReachNamesNoRule() {
@@ -104,7 +109,7 @@ class WhatWasNotReadIsSaidByWhoeverKnowsWhichRuleTest {
     void theTwoAreWrittenApart() {
         assertTrue(human(A_RULE).contains("not read: comparison@"), human(A_RULE));
         assertFalse(human(A_RULE).contains("not read: n "), human(A_RULE));
-        assertTrue(human(A_POSITION).contains("not read: items[*].charge ("), human(A_POSITION));
+        assertTrue(human(A_POSITION).contains("not read: b.item ("), human(A_POSITION));
     }
 
     private static List<Adequacy.Kind> kinds(String model) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatWasNotReadIsSaidByWhoeverKnowsWhichRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatWasNotReadIsSaidByWhoeverKnowsWhichRuleTest.java
@@ -137,4 +137,32 @@ class WhatWasNotReadIsSaidByWhoeverKnowsWhichRuleTest {
         compilation.answerEverything();
         return AdequacyReport.of(compilation);
     }
+    /**
+     * And the model that leaves a rule unread at a position it measured is one this compiler
+     * refuses.
+     *
+     * <p>Said out loud, because it is what the word means now and not an accident of the fixture.
+     * A rule written under a container, a case or an optional is read where it governs, one position
+     * down (#1072); a rule this compiler cannot find a value for is a shortfall of its own. What is
+     * left is a clause the front end could not type — and a model carrying one is refused, so a
+     * document that says a measured position went short of a rule is a document about a model that
+     * did not compile.
+     *
+     * <p>A tripwire and not a preference. The day a clause can go unread in a model that compiles,
+     * this fails and whoever made it so is the one who should decide what the word means then.
+     */
+    @Test
+    void theModelThatSaysSoIsOneThisCompilerRefuses() {
+        assertTrue(isRefused(A_POSITION), A_POSITION);
+        assertFalse(isRefused(A_RULE), "and a rule read and given up on is not that");
+    }
+
+    /** Whether this compiler refuses {@code source}, which is what the fixture above turns on. */
+    private static boolean isRefused(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        return !compilation.diagnostics().values().stream()
+                .flatMap(java.util.List::stream).toList().isEmpty();
+    }
+
 }

--- a/souther-compiler/src/test/java/souther/compiler/report/AWordTheSchemaAdmitsIsOneADocumentCarriesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/AWordTheSchemaAdmitsIsOneADocumentCarriesTest.java
@@ -52,13 +52,10 @@ class AWordTheSchemaAdmitsIsOneADocumentCarriesTest {
     /**
      * A position the walk reached, whose rules it did not.
      *
-     * <p>What a list holds is a position, and nothing this reading does places a rule at it. The
-     * elements a combinator hands a closure are named where the operation still stands, so a
-     * comparison written inside one is read; a relation stated of every element by an
-     * {@code invariant} is held as a quantifier over the clause and is not, and the model below has
-     * only the second. So the word is the one for a position whose rules were never arrived at, and
-     * not the one for values held inside something the walk does not reach into: the reaching was
-     * made.
+     * <p>The clause below states nothing that could be typed, so it never reaches a reading and
+     * which position it governed is exactly what is unknown about it. So the word is the one for a
+     * position whose rules were never arrived at, and not the one for values held inside something
+     * the walk does not reach into: the reaching was made.
      *
      * <p>This model used to carry {@code unsupported_traversal}, and it was the only model here
      * that did. What is left carrying that word is an {@code Option} and a {@code Map}, and no
@@ -73,11 +70,11 @@ class AWordTheSchemaAdmitsIsOneADocumentCarriesTest {
         String json = reportOf("""
                 module demo
                 data Ok
-                data Item = { charge: Int }
-                data Basket = List<Item>
-                    invariant List.all(i -> i.charge >= 1, value)
-                behavior run : (items: Basket) -> Ok
-                let run (items) = Ok
+                data Item = String
+                    invariant unreadable = value == 1
+                data Basket = { item: Item }
+                behavior run : (b: Basket) -> Ok
+                let run (b) = Ok
                 """);
 
         assertTrue(json.contains("\"rules_not_read_at_all\""), json);

--- a/souther-compiler/src/test/java/souther/compiler/report/AWordTheSchemaAdmitsIsOneADocumentCarriesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/AWordTheSchemaAdmitsIsOneADocumentCarriesTest.java
@@ -65,19 +65,41 @@ class AWordTheSchemaAdmitsIsOneADocumentCarriesTest {
      * what still holds it to meaning one thing is the projection that writes it
      * ({@link souther.compiler.partition.ReportedReason}), tested where that is.
      */
+    private static final String RULES_NEVER_ARRIVED_AT = """
+            module demo
+            data Ok
+            data Item = String
+                invariant unreadable = value == 1
+            data Basket = { item: Item }
+            behavior run : (b: Basket) -> Ok
+            let run (b) = Ok
+            """;
+
     @Test
     void aPositionWhoseRulesTheReadingNeverArrivedAtIsWrittenAsThatWord() {
-        String json = reportOf("""
-                module demo
-                data Ok
-                data Item = String
-                    invariant unreadable = value == 1
-                data Basket = { item: Item }
-                behavior run : (b: Basket) -> Ok
-                let run (b) = Ok
-                """);
+        String json = reportOf(RULES_NEVER_ARRIVED_AT);
 
         assertTrue(json.contains("\"rules_not_read_at_all\""), json);
         assertFalse(json.contains("\"unsupported_traversal\""), json);
     }
+    /**
+     * And the model that carries the word is one this compiler refuses.
+     *
+     * <p>Said out loud, because it is what the word means now and not an accident of the fixture.
+     * A rule written under a container, a case or an optional is read where it governs, one position
+     * down (#1072). What is left that can go unread at a position this reading arrived at is a
+     * clause the front end could not type, and a model carrying one is refused.
+     *
+     * <p>A tripwire and not a preference. The day a clause can go unread in a model that compiles,
+     * this fails and whoever made it so is the one who should decide what the word means then.
+     */
+    @Test
+    void theModelThatCarriesThatWordIsOneThisCompilerRefuses() {
+        Compilation compilation = Compilation.ofSource(RULES_NEVER_ARRIVED_AT, "Main");
+        compilation.answerEverything();
+        assertFalse(compilation.diagnostics().values().stream()
+                        .flatMap(java.util.List::stream).toList().isEmpty(),
+                "a position whose rules never arrived takes a clause nothing could type");
+    }
+
 }

--- a/souther-compiler/src/test/java/souther/compiler/report/WhatAWholeWentWithoutIsWhatItsPartsWentWithoutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/WhatAWholeWentWithoutIsWhatItsPartsWentWithoutTest.java
@@ -44,6 +44,15 @@ class WhatAWholeWentWithoutIsWhatItsPartsWentWithoutTest {
      * <p>Each is a different way for a fact to arrive, and a whole that dropped one of them is what
      * this is looking for — so a model producing only one kind would hold the rule over one path
      * and say nothing about the rest.
+     *
+     * <p>The mapping is what leaves a reading short. What it holds is a value this compiler does not
+     * name a position for, so {@code Amount}'s rule is written under a position no reading is ever
+     * opened at — and nothing a row does reaches it.
+     *
+     * <p>It used to be an {@code Assignee?} with a clause behind the option. That clause is read at
+     * the narrowing, where a row meets it and a border is owed against it, so the model went short of
+     * nothing (#1072). What is wanted here is a reading that really did not happen, which is what a
+     * mapping still is.
      */
     private static final String MODEL = """
             module example.whole
@@ -51,9 +60,9 @@ class WhatAWholeWentWithoutIsWhatItsPartsWentWithoutTest {
             data Draft = { n: Int }
             data Done = { n: Int }
             data Small = { n: Int }
-            data Assignee = String
-                invariant String.length(value) >= 1
-            data Issue = { assignee: Assignee? }
+            data Amount = Int
+                invariant ranged = value >= 0
+            data Issue = { cost: Map<String, Amount> }
 
             partial let spin (n: Int): Int = spin(n)
 

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
@@ -2,7 +2,7 @@
   "schemaVersion" : 7,
   "compilerVersion" : "<version>",
   "status" : "partial",
-  "weakening" : [ "rule_unread", "rules_not_reached" ],
+  "weakening" : [ "rule_unread" ],
   "adequacy" : "not_satisfied",
   "modules" : [ {
     "module" : "conformance.catalog",
@@ -220,7 +220,7 @@
   }, {
     "module" : "conformance.shipping",
     "status" : "partial",
-    "weakening" : [ "rules_not_reached", "rule_unread" ],
+    "weakening" : [ "rule_unread" ],
     "incompleteness" : [ ],
     "declarations" : [ {
       "name" : "Sku",
@@ -236,8 +236,7 @@
       "implementation" : "injected",
       "rows" : 6,
       "pending" : 6,
-      "status" : "partial",
-      "weakening" : [ "rules_not_reached" ],
+      "status" : "complete",
       "signature" : {
         "status" : "complete",
         "output" : {
@@ -257,12 +256,10 @@
       },
       "partition" : {
         "axesMeasure" : {
-          "status" : "partial",
-          "weakening" : [ "rules_not_reached" ]
+          "status" : "complete"
         },
         "boundariesMeasure" : {
-          "status" : "partial",
-          "weakening" : [ "rules_not_reached" ]
+          "status" : "complete"
         },
         "axes" : [ {
           "axis" : "台帳へ書く/指示.区分",
@@ -371,17 +368,18 @@
           "provenInfeasible" : 0,
           "unknown" : 0
         },
-        "notDerivable" : [ "指示.受付日", "指示.締切", "指示.集荷時刻", "指示.記録時刻" ],
-        "notRead" : [ {
-          "position" : "指示.品目",
-          "reason" : "rules_not_read_at_all"
-        } ]
+        "notDerivable" : [ "指示.品目", "指示.受付日", "指示.締切", "指示.集荷時刻", "指示.記録時刻" ],
+        "notRead" : [ ]
       },
       "branch" : {
         "status" : "unavailable",
         "reason" : "no_body"
       },
       "findings" : [ {
+        "kind" : "partition_not_derivable",
+        "disposition" : "reported",
+        "subject" : "指示.品目"
+      }, {
         "kind" : "partition_not_derivable",
         "disposition" : "reported",
         "subject" : "指示.受付日"
@@ -397,11 +395,6 @@
         "kind" : "partition_not_derivable",
         "disposition" : "reported",
         "subject" : "指示.記録時刻"
-      }, {
-        "kind" : "partition_not_read",
-        "disposition" : "reported",
-        "subject" : "指示.品目",
-        "reason" : "rules_not_read_at_all"
       } ]
     }, {
       "name" : "出荷する",
@@ -409,7 +402,7 @@
       "rows" : 10,
       "pending" : 0,
       "status" : "partial",
-      "weakening" : [ "rule_unread", "rules_not_reached" ],
+      "weakening" : [ "rule_unread" ],
       "signature" : {
         "status" : "complete",
         "output" : {
@@ -430,11 +423,11 @@
       "partition" : {
         "axesMeasure" : {
           "status" : "partial",
-          "weakening" : [ "rule_unread", "rules_not_reached" ]
+          "weakening" : [ "rule_unread" ]
         },
         "boundariesMeasure" : {
           "status" : "partial",
-          "weakening" : [ "rule_unread", "rules_not_reached" ]
+          "weakening" : [ "rule_unread" ]
         },
         "axes" : [ {
           "axis" : "出荷する/指示.重量",
@@ -643,7 +636,7 @@
           "provenInfeasible" : 0,
           "unknown" : 5
         },
-        "notDerivable" : [ "指示.記録時刻" ],
+        "notDerivable" : [ "指示.品目", "指示.記録時刻" ],
         "notRead" : [ {
           "position" : "指示.受付日",
           "reason" : "rule_about_a_derived_value",
@@ -666,9 +659,6 @@
             "ordinal" : 4,
             "lowered" : 0
           }
-        }, {
-          "position" : "指示.品目",
-          "reason" : "rules_not_read_at_all"
         } ]
       },
       "branch" : {
@@ -693,6 +683,10 @@
         "disposition" : "refused",
         "subject" : "出荷する/Time.hour(指示.集荷時刻) = 12",
         "code" : "E1916"
+      }, {
+        "kind" : "partition_not_derivable",
+        "disposition" : "reported",
+        "subject" : "指示.品目"
       }, {
         "kind" : "partition_not_derivable",
         "disposition" : "reported",
@@ -721,11 +715,6 @@
           "lowered" : 0
         },
         "reason" : "rule_about_a_derived_value"
-      }, {
-        "kind" : "partition_not_read",
-        "disposition" : "reported",
-        "subject" : "指示.品目",
-        "reason" : "rules_not_read_at_all"
       } ]
     } ]
   } ],


### PR DESCRIPTION
Closes #1072.

A reading of a value ends where no declaration stands to be read: at a container, at an optional, at
a choice between declarations. What is written under one of those is written about a value one
position down, and that is where this compiler already went — it opens a reading at the narrowing,
and a row meets the rule there. The accounting was working the shortfall out for itself from the
type graph (`anyRuleUnder`), so the position above was told a rule under it had not been reached.
No row could discharge it, because the walk had been to the rule already.

## The shape

A stop is a handing over, and it is discharged by something saying it took the rules.
`RuleHandoffs` holds one entry per (reading, position):

- the reading that stopped says it owes one (`owes`)
- the descent past the position says which values it is passing them to (`passesTo`), settled from
  the branches the position is owed at
- each reading actually opened says it took them (`accepts`)

Nothing is worked out afterwards from the readings that happen to exist under a path. A reading
opened there for some other purpose is not one anybody handed anything to, and letting it count
would read the absence of a failure as evidence that something was read — the same mistake as the
defect, pointed the other way. Accepting a position nobody named is refused rather than ignored:
two halves of one walk disagreeing is a fault here and not a state of the model.

Taking the rules over is not reading them. A reading that was opened and came back short reports
that itself, at its own position; the handoff above is met all the same. What leaves one standing is
that no reading was opened at all — a shape this compiler does not enter, a depth this walk stops
at, a value it has already been to.

Asked of the stop and never of `Borne`. What a stop leaves unread and whether it passes the rules on
agree today by coincidence, and reading the second off the first would make the coincidence the rule.

## What moved with it

**A sequence's element crosses the same boundary as a narrowing.** A clause is not written across
either: what `Tag` says about itself is written in `Tag`, whether the position is reached by
narrowing an optional or by being one of however many a list holds. Before this an element had no
reading of its own, so a list of a rule-carrying type divided nowhere — while the border at the
element was derived and owed from the very rule the report said was out of sight.

**A clause the container writes about its elements stays where it is written.**
`List.all(i -> i.charge >= 1, value)` is a rule about the sequence that nothing placed, which is a
question the model raised and nothing answered — at the sequence, where an author would edit it.
Lent to the element, one rule was short at two positions and was named at the one nobody could act on.

**A measured position short of a rule is a refused model.** After this, the only rule that can go
unread at a position the reading arrived at is a clause the front end could not type. The four
fixtures that produce the word now say so, with a compiling model beside them as the control, and
fail the day a clause can go unread in a model that compiles.

## Held to

- `RulesUnderAContainerAreReachedWhereTheyGovernTest` — optional, sum and sequence, each with a rule
  that names values, so reaching it is visible as classes and not only as a word about reach
- `TakingRulesOverIsSaidAndNotInferredTest` — a reading nobody passed the rules to discharges
  nothing; a handoff no descent reached stands whatever was read beside it; every position passed to
  has to have been opened; a reading that took the rules and came back short is short by itself
- `WhatRelatesTwoPositionsIsNotMovedByWhatIsReadUnderOneOfThemTest` — what relates two positions is
  settled by the clauses relating them and not by the readings a walk opened underneath either one,
  which is what the new element roots could have moved
- `AMeasureIsShortOfWhateverItsReadingDidNotReachTest` unchanged: a mapping is still a position
  nothing was reached into

The conformance corpus moves with it. A behavior whose only weakening was this sentence is complete,
and a list nothing bounds is a position the model divides nowhere rather than one whose rules went
unread.

#1084 is split out: a position this compiler cannot enter is written down as two weakenings, which
this change makes total rather than occasional but does not cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)