### PR TITLE
Ask the order where a row goes, rather than reading it off the cut

### DIFF
--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -49,7 +49,16 @@ final class AReportOfOneBorder {
 
     private AReportOfOneBorder() {}
 
-    /** A bound at 100 over a position the rules run from 1 to 1000, so all four points are owed. */
+    /**
+     * A bound at 100 over a position the rules run from 100 to 1000: a point against the line and a
+     * point away from it, both owed.
+     *
+     * <p>The line is where what the bound leaves stops, which is what makes it this position's lower
+     * end rather than a value inside it. Written as a bound at 100 over a run from 1, the fixture
+     * asked for a border no model draws — nothing is below a bound — and got one with an {@code ON}
+     * point at the line and an {@code IN} point over the whole run including the values the bound
+     * refuses.
+     */
     static Border aBoundedBorder() {
         OriginRef origin = new OriginRef.InvariantOrigin(new RuleRef.Invariant(new Clause.Ref(
                 new Clause.Id(TypeSymbols.declared(new TypeKey("example.rate", "Amount")), 0),
@@ -62,7 +71,7 @@ final class AReportOfOneBorder {
                         new souther.compiler.partition.Level.OnACarrier(Carrier.WHOLE,
                                 Count.of(100))),
                 origin,
-                new NumericDomain.Bounds(Endpoint.inclusive(Count.of(1)),
+                new NumericDomain.Bounds(Endpoint.inclusive(Count.of(100)),
                         Endpoint.inclusive(Count.of(1000))));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Band.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Band.java
@@ -221,10 +221,7 @@ public record Band(Seam under, Seam over, Bound from, Bound to) {
         if (end == null) {
             return "";
         }
-        Level at = end.at().asALevelOfTheQuantity();
-        if (at == null) {
-            return "";
-        }
+        Level at = valueOrRefuse(end);
         return side == Towards.ABOVE
                 ? of.writtenAt(at) + (end.inclusive() ? " <= " : " < ")
                 : (end.inclusive() ? " <= " : " < ") + of.writtenAt(at);
@@ -294,11 +291,25 @@ public record Band(Seam under, Seam over, Bound from, Bound to) {
     /** An end the rules leave, read on another order. Whether the run keeps the place it stops at
      *  is the end's own and does not move with it. */
     private static Bound mapped(Bound end, java.util.function.UnaryOperator<Level> onto) {
-        if (end == null) {
-            return null;
-        }
+        return end == null ? null : Bound.at(onto.apply(valueOrRefuse(end)), end.inclusive());
+    }
+
+    /**
+     * Where an end the rules leave stands, as a value of the quantity.
+     *
+     * <p>Always one. Such an end comes off a bound the rules wrote about the quantity itself, so it
+     * is at a level of it — unlike a line, which a rule may draw at a place the quantity stands at
+     * no value of ({@code 3 * d <= 1} cuts at a third). A place with no value has an answer where a
+     * line has one, and it has none here: there is no seam to name it by. So it is refused rather
+     * than written as no end at all, which would leave the run reaching past what the rules leave.
+     */
+    private static Level valueOrRefuse(Bound end) {
         Level at = end.at().asALevelOfTheQuantity();
-        return at == null ? null : Bound.at(onto.apply(at), end.inclusive());
+        if (at == null) {
+            throw new IllegalStateException(
+                    "an end the rules leave, at no value of the quantity: " + end);
+        }
+        return at;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Band.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Band.java
@@ -12,10 +12,16 @@ import souther.compiler.numeric.Towards;
  * @param under the seam this run starts above, or null where nothing parts it there
  * @param over  the seam it stops below, or null on the same reading
  * @param from  what the rules leave the quantity at the low end, which is where a run with no seam
- *              under it starts. Null where they leave it everything that way
+ *              under it starts. Null where they leave it everything that way.
+ *              <p>Where it stops and whether it keeps the place it stops at, and not the first value
+ *              in it. The two are one thing on a carrier that steps, because a strict end is moved
+ *              onto the value it leaves before it is ever read — and on one with no step there is no
+ *              such value: {@code value > 0.00m} leaves every decimal above zero and no least one.
+ *              Held as the value, such a run either ran to the end of the order or held the very
+ *              value its bound refuses, and the class it is came out spelled {@code 0 <= rate}
  * @param to    the same at the high end
  */
-public record Band(Seam under, Seam over, Level from, Level to) {
+public record Band(Seam under, Seam over, Bound from, Bound to) {
 
     /**
      * How this run reads: the first value in it and the last.
@@ -89,12 +95,24 @@ public record Band(Seam under, Seam over, Level from, Level to) {
 
     /** The first value in this run, or null where the order names none there. */
     public Level first() {
-        return under == null ? from : under.above();
+        return under == null ? valueAt(from) : under.above();
     }
 
     /** The last, on the same reading. */
     public Level last() {
-        return over == null ? to : over.below();
+        return over == null ? valueAt(to) : over.below();
+    }
+
+    /**
+     * The value an end the rules leave stands at, where the run holds it and the quantity has one
+     * there.
+     *
+     * <p>Null for an end the run stops short of, which is what a strict bound on a carrier with no
+     * step leaves: the run has no first value, and saying it starts at the bound's own would put the
+     * one value the rule refuses inside it.
+     */
+    private static Level valueAt(Bound end) {
+        return end == null || !end.inclusive() ? null : end.at().asALevelOfTheQuantity();
     }
 
     /**
@@ -121,12 +139,10 @@ public record Band(Seam under, Seam over, Level from, Level to) {
     public String written(BorderQuantity of, Level except) {
         String low = except != null && same(except, first())
                 ? of.writtenAt(except) + " < "
-                : under != null ? said(of, under, Towards.ABOVE)
-                        : from == null ? "" : of.writtenAt(from) + " <= ";
+                : under != null ? said(of, under, Towards.ABOVE) : leaves(of, from, Towards.ABOVE);
         String high = except != null && same(except, last())
                 ? " < " + of.writtenAt(except)
-                : over != null ? said(of, over, Towards.BELOW)
-                        : to == null ? "" : " <= " + of.writtenAt(to);
+                : over != null ? said(of, over, Towards.BELOW) : leaves(of, to, Towards.BELOW);
         // An end only the rule that drew it can name relates a row to the quantity rather than to
         // the position, so it is a condition of its own beside the rest. Dropped, the run read as
         // reaching past the very line that ends it.
@@ -193,6 +209,27 @@ public record Band(Seam under, Seam over, Level from, Level to) {
         return null;
     }
 
+    /**
+     * One end of the run as the rules leave it, where no line parts the values there.
+     *
+     * <p>The relation is the end's own: a bound that keeps the place it stops at reads {@code <=},
+     * and one that stops short of it reads {@code <}. Written as {@code <=} either way, the class a
+     * strict bound on a carrier with no step leaves was spelled as holding the very value the rule
+     * refuses.
+     */
+    private static String leaves(BorderQuantity of, Bound end, Towards side) {
+        if (end == null) {
+            return "";
+        }
+        Level at = end.at().asALevelOfTheQuantity();
+        if (at == null) {
+            return "";
+        }
+        return side == Towards.ABOVE
+                ? of.writtenAt(at) + (end.inclusive() ? " <= " : " < ")
+                : (end.inclusive() ? " <= " : " < ") + of.writtenAt(at);
+    }
+
     private static boolean same(Level one, Level other) {
         return one != null && other != null && one.key().equals(other.key());
     }
@@ -251,8 +288,17 @@ public record Band(Seam under, Seam over, Level from, Level to) {
         if (under != null && below == null || over != null && above == null) {
             return null;
         }
-        return new Band(below, above, from == null ? null : onto.apply(from),
-                to == null ? null : onto.apply(to));
+        return new Band(below, above, mapped(from, onto), mapped(to, onto));
+    }
+
+    /** An end the rules leave, read on another order. Whether the run keeps the place it stops at
+     *  is the end's own and does not move with it. */
+    private static Bound mapped(Bound end, java.util.function.UnaryOperator<Level> onto) {
+        if (end == null) {
+            return null;
+        }
+        Level at = end.at().asALevelOfTheQuantity();
+        return at == null ? null : Bound.at(onto.apply(at), end.inclusive());
     }
 
     /**
@@ -284,8 +330,7 @@ public record Band(Seam under, Seam over, Level from, Level to) {
      * what the rules leave at once. Read as one or the other, a run bounded by a rule and parted by
      * a line reached past whichever of them was not consulted.
      */
-    private static Bound endOf(Seam parted, Level leaves, Towards side) {
-        Bound left = leaves == null ? null : Bound.at(leaves, true);
+    private static Bound endOf(Seam parted, Bound left, Towards side) {
         if (parted == null) {
             return left;
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -233,7 +233,7 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
      * rows the same way, so they are one quantity and their lines are one arrangement.
      */
     public static java.util.List<Border> allOf(java.util.List<LineDrawn> drawn) {
-        return allOf(drawn, java.util.Map.of());
+        return allOf(drawn, java.util.Map.of(), new LinesRead());
     }
 
     /**
@@ -250,7 +250,8 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
      */
     public static java.util.List<Border> allOf(java.util.List<LineDrawn> drawn,
                                                java.util.Map<String,
-                                                       java.util.List<Seam>> alsoParted) {
+                                                       java.util.List<Seam>> alsoParted,
+                                               LinesRead read) {
         // Collected in the quantity's own units, because that is the only order the lines of one
         // quantity are all on. Two rules can write one quantity at two scales — `3a + 6b > 48` and
         // `a + 2b > 20` run the same way — and the numbers they carry are not comparable until both
@@ -282,9 +283,15 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
             // rules — a comparison whose line the quantity does not reach is no line, and says so
             // there ({@code ComparisonAssessment.OutsideTheDomain}) — so nothing here decides it
             // again and nothing is dropped for having come back empty.
+            //
+            // Written down as it is met and again where it lands. One line met twice by this
+            // reading is one line, which is why the second of two equal borders is not a border
+            // this reading lost — the account is asked of the lines and not of how many times the
+            // loop went round.
+            read.found(each.cuts().target(), each.by());
             Border made = at(each.cuts().target(), each.by(), each.cuts().within(), beside);
             if (out.stream().noneMatch(had -> had.equals(made))) {
-                out.add(made);
+                out.add(read.drew(made));
             }
         }
         return java.util.List.copyOf(out);
@@ -428,12 +435,7 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
                     throw new IllegalStateException(
                             "a bound whose line is not an end of what it leaves: " + origin.named());
                 }
-                // The point against the line, asked of the order and never read off the cut. The
-                // cut itself where the position holds it — which is every strict bound on a carrier
-                // that steps, the end having been moved onto the value it leaves before it got here
-                // — and the nearest value the rules leave otherwise. A carrier with no step names
-                // none, and then the technique's point cannot be written down at all.
-                Demand on = pointAt(space, cut, kept, holdsHere, within);
+                Demand on = againstABound(space, cut, kept, holdsHere, within, origin);
                 demands.put(PointRole.ON, on);
                 demands.put(PointRole.OFF, new Demand.NotOwed(NotOwedReason.THE_RULES_REFUSE_IT));
                 // The partition the bound bounds, without the value against the line. Everything
@@ -471,6 +473,43 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
             case THE_CARRIER_NAMES_NO_NEIGHBOUR -> throw new IllegalStateException(
                     "a line with no second side because of the order: " + origin.named());
         }
+    }
+
+    /**
+     * The point against a bound's line: the value a row inside it is written at, or why there is
+     * none.
+     *
+     * <p>Asked of the order and never read off the cut. Where the position holds the line's own
+     * value that value is the point, and where it does not the point is the nearest value the rules
+     * leave — which on a carrier with no step is no value at all, and then the technique's point
+     * cannot be written down.
+     *
+     * <p><b>And a bound that stops short of its own line where the order does name a value beside
+     * it is refused, not repaired.</b> Such an end is not canonical: a strict bound is moved onto
+     * the value it leaves where the carrier steps, by {@code InvariantBound} for a type's own clause
+     * and by the solver for what a record leaves, so {@code value > 5} on an {@code Int} reaches
+     * here as an inclusive 6 and never as an exclusive 5. Answered by stepping to the 6 here, this
+     * would be a third place that normalizes ends — and the day either of the two above stopped
+     * doing it, the border would come out right and nothing would say the reading had been repaired
+     * on its way through.
+     *
+     * <p>No carrier is asked. What tells the two apart is whether the order names a value on the
+     * side the bound keeps, which is the question the point is about anyway.
+     */
+    private static Demand againstABound(LevelSpace space, Level cut, Towards kept, boolean holdsHere,
+                                        NumericDomain.Bounds within, OriginRef origin) {
+        if (holdsHere) {
+            return pointAt(space, cut, kept, true, within);
+        }
+        Optional<Level> beside = beyond(space, cut, kept);
+        if (beside.isPresent()) {
+            throw new IllegalStateException(
+                    "a bound that stops short of its own line where the order names "
+                            + beside.get().key() + " beside it: " + origin.named()
+                            + " — an end this compiler could step was to have been stepped before"
+                            + " it got here");
+        }
+        return new Demand.NotOwed(NotOwedReason.THE_CARRIER_NAMES_NO_NEIGHBOUR);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -109,12 +109,16 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
     /**
      * The border a rule drew.
      *
-     * <p>Total. Whether the quantity reaches the line at all is {@link #reaches}, asked before this
-     * by whoever holds the rule, and a caller here has already had that answer — so there is no
-     * second reading of it and no way for one to come back empty. It used to be answered twice, and
-     * the answer here was a null the two callers dropped without a word: a rule of the model went
-     * unmeasured, nothing recorded that it had, and the measure came back saying the behavior's
-     * rules draw no line anywhere (issue #1079).
+     * <p>Total, and never null. Whether the quantity reaches the line is settled before this and by
+     * two different things: a comparison is asked through {@link #reaches} where its rule is read,
+     * and comes here only where the answer was yes ({@code ComparisonAssessment.OutsideTheDomain});
+     * a bound is not asked at all, because its line is an end of what it leaves and so is never
+     * outside it. The check below holds the second of those, which is an invariant of this compiler
+     * rather than anything a model states.
+     *
+     * <p>It used to be a third reading of the same question, answered with a null the two callers
+     * dropped without a word: a rule of the model went unmeasured, nothing recorded that it had, and
+     * the measure came back saying the behavior's rules draw no line anywhere (issue #1079).
      *
      * <p><b>Where the rule stops is not where a row is written.</b> The two are one value on a
      * carrier that steps, because a strict end is moved onto the value it leaves before it ever gets

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -107,18 +107,21 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
     }
 
     /**
-     * The border a rule drew, or null where the quantity does not reach the line.
+     * The border a rule drew.
      *
-     * <p>Null is the line and not one of its points. A rule draws where it draws about the type, and
-     * what the record holding the position leaves may stop short of it — {@code low < high} under one
-     * {@code [0, 1]} leaves {@code low} every value up to 1 and not 1 itself. There is no border
-     * then, and there never was one for a point to be owed at: a reading that dropped the value and
-     * went on to ask for the value beside it produced a border with an {@code OFF} point and no
-     * {@code ON} point, which is not a shape the technique has.
+     * <p>Total. Whether the quantity reaches the line at all is {@link #reaches}, asked before this
+     * by whoever holds the rule, and a caller here has already had that answer — so there is no
+     * second reading of it and no way for one to come back empty. It used to be answered twice, and
+     * the answer here was a null the two callers dropped without a word: a rule of the model went
+     * unmeasured, nothing recorded that it had, and the measure came back saying the behavior's
+     * rules draw no line anywhere (issue #1079).
      *
-     * <p>Asked of the level rather than of the value, so every quantity is asked the same question.
-     * Asked of the value, a date came back as one the range could say nothing about, which read as
-     * reachable and put a row at an edge the record refuses.
+     * <p><b>Where the rule stops is not where a row is written.</b> The two are one value on a
+     * carrier that steps, because a strict end is moved onto the value it leaves before it ever gets
+     * here — {@code value > 5} on an {@code Int} arrives as an inclusive 6. A carrier with no step
+     * has no such move, so {@code value > 5.0m} arrives as an exclusive 5, and the point against
+     * that line is a value the order cannot name. Both are lines. Which value each of the four
+     * points stands at is asked of the order below, and never read off the cut.
      *
      * @param within what the rules leave the quantity, on the quantity's own order. Null where they
      *               leave it everything
@@ -144,8 +147,12 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
         NumericDomain.Bounds reach = within == null ? new NumericDomain.Bounds(null, null) : within;
         LevelSpace space = target.levels();
         Level cut = target.at();
-        if (!reach.admits(placeOf(cut))) {
-            return null;
+        if (!reaches(target, within)) {
+            // Asked and answered by whoever holds the rule. Reaching here is that reader and this
+            // one disagreeing about one line, which is not a state a model can put them in.
+            throw new IllegalStateException(
+                    "a border built on a line the quantity does not reach: " + target.left()
+                            + " at " + target.right());
         }
         Seam mine = parts(target, origin);
         java.util.List<Seam> all = new java.util.ArrayList<>(parted);
@@ -158,13 +165,7 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
         boolean holdsHere = holdsAtTheValue(origin);
         Map<PointRole, Demand> demands = new EnumMap<>(PointRole.class);
         if (!ordersAroundTheCut(origin)) {
-            // Which of the two points the line's own level serves as. A rule that leaves the line one
-            // side has no second point, and the level it named is the point on the side it has.
-            PointRole atTheCut = holdsHere ? PointRole.ON : PointRole.OFF;
-            demands.put(atTheCut, new Demand.Owed(new Criterion.AtTheLevel(cut)));
-            demands.put(atTheCut == PointRole.ON ? PointRole.OFF : PointRole.ON,
-                    new Demand.NotOwed(noSideOf(origin)));
-            sidesOfAOneSidedLine(demands, origin, cut, holdsHere, space, reach, arrangement, mine);
+            aLineWithOneSide(demands, origin, cut, holdsHere, space, reach, arrangement);
             return new Border(target, origin, demands);
         }
         // Which way the rule is satisfied from the threshold, which is the one thing the two points
@@ -202,9 +203,22 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
      * to be reported as drawing nothing rather than joining the arrangement: three times a length is
      * never negative, and a rule comparing one against a negative draws no line for anything to be
      * beside.
+     *
+     * <p><b>Whether the line is outside what the rules leave, and not whether they leave its own
+     * value.</b> A bound's line stands at the very end of what the bound leaves, and a strict one on
+     * a carrier with no step stands at a value the position does not hold — the quantity comes
+     * arbitrarily close to it and never arrives, which is a line with values on one side of it and
+     * not a line nothing reaches. Asked as {@code admits}, the two were one answer: every strict
+     * bound on a {@code Decimal} was read as drawing no line, and a model whose every rule was one
+     * came back adequate on the strength of no measure at all (issue #1079).
      */
     public static boolean reaches(BoundaryTarget target, NumericDomain.Bounds within) {
-        return within == null || within.admits(placeOf(target.at()));
+        if (within == null) {
+            return true;
+        }
+        Place at = placeOf(target.at());
+        return (within.min() == null || at.compareTo(within.min().at()) >= 0)
+                && (within.max() == null || at.compareTo(within.max().at()) <= 0);
     }
 
     /**
@@ -260,8 +274,12 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
             java.util.List<Seam> beside =
                     byQuantity.getOrDefault(each.cuts().quantity().key(), java.util.List.of())
                             .stream().map(seam -> seam.scaledBy(per)).toList();
+            // One line drawn, one border. Which lines there are was settled by whoever read the
+            // rules — a comparison whose line the quantity does not reach is no line, and says so
+            // there ({@code ComparisonAssessment.OutsideTheDomain}) — so nothing here decides it
+            // again and nothing is dropped for having come back empty.
             Border made = at(each.cuts().target(), each.by(), each.cuts().within(), beside);
-            if (made != null && out.stream().noneMatch(had -> had.equals(made))) {
+            if (out.stream().noneMatch(had -> had.equals(made))) {
                 out.add(made);
             }
         }
@@ -319,15 +337,23 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
      * does not stand at leaves the first value it does, and a bound it stands at but does not keep
      * leaves the one beside it.
      */
-    private static Level endOf(LevelSpace space, Endpoint end, Towards inward, Level like) {
+    private static Bound endOf(LevelSpace space, Endpoint end, Towards inward, Level like) {
         if (end == null) {
             return null;
         }
         Level at = like instanceof Level.OnACarrier on
                 ? new Level.OnACarrier(on.of(), end.at())
                 : new Level.ACount(souther.compiler.numeric.Count.number(end.at()));
-        return (end.inclusive() ? space.nearestAtOrBeyond(at, inward)
-                : beyond(space, at, inward)).orElse(null);
+        Optional<Level> value = end.inclusive() ? space.nearestAtOrBeyond(at, inward)
+                : beyond(space, at, inward);
+        if (value.isPresent()) {
+            return Bound.at(value.get(), true);
+        }
+        // A strict end the quantity takes no first value past. The run stops where the rule stops
+        // and does not keep the place it stops at, which is what the two together say: read as no
+        // end at all, such a run ran to the end of the order and held every value the bound
+        // refuses; read as the value, it held the one value the bound refuses.
+        return end.inclusive() ? null : Bound.at(at, false);
     }
 
     /**
@@ -380,37 +406,54 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
      * the one value from every other one. Read as one case, a bound's whole admitted range was
      * offered as the {@code OUT} point of a border nothing can be outside of.
      */
-    private static void sidesOfAOneSidedLine(Map<PointRole, Demand> demands, OriginRef origin,
-                                             Level cut, boolean holdsHere, LevelSpace space,
-                                             NumericDomain.Bounds within,
-                                             QuantityArrangement arrangement, Seam mine) {
+    private static void aLineWithOneSide(Map<PointRole, Demand> demands, OriginRef origin,
+                                         Level cut, boolean holdsHere, LevelSpace space,
+                                         NumericDomain.Bounds within,
+                                         QuantityArrangement arrangement) {
         Criterion rest = new Criterion.AnythingBut(cut);
         switch (noSideOf(origin)) {
             case THE_RULES_REFUSE_IT -> {
-                if (!holdsHere) {
-                    // A bound the position does not admit its own cut value at draws no border, and
-                    // that is settled above. Reaching here is the reader of what a position admits
-                    // and the reader of where a bound stops disagreeing about one rule.
+                // Which way the bound keeps its values, taken from the end of what the rules leave
+                // that this line is: a bound orders nothing around itself, so there is no side to
+                // read off the rule, and its line is where what it leaves stops.
+                Towards kept = keptBy(within, cut);
+                if (kept == null) {
+                    // The reader of where a bound stops and the reader of what the position is left
+                    // with disagreeing about one rule. A bound's line is an end of what it leaves,
+                    // and a line inside that is not one this rule drew.
                     throw new IllegalStateException(
-                            "a bound whose own value the position admits and the bound does not: "
-                                    + origin.named());
+                            "a bound whose line is not an end of what it leaves: " + origin.named());
                 }
-                // The partition the bound bounds, without the edge itself. Everything else was what
-                // this asked for before, which is every value the rules leave — including the ones
-                // past the next line along, in a partition this border does not bound.
-                // The run the bound's own value is in, which is the one it bounds. Asked of the
-                // value rather than worked out from which end of the rules the bound is: a bound
-                // orders nothing around itself, so there is no side to read off it.
-                // A bound's own value is at an end of what it leaves, and the run runs away from it
-                // into what the rules admit — which is the side the bound keeps.
-                Band bounded = arrangement.holding(cut);
-                demands.put(PointRole.IN, runOf(space, bounded, cut,
-                        bounded != null && bounded.last() != null
-                                && bounded.last().key().equals(cut.key())
-                                ? Towards.BELOW : Towards.ABOVE));
+                // The point against the line, asked of the order and never read off the cut. The
+                // cut itself where the position holds it — which is every strict bound on a carrier
+                // that steps, the end having been moved onto the value it leaves before it got here
+                // — and the nearest value the rules leave otherwise. A carrier with no step names
+                // none, and then the technique's point cannot be written down at all.
+                Demand on = pointAt(space, cut, kept, holdsHere, within);
+                demands.put(PointRole.ON, on);
+                demands.put(PointRole.OFF, new Demand.NotOwed(NotOwedReason.THE_RULES_REFUSE_IT));
+                // The partition the bound bounds, without the value against the line. Everything
+                // else was what this asked for before, which is every value the rules leave —
+                // including the ones past the next line along, in a partition this border does not
+                // bound.
+                //
+                // Found by the point and not by the cut, and short of a point by the cut. The two
+                // are one level wherever the position holds the line's own value, and where it does
+                // not the run starts past the cut: looked up by the cut, the run a bound leaves was
+                // no run of the arrangement at all and its `IN` point came back refused.
+                Level against = against(on) != null ? against(on) : cut;
+                demands.put(PointRole.IN, runOf(space, arrangement.endmost(kept), against, kept));
                 demands.put(PointRole.OUT, new Demand.NotOwed(NotOwedReason.THE_RULES_REFUSE_IT));
             }
             case THE_RULE_NAMES_A_VALUE_NOT_A_SIDE -> {
+                // The value the rule names, which is the one point against this line: a rule that
+                // singles a value out orders nothing around it, so neither neighbour is nearer to
+                // being outside than the other. Which of the two roles the value serves as is
+                // whether the rule holds there — `x == 5` is met at five and `x /= 5` is not.
+                PointRole atTheCut = holdsHere ? PointRole.ON : PointRole.OFF;
+                demands.put(atTheCut, new Demand.Owed(new Criterion.AtTheLevel(cut)));
+                demands.put(atTheCut == PointRole.ON ? PointRole.OFF : PointRole.ON,
+                        new Demand.NotOwed(NotOwedReason.THE_RULE_NAMES_A_VALUE_NOT_A_SIDE));
                 // The value's own class is the value, so the side the cut is on has nothing away
                 // from the border; the rest of the quantity is the other side. `x == 5` puts the cut
                 // inside and `x /= 5` puts it outside, which is what `holdsHere` says.
@@ -424,6 +467,28 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
             case THE_CARRIER_NAMES_NO_NEIGHBOUR -> throw new IllegalStateException(
                     "a line with no second side because of the order: " + origin.named());
         }
+    }
+
+    /**
+     * Which way a bound keeps its values, from the end of what the rules leave that its line is.
+     *
+     * <p>Asked of what the rules leave rather than of the rule. A bound records where it stops and
+     * not which side of that it keeps ({@link OriginRef.InvariantOrigin}), and it does not have to:
+     * a bound's line is an end of what it leaves, so which end it is says which way the values run.
+     *
+     * <p>Null where the line is neither end, which is nothing a model can write. Where both ends are
+     * the line — a rule leaving one value — either answer names the same point, and the low end is
+     * taken.
+     */
+    private static Towards keptBy(NumericDomain.Bounds within, Level cut) {
+        if (within == null) {
+            return null;
+        }
+        Place at = placeOf(cut);
+        if (within.min() != null && within.min().at().sameAs(at)) {
+            return Towards.ABOVE;
+        }
+        return within.max() != null && within.max().at().sameAs(at) ? Towards.BELOW : null;
     }
 
     /** A side of the border, or the reason the rules leave nothing there for a row to be at. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/LinesRead.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LinesRead.java
@@ -1,0 +1,107 @@
+package souther.compiler.partition;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Every line one behavior's reading of the rules found, and every border it made of one.
+ *
+ * <p>Two records of one pass, kept apart so that neither is counted from the other. What a measure
+ * is short of is what the model raised and nothing answered; that a measure may be called complete
+ * at all is a separate claim — that the reading got to the end of what it was reading — and there is
+ * nothing in the gaps to say it. A line dropped before it could be set aside leaves no gap behind,
+ * so an empty account of what went missing is what a whole reading and a lossy one both produce.
+ * That is issue #1079, and holding these two against each other is what refuses it.
+ *
+ * <p><b>Both producers, because there are two.</b> A line that divides a position leaves its border
+ * on the position ({@link Partitions#bordersOf}) and a line between two positions leaves its border
+ * beside them ({@link Border#allOf}). They are the same reading and the same kind of loss, and an
+ * accounting over one of them says nothing about the other — which is how a check written for the
+ * first would have watched a {@code continue} go into the second.
+ *
+ * <p><b>Identity and not a count.</b> Two lines are one line where they are at one place and drawn
+ * by one rule, which is what {@link Line} is. Counted instead, a reading that lost one line and made
+ * another twice comes back whole; asked of the lines themselves, neither is possible.
+ *
+ * <p>Recorded where each thing happens: a line as the reading meets it, and a border where it lands
+ * in what the reading returns. Recorded together, the two would agree by construction and the
+ * account would prove nothing — what it is for is the day something is written between them.
+ */
+public final class LinesRead {
+
+    /**
+     * One line, told from another by where it is and whose rule drew it.
+     *
+     * <p>Not {@link BorderObligationId}, which is what several readings of one authored line share
+     * and folds the positions it was met at into one (issue #1062). This tells one reading from
+     * another, because that is what a reading has to account for: a clause carried by two positions
+     * is two lines here and one obligation there, and an accounting keyed on the obligation would
+     * call the second of them a duplicate and let it go missing.
+     */
+    public record Line(BoundaryTarget at, OriginRef by) {}
+
+    private final Set<Line> found = new LinkedHashSet<>();
+    private final List<Border> drawn = new ArrayList<>();
+
+    /**
+     * One line the rules draw, as the reading meets it and before anything is made of it.
+     *
+     * <p>Twice for one line is once. A rule read in two places draws two lines and they are told
+     * apart by where they are; one line met twice by one reading is the reading passing the same
+     * place again, and a border is made of it once.
+     */
+    public void found(BoundaryTarget at, OriginRef by) {
+        found.add(new Line(at, by));
+    }
+
+    /** The border made of one, recorded where it lands in what the reading returns. */
+    public Border drew(Border border) {
+        drawn.add(border);
+        return border;
+    }
+
+    /**
+     * That every line this reading found became a border, and no border came from nowhere.
+     *
+     * <p>The claim {@code Closed} rests on. Said as three sentences and not one count: a line found
+     * and not drawn is a reading that lost part of the model, a line drawn and not found is a border
+     * this reading cannot account for, and one line drawn twice asks for the same row twice under
+     * two names.
+     */
+    void everyLineFoundWasDrawn() {
+        Map<Line, Integer> made = new LinkedHashMap<>();
+        for (Border border : drawn) {
+            made.merge(new Line(border.cut(), border.origin()), 1, Integer::sum);
+        }
+        List<Line> twice = made.entrySet().stream().filter(each -> each.getValue() > 1)
+                .map(Map.Entry::getKey).toList();
+        if (!twice.isEmpty()) {
+            throw new IllegalStateException(
+                    "a line drawn more than once: " + said(twice));
+        }
+        List<Line> lost = found.stream().filter(each -> !made.containsKey(each)).toList();
+        if (!lost.isEmpty()) {
+            throw new IllegalStateException(
+                    "a line this reading found and did not draw: " + said(lost)
+                            + " — what a measure is short of cannot be counted from what a reading"
+                            + " lost");
+        }
+        List<Line> unaccounted = made.keySet().stream().filter(each -> !found.contains(each))
+                .toList();
+        if (!unaccounted.isEmpty()) {
+            throw new IllegalStateException(
+                    "a border this reading cannot account for: " + said(unaccounted));
+        }
+    }
+
+    private static String said(List<Line> lines) {
+        return lines.stream()
+                .map(each -> each.at().left() + " = " + each.at().right()
+                        + " (" + each.by().named() + ")")
+                .collect(java.util.stream.Collectors.joining(", "));
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
@@ -153,7 +153,9 @@ public final class MeasureClosure {
      *                ({@link souther.compiler.inputs.BlockReason.RuleWithoutLineReason#leavesShort})
      */
     static Both of(List<Axis> axes, List<souther.compiler.inputs.StandingQuestion> asked,
-                   List<souther.compiler.inputs.RuleWithoutALine> refused) {
+                   List<souther.compiler.inputs.RuleWithoutALine> refused,
+                   java.util.Map<AxisId, List<Border>> lines) {
+        everyLineWasDrawn(axes, lines);
         Set<ClosureGap> partition = new LinkedHashSet<>();
         Set<ClosureGap> border = new LinkedHashSet<>();
         for (souther.compiler.inputs.RuleWithoutALine rule : refused) {
@@ -200,6 +202,41 @@ public final class MeasureClosure {
         return new Both(
                 partition.isEmpty() ? new OfThePartition.Closed() : new OfThePartition.Open(partition),
                 border.isEmpty() ? new OfTheBorder.Closed() : new OfTheBorder.Open(border));
+    }
+
+    /**
+     * That every line this reading found was drawn, which is what {@code Closed} is a conclusion
+     * from.
+     *
+     * <p><b>An empty set of gaps is not a reading that ran out.</b> Nothing was set aside, nothing
+     * went unanswered and no position was left unreached are three absences, and the reading having
+     * got to the end of the rules is a fourth thing that none of them says: a rule dropped before it
+     * could be set aside leaves exactly the same three absences behind, and the measure then reports
+     * a model read in full on the strength of a reading that lost some of it. That is the whole of
+     * issue #1079, and it is what this refuses.
+     *
+     * <p>Asked as a count because that is the shape the loss takes. Every rule that drew a cut is
+     * one line, so a reading that kept an axis and came back with fewer lines than the axis has cuts
+     * has dropped one — whether by a null nobody tested for, a {@code continue}, or a filter. What
+     * the reading found and what it produced are held against each other here rather than each being
+     * trusted on its own.
+     */
+    private static void everyLineWasDrawn(List<Axis> axes,
+                                          java.util.Map<AxisId, List<Border>> lines) {
+        for (Axis axis : axes) {
+            if (!axis.measurable()) {
+                continue;
+            }
+            int drawn = lines.getOrDefault(axis.id(), List.of()).size();
+            int cut = axis.cuts().stream().mapToInt(each -> each.origins().size()).sum();
+            if (drawn != cut) {
+                throw new IllegalStateException(
+                        "a reading of `" + axis.term() + "` that found " + cut + " line"
+                                + (cut == 1 ? "" : "s") + " and drew " + drawn
+                                + ": what a measure is short of cannot be counted from what a"
+                                + " reading lost");
+            }
+        }
     }
 
     /** An open closure's own account of itself: never empty, and in the order the readers found it,

--- a/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
@@ -146,9 +146,10 @@ public final class MeasureClosure {
      * is the second bookkeeping this type exists to prevent.
      *
      * @param axes    every position the reading kept, measured or not
-     * @param lines   the borders it drew, by the position they are on. Here so that a conclusion
-     *                about the reading is drawn from what it produced beside what it found, and not
-     *                from the gaps alone — see {@link #everyLineWasDrawn}
+     * @param lines   what the line reading of this behavior found and what it made of each, from
+     *                both of the producers there are. Here so that a conclusion about the reading is
+     *                drawn from what it produced beside what it found, and not from the gaps alone
+     *                — see {@link LinesRead#everyLineFoundWasDrawn}
      * @param refused the rules of the model this reading set aside, each from the reader that did.
      *                Asked which measures it leaves short rather than counted: a comparison relating
      *                two positions is set aside by what it says and not by anything missing here,
@@ -156,9 +157,8 @@ public final class MeasureClosure {
      *                ({@link souther.compiler.inputs.BlockReason.RuleWithoutLineReason#leavesShort})
      */
     static Both of(List<Axis> axes, List<souther.compiler.inputs.StandingQuestion> asked,
-                   List<souther.compiler.inputs.RuleWithoutALine> refused,
-                   java.util.Map<AxisId, List<Border>> lines) {
-        everyLineWasDrawn(axes, lines);
+                   List<souther.compiler.inputs.RuleWithoutALine> refused, LinesRead lines) {
+        lines.everyLineFoundWasDrawn();
         Set<ClosureGap> partition = new LinkedHashSet<>();
         Set<ClosureGap> border = new LinkedHashSet<>();
         for (souther.compiler.inputs.RuleWithoutALine rule : refused) {
@@ -205,41 +205,6 @@ public final class MeasureClosure {
         return new Both(
                 partition.isEmpty() ? new OfThePartition.Closed() : new OfThePartition.Open(partition),
                 border.isEmpty() ? new OfTheBorder.Closed() : new OfTheBorder.Open(border));
-    }
-
-    /**
-     * That every line this reading found was drawn, which is what {@code Closed} is a conclusion
-     * from.
-     *
-     * <p><b>An empty set of gaps is not a reading that ran out.</b> Nothing was set aside, nothing
-     * went unanswered and no position was left unreached are three absences, and the reading having
-     * got to the end of the rules is a fourth thing that none of them says: a rule dropped before it
-     * could be set aside leaves exactly the same three absences behind, and the measure then reports
-     * a model read in full on the strength of a reading that lost some of it. That is the whole of
-     * issue #1079, and it is what this refuses.
-     *
-     * <p>Asked as a count because that is the shape the loss takes. Every rule that drew a cut is
-     * one line, so a reading that kept an axis and came back with fewer lines than the axis has cuts
-     * has dropped one — whether by a null nobody tested for, a {@code continue}, or a filter. What
-     * the reading found and what it produced are held against each other here rather than each being
-     * trusted on its own.
-     */
-    private static void everyLineWasDrawn(List<Axis> axes,
-                                          java.util.Map<AxisId, List<Border>> lines) {
-        for (Axis axis : axes) {
-            if (!axis.measurable()) {
-                continue;
-            }
-            int drawn = lines.getOrDefault(axis.id(), List.of()).size();
-            int cut = axis.cuts().stream().mapToInt(each -> each.origins().size()).sum();
-            if (drawn != cut) {
-                throw new IllegalStateException(
-                        "a reading of `" + axis.term() + "` that found " + cut + " line"
-                                + (cut == 1 ? "" : "s") + " and drew " + drawn
-                                + ": what a measure is short of cannot be counted from what a"
-                                + " reading lost");
-            }
-        }
     }
 
     /** An open closure's own account of itself: never empty, and in the order the readers found it,

--- a/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
@@ -146,6 +146,9 @@ public final class MeasureClosure {
      * is the second bookkeeping this type exists to prevent.
      *
      * @param axes    every position the reading kept, measured or not
+     * @param lines   the borders it drew, by the position they are on. Here so that a conclusion
+     *                about the reading is drawn from what it produced beside what it found, and not
+     *                from the gaps alone — see {@link #everyLineWasDrawn}
      * @param refused the rules of the model this reading set aside, each from the reader that did.
      *                Asked which measures it leaves short rather than counted: a comparison relating
      *                two positions is set aside by what it says and not by anything missing here,

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -228,10 +228,13 @@ public final class Partitions {
         for (Axis axis : kept) {
             keep(new ArrayList<>(), measured, axis, null, rulesWithoutALine);
         }
-        MeasureClosure.Both closed = MeasureClosure.of(kept, standing, rulesWithoutALine);
+        // The lines first, because the closure is a conclusion about them: whether the reading ran
+        // out is asked of what it produced beside what it found, and not of the gaps alone.
+        java.util.Map<AxisId, List<Border>> lines = linesAlong(kept, quantities, symbols);
+        MeasureClosure.Both closed = MeasureClosure.of(kept, standing, rulesWithoutALine, lines);
         return new Partitioning(kept, standing, uncertain, undividedIn(measured),
                 List.copyOf(rulesWithoutALine), blockedIn(measured), List.copyOf(notSeparated),
-                List.of(), linesAlong(kept, quantities, symbols), ReachingCuts.NONE,
+                List.of(), lines, ReachingCuts.NONE,
                 closed.partition(), closed.border());
     }
 
@@ -537,7 +540,8 @@ public final class Partitions {
                     reachable.stream().map(Threshold::parts).toList()),
                     reachable.isEmpty() ? null : new BodyCutInspection.Evidence(), rules);
         }
-        MeasureClosure.Both closed = MeasureClosure.of(out, base.unanswered(), rules);
+        java.util.Map<AxisId, List<Border>> lines = linesAlong(out, reading, symbols);
+        MeasureClosure.Both closed = MeasureClosure.of(out, base.unanswered(), rules, lines);
         return new Partitioning(out, base.unanswered(), base.uncertain(),
                 undividedIn(measured), List.copyOf(rules), blockedIn(measured),
                 // Carried across: what a reading could not hold together is a fact about the
@@ -551,7 +555,7 @@ public final class Partitions {
                 // where the position has no value beside it, its border over here — and the two
                 // sides of that border are runs of what all of them leave.
                 base.notSeparated(), Border.allOf(between, partedByQuantity(out)),
-                linesAlong(out, reading, symbols),
+                lines,
                 reaching, closed.partition(), closed.border());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -229,9 +229,12 @@ public final class Partitions {
             keep(new ArrayList<>(), measured, axis, null, rulesWithoutALine);
         }
         // The lines first, because the closure is a conclusion about them: whether the reading ran
-        // out is asked of what it produced beside what it found, and not of the gaps alone.
-        java.util.Map<AxisId, List<Border>> lines = linesAlong(kept, quantities, symbols);
-        MeasureClosure.Both closed = MeasureClosure.of(kept, standing, rulesWithoutALine, lines);
+        // out is asked of what it produced beside what it found, and not of the gaps alone. Both
+        // producers write into the one account — here there is only the one, and no rule of this
+        // reading draws a line between two positions.
+        LinesRead read = new LinesRead();
+        java.util.Map<AxisId, List<Border>> lines = linesAlong(kept, quantities, symbols, read);
+        MeasureClosure.Both closed = MeasureClosure.of(kept, standing, rulesWithoutALine, read);
         return new Partitioning(kept, standing, uncertain, undividedIn(measured),
                 List.copyOf(rulesWithoutALine), blockedIn(measured), List.copyOf(notSeparated),
                 List.of(), lines, ReachingCuts.NONE,
@@ -540,8 +543,13 @@ public final class Partitions {
                     reachable.stream().map(Threshold::parts).toList()),
                     reachable.isEmpty() ? null : new BodyCutInspection.Evidence(), rules);
         }
-        java.util.Map<AxisId, List<Border>> lines = linesAlong(out, reading, symbols);
-        MeasureClosure.Both closed = MeasureClosure.of(out, base.unanswered(), rules, lines);
+        // Both producers into the one account. A line that divides a position leaves its border on
+        // the position and a line between two leaves its border beside them; they are the same
+        // reading, and an accounting over one of them says nothing about the other.
+        LinesRead read = new LinesRead();
+        java.util.Map<AxisId, List<Border>> lines = linesAlong(out, reading, symbols, read);
+        List<Border> across = Border.allOf(between, partedByQuantity(out), read);
+        MeasureClosure.Both closed = MeasureClosure.of(out, base.unanswered(), rules, read);
         return new Partitioning(out, base.unanswered(), base.uncertain(),
                 undividedIn(measured), List.copyOf(rules), blockedIn(measured),
                 // Carried across: what a reading could not hold together is a fact about the
@@ -554,7 +562,7 @@ public final class Partitions {
                 // came from. A line that divides a position leaves its division on the axis and,
                 // where the position has no value beside it, its border over here — and the two
                 // sides of that border are runs of what all of them leave.
-                base.notSeparated(), Border.allOf(between, partedByQuantity(out)),
+                base.notSeparated(), across,
                 lines,
                 reaching, closed.partition(), closed.border());
     }
@@ -571,11 +579,13 @@ public final class Partitions {
      * has no line to draw, and an entry saying so would be a list of nothings per behavior.
      */
     private static java.util.Map<AxisId, List<Border>> linesAlong(
-            List<Axis> axes, souther.compiler.inputs.Quantities reading, Symbols symbols) {
+            List<Axis> axes, souther.compiler.inputs.Quantities reading, Symbols symbols,
+            LinesRead read) {
         Map<AxisId, List<Border>> out = new LinkedHashMap<>();
         for (Axis axis : axes) {
             if (axis.measurable()) {
-                out.put(axis.id(), bordersOf(axis, symbols, reading.runsBetween(axis.term())));
+                out.put(axis.id(),
+                        bordersOf(axis, symbols, reading.runsBetween(axis.term()), read));
             }
         }
         return out;
@@ -784,7 +794,8 @@ public final class Partitions {
      * what the rules leave the term, which is a reading of the declarations — so a caller that could
      * assemble them would be deciding, from a reading of its own, which lines exist to be measured.
      */
-    static List<Border> bordersOf(Axis axis, Symbols symbols, NumericDomain.Bounds within) {
+    static List<Border> bordersOf(Axis axis, Symbols symbols, NumericDomain.Bounds within,
+                                  LinesRead read) {
         List<Border> out = new ArrayList<>();
         // Every place the rules part this position's values, collected before any border is built.
         // What each border owes away from its line is a run of the arrangement they make together,
@@ -823,7 +834,11 @@ public final class Partitions {
                 // nothing to test here and nothing to drop. It used to answer null and be dropped
                 // without a word, which is how a strict bound on a carrier with no step left the
                 // measure saying the behavior's rules draw no line anywhere (issue #1079).
-                out.add(Border.at(target, origin, within, parted));
+                //
+                // The line is written down as it is met and the border where it lands, so that the
+                // day something is written between the two the reading is held to having lost one.
+                read.found(target, origin);
+                out.add(read.drew(Border.at(target, origin, within, parted)));
             }
         }
         return List.copyOf(out);

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -814,14 +814,12 @@ public final class Partitions {
                                     axis.term().observedOn(axis.type(), symbols), cut.carrier())),
                     new Level.OnACarrier(cut.carrier(), cut.at()));
             for (OriginRef origin : cut.origins()) {
-                // Null where the position does not reach the line at all, which is the line and not
-                // one of its points: the rule drew it about the type, and what is left of the type
-                // here may stop short of it — `low < high` under one `[0, 1]` leaves `low` every
-                // value up to 1 and not 1 itself.
-                Border border = Border.at(target, origin, within, parted);
-                if (border != null) {
-                    out.add(border);
-                }
+                // One cut, one border. Whether the quantity reaches the line is settled where the
+                // cut was made — a bound's line is an end of what the bound leaves — so there is
+                // nothing to test here and nothing to drop. It used to answer null and be dropped
+                // without a word, which is how a strict bound on a carrier with no step left the
+                // measure saying the behavior's rules draw no line anywhere (issue #1079).
+                out.add(Border.at(target, origin, within, parted));
             }
         }
         return List.copyOf(out);

--- a/souther-compiler/src/main/java/souther/compiler/partition/QuantityArrangement.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/QuantityArrangement.java
@@ -149,16 +149,6 @@ public record QuantityArrangement(List<Seam> seams, List<Band> bands) {
         if (first != null && last != null && space.compare(first, last) > 0) {
             return;
         }
-        // And a run between two ends at one place that at least one of them stops short of. Asked
-        // of the values alone, such a run has none to compare — an end with no first value names
-        // nothing — and it was kept as a run holding whatever lies strictly between a place and
-        // itself, which is a class an author would be told to write a row for and could not.
-        if (band.under() == null && band.over() == null
-                && band.from() != null && band.to() != null
-                && band.from().at().compareTo(band.to().at()) == 0
-                && !(band.from().inclusive() && band.to().inclusive())) {
-            return;
-        }
         bands.add(band);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/QuantityArrangement.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/QuantityArrangement.java
@@ -1,5 +1,7 @@
 package souther.compiler.partition;
 
+import souther.compiler.numeric.Towards;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -50,13 +52,15 @@ public record QuantityArrangement(List<Seam> seams, List<Band> bands) {
      * is stop the run beside it, which is why the two either side of a line at ten run from the
      * bound rather than from the order's own extent.
      *
-     * @param from the first value the rules leave the quantity, or null where they leave it
-     *             everything that way. A value the quantity takes, and not the number a bound was
-     *             written with: which of those two it is belongs to whoever holds the bound
-     * @param to   the last, on the same reading
+     * @param from where the rules leave off at the low end and whether they keep the place they
+     *             leave off at, or null where they leave it everything that way. Not the first value
+     *             in the run: a strict bound on a carrier with no step leaves no first value, and
+     *             read as one such a run either had no end at all or held the value its bound
+     *             refuses
+     * @param to   the same at the high end
      */
-    public static QuantityArrangement of(LevelSpace space, List<Seam> parted, Level from,
-                                         Level to) {
+    public static QuantityArrangement of(LevelSpace space, List<Seam> parted, Bound from,
+                                         Bound to) {
         Map<String, Seam> distinct = new LinkedHashMap<>();
         for (Seam each : parted) {
             // A place the rules leave nothing at divides nothing. The values it would tell apart are
@@ -119,6 +123,21 @@ public record QuantityArrangement(List<Seam> seams, List<Band> bands) {
         return bands.stream().filter(each -> each.holds(at)).findFirst().orElse(null);
     }
 
+    /**
+     * The run at one end of what the rules leave: the one nothing parts below it, or nothing parts
+     * above it.
+     *
+     * <p>What a bound bounds. A bound's line is where what it leaves stops, so the run it bounds is
+     * the one against that end — and it is found by being the endmost rather than by holding the
+     * line's own value, which a bound that stops short of that value does not leave in any run at
+     * all. Null where the rules leave no run there, which is a point nobody is owed a row at.
+     */
+    public Band endmost(Towards inward) {
+        return bands.stream()
+                .filter(each -> inward == Towards.ABOVE ? each.under() == null : each.over() == null)
+                .findFirst().orElse(null);
+    }
+
     private static boolean is(Seam one, Seam other) {
         return one != null && other != null && one.key().equals(other.key());
     }
@@ -128,6 +147,16 @@ public record QuantityArrangement(List<Seam> seams, List<Band> bands) {
         Level first = band.first();
         Level last = band.last();
         if (first != null && last != null && space.compare(first, last) > 0) {
+            return;
+        }
+        // And a run between two ends at one place that at least one of them stops short of. Asked
+        // of the values alone, such a run has none to compare — an end with no first value names
+        // nothing — and it was kept as a run holding whatever lies strictly between a place and
+        // itself, which is a class an author would be told to write a row for and could not.
+        if (band.under() == null && band.over() == null
+                && band.from() != null && band.to() != null
+                && band.from().at().compareTo(band.to().at()) == 0
+                && !(band.from().inclusive() && band.to().inclusive())) {
             return;
         }
         bands.add(band);
@@ -141,8 +170,8 @@ public record QuantityArrangement(List<Seam> seams, List<Band> bands) {
      * read off that value, a bound's own line was dropped from the arrangement and the run it starts
      * belonged to no seam at all.
      */
-    private static boolean outside(Seam seam, Level from, Level to) {
-        return from != null && seam.at().compare(from) > 0
-                || to != null && seam.at().compare(to) < 0;
+    private static boolean outside(Seam seam, Bound from, Bound to) {
+        return from != null && seam.at().compareTo(from.at()) < 0
+                || to != null && seam.at().compareTo(to.at()) > 0;
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
@@ -217,7 +217,7 @@ class ABorderDebtIsTheLineTheAuthorWroteTest {
         Axis axis = partitioning.axes().stream()
                 .filter(a -> a.path().toString().equals(path)).findFirst().orElseThrow();
         return Partitions.bordersOf(axis, symbols,
-                domain.quantities(symbols).runsBetween(axis.term()));
+                domain.quantities(symbols).runsBetween(axis.term()), new LinesRead());
     }
 
     /** A newtype's own clause, reached through the record that holds it. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
@@ -185,26 +185,34 @@ class ABorderSaysWhichOfItsTwoPointsALineIsTest {
     }
 
     /**
-     * The end is read rather than assumed closed, at the one place both kinds are built.
+     * The end is read rather than assumed closed, at the one place both kinds are built, and what
+     * reads it is the point rather than the line.
      *
      * <p>A continuous carrier has no step to take, so {@code value > 5.0m} on a {@code Decimal}
      * reaches {@link OriginRef.InvariantOrigin} as an exclusive 5 — measured at the construction
-     * site, where both kinds arrive. No report shows one: such a cut is dropped further down. That
-     * makes the closed end a fact about how far the derivation gets rather than about bounds, and
-     * an origin that assumed it would answer {@code ON} for a value its own type refuses on the day
-     * the derivation reaches further.
+     * site, where both kinds arrive. Where the rule stops is the line either way; which value the
+     * point against it stands at is the order's answer, and the two are one value only where the
+     * position holds the line's own.
+     *
+     * <p>Both ends here on one carrier, which is what makes this about the end and not about the
+     * carrier. The bound that admits its value is at that value; the one that does not is at the
+     * value it leaves. Asked as one question, the second was read as a line the quantity does not
+     * reach, dropped, and its rule went unmeasured with nothing saying so (issue #1079).
      */
     @Test
-    void aBoundThatStopsShortOfItsValueDrawsNoBorderAtIt() {
-        assertEquals(Criterion.AtTheLevel.class,
-                borderOf(new OriginRef.InvariantOrigin(invariant(), THE_ONLY_CONJUNCT, true))
-                        .demand(PointRole.ON).criterion().getClass(),
+    void aBoundIsAtItsOwnEndWhereItKeepsItAndAtTheValueItLeavesWhereItDoesNot() {
+        assertEquals("= 5", pointAgainstTheLine(true),
                 "a bound that admits its own end is at that end's ON point");
-        // And where it does not admit it, the position does not reach the line: the value is outside
-        // what the rules leave, so there is no border here and no point of one either. Read as a
-        // border, it would owe an ON point one step in that no carrier here names.
-        assertEquals(null, borderOf(new OriginRef.InvariantOrigin(invariant(), THE_ONLY_CONJUNCT, false)),
-                "a bound whose own end its position refuses draws no line at it");
+        assertEquals("= 6", pointAgainstTheLine(false),
+                "and one that does not is at the first value it leaves");
+    }
+
+    /** What the {@code ON} point of a bound at 5 asks for, where the bound does or does not keep
+     *  the 5 itself. */
+    private static String pointAgainstTheLine(boolean keepsIt) {
+        Border border = borderOf(
+                new OriginRef.InvariantOrigin(invariant(), THE_ONLY_CONJUNCT, keepsIt));
+        return border.demand(PointRole.ON).criterion().asked(border.cut().of());
     }
 
     /** The border a bound draws at 5 on an `Int` whose rules leave 5 and up. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -185,34 +186,38 @@ class ABorderSaysWhichOfItsTwoPointsALineIsTest {
     }
 
     /**
-     * The end is read rather than assumed closed, at the one place both kinds are built, and what
-     * reads it is the point rather than the line.
+     * The end is read rather than assumed closed, at the one place both kinds are built, and a bound
+     * that stops short of its own line on a carrier that steps is refused rather than stepped here.
      *
      * <p>A continuous carrier has no step to take, so {@code value > 5.0m} on a {@code Decimal}
      * reaches {@link OriginRef.InvariantOrigin} as an exclusive 5 — measured at the construction
-     * site, where both kinds arrive. Where the rule stops is the line either way; which value the
-     * point against it stands at is the order's answer, and the two are one value only where the
-     * position holds the line's own.
+     * site, where both kinds arrive. Where the rule stops is the line either way, and which value
+     * the point against it stands at is the order's answer.
      *
-     * <p>Both ends here on one carrier, which is what makes this about the end and not about the
-     * carrier. The bound that admits its value is at that value; the one that does not is at the
-     * value it leaves. Asked as one question, the second was read as a line the quantity does not
-     * reach, dropped, and its rule went unmeasured with nothing saying so (issue #1079).
+     * <p><b>Which is not a licence to step one here.</b> An end a carrier can step is stepped before
+     * it arrives — by {@code InvariantBound} for a type's own clause and by the solver for what a
+     * record leaves — so {@code value > 5} on an {@code Int} is an inclusive 6 by the time a border
+     * is built and never an exclusive 5. Answered by stepping to the 6, this would be a third place
+     * that normalizes ends, and the day either of the two above stopped doing it the border would
+     * still come out right with nothing saying the reading had been repaired on the way through.
+     *
+     * <p>What a {@code Decimal} does with the same shape is {@code
+     * ABoundOnACarrierWithNoStepIsStillALineTest}, over a model rather than a hand-made origin: the
+     * order names no value beside the line, so the point cannot be written down and says so.
      */
     @Test
-    void aBoundIsAtItsOwnEndWhereItKeepsItAndAtTheValueItLeavesWhereItDoesNot() {
-        assertEquals("= 5", pointAgainstTheLine(true),
+    void aBoundThatStopsShortOfItsLineWhereTheOrderStepsIsRefused() {
+        Border kept = borderOf(
+                new OriginRef.InvariantOrigin(invariant(), THE_ONLY_CONJUNCT, true));
+        assertEquals("= 5", kept.demand(PointRole.ON).criterion().asked(kept.cut().of()),
                 "a bound that admits its own end is at that end's ON point");
-        assertEquals("= 6", pointAgainstTheLine(false),
-                "and one that does not is at the first value it leaves");
-    }
 
-    /** What the {@code ON} point of a bound at 5 asks for, where the bound does or does not keep
-     *  the 5 itself. */
-    private static String pointAgainstTheLine(boolean keepsIt) {
-        Border border = borderOf(
-                new OriginRef.InvariantOrigin(invariant(), THE_ONLY_CONJUNCT, keepsIt));
-        return border.demand(PointRole.ON).criterion().asked(border.cut().of());
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> borderOf(new OriginRef.InvariantOrigin(invariant(), THE_ONLY_CONJUNCT, false)),
+                "an `Int` bounded strictly at 5 is an inclusive 6 long before it reaches a border");
+        assertTrue(refused.getMessage().startsWith(
+                        "a bound that stops short of its own line where the order names 6 beside it"),
+                refused.getMessage());
     }
 
     /** The border a bound draws at 5 on an `Int` whose rules leave 5 and up. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABoundOnACarrierWithNoStepIsStillALineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABoundOnACarrierWithNoStepIsStillALineTest.java
@@ -1,0 +1,142 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.ItemAssessment;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * A bound is a line wherever the rule stops, and the value a row is written at is asked of the order
+ * afterwards.
+ *
+ * <p>The two used to be one. A strict bound is finished by moving the end onto a value the position
+ * holds — {@code value > 5} on an {@code Int} arrives as an inclusive 6 — and every reader after that
+ * took the cut for the point. A carrier with no step has no such move, so {@code value > 5.0m}
+ * arrives as an exclusive 5, which is a value the position does not hold; the line was then dropped
+ * for having no point on it, and the measure came back saying the rules of the behavior draw no line
+ * anywhere.
+ *
+ * <p>Both carriers are here and they differ in one thing. A model whose every rule is a bound on a
+ * {@code Decimal} was reported adequate on the strength of no measure at all (issue #1079), and an
+ * expectation written against the decimal alone holds against a reader that draws no line on either.
+ */
+class ABoundOnACarrierWithNoStepIsStillALineTest {
+
+    /** One field bounded strictly away from zero, on whichever carrier is asked for. */
+    private static String model(String carrier, String bound) {
+        return """
+                module example.step
+
+                data Positive = %s
+                    invariant positive = value > %s
+
+                data Holder = { p: Positive }
+
+                data Ok
+
+                behavior take : (h: Holder) -> Ok
+                let take (h) = Ok
+                """.formatted(carrier, bound);
+    }
+
+    /**
+     * The line is where the rule stops, on both carriers, and it is one line either way.
+     *
+     * <p>Where the rule stops is what the author wrote. A step onto the next value is how a discrete
+     * carrier says the same thing, and the line an {@code Int} draws at 1 and the line a
+     * {@code Decimal} draws at 0 are one rule's line read on two orders.
+     */
+    @Test
+    void aStrictBoundDrawsALineOnEitherCarrier() {
+        assertEquals(List.of("h.p = 0"), labels(model("Decimal", "0m")),
+                "`value > 0m` stops the position at zero");
+        assertEquals(List.of("h.p = 1"), labels(model("Int", "0")),
+                "`value > 0` on a whole number stops it at the one it leaves");
+    }
+
+    /**
+     * The point against the line is the carrier's answer, and the two carriers answer differently.
+     *
+     * <p>An {@code Int} has a least admitted value and a row can be written at it. A {@code Decimal}
+     * has none — every value above zero has one below it that is also above zero — so the point the
+     * technique asks for cannot be written down, which is a limit of the language and not a row
+     * anybody is short of.
+     */
+    @Test
+    void theOnPointIsOwedWhereTheCarrierNamesItAndNotWhereItDoesNot() {
+        assertEquals(new ItemAssessment.NotOwed(NotOwedReason.THE_CARRIER_NAMES_NO_NEIGHBOUR),
+                border(model("Decimal", "0m")).at(PointRole.ON),
+                "no decimal is the least one above zero");
+        assertInstanceOf(ItemAssessment.Owed.class, border(model("Int", "0")).at(PointRole.ON),
+                "one is the least whole number above zero, and a row can be written there");
+    }
+
+    /**
+     * Nothing outside a bound can be constructed, whichever carrier it is on.
+     *
+     * <p>Which is what tells this from the point above. The far side holds no value because the
+     * model refuses it, and the point against the line on the near side is missing because the order
+     * has no name for it — a reader told the second where the first is true would go looking for a
+     * conversion, and one told the first where the second is true would think the rules had
+     * discharged something.
+     */
+    @Test
+    void aBoundOwesNothingOutsideItselfOnEitherCarrier() {
+        for (String carrier : List.of("Decimal", "Int")) {
+            BorderAssessment line = border(model(carrier, carrier.equals("Decimal") ? "0m" : "0"));
+            assertEquals(new ItemAssessment.NotOwed(NotOwedReason.THE_RULES_REFUSE_IT),
+                    line.at(PointRole.OFF), carrier + ": nothing is just outside a bound");
+            assertEquals(new ItemAssessment.NotOwed(NotOwedReason.THE_RULES_REFUSE_IT),
+                    line.at(PointRole.OUT), carrier + ": nothing is outside a bound at all");
+        }
+    }
+
+    /**
+     * And the side the bound keeps is owed a row on both.
+     *
+     * <p>The whole of what the measure gains here. A {@code Decimal} above zero is a value anybody
+     * can write, so the model owes a row for it — and while the line was dropped the behavior was
+     * reported adequate without one.
+     */
+    @Test
+    void theSideTheBoundKeepsIsOwedARowOnEitherCarrier() {
+        assertInstanceOf(ItemAssessment.Owed.class, border(model("Decimal", "0m")).at(PointRole.IN),
+                "some decimal is above zero");
+        assertInstanceOf(ItemAssessment.Owed.class, border(model("Int", "0")).at(PointRole.IN),
+                "some whole number is above zero");
+    }
+
+    /** The one line this model draws. */
+    private static BorderAssessment border(String model) {
+        List<BorderAssessment> lines = bordersOf(model);
+        assertEquals(1, lines.size(), () -> "one rule, one line: " + labelsOf(lines));
+        return lines.getFirst();
+    }
+
+    private static List<String> labels(String model) {
+        return labelsOf(bordersOf(model));
+    }
+
+    private static List<String> labelsOf(List<BorderAssessment> lines) {
+        return lines.stream().map(BorderAssessment::label).toList();
+    }
+
+    private static List<BorderAssessment> bordersOf(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, List<BorderAssessment>> boundaries =
+                Adequacy.boundariesOf(compilation.db(), "example.step");
+        assertNotNull(boundaries, "the model under test compiles");
+        return boundaries.values().stream().flatMap(List::stream).toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABoundaryRowWearsEveryNameThePositionDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABoundaryRowWearsEveryNameThePositionDeclaresTest.java
@@ -110,7 +110,7 @@ class ABoundaryRowWearsEveryNameThePositionDeclaresTest {
         List<String> out = new ArrayList<>();
         for (Axis axis : p.axes()) {
             for (Border border
-                    : Partitions.bordersOf(axis, symbols, reading.runsBetween(axis.term()))) {
+                    : Partitions.bordersOf(axis, symbols, reading.runsBetween(axis.term()), new LinesRead())) {
               for (PointRole role : List.of(PointRole.ON, PointRole.OFF)) {
                 if (!(border.demand(role).criterion()
                         instanceof Criterion.AtTheLevel each)) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACarrierNothingReadsUnmeasuresItsSiblingsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACarrierNothingReadsUnmeasuresItsSiblingsTest.java
@@ -105,7 +105,7 @@ class ACarrierNothingReadsUnmeasuresItsSiblingsTest {
         String standing = read.partitioning().edgeIsKnownWritable(axis.term())
                 ? " writable" : " not known to be writable";
         return Partitions.bordersOf(axis, read.symbols(),
-                        read.reading().runsBetween(axis.term())).stream()
+                        read.reading().runsBetween(axis.term()), new LinesRead()).stream()
                 .flatMap(border -> java.util.stream.Stream.of(PointRole.ON, PointRole.OFF)
                         .filter(role -> border.demand(role).criterion() != null)
                         .map(role -> role + " "

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
@@ -1,0 +1,116 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Carrier;
+import souther.compiler.check.Clause;
+import souther.compiler.check.ClauseName;
+import souther.compiler.check.RuleRef;
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.numeric.Count;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A reading that lost a line is not a reading that ran out.
+ *
+ * <p>{@code Closed} is what takes a behavior out of the verdict, and it used to follow from three
+ * absences: nothing was set aside, nothing went unanswered, no position went unreached. A rule
+ * dropped before it could be set aside leaves all three of those exactly as they were, so a measure
+ * built from them reported a model read in full on the strength of a reading that had lost part of
+ * it — a {@code Decimal} bounded by two clauses came back as a behavior whose rules draw no line
+ * anywhere, and the module was called adequate (issue #1079).
+ *
+ * <p>So what the reading produced is held against what it found. One rule that drew a cut is one
+ * line, and a reading holding fewer lines than cuts has lost one however it went — a null nobody
+ * tested for, a {@code continue}, a filter. The count is the only thing that catches all three,
+ * since each of them leaves a shorter list and nothing else.
+ */
+class AClosedReadingIsOneThatDrewEveryLineItFoundTest {
+
+    private static final AxisId AT = new AxisId("take", "h.a");
+
+    /** A reading of one bound that drew its line, which is what a closed one is. */
+    @Test
+    void aReadingThatDrewItsLineMayBeClosed() {
+        MeasureClosure.Both closed =
+                MeasureClosure.of(List.of(anAxisWithOneCut()), List.of(), List.of(),
+                        Map.of(AT, List.of(aBorder())));
+
+        assertInstanceOf(MeasureClosure.OfTheBorder.Closed.class, closed.border(),
+                "every question this measure answers was answered");
+        assertInstanceOf(MeasureClosure.OfThePartition.Closed.class, closed.partition());
+    }
+
+    /**
+     * And one that found a cut and came back without its line is refused rather than closed.
+     *
+     * <p>Refused and not reported as a gap. What was lost is not known here — a gap says which rule
+     * or which position a measure is short of, and a reading that dropped one has nothing to name.
+     * This is this compiler having lost something, which is the one thing a document may not be
+     * written from.
+     */
+    @Test
+    void aReadingThatLostItsLineIsRefused() {
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> MeasureClosure.of(List.of(anAxisWithOneCut()), List.of(), List.of(),
+                        Map.of()));
+
+        assertEquals("a reading of `h.a` that found 1 line and drew 0: what a measure is short of"
+                + " cannot be counted from what a reading lost", refused.getMessage());
+    }
+
+    /**
+     * Counted per rule that drew the cut and not per cut.
+     *
+     * <p>An invariant and a {@code guard} naming one value are two rules and one place, and each of
+     * them is owed a row: reaching the line through one says nothing about the other. Counted by
+     * cuts, a reading that drew one of the two and lost the other came back whole.
+     */
+    @Test
+    void aCutTwoRulesDrewIsTwoLines() {
+        Cut both = Cut.at(Carrier.WHOLE, Count.of(5), bound("cap")).and(bound("floor"));
+        Axis axis = new Axis(AT, new NumericTerm.ValueOf(TermPath.of("h").then("a")), Type.INT,
+                List.of(), List.of(both));
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> MeasureClosure.of(List.of(axis), List.of(), List.of(),
+                        Map.of(AT, List.of(aBorder()))));
+
+        assertEquals("a reading of `h.a` that found 2 lines and drew 1: what a measure is short of"
+                + " cannot be counted from what a reading lost", refused.getMessage());
+    }
+
+    /** One position bounded at 5, which is one cut drawn by one rule. */
+    private static Axis anAxisWithOneCut() {
+        return new Axis(AT, new NumericTerm.ValueOf(TermPath.of("h").then("a")), Type.INT,
+                List.of(), List.of(Cut.at(Carrier.WHOLE, Count.of(5), bound("cap"))));
+    }
+
+    private static Border aBorder() {
+        return Border.at(
+                BoundaryTarget.at(
+                        new BorderQuantity.OfACoordinate(AT,
+                                new NumericTerm.ValueOf(TermPath.of("h").then("a")),
+                                souther.compiler.inputs.TermOrders.itself(Carrier.WHOLE)),
+                        new Level.OnACarrier(Carrier.WHOLE, Count.of(5))),
+                bound("cap"),
+                new souther.compiler.numeric.NumericDomain.Bounds(
+                        souther.compiler.numeric.Endpoint.inclusive(Count.of(5)), null));
+    }
+
+    private static OriginRef bound(String clause) {
+        return new OriginRef.InvariantOrigin(new RuleRef.Invariant(new Clause.Ref(
+                new Clause.Id(TypeSymbols.declared(new TypeKey("example.rate", "Amount")), 0),
+                java.util.Optional.of(new ClauseName(clause)))), 0, true);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
@@ -14,37 +14,38 @@ import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbols;
 
 import java.util.List;
-import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A reading that lost a line is not a reading that ran out.
  *
  * <p>{@code Closed} is what takes a behavior out of the verdict, and it used to follow from three
- * absences: nothing was set aside, nothing went unanswered, no position went unreached. A rule
+ * absences: nothing was set aside, nothing went unanswered, no position went unreached. A line
  * dropped before it could be set aside leaves all three of those exactly as they were, so a measure
  * built from them reported a model read in full on the strength of a reading that had lost part of
  * it — a {@code Decimal} bounded by two clauses came back as a behavior whose rules draw no line
  * anywhere, and the module was called adequate (issue #1079).
  *
- * <p>So what the reading produced is held against what it found. One rule that drew a cut is one
- * line, and a reading holding fewer lines than cuts has lost one however it went — a null nobody
- * tested for, a {@code continue}, a filter. The count is the only thing that catches all three,
- * since each of them leaves a shorter list and nothing else.
+ * <p>So what the reading produced is held against what it found, by identity. Counted instead, a
+ * reading that lost one line and made another twice comes back whole; asked of the lines themselves,
+ * neither is possible.
  */
 class AClosedReadingIsOneThatDrewEveryLineItFoundTest {
 
     private static final AxisId AT = new AxisId("take", "h.a");
 
-    /** A reading of one bound that drew its line, which is what a closed one is. */
+    /** A reading of one line that drew it, which is what a closed one is. */
     @Test
     void aReadingThatDrewItsLineMayBeClosed() {
+        LinesRead read = new LinesRead();
+        read.found(aLine(), bound("cap"));
+        read.drew(aBorder("cap"));
+
         MeasureClosure.Both closed =
-                MeasureClosure.of(List.of(anAxisWithOneCut()), List.of(), List.of(),
-                        Map.of(AT, List.of(aBorder())));
+                MeasureClosure.of(List.of(anAxis()), List.of(), List.of(), read);
 
         assertInstanceOf(MeasureClosure.OfTheBorder.Closed.class, closed.border(),
                 "every question this measure answers was answered");
@@ -52,58 +53,76 @@ class AClosedReadingIsOneThatDrewEveryLineItFoundTest {
     }
 
     /**
-     * And one that found a cut and came back without its line is refused rather than closed.
+     * One found and not drawn is refused rather than reported as a gap.
      *
-     * <p>Refused and not reported as a gap. What was lost is not known here — a gap says which rule
-     * or which position a measure is short of, and a reading that dropped one has nothing to name.
-     * This is this compiler having lost something, which is the one thing a document may not be
-     * written from.
+     * <p>What was lost is not known: a gap says which rule or which position a measure is short of,
+     * and a reading that dropped one has nothing to name. This is this compiler having lost
+     * something, which is the one thing a document may not be written from.
      */
     @Test
-    void aReadingThatLostItsLineIsRefused() {
-        IllegalStateException refused = assertThrows(IllegalStateException.class,
-                () -> MeasureClosure.of(List.of(anAxisWithOneCut()), List.of(), List.of(),
-                        Map.of()));
+    void aLineFoundAndNotDrawnIsRefused() {
+        LinesRead read = new LinesRead();
+        read.found(aLine(), bound("cap"));
 
-        assertEquals("a reading of `h.a` that found 1 line and drew 0: what a measure is short of"
-                + " cannot be counted from what a reading lost", refused.getMessage());
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> MeasureClosure.of(List.of(anAxis()), List.of(), List.of(), read));
+
+        assertTrue(refused.getMessage().startsWith("a line this reading found and did not draw"),
+                refused.getMessage());
+        assertTrue(refused.getMessage().contains("invariant Amount (cap)"), refused.getMessage());
     }
 
     /**
-     * Counted per rule that drew the cut and not per cut.
+     * And one drawn twice, which a count cannot tell from one drawn once beside one lost.
      *
-     * <p>An invariant and a {@code guard} naming one value are two rules and one place, and each of
-     * them is owed a row: reaching the line through one says nothing about the other. Counted by
-     * cuts, a reading that drew one of the two and lost the other came back whole.
+     * <p>Two borders at one place drawn by one rule ask for the same row under two names. Held as a
+     * number, a reading that dropped a line and made another twice adds up to what a whole one does
+     * — which is why the account is of the lines and not of how many there were.
      */
     @Test
-    void aCutTwoRulesDrewIsTwoLines() {
-        Cut both = Cut.at(Carrier.WHOLE, Count.of(5), bound("cap")).and(bound("floor"));
-        Axis axis = new Axis(AT, new NumericTerm.ValueOf(TermPath.of("h").then("a")), Type.INT,
-                List.of(), List.of(both));
+    void aLineDrawnTwiceIsRefused() {
+        LinesRead read = new LinesRead();
+        read.found(aLine(), bound("cap"));
+        read.drew(aBorder("cap"));
+        read.drew(aBorder("cap"));
 
         IllegalStateException refused = assertThrows(IllegalStateException.class,
-                () -> MeasureClosure.of(List.of(axis), List.of(), List.of(),
-                        Map.of(AT, List.of(aBorder()))));
+                () -> MeasureClosure.of(List.of(anAxis()), List.of(), List.of(), read));
 
-        assertEquals("a reading of `h.a` that found 2 lines and drew 1: what a measure is short of"
-                + " cannot be counted from what a reading lost", refused.getMessage());
+        assertTrue(refused.getMessage().startsWith("a line drawn more than once"),
+                refused.getMessage());
     }
 
-    /** One position bounded at 5, which is one cut drawn by one rule. */
-    private static Axis anAxisWithOneCut() {
+    /** And a border off a line this reading never met, which is the other way the two come apart. */
+    @Test
+    void aBorderTheReadingNeverFoundIsRefused() {
+        LinesRead read = new LinesRead();
+        read.found(aLine(), bound("cap"));
+        read.drew(aBorder("cap"));
+        read.drew(aBorder("floor"));
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> MeasureClosure.of(List.of(anAxis()), List.of(), List.of(), read));
+
+        assertTrue(refused.getMessage().startsWith("a border this reading cannot account for"),
+                refused.getMessage());
+    }
+
+    private static Axis anAxis() {
         return new Axis(AT, new NumericTerm.ValueOf(TermPath.of("h").then("a")), Type.INT,
                 List.of(), List.of(Cut.at(Carrier.WHOLE, Count.of(5), bound("cap"))));
     }
 
-    private static Border aBorder() {
-        return Border.at(
-                BoundaryTarget.at(
-                        new BorderQuantity.OfACoordinate(AT,
-                                new NumericTerm.ValueOf(TermPath.of("h").then("a")),
-                                souther.compiler.inputs.TermOrders.itself(Carrier.WHOLE)),
-                        new Level.OnACarrier(Carrier.WHOLE, Count.of(5))),
-                bound("cap"),
+    private static BoundaryTarget aLine() {
+        return BoundaryTarget.at(
+                new BorderQuantity.OfACoordinate(AT,
+                        new NumericTerm.ValueOf(TermPath.of("h").then("a")),
+                        souther.compiler.inputs.TermOrders.itself(Carrier.WHOLE)),
+                new Level.OnACarrier(Carrier.WHOLE, Count.of(5)));
+    }
+
+    private static Border aBorder(String clause) {
+        return Border.at(aLine(), bound(clause),
                 new souther.compiler.numeric.NumericDomain.Bounds(
                         souther.compiler.numeric.Endpoint.inclusive(Count.of(5)), null));
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACountTheCarrierDoesNotHoldIsNotAnEndTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACountTheCarrierDoesNotHoldIsNotAnEndTest.java
@@ -217,7 +217,7 @@ class ACountTheCarrierDoesNotHoldIsNotAnEndTest {
                 Partitions.of(spec.name(), domain, symbols, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
         return p.axes().stream()
                 .flatMap(axis -> Partitions.bordersOf(axis, symbols,
-                        reading.runsBetween(axis.term())).stream())
+                        reading.runsBetween(axis.term()), new LinesRead()).stream())
                 .flatMap(border -> java.util.stream.Stream.of(PointRole.ON, PointRole.OFF)
                         .filter(role -> border.demand(role).criterion() != null)
                         .map(role -> role + " "

--- a/souther-compiler/src/test/java/souther/compiler/partition/ThresholdNormalizationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ThresholdNormalizationTest.java
@@ -314,7 +314,7 @@ class ThresholdNormalizationTest {
     /** The points against each of {@code axis}'s borders, as {@code role value}. */
     private static List<String> pointsAgainstTheLines(Axis axis, Symbols symbols,
                                                       NumericDomain.Bounds within) {
-        return Partitions.bordersOf(axis, symbols, within).stream()
+        return Partitions.bordersOf(axis, symbols, within, new LinesRead()).stream()
                 .flatMap(border -> java.util.stream.Stream.of(PointRole.ON, PointRole.OFF)
                         .filter(role -> border.demand(role).criterion() != null)
                         .map(role -> role + " "

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatARuleOnAStringIsMeasuredAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatARuleOnAStringIsMeasuredAtTest.java
@@ -193,7 +193,7 @@ class WhatARuleOnAStringIsMeasuredAtTest {
                         : made.stream().map(FixtureTemplate::text)
                                 .map(WhatARuleOnAStringIsMeasuredAtTest::bare).toList().toString());
             }
-            Partitions.bordersOf(axis, symbols, reading.runsBetween(axis.term()))
+            Partitions.bordersOf(axis, symbols, reading.runsBetween(axis.term()), new LinesRead())
                     .forEach(border -> java.util.stream.Stream.of(PointRole.ON, PointRole.OFF)
                             .filter(role -> border.demand(role).criterion() != null)
                             .forEach(role -> owed.add(role + " "

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatTheRulesTogetherLeaveAQuantityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatTheRulesTogetherLeaveAQuantityTest.java
@@ -49,7 +49,8 @@ class WhatTheRulesTogetherLeaveAQuantityTest {
     /** The same, where the rules leave the quantity only what lies between two values. */
     private static List<String> within(String low, String high, Seam... parted) {
         return QuantityArrangement.of(NUMBERS, List.of(parted),
-                        low == null ? null : at(low), high == null ? null : at(high))
+                        low == null ? null : Bound.at(at(low), true),
+                        high == null ? null : Bound.at(at(high), true))
                 .bands().stream().map(Band::key).toList();
     }
 
@@ -74,7 +75,8 @@ class WhatTheRulesTogetherLeaveAQuantityTest {
     /** And a run with no seam under it runs from wherever the rules start the quantity. */
     @Test
     void aRunWithNothingPartingItBelowRunsFromTheStart() {
-        Band first = QuantityArrangement.of(NUMBERS, List.of(upTo("10")), at("0"), null)
+        Band first = QuantityArrangement.of(NUMBERS, List.of(upTo("10")),
+                        Bound.at(at("0"), true), null)
                 .bands().get(0);
 
         assertEquals(false, first.holds(at("-1")), "the rules leave nothing below zero");

--- a/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
+++ b/souther-compiler/src/test/resources/souther/compiler/conformance/catalog/expected.report.json
@@ -146,6 +146,52 @@
             "point" : "out",
             "notOwed" : "the_rules_refuse_it"
           } ]
+        }, {
+          "axis" : "discount/rate",
+          "origin" : "invariant Rate #1",
+          "kind" : "at_value",
+          "value" : "0",
+          "items" : [ {
+            "point" : "on",
+            "notOwed" : "the_carrier_names_no_neighbour"
+          }, {
+            "point" : "off",
+            "notOwed" : "the_rules_refuse_it"
+          }, {
+            "point" : "in",
+            "relation" : "in",
+            "against" : "0 < rate < 1",
+            "knownWritable" : true,
+            "writableBecause" : [ "the_rules_prove_it", "a_row_is_at_it" ],
+            "status" : "complete",
+            "hit" : true
+          }, {
+            "point" : "out",
+            "notOwed" : "the_rules_refuse_it"
+          } ]
+        }, {
+          "axis" : "discount/rate",
+          "origin" : "invariant Rate #1",
+          "kind" : "at_value",
+          "value" : "1",
+          "items" : [ {
+            "point" : "on",
+            "notOwed" : "the_carrier_names_no_neighbour"
+          }, {
+            "point" : "off",
+            "notOwed" : "the_rules_refuse_it"
+          }, {
+            "point" : "in",
+            "relation" : "in",
+            "against" : "0 < rate < 1",
+            "knownWritable" : true,
+            "writableBecause" : [ "the_rules_prove_it", "a_row_is_at_it" ],
+            "status" : "complete",
+            "hit" : true
+          }, {
+            "point" : "out",
+            "notOwed" : "the_rules_refuse_it"
+          } ]
         } ],
         "pairs" : {
           "total" : 0,


### PR DESCRIPTION
Towards #1079. The first of two: this closes the semantics, and a second will
take care of how the measures are shown and of the tests that keep them.

## What was wrong

```souther
data Positive = Decimal
    invariant positive = value > 0m

data AboveFive = Decimal
    invariant above = value > 5.0m

data Holder = { p: Positive, a: AboveFive }
```

Two clauses place an end apiece, and the report printed no `border` section, no
reason, and `adequacy: satisfied`. `--strict` refused nothing over it.

A strict bound is finished by moving its end onto the value it leaves, so
`value > 5` on an `Int` arrives as an inclusive 6 and the cut and the point
against the line are one value. A carrier with no step has no such move:
`value > 5.0m` arrives as an exclusive 5, which the position does not hold.
Every reader after that took the cut for the point, so `Border.at` answered null
for "the quantity does not reach the line", its two callers dropped the null
without a word, and nothing recorded that a rule of the model had gone
unmeasured. `MeasureClosure` then saw no gaps and concluded the reading had run
out, which is how the border measure came back saying the behavior's rules draw
no line anywhere.

## What this does

**Where the rule stops and where a row is written are two questions.**
`Border.reaches` asks whether the line is outside what the rules leave rather
than whether they leave its own value. `Border.at` is total. The point against a
bound's line is asked of the order, which names the cut where the position holds
it and the value beside it otherwise; a carrier with no step names neither, and
that is `THE_CARRIER_NAMES_NO_NEIGHBOUR` — a word the vocabulary already had and
no bound could reach.

**A run's ends move with it.** `Band` held the first and last value in a run,
which a strict end on such a carrier does not have, so the run either ran to the
end of the order or held the very value its bound refuses. They are now where
the run stops and whether it keeps the place it stops at, which is what makes
the class read `0 < rate < 1`.

**The closure is drawn from what the reading produced.** `Closed` followed from
three absences — nothing set aside, nothing unanswered, no position unreached —
and a rule dropped before it could be set aside leaves all three as they were.
`MeasureClosure.of` is now handed the lines and holds them against the cuts:
one rule that drew a cut is one line, so a reading holding fewer lines than cuts
has lost one however it went, and that is refused rather than reported as a gap.

The two callers that dropped a null border no longer can.

## What the report says now

```
  take                     implemented   rows 0    pending 0
    signature   not applicable (this behavior's output is not a sum)
    partition   not applicable (the rules of this behavior divide no position)
    border      borders 2   coverage items 0/0   excluded 4   (2 not measured: no row names this behavior)
      · no ON point is owed at h.p = 0 (invariant Positive (positive)): this order names no value there, so the point cannot be written
      · no OFF point is owed at h.p = 0 (invariant Positive (positive)): excluded — the rules leave no value there
      · no OUT point is owed at h.p = 0 (invariant Positive (positive)): excluded — the rules leave no value there
      · ... the same at h.a = 5
    branch      not applicable (this body owes no arm)

adequacy: undetermined
```

The `IN` point of each line is owed and unmet, which is the row the model was
short of all along.

## Notes for the reviewer

- `AReportOfOneBorder.aBoundedBorder` built a bound at 100 over a run from 1, so
  its line sat inside what it leaves. No model draws that — nothing is below a
  bound — and the fixture's `ON` point at the line came with an `IN` point over
  the values the bound refuses. It is a bound at 100 over 100..1000 now. Its
  comment said all four points were owed, which an invariant never has.
- `aBoundThatStopsShortOfItsValueDrawsNoBorderAtIt` asserted the null this fixes.
  Its own prose said the origin "would answer `ON` for a value its own type
  refuses on the day the derivation reaches further"; that day is this one, so
  it now reads the point rather than the line.
- The `catalog` corpus gains two borders on `discount/rate`, whose type is
  `Decimal` bounded `> 0.00m && < 1.00m`. Both `IN` points are already hit by
  rows that exist. Regenerated and run.

## Still to come

`AdequacyReport` decides whether to print the two measures from the evidence
lists beside them rather than from the measures themselves, and the JSON report
decides it differently — so this model prints nothing in one and a
`NO_RULE_DRAWS_A_LINE` in the other. That, the positive form of
`AnEndIsWhereItsRuleStopsTest`, and the structural tests go in the second PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)