### PR TITLE
Say which kernel a call to the standard library reaches

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -3,6 +3,7 @@ package souther.compiler.check;
 import souther.compiler.stdlib.Stdlib;
 import souther.compiler.ast.Hir;
 import souther.compiler.core.Core;
+import souther.compiler.core.Kernel;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.Region;
@@ -41,10 +42,10 @@ public final class CallElaborator {
      * say (ADR-0053). The declaration states the shape and this states the rest, keyed by the kernel
      * it constrains — which is what {@code sort} has always done, written out by hand.
      */
-    private static final Map<String, OrderedElement> ORDERED_ELEMENT = Map.of(
-            "list.sort", OrderedElement.OF_THE_LIST,
-            "list.max", OrderedElement.OF_THE_OPTION,
-            "list.min", OrderedElement.OF_THE_OPTION);
+    private static final Map<Kernel, OrderedElement> ORDERED_ELEMENT = Map.of(
+            Kernel.LIST_SORT, OrderedElement.OF_THE_LIST,
+            Kernel.LIST_MAX, OrderedElement.OF_THE_OPTION,
+            Kernel.LIST_MIN, OrderedElement.OF_THE_OPTION);
 
     /**
      * Refuses an element with no natural order. An ordered primitive has one, and so does a newtype
@@ -52,8 +53,9 @@ public final class CallElaborator {
      * throw at run time, so it is refused here. The empty-list literal (element {@code Nothing}) is
      * fine: it sorts to itself and its max is {@code None}.
      */
-    private static void requiresOrdering(String key, Hir.Apply call, Type result, CheckContext ctx) {
-        OrderedElement where = ORDERED_ELEMENT.get(key);
+    private static void requiresOrdering(Kernel kernel, Hir.Apply call, Type result,
+                                         CheckContext ctx) {
+        OrderedElement where = ORDERED_ELEMENT.get(kernel);
         if (where == null) {
             return;
         }
@@ -79,9 +81,9 @@ public final class CallElaborator {
      * what the list holds, so it reads the binding the key's declared result took rather than the
      * call's result.
      */
-    private static void requiresOrderedKey(String key, Hir.Apply call, Type.FnOf declaredKey,
+    private static void requiresOrderedKey(Kernel kernel, Hir.Apply call, Type.FnOf declaredKey,
                                            Map<String, Type> bindings, CheckContext ctx) {
-        if (!key.equals("list.sortBy")) {
+        if (kernel != Kernel.LIST_SORT_BY) {
             return;
         }
         Type answered = TypeOps.substitute(declaredKey.result(), bindings);
@@ -116,8 +118,33 @@ public final class CallElaborator {
         Type declared = entry.signature().result();
         Map<String, Type> bindings = new HashMap<>();
         BottomInfer.pinResultTypeVars(declared, expected, bindings, ctx.symbols());
-        return new Core.Call(new ReachName.OfLibrary(lib), lib, List.of(),
-                TypeOps.toBottom(TypeOps.substitute(declared, bindings)), v.pos());
+        return new Core.Call(reached(new ReachName.OfLibrary(lib), lib, ctx),
+                List.of(), TypeOps.toBottom(TypeOps.substitute(declared, bindings)), v.pos());
+    }
+
+    /**
+     * What a call to a name applies, as this compiler has settled it: the name the module reaches
+     * the callee by, what that name denotes, and — where the declaration behind it is a kernel of
+     * the standard library — which kernel that is.
+     *
+     * <p>The one place a {@link Core.Reached} is built. Two things reach it — an application, and a
+     * library value written on its own — and each of them asking the library whether what it reached
+     * is a kernel would be one rule kept in as many places as there are callers, which is how one of
+     * them comes to be the one that forgets. {@code Core.Call} takes what is applied and no longer
+     * takes a name, so there is no way past here to a call target built out of a spelling.
+     *
+     * <p>Asked of what the name denotes rather than of how it renders. Whether an operation is a
+     * kernel is a property of the declaration the resolver picked, and the two are one string apart
+     * only for as long as they happen to be.
+     */
+    private static Core.Reached reached(ReachName name, ValueName denotes, CheckContext ctx) {
+        if (denotes instanceof ValueName.Stdlib operation) {
+            Stdlib.Intrinsic kernel = ctx.symbols().library().intrinsicOf(operation.qualified());
+            if (kernel != null) {
+                return new Core.Reached.OfKernel(name, denotes, kernel.kernel());
+            }
+        }
+        return new Core.Reached.OfDeclaration(name, denotes);
     }
 
     static Core elaborateCall(Hir.Apply call, Scope env, CheckContext ctx,
@@ -168,7 +195,8 @@ public final class CallElaborator {
         ValueName denotes = callee.denotes() instanceof ValueName.Local local
                 && ctx.dependencyOf(local.id()) != null
                 ? ctx.dependencyOf(local.id()) : callee.denotes();
-        return new Core.Call(callee.reachedAs(), denotes, ca.cores(), result, call.pos());
+        return new Core.Call(reached(callee.reachedAs(), denotes, ctx), ca.cores(), result,
+                call.pos());
     }
 
     /**
@@ -535,11 +563,14 @@ public final class CallElaborator {
                             .hint(new NameMessage.WriteItOnItsOwn(call.written())).say(new NameMessage.ItIsNotAFunctionHere(call.written())).build());
         }
         // A shipped kernel behaves like a built-in: check the call against the declared signature
-        // and yield its result type; the backend emits the primitive for its key. A Souther-bodied
-        // library call — a recursive helper such as `List.foldFrom` — is not one of these and takes
-        // the paths below, as any helper does.
-        if (entry != null && entry.declaration().body() instanceof Hir.FnBody.Intrinsic kernel) {
-            Stdlib.Signature intrinsic = entry.signature();
+        // and yield its result type; the backend emits the primitive the call says it reaches. A
+        // Souther-bodied library call — a recursive helper such as `List.foldFrom` — is not one of
+        // these and takes the paths below, as any helper does.
+        Stdlib.Intrinsic declaredKernel = callee.denotes() instanceof ValueName.Stdlib operation
+                ? ctx.symbols().library().intrinsicOf(operation.qualified()) : null;
+        if (declaredKernel != null) {
+            Kernel kernel = declaredKernel.kernel();
+            Stdlib.Signature intrinsic = declaredKernel.signature();
             if (args.size() != intrinsic.params().size()) {
                 throw CompileException.of(Diagnostic
                                 .at(call.appliedAt())
@@ -547,20 +578,20 @@ public final class CallElaborator {
             }
             Applied applied = applySignature(call,
                     new Type.FnOf(intrinsic.params(), intrinsic.result()), ca, expected, env, ctx);
-            // What remains is the kernel's own: constraints its key names on the outcome the
+            // What remains is the kernel's own: constraints the kernel places on the outcome the
             // signature could not state, and the emitter's special cases. They read the settled
             // substitution and result — they are checks on what the application became, not part
             // of how an application is typed.
             for (Type param : intrinsic.params()) {
                 if (param instanceof Type.FnOf declaredStep) {
-                    requiresOrderedKey(kernel.key(), call, declaredStep, applied.substitution(), ctx);
+                    requiresOrderedKey(kernel, call, declaredStep, applied.substitution(), ctx);
                 }
             }
-            requiresOrdering(kernel.key(), call, applied.result(), ctx);
-            if (kernel.key().equals("list.sum") || kernel.key().equals("list.product")) {
+            requiresOrdering(kernel, call, applied.result(), ctx);
+            if (kernel == Kernel.LIST_SUM || kernel == Kernel.LIST_PRODUCT) {
                 return numericFold(call, applied.result(), expected);
             }
-            if (kernel.key().equals("string.matches")) {
+            if (kernel == Kernel.STRING_MATCHES) {
                 validateRegexPattern(args.get(0));
             }
             return applied.result();

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -139,7 +139,7 @@ public final class CallElaborator {
      */
     private static Core.Reached reached(ReachName name, ValueName denotes, CheckContext ctx) {
         if (denotes instanceof ValueName.Stdlib operation) {
-            Stdlib.Intrinsic kernel = ctx.symbols().library().intrinsicOf(operation.qualified());
+            Stdlib.Intrinsic kernel = ctx.symbols().library().intrinsicOf(operation);
             if (kernel != null) {
                 return new Core.Reached.OfKernel(name, denotes, kernel.kernel());
             }
@@ -567,7 +567,7 @@ public final class CallElaborator {
         // Souther-bodied library call — a recursive helper such as `List.foldFrom` — is not one of
         // these and takes the paths below, as any helper does.
         Stdlib.Intrinsic declaredKernel = callee.denotes() instanceof ValueName.Stdlib operation
-                ? ctx.symbols().library().intrinsicOf(operation.qualified()) : null;
+                ? ctx.symbols().library().intrinsicOf(operation) : null;
         if (declaredKernel != null) {
             Kernel kernel = declaredKernel.kernel();
             Stdlib.Signature intrinsic = declaredKernel.signature();

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -710,6 +710,20 @@ final class DischargeRules {
         return params.get(ROUNDING_POLICY_ARGUMENT);
     }
 
+    /** The library operation {@code operation} names. Every fact is declared of one, so the name
+     *  says which library and which operation rather than a spelling a reader would have to take
+     *  apart — and a reader that has held a name to the library holds this rather than narrowing the
+     *  name a second time.
+     *
+     *  @throws IllegalStateException where the name is no library operation. */
+    static ValueName.Stdlib theLibraryOperation(ValueName operation) {
+        if (!(operation instanceof ValueName.Stdlib library)) {
+            throw new IllegalStateException("a fact is declared of " + operation
+                    + ", which is not a library operation");
+        }
+        return library;
+    }
+
     /**
      * The library's declaration of {@code operation}, or a build that does not start.
      *
@@ -724,12 +738,7 @@ final class DischargeRules {
      * lost the same way, silently, on the day its arm was written empty.
      */
     static Stdlib.Entry holdTheOperationToTheLibrary(Stdlib stdlib, ValueName operation) {
-        // Every fact is about an operation the library declares, so the operation says which
-        // library and which name rather than a spelling this would have to take apart.
-        if (!(operation instanceof ValueName.Stdlib library)) {
-            throw new IllegalStateException("a fact is declared of " + operation
-                    + ", which is not a library operation");
-        }
+        ValueName.Stdlib library = theLibraryOperation(operation);
         Stdlib.Entry entry = stdlib.entry(library.qualified());
         if (entry == null) {
             throw new IllegalStateException("a fact is declared of " + library.qualified()

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -1077,9 +1077,12 @@ final class HelperParams {
             }
             // Only a kernel's signature: a Souther-bodied library callee here is a recursive
             // helper, and those are answered above with the types their call site instantiated.
-            // Whether the name is a kernel is a fact about the library and is asked of it, rather
-            // than read off the body of the declaration behind the name.
-            Stdlib.Intrinsic kernel = symbols.library().intrinsicOf(fn);
+            // Whether the name is a kernel is a fact about the library, asked of it and asked with
+            // the operation this call was resolved to rather than with the name it renders as.
+            if (!(call.answered().denotes() instanceof ValueName.Stdlib operation)) {
+                return null;
+            }
+            Stdlib.Intrinsic kernel = symbols.library().intrinsicOf(operation);
             if (kernel == null) {
                 return null;
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -1077,11 +1077,13 @@ final class HelperParams {
             }
             // Only a kernel's signature: a Souther-bodied library callee here is a recursive
             // helper, and those are answered above with the types their call site instantiated.
-            Stdlib.Entry entry = symbols.library().entry(fn);
-            if (entry == null || !(entry.declaration().body() instanceof Hir.FnBody.Intrinsic)) {
+            // Whether the name is a kernel is a fact about the library and is asked of it, rather
+            // than read off the body of the declaration behind the name.
+            Stdlib.Intrinsic kernel = symbols.library().intrinsicOf(fn);
+            if (kernel == null) {
                 return null;
             }
-            return new Type.FnOf(entry.signature().params(), entry.signature().result());
+            return new Type.FnOf(kernel.signature().params(), kernel.signature().result());
         }
 
         private boolean isParam(Hir.Expr e, BindingId target) {

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericReadings.java
@@ -115,8 +115,7 @@ final class NumericReadings {
     private static List<NumericReading> readingsOf(Stdlib stdlib,
             List<OperationFacts.Declared> declared, ValueName operation) {
         Stdlib.Entry entry = DischargeRules.holdTheOperationToTheLibrary(stdlib, operation);
-        // Which it held to be a library operation, so the name is one here.
-        ValueName.Stdlib named = (ValueName.Stdlib) operation;
+        ValueName.Stdlib named = DischargeRules.theLibraryOperation(operation);
         if (NumericAnswers.in(entry.signature().result()) == null) {
             return List.of();
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericReadings.java
@@ -1,6 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.semantics.ArgumentRef;
 import souther.compiler.semantics.NumericResult;
@@ -116,6 +115,8 @@ final class NumericReadings {
     private static List<NumericReading> readingsOf(Stdlib stdlib,
             List<OperationFacts.Declared> declared, ValueName operation) {
         Stdlib.Entry entry = DischargeRules.holdTheOperationToTheLibrary(stdlib, operation);
+        // Which it held to be a library operation, so the name is one here.
+        ValueName.Stdlib named = (ValueName.Stdlib) operation;
         if (NumericAnswers.in(entry.signature().result()) == null) {
             return List.of();
         }
@@ -164,7 +165,9 @@ final class NumericReadings {
         List<NumericReading> found = new ArrayList<>(terms);
         found.addAll(forms);
         found.addAll(arithmetic);
-        if (!(entry.declaration().body() instanceof Hir.FnBody.Intrinsic)) {
+        // Whether the operation is a kernel is a fact about the library and is asked of it, rather
+        // than read off the body of the declaration behind the name.
+        if (stdlib.intrinsicOf(named.qualified()) == null) {
             found.add(new NumericReading.ByTheBodyTheLanguageWritesOut());
         }
         return List.copyOf(found);

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericReadings.java
@@ -166,7 +166,7 @@ final class NumericReadings {
         found.addAll(arithmetic);
         // Whether the operation is a kernel is a fact about the library and is asked of it, rather
         // than read off the body of the declaration behind the name.
-        if (stdlib.intrinsicOf(named.qualified()) == null) {
+        if (stdlib.intrinsicOf(named) == null) {
             found.add(new NumericReading.ByTheBodyTheLanguageWritesOut());
         }
         return List.copyOf(found);

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -31,6 +31,7 @@ import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -1145,18 +1146,20 @@ final class BodyGen {
         /**
          * Emits a call to a kernel.
          *
-         * <p>Three of them are not a row of {@link Intrinsics}' table. An enumeration's order lives
-         * on its sum, so the ordered family takes it as a comparator rather than reading a
-         * {@code Comparable} off the value (issue #161); and a partial Int division answers a case
-         * rather than a number when its divisor is zero, so it emits a branch where the table's row
-         * shape is one call with one result. {@code Decimal.divide} was a fourth: it is an ordinary
-         * kernel now, and its zero divisor is answered by the runtime that owns the operation
-         * (ADR-0112).
+         * <p>What is written here is what a table row cannot say, and it is of two kinds. An
+         * enumeration's order lives on its sum, so the ordered family is handed a comparator rather
+         * than reading a {@code Comparable} off the value (issue #161) — the arm puts the comparator
+         * on the stack and the row still says what is called with it. A partial Int division answers
+         * a case rather than a number when its divisor is zero, so it emits a branch, which the row
+         * shape of one call with one result has nowhere to put; those two are the whole of what this
+         * emits itself, and {@code WRITTEN_OUT} is where they are named. {@code Decimal.divide} was
+         * a third: it is an ordinary kernel now, and its zero divisor is answered by the runtime
+         * that owns the operation (ADR-0112).
          *
-         * <p>Each of those three arms falls through to the table where its own condition does not
-         * hold — the ordered family over an element the JVM already compares, a {@code sortBy} whose
-         * key answers something with no sum to take an ordering off. What no arm and no row answers
-         * is this backend being behind the library, which {@link Intrinsics#emit} says.
+         * <p>An ordered arm falls through to the table where its own condition does not hold — an
+         * element the JVM already compares, a {@code sortBy} whose key answers something with no sum
+         * to take an ordering off. What no arm and no row answers is this backend being behind the
+         * library, which {@link Intrinsics#emit} says.
          */
         private void kernel(Kernel kernel, Core.Call call) {
             switch (kernel) {
@@ -1166,8 +1169,8 @@ final class BodyGen {
                         break;
                     }
                     code.invokestatic(cd(ordering), ORDERING_METHOD, MTD_ordering, true);
-                    Intrinsics.emitOrderedByComparator(this, kernel,
-                            genExpr(call.args().get(0)));
+                    Intrinsics.emitWithComparator(this, kernel,
+                            List.of(genExpr(call.args().get(0))));
                     return;
                 }
                 // `sortBy` orders by what its key answers, not by what the list holds, so its
@@ -1180,9 +1183,8 @@ final class BodyGen {
                     code.invokestatic(cd(ordering), ORDERING_METHOD, MTD_ordering, true);
                     emitFunctionValue(call.args().get(0),
                             List.of(((Type.ListOf) call.args().get(1).type()).element()));
-                    genExpr(call.args().get(1));
-                    code.invokestatic(CD_Lists, "sortBy",
-                            MethodTypeDesc.of(CD_List, CD_Comparator, CD_Fn, CD_List));
+                    Intrinsics.emitWithComparator(this, kernel,
+                            List.of(key, genExpr(call.args().get(1))));
                     return;
                 }
                 case INT_DIVIDE -> {
@@ -1197,6 +1199,13 @@ final class BodyGen {
             }
             Intrinsics.emit(this, kernel, call);
         }
+
+        /** The kernels this emits itself, which are the kernels {@link Intrinsics}' table has no row
+         *  for. Named rather than left to be read off the arms above, so the two sets can be held
+         *  apart: a kernel emitted here and held there too would be one operation with two answers,
+         *  and the one that ran would be whichever the arm above happened to reach first. */
+        static final Set<Kernel> WRITTEN_OUT =
+                EnumSet.of(Kernel.INT_DIVIDE, Kernel.INT_TRUNCATING_REMAINDER);
 
         private void call(Core.Call call, Type expected) {
             // Which kernel a call reaches is on the call, so what is emitted for one is asked of

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -1166,10 +1166,8 @@ final class BodyGen {
                         break;
                     }
                     code.invokestatic(cd(ordering), ORDERING_METHOD, MTD_ordering, true);
-                    genExpr(call.args().get(0));
-                    code.invokestatic(CD_Lists, RUNTIME_ORDERED.get(kernel),
-                            MethodTypeDesc.of(kernel == Kernel.LIST_SORT ? CD_List : CD_Option,
-                                    CD_Comparator, CD_List));
+                    Intrinsics.emitOrderedByComparator(this, kernel,
+                            genExpr(call.args().get(0)));
                     return;
                 }
                 // `sortBy` orders by what its key answers, not by what the list holds, so its
@@ -1199,12 +1197,6 @@ final class BodyGen {
             }
             Intrinsics.emit(this, kernel, call);
         }
-
-        /** What the runtime calls each of the ordered family when it is handed a comparator. The
-         *  runtime's own name for the operation, which is the JVM ABI's to say — spelled out here
-         *  rather than taken off the library's alias, which is what a module imported it under. */
-        private static final Map<Kernel, String> RUNTIME_ORDERED = Map.of(
-                Kernel.LIST_SORT, "sort", Kernel.LIST_MAX, "max", Kernel.LIST_MIN, "min");
 
         private void call(Core.Call call, Type expected) {
             // Which kernel a call reaches is on the call, so what is emitted for one is asked of

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -12,11 +12,11 @@ import souther.compiler.check.CheckContext;
 import souther.compiler.check.DataChecker;
 import souther.compiler.check.ReqSig;
 import souther.compiler.types.BindingId;
-import souther.compiler.types.ReachName;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.check.Ordering;
 import souther.compiler.core.Core;
+import souther.compiler.core.Kernel;
 import souther.compiler.core.GrowingFold;
 
 import souther.compiler.core.EnsuresEnforcement;
@@ -1142,53 +1142,76 @@ final class BodyGen {
             emitFunctionValue(value, paramTypes);
         }
 
-        private void call(Core.Call call, Type expected) {
-            // An enumeration's order lives on its sum, so the ordered family takes it as a comparator
-            // rather than reading a Comparable off the value (issue #161). Everything else about
-            // these is what their declaration says, so only this prefix is written out here.
-            if (ORDERED_BY_COMPARATOR.contains(call.name())) {
-                TypeSymbol ordering = elementOrdering(call.args().get(0));
-                if (ordering != null) {
+        /**
+         * Emits a call to a kernel.
+         *
+         * <p>Three of them are not a row of {@link Intrinsics}' table. An enumeration's order lives
+         * on its sum, so the ordered family takes it as a comparator rather than reading a
+         * {@code Comparable} off the value (issue #161); and a partial Int division answers a case
+         * rather than a number when its divisor is zero, so it emits a branch where the table's row
+         * shape is one call with one result. {@code Decimal.divide} was a fourth: it is an ordinary
+         * kernel now, and its zero divisor is answered by the runtime that owns the operation
+         * (ADR-0112).
+         *
+         * <p>Each of those three arms falls through to the table where its own condition does not
+         * hold — the ordered family over an element the JVM already compares, a {@code sortBy} whose
+         * key answers something with no sum to take an ordering off. What no arm and no row answers
+         * is this backend being behind the library, which {@link Intrinsics#emit} says.
+         */
+        private void kernel(Kernel kernel, Core.Call call) {
+            switch (kernel) {
+                case LIST_SORT, LIST_MAX, LIST_MIN -> {
+                    TypeSymbol ordering = elementOrdering(call.args().get(0));
+                    if (ordering == null) {
+                        break;
+                    }
                     code.invokestatic(cd(ordering), ORDERING_METHOD, MTD_ordering, true);
                     genExpr(call.args().get(0));
-                    String bare = operationOf(call);
-                    code.invokestatic(CD_Lists, bare, MethodTypeDesc.of(
-                            bare.equals("sort") ? CD_List : CD_Option, CD_Comparator, CD_List));
+                    code.invokestatic(CD_Lists, RUNTIME_ORDERED.get(kernel),
+                            MethodTypeDesc.of(kernel == Kernel.LIST_SORT ? CD_List : CD_Option,
+                                    CD_Comparator, CD_List));
                     return;
                 }
-            }
-            // `sortBy` orders by what its key answers, not by what the list holds, so its comparator
-            // is read off the key's result type.
-            if ("List.sortBy".equals(call.name())
-                    && call.args().get(0).type() instanceof Type.FnOf key
-                    && sumOrdering(key.result()) instanceof TypeSymbol ordering) {
-                code.invokestatic(cd(ordering), ORDERING_METHOD, MTD_ordering, true);
-                emitFunctionValue(call.args().get(0),
-                        List.of(((Type.ListOf) call.args().get(1).type()).element()));
-                genExpr(call.args().get(1));
-                code.invokestatic(CD_Lists, "sortBy",
-                        MethodTypeDesc.of(CD_List, CD_Comparator, CD_Fn, CD_List));
-                return;
-            }
-            // A partial Int division answers a case rather than a number when its divisor is zero,
-            // so it emits a branch. The table's row shape is one call with one result; these two are
-            // written out here, and their declarations still say what they take and answer.
-            // `Decimal.divide` was a third: it is an ordinary kernel now, and its zero divisor is
-            // answered by the runtime that owns the operation (ADR-0112).
-            switch (call.name()) {
-                case "Int.divide" -> {
+                // `sortBy` orders by what its key answers, not by what the list holds, so its
+                // comparator is read off the key's result type.
+                case LIST_SORT_BY -> {
+                    if (!(call.args().get(0).type() instanceof Type.FnOf key)
+                            || !(sumOrdering(key.result()) instanceof TypeSymbol ordering)) {
+                        break;
+                    }
+                    code.invokestatic(cd(ordering), ORDERING_METHOD, MTD_ordering, true);
+                    emitFunctionValue(call.args().get(0),
+                            List.of(((Type.ListOf) call.args().get(1).type()).element()));
+                    genExpr(call.args().get(1));
+                    code.invokestatic(CD_Lists, "sortBy",
+                            MethodTypeDesc.of(CD_List, CD_Comparator, CD_Fn, CD_List));
+                    return;
+                }
+                case INT_DIVIDE -> {
                     intDivide(call, true);
                     return;
                 }
-                case "Int.truncatingRemainder" -> {
+                case INT_TRUNCATING_REMAINDER -> {
                     intDivide(call, false);
                     return;
                 }
                 default -> { }
             }
-            Stdlib.Entry entry = ctx.library().entry(call.name());
-            if (entry != null && entry.declaration().body() instanceof Hir.FnBody.Intrinsic kernel) {
-                Intrinsics.emit(this, kernel.key(), call);
+            Intrinsics.emit(this, kernel, call);
+        }
+
+        /** What the runtime calls each of the ordered family when it is handed a comparator. The
+         *  runtime's own name for the operation, which is the JVM ABI's to say — spelled out here
+         *  rather than taken off the library's alias, which is what a module imported it under. */
+        private static final Map<Kernel, String> RUNTIME_ORDERED = Map.of(
+                Kernel.LIST_SORT, "sort", Kernel.LIST_MAX, "max", Kernel.LIST_MIN, "min");
+
+        private void call(Core.Call call, Type expected) {
+            // Which kernel a call reaches is on the call, so what is emitted for one is asked of
+            // the operation. Matched against the rendered reach name instead, these arms would turn
+            // on the alias the library publishes the operation under.
+            if (call.fn() instanceof Core.Reached.OfKernel(_, _, Kernel kernel)) {
+                kernel(kernel, call);
                 return;
             }
             if (call.fn() == Core.Emitted.BUILD_LIST) {
@@ -1456,13 +1479,6 @@ final class BodyGen {
         /** The self-hosted walk of {@code souther.list}: a recursive helper everywhere else, and the
          *  loop every fold in a program is, which is why the emitter knows its name. */
         private static final String FOLD = "List.foldFrom";
-
-        /** The operation a library call names ({@code List.max} → {@code max}) — read off the
-         * name, which holds the library's alias and the operation as two values. */
-        private static String operationOf(Core.Call call) {
-            Core.Reached reached = (Core.Reached) call.fn();
-            return ((ReachName.OfLibrary) reached.name()).target().name();
-        }
 
         /**
          * {@code divide}/{@code remainder} on Int: a zero divisor takes the DivisionByZero case,

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Descriptors.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Descriptors.java
@@ -338,10 +338,6 @@ final class Descriptors {
     static final String ORDER_METHOD = "__order";
     static final String ORDERING_METHOD = "__ordering";
 
-    /** The library functions that compare by natural order. An enumeration's order lives on its sum
-     *  rather than on its values, so for one of these the emitter passes a comparator (issue #161). */
-    static final java.util.Set<String> ORDERED_BY_COMPARATOR =
-            java.util.Set.of("List.sort", "List.max", "List.min");
     static final MethodTypeDesc MTD_order = MethodTypeDesc.of(ConstantDescs.CD_int, CD_Object);
     static final ClassDesc CD_Comparator = ClassDesc.of("java.util.Comparator");
     static final ClassDesc CD_ToIntFunction = ClassDesc.of("java.util.function.ToIntFunction");

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Intrinsics.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Intrinsics.java
@@ -4,6 +4,7 @@ import souther.compiler.jvm.SoutherJvmAbi;
 import souther.compiler.stdlib.Stdlib;
 import souther.compiler.types.Type;
 import souther.compiler.core.Core;
+import souther.compiler.core.Kernel;
 
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
@@ -36,20 +37,20 @@ final class Intrinsics {
     private Intrinsics() {
     }
 
-    /** Emits the intrinsic named by {@code key}, leaving its result on the stack, and returns the
-     * result's Souther type (spec §stdlib). Throws on an unknown key — the checker admits only keys
-     * that were declared {@code = intrinsic "..."} in a prelude module, so this is a compiler bug. */
-    static Type emit(BodyGen g, String key, Core.Call call) {
-        Emit e = TABLE.get(key);
+    /** Emits {@code kernel}, leaving its result on the stack, and returns the result's Souther type
+     * (spec §stdlib). Throws where this table has no row for it — the language names the kernel and
+     * the JVM answers it, so a kernel with no answer here is this backend behind the library. */
+    static Type emit(BodyGen g, Kernel kernel, Core.Call call) {
+        Emit e = TABLE.get(kernel);
         if (e == null) {
-            throw new IllegalStateException("unknown intrinsic `" + key + "`");
+            throw new IllegalStateException("the JVM emits nothing for `" + kernel.key() + "`");
         }
-        return e.emit(g, key, call);
+        return e.emit(g, kernel, call);
     }
 
     sealed interface Emit permits RuntimeStatic, JdkVirtual, NumericFold, TakesAFunction,
             DeclaredStatic {
-        Type emit(BodyGen g, String key, Core.Call call);
+        Type emit(BodyGen g, Kernel kernel, Core.Call call);
     }
 
     /**
@@ -61,8 +62,8 @@ final class Intrinsics {
      * happens to be, while the declaration names the sum.
      */
     record DeclaredStatic(ClassDesc owner, String method) implements Emit {
-        public Type emit(BodyGen g, String key, Core.Call call) {
-            Stdlib.Signature declared = g.library().intrinsic(key).signature();
+        public Type emit(BodyGen g, Kernel kernel, Core.Call call) {
+            Stdlib.Signature declared = g.library().intrinsic(kernel).signature();
             ClassDesc[] params = new ClassDesc[declared.params().size()];
             for (int i = 0; i < params.length; i++) {
                 params[i] = boundaryDesc(declared.params().get(i));
@@ -88,7 +89,7 @@ final class Intrinsics {
     record TakesAFunction(ClassDesc owner, String method, int container,
                           Function<Type, List<Type>> paramTypes,
                           Function<List<Type>, Type> result) implements Emit {
-        public Type emit(BodyGen g, String key, Core.Call call) {
+        public Type emit(BodyGen g, Kernel kernel, Core.Call call) {
             Type held = call.args().get(container).type();
             g.emitFn(call.args().get(0), paramTypes.apply(held));
             g.genExpr(call.args().get(container));
@@ -109,7 +110,7 @@ final class Intrinsics {
      */
     record RuntimeStatic(ClassDesc owner, String method, int[] argOrder,
                          Set<Integer> objectSlots, Function<List<Type>, Type> result) implements Emit {
-        public Type emit(BodyGen g, String key, Core.Call call) {
+        public Type emit(BodyGen g, Kernel kernel, Core.Call call) {
             int n = argOrder.length;
             Type[] byArg = new Type[n];
             ClassDesc[] params = new ClassDesc[n];
@@ -146,7 +147,7 @@ final class Intrinsics {
      */
     record JdkVirtual(ClassDesc owner, String method, MethodTypeDesc desc, int[] argOrder,
                       Type result) implements Emit {
-        public Type emit(BodyGen g, String key, Core.Call call) {
+        public Type emit(BodyGen g, Kernel kernel, Core.Call call) {
             for (int src : argOrder) {
                 g.genExpr(call.args().get(src));
             }
@@ -163,7 +164,7 @@ final class Intrinsics {
      * position the call was written in.
      */
     record NumericFold(String intMethod, String decimalMethod) implements Emit {
-        public Type emit(BodyGen g, String key, Core.Call call) {
+        public Type emit(BodyGen g, Kernel kernel, Core.Call call) {
             Type result = call.type();
             if (result != Type.INT && result != Type.DECIMAL) {
                 // the checker admits these two and nothing else; anything here is this compiler
@@ -221,16 +222,16 @@ final class Intrinsics {
 
     // --- the registry ---
 
-    private static final Map<String, Emit> TABLE = buildTable();
+    private static final Map<Kernel, Emit> TABLE = buildTable();
 
-    /** Every kernel key this table emits. A key here with no declaration naming it is a kernel the
-     *  library ships and no signature describes, which is what {@code BUILTINS} used to be. */
-    static Set<String> keys() {
+    /** Every kernel this table emits. One here with no declaration naming it is a kernel the library
+     *  ships and no signature describes, which is what {@code BUILTINS} used to be. */
+    static Set<Kernel> kernels() {
         return TABLE.keySet();
     }
 
-    /** How each key is emitted — read by the test that holds the descriptor invariant. */
-    static Map<String, Emit> emitters() {
+    /** How each kernel is emitted — read by the test that holds the descriptor invariant. */
+    static Map<Kernel, Emit> emitters() {
         return Map.copyOf(TABLE);
     }
 
@@ -262,155 +263,155 @@ final class Intrinsics {
         return MethodTypeDesc.of(ret, params);
     }
 
-    private static Map<String, Emit> buildTable() {
+    private static Map<Kernel, Emit> buildTable() {
         ClassDesc bool = ConstantDescs.CD_boolean;
         ClassDesc lng = ConstantDescs.CD_long;
-        Map<String, Emit> t = new java.util.LinkedHashMap<>();
+        Map<Kernel, Emit> t = new java.util.EnumMap<>(Kernel.class);
 
         // String — JDK-native instance methods (explicit descriptor); receiver is the last Souther arg.
-        t.put("string.toInt", rtDeclared(CD_Strings, "toInt", order(0)));
-        t.put("string.toDecimal", rtDeclared(CD_Strings, "toDecimal", order(0)));
-        t.put("string.length", rt(CD_Strings, "length", order(0), ts -> Type.INT));
-        t.put("string.trim", jdk(CD_String, "trim", mtd(CD_String), order(0), Type.STRING));
-        t.put("string.lowercase", jdk(CD_String, "toLowerCase", mtd(CD_String), order(0), Type.STRING));
-        t.put("string.uppercase", jdk(CD_String, "toUpperCase", mtd(CD_String), order(0), Type.STRING));
-        t.put("string.contains", jdk(CD_String, "contains", mtd(bool, CD_CharSequence), order(1, 0), Type.BOOL));
-        t.put("string.startsWith", jdk(CD_String, "startsWith", mtd(bool, CD_String), order(1, 0), Type.BOOL));
-        t.put("string.endsWith", jdk(CD_String, "endsWith", mtd(bool, CD_String), order(1, 0), Type.BOOL));
-        t.put("string.append", jdk(CD_String, "concat", mtd(CD_String, CD_String), order(0, 1), Type.STRING));
+        t.put(Kernel.STRING_TO_INT, rtDeclared(CD_Strings, "toInt", order(0)));
+        t.put(Kernel.STRING_TO_DECIMAL, rtDeclared(CD_Strings, "toDecimal", order(0)));
+        t.put(Kernel.STRING_LENGTH, rt(CD_Strings, "length", order(0), ts -> Type.INT));
+        t.put(Kernel.STRING_TRIM, jdk(CD_String, "trim", mtd(CD_String), order(0), Type.STRING));
+        t.put(Kernel.STRING_LOWERCASE, jdk(CD_String, "toLowerCase", mtd(CD_String), order(0), Type.STRING));
+        t.put(Kernel.STRING_UPPERCASE, jdk(CD_String, "toUpperCase", mtd(CD_String), order(0), Type.STRING));
+        t.put(Kernel.STRING_CONTAINS, jdk(CD_String, "contains", mtd(bool, CD_CharSequence), order(1, 0), Type.BOOL));
+        t.put(Kernel.STRING_STARTS_WITH, jdk(CD_String, "startsWith", mtd(bool, CD_String), order(1, 0), Type.BOOL));
+        t.put(Kernel.STRING_ENDS_WITH, jdk(CD_String, "endsWith", mtd(bool, CD_String), order(1, 0), Type.BOOL));
+        t.put(Kernel.STRING_APPEND, jdk(CD_String, "concat", mtd(CD_String, CD_String), order(0, 1), Type.STRING));
         // String — Strings runtime statics (descriptor derived).
         // `slice` left the JDK's `substring` when the language settled on code points: the JDK method
         // indexes UTF-16 units, so the conversion — and the abort for an index the string has not
         // got — lives in the runtime rather than in a descriptor here.
-        t.put("string.slice", rt(CD_Strings, "slice", order(2, 0, 1), ts -> Type.STRING));
-        t.put("string.split", rt(CD_Strings, "split", order(1, 0), ts -> Type.list(Type.STRING)));
-        t.put("string.join", rt(CD_Strings, "join", order(1, 0), ts -> Type.STRING));
-        t.put("string.replace", rt(CD_Strings, "replace", order(2, 0, 1), ts -> Type.STRING));
-        t.put("string.words", rt(CD_Strings, "words", order(0), ts -> Type.list(Type.STRING)));
-        t.put("string.matches", rt(CD_Strings, "matches", order(1, 0), ts -> Type.BOOL));
-        t.put("string.characters", rt(CD_Strings, "characters", order(0), ts -> Type.list(Type.STRING)));
-        t.put("string.codePoints", rt(CD_Strings, "codePoints", order(0), ts -> Type.list(Type.INT)));
-        t.put("string.fromInt", rt(CD_Strings, "fromInt", order(0), ts -> Type.STRING));
-        t.put("string.concat", rt(CD_Strings, "concat", order(0), ts -> Type.STRING));
-        t.put("string.reverse", rt(CD_Strings, "reverse", order(0), ts -> Type.STRING));
-        t.put("string.repeat", rt(CD_Strings, "repeat", order(1, 0), ts -> Type.STRING));
-        t.put("string.lines", rt(CD_Strings, "lines", order(0), ts -> Type.list(Type.STRING)));
-        t.put("string.padLeft", rt(CD_Strings, "padLeft", order(2, 0, 1), ts -> Type.STRING));
-        t.put("string.padRight", rt(CD_Strings, "padRight", order(2, 0, 1), ts -> Type.STRING));
-        t.put("string.fromDecimal", rt(CD_Strings, "fromDecimal", order(0), ts -> Type.STRING));
+        t.put(Kernel.STRING_SLICE, rt(CD_Strings, "slice", order(2, 0, 1), ts -> Type.STRING));
+        t.put(Kernel.STRING_SPLIT, rt(CD_Strings, "split", order(1, 0), ts -> Type.list(Type.STRING)));
+        t.put(Kernel.STRING_JOIN, rt(CD_Strings, "join", order(1, 0), ts -> Type.STRING));
+        t.put(Kernel.STRING_REPLACE, rt(CD_Strings, "replace", order(2, 0, 1), ts -> Type.STRING));
+        t.put(Kernel.STRING_WORDS, rt(CD_Strings, "words", order(0), ts -> Type.list(Type.STRING)));
+        t.put(Kernel.STRING_MATCHES, rt(CD_Strings, "matches", order(1, 0), ts -> Type.BOOL));
+        t.put(Kernel.STRING_CHARACTERS, rt(CD_Strings, "characters", order(0), ts -> Type.list(Type.STRING)));
+        t.put(Kernel.STRING_CODE_POINTS, rt(CD_Strings, "codePoints", order(0), ts -> Type.list(Type.INT)));
+        t.put(Kernel.STRING_FROM_INT, rt(CD_Strings, "fromInt", order(0), ts -> Type.STRING));
+        t.put(Kernel.STRING_CONCAT, rt(CD_Strings, "concat", order(0), ts -> Type.STRING));
+        t.put(Kernel.STRING_REVERSE, rt(CD_Strings, "reverse", order(0), ts -> Type.STRING));
+        t.put(Kernel.STRING_REPEAT, rt(CD_Strings, "repeat", order(1, 0), ts -> Type.STRING));
+        t.put(Kernel.STRING_LINES, rt(CD_Strings, "lines", order(0), ts -> Type.list(Type.STRING)));
+        t.put(Kernel.STRING_PAD_LEFT, rt(CD_Strings, "padLeft", order(2, 0, 1), ts -> Type.STRING));
+        t.put(Kernel.STRING_PAD_RIGHT, rt(CD_Strings, "padRight", order(2, 0, 1), ts -> Type.STRING));
+        t.put(Kernel.STRING_FROM_DECIMAL, rt(CD_Strings, "fromDecimal", order(0), ts -> Type.STRING));
 
-        t.put("decimal.toInt", new DeclaredStatic(CD_DecimalMath, "toInt"));
-        t.put("decimal.round", new DeclaredStatic(CD_DecimalMath, "round"));
+        t.put(Kernel.DECIMAL_TO_INT, new DeclaredStatic(CD_DecimalMath, "toInt"));
+        t.put(Kernel.DECIMAL_ROUND, new DeclaredStatic(CD_DecimalMath, "round"));
 
         // List
-        t.put("list.sortBy", new TakesAFunction(CD_Lists, "sortBy", 1,
+        t.put(Kernel.LIST_SORT_BY, new TakesAFunction(CD_Lists, "sortBy", 1,
                 held -> List.of(((Type.ListOf) held).element()),
                 ts -> ts.get(1)));
-        t.put("list.find", new TakesAFunction(CD_Lists, "find", 1,
+        t.put(Kernel.LIST_FIND, new TakesAFunction(CD_Lists, "find", 1,
                 held -> List.of(((Type.ListOf) held).element()),
                 ts -> Type.option(((Type.ListOf) ts.get(1)).element())));
-        t.put("option.map", new TakesAFunction(CD_Options, "map", 1,
+        t.put(Kernel.OPTION_MAP, new TakesAFunction(CD_Options, "map", 1,
                 held -> List.of(((Type.OptionOf) held).element()),
                 ts -> Type.option(((Type.FnOf) ts.get(0)).result())));
-        t.put("list.max", rt(CD_Lists, "max", order(0), ts -> Type.option(listOf(ts, 0).element())));
-        t.put("list.min", rt(CD_Lists, "min", order(0), ts -> Type.option(listOf(ts, 0).element())));
-        t.put("list.length", rt(CD_Lists, "length", order(0), ts -> Type.INT));
-        t.put("list.get", rt(CD_Lists, "get", order(1, 0), ts -> Type.option(listOf(ts, 1).element())));
-        t.put("list.sort", rt(CD_Lists, "sort", order(0), ts -> ts.get(0)));
-        t.put("list.reverse", rt(CD_Lists, "reverse", order(0), ts -> ts.get(0)));
-        t.put("list.rangeInclusive", rt(CD_Lists, "rangeInclusive", order(0, 1), ts -> Type.list(Type.INT)));
-        t.put("list.sum", new NumericFold("sumInt", "sumDecimal"));
-        t.put("list.product", new NumericFold("productInt", "productDecimal"));
+        t.put(Kernel.LIST_MAX, rt(CD_Lists, "max", order(0), ts -> Type.option(listOf(ts, 0).element())));
+        t.put(Kernel.LIST_MIN, rt(CD_Lists, "min", order(0), ts -> Type.option(listOf(ts, 0).element())));
+        t.put(Kernel.LIST_LENGTH, rt(CD_Lists, "length", order(0), ts -> Type.INT));
+        t.put(Kernel.LIST_GET, rt(CD_Lists, "get", order(1, 0), ts -> Type.option(listOf(ts, 1).element())));
+        t.put(Kernel.LIST_SORT, rt(CD_Lists, "sort", order(0), ts -> ts.get(0)));
+        t.put(Kernel.LIST_REVERSE, rt(CD_Lists, "reverse", order(0), ts -> ts.get(0)));
+        t.put(Kernel.LIST_RANGE_INCLUSIVE, rt(CD_Lists, "rangeInclusive", order(0, 1), ts -> Type.list(Type.INT)));
+        t.put(Kernel.LIST_SUM, new NumericFold("sumInt", "sumDecimal"));
+        t.put(Kernel.LIST_PRODUCT, new NumericFold("productInt", "productDecimal"));
 
         // Map — keys/values are erased to Object; the map argument stays a raw Map.
-        t.put("map.get", rtErased(CD_Maps, "get", order(1, 0), Set.of(0),
+        t.put(Kernel.MAP_GET, rtErased(CD_Maps, "get", order(1, 0), Set.of(0),
                 ts -> Type.option(mapOf(ts, 1).value())));
-        t.put("map.empty", rt(CD_Maps, "empty", order(), ts -> Type.map(Type.NOTHING, Type.NOTHING)));
-        t.put("map.containsKey", rtErased(CD_Maps, "containsKey", order(1, 0), Set.of(0), ts -> Type.BOOL));
-        t.put("map.keys", rt(CD_Maps, "keys", order(0), ts -> Type.list(mapOf(ts, 0).key())));
-        t.put("map.values", rt(CD_Maps, "values", order(0), ts -> Type.list(mapOf(ts, 0).value())));
-        t.put("map.singleton", rtErased(CD_Maps, "singleton", order(0, 1), Set.of(0, 1),
+        t.put(Kernel.MAP_EMPTY, rt(CD_Maps, "empty", order(), ts -> Type.map(Type.NOTHING, Type.NOTHING)));
+        t.put(Kernel.MAP_CONTAINS_KEY, rtErased(CD_Maps, "containsKey", order(1, 0), Set.of(0), ts -> Type.BOOL));
+        t.put(Kernel.MAP_KEYS, rt(CD_Maps, "keys", order(0), ts -> Type.list(mapOf(ts, 0).key())));
+        t.put(Kernel.MAP_VALUES, rt(CD_Maps, "values", order(0), ts -> Type.list(mapOf(ts, 0).value())));
+        t.put(Kernel.MAP_SINGLETON, rtErased(CD_Maps, "singleton", order(0, 1), Set.of(0, 1),
                 ts -> Type.map(ts.get(0), ts.get(1))));
-        t.put("map.insert", rtErased(CD_Maps, "insert", order(0, 1, 2), Set.of(0, 1),
+        t.put(Kernel.MAP_INSERT, rtErased(CD_Maps, "insert", order(0, 1, 2), Set.of(0, 1),
                 Intrinsics::mapInsertResult));
-        t.put("map.remove", rtErased(CD_Maps, "remove", order(0, 1), Set.of(0), ts -> ts.get(1)));
-        t.put("map.isEmpty", rt(CD_Maps, "isEmpty", order(0), ts -> Type.BOOL));
-        t.put("map.size", rt(CD_Maps, "size", order(0), ts -> Type.INT));
-        t.put("map.toList", rt(CD_Maps, "toList", order(0), ts -> {
+        t.put(Kernel.MAP_REMOVE, rtErased(CD_Maps, "remove", order(0, 1), Set.of(0), ts -> ts.get(1)));
+        t.put(Kernel.MAP_IS_EMPTY, rt(CD_Maps, "isEmpty", order(0), ts -> Type.BOOL));
+        t.put(Kernel.MAP_SIZE, rt(CD_Maps, "size", order(0), ts -> Type.INT));
+        t.put(Kernel.MAP_TO_LIST, rt(CD_Maps, "toList", order(0), ts -> {
             Type.MapOf m = mapOf(ts, 0);
             return Type.list(Type.tuple(List.of(m.key(), m.value())));
         }));
-        t.put("map.fromList", rt(CD_Maps, "fromList", order(0), Intrinsics::mapFromListResult));
+        t.put(Kernel.MAP_FROM_LIST, rt(CD_Maps, "fromList", order(0), Intrinsics::mapFromListResult));
 
         // Set — the element is erased to Object; a set argument stays a raw Set.
-        t.put("set.empty", rt(CD_Sets, "empty", order(), ts -> Type.set(Type.NOTHING)));
-        t.put("set.singleton", rtErased(CD_Sets, "singleton", order(0), Set.of(0), ts -> Type.set(ts.get(0))));
-        t.put("set.insert", rtErased(CD_Sets, "insert", order(0, 1), Set.of(0), Intrinsics::setInsertResult));
-        t.put("set.remove", rtErased(CD_Sets, "remove", order(0, 1), Set.of(0), ts -> ts.get(1)));
-        t.put("set.contains", rtErased(CD_Sets, "contains", order(0, 1), Set.of(0), ts -> Type.BOOL));
-        t.put("set.union", rt(CD_Sets, "union", order(0, 1), ts -> setUnionType(ts.get(0), ts.get(1))));
-        t.put("set.intersection", rt(CD_Sets, "intersection", order(0, 1), ts -> ts.get(0)));
-        t.put("set.difference", rt(CD_Sets, "difference", order(0, 1), ts -> ts.get(0)));
-        t.put("set.isEmpty", rt(CD_Sets, "isEmpty", order(0), ts -> Type.BOOL));
-        t.put("set.size", rt(CD_Sets, "size", order(0), ts -> Type.INT));
-        t.put("set.toList", rt(CD_Sets, "toList", order(0), ts -> Type.list(setOf(ts, 0).element())));
-        t.put("set.fromList", rt(CD_Sets, "fromList", order(0), ts -> Type.set(listOf(ts, 0).element())));
+        t.put(Kernel.SET_EMPTY, rt(CD_Sets, "empty", order(), ts -> Type.set(Type.NOTHING)));
+        t.put(Kernel.SET_SINGLETON, rtErased(CD_Sets, "singleton", order(0), Set.of(0), ts -> Type.set(ts.get(0))));
+        t.put(Kernel.SET_INSERT, rtErased(CD_Sets, "insert", order(0, 1), Set.of(0), Intrinsics::setInsertResult));
+        t.put(Kernel.SET_REMOVE, rtErased(CD_Sets, "remove", order(0, 1), Set.of(0), ts -> ts.get(1)));
+        t.put(Kernel.SET_CONTAINS, rtErased(CD_Sets, "contains", order(0, 1), Set.of(0), ts -> Type.BOOL));
+        t.put(Kernel.SET_UNION, rt(CD_Sets, "union", order(0, 1), ts -> setUnionType(ts.get(0), ts.get(1))));
+        t.put(Kernel.SET_INTERSECTION, rt(CD_Sets, "intersection", order(0, 1), ts -> ts.get(0)));
+        t.put(Kernel.SET_DIFFERENCE, rt(CD_Sets, "difference", order(0, 1), ts -> ts.get(0)));
+        t.put(Kernel.SET_IS_EMPTY, rt(CD_Sets, "isEmpty", order(0), ts -> Type.BOOL));
+        t.put(Kernel.SET_SIZE, rt(CD_Sets, "size", order(0), ts -> Type.INT));
+        t.put(Kernel.SET_TO_LIST, rt(CD_Sets, "toList", order(0), ts -> Type.list(setOf(ts, 0).element())));
+        t.put(Kernel.SET_FROM_LIST, rt(CD_Sets, "fromList", order(0), ts -> Type.set(listOf(ts, 0).element())));
 
         // Date / DateTime — the temporal is the receiver (emitted first); the count is a long.
         // Through the runtime rather than straight to `java.time`: a shift off the end of the range
         // aborts saying what it was doing, instead of the JVM's own exception reaching the boundary
         // and naming a class the language has no type for.
-        t.put("date.addDays", rt(CD_Temporals, "addDays", order(1, 0), ts -> Type.DATE));
-        t.put("date.addMonths", rt(CD_Temporals, "addMonths", order(1, 0), ts -> Type.DATE));
-        t.put("date.addYears", rt(CD_Temporals, "addYears", order(1, 0), ts -> Type.DATE));
-        t.put("date.daysBetween", rt(CD_Temporals, "daysBetween", order(0, 1), ts -> Type.INT));
-        t.put("date.year", rt(CD_Temporals, "year", order(0), ts -> Type.INT));
-        t.put("date.month", rt(CD_Temporals, "month", order(0), ts -> Type.INT));
-        t.put("date.day", rt(CD_Temporals, "day", order(0), ts -> Type.INT));
+        t.put(Kernel.DATE_ADD_DAYS, rt(CD_Temporals, "addDays", order(1, 0), ts -> Type.DATE));
+        t.put(Kernel.DATE_ADD_MONTHS, rt(CD_Temporals, "addMonths", order(1, 0), ts -> Type.DATE));
+        t.put(Kernel.DATE_ADD_YEARS, rt(CD_Temporals, "addYears", order(1, 0), ts -> Type.DATE));
+        t.put(Kernel.DATE_DAYS_BETWEEN, rt(CD_Temporals, "daysBetween", order(0, 1), ts -> Type.INT));
+        t.put(Kernel.DATE_YEAR, rt(CD_Temporals, "year", order(0), ts -> Type.INT));
+        t.put(Kernel.DATE_MONTH, rt(CD_Temporals, "month", order(0), ts -> Type.INT));
+        t.put(Kernel.DATE_DAY, rt(CD_Temporals, "day", order(0), ts -> Type.INT));
         // Building from parts: partial, so the declaration states `Date | NotADate` and the emitter
         // takes the result from it rather than working one out.
-        t.put("date.fromParts", rtDeclared(CD_Temporals, "fromDateParts", order(0, 1, 2)));
-        t.put("time.fromParts", rtDeclared(CD_Temporals, "fromTimeParts", order(0, 1, 2)));
-        t.put("time.hour", rt(CD_Temporals, "hour", order(0), ts -> Type.INT));
-        t.put("time.minute", rt(CD_Temporals, "minute", order(0), ts -> Type.INT));
-        t.put("time.second", rt(CD_Temporals, "second", order(0), ts -> Type.INT));
-        t.put("datetime.addMinutes", rt(CD_Temporals, "addMinutes", order(1, 0), ts -> Type.DATETIME));
-        t.put("datetime.addHours", rt(CD_Temporals, "addHours", order(1, 0), ts -> Type.DATETIME));
+        t.put(Kernel.DATE_FROM_PARTS, rtDeclared(CD_Temporals, "fromDateParts", order(0, 1, 2)));
+        t.put(Kernel.TIME_FROM_PARTS, rtDeclared(CD_Temporals, "fromTimeParts", order(0, 1, 2)));
+        t.put(Kernel.TIME_HOUR, rt(CD_Temporals, "hour", order(0), ts -> Type.INT));
+        t.put(Kernel.TIME_MINUTE, rt(CD_Temporals, "minute", order(0), ts -> Type.INT));
+        t.put(Kernel.TIME_SECOND, rt(CD_Temporals, "second", order(0), ts -> Type.INT));
+        t.put(Kernel.DATETIME_ADD_MINUTES, rt(CD_Temporals, "addMinutes", order(1, 0), ts -> Type.DATETIME));
+        t.put(Kernel.DATETIME_ADD_HOURS, rt(CD_Temporals, "addHours", order(1, 0), ts -> Type.DATETIME));
         // `addDateTimeDays` rather than a second `addDays`: the runtime is Java, which would take the
-        // two as overloads and leave the emitter's descriptor deciding which, where the key already
+        // two as overloads and leave the emitter's descriptor deciding which, where the kernel already
         // says which temporal it is for.
-        t.put("datetime.addDays", rt(CD_Temporals, "addDateTimeDays", order(1, 0), ts -> Type.DATETIME));
-        t.put("datetime.minutesBetween", rt(CD_Temporals, "minutesBetween", order(0, 1), ts -> Type.INT));
-        t.put("datetime.toDate",
+        t.put(Kernel.DATETIME_ADD_DAYS, rt(CD_Temporals, "addDateTimeDays", order(1, 0), ts -> Type.DATETIME));
+        t.put(Kernel.DATETIME_MINUTES_BETWEEN, rt(CD_Temporals, "minutesBetween", order(0, 1), ts -> Type.INT));
+        t.put(Kernel.DATETIME_TO_DATE,
                 jdk(CD_LocalDateTime, "toLocalDate", mtd(CD_LocalDate), order(0), Type.DATE));
-        t.put("datetime.toTime",
+        t.put(Kernel.DATETIME_TO_TIME,
                 jdk(CD_LocalDateTime, "toLocalTime", mtd(CD_LocalTime), order(0), Type.TIME));
         // A date and a time of day are both settled values, so joining them cannot fail: total, with
         // the date as the receiver of `LocalDate.atTime`.
-        t.put("datetime.fromDateAndTime",
+        t.put(Kernel.DATETIME_FROM_DATE_AND_TIME,
                 jdk(CD_LocalDate, "atTime", mtd(CD_LocalDateTime, CD_LocalTime), order(0, 1), Type.DATETIME));
 
         // Int — IntMath statics. add/subtract/multiply share the overflow-aborting kernel with the
         // `+ - *` operators; modBy aborts on a zero divisor; compare returns -1/0/1.
-        t.put("int.add", rt(CD_IntMath, "addExact", order(0, 1), ts -> Type.INT));
-        t.put("int.subtract", rt(CD_IntMath, "subtractExact", order(0, 1), ts -> Type.INT));
-        t.put("int.multiply", rt(CD_IntMath, "multiplyExact", order(0, 1), ts -> Type.INT));
-        t.put("int.compare", rt(CD_IntMath, "compare", order(0, 1), ts -> Type.INT));
-        t.put("int.floorMod", rt(CD_IntMath, "floorMod", order(0, 1), ts -> Type.INT));
+        t.put(Kernel.INT_ADD, rt(CD_IntMath, "addExact", order(0, 1), ts -> Type.INT));
+        t.put(Kernel.INT_SUBTRACT, rt(CD_IntMath, "subtractExact", order(0, 1), ts -> Type.INT));
+        t.put(Kernel.INT_MULTIPLY, rt(CD_IntMath, "multiplyExact", order(0, 1), ts -> Type.INT));
+        t.put(Kernel.INT_COMPARE, rt(CD_IntMath, "compare", order(0, 1), ts -> Type.INT));
+        t.put(Kernel.INT_FLOOR_MOD, rt(CD_IntMath, "floorMod", order(0, 1), ts -> Type.INT));
 
         // Decimal — every one of them a DecimalMath static, read off its declaration. What a
         // BigDecimal method does is not what a Souther operation means: each of these is partial at
         // the ends of the scale range, and the abort that reports it belongs to the operation rather
         // than to whoever emitted the call (ADR-0112). One emitter for the whole module, so a
         // Decimal operation added later has one place to be written and no second shape to pick.
-        t.put("decimal.add", new DeclaredStatic(CD_DecimalMath, "add"));
-        t.put("decimal.subtract", new DeclaredStatic(CD_DecimalMath, "subtract"));
-        t.put("decimal.multiply", new DeclaredStatic(CD_DecimalMath, "multiply"));
-        t.put("decimal.divide", new DeclaredStatic(CD_DecimalMath, "divide"));
-        t.put("decimal.compare", new DeclaredStatic(CD_DecimalMath, "compare"));
-        t.put("decimal.fromInt", new DeclaredStatic(CD_DecimalMath, "fromInt"));
+        t.put(Kernel.DECIMAL_ADD, new DeclaredStatic(CD_DecimalMath, "add"));
+        t.put(Kernel.DECIMAL_SUBTRACT, new DeclaredStatic(CD_DecimalMath, "subtract"));
+        t.put(Kernel.DECIMAL_MULTIPLY, new DeclaredStatic(CD_DecimalMath, "multiply"));
+        t.put(Kernel.DECIMAL_DIVIDE, new DeclaredStatic(CD_DecimalMath, "divide"));
+        t.put(Kernel.DECIMAL_COMPARE, new DeclaredStatic(CD_DecimalMath, "compare"));
+        t.put(Kernel.DECIMAL_FROM_INT, new DeclaredStatic(CD_DecimalMath, "fromInt"));
 
-        return Map.copyOf(t);
+        return java.util.Collections.unmodifiableMap(t);
     }
 
     // --- result-type formulas for the intrinsics whose result is learned from argument types ---

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Intrinsics.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Intrinsics.java
@@ -230,6 +230,27 @@ final class Intrinsics {
         return TABLE.keySet();
     }
 
+    /**
+     * The ordered family over an element whose order lives on its sum: the runtime call this table
+     * already holds for {@code kernel}, taking a comparator ahead of the container. The comparator
+     * and the container are on the stack, and {@code container} is the container's type as it was
+     * emitted.
+     *
+     * <p>Here rather than in the emitter that pushes the comparator, because which runtime method
+     * answers a kernel and what it answers with are this table's to say. Written out there, the
+     * class, the method and the result would each be stated a second time, and a row changed here
+     * would leave the second statement behind.
+     */
+    static void emitOrderedByComparator(BodyGen g, Kernel kernel, Type container) {
+        if (!(TABLE.get(kernel) instanceof RuntimeStatic row) || row.result() == null) {
+            throw new IllegalStateException("`" + kernel.key()
+                    + "` is not emitted as a runtime call that works its result out");
+        }
+        g.emitInvokeStatic(row.owner(), row.method(),
+                MethodTypeDesc.of(boundaryDesc(row.result().apply(List.of(container))),
+                        CD_Comparator, boundaryDesc(container)));
+    }
+
     /** How each kernel is emitted — read by the test that holds the descriptor invariant. */
     static Map<Kernel, Emit> emitters() {
         return Map.copyOf(TABLE);
@@ -411,6 +432,9 @@ final class Intrinsics {
         t.put(Kernel.DECIMAL_COMPARE, new DeclaredStatic(CD_DecimalMath, "compare"));
         t.put(Kernel.DECIMAL_FROM_INT, new DeclaredStatic(CD_DecimalMath, "fromInt"));
 
+        // Not a copy: the map is a local nothing else holds, and read back through an EnumMap it
+        // answers in the order the kernels are declared in rather than in whatever order a copy
+        // happens to hash them into.
         return java.util.Collections.unmodifiableMap(t);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Intrinsics.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Intrinsics.java
@@ -231,24 +231,45 @@ final class Intrinsics {
     }
 
     /**
-     * The ordered family over an element whose order lives on its sum: the runtime call this table
-     * already holds for {@code kernel}, taking a comparator ahead of the container. The comparator
-     * and the container are on the stack, and {@code container} is the container's type as it was
-     * emitted.
+     * A kernel of the ordered family, over an element whose order lives on its sum: the runtime call
+     * this table already holds for it, taking a comparator ahead of what it was already taking. The
+     * comparator and the kernel's own arguments are on the stack, and {@code byArg} is their types
+     * as they were emitted, in the order the kernel declares them.
      *
      * <p>Here rather than in the emitter that pushes the comparator, because which runtime method
      * answers a kernel and what it answers with are this table's to say. Written out there, the
      * class, the method and the result would each be stated a second time, and a row changed here
      * would leave the second statement behind.
+     *
+     * <p>Both row shapes that can take one. A kernel walking a container takes the container alone;
+     * one applying a function takes the function too, as an {@code Fn}, and which argument the
+     * container is is the row's answer rather than a position written out again.
      */
-    static void emitOrderedByComparator(BodyGen g, Kernel kernel, Type container) {
-        if (!(TABLE.get(kernel) instanceof RuntimeStatic row) || row.result() == null) {
-            throw new IllegalStateException("`" + kernel.key()
-                    + "` is not emitted as a runtime call that works its result out");
+    static void emitWithComparator(BodyGen g, Kernel kernel, List<Type> byArg) {
+        ClassDesc owner;
+        String method;
+        Type result;
+        ClassDesc[] params;
+        switch (TABLE.get(kernel)) {
+            case RuntimeStatic row when row.result() != null && byArg.size() == 1 -> {
+                owner = row.owner();
+                method = row.method();
+                result = row.result().apply(byArg);
+                params = new ClassDesc[] {CD_Comparator, boundaryDesc(byArg.get(0))};
+            }
+            case TakesAFunction row when byArg.size() == 2 -> {
+                owner = row.owner();
+                method = row.method();
+                result = row.result().apply(byArg);
+                params = new ClassDesc[] {
+                        CD_Comparator, CD_Fn, boundaryDesc(byArg.get(row.container()))};
+            }
+            case Emit row -> throw new IllegalStateException("`" + kernel.key() + "` is emitted as "
+                    + row + ", which takes no comparator over " + byArg.size() + " argument(s)");
+            case null -> throw new IllegalStateException(
+                    "the JVM emits nothing for `" + kernel.key() + "`");
         }
-        g.emitInvokeStatic(row.owner(), row.method(),
-                MethodTypeDesc.of(boundaryDesc(row.result().apply(List.of(container))),
-                        CD_Comparator, boundaryDesc(container)));
+        g.emitInvokeStatic(owner, method, MethodTypeDesc.of(boundaryDesc(result), params));
     }
 
     /** How each kernel is emitted — read by the test that holds the descriptor invariant. */

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -157,17 +157,59 @@ public sealed interface Core {
      * from outside — asks what the name denotes. Working the second out of the first would be
      * resolving a name this compiler resolved already, and a bare spelling reaches a helper and an
      * injected behavior alike.
+     *
+     * <p>A kernel call is one of these and not something beside them. {@code List.sort} is reached
+     * by a name and resolves to a library operation, and its declaration being a kernel is what that
+     * operation turned out to be — so a reader asking what a call reaches asks this, whichever arm
+     * it is, and only a reader that has to emit the operation goes on to ask which kernel. Put
+     * beside {@code Reached}, the arms would divide by provenance for two of them and by what the
+     * declaration holds for the third, and a reader that wanted only the name would stop seeing
+     * kernels without being told.
      */
-    record Reached(ReachName name, ValueName denotes) implements CallTarget {
+    sealed interface Reached extends CallTarget {
+
+        /** The name the module being emitted reaches the callee by. */
+        ReachName name();
+
+        /** What that name was resolved to. */
+        ValueName denotes();
 
         @Override
-        public String rendered() {
-            return name.rendered();
+        default String rendered() {
+            return name().rendered();
         }
 
-        @Override
-        public String toString() {
-            return rendered();
+        /** A callee whose declaration this compilation carries: a module's own helper, another
+         *  module's, an injected behavior, a library operation written in Souther. What is emitted
+         *  for it is a call. */
+        record OfDeclaration(ReachName name, ValueName denotes) implements Reached {
+
+            @Override
+            public String toString() {
+                return rendered();
+            }
+        }
+
+        /**
+         * A callee whose declaration is a kernel of the standard library, and which kernel it is.
+         *
+         * <p>Which kernel is the answer to a question this compiler settled: the checker typed the
+         * call against the library's signature, and the declaration behind that signature named the
+         * operation. An output reads the operation here rather than going back to a table this
+         * compiler keeps for itself — and a spelling it guessed from would be resolving, by the
+         * alias and the name, what was resolved already.
+         *
+         * <p>Still carries both the reach name and what it denotes, and neither is the kernel. The
+         * name says how this module got here, the denotation says which declaration was chosen, and
+         * the kernel says what that declaration is. Two declarations naming one kernel is a thing
+         * the library is refused for while it is built, not a thing this collapses.
+         */
+        record OfKernel(ReachName name, ValueName denotes, Kernel kernel) implements Reached {
+
+            @Override
+            public String toString() {
+                return rendered();
+            }
         }
     }
 
@@ -212,17 +254,12 @@ public sealed interface Core {
      *
      * <p>{@code fn} says what is applied ({@link CallTarget}). Where that is a name, it is the one
      * the module being emitted reaches the callee by, carried from where resolution settled it, and
-     * held as what it is rather than as the spelling of it: the backend needs both the whole name, to
-     * emit the method it calls, and the operation inside it, to reach the runtime method a library
-     * call becomes — and taking the second out of the first meant splitting a name this compiler had
-     * joined a moment earlier.
+     * held as what it is rather than as the spelling of it: the backend needs the whole name to emit
+     * the method it calls, and what the name denotes to know what kind of thing was called. Where
+     * the callee turned out to be a kernel of the standard library, the call says which one
+     * ({@link Reached.OfKernel}), so an output emitting it asks the call rather than this compiler.
      */
     record Call(CallTarget fn, List<Core> args, Type type, SourcePos pos) implements Core {
-
-        /** A call to a name, as the name it reaches and what that name denotes. */
-        public Call(ReachName fn, ValueName denotes, List<Core> args, Type type, SourcePos pos) {
-            this(new Reached(fn, denotes), args, type, pos);
-        }
 
         /** The callee as it renders — the reach name for a call to one, the operation's own
          * spelling for one this compiler emits. What a method name is built from and what a report

--- a/souther-compiler/src/main/java/souther/compiler/core/Kernel.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Kernel.java
@@ -1,0 +1,188 @@
+package souther.compiler.core;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A kernel of the standard library: an operation the language names, and which every output answers
+ * with instructions of its own.
+ *
+ * <p>What a core module declares as {@code intrinsic "string.trim"}, held as the operation rather
+ * than as the spelling of it. The written key is how a declaration names one and what a report
+ * quotes; it is not what tells two apart here, so nothing reads a kernel back out of a string. The
+ * one place a key becomes a kernel is where the library is frozen
+ * ({@code stdlib.Stdlib.Builder#freeze}) — the place a declaration written in a {@code .sou}
+ * resource becomes what this compiler means by it — and everything after that carries the kernel.
+ *
+ * <p>Closed, and that is not a limitation of what the library may declare. Which kernels there are
+ * is a decision of the language rather than an extension point: an output that met one it had never
+ * heard of could not emit it, so nothing is gained by being able to carry it. A reader switches over
+ * these and javac says which arms it has not answered.
+ *
+ * <p>What a kernel is on some machine is not stated here. {@code string.trim} names an operation;
+ * what instructions answer it is whichever output is emitting, exactly as {@code codegen.Intrinsics}
+ * is the JVM's answer and no part of the language.
+ *
+ * <p>In {@code Reserved.MODULES} order, and inside a module in the order that module declares them,
+ * so this list and the sources read alongside each other.
+ */
+public enum Kernel {
+
+    // string
+    STRING_LENGTH("string.length"),
+    STRING_TO_INT("string.toInt"),
+    STRING_TO_DECIMAL("string.toDecimal"),
+    STRING_TRIM("string.trim"),
+    STRING_LOWERCASE("string.lowercase"),
+    STRING_UPPERCASE("string.uppercase"),
+    STRING_CONTAINS("string.contains"),
+    STRING_STARTS_WITH("string.startsWith"),
+    STRING_ENDS_WITH("string.endsWith"),
+    STRING_MATCHES("string.matches"),
+    STRING_SLICE("string.slice"),
+    STRING_APPEND("string.append"),
+    STRING_SPLIT("string.split"),
+    STRING_JOIN("string.join"),
+    STRING_REPLACE("string.replace"),
+    STRING_WORDS("string.words"),
+    STRING_FROM_INT("string.fromInt"),
+    STRING_CONCAT("string.concat"),
+    STRING_REVERSE("string.reverse"),
+    STRING_REPEAT("string.repeat"),
+    STRING_LINES("string.lines"),
+    STRING_PAD_LEFT("string.padLeft"),
+    STRING_PAD_RIGHT("string.padRight"),
+    STRING_FROM_DECIMAL("string.fromDecimal"),
+    STRING_CHARACTERS("string.characters"),
+    STRING_CODE_POINTS("string.codePoints"),
+    // map
+    MAP_EMPTY("map.empty"),
+    MAP_GET("map.get"),
+    MAP_CONTAINS_KEY("map.containsKey"),
+    MAP_KEYS("map.keys"),
+    MAP_VALUES("map.values"),
+    MAP_SINGLETON("map.singleton"),
+    MAP_INSERT("map.insert"),
+    MAP_REMOVE("map.remove"),
+    MAP_IS_EMPTY("map.isEmpty"),
+    MAP_SIZE("map.size"),
+    MAP_TO_LIST("map.toList"),
+    MAP_FROM_LIST("map.fromList"),
+    // list
+    LIST_LENGTH("list.length"),
+    LIST_FIND("list.find"),
+    LIST_SORT_BY("list.sortBy"),
+    LIST_MAX("list.max"),
+    LIST_MIN("list.min"),
+    LIST_GET("list.get"),
+    LIST_REVERSE("list.reverse"),
+    LIST_SUM("list.sum"),
+    LIST_PRODUCT("list.product"),
+    LIST_SORT("list.sort"),
+    LIST_RANGE_INCLUSIVE("list.rangeInclusive"),
+    // set
+    SET_EMPTY("set.empty"),
+    SET_SINGLETON("set.singleton"),
+    SET_INSERT("set.insert"),
+    SET_REMOVE("set.remove"),
+    SET_CONTAINS("set.contains"),
+    SET_UNION("set.union"),
+    SET_INTERSECTION("set.intersection"),
+    SET_DIFFERENCE("set.difference"),
+    SET_IS_EMPTY("set.isEmpty"),
+    SET_SIZE("set.size"),
+    SET_TO_LIST("set.toList"),
+    SET_FROM_LIST("set.fromList"),
+    // date
+    DATE_ADD_DAYS("date.addDays"),
+    DATE_ADD_MONTHS("date.addMonths"),
+    DATE_ADD_YEARS("date.addYears"),
+    DATE_DAYS_BETWEEN("date.daysBetween"),
+    DATE_YEAR("date.year"),
+    DATE_MONTH("date.month"),
+    DATE_DAY("date.day"),
+    DATE_FROM_PARTS("date.fromParts"),
+    // time
+    TIME_FROM_PARTS("time.fromParts"),
+    TIME_HOUR("time.hour"),
+    TIME_MINUTE("time.minute"),
+    TIME_SECOND("time.second"),
+    // datetime
+    DATETIME_ADD_MINUTES("datetime.addMinutes"),
+    DATETIME_ADD_HOURS("datetime.addHours"),
+    DATETIME_ADD_DAYS("datetime.addDays"),
+    DATETIME_MINUTES_BETWEEN("datetime.minutesBetween"),
+    DATETIME_TO_DATE("datetime.toDate"),
+    DATETIME_TO_TIME("datetime.toTime"),
+    DATETIME_FROM_DATE_AND_TIME("datetime.fromDateAndTime"),
+    // int
+    INT_DIVIDE("int.divide"),
+    INT_TRUNCATING_REMAINDER("int.truncatingRemainder"),
+    INT_ADD("int.add"),
+    INT_SUBTRACT("int.subtract"),
+    INT_MULTIPLY("int.multiply"),
+    INT_COMPARE("int.compare"),
+    INT_FLOOR_MOD("int.floorMod"),
+    // decimal
+    DECIMAL_DIVIDE("decimal.divide"),
+    DECIMAL_TO_INT("decimal.toInt"),
+    DECIMAL_ROUND("decimal.round"),
+    DECIMAL_ADD("decimal.add"),
+    DECIMAL_SUBTRACT("decimal.subtract"),
+    DECIMAL_MULTIPLY("decimal.multiply"),
+    DECIMAL_COMPARE("decimal.compare"),
+    DECIMAL_FROM_INT("decimal.fromInt"),
+    // option
+    OPTION_MAP("option.map");
+
+    private static final Map<String, Kernel> BY_KEY = byKey();
+
+    private final String key;
+
+    Kernel(String key) {
+        this.key = key;
+    }
+
+    /** The key a declaration names this kernel by: {@code "string.trim"}. What a declaration is read
+     *  through and what a report quotes — never how two kernels are told apart. */
+    public String key() {
+        return key;
+    }
+
+    /**
+     * The kernel {@code key} names.
+     *
+     * <p>Called where the library is frozen and nowhere else. A reader downstream of that holds the
+     * kernel already, and one that went back to a key to ask this again would be resolving, by
+     * spelling, what the library had resolved for it.
+     *
+     * @throws IllegalStateException where the library names a kernel this compiler does not have. The
+     *     declaration and this enum are two halves of one vocabulary and a compilation cannot mend a
+     *     disagreement between them, so it is refused while the library is being built rather than
+     *     where some program happens to call it — a kernel nothing calls is wrong just as early.
+     */
+    public static Kernel fromKey(String key) {
+        Kernel kernel = BY_KEY.get(key);
+        if (kernel == null) {
+            throw new IllegalStateException(
+                    "the standard library declares `intrinsic \"" + key
+                            + "\"`, which this compiler has no kernel for");
+        }
+        return kernel;
+    }
+
+    @Override
+    public String toString() {
+        return key;
+    }
+
+    private static Map<String, Kernel> byKey() {
+        Map<String, Kernel> byKey = new LinkedHashMap<>();
+        for (Kernel kernel : values()) {
+            if (byKey.put(kernel.key, kernel) != null) {
+                throw new IllegalStateException("two kernels are written `" + kernel.key + "`");
+            }
+        }
+        return byKey;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/core/Kernel.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Kernel.java
@@ -1,18 +1,18 @@
 package souther.compiler.core;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 /**
  * A kernel of the standard library: an operation the language names, and which every output answers
  * with instructions of its own.
  *
  * <p>What a core module declares as {@code intrinsic "string.trim"}, held as the operation rather
  * than as the spelling of it. The written key is how a declaration names one and what a report
- * quotes; it is not what tells two apart here, so nothing reads a kernel back out of a string. The
- * one place a key becomes a kernel is where the library is frozen
- * ({@code stdlib.Stdlib.Builder#freeze}) — the place a declaration written in a {@code .sou}
- * resource becomes what this compiler means by it — and everything after that carries the kernel.
+ * quotes; it is not what tells two apart.
+ *
+ * <p>Reading a key back as a kernel is not something this can do. Turning a written key into the
+ * operation it names is the library's, done where the library is frozen
+ * ({@code stdlib.Stdlib.Builder#freeze}), and a kernel that could hand back the way it was made
+ * would be that route open to everything downstream — which is the thing being closed. What this
+ * publishes is the identity and the key a declaration or a report writes it as.
  *
  * <p>Closed, and that is not a limitation of what the library may declare. Which kernels there are
  * is a decision of the language rather than an extension point: an output that met one it had never
@@ -135,8 +135,6 @@ public enum Kernel {
     // option
     OPTION_MAP("option.map");
 
-    private static final Map<String, Kernel> BY_KEY = byKey();
-
     private final String key;
 
     Kernel(String key) {
@@ -147,42 +145,5 @@ public enum Kernel {
      *  through and what a report quotes — never how two kernels are told apart. */
     public String key() {
         return key;
-    }
-
-    /**
-     * The kernel {@code key} names.
-     *
-     * <p>Called where the library is frozen and nowhere else. A reader downstream of that holds the
-     * kernel already, and one that went back to a key to ask this again would be resolving, by
-     * spelling, what the library had resolved for it.
-     *
-     * @throws IllegalStateException where the library names a kernel this compiler does not have. The
-     *     declaration and this enum are two halves of one vocabulary and a compilation cannot mend a
-     *     disagreement between them, so it is refused while the library is being built rather than
-     *     where some program happens to call it — a kernel nothing calls is wrong just as early.
-     */
-    public static Kernel fromKey(String key) {
-        Kernel kernel = BY_KEY.get(key);
-        if (kernel == null) {
-            throw new IllegalStateException(
-                    "the standard library declares `intrinsic \"" + key
-                            + "\"`, which this compiler has no kernel for");
-        }
-        return kernel;
-    }
-
-    @Override
-    public String toString() {
-        return key;
-    }
-
-    private static Map<String, Kernel> byKey() {
-        Map<String, Kernel> byKey = new LinkedHashMap<>();
-        for (Kernel kernel : values()) {
-            if (byKey.put(kernel.key, kernel) != null) {
-                throw new IllegalStateException("two kernels are written `" + kernel.key + "`");
-            }
-        }
-        return byKey;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/stdlib/Stdlib.java
+++ b/souther-compiler/src/main/java/souther/compiler/stdlib/Stdlib.java
@@ -2,6 +2,7 @@ package souther.compiler.stdlib;
 
 import souther.compiler.Reserved;
 import souther.compiler.ast.Hir;
+import souther.compiler.core.Kernel;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeKey;
 import souther.compiler.types.TypeSymbol;
@@ -10,6 +11,7 @@ import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -84,10 +86,10 @@ public final class Stdlib {
         }
     }
 
-    /** A kernel the library names, and the signature it was declared with. The key is the language's
-     *  ({@code "decimal.round"}); what a backend emits for it is that backend's, and a signature is
-     *  what both of them derive their own boundary form from. */
-    public record Intrinsic(String key, Signature signature) {
+    /** A kernel the library names, and the signature it was declared with. The kernel is the
+     *  language's operation ({@link Kernel#DECIMAL_ROUND}); what a backend emits for it is that
+     *  backend's, and a signature is what both of them derive their own boundary form from. */
+    public record Intrinsic(Kernel kernel, Signature signature) {
     }
 
     private final Map<String, Entry> entries;
@@ -98,7 +100,10 @@ public final class Stdlib {
     /** And the same declarations by the library module that writes them, worked out once with
      *  everything else rather than gathered on each ask. */
     private final Map<String, Map<String, Hir.Def>> byModule;
-    private final Map<String, Intrinsic> intrinsics;
+    private final Map<Kernel, Intrinsic> intrinsics;
+    /** And which kernel each operation that is one reaches, so a reader holding a name asks the
+     *  library rather than the declaration it would have to open to find out. */
+    private final Map<String, Intrinsic> kernelOperations;
     private final Map<String, Hir.FnDef> helpers;
     private final Set<String> published;
     private final Map<String, List<String>> candidates;
@@ -108,7 +113,8 @@ public final class Stdlib {
 
     private Stdlib(Map<String, Entry> entries, Set<String> privateNames,
                    Map<String, ValueName.Stdlib> operations, Map<String, Rewrite> sugars,
-                   Map<TypeKey, Hir.Def> language, Map<String, Intrinsic> intrinsics,
+                   Map<TypeKey, Hir.Def> language, Map<Kernel, Intrinsic> intrinsics,
+                   Map<String, Intrinsic> kernelOperations,
                    Map<String, Hir.FnDef> helpers, Set<String> published,
                    Map<String, List<String>> candidates) {
         this.entries = entries;
@@ -127,6 +133,7 @@ public final class Stdlib {
         grouped.replaceAll((_, defs) -> Collections.unmodifiableMap(defs));
         this.byModule = Collections.unmodifiableMap(grouped);
         this.intrinsics = intrinsics;
+        this.kernelOperations = kernelOperations;
         this.helpers = helpers;
         this.published = published;
         this.candidates = candidates;
@@ -211,9 +218,23 @@ public final class Stdlib {
         return helpers;
     }
 
-    /** The kernel written {@code intrinsic "key"}, or null where no declaration names that key. */
-    public Intrinsic intrinsic(String key) {
-        return intrinsics.get(key);
+    /** What the library declares for {@code kernel}, or null where no declaration names it. */
+    public Intrinsic intrinsic(Kernel kernel) {
+        return intrinsics.get(kernel);
+    }
+
+    /**
+     * What the library declares under {@code qualifiedName} where that operation is a kernel, and
+     * null where it is anything else — a Souther-bodied helper, a sugar, a name the library does not
+     * have.
+     *
+     * <p>Whether an operation is a kernel is a fact about the library and is answered by the
+     * library. A reader that opened the declaration to look at its body would be reading how the
+     * library is written to learn what it means, and would go on holding the declaration — which is
+     * {@code Hir}, and is this compiler's own.
+     */
+    public Intrinsic intrinsicOf(String qualifiedName) {
+        return kernelOperations.get(qualifiedName);
     }
 
     /**
@@ -352,13 +373,27 @@ public final class Stdlib {
         /** The finished library. */
         public Stdlib freeze() {
             Map<String, Rewrite> sugars = sugars();
-            Map<String, Intrinsic> intrinsics = new LinkedHashMap<>();
+            Map<Kernel, Intrinsic> intrinsics = new EnumMap<>(Kernel.class);
+            Map<String, Intrinsic> kernelOperations = new LinkedHashMap<>();
             Map<String, Hir.FnDef> helpers = new LinkedHashMap<>();
             for (Map.Entry<String, Entry> e : entries.entrySet()) {
                 Hir.FnBody body = e.getValue().declaration().body();
-                if (body instanceof Hir.FnBody.Intrinsic kernel) {
-                    intrinsics.put(kernel.key(),
-                            new Intrinsic(kernel.key(), e.getValue().signature()));
+                if (body instanceof Hir.FnBody.Intrinsic written) {
+                    // The one place a written key becomes the operation it names. Everything after
+                    // this holds the kernel, so a key that names none is refused here — while the
+                    // library is being built, and so for a kernel nothing goes on to call as much as
+                    // for one every program calls.
+                    Intrinsic intrinsic =
+                            new Intrinsic(Kernel.fromKey(written.key()), e.getValue().signature());
+                    // And one kernel is declared once. A backend builds its boundary form out of
+                    // the signature this holds, so two declarations of one kernel would be two
+                    // answers to a question that has one — and put into a map, the second would
+                    // replace the first in silence.
+                    if (intrinsics.put(intrinsic.kernel(), intrinsic) != null) {
+                        throw new IllegalStateException("two standard-library declarations name the"
+                                + " kernel `" + intrinsic.kernel().key() + "`");
+                    }
+                    kernelOperations.put(e.getKey(), intrinsic);
                 }
                 if (body instanceof Hir.FnBody.Written) {
                     helpers.put(e.getKey(), e.getValue().declaration());
@@ -376,6 +411,7 @@ public final class Stdlib {
                     Collections.unmodifiableMap(sugars),
                     Collections.unmodifiableMap(new LinkedHashMap<>(language)),
                     Collections.unmodifiableMap(intrinsics),
+                    Collections.unmodifiableMap(kernelOperations),
                     Collections.unmodifiableMap(helpers),
                     published,
                     candidates(published));

--- a/souther-compiler/src/main/java/souther/compiler/stdlib/Stdlib.java
+++ b/souther-compiler/src/main/java/souther/compiler/stdlib/Stdlib.java
@@ -31,7 +31,7 @@ import java.util.Set;
  * reader that wants to know what the library declares takes this and nothing else.
  *
  * <p>Neutral about how any of it is implemented. A declaration says what an operation means in
- * Souther — its parameters, what it answers, the kernel key behind it where there is one. What a
+ * Souther — its parameters, what it answers, the kernel behind it where there is one. What a
  * kernel is emitted as, and what class or module a language-declared type is represented by, is the
  * backend's and is not stated here: a second backend answers those differently for the same
  * declarations, and a fact recorded here that only one of them could honour would be a fact about
@@ -221,6 +221,13 @@ public final class Stdlib {
     /** What the library declares for {@code kernel}, or null where no declaration names it. */
     public Intrinsic intrinsic(Kernel kernel) {
         return intrinsics.get(kernel);
+    }
+
+    /** Every kernel the library declares, with what it declares for each. Which kernels those are is
+     *  the library's own answer: a reader that walked the names asking after each would be building
+     *  this again, and would be right only about the names it thought to walk. */
+    public Map<Kernel, Intrinsic> intrinsics() {
+        return intrinsics;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/stdlib/Stdlib.java
+++ b/souther-compiler/src/main/java/souther/compiler/stdlib/Stdlib.java
@@ -231,17 +231,22 @@ public final class Stdlib {
     }
 
     /**
-     * What the library declares under {@code qualifiedName} where that operation is a kernel, and
-     * null where it is anything else — a Souther-bodied helper, a sugar, a name the library does not
+     * What the library declares for {@code operation} where that operation is a kernel, and null
+     * where it is anything else — a Souther-bodied helper, a sugar, a name the library does not
      * have.
      *
      * <p>Whether an operation is a kernel is a fact about the library and is answered by the
      * library. A reader that opened the declaration to look at its body would be reading how the
      * library is written to learn what it means, and would go on holding the declaration — which is
      * {@code Hir}, and is this compiler's own.
+     *
+     * <p>Asked with the operation and not with a spelling of it. A qualified name is how this is
+     * stored and a reach name renders as one today, which is a thing that is true rather than a
+     * thing that is held: a reader handing over a rendered name would be asking the library to
+     * resolve a spelling, and would go on doing it correctly for exactly as long as the two agreed.
      */
-    public Intrinsic intrinsicOf(String qualifiedName) {
-        return kernelOperations.get(qualifiedName);
+    public Intrinsic intrinsicOf(ValueName.Stdlib operation) {
+        return kernelOperations.get(operation.qualified());
     }
 
     /**
@@ -380,6 +385,7 @@ public final class Stdlib {
         /** The finished library. */
         public Stdlib freeze() {
             Map<String, Rewrite> sugars = sugars();
+            Map<String, Kernel> byKey = kernelsByKey();
             Map<Kernel, Intrinsic> intrinsics = new EnumMap<>(Kernel.class);
             Map<String, Intrinsic> kernelOperations = new LinkedHashMap<>();
             Map<String, Hir.FnDef> helpers = new LinkedHashMap<>();
@@ -390,8 +396,12 @@ public final class Stdlib {
                     // this holds the kernel, so a key that names none is refused here — while the
                     // library is being built, and so for a kernel nothing goes on to call as much as
                     // for one every program calls.
-                    Intrinsic intrinsic =
-                            new Intrinsic(Kernel.fromKey(written.key()), e.getValue().signature());
+                    Kernel named = byKey.get(written.key());
+                    if (named == null) {
+                        throw new IllegalStateException("the standard library declares `intrinsic \""
+                                + written.key() + "\"`, which this compiler has no kernel for");
+                    }
+                    Intrinsic intrinsic = new Intrinsic(named, e.getValue().signature());
                     // And one kernel is declared once. A backend builds its boundary form out of
                     // the signature this holds, so two declarations of one kernel would be two
                     // answers to a question that has one — and put into a map, the second would
@@ -422,6 +432,24 @@ public final class Stdlib {
                     Collections.unmodifiableMap(helpers),
                     published,
                     candidates(published));
+        }
+
+        /**
+         * The kernels this compiler has, by the key a declaration names one by.
+         *
+         * <p>Here rather than on {@link Kernel}, because turning a written key into an operation is
+         * what this step is and not something a kernel can do. Held there, every reader downstream
+         * could take the key off a kernel and ask for the kernel back, which is the route out of the
+         * operation and into a spelling that this exists to close.
+         */
+        private static Map<String, Kernel> kernelsByKey() {
+            Map<String, Kernel> byKey = new LinkedHashMap<>();
+            for (Kernel kernel : Kernel.values()) {
+                if (byKey.put(kernel.key(), kernel) != null) {
+                    throw new IllegalStateException("two kernels are written `" + kernel.key() + "`");
+                }
+            }
+            return byKey;
         }
 
         /** Each sugar with what it keeps in place: the target's own parameter count, less what the

--- a/souther-compiler/src/test/java/souther/compiler/check/AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest.java
@@ -224,19 +224,22 @@ class AnArmSaysWhichCaseAValueIsAndDoesNotMakeASecondOneTest {
     }
 
     private static Core answer() {
-        return new Core.Call(ReachName.of(FIND, "findIt", "demo"), FIND, List.of(),
+        return new Core.Call(new Core.Reached.OfDeclaration(
+                ReachName.of(FIND, "findIt", "demo"), FIND), List.of(),
                 Type.ref(FOUND), POS);
     }
 
     /** The same call, answering an optional — what an arm naming a present carrier is written over. */
     private static Core optionalAnswer() {
-        return new Core.Call(ReachName.of(FIND, "findIt", "demo"), FIND, List.of(),
+        return new Core.Call(new Core.Reached.OfDeclaration(
+                ReachName.of(FIND, "findIt", "demo"), FIND), List.of(),
                 Type.option(Type.INT), POS);
     }
 
     /** A call answering {@code Int | Missing}, which an arm may name either case of. */
     private static Core numericAnswer() {
-        return new Core.Call(ReachName.of(FIND, "findIt", "demo"), FIND, List.of(),
+        return new Core.Call(new Core.Reached.OfDeclaration(
+                ReachName.of(FIND, "findIt", "demo"), FIND), List.of(),
                 Type.union(new java.util.LinkedHashSet<>(List.of(AN_INT, MISSING))), POS);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatANameIsAboutIsWhatItWasGivenIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatANameIsAboutIsWhatItWasGivenIsAboutTest.java
@@ -112,6 +112,7 @@ class WhatANameIsAboutIsWhatItWasGivenIsAboutTest {
     }
 
     private static Core answer() {
-        return new Core.Call(ReachName.of(FIND, "findIt", "demo"), FIND, List.of(), Type.INT, POS);
+        return new Core.Call(new Core.Reached.OfDeclaration(
+                ReachName.of(FIND, "findIt", "demo"), FIND), List.of(), Type.INT, POS);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatWasWrittenIsFoundByFollowingWhatANameWasGivenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatWasWrittenIsFoundByFollowingWhatANameWasGivenTest.java
@@ -99,7 +99,8 @@ class WhatWasWrittenIsFoundByFollowingWhatANameWasGivenTest {
     /** And an arm opening an answer opens nothing written, however the arm was entered. */
     @Test
     void anArmOpeningAnAnswerOpensNoText() {
-        Core answer = new Core.Call(ReachName.of(FIND, "findIt", "demo"), FIND, List.of(),
+        Core answer = new Core.Call(new Core.Reached.OfDeclaration(
+                ReachName.of(FIND, "findIt", "demo"), FIND), List.of(),
                 Type.ref(FOUND), POS);
         Core.Binder x = CoreBinders.of(binders.binder("x", POS));
 

--- a/souther-compiler/src/test/java/souther/compiler/codegen/DecimalArithmeticIsTheRunTimesAndNotTheBackendsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/DecimalArithmeticIsTheRunTimesAndNotTheBackendsTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.codegen;
 
 import souther.compiler.Compiler;
+import souther.compiler.core.Kernel;
 
 import org.junit.jupiter.api.Test;
 
@@ -136,14 +137,16 @@ class DecimalArithmeticIsTheRunTimesAndNotTheBackendsTest {
     void everyDecimalKernelIsOneEmitterOwnedByTheDecimalRunTime() {
         List<String> otherwise = new ArrayList<>();
         Set<String> seen = new LinkedHashSet<>();
-        for (Map.Entry<String, Intrinsics.Emit> row : Intrinsics.emitters().entrySet()) {
-            if (!row.getKey().startsWith("decimal.")) {
+        // By the module that declares them, which is what a kernel's key spells. The question here
+        // is about one module of the library, not about which operation a call reaches.
+        for (Map.Entry<Kernel, Intrinsics.Emit> row : Intrinsics.emitters().entrySet()) {
+            if (!row.getKey().key().startsWith("decimal.")) {
                 continue;
             }
-            seen.add(row.getKey());
+            seen.add(row.getKey().key());
             if (!(row.getValue() instanceof Intrinsics.DeclaredStatic kernel)
                     || !Descriptors.CD_DecimalMath.equals(kernel.owner())) {
-                otherwise.add(row.getKey() + " is emitted as " + row.getValue());
+                otherwise.add(row.getKey().key() + " is emitted as " + row.getValue());
             }
         }
 

--- a/souther-compiler/src/test/java/souther/compiler/codegen/EveryKernelIsDeclaredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/EveryKernelIsDeclaredTest.java
@@ -12,33 +12,30 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Every kernel the library ships is described by a declaration (ADR-0053), and every kernel this
- * compiler has a name for is one of them. The signature lives in a core module and the compiler
- * holds only what a declaration cannot say — a kind, an ordering, the branch a partial division
- * emits.
+ * Every kernel the library ships is described by a declaration (ADR-0053), every kernel this
+ * compiler has a name for is one of them, and each is emitted in one place. The signature lives in a
+ * core module and the compiler holds only what a declaration cannot say — a kind, an ordering, the
+ * branch a partial division emits.
  *
  * <p>Asked as a correspondence rather than as "the table of signatures is empty": an emitter added
  * without a declaration is a function that can be called and whose type nothing states, which is
  * what the table of signatures was.
  *
- * <p>Three sets, and they are one set:
+ * <p>Three sets, and they are one set, split in two:
  *
  * <pre>{@code
- *   Kernel = what the library declares = what the JVM's table emits ∪ what BodyGen writes out
+ *   Kernel = what the library declares = what the JVM's table emits ⊎ what BodyGen writes out
  * }</pre>
  *
  * <p>The vocabulary lives in two places on purpose — the {@code .sou} declarations say what an
  * operation takes and answers, {@link Kernel} is what a checked program carries it as — and this is
  * what makes the two one vocabulary rather than two that are meant to agree.
+ *
+ * <p>What each side holds is asked of that side. A list of the written-out kernels kept here would
+ * be a second statement of what the backend does, and would go on passing on the day the backend
+ * stopped doing it.
  */
 class EveryKernelIsDeclaredTest {
-
-    /** The two the JVM writes out rather than holding as a table row. A partial Int division
-     *  answers a case rather than a number when its divisor is zero, so it emits a branch.
-     *  {@code decimal.divide} was a third until the runtime that owns Decimal arithmetic took the
-     *  whole operation, zero divisor included (ADR-0112). */
-    private static final Set<Kernel> WRITTEN_OUT =
-            EnumSet.of(Kernel.INT_DIVIDE, Kernel.INT_TRUNCATING_REMAINDER);
 
     @Test
     void everyEmittedKernelHasADeclarationNamingIt() {
@@ -53,7 +50,7 @@ class EveryKernelIsDeclaredTest {
     void everyDeclaredKernelHasAnEmitterOrIsWrittenOutInTheBackend() {
         Set<Kernel> declaredWithNoEmitter = new LinkedHashSet<>();
         for (Kernel kernel : declared()) {
-            if (!Intrinsics.kernels().contains(kernel) && !WRITTEN_OUT.contains(kernel)) {
+            if (!Intrinsics.kernels().contains(kernel) && !BodyGen.WRITTEN_OUT.contains(kernel)) {
                 declaredWithNoEmitter.add(kernel);
             }
         }
@@ -63,11 +60,28 @@ class EveryKernelIsDeclaredTest {
     }
 
     /**
+     * And no kernel is emitted twice.
+     *
+     * <p>The half the two above cannot see. A union covers a kernel held on both sides as readily as
+     * one held on either, so a row added for something the backend already writes out passes them
+     * both — and the emitter would go on running its own arm, with the row it disagrees with sitting
+     * there unread.
+     */
+    @Test
+    void noKernelIsBothWrittenOutAndHeldInTheTable() {
+        Set<Kernel> both = new LinkedHashSet<>(BodyGen.WRITTEN_OUT);
+        both.retainAll(Intrinsics.kernels());
+
+        assertEquals(Set.of(), both,
+                "the backend writes these out and the table holds them too");
+    }
+
+    /**
      * And every kernel this compiler names is declared.
      *
-     * <p>The direction the other two do not hold. A key a declaration writes that {@link Kernel}
-     * has no constant for is refused while the library is built, so a compilation that runs at all
-     * has crossed that way already; a constant with no declaration behind it is a kernel a checked
+     * <p>The direction the others do not hold. A key a declaration writes that {@link Kernel} has no
+     * constant for is refused while the library is built, so a compilation that runs at all has
+     * crossed that way already; a constant with no declaration behind it is a kernel a checked
      * program could be said to reach and no signature describes, and nothing else would say so.
      */
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/codegen/EveryKernelIsDeclaredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/EveryKernelIsDeclaredTest.java
@@ -2,7 +2,6 @@ package souther.compiler.codegen;
 
 import souther.compiler.DefaultStdlib;
 import souther.compiler.core.Kernel;
-import souther.compiler.stdlib.Stdlib;
 
 import org.junit.jupiter.api.Test;
 
@@ -79,14 +78,6 @@ class EveryKernelIsDeclaredTest {
 
     /** The kernels the library's declarations name. */
     private static Set<Kernel> declared() {
-        Stdlib library = DefaultStdlib.get();
-        Set<Kernel> declared = EnumSet.noneOf(Kernel.class);
-        for (String qualified : library.entries().keySet()) {
-            Stdlib.Intrinsic kernel = library.intrinsicOf(qualified);
-            if (kernel != null) {
-                declared.add(kernel.kernel());
-            }
-        }
-        return declared;
+        return DefaultStdlib.get().intrinsics().keySet();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/codegen/EveryKernelIsDeclaredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/EveryKernelIsDeclaredTest.java
@@ -1,31 +1,50 @@
 package souther.compiler.codegen;
 
 import souther.compiler.DefaultStdlib;
+import souther.compiler.core.Kernel;
 import souther.compiler.stdlib.Stdlib;
-import souther.compiler.ast.Hir;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Every kernel the library ships is described by a declaration (ADR-0053). The signature lives in a
- * core module and the compiler holds only what a declaration cannot say — a kind, an ordering, the
- * branch a partial division emits.
+ * Every kernel the library ships is described by a declaration (ADR-0053), and every kernel this
+ * compiler has a name for is one of them. The signature lives in a core module and the compiler
+ * holds only what a declaration cannot say — a kind, an ordering, the branch a partial division
+ * emits.
  *
  * <p>Asked as a correspondence rather than as "the table of signatures is empty": an emitter added
  * without a declaration is a function that can be called and whose type nothing states, which is
  * what the table of signatures was.
+ *
+ * <p>Three sets, and they are one set:
+ *
+ * <pre>{@code
+ *   Kernel = what the library declares = what the JVM's table emits ∪ what BodyGen writes out
+ * }</pre>
+ *
+ * <p>The vocabulary lives in two places on purpose — the {@code .sou} declarations say what an
+ * operation takes and answers, {@link Kernel} is what a checked program carries it as — and this is
+ * what makes the two one vocabulary rather than two that are meant to agree.
  */
 class EveryKernelIsDeclaredTest {
 
+    /** The two the JVM writes out rather than holding as a table row. A partial Int division
+     *  answers a case rather than a number when its divisor is zero, so it emits a branch.
+     *  {@code decimal.divide} was a third until the runtime that owns Decimal arithmetic took the
+     *  whole operation, zero divisor included (ADR-0112). */
+    private static final Set<Kernel> WRITTEN_OUT =
+            EnumSet.of(Kernel.INT_DIVIDE, Kernel.INT_TRUNCATING_REMAINDER);
+
     @Test
     void everyEmittedKernelHasADeclarationNamingIt() {
-        Set<String> emittedWithNoDeclaration = new LinkedHashSet<>(Intrinsics.keys());
-        emittedWithNoDeclaration.removeAll(declaredKeys());
+        Set<Kernel> emittedWithNoDeclaration = new LinkedHashSet<>(Intrinsics.kernels());
+        emittedWithNoDeclaration.removeAll(declared());
 
         assertEquals(Set.of(), emittedWithNoDeclaration,
                 "a kernel is emitted that no declaration describes");
@@ -33,16 +52,10 @@ class EveryKernelIsDeclaredTest {
 
     @Test
     void everyDeclaredKernelHasAnEmitterOrIsWrittenOutInTheBackend() {
-        // The two partial Int divisions answer a case rather than a number when the divisor is
-        // zero, so they emit a branch and are written out in BodyGen rather than held as a table
-        // row. `decimal.divide` was a third until the runtime that owns Decimal arithmetic took the
-        // whole operation, zero divisor included (ADR-0112).
-        Set<String> writtenOut = Set.of("int.divide", "int.truncatingRemainder");
-
-        Set<String> declaredWithNoEmitter = new LinkedHashSet<>();
-        for (String key : declaredKeys()) {
-            if (!Intrinsics.keys().contains(key) && !writtenOut.contains(key)) {
-                declaredWithNoEmitter.add(key);
+        Set<Kernel> declaredWithNoEmitter = new LinkedHashSet<>();
+        for (Kernel kernel : declared()) {
+            if (!Intrinsics.kernels().contains(kernel) && !WRITTEN_OUT.contains(kernel)) {
+                declaredWithNoEmitter.add(kernel);
             }
         }
 
@@ -50,12 +63,28 @@ class EveryKernelIsDeclaredTest {
                 "a kernel is declared that nothing emits");
     }
 
-    /** The kernel keys the library's declarations name: the entries whose body is a kernel. */
-    private static Set<String> declaredKeys() {
-        Set<String> declared = new LinkedHashSet<>();
-        for (Stdlib.Entry entry : DefaultStdlib.get().entries().values()) {
-            if (entry.declaration().body() instanceof Hir.FnBody.Intrinsic kernel) {
-                declared.add(kernel.key());
+    /**
+     * And every kernel this compiler names is declared.
+     *
+     * <p>The direction the other two do not hold. A key a declaration writes that {@link Kernel}
+     * has no constant for is refused while the library is built, so a compilation that runs at all
+     * has crossed that way already; a constant with no declaration behind it is a kernel a checked
+     * program could be said to reach and no signature describes, and nothing else would say so.
+     */
+    @Test
+    void everyKernelThisCompilerNamesIsDeclared() {
+        assertEquals(EnumSet.allOf(Kernel.class), declared(),
+                "a kernel this compiler names is declared by no core module");
+    }
+
+    /** The kernels the library's declarations name. */
+    private static Set<Kernel> declared() {
+        Stdlib library = DefaultStdlib.get();
+        Set<Kernel> declared = EnumSet.noneOf(Kernel.class);
+        for (String qualified : library.entries().keySet()) {
+            Stdlib.Intrinsic kernel = library.intrinsicOf(qualified);
+            if (kernel != null) {
+                declared.add(kernel.kernel());
             }
         }
         return declared;

--- a/souther-compiler/src/test/java/souther/compiler/codegen/KernelDescriptorsComeFromDeclarationsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/KernelDescriptorsComeFromDeclarationsTest.java
@@ -49,7 +49,7 @@ class KernelDescriptorsComeFromDeclarationsTest {
                 }
                 Type param = declared.params().get(i);
                 if (!fixesItsOwnBoundaryForm(param)) {
-                    readOffTheCall.add(entry.getKey() + " parameter " + (i + 1)
+                    readOffTheCall.add(entry.getKey().key() + " parameter " + (i + 1)
                             + " is declared " + Type.show(param));
                 }
             }

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputOutsideTheCompilerReadsACheckedProgramTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputOutsideTheCompilerReadsACheckedProgramTest.java
@@ -4,6 +4,7 @@ import souther.compiler.Compiler;
 import souther.compiler.core.Composition;
 import souther.compiler.diag.CompileException;
 import souther.compiler.core.Core;
+import souther.compiler.core.Kernel;
 import souther.compiler.program.CheckedBehavior;
 import souther.compiler.program.CheckedHelper;
 import souther.compiler.program.CheckedImplementation;
@@ -99,6 +100,24 @@ class AnOutputOutsideTheCompilerReadsACheckedProgramTest {
             let shipIt (p) = Shipped { total = p.total }
 
             behavior process = classify >-> priceIt >-> shipIt
+            """;
+
+    /**
+     * A body that reaches the standard library: a kernel over a string and one over a list.
+     *
+     * <p>{@code List.map} is not among them and is not missing. The derivable layer is ordinary
+     * Souther over the kernels and expands where it is called (ADR-0028), so what a backend meets is
+     * the walk it became.
+     */
+    private static final String CALLS_THE_LIBRARY = """
+            module demo
+
+            data Tidied = { label: String, items: Int }
+
+            behavior tidy : (label: String, items: List<Int>) -> Tidied constructs Tidied
+
+            let tidy (label, items) =
+                Tidied { label = String.trim(label), items = List.length(items) }
             """;
 
     private static CheckedModule demo() {
@@ -409,6 +428,36 @@ class AnOutputOutsideTheCompilerReadsACheckedProgramTest {
         assertNotNull(depth.body().type(), "what it answers, as the checker typed it");
         assertTrue(helpersCalledIn(depth.body()).contains(new ValueName.Helper("demo", "depth")),
                 "and it calls itself, which is why it is a definition of its own");
+    }
+
+    /**
+     * And a call reaching a kernel of the standard library says which kernel.
+     *
+     * <p>The operation, not a spelling of it. What is on the other side of {@code String.trim} is a
+     * decision the language made, and an output that read the alias and the name back apart would be
+     * resolving, by spelling, a name this compiler had resolved already.
+     *
+     * <p>Reached all the same, which is the shape of it: the same node still says what name the
+     * module wrote and what that name denotes, so a reader with no business emitting the operation
+     * asks what it always asked.
+     */
+    @Test
+    void aCallReachingAKernelSaysWhichKernel() {
+        CheckedProgram program = CheckedProgram.of(List.of(CALLS_THE_LIBRARY));
+        Core body = ((CheckedImplementation.Body)
+                named(program.module("demo"), "tidy").implementation()).body();
+
+        Set<Kernel> reached = new LinkedHashSet<>();
+        for (Core node : everyNodeOf(body)) {
+            if (node instanceof Core.Call call
+                    && call.fn() instanceof Core.Reached.OfKernel kernel) {
+                reached.add(kernel.kernel());
+                assertNotNull(kernel.denotes(), "and what the name denotes: " + kernel.rendered());
+            }
+        }
+
+        assertEquals(Set.of(Kernel.STRING_TRIM, Kernel.LIST_LENGTH), reached,
+                "the kernels this body reaches, as the operations they are");
     }
 
     /** Every helper a call in {@code body} reaches, walking every node of it. */

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputOutsideTheCompilerReadsACheckedProgramTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputOutsideTheCompilerReadsACheckedProgramTest.java
@@ -103,7 +103,12 @@ class AnOutputOutsideTheCompilerReadsACheckedProgramTest {
             """;
 
     /**
-     * A body that reaches the standard library: a kernel over a string and one over a list.
+     * A body that reaches the standard library two ways: an operation applied to arguments, and one
+     * written on its own.
+     *
+     * <p>{@code Map.empty} is declared with no parameter list, so it is a value and reaches the
+     * checker by a route of its own rather than as an application. It is a kernel all the same, and
+     * a reader outside this compiler has no way to tell which route a call was built by.
      *
      * <p>{@code List.map} is not among them and is not missing. The derivable layer is ordinary
      * Souther over the kernels and expands where it is called (ADR-0028), so what a backend meets is
@@ -118,6 +123,10 @@ class AnOutputOutsideTheCompilerReadsACheckedProgramTest {
 
             let tidy (label, items) =
                 Tidied { label = String.trim(label), items = List.length(items) }
+
+            behavior counts : (label: String) -> Map<String, Int>
+
+            let counts (label) = Map.insert(label, String.length(label), Map.empty)
             """;
 
     private static CheckedModule demo() {
@@ -463,6 +472,34 @@ class AnOutputOutsideTheCompilerReadsACheckedProgramTest {
                 "the kernels this body reaches, as the operations they are");
         assertEquals(Set.of("String.trim", "List.length"), named,
                 "and the same nodes still say what name the module wrote");
+    }
+
+    /**
+     * And so does one written where a value goes rather than applied.
+     *
+     * <p>{@code Map.empty} takes no arguments, so it is not written as an application and is not
+     * built as one. Two routes reach a call to a name, and a rule kept by each of them is a rule one
+     * of them will be missing: what a body holds is the same node either way, and an output reading
+     * it cannot tell — and must not have to tell — which route made it.
+     */
+    @Test
+    void andSoDoesAKernelWrittenWhereAValueGoes() {
+        CheckedProgram program = CheckedProgram.of(List.of(CALLS_THE_LIBRARY));
+        Core body = ((CheckedImplementation.Body)
+                named(program.module("demo"), "counts").implementation()).body();
+
+        Set<Kernel> reached = new LinkedHashSet<>();
+        for (Core node : everyNodeOf(body)) {
+            if (node instanceof Core.Call call
+                    && call.fn() instanceof Core.Reached.OfKernel kernel) {
+                reached.add(kernel.kernel());
+            }
+        }
+
+        assertTrue(reached.contains(Kernel.MAP_EMPTY),
+                () -> "the empty map is a kernel here too, and this body reaches " + reached);
+        assertEquals(Set.of(Kernel.MAP_INSERT, Kernel.STRING_LENGTH, Kernel.MAP_EMPTY), reached,
+                "every kernel this body reaches, however it was written");
     }
 
     /** Every helper a call in {@code body} reaches, walking every node of it. */

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputOutsideTheCompilerReadsACheckedProgramTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputOutsideTheCompilerReadsACheckedProgramTest.java
@@ -448,16 +448,21 @@ class AnOutputOutsideTheCompilerReadsACheckedProgramTest {
                 named(program.module("demo"), "tidy").implementation()).body();
 
         Set<Kernel> reached = new LinkedHashSet<>();
+        Set<String> named = new LinkedHashSet<>();
         for (Core node : everyNodeOf(body)) {
             if (node instanceof Core.Call call
                     && call.fn() instanceof Core.Reached.OfKernel kernel) {
                 reached.add(kernel.kernel());
-                assertNotNull(kernel.denotes(), "and what the name denotes: " + kernel.rendered());
+                named.add(kernel.rendered());
+                assertInstanceOf(ValueName.Stdlib.class, kernel.denotes(),
+                        "what " + kernel.rendered() + " denotes");
             }
         }
 
         assertEquals(Set.of(Kernel.STRING_TRIM, Kernel.LIST_LENGTH), reached,
                 "the kernels this body reaches, as the operations they are");
+        assertEquals(Set.of("String.trim", "List.length"), named,
+                "and the same nodes still say what name the module wrote");
     }
 
     /** Every helper a call in {@code body} reaches, walking every node of it. */

--- a/souther-program-api-test/src/test/java/souther/program/api/NothingReachableFromACheckedProgramNamesTheCompilerTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/NothingReachableFromACheckedProgramNamesTheCompilerTest.java
@@ -67,6 +67,11 @@ class NothingReachableFromACheckedProgramNamesTheCompilerTest {
                 () -> "no invariant clause in " + reached);
         assertTrue(reached.contains("souther.compiler.core.Contract$Rule"),
                 () -> "no ensures rule in " + reached);
+        // And which kernel a call to the standard library reaches, reached through the arm of a
+        // call target that carries it — the walk going down into what a body is made of rather than
+        // reading the top of the model.
+        assertTrue(reached.contains("souther.compiler.core.Kernel"),
+                () -> "no kernel in " + reached);
         assertTrue(reached.size() > 50, () -> "the walk reached only " + reached.size());
     }
 


### PR DESCRIPTION
Closes #1088.

## What crosses now

`Core.Reached` is a sum. A call to a standard-library kernel says which kernel, beside the name it
was reached by and what that name denotes:

```java
sealed interface Reached extends CallTarget {
    ReachName name();
    ValueName denotes();

    record OfDeclaration(ReachName name, ValueName denotes) implements Reached {}
    record OfKernel(ReachName name, ValueName denotes, Kernel kernel) implements Reached {}
}
```

Under `Reached` rather than beside it. A kernel call is reached — `List.sort` is written as a name,
resolves to a library operation, and its declaration being a kernel is what that operation turned
out to be. Put beside, `inputs.InputPath` — which takes `Core.Reached` and asks
`ElementLineage.holdsTheElementsOf(denotes())` — would have stopped seeing `List.reverse` and
`List.sort` without being told.

The three values are three questions and none is derived from another: how this module got here,
which declaration was chosen, what that declaration is.

## Where a key becomes a kernel, and where it cannot

`Kernel` is closed, one constant per operation the library declares as `intrinsic "..."`. What it
publishes is the identity and the key a declaration or a report writes it as. It cannot read a key
back as a kernel: that conversion is what freezing the library *is*, so the table it needs belongs
to `Stdlib.Builder`.

```
intrinsic "list.sort"  --Resolve-->  Hir.FnBody.Intrinsic  --freeze()-->  Kernel.LIST_SORT  -->  Core  -->  backend
```

A `Kernel.fromKey` would have been that route open to everything downstream — `Kernel` is a type an
output outside this compiler reads, so `fromKey(k.key())` would be writable there. Being called in
one place and not existing are different things.

A key naming no kernel is refused while the library is built, so a kernel nothing goes on to call is
wrong as early as one every program calls; `Resolve` stays an Ast→Hir copy and `ast` does not name
`core`. `freeze()` also refuses one kernel declared twice — a backend derives its boundary form from
the signature the kernel holds, and that is one answer.

## What the library answers, and with what

```java
Intrinsic intrinsicOf(ValueName.Stdlib operation);   // is this operation a kernel, and which
Intrinsic intrinsic(Kernel kernel);                  // what is declared for this kernel
Map<Kernel, Intrinsic> intrinsics();                 // which kernels are declared at all
```

Asked with the operation and not with a spelling of it. A qualified name is how this is stored and a
reach name renders as one today, which is a thing that is true rather than a thing that is held.
Nothing after `freeze()` opens a declaration to ask whether an operation is a kernel.

## Spelling comparisons that moved

Anything whose answer would change if the library published the operation under another alias:

| was | is |
|---|---|
| `BodyGen`: `ORDERED_BY_COMPARATOR.contains(call.name())`, `"List.sortBy".equals(...)`, `case "Int.divide"` | `switch (kernel)` |
| `BodyGen`: `library().entry(call.name())`, then the declaration's body | `call.fn() instanceof Core.Reached.OfKernel` |
| `CallElaborator`: `kernel.key().equals("list.sum")`, `ORDERED_ELEMENT` keyed by key | `kernel == Kernel.LIST_SUM`, `Map<Kernel, OrderedElement>` |
| `codegen.Intrinsics`: `Map<String, Emit>` | `EnumMap<Kernel, Emit>` |

`ReachName.rendered()` where a JVM method name is built from it stays what it is — there the
spelling is the question. `Intrinsics.DeclaredStatic` still reads the declared signature
(`intrinsic(kernel).signature()`): a sum-typed formal parameter cannot be recovered from the types
observed at the call, and signatures are out of scope here.

`Core.Call(ReachName, ValueName, …)` is gone. It would have had to decide which arm to build, and
`Core` does not know the library; without it `CallElaborator.reached(…)` is the only way a call to a
name is made, and both routes — an application, and a library value written on its own
(`Map.empty`) — go through it.

## One answer per question

An emitter arm that hands a kernel a comparator says only that: `Intrinsics.emitWithComparator`
reads the runtime class, the method and the result off the row the table already holds, for both row
shapes that can take one. Written out in the emitter, each would be stated a second time and a row
changed here would leave the second statement behind.

`EveryKernelIsDeclaredTest` fixes the kernels as one set split in two, and reads each side from the
side that decides it — `Intrinsics.kernels()` and `BodyGen.WRITTEN_OUT`:

```
Kernel = what the library declares = what the table emits ⊎ what BodyGen writes out
```

Disjoint, not merely covering. A union passes a kernel held on both sides as readily as one held on
either, so a row added for something the backend already writes out would satisfy every other check
while the emitter went on ignoring it.

The direction that needed a new test is `Kernel → declaration`: the other way is held by
`DefaultStdlib.get()` succeeding at all.

## And an output outside this compiler

`AnOutputOutsideTheCompilerReadsACheckedProgramTest` compiles a body calling `String.trim` and
`List.length` and reads `{STRING_TRIM, LIST_LENGTH}` off it — and the same nodes still answer what
name the module wrote — without naming `souther.compiler.stdlib` or `souther.compiler.ast`. A second
case reads `MAP_EMPTY` off `Map.empty`, which is written where a value goes rather than applied and
reaches the checker by a route of its own: a reader cannot tell, and must not have to tell, which
route built the node.

`NothingReachableFromACheckedProgramNamesTheCompilerTest` gains `Kernel` to its list of what the
walk must reach, and still passes.

`mvn -o test`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)