### PR TITLE
Say a stop this compiler made once, and say what it was

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/inputs/BlockedDescent.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/BlockedDescent.java
@@ -1,0 +1,45 @@
+package souther.compiler.inputs;
+
+/**
+ * That the walk could not go on into what a position holds, and what stopped it.
+ *
+ * <p><b>An observation and not a state still to be settled.</b> The same stop reaches a reader two
+ * ways: as {@link StructuralInspection.Continuation.Blocked}, which is what the position is left
+ * with <em>if nothing else answers for it</em>, and as this, which stays true whatever answers
+ * later. A body's rule may draw a line on the same position — a size, a length — and the position is
+ * then measured, has no continuation left to be pending, and was still never entered. Read off the
+ * continuation, that position came back with nothing to say the walk had stopped there
+ * (issue #1084).
+ *
+ * <p>So this is the half of the stop that outlives the phase that found it. What a report says about
+ * a position the walk could not enter is written from here and never from what the position is still
+ * waiting on.
+ *
+ * <p><b>No axis.</b> Which axis carries the fact is settled where the axes are, and can change: one
+ * position is measured at more than one number, and a body's rule re-points an axis at a term taken
+ * of the position. An identity written in here would have to be rebuilt every time that happened,
+ * and would be the wrong one for whoever asked afterwards.
+ */
+public record BlockedDescent(BlockReason.AboutThePosition why) {
+
+    public BlockedDescent {
+        if (why == null) {
+            throw new IllegalArgumentException("a descent stopped by nothing is one that went on");
+        }
+    }
+
+    /**
+     * What {@code structure} found, or null where the walk went on.
+     *
+     * <p>Asked of the one structural reading rather than worked out again. A second reading of what
+     * is under a position is the two disagreeing about whether it was entered, which is the shape of
+     * mistake this type is here to close.
+     */
+    public static BlockedDescent of(StructuralInspection structure) {
+        return structure instanceof StructuralInspection.Retained retained
+                && retained.continuation()
+                        instanceof StructuralInspection.Continuation.Blocked blocked
+                ? new BlockedDescent(blocked.why())
+                : null;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -164,7 +164,7 @@ public final class InputDomain {
         // rules on would have to be read after everything under it, and the order positions are
         // reported in is the order they are declared and descended into.
         List<Position> settled = found.stream()
-                .map(each -> handoffs.unresolvedAt(each.path()) ? shortOfHandedOnRules(each) : each)
+                .map(each -> shortOfHandedOnRules(each, handoffs.unresolvedAt(each.path())))
                 .toList();
         return settled.isEmpty() ? NONE
                 : new InputDomain(settled, read, parameters, roots, policy);
@@ -424,16 +424,50 @@ public final class InputDomain {
      * <p>Read off the ledger and not off whether a reading exists somewhere under the path: an
      * obligation discharged by whatever happens to be below it is one no descent ever had to meet
      * ({@link RuleHandoffs}).
+     *
+     * <p><b>This is where the two readings are joined, and the only place that may be.</b> The
+     * ledger knows that no recipient was named; the structural reading knows whether the walk could
+     * go into the position at all. Neither is the provenance on its own, and whoever asked later
+     * would be joining whatever state each phase still happened to be holding — which for the
+     * structural side is nothing, since a position a body's rule measures keeps no continuation
+     * (issue #1084). So the answer is settled here and carried from here.
+     *
+     * <p>Added to whatever the position already found. A reading that lost a clause of its own and
+     * handed rules on that nobody took is short of both, and answering with the first was how the
+     * second went missing.
      */
-    private static Position shortOfHandedOnRules(Position position) {
+    private static Position shortOfHandedOnRules(Position position,
+                                                 RuleHandoffs.Shortfall shortfall) {
+        if (shortfall == null) {
+            return position;
+        }
         ReadPosition read = (ReadPosition) position;
-        return read.rulesNotReached() ? read
-                : new ReadPosition(read.path(), read.view(), read.term(), read.numericDomain(),
-                        read.ownEnds(), read.narrowedEnds(), read.rangeLeft(), read.narrowedLower(),
-                        read.narrowedUpper(), read.nothingExists(), read.projection(),
-                        read.declared(), read.reading(), read.obligations(), read.completeness(),
-                        read.valuesUnread(), read.rulesWithoutALine(), read.unansweredQuestions(),
-                        true, read.structure());
+        RulesLeftUnread.HandoffUnread why = switch (shortfall) {
+            // Named a recipient for nobody, which for a position the walk went into would be the
+            // descent and the ledger disagreeing about one path — two walks over one model joined
+            // by the spelling of it, and the join is what this refuses to let through. Never a
+            // state of the model: every position that hands its rules on and is entered names the
+            // positions it passes them to.
+            case RuleHandoffs.Shortfall.NothingExpected _ -> {
+                if (BlockedDescent.of(read.structure()) == null) {
+                    throw new IllegalStateException(
+                            "nothing was passed the rules at " + read.path()
+                                    + ", which the walk went into: " + read.structure());
+                }
+                yield new RulesLeftUnread.HandoffUnread.FromBlockedDescent();
+            }
+            case RuleHandoffs.Shortfall.NotFullyAccepted _ ->
+                    new RulesLeftUnread.HandoffUnread.NotFullyAccepted();
+        };
+        java.util.Set<RulesLeftUnread> left =
+                new java.util.LinkedHashSet<>(read.rulesLeftUnread());
+        left.add(new RulesLeftUnread.Handoff(why));
+        return new ReadPosition(read.path(), read.view(), read.term(), read.numericDomain(),
+                read.ownEnds(), read.narrowedEnds(), read.rangeLeft(), read.narrowedLower(),
+                read.narrowedUpper(), read.nothingExists(), read.projection(),
+                read.declared(), read.reading(), read.obligations(), read.completeness(),
+                read.valuesUnread(), read.rulesWithoutALine(), read.unansweredQuestions(),
+                left, read.structure());
     }
 
     /**
@@ -722,7 +756,12 @@ public final class InputDomain {
                 // say every rule was accounted for. Read off the reading's own reason instead, a
                 // position carrying both a rule it could not read and a subtree it never entered
                 // answered with the first and lost the second.
-                !placed.everyRuleReachedAt(path),
+                //
+                // Only this reading's own loss is known here. Whether a handing over was taken up
+                // is the descent's to say, and it is added afterwards
+                // ({@link #shortOfHandedOnRules}).
+                placed.everyRuleReachedAt(path) ? java.util.Set.of()
+                        : java.util.Set.of(new RulesLeftUnread.ClauseOfThisReadingWasUnread()),
                 structure);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/InputDomain.java
@@ -442,23 +442,24 @@ public final class InputDomain {
             return position;
         }
         ReadPosition read = (ReadPosition) position;
+        BlockedDescent blocked = BlockedDescent.of(read.structure());
         RulesLeftUnread.HandoffUnread why = switch (shortfall) {
-            // Named a recipient for nobody, which for a position the walk went into would be the
-            // descent and the ledger disagreeing about one path — two walks over one model joined
-            // by the spelling of it, and the join is what this refuses to let through. Never a
-            // state of the model: every position that hands its rules on and is entered names the
-            // positions it passes them to.
-            case RuleHandoffs.Shortfall.NothingExpected _ -> {
-                if (BlockedDescent.of(read.structure()) == null) {
-                    throw new IllegalStateException(
-                            "nothing was passed the rules at " + read.path()
-                                    + ", which the walk went into: " + read.structure());
-                }
-                yield new RulesLeftUnread.HandoffUnread.FromBlockedDescent();
-            }
+            case RuleHandoffs.Shortfall.NothingExpected _ ->
+                    new RulesLeftUnread.HandoffUnread.FromBlockedDescent();
             case RuleHandoffs.Shortfall.NotFullyAccepted _ ->
                     new RulesLeftUnread.HandoffUnread.NotFullyAccepted();
         };
+        // The whole agreement and not the half this arm happens to need. Over an owed handing over,
+        // nobody was named as a recipient exactly where the walk could not go in — so a ledger that
+        // named nobody at a position this entered and a ledger that named somebody at a position it
+        // could not enter are both two walks over one model disagreeing about one path, joined by
+        // the spelling of it. Held one way, the second would arrive as an arm nothing folds beside a
+        // descent that is reported, which is #1084's own two entries, reached by a different road.
+        if (why.namesABlockedDescent() != (blocked != null)) {
+            throw new IllegalStateException(
+                    "the ledger and the walk disagree at " + read.path() + ": " + shortfall
+                            + " beside " + read.structure());
+        }
         java.util.Set<RulesLeftUnread> left =
                 new java.util.LinkedHashSet<>(read.rulesLeftUnread());
         left.add(new RulesLeftUnread.Handoff(why));

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
@@ -152,7 +152,7 @@ public sealed interface Position permits ReadPosition {
     List<StandingQuestion> unansweredQuestions();
 
     /**
-     * Whether a rule this position was owed went unread.
+     * The rules this position was owed that went unread, each as the reason it went unread.
      *
      * <p>Beside {@link #unansweredQuestions()} and not among them. A rule nothing took in is a rule
      * this compiler saw and made nothing of; here nothing was seen, so there is no rule to name and
@@ -165,8 +165,16 @@ public sealed interface Position permits ReadPosition {
      * written under a container, a case, or an optional is not one of them — it is read where it
      * governs, one position down, and a row meets it there. Said here, the measure was short of
      * something nobody could supply, because the walk had already gone to it (#1072).
+     *
+     * <p><b>The reasons and not a boolean.</b> Both can hold at once, and one of them is the same
+     * stop {@link BlockedDescent} reports from the other end — so a reader deciding whether what it
+     * holds is already said elsewhere has to be able to ask which this is. Answered {@code true},
+     * that reader could not ask, and reported one stop as two (issue #1084).
+     *
+     * <p>Empty where the rules this position was owed were all reached. In the order they were
+     * found, so that two runs over one model produce the same value.
      */
-    boolean rulesNotReached();
+    java.util.Set<RulesLeftUnread> rulesLeftUnread();
 
     /**
      * What stopped the reading of which values this position may hold, or null where nothing did.

--- a/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/Position.java
@@ -9,6 +9,7 @@ import souther.compiler.types.TypeSymbol;
 import souther.compiler.values.AdmissibleSet;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * One position of a behavior's input, read once.
@@ -174,7 +175,7 @@ public sealed interface Position permits ReadPosition {
      * <p>Empty where the rules this position was owed were all reached. In the order they were
      * found, so that two runs over one model produce the same value.
      */
-    java.util.Set<RulesLeftUnread> rulesLeftUnread();
+    Set<RulesLeftUnread> rulesLeftUnread();
 
     /**
      * What stopped the reading of which values this position may hold, or null where nothing did.

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadPosition.java
@@ -8,7 +8,10 @@ import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.values.AdmissibleSet;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * The one reading of a position, and what it came to.
@@ -36,7 +39,7 @@ record ReadPosition(TermPath path, TypeView view, NumericTerm term,
                     BlockReason.ReadingStopReason valuesUnread,
                     List<RuleWithoutALine> rulesWithoutALine,
                     List<StandingQuestion> unansweredQuestions,
-                    java.util.Set<RulesLeftUnread> rulesLeftUnread,
+                    Set<RulesLeftUnread> rulesLeftUnread,
                     StructuralInspection structure) implements Position {
 
     ReadPosition {
@@ -47,8 +50,7 @@ record ReadPosition(TermPath path, TypeView view, NumericTerm term,
         unansweredQuestions = List.copyOf(unansweredQuestions);
         // Kept in the order the readers found them, so that two runs over one model produce the
         // same value — the reason `MeasureClosure` keeps its gaps that way too.
-        rulesLeftUnread = java.util.Collections.unmodifiableSet(
-                new java.util.LinkedHashSet<>(rulesLeftUnread));
+        rulesLeftUnread = Collections.unmodifiableSet(new LinkedHashSet<>(rulesLeftUnread));
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/inputs/ReadPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/ReadPosition.java
@@ -35,7 +35,8 @@ record ReadPosition(TermPath path, TypeView view, NumericTerm term,
                     ObligationDomain obligations, AdmissibleSet.Completeness completeness,
                     BlockReason.ReadingStopReason valuesUnread,
                     List<RuleWithoutALine> rulesWithoutALine,
-                    List<StandingQuestion> unansweredQuestions, boolean rulesNotReached,
+                    List<StandingQuestion> unansweredQuestions,
+                    java.util.Set<RulesLeftUnread> rulesLeftUnread,
                     StructuralInspection structure) implements Position {
 
     ReadPosition {
@@ -44,6 +45,10 @@ record ReadPosition(TermPath path, TypeView view, NumericTerm term,
         declared = List.copyOf(declared);
         rulesWithoutALine = List.copyOf(rulesWithoutALine);
         unansweredQuestions = List.copyOf(unansweredQuestions);
+        // Kept in the order the readers found them, so that two runs over one model produce the
+        // same value — the reason `MeasureClosure` keeps its gaps that way too.
+        rulesLeftUnread = java.util.Collections.unmodifiableSet(
+                new java.util.LinkedHashSet<>(rulesLeftUnread));
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/inputs/RuleHandoffs.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/RuleHandoffs.java
@@ -127,7 +127,8 @@ final class RuleHandoffs {
     }
 
     /**
-     * Whether the reading that ended at {@code at} left rules under it that nothing took over.
+     * How the reading that ended at {@code at} was left with rules under it that nothing took over,
+     * or null where nothing is standing.
      *
      * <p>Every position the rules were passed to has to have been opened, and not merely some of
      * them: a sum whose second case nothing walked has left the rules of that case unread however
@@ -137,19 +138,46 @@ final class RuleHandoffs {
      * {@link #owes} refuses a second reading at one position. Left to be true rather than made so, a
      * handoff owed by one reading would answer for a position another reading reports — and an
      * answer taken from something other than what established it is what this issue was.
+     *
+     * <p>The first standing handoff answers. Two of them at one position would be two readings
+     * answering for it, which {@link #owes} has already refused.
      */
-    boolean unresolvedAt(TermPath at) {
+    Shortfall unresolvedAt(TermPath at) {
         for (Handoff handoff : owed) {
-            if (handoff.at().equals(at) && !resolved(handoff)) {
-                return true;
+            if (!handoff.at().equals(at)) {
+                continue;
+            }
+            Set<TermPath> supposed = expected.get(handoff);
+            if (supposed == null) {
+                return new Shortfall.NothingExpected();
+            }
+            if (!accepted.getOrDefault(handoff, Set.of()).containsAll(supposed)) {
+                return new Shortfall.NotFullyAccepted();
             }
         }
-        return false;
+        return null;
     }
 
-    private boolean resolved(Handoff handoff) {
-        Set<TermPath> supposed = expected.get(handoff);
-        return supposed != null
-                && accepted.getOrDefault(handoff, Set.of()).containsAll(supposed);
+    /**
+     * How a handing over was left standing, in this ledger's own words.
+     *
+     * <p><b>Why the descent got no further is not said here.</b> This knows that no recipient was
+     * ever named, and that is a fact about the entries it holds; whether the walk was stopped by a
+     * shape it cannot enter or went on and left a recipient unopened is a fact about the structural
+     * reading, which this has never seen. Answered here, the ledger would be deciding what a
+     * traversal means from the absence of an entry — the same reading of silence as evidence that
+     * #1072 was about.
+     *
+     * <p>Whoever holds both readings joins them ({@code InputDomain}), and it is there that
+     * {@link RulesLeftUnread.HandoffUnread} is settled.
+     */
+    sealed interface Shortfall {
+
+        /** No recipient was ever named for the handing over: the descent past this position made no
+         *  entry at all. */
+        record NothingExpected() implements Shortfall {}
+
+        /** Recipients were named and a reading was not opened at every one of them. */
+        record NotFullyAccepted() implements Shortfall {}
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/inputs/RuleHandoffs.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/RuleHandoffs.java
@@ -29,7 +29,13 @@ import java.util.Set;
  * then came back short of something reports that shortfall itself, at its own position. The handoff
  * above it is discharged all the same: the rules reached a reader, and saying so twice would report
  * one gap at two positions. What leaves a handoff standing is that no reading was opened at all —
- * a shape this compiler cannot enter, a depth this walk stops at, a value it has already been to.
+ * a shape this compiler cannot enter, or a recipient the descent named and nothing opened.
+ *
+ * <p>A depth this walk stops at is not one of them, though it reads like one. A stop at the depth
+ * leaves the rules under it unread and hands nothing on
+ * ({@code PathEngine.leftBy}), so no handing over is made there and none is left standing — which is
+ * why a record four levels down is reported as a position nothing was read into and not also as one
+ * whose rules nobody took (issue #1084).
  */
 final class RuleHandoffs {
 

--- a/souther-compiler/src/main/java/souther/compiler/inputs/RulesLeftUnread.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/RulesLeftUnread.java
@@ -46,6 +46,30 @@ public sealed interface RulesLeftUnread {
     sealed interface HandoffUnread {
 
         /**
+         * Whether this is the arm a descent that could not be made leaves behind.
+         *
+         * <p><b>The one place the agreement between the two walks is written.</b> Over an owed
+         * handing over the ledger and the structural reading say the same thing two ways: nobody was
+         * named as a recipient exactly where the walk could not go into the position. That is a
+         * biconditional and not an implication, and written out at each place that needs it, each
+         * would state the half it happened to be constructing — which is the shape of the defect
+         * #1084 was, one stop written from two ends with nothing relating them.
+         *
+         * <p>So both places ask this and compare it against the descent they hold: the reader that
+         * settles the arm ({@code InputDomain}) and the value that carries it afterwards
+         * ({@link souther.compiler.partition.ReadingResidue}). Neither can hold to half of it.
+         *
+         * <p>Exhaustive with no {@code default}: an arm added later says which side of the
+         * agreement it is on, or does not compile.
+         */
+        default boolean namesABlockedDescent() {
+            return switch (this) {
+                case FromBlockedDescent _ -> true;
+                case NotFullyAccepted _ -> false;
+            };
+        }
+
+        /**
          * Nothing was opened under the position, because the walk could not go into it.
          *
          * <p>The one arm with a cause named elsewhere. {@link BlockedDescent} is the same stop said

--- a/souther-compiler/src/main/java/souther/compiler/inputs/RulesLeftUnread.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/RulesLeftUnread.java
@@ -1,0 +1,72 @@
+package souther.compiler.inputs;
+
+/**
+ * Why the rules a position was owed went unread.
+ *
+ * <p>What {@link Position#rulesLeftUnread()} used to answer with a boolean. The two facts under it
+ * are of different origin — a reading that lost a clause of its own, and a handing over nobody took
+ * — and a reader deciding whether one of them is already reported by the finding beside it has to
+ * know which. Given the boolean, {@code MeasureClosure} could not know, and reported one stop twice
+ * (issue #1084).
+ *
+ * <p><b>Two levels, because the arms are of two kinds.</b> Whether the rules were this reading's own
+ * or somebody else's is the first question; how a handing over came to be unread is the second, and
+ * it belongs to the handoff protocol. Written flat, a failure the protocol grows later would widen
+ * the vocabulary every reader of this switch has to answer about.
+ *
+ * <p><b>Determined where it is observed.</b> Each of these is settled by the reader that had both
+ * facts in hand and is carried unchanged from there ({@link souther.compiler.partition.ReadingResidue}).
+ * Worked out again further down, the answer would be a join of whatever state each phase happened to
+ * still be holding — which is how the fact this replaces came to be a boolean in the first place.
+ */
+public sealed interface RulesLeftUnread {
+
+    /**
+     * The reading that owns this position lost a clause of its own.
+     *
+     * <p>The position was entered. Its rules were there to be read and one of them was not, so the
+     * questions standing at it are real questions and this is a finding of its own — never one
+     * suppressed because something else was found at the same path.
+     */
+    record ClauseOfThisReadingWasUnread() implements RulesLeftUnread {}
+
+    /** This position handed its rules on and no reading took them over, in one of the ways a
+     *  handing over can be left standing. */
+    record Handoff(HandoffUnread why) implements RulesLeftUnread {
+
+        public Handoff {
+            if (why == null) {
+                throw new IllegalArgumentException(
+                        "a handing over unread for no reason is one that was taken over");
+            }
+        }
+    }
+
+    /** How a handing over came to be unread. */
+    sealed interface HandoffUnread {
+
+        /**
+         * Nothing was opened under the position, because the walk could not go into it.
+         *
+         * <p>The one arm with a cause named elsewhere. {@link BlockedDescent} is the same stop said
+         * from the other end, and it is the one a document reports — so this yields no finding of
+         * its own ({@code MeasureClosure}). Kept as an arm all the same: the fold is on this
+         * provenance and not on two findings happening to share a path.
+         *
+         * <p>Only made where a {@link BlockedDescent} was found beside it. That the two agree is a
+         * fact about two walks over one model, and it is checked where they are joined rather than
+         * assumed by whoever reads this later.
+         */
+        record FromBlockedDescent() implements HandoffUnread {}
+
+        /**
+         * The descent named the positions the rules were passed to, and a reading was not opened at
+         * every one of them.
+         *
+         * <p>Nothing else reports this. The walk did go on, so no {@link BlockedDescent} stands
+         * here, and the rules of the positions that got no reading were read by nobody — which
+         * raises no question, since a rule nothing read is a rule nothing could find wanting.
+         */
+        record NotFullyAccepted() implements HandoffUnread {}
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/inputs/StructuralInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/StructuralInspection.java
@@ -130,8 +130,14 @@ public sealed interface StructuralInspection {
          * <p>{@code why} is the reason this position is left with if nothing else answers for it,
          * not a verdict. A rule a body writes may still draw a line on this same position — a
          * length, a size — and where one does, that is what the position is measured at and this
-         * reason is never reported. What it does not do is let a rule about what is <em>inside</em>
-         * stand in for reaching inside.
+         * continuation no longer stands. What it does not do is let a rule about what is
+         * <em>inside</em> stand in for reaching inside.
+         *
+         * <p><b>The stop it observed outlives that.</b> A position something else answers for is
+         * still a position the walk never went into, and this arm is gone by then — so what a report
+         * says about the walk is written from {@link BlockedDescent}, which is the same observation
+         * kept as one nothing later takes away. Read from here instead, a {@code Map} under a rule
+         * about its size came back with nothing to say the walk had ever stopped (issue #1084).
          */
         record Blocked(BlockReason.AboutThePosition why) implements Continuation {}
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -51,10 +51,15 @@ import java.util.List;
  *                 path is how a reason came to be recovered by string match. A reason travels with
  *                 the position or it is a reason about whatever the strings happened to pair it
  *                 with.
- * @param rulesNotReached whether the walk reached the rules written about this position at all.
- *                 Beside the questions and not among them: a position whose rules were never
+ * @param residue  what the reading of this position left behind that nothing later takes away: the
+ *                 rules it was owed and did not reach, and whether the walk could go into what it
+ *                 holds. Beside the questions and not among them — a position whose rules were never
  *                 enumerated raises no question and is not one whose rules were all accounted for,
- *                 and an empty list says the second (issue #791)
+ *                 and an empty list says the second (issue #791).
+ *
+ *                 <p>Apart from {@link #pending} because the two do not live as long. A position a
+ *                 body's rule divides keeps no continuation to be pending on, and was still never
+ *                 entered; read off the continuation, that stop went unsaid (issue #1084)
  * @param leftWith what the position is left with where the local reading gave it no axis, or null
  *                 where nothing is. Which of the two it is comes with it: a reading stopped, or a
  *                 rule was read to the end and draws no line. Carried for the same reason
@@ -64,18 +69,22 @@ import java.util.List;
  *                 from the other end
  */
 public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> classes,
-                   List<Cut> cuts, List<Seam> parted, boolean rulesNotReached,
+                   List<Cut> cuts, List<Seam> parted, ReadingResidue residue,
                    StructuralInspection.Continuation pending, LeftAtThePosition leftWith) {
 
     public Axis {
         classes = List.copyOf(classes);
         cuts = List.copyOf(cuts);
         parted = List.copyOf(parted);
+        if (residue == null) {
+            throw new IllegalArgumentException(
+                    "an axis with no account of what its reading came to");
+        }
     }
 
     public Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> classes,
                 List<Cut> cuts) {
-        this(id, term, type, classes, cuts, List.of(), false, null, null);
+        this(id, term, type, classes, cuts, List.of(), ReadingResidue.NOTHING, null, null);
     }
 
     /**
@@ -85,11 +94,11 @@ public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> 
      * and only where none does is what was found here what a report says — an absence where every
      * reading ran to the end and found nothing, and what stopped one where it did not.
      */
-    public static Axis pendingAt(AxisId id, NumericTerm term, Type type, boolean rulesNotReached,
+    public static Axis pendingAt(AxisId id, NumericTerm term, Type type, ReadingResidue residue,
                                  StructuralInspection.Continuation found,
                                  LeftAtThePosition leftWith) {
         return new Axis(id, term, type, List.of(), List.of(), List.of(),
-                rulesNotReached, found, leftWith);
+                residue, found, leftWith);
     }
 
     /**
@@ -103,12 +112,12 @@ public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> 
      * as one the model divides no way.
      */
     public Axis measuredAt(AxisId id, NumericTerm term) {
-        return new Axis(id, term, type, classes, cuts, parted, rulesNotReached, pending, leftWith);
+        return new Axis(id, term, type, classes, cuts, parted, residue, pending, leftWith);
     }
 
     /** The same position, with what a body's rules divided it into and the lines they drew. */
     public Axis carrying(List<PartitionClass> classes, List<Cut> cuts, List<Seam> parted) {
-        return new Axis(id, term, type, classes, cuts, parted, rulesNotReached, pending, leftWith);
+        return new Axis(id, term, type, classes, cuts, parted, residue, pending, leftWith);
     }
 
     /** Where the value this axis is about sits, which is where a row is walked to before the term is

--- a/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
@@ -65,6 +65,14 @@ public sealed interface ClosureGap {
      * ({@link souther.compiler.inputs.RulesLeftUnread}): a position the reading entered and lost a
      * clause of its own is an independent finding, and a fold on the path would take it with the
      * other (issue #1084).
+     *
+     * <p><b>And two of those ways reach a document as this one word.</b> A reading that lost a
+     * clause of its own and a recipient that got no reading are different causes and both are
+     * things an author is told about; what they are told is that the rules at this position were
+     * not all reached, which is what this says. The reason stays inside
+     * ({@link souther.compiler.inputs.RulesLeftUnread}) because a document naming it would make a
+     * change to how this compiler traverses a model into a change to what its documents carry. Two
+     * of these at one axis are one entry, which is that sentence said once.
      */
     record RulesNotReached(AxisId at) implements ClosureGap {}
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ClosureGap.java
@@ -54,8 +54,18 @@ public sealed interface ClosureGap {
     record QuestionUnanswered(souther.compiler.inputs.StandingQuestion question)
             implements ClosureGap {}
 
-    /** A position whose rules nothing enumerated. It raises no question, so it cannot be short of
-     *  one — which is why it is a gap of its own and not one of the two above. */
+    /**
+     * A position whose rules nothing enumerated. It raises no question, so it cannot be short of
+     * one — which is why it is a gap of its own and not one of the two above.
+     *
+     * <p><b>Not every way the rules go unread reaches this.</b> A handing over left standing because
+     * the walk could not go into the position is the same stop {@link PositionNotReachedInto}
+     * reports, and it is written there once. Which of the ways this is comes off the arm the reading
+     * settled and never off what else was found at the path
+     * ({@link souther.compiler.inputs.RulesLeftUnread}): a position the reading entered and lost a
+     * clause of its own is an independent finding, and a fold on the path would take it with the
+     * other (issue #1084).
+     */
     record RulesNotReached(AxisId at) implements ClosureGap {}
 
     /**
@@ -67,6 +77,18 @@ public sealed interface ClosureGap {
      * the measures rather than from what {@link MeasureClosure#of} finds, so nothing ever built one:
      * an arm taken from a second representation of a fact, which is the mistake #953 is about, in
      * miniature.
+     *
+     * <p><b>{@code at} names the axis carrying the fact, and the position is that axis's path.</b>
+     * The two come apart: a {@code Map} nothing can be read into, under a rule about its size, is
+     * measured at the size and the axis is named for that term. So this is not "the identity of the
+     * position that was blocked" — it is the axis a reader holding these numbers is being told
+     * something about, which is the one thing a gap beside a measurement is for. Keyed by the
+     * position instead, this arm and {@link RulesNotReached} would name a behavior's findings in two
+     * vocabularies.
+     *
+     * <p>Written from {@link souther.compiler.inputs.BlockedDescent} and never from what the axis is
+     * still waiting on. A position something answered for keeps no continuation, and was still never
+     * entered.
      */
     record PositionNotReachedInto(AxisId at, BlockReason.AboutThePosition why) implements ClosureGap {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
@@ -56,8 +56,10 @@ final class LocalInspection {
         // that value can be refused, wherever in it the rule is written.
         CutEvidence drawn = cuts.isEmpty() ? new CutEvidence.None()
                 : new CutEvidence.Present(cuts, position.projection());
-        return new LocalPartition.Divided(classes, drawn,
-                position.rulesNotReached());
+        // What the reading was short of is not restated here. It is the position's own answer and
+        // travels as one value from there (`ReadingResidue`), so a local inspection copying half of
+        // it would be a second place the pair could come apart.
+        return new LocalPartition.Divided(classes, drawn);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/LocalPartition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LocalPartition.java
@@ -29,8 +29,7 @@ public sealed interface LocalPartition {
      * dressed as a divided one, and the phase after this one would never be reached for it.
      *
      */
-    record Divided(List<PartitionClass> classes, CutEvidence cuts,
-                   boolean rulesNotReached) implements LocalPartition {
+    record Divided(List<PartitionClass> classes, CutEvidence cuts) implements LocalPartition {
 
         public Divided {
             classes = List.copyOf(classes);

--- a/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/MeasureClosure.java
@@ -1,7 +1,8 @@
 package souther.compiler.partition;
 
 import souther.compiler.check.CoverageObligation;
-import souther.compiler.inputs.StructuralInspection;
+import souther.compiler.inputs.BlockedDescent;
+import souther.compiler.inputs.RulesLeftUnread;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -31,7 +32,7 @@ import java.util.Set;
  *
  * <p><b>And two facts no question carries.</b> A position whose rules were never enumerated
  * raises none, and a set of raised questions all answered is what a reading that never looked also
- * produces ({@link Axis#rulesNotReached}). And a rule the model wrote that this could not use is one
+ * produces ({@link ReadingResidue}). And a rule the model wrote that this could not use is one
  * whose question a reading may well have answered before the position refused the answer — two
  * clauses placing ends on a {@code String}'s two coordinates are read, accounted for, and then
  * both dropped, and the accounting is right to say they were read. What an accounting cannot say
@@ -42,6 +43,19 @@ import java.util.Set;
  * because what is not known about them is not known for either. And a rule set aside answers
  * through its own reason ({@link souther.compiler.inputs.BlockReason.RuleWithoutLineReason#leavesShort}),
  * which for a comparison relating two positions is neither measure.
+ *
+ * <p><b>One stop, one gap, and the fold is on where the gap came from.</b> Two of the things a
+ * reading can be short of are one stop said from two ends: the walk could not go into a position,
+ * and so the rules it handed on reached nobody. The second is a consequence of the first, and the
+ * arm that says so is what this reads to leave it out ({@link #derived}). Never the path — a
+ * position the reading did enter and lost a clause of its own is an independent finding sitting at
+ * the same place, and a fold on "there is already something here" takes that one with it (#1084).
+ *
+ * <p><b>And a question stands whatever else was found at its position.</b> A question comes off a
+ * rule this compiler read and neither reader answered, so the rules a stop left unread raise none —
+ * which means a suppression by position could only ever reach the real ones. What it did reach was a
+ * rule about a {@code Map}'s size that nothing answered, dropped because the map's contents are out
+ * of reach, which is a fact about other rules entirely.
  *
  * <p><b>A clause's question may stand and a comparison's may not.</b> A comparison raises a question
  * exactly where the reading of it reached a line, and that line answers it — both come off the one
@@ -169,33 +183,33 @@ public final class MeasureClosure {
                 border.add(new ClosureGap.RuleUnread(rule));
             }
         }
-        // The positions a gap of their own already stands for. A position whose rules nothing
-        // enumerated, and one the walk could not reach into: neither raises a question, so neither
-        // can be short of one, and what is short there is said once for the position rather than
-        // once per question it never got as far as raising.
-        Set<souther.compiler.inputs.TermPath> unreached = new LinkedHashSet<>();
         for (Axis axis : axes) {
-            if (axis.rulesNotReached()) {
-                ClosureGap gap = new ClosureGap.RulesNotReached(axis.id());
-                partition.add(gap);
-                border.add(gap);
-                unreached.add(axis.path());
-            }
-            if (axis.pending() instanceof StructuralInspection.Continuation.Blocked blocked) {
+            // Read off what the reading settled and never off what the axis is still waiting on. A
+            // position a body's rule divides keeps no continuation, and was still never entered:
+            // asked of the continuation, the one model where the two come apart said nothing at all
+            // about the position it could not read (issue #1084).
+            BlockedDescent blocked = axis.residue().blockedDescent();
+            if (blocked != null) {
                 ClosureGap gap = new ClosureGap.PositionNotReachedInto(axis.id(), blocked.why());
                 partition.add(gap);
                 border.add(gap);
-                unreached.add(axis.path());
+            }
+            for (RulesLeftUnread unread : axis.residue().rulesLeftUnread()) {
+                if (derived(unread)) {
+                    continue;
+                }
+                ClosureGap gap = new ClosureGap.RulesNotReached(axis.id());
+                partition.add(gap);
+                border.add(gap);
             }
         }
-        // Asked of the question and of the position it is about, and not of whichever axis it was
-        // found beside. One position can be measured at more than one number, and an axis is
-        // re-pointed at another term as a body's rules are read — so an axis is not what a question
-        // belongs to, and a suppression written per axis decided from whichever one the loop met.
+        // Every question that stands, whatever else was found at the same path. A question is
+        // raised by a rule this compiler read and neither reader answered, so the rules a stop left
+        // unread raise none — and the only questions a suppression here could ever reach are the
+        // real ones. Written as "there is already a finding at this path", a rule about a `Map`'s
+        // size that nothing answered went unsaid because the walk could not read what the map holds,
+        // which are two facts about two different rules (issue #1084).
         for (souther.compiler.inputs.StandingQuestion each : asked) {
-            if (unreached.contains(each.asks().path())) {
-                continue;
-            }
             ClosureGap gap = new ClosureGap.QuestionUnanswered(each);
             switch (each.obligation().answeredBy()) {
                 case PARTITION -> partition.add(gap);
@@ -205,6 +219,34 @@ public final class MeasureClosure {
         return new Both(
                 partition.isEmpty() ? new OfThePartition.Closed() : new OfThePartition.Open(partition),
                 border.isEmpty() ? new OfTheBorder.Closed() : new OfTheBorder.Open(border));
+    }
+
+    /**
+     * Whether this way of leaving the rules unread is already reported by a finding beside it.
+     *
+     * <p><b>The fold, and the whole of it.</b> One way of leaving the rules unread is a consequence
+     * of another finding rather than a second thing that went wrong: a handing over nobody took
+     * because the walk could not go into the position is the blocked descent written above, said
+     * from the other end. Both sentences are true and a reader is told the stop once.
+     *
+     * <p><b>On the provenance and never on the path.</b> A position the reading did enter and lost a
+     * clause of its own is an independent finding, and it can sit at the same path as anything else.
+     * Suppressed by "there is already a finding here", that one would go with it — which is why this
+     * asks the arm and is handed nothing else to decide from.
+     *
+     * <p>Exhaustive with no {@code default}: a way of leaving the rules unread added later is
+     * answered here or is a compile error, rather than quietly folding into somebody else's finding.
+     */
+    private static boolean derived(RulesLeftUnread unread) {
+        return switch (unread) {
+            // The reading was there and lost a rule of its own. Nothing else says so.
+            case RulesLeftUnread.ClauseOfThisReadingWasUnread _ -> false;
+            case RulesLeftUnread.Handoff handoff -> switch (handoff.why()) {
+                case RulesLeftUnread.HandoffUnread.FromBlockedDescent _ -> true;
+                // The walk went on and left a recipient with no reading. Nothing else says so.
+                case RulesLeftUnread.HandoffUnread.NotFullyAccepted _ -> false;
+            };
+        };
     }
 
     /** An open closure's own account of itself: never empty, and in the order the readers found it,

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -887,9 +887,14 @@ public final class Partitions {
                 if (divided.cuts() instanceof CutEvidence.Present drawn && drawn.uncertain()) {
                     uncertain.add(term);
                 }
+                // No continuation, because something answered for the position and a fallback is
+                // what a position with no answer is left with. What the reading came to is carried
+                // all the same: a `Map` a rule about its size divides is one nothing was read into,
+                // and taking that off the axis with the fallback is how the stop went unreported
+                // (issue #1084).
                 out.add(new Axis(id, term, position.type(), divided.classes(),
                         divided.cuts().cuts(), List.of(),
-                        divided.rulesNotReached(), null, null));
+                        ReadingResidue.of(position), null, null));
             }
             // Nothing local divides the position, which is what licenses asking what it is made of.
             // Whether the reading got to the end of the rules is carried rather than acted on here:
@@ -907,7 +912,7 @@ public final class Partitions {
                     // position from completing as one the model divides no way.
                     case StructuralInspection.Retained retained ->
                             out.add(Axis.pendingAt(id, term, position.type(),
-                                    position.rulesNotReached(),
+                                    ReadingResidue.of(position),
                                     retained.continuation(), leftAt(position)));
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReadingResidue.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReadingResidue.java
@@ -38,18 +38,19 @@ public record ReadingResidue(BlockedDescent blockedDescent,
 
     public ReadingResidue {
         rulesLeftUnread = Collections.unmodifiableSet(new LinkedHashSet<>(rulesLeftUnread));
-        // What the arm says about itself, held to. `FromBlockedDescent` is the one arm whose finding
-        // is somebody else's — the stop is reported as the blocked descent beside it, and this is
-        // folded away — so an arm arriving without the descent it names would fold into a finding
-        // nothing writes, and the stop would go unsaid. The producer proved the two agree
-        // (`InputDomain`); this is where a copy that dropped one of them is caught.
-        if (blockedDescent == null && rulesLeftUnread.stream().anyMatch(
-                each -> each instanceof RulesLeftUnread.Handoff handoff
-                        && handoff.why()
-                                instanceof RulesLeftUnread.HandoffUnread.FromBlockedDescent)) {
-            throw new IllegalArgumentException(
-                    "a handing over left standing by a blocked descent, with no blocked descent: "
-                            + rulesLeftUnread);
+        // What the arms say about themselves, held to — the same agreement the reader that settled
+        // them held, asked the same way ({@link RulesLeftUnread.HandoffUnread#namesABlockedDescent}).
+        // An arm naming a descent this does not carry would fold into a finding nothing writes and
+        // the stop would go unsaid; an arm denying one beside a descent that is reported puts the
+        // stop out twice. Both are a copy that dropped one of the pair, and this is where a copy is
+        // caught.
+        for (RulesLeftUnread each : rulesLeftUnread) {
+            if (each instanceof RulesLeftUnread.Handoff handoff
+                    && handoff.why().namesABlockedDescent() != (blockedDescent != null)) {
+                throw new IllegalArgumentException(
+                        "a handing over and the descent beside it disagree: " + handoff.why()
+                                + " with " + blockedDescent);
+            }
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReadingResidue.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReadingResidue.java
@@ -1,0 +1,66 @@
+package souther.compiler.partition;
+
+import souther.compiler.inputs.BlockedDescent;
+import souther.compiler.inputs.Position;
+import souther.compiler.inputs.RulesLeftUnread;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * What a reading of one position left behind that no later phase can take away.
+ *
+ * <p><b>Two facts with one lifetime, held together so that one cannot be carried without the
+ * other.</b> An axis is rebuilt whenever a body's rules re-point it at another number
+ * ({@link Axis#measuredAt}) or divide it ({@link Axis#carrying}), and each of those is a place a
+ * caller writes the parts out by hand. A position whose elements could not be reached once came
+ * back from the second phase with nothing to say it had ever stopped, because one such rebuild did
+ * not name the field. Written as one value, a rebuild names it or does not compile.
+ *
+ * <p><b>Not what the position is still waiting on.</b> {@link Axis#pending} is a fallback: it is
+ * what a position is left with <em>if nothing else answers for it</em>, and it is gone the moment
+ * something does. These two are observations, and they stay true whatever answers later — a
+ * {@code Map} nothing can be read into is one nothing was read into however plainly a rule about its
+ * size divides it. Holding the three in one value would put a phase-local state and two settled
+ * facts under one lifetime, which is the merge issue #1084 is about, one level up.
+ *
+ * @param blockedDescent that the walk could not go into what the position holds, or null where it
+ *                       did
+ * @param rulesLeftUnread why the rules the position was owed went unread, empty where they were all
+ *                       reached
+ */
+public record ReadingResidue(BlockedDescent blockedDescent,
+                             Set<RulesLeftUnread> rulesLeftUnread) {
+
+    /** A reading that got to the end of everything it was owed. */
+    public static final ReadingResidue NOTHING = new ReadingResidue(null, Set.of());
+
+    public ReadingResidue {
+        rulesLeftUnread = Collections.unmodifiableSet(new LinkedHashSet<>(rulesLeftUnread));
+        // What the arm says about itself, held to. `FromBlockedDescent` is the one arm whose finding
+        // is somebody else's — the stop is reported as the blocked descent beside it, and this is
+        // folded away — so an arm arriving without the descent it names would fold into a finding
+        // nothing writes, and the stop would go unsaid. The producer proved the two agree
+        // (`InputDomain`); this is where a copy that dropped one of them is caught.
+        if (blockedDescent == null && rulesLeftUnread.stream().anyMatch(
+                each -> each instanceof RulesLeftUnread.Handoff handoff
+                        && handoff.why()
+                                instanceof RulesLeftUnread.HandoffUnread.FromBlockedDescent)) {
+            throw new IllegalArgumentException(
+                    "a handing over left standing by a blocked descent, with no blocked descent: "
+                            + rulesLeftUnread);
+        }
+    }
+
+    /** What one position's reading came to, as the reading itself answered it. */
+    public static ReadingResidue of(Position position) {
+        return new ReadingResidue(BlockedDescent.of(position.structure()),
+                position.rulesLeftUnread());
+    }
+
+    /** Whether anything here leaves a measure short. */
+    public boolean isEmpty() {
+        return blockedDescent == null && rulesLeftUnread.isEmpty();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReadingResidue.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReadingResidue.java
@@ -58,9 +58,4 @@ public record ReadingResidue(BlockedDescent blockedDescent,
         return new ReadingResidue(BlockedDescent.of(position.structure()),
                 position.rulesLeftUnread());
     }
-
-    /** Whether anything here leaves a measure short. */
-    public boolean isEmpty() {
-        return blockedDescent == null && rulesLeftUnread.isEmpty();
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/package-info.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/package-info.java
@@ -27,7 +27,7 @@
  * hold a wide clause's alternatives apart, a rule may be one this compiler cannot turn into a line.
  * None of those is a budget choosing which evidence to keep: the position is still there, and what
  * the reading could not do with it is reported at that position — {@code notRead},
- * {@link souther.compiler.partition.Axis#rulesNotReached}, {@code PositionValuesNotSeparated}. A
+ * {@link souther.compiler.partition.ReadingResidue}, {@code PositionValuesNotSeparated}. A
  * limit that takes the position out of the measure is different in kind, because a position nobody
  * measured leaves the same absence as one the rows cover.
  *

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -435,9 +435,9 @@ final class Coverages {
         // different question, and borrowing it left a reader with a sentence that named neither
         // (issue #842).
         PartitionEvidence.AxisCoverage.Reading read = new PartitionEvidence.AxisCoverage.Reading(
-                axis.rulesNotReached()
-                        ? PartitionEvidence.AxisCoverage.Reach.SOME_OUT_OF_SIGHT
-                        : PartitionEvidence.AxisCoverage.Reach.EVERY_RULE,
+                axis.residue().rulesLeftUnread().isEmpty()
+                        ? PartitionEvidence.AxisCoverage.Reach.EVERY_RULE
+                        : PartitionEvidence.AxisCoverage.Reach.SOME_OUT_OF_SIGHT,
                 // Of the questions standing at this position, the ones this measure is the reader
                 // of. What classes are made of is which values may stand somewhere; where the line
                 // falls is the border measure's question, and counting it here would put a number

--- a/souther-compiler/src/main/java/souther/compiler/query/Weakening.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Weakening.java
@@ -26,6 +26,20 @@ import souther.compiler.types.CoverageOrigin;
  * collapse — one rule this compiler could not read, found from three behaviors, is one thing to tell
  * an author — and two that are not must not. A bare probe number is not a fact, which is why the
  * arms that are about one behavior say which.
+ *
+ * <p><b>What a set of these is.</b> Not every true thing that follows from a measurement being
+ * weaker than it looks: the causes a reader is to be told about, each said once. A stop this
+ * compiler made has consequences that are true sentences about the model — a position nothing could
+ * be read into is a position whose rules nothing read — and a reader given both has to work out that
+ * the second follows from the first (issue #1084).
+ *
+ * <p>So one of two findings is left out exactly where a provenance says it is derived from the
+ * other, and never because the two arrive with the same path on them. A path is where something is
+ * and not what caused it: at one position a reading can enter and lose a clause of its own while a
+ * rule about the value from outside goes unanswered, and those are two causes an author acts on
+ * separately. Which findings stand in that relation is written down where the arms are
+ * ({@link souther.compiler.partition.MeasureClosure}), so a fold is a case of a {@code switch} with
+ * no {@code default} rather than a rule anybody applies by eye.
  */
 public sealed interface Weakening {
 

--- a/souther-compiler/src/test/java/souther/compiler/inputs/APositionUnderACaseIsAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/APositionUnderACaseIsAPositionTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * What a case of a sum declares is declared, so it is read.
@@ -181,7 +182,7 @@ class APositionUnderACaseIsAPositionTest {
         Position least = read.at(TermPath.of("b").refine(
                 Refinement.sumCase(caseNamed(read, "Held"))).then("least"));
         assertNotNull(least, "a field of the case is a position");
-        assertFalse(least.rulesNotReached(),
+        assertTrue(least.rulesLeftUnread().isEmpty(),
                 "and the clause relating it to the field beside it was reached");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/inputs/TakingRulesOverIsSaidAndNotInferredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/TakingRulesOverIsSaidAndNotInferredTest.java
@@ -15,9 +15,11 @@ import souther.compiler.query.Shapes;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -58,8 +60,9 @@ class TakingRulesOverIsSaidAndNotInferredTest {
         assertThrows(IllegalArgumentException.class,
                 () -> handoffs.accepts(P, HANDS_ON, P.then("y")),
                 "a reading at a position this handoff never named is not one it passed rules to");
-        assertTrue(handoffs.unresolvedAt(HANDS_ON),
-                "and the handoff is where it was");
+        assertInstanceOf(RuleHandoffs.Shortfall.NotFullyAccepted.class,
+                handoffs.unresolvedAt(HANDS_ON),
+                "and the handoff is where it was: a recipient was named and none was opened");
     }
 
     /** And a handoff no descent ever reached stands however many readings were opened elsewhere. */
@@ -72,8 +75,12 @@ class TakingRulesOverIsSaidAndNotInferredTest {
         handoffs.passesTo(P, elsewhere, List.of(elsewhere.element()));
         handoffs.accepts(P, elsewhere, elsewhere.element());
 
-        assertFalse(handoffs.unresolvedAt(elsewhere), "that one was passed on and taken");
-        assertTrue(handoffs.unresolvedAt(HANDS_ON),
+        assertNull(handoffs.unresolvedAt(elsewhere), "that one was passed on and taken");
+        // And which of the two ways it is left standing, because that is what tells a reader
+        // whether anything else already reports the stop. A descent that named nobody is one the
+        // walk could not make; a recipient left unopened is a walk that went on.
+        assertInstanceOf(RuleHandoffs.Shortfall.NothingExpected.class,
+                handoffs.unresolvedAt(HANDS_ON),
                 "and this one was never passed to anybody, whatever happened beside it");
     }
 
@@ -93,10 +100,11 @@ class TakingRulesOverIsSaidAndNotInferredTest {
         handoffs.passesTo(P, HANDS_ON, List.of(one, other));
 
         handoffs.accepts(P, HANDS_ON, one);
-        assertTrue(handoffs.unresolvedAt(HANDS_ON), "the other case was passed the rules too");
+        assertInstanceOf(RuleHandoffs.Shortfall.NotFullyAccepted.class,
+                handoffs.unresolvedAt(HANDS_ON), "the other case was passed the rules too");
 
         handoffs.accepts(P, HANDS_ON, other);
-        assertFalse(handoffs.unresolvedAt(HANDS_ON), "and now both of them were opened");
+        assertNull(handoffs.unresolvedAt(HANDS_ON), "and now both of them were opened");
     }
 
     /**
@@ -147,7 +155,7 @@ class TakingRulesOverIsSaidAndNotInferredTest {
     void aReadingThatTookTheRulesOverAndCameBackShortIsShortByItself() {
         InputDomain read = read(THE_READING_OPENED_IS_SHORT);
 
-        assertFalse(read.at(TermPath.of("p").then("x")).rulesNotReached(),
+        assertEquals(java.util.Set.of(), read.at(TermPath.of("p").then("x")).rulesLeftUnread(),
                 "the optional passed the rules on and something took them");
         assertTrue(shortSomewhereUnder(read, TermPath.of("p").then("x")),
                 "and the reading that took them says what it could not read");
@@ -157,7 +165,7 @@ class TakingRulesOverIsSaidAndNotInferredTest {
         return read.positions().stream()
                 .anyMatch(each -> !each.path().equals(above)
                         && each.path().toString().startsWith(above.toString())
-                        && each.rulesNotReached());
+                        && !each.rulesLeftUnread().isEmpty());
     }
 
     private static InputDomain read(String source) {

--- a/souther-compiler/src/test/java/souther/compiler/inputs/WhatASequenceHoldsIsAPositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/WhatASequenceHoldsIsAPositionTest.java
@@ -113,10 +113,11 @@ class WhatASequenceHoldsIsAPositionTest {
      */
     @Test
     void nothingIsShortOfARuleThatWasNeverWritten() {
-        assertFalse(at("people[*]").rulesNotReached(),
+        assertTrue(at("people[*]").rulesLeftUnread().isEmpty(),
                 "no clause of this list says anything about what it holds");
-        assertFalse(at("people[*].age").rulesNotReached(), "nor at a field of what it holds");
-        assertFalse(at("people").rulesNotReached(),
+        assertTrue(at("people[*].age").rulesLeftUnread().isEmpty(),
+                "nor at a field of what it holds");
+        assertTrue(at("people").rulesLeftUnread().isEmpty(),
                 "and the list's own rules are reached, as any other position's are");
     }
 
@@ -154,9 +155,9 @@ class WhatASequenceHoldsIsAPositionTest {
         InputDomain read = compilation.db().ask(new Adequacy.Inputs(MODULE)).value().get("roster");
         assertNotNull(read, "the model under test compiles");
 
-        assertFalse(read.at(pathTo("people", "[*]")).rulesNotReached(),
+        assertTrue(read.at(pathTo("people", "[*]")).rulesLeftUnread().isEmpty(),
                 "the element is read by a reading of its own, and this clause is not its");
-        assertFalse(read.positions().get(0).rulesNotReached(),
+        assertTrue(read.positions().get(0).rulesLeftUnread().isEmpty(),
                 "and the list itself was read: the clause is written about it and arrived");
         assertFalse(read.positions().get(0).unansweredQuestions().isEmpty(),
                 "what the clause leaves is a question about the list that nothing answered");

--- a/souther-compiler/src/test/java/souther/compiler/partition/AStopThisCompilerMadeIsSaidOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AStopThisCompilerMadeIsSaidOnceTest.java
@@ -1,0 +1,178 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.inputs.BlockReason;
+import souther.compiler.inputs.RulesLeftUnread;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.PartitionEvidence;
+import souther.compiler.query.Weakening;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * One position this compiler could not enter is one finding, and the findings beside it are not
+ * folded away with it.
+ *
+ * <p>Issue #1084. A {@code Map} was reported twice: once as a position the walk could not reach
+ * into, and once as a position whose rules nothing reached — which is the first said from the other
+ * end, because the rules under the map are read by a reading nothing opened. Both sentences are
+ * true, and only one of them is something that went wrong.
+ *
+ * <p><b>Held against sources, and the pairs asserted rather than a count.</b> What is being fixed is
+ * which findings a document carries, so a test that only counted them would pass over the wrong one
+ * surviving. Each of these names the finding it wants and the finding it does not.
+ */
+class AStopThisCompilerMadeIsSaidOnceTest {
+
+    /** The model from the issue. Nothing measures the map, so the axis is still waiting on the
+     *  structural reading when the closure is taken. */
+    private static final String A_MAP_NOTHING_MEASURES = """
+            module probe.map
+
+            data Ok
+            data Amount = Int
+                invariant ranged = value >= 0 && value <= 100
+            data Req = { cost: Map<String, Amount> }
+
+            behavior f : (r: Req) -> Ok
+                constructs Ok
+            let f (r) = Ok
+            """;
+
+    /**
+     * The same map, with a rule that measures it.
+     *
+     * <p>The one model where what a position is waiting on and what its reading came to disagree.
+     * {@code Map.size} divides the position, so the axis is answered for and keeps no continuation —
+     * and the walk still never went into what the map holds.
+     */
+    private static final String A_MAP_A_RULE_MEASURES = """
+            module probe.mapsize
+
+            data Ok
+            data Amount = Int
+                invariant ranged = value >= 0 && value <= 100
+            data Req = { cost: Map<String, Amount> }
+                invariant nonEmpty = Map.size(cost) > 0
+
+            behavior f : (r: Req) -> Ok
+                constructs Ok
+            let f (r) = Ok
+            """;
+
+    /**
+     * A rule about the map's own size that nothing answered, at a position the walk could not enter.
+     *
+     * <p>Two facts about two different rules at one path. What {@code notEmpty} says about the size
+     * was read — {@code M} is a declaration and its clause reached a reader — and no reading turned
+     * it into the values the position may hold. That the contents of the map are out of reach says
+     * nothing about it.
+     */
+    private static final String A_QUESTION_AT_A_POSITION_NOTHING_ENTERED = """
+            module probe.question
+
+            data Domestic
+            data Overseas
+            data Kind = Domestic | Overseas
+            data K = String
+            data V = String
+            data M = Map<K, V>
+                invariant notEmpty = Map.size(value) /= 0
+            data T = { kind: Kind, m: M }
+
+            behavior look : (t: T) -> Int
+            let look (t) = 1
+            """;
+
+    /**
+     * The stop is reported as the stop, and the handing over it left standing is not reported again.
+     *
+     * <p>The pair the issue is about. {@code RulesNotReached} here would be the consequence of the
+     * finding beside it and not a second thing an author could act on.
+     */
+    @Test
+    void aPositionTheWalkCouldNotEnterIsOneFinding() {
+        List<Weakening> said = weakeningOf(A_MAP_NOTHING_MEASURES, "f");
+
+        assertEquals(1, said.size(), () -> "one stop, one finding: " + said);
+        assertTrue(said.getFirst() instanceof Weakening.ModelReadingIncomplete(
+                        ClosureGap.PositionNotReachedInto gap)
+                        && gap.why() instanceof BlockReason.UnsupportedTraversal,
+                () -> "and it is the stop itself: " + said);
+    }
+
+    /**
+     * And it goes on being reported once something else measures the position.
+     *
+     * <p>What the fold would have cost if it were taken from what the axis is waiting on. This
+     * position is answered for, so it keeps no continuation; read from there, the handing over
+     * folds into a finding nothing writes and the model says nothing about the map at all.
+     */
+    @Test
+    void andTheStopSurvivesARuleThatMeasuresThePosition() {
+        List<Weakening> said = weakeningOf(A_MAP_A_RULE_MEASURES, "f");
+
+        assertTrue(said.stream().anyMatch(each -> each instanceof Weakening.ModelReadingIncomplete(
+                        ClosureGap.PositionNotReachedInto _)),
+                () -> "the walk did not go into the map, whatever divides it: " + said);
+        assertTrue(said.stream().noneMatch(each -> each instanceof Weakening.ModelReadingIncomplete(
+                        ClosureGap.RulesNotReached _)),
+                () -> "and the handing over it left standing is that same stop: " + said);
+    }
+
+    /**
+     * A question standing at such a position stands.
+     *
+     * <p>The other half of not folding on the path. A question is raised by a rule this compiler
+     * read and neither reader answered, so the rules a stop left unread raise none — and the only
+     * questions a suppression at the path could ever reach are the real ones. This one was being
+     * dropped because the map's contents are out of reach, which is a fact about other rules
+     * entirely.
+     */
+    @Test
+    void aQuestionAtSuchAPositionIsStillAsked() {
+        List<Weakening> said = weakeningOf(A_QUESTION_AT_A_POSITION_NOTHING_ENTERED, "look");
+
+        assertTrue(said.stream().anyMatch(each -> each instanceof Weakening.ModelReadingIncomplete(
+                        ClosureGap.QuestionUnanswered _)),
+                () -> "the rule about the map's size was read and nothing answered it: " + said);
+        assertTrue(said.stream().anyMatch(each -> each instanceof Weakening.ModelReadingIncomplete(
+                        ClosureGap.PositionNotReachedInto _)),
+                () -> "and the map's contents are still out of reach: " + said);
+    }
+
+    /**
+     * A handing over left standing by a blocked descent may not travel without the descent.
+     *
+     * <p>The transport half. Which of the two the reading found is settled where both were in hand,
+     * and every rebuild of an axis after that is a place one of them can be dropped — a position
+     * whose elements could not be reached came back out of the second phase with nothing to say it
+     * had ever stopped, once. Dropped here, the arm would fold into a finding nothing writes and the
+     * stop would go unsaid, so the pair is refused rather than reported short.
+     */
+    @Test
+    void anArmNamingABlockedDescentMayNotTravelWithoutIt() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new ReadingResidue(null,
+                        Set.of(new RulesLeftUnread.Handoff(
+                                new RulesLeftUnread.HandoffUnread.FromBlockedDescent()))),
+                "the arm names a descent this residue does not carry");
+    }
+
+    private static List<Weakening> weakeningOf(String source, String behavior) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, PartitionEvidence> partitions = compilation.db()
+                .ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
+        return List.copyOf(partitions.get(behavior).weakening().causes());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AStopThisCompilerMadeIsSaidOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AStopThisCompilerMadeIsSaidOnceTest.java
@@ -69,6 +69,25 @@ class AStopThisCompilerMadeIsSaidOnceTest {
             """;
 
     /**
+     * The same map again, with the line drawn by the body rather than by a declaration.
+     *
+     * <p>The other way an axis is rebuilt. Nothing divides the map, so the axis is re-pointed at the
+     * number the body measures ({@link Axis#measuredAt}) — a caller writing the parts of an axis out
+     * by hand, and the place a position that had stopped once came back with nothing to say so.
+     * Named for a module of its own because {@code guard} is a word of the language.
+     */
+    private static final String A_MAP_A_BODY_MEASURES = """
+            module probe.bodyline
+
+            data Amount = Int
+                invariant ranged = value >= 0 && value <= 100
+            data Req = { cost: Map<String, Amount> }
+
+            behavior f : (r: Req) -> Int
+            let f (r) = if Map.size(r.cost) > 0 then 1 else 2
+            """;
+
+    /**
      * A rule about the map's own size that nothing answered, at a position the walk could not enter.
      *
      * <p>Two facts about two different rules at one path. What {@code notEmpty} says about the size
@@ -126,6 +145,26 @@ class AStopThisCompilerMadeIsSaidOnceTest {
         assertTrue(said.stream().noneMatch(each -> each instanceof Weakening.ModelReadingIncomplete(
                         ClosureGap.RulesNotReached _)),
                 () -> "and the handing over it left standing is that same stop: " + said);
+    }
+
+    /**
+     * And it survives the axis being re-pointed at the number a body measures.
+     *
+     * <p>Both ways an axis is rebuilt, because what holds the two facts together is that they
+     * travel as one value and every rebuild is a place a caller can drop one. This one goes through
+     * {@link Axis#measuredAt}; the test above goes through the division. The finding names the term
+     * the axis was re-pointed to, which is the axis carrying the fact and not the position that was
+     * blocked — the position is that axis's path.
+     */
+    @Test
+    void andItSurvivesTheAxisBeingRePointedAtWhatABodyMeasures() {
+        List<Weakening> said = weakeningOf(A_MAP_A_BODY_MEASURES, "f");
+
+        assertEquals(1, said.size(), () -> "one stop, one finding: " + said);
+        assertTrue(said.getFirst() instanceof Weakening.ModelReadingIncomplete(
+                        ClosureGap.PositionNotReachedInto gap)
+                        && gap.why() instanceof BlockReason.UnsupportedTraversal,
+                () -> "the walk did not go into the map, and the axis is now the size: " + said);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/AStopThisCompilerMadeIsSaidOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AStopThisCompilerMadeIsSaidOnceTest.java
@@ -3,7 +3,11 @@ package souther.compiler.partition;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.inputs.BlockReason;
+import souther.compiler.inputs.BlockedDescent;
+import souther.compiler.inputs.NumericTerm;
 import souther.compiler.inputs.RulesLeftUnread;
+import souther.compiler.inputs.TermPath;
+import souther.compiler.types.Type;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.PartitionEvidence;
@@ -204,6 +208,110 @@ class AStopThisCompilerMadeIsSaidOnceTest {
                         Set.of(new RulesLeftUnread.Handoff(
                                 new RulesLeftUnread.HandoffUnread.FromBlockedDescent()))),
                 "the arm names a descent this residue does not carry");
+    }
+
+    /**
+     * Every way the two facts can arrive together, and what each comes to.
+     *
+     * <p><b>The relation and not one direction of it.</b> Which findings a residue comes to is a
+     * biconditional between what the ledger recorded and what the walk found, crossed with the one
+     * fold. Asserted a case at a time from whichever side a reader happens to be building, each
+     * assertion holds the half it was written for — which is how one stop came to be written from
+     * two ends with nothing relating them in the first place (issue #1084).
+     *
+     * <p>Built here rather than compiled from sources. Two of the six rows are this compiler
+     * contradicting itself and no model produces them, and a row of the other four needs a position
+     * that both loses a clause of its own and cannot be entered, which no model this compiler
+     * accepts carries either. What is being held is the arithmetic over the arms, and that is what a
+     * synthetic axis is exactly good for.
+     */
+    @Test
+    void whatEachPairOfFactsComesTo() {
+        // The walk could not go in, and the handing over it left standing is that same stop.
+        assertEquals(Set.of(ClosureGap.PositionNotReachedInto.class),
+                gapKindsOf(residue(BLOCKED, fromBlockedDescent())),
+                "the stop, once");
+        // And a clause this reading lost beside it is a finding of its own, at the same path.
+        // The one the issue names: folded on the path, this one goes with the other.
+        assertEquals(Set.of(ClosureGap.PositionNotReachedInto.class,
+                        ClosureGap.RulesNotReached.class),
+                gapKindsOf(residue(BLOCKED,
+                        new RulesLeftUnread.ClauseOfThisReadingWasUnread(),
+                        fromBlockedDescent())),
+                "a clause this reading lost is not the stop, and does not fold into it");
+        // The walk went on and left a recipient with no reading. Nothing else says so.
+        assertEquals(Set.of(ClosureGap.RulesNotReached.class),
+                gapKindsOf(residue(null, notFullyAccepted())),
+                "a recipient nothing opened is its own finding");
+        assertEquals(Set.of(ClosureGap.RulesNotReached.class),
+                gapKindsOf(residue(null, new RulesLeftUnread.ClauseOfThisReadingWasUnread())),
+                "and so is a clause lost where nothing stopped the walk");
+
+        // And the two rows where the ledger and the walk contradict each other. Neither is a state
+        // of a model: over an owed handing over, nobody was named as a recipient exactly where the
+        // walk could not go in. Let through, the second is #1084's two entries reached another way.
+        assertThrows(IllegalArgumentException.class,
+                () -> residue(BLOCKED, notFullyAccepted()),
+                "a recipient was named at a position the walk could not enter");
+        assertThrows(IllegalArgumentException.class,
+                () -> residue(null, fromBlockedDescent()),
+                "nobody was named at a position the walk went into");
+    }
+
+    private static final BlockedDescent BLOCKED = new BlockedDescent(
+            new BlockReason.UnsupportedTraversal(BlockReason.Traversal.MAPPING_CONTENT));
+
+    private static RulesLeftUnread fromBlockedDescent() {
+        return new RulesLeftUnread.Handoff(
+                new RulesLeftUnread.HandoffUnread.FromBlockedDescent());
+    }
+
+    private static RulesLeftUnread notFullyAccepted() {
+        return new RulesLeftUnread.Handoff(
+                new RulesLeftUnread.HandoffUnread.NotFullyAccepted());
+    }
+
+    private static ReadingResidue residue(BlockedDescent blocked, RulesLeftUnread... unread) {
+        return new ReadingResidue(blocked, Set.of(unread));
+    }
+
+    /**
+     * Which kinds of gap one axis carrying {@code residue} leaves the partition measure short of.
+     *
+     * <p>The kinds and not the values: what a gap is keyed by is asserted where that decision is
+     * ({@link #theStopIsNamedForTheAxisCarryingIt}), and repeating it in every row here would make
+     * every row of the arithmetic fail the day the identity is revisited.
+     */
+    private static Set<Class<?>> gapKindsOf(ReadingResidue residue) {
+        MeasureClosure.Both closed = MeasureClosure.of(
+                List.of(new Axis(new AxisId("f", "r.cost"),
+                        new NumericTerm.ValueOf(TermPath.of("r").then("cost")),
+                        Type.BOOL, List.of(), List.of(), List.of(), residue, null, null)),
+                List.of(), List.of(), new LinesRead());
+        return ((MeasureClosure.OfThePartition.Open) closed.partition()).by().stream()
+                .map(Object::getClass).collect(java.util.stream.Collectors.toSet());
+    }
+
+    /**
+     * The stop is named for the axis carrying it, which is not always the position that was blocked.
+     *
+     * <p>Where the two come apart, and the whole of why this arm is keyed by an axis. The map's
+     * contents are what the walk could not reach; the axis is the size a rule measures. A reader is
+     * being told something about the number it holds, so that is what the finding names — and the
+     * position is that axis's path.
+     */
+    @Test
+    void theStopIsNamedForTheAxisCarryingIt() {
+        List<Weakening> said = weakeningOf(A_MAP_A_BODY_MEASURES, "f");
+
+        assertEquals(List.of("f/Map.size(r.cost)"),
+                said.stream()
+                        .filter(each -> each instanceof Weakening.ModelReadingIncomplete(
+                                ClosureGap.PositionNotReachedInto _))
+                        .map(each -> ((ClosureGap.PositionNotReachedInto)
+                                ((Weakening.ModelReadingIncomplete) each).cause()).at().toString())
+                        .toList(),
+                () -> "the axis carrying the stop, not the position blocked: " + said);
     }
 
     private static List<Weakening> weakeningOf(String source, String behavior) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -62,7 +62,8 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
     /** The same, with a rule about the position's own values that the local reading could not take
      *  in — which is a second way a position can be left unable to reach an absence. */
     private static Axis pending(StructuralInspection.Continuation found, BlockReason unread) {
-        return Axis.pendingAt(ID, new NumericTerm.ValueOf(AT), Type.BOOL, false, found,
+        return Axis.pendingAt(ID, new NumericTerm.ValueOf(AT), Type.BOOL,
+                ReadingResidue.NOTHING, found,
                 unread == null ? null : LeftAtThePosition.of(unread));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnOpenPositionIsAReadingThatRanToTheEndTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnOpenPositionIsAReadingThatRanToTheEndTest.java
@@ -156,7 +156,7 @@ class AnOpenPositionIsAReadingThatRanToTheEndTest {
     @Test
     void anEmptyDivisionIsNotAnAnswer() {
         assertThrows(IllegalArgumentException.class,
-                () -> new LocalPartition.Divided(List.of(), new CutEvidence.None(), false));
+                () -> new LocalPartition.Divided(List.of(), new CutEvidence.None()));
     }
 
     /**


### PR DESCRIPTION
Closes #1084.

## What was wrong

A position a `Map` holds its values inside was reported twice — as one the walk
could not reach into, and as one whose rules nothing reached. Both sentences are
true, and the second is the first said from the other end: the rules under the
map are read by a reading nothing opened.

`Axis` carried the second as a boolean, and that boolean is the OR of two facts
of different origin — a reading that lost a clause of its own, and a handing
over nobody took. `MeasureClosure` wanted to know whether what it held was
already reported beside it, had nothing to ask, and reported both.

## What this does

- `RuleHandoffs` answers **how** a handing over was left standing and says
  nothing about why. Whether the walk was stopped or went on and left a
  recipient unopened is not a fact the ledger has ever seen.
- `InputDomain` joins that with the structural reading, where both facts are in
  hand, and settles which arm of `RulesLeftUnread` it is. Nothing downstream
  re-derives it.
- The fold is a `switch` with no `default` over the arm, and never over the
  path. A position the reading *entered* and lost a clause of its own is an
  independent finding sitting at the same place; folded on the path, it would go
  with the other.
- `pending` could not carry the other half. It is what a position is left with
  *if nothing else answers* — and a rule measuring the map's size answers, so
  that position keeps no continuation and was still never entered. Read from
  there, the fold would have left the model saying nothing about the map at all.
  `BlockedDescent` is that stop as an observation; it and the arms travel as one
  `ReadingResidue`, so a rebuilt axis names both or does not compile.
- Questions are no longer suppressed by position. A question comes off a rule
  this compiler read and neither reader answered, so the rules a stop left
  unread raise none — a suppression there could only ever reach the real ones,
  and it did: a rule about a map's size that nothing answered, dropped because
  the map's contents are out of reach.

## What a document says now

The probe from the issue reports the stop once, as the stop. A model whose map
is measured by `Map.size` keeps that finding instead of losing it. No schema
change: `WeakeningWord` is untouched and `RULES_NOT_REACHED` still has
producers.

## Checks

`mvn -o test` from the reactor root, green after rebasing onto `develop`.
`AStopThisCompilerMadeIsSaidOnceTest` holds each of the four claims against
sources rather than counting findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)