### PR TITLE
Let a surface say less than the measurement, and never decide what it holds

### DIFF
--- a/souther-cli/src/test/java/souther/cli/AnEndIsWhereItsRuleStopsTest.java
+++ b/souther-cli/src/test/java/souther/cli/AnEndIsWhereItsRuleStopsTest.java
@@ -43,22 +43,48 @@ class AnEndIsWhereItsRuleStopsTest {
             let take (h) = Ok
             """;
 
-    /** A boundary is at a value some rule wrote. Nothing here writes a one. */
+    /**
+     * A boundary is at the value the rule wrote, and both of these rules get one.
+     *
+     * <p>Said as where the lines are rather than as a value the report must not print. Written the
+     * second way — and it was — the expectation held over a report that named no line at all, which
+     * is exactly what this model got for as long as a cut on a carrier with no step went no further
+     * than being built (issue #1079).
+     */
     @Test
-    void anEdgeIsNotAtAValueNoRuleNamed() throws Exception {
+    void eachRuleDrawsItsLineWhereItStops() throws Exception {
         String report = reportOn(MODEL);
 
+        assertTrue(report.contains("h.p = 0"),
+                () -> "`value > 0m` stops the position at zero:\n" + report);
+        assertTrue(report.contains("h.a = 5"),
+                () -> "`value > 5.0m` stops it at five:\n" + report);
+        assertTrue(report.contains("border      borders 2"),
+                () -> "two rules, two lines:\n" + report);
+        // And not at the whole number a positive integer starts at, which is the reading these
+        // lines were once taken from and a value no decimal rule here mentions.
         assertFalse(report.contains("point value = 1"),
                 () -> "`value > 0m` says nothing about one:\n" + report);
     }
 
-    /** And a line five is drawn at is a line, though the runtime has no word for it. */
+    /**
+     * And the point against each line is one the order cannot name, said rather than left out.
+     *
+     * <p>What a strict bound on a carrier with no step costs is the value beside its line and
+     * nothing else — there is no least decimal above zero — and that is a limit of the language
+     * rather than a row anybody is short of. The line, the class it bounds and the row inside it are
+     * not costs, and all four were being lost with it.
+     */
     @Test
-    void aStrictBoundAwayFromZeroIsALineTheModelDraws() throws Exception {
+    void thePointAgainstSuchALineSaysWhyItCannotBeWritten() throws Exception {
         String report = reportOn(MODEL);
 
-        assertFalse(report.contains("not derivable: h.a"),
-                () -> "`value > 5.0m` divides the position at five:\n" + report);
+        assertTrue(report.contains(
+                        "no ON point is owed at h.p = 0 (invariant Positive (positive)):"
+                                + " this order names no value there, so the point cannot be written"),
+                () -> report);
+        assertTrue(report.contains("adequacy: undetermined"),
+                () -> "and the row inside each line is owed and unwritten:\n" + report);
     }
 
     /**

--- a/souther-cli/src/test/java/souther/cli/AnEndIsWhereItsRuleStopsTest.java
+++ b/souther-cli/src/test/java/souther/cli/AnEndIsWhereItsRuleStopsTest.java
@@ -83,8 +83,11 @@ class AnEndIsWhereItsRuleStopsTest {
                         "no ON point is owed at h.p = 0 (invariant Positive (positive)):"
                                 + " this order names no value there, so the point cannot be written"),
                 () -> report);
-        assertTrue(report.contains("adequacy: undetermined"),
-                () -> "and the row inside each line is owed and unwritten:\n" + report);
+        // Two of the eight items these lines owe are asked for and nobody measured them, which
+        // are the two rows inside the bounds. Read off `adequacy` instead, the sentence would be
+        // true of this model for having no rows at all and would say nothing about the lines.
+        assertTrue(report.contains("(2 not measured: no row names this behavior)"),
+                () -> "and the row inside each line is one somebody is owed:\n" + report);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/LinesRead.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LinesRead.java
@@ -17,11 +17,16 @@ import java.util.Set;
  * so an empty account of what went missing is what a whole reading and a lossy one both produce.
  * That is issue #1079, and holding these two against each other is what refuses it.
  *
- * <p><b>Both producers, because there are two.</b> A line that divides a position leaves its border
- * on the position ({@link Partitions#bordersOf}) and a line between two positions leaves its border
- * beside them ({@link Border#allOf}). They are the same reading and the same kind of loss, and an
- * accounting over one of them says nothing about the other — which is how a check written for the
- * first would have watched a {@code continue} go into the second.
+ * <p><b>Every producer, and not the two there are today.</b> A line that divides a position leaves
+ * its border on the position ({@link Partitions#bordersOf}) and a line between two positions leaves
+ * its border beside them ({@link Border#allOf}). They are the same reading and the same kind of
+ * loss, and an accounting over one of them says nothing about the other — which is how a check
+ * written for the first would have watched a {@code continue} go into the second.
+ *
+ * <p>Which is why the borders the reading hands back are held against this as well
+ * ({@link #returning}). Kept by the producers alone, the account is worth what a producer
+ * remembered to write in it, and a third one added later is off the books from the day it is
+ * written — the same silence, one level up, and this whole arrangement is against exactly that.
  *
  * <p><b>Identity and not a count.</b> Two lines are one line where they are at one place and drawn
  * by one rule, which is what {@link Line} is. Counted instead, a reading that lost one line and made
@@ -46,6 +51,7 @@ public final class LinesRead {
 
     private final Set<Line> found = new LinkedHashSet<>();
     private final List<Border> drawn = new ArrayList<>();
+    private final List<Border> returning = new ArrayList<>();
 
     /**
      * One line the rules draw, as the reading meets it and before anything is made of it.
@@ -62,6 +68,17 @@ public final class LinesRead {
     public Border drew(Border border) {
         drawn.add(border);
         return border;
+    }
+
+    /**
+     * The borders this reading is about to hand back, whoever made them.
+     *
+     * <p>Told at the one place they are assembled rather than by each producer. What a producer
+     * volunteers is what a producer remembered to volunteer, and the point of an account is to hold
+     * a reading to what it returns.
+     */
+    public void returning(java.util.Collection<Border> borders) {
+        returning.addAll(borders);
     }
 
     /**
@@ -95,6 +112,26 @@ public final class LinesRead {
         if (!unaccounted.isEmpty()) {
             throw new IllegalStateException(
                     "a border this reading cannot account for: " + said(unaccounted));
+        }
+        // And what the reading returns is what it wrote down. A border reaching a caller off the
+        // books is a producer this account does not know about, and one written down and not
+        // returned is a loss between the two — both leave the closure resting on a reading it did
+        // not see the whole of.
+        List<Line> offTheBooks = returning.stream()
+                .map(each -> new Line(each.cut(), each.origin()))
+                .filter(each -> !made.containsKey(each)).distinct().toList();
+        if (!offTheBooks.isEmpty()) {
+            throw new IllegalStateException(
+                    "a border returned by a reading that did not write it down: "
+                            + said(offTheBooks));
+        }
+        List<Line> dropped = made.keySet().stream()
+                .filter(each -> returning.stream()
+                        .noneMatch(had -> new Line(had.cut(), had.origin()).equals(each)))
+                .toList();
+        if (!dropped.isEmpty()) {
+            throw new IllegalStateException(
+                    "a border this reading drew and did not return: " + said(dropped));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -234,6 +234,7 @@ public final class Partitions {
         // reading draws a line between two positions.
         LinesRead read = new LinesRead();
         java.util.Map<AxisId, List<Border>> lines = linesAlong(kept, quantities, symbols, read);
+        read.returning(lines.values().stream().flatMap(List::stream).toList());
         MeasureClosure.Both closed = MeasureClosure.of(kept, standing, rulesWithoutALine, read);
         return new Partitioning(kept, standing, uncertain, undividedIn(measured),
                 List.copyOf(rulesWithoutALine), blockedIn(measured), List.copyOf(notSeparated),
@@ -549,6 +550,8 @@ public final class Partitions {
         LinesRead read = new LinesRead();
         java.util.Map<AxisId, List<Border>> lines = linesAlong(out, reading, symbols, read);
         List<Border> across = Border.allOf(between, partedByQuantity(out), read);
+        read.returning(lines.values().stream().flatMap(List::stream).toList());
+        read.returning(across);
         MeasureClosure.Both closed = MeasureClosure.of(out, base.unanswered(), rules, read);
         return new Partitioning(out, base.unanswered(), base.uncertain(),
                 undividedIn(measured), List.copyOf(rules), blockedIn(measured),

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -942,9 +942,12 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      */
     private void partition(StringBuilder out, BehaviorReport behavior,
                                   SourceId declaredIn, SourceNameResolver names) {
-        PartitionEvidence partition = behavior.partition();
-        if (partition == null || (partition.axes().isEmpty() && partition.boundaries().isEmpty()
-                && partition.notDerivable().isEmpty() && behavior.claimed().all().isEmpty())) {
+        // Whether there is a section at all is settled once, for every surface, and asked of the
+        // measurement rather than of the entries beside it. Asked of the entries, a behavior whose
+        // measures both had something to say and whose lists happened to be empty was left out of
+        // the page while the document wrote what they said (issue #1079).
+        if (!(PartitionSection.of(behavior.partition())
+                instanceof PartitionSection.Present(PartitionEvidence partition))) {
             return;
         }
         ReportMeasurement<List<PartitionEvidence.AxisCoverage>> partitioned =
@@ -2000,14 +2003,9 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
 
     private void partition(ObjectNode behavior, PartitionEvidence partition,
                                   ClaimAnnotations claimed, DocumentSources sources) {
-        if (partition == null) {
-            return;
-        }
-        // And no section where the boundary the positions come off was not worked out, for the
-        // reason the signature section is left out: what this section owes is the positions, the
-        // lines and the size of the space they make, and every one of those is a product over
-        // positions nobody could count. Said here as the behavior's `weakening`, once.
-        if (partition.boundaryNotDerived()) {
+        // The one decision, the same one the page reads. Written here as well, the two surfaces
+        // answered a reader differently about which behaviors have a section at all.
+        if (!(PartitionSection.of(partition) instanceof PartitionSection.Present)) {
             return;
         }
         ObjectNode out = behavior.putObject("partition");

--- a/souther-compiler/src/main/java/souther/compiler/report/PartitionSection.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/PartitionSection.java
@@ -18,10 +18,12 @@ import souther.compiler.query.PartitionEvidence;
  * What it may not do is work out for itself whether the result exists, because that is a fact about
  * the measurement and the surfaces then disagree about the model rather than about how much to say.
  *
- * <p>So the two states here are about the measurement and not about either surface. A behavior
- * measured at its stages has a section, and both surfaces say why the measures do not apply to it;
- * the two absences below are measurements nobody made, and there is nothing for a section to be
- * about.
+ * <p><b>And what is decided here is whether the section is written, not whether the measurement
+ * exists.</b> One of the two absences below is a measurement nobody made; the other is a measure
+ * that was asked for, started and could not be finished, and what is left of it is said as the
+ * behavior's own weakening rather than as a section with no number in it. Read as one sentence
+ * about the model, the second would have this deciding what a measurement is — which is the thing
+ * the split is against, pointed the other way.
  */
 sealed interface PartitionSection {
 
@@ -46,13 +48,15 @@ sealed interface PartitionSection {
      * of the report — which is how a model bounded only on a {@code Decimal} came back adequate with
      * no measure printed anywhere.
      *
-     * <p>Two absences here, and both are a measurement nobody made. A null is the compile not
-     * having got far enough to be asked, which is not a measure that came back with nothing —
-     * every measure that ran says why it has no number. And a boundary that could not be worked
-     * out leaves this section nothing to qualify, for the reason the signature section is left out
-     * where its cases could not be counted: what it owes is the positions, the lines and the size
-     * of the space they make, and every one of those is a product over positions nobody could
-     * count. What weakened the behavior is said once, as the behavior's own weakening.
+     * <p>Two absences here and they are not the same absence. A null is the compile not having got
+     * far enough to be asked, which is not a measure that came back with nothing — every measure
+     * that ran says why it has no number. A boundary that could not be worked out is the other way
+     * about: the measures exist and both failed, and what this section owes is the positions, the
+     * lines and the size of the space they make — every one of those a product over positions
+     * nobody could count, so there is no number here to qualify. That is a policy about the
+     * section and not a claim about the model, and what weakened the behavior is said once, as the
+     * behavior's own weakening. It is the same reason the signature section is left out where its
+     * cases could not be counted.
      */
     static PartitionSection of(PartitionEvidence evidence) {
         if (evidence == null || evidence.boundaryNotDerived()) {

--- a/souther-compiler/src/main/java/souther/compiler/report/PartitionSection.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/PartitionSection.java
@@ -28,30 +28,15 @@ sealed interface PartitionSection {
     /** There is a section, and this is the reading it is written from. */
     record Present(PartitionEvidence evidence) implements PartitionSection {}
 
-    /** There is none, and this is what settled it. */
-    record Omitted(Why why) implements PartitionSection {}
-
-    /** Why a behavior has no section about its positions. */
-    enum Why {
-
-        /**
-         * The compile did not get far enough to be asked. Not a measure that came back with
-         * nothing: every measure that ran says why it has no number, and this is the absence of
-         * the run.
-         */
-        THE_COMPILE_DID_NOT_GET_THERE,
-
-        /**
-         * The boundary the positions come off could not be worked out.
-         *
-         * <p>The same reason the signature section is left out where its cases could not be
-         * counted. What this section owes is the positions, the lines and the size of the space
-         * they make, and every one of those is a product over positions nobody could count — so
-         * there is no number here to qualify. What weakened the behavior is said once, as the
-         * behavior's own weakening.
-         */
-        THE_BOUNDARY_WAS_NOT_DERIVED
-    }
+    /**
+     * There is none.
+     *
+     * <p>Carrying no reason, because nothing reads one. Two things settle it and they are two
+     * different absences — see {@link #of} — and what a surface does about either is the same
+     * thing: there is no measurement for a section to be about. The day one of them is worth
+     * saying out loud, the reason comes back with the reader that says it.
+     */
+    record Omitted() implements PartitionSection {}
 
     /**
      * Which of the two {@code evidence} comes to.
@@ -60,13 +45,18 @@ sealed interface PartitionSection {
      * whose measures both had something to say and whose lists happened to be empty was written out
      * of the report — which is how a model bounded only on a {@code Decimal} came back adequate with
      * no measure printed anywhere.
+     *
+     * <p>Two absences here, and both are a measurement nobody made. A null is the compile not
+     * having got far enough to be asked, which is not a measure that came back with nothing —
+     * every measure that ran says why it has no number. And a boundary that could not be worked
+     * out leaves this section nothing to qualify, for the reason the signature section is left out
+     * where its cases could not be counted: what it owes is the positions, the lines and the size
+     * of the space they make, and every one of those is a product over positions nobody could
+     * count. What weakened the behavior is said once, as the behavior's own weakening.
      */
     static PartitionSection of(PartitionEvidence evidence) {
-        if (evidence == null) {
-            return new Omitted(Why.THE_COMPILE_DID_NOT_GET_THERE);
-        }
-        if (evidence.boundaryNotDerived()) {
-            return new Omitted(Why.THE_BOUNDARY_WAS_NOT_DERIVED);
+        if (evidence == null || evidence.boundaryNotDerived()) {
+            return new Omitted();
         }
         return new Present(evidence);
     }

--- a/souther-compiler/src/main/java/souther/compiler/report/PartitionSection.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/PartitionSection.java
@@ -1,0 +1,73 @@
+package souther.compiler.report;
+
+import souther.compiler.query.PartitionEvidence;
+
+/**
+ * Whether a report has a section to write about what a behavior's rules divide and bound.
+ *
+ * <p>One decision, made here, read by every surface. It used to be made twice and differently: the
+ * text left the two lines out where the lists beside the measures were all empty, and the document
+ * left the object out where the boundary the positions come off was not worked out. So one
+ * compilation answered a reader two ways — a {@code >->} composition, which has no positions of its
+ * own, wrote a {@code partition} object saying {@code no_subject} and no line of text at all; and a
+ * behavior whose every rule is a bound on a {@code Decimal} wrote a document saying its rules draw
+ * no line and a page saying nothing (issue #1079).
+ *
+ * <p><b>What a surface may do and what it may not.</b> A surface may leave a semantic result out —
+ * a page for a person and a document for a program are owed different amounts of the same reading.
+ * What it may not do is work out for itself whether the result exists, because that is a fact about
+ * the measurement and the surfaces then disagree about the model rather than about how much to say.
+ *
+ * <p>So the two states here are about the measurement and not about either surface. A behavior
+ * measured at its stages has a section, and both surfaces say why the measures do not apply to it;
+ * the two absences below are measurements nobody made, and there is nothing for a section to be
+ * about.
+ */
+sealed interface PartitionSection {
+
+    /** There is a section, and this is the reading it is written from. */
+    record Present(PartitionEvidence evidence) implements PartitionSection {}
+
+    /** There is none, and this is what settled it. */
+    record Omitted(Why why) implements PartitionSection {}
+
+    /** Why a behavior has no section about its positions. */
+    enum Why {
+
+        /**
+         * The compile did not get far enough to be asked. Not a measure that came back with
+         * nothing: every measure that ran says why it has no number, and this is the absence of
+         * the run.
+         */
+        THE_COMPILE_DID_NOT_GET_THERE,
+
+        /**
+         * The boundary the positions come off could not be worked out.
+         *
+         * <p>The same reason the signature section is left out where its cases could not be
+         * counted. What this section owes is the positions, the lines and the size of the space
+         * they make, and every one of those is a product over positions nobody could count — so
+         * there is no number here to qualify. What weakened the behavior is said once, as the
+         * behavior's own weakening.
+         */
+        THE_BOUNDARY_WAS_NOT_DERIVED
+    }
+
+    /**
+     * Which of the two {@code evidence} comes to.
+     *
+     * <p>Asked of the measurement and of nothing else. Asked of the entries beside it, a behavior
+     * whose measures both had something to say and whose lists happened to be empty was written out
+     * of the report — which is how a model bounded only on a {@code Decimal} came back adequate with
+     * no measure printed anywhere.
+     */
+    static PartitionSection of(PartitionEvidence evidence) {
+        if (evidence == null) {
+            return new Omitted(Why.THE_COMPILE_DID_NOT_GET_THERE);
+        }
+        if (evidence.boundaryNotDerived()) {
+            return new Omitted(Why.THE_BOUNDARY_WAS_NOT_DERIVED);
+        }
+        return new Present(evidence);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
@@ -167,6 +167,25 @@ class AMeasureWithNoNumberSaysWhyTest {
     }
 
     /**
+     * A composition says why the two measures do not apply to it, rather than leaving them out.
+     *
+     * <p>It is measured at its stages and has no positions of its own, which is a fact about the
+     * model and is what the other two measures say of it in the same breath. Left out, the same page
+     * was what a behavior whose measures had something to say and whose evidence lists were empty
+     * got — and a document written from the same compilation said {@code no_subject} where the page
+     * said nothing at all (issue #1079).
+     */
+    @Test
+    void aCompositionSaysWhyItsPositionsAreNotMeasuredHere() {
+        String both = behaviorBlock(human(), "both");
+
+        assertTrue(both.contains(
+                "partition   not applicable (this behavior is measured at its stages)"), both);
+        assertTrue(both.contains(
+                "border      not applicable (this behavior is measured at its stages)"), both);
+    }
+
+    /**
      * The whole report, fixed.
      *
      * <p>Fixed whole rather than line by line. Every wrong line this issue was about could have been
@@ -191,6 +210,8 @@ class AMeasureWithNoNumberSaysWhyTest {
                     branch      not applicable (this body owes no arm)
                   both                     implemented   rows 1    pending 0
                     signature   not applicable (this behavior's output is not a sum)
+                    partition   not applicable (this behavior is measured at its stages)
+                    border      not applicable (this behavior is measured at its stages)
                     branch      not applicable (this behavior has no body)
                   baseRate                 injected      rows 0    pending 0
                     signature   not applicable (this behavior's output is not a sum)

--- a/souther-compiler/src/test/java/souther/compiler/inputs/WhatEachWayOfDrawingNoLineLeavesIsWrittenDownOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/WhatEachWayOfDrawingNoLineLeavesIsWrittenDownOnceTest.java
@@ -129,13 +129,40 @@ class WhatEachWayOfDrawingNoLineLeavesIsWrittenDownOnceTest {
     }
 
     /**
-     * Every member of the seal, one of each.
+     * Every member of the seal is in the lists above.
      *
-     * <p>Listed rather than found by reflection, because what this test is about is the answers and
-     * a list that built itself from the same source would move with them. A member added is refused
-     * by the switch in {@code leavesShort} before it reaches here, and one added and left out of the
-     * table is what the assertions above catch.
+     * <p>The lists are written out rather than found by reflection, because what this test is about
+     * is the answers and a list that built itself from the reasons would move with them. That is
+     * what this check is for: written out, a list is a thing to forget, and a fourteenth reason
+     * added and answered for in {@code leavesShort} would leave the rows above passing over
+     * thirteen.
      */
+    @Test
+    void everyReasonThereIsHasARowAbove() {
+        assertEquals(named(BlockReason.RuleWithoutLineReason.class.getPermittedSubclasses()),
+                theRulesWithNoLine().keySet(),
+                "a rule with no line, answered for and not written down");
+        assertEquals(named(BlockReason.AboutThePosition.class.getPermittedSubclasses()),
+                theStopsAtAPosition().keySet(),
+                "a stop at a position, answered for and not written down");
+    }
+
+    /**
+     * The names of a seal's members, less the halves that are seals of their own.
+     *
+     * <p>{@link BlockReason.RuleReadingStopped} is a member of both capabilities and a seal rather
+     * than a reason, so its own members are what the rows are about and it is not one of them.
+     */
+    private static java.util.Set<String> named(Class<?>[] members) {
+        return java.util.Arrays.stream(members)
+                .flatMap(each -> each.isSealed()
+                        ? java.util.Arrays.stream(each.getPermittedSubclasses())
+                        : java.util.stream.Stream.of(each))
+                .map(Class::getSimpleName)
+                .collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new));
+    }
+
+    /** One of each, for the rows to be read off. */
     private static List<BlockReason.RuleWithoutLineReason> everyRuleWithoutALine() {
         return List.of(
                 new BlockReason.UnreadComparisonForm(),

--- a/souther-compiler/src/test/java/souther/compiler/inputs/WhatEachWayOfDrawingNoLineLeavesIsWrittenDownOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/WhatEachWayOfDrawingNoLineLeavesIsWrittenDownOnceTest.java
@@ -1,0 +1,159 @@
+package souther.compiler.inputs;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.CoverageObligation;
+import souther.compiler.partition.ReportedReason;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Every way a reading comes back without a line, and what each of them leaves behind, in one table.
+ *
+ * <p>The seal already refuses a reason nobody answered for: {@link BlockReason.RuleReadingStopped}
+ * switches over its members with no {@code default}, so a fourteenth is a build failure. What it
+ * does not refuse is a reason moved from one arm to another. Both switches keep compiling when a
+ * reason changes which measure it leaves short or which word a document writes for it, and every
+ * sentence built on the old answer goes on being written and is now wrong.
+ *
+ * <p>Which is not hypothetical here. Six of the nine rules below say both measures are short of
+ * something and three say neither is, and that difference is what decides whether a behavior is
+ * taken out of the verdict — a reason that quietly stopped leaving the border measure short would
+ * let a model be called adequate over a rule this compiler never read. Issue #1079 is what that
+ * costs when the answer is arrived at rather than written down.
+ *
+ * <p>So the answers are here, written out, and this is where they are changed. A reason that moves
+ * fails this test and is meant to: what it is asking is not whether the code is right but whether
+ * the person moving it meant to move it.
+ */
+class WhatEachWayOfDrawingNoLineLeavesIsWrittenDownOnceTest {
+
+    /**
+     * Every rule this compiler read and drew no line from, and what it leaves.
+     *
+     * <p>Written as {@code partition/boundary/word}: which of the two measures the rule leaves short
+     * of something, and the word a document writes for it. A reason that leaves neither measure
+     * short is one the model states rather than one this compiler fell short on.
+     */
+    private static Map<String, String> theRulesWithNoLine() {
+        Map<String, String> table = new LinkedHashMap<>();
+        // Read partway. What the rule would have divided or bounded is exactly the part that was
+        // not read, so neither measure knows what it is missing and both are short.
+        table.put("UnreadComparisonForm", "short/short/UNSUPPORTED_SYNTAX");
+        table.put("UnreadComparisonDomain", "short/short/UNSUPPORTED_DOMAIN");
+        table.put("RuleAboutADerivedValue", "short/short/RULE_ABOUT_A_DERIVED_VALUE");
+        table.put("UnreadValueRule", "short/short/UNSUPPORTED_SYNTAX");
+        // One word with `ComparisonBetweenPositions` below, and on purpose: they are the two
+        // readings of `a < b`, opposite sentences about this compiler, and a document promises
+        // its reader which kind of thing stopped a derivation rather than which reader stopped.
+        table.put("ValueRuleRelatingTwoPositions", "short/short/UNSUPPORTED_PARTITION_SHAPE");
+        table.put("CompetingCoordinates", "short/short/COMPETING_COORDINATES");
+        // Read to the end. Whatever the rule places has been placed, and there is none to be owed.
+        table.put("ComparisonCuttingNothing", "whole/whole/RULE_CUTS_NOTHING");
+        table.put("ComparisonCuttingOutsideDomain",
+                "whole/whole/RULE_CUTS_OUTSIDE_WHAT_THE_QUANTITY_HOLDS");
+        table.put("ComparisonBetweenPositions", "whole/whole/UNSUPPORTED_PARTITION_SHAPE");
+        return table;
+    }
+
+    /**
+     * And every way the reading never got to a rule at all, which names a position and no rule.
+     *
+     * <p>Apart from the above because there is nothing to ask them: a reason with no rule behind it
+     * has no {@code leavesShort} to answer, and the position it is about is short for both measures
+     * by the position rather than by anything written about it.
+     */
+    private static Map<String, String> theStopsAtAPosition() {
+        Map<String, String> table = new LinkedHashMap<>();
+        table.put("TypeUnresolved", "TYPE_UNRESOLVED");
+        table.put("DepthLimit", "DEPTH_LIMIT");
+        table.put("UnsupportedTraversal", "UNSUPPORTED_TRAVERSAL");
+        table.put("ValueRulesNotReached", "RULES_NOT_READ_AT_ALL");
+        return table;
+    }
+
+    /**
+     * The table, held against what the reasons answer.
+     *
+     * <p>Every member of the seal is here: the map is built from the reasons themselves, so one
+     * added and left out of the table above comes back with no expectation beside it and fails.
+     */
+    @Test
+    void everyRuleWithNoLineSaysWhatItLeavesAndWhatItIsCalled() {
+        Map<String, String> said = new LinkedHashMap<>();
+        for (BlockReason.RuleWithoutLineReason each : everyRuleWithoutALine()) {
+            said.put(each.getClass().getSimpleName(),
+                    (each.leavesShort(CoverageObligation.Measure.PARTITION) ? "short" : "whole")
+                            + "/"
+                            + (each.leavesShort(CoverageObligation.Measure.BOUNDARY)
+                                    ? "short" : "whole")
+                            + "/" + ReportedReason.of((BlockReason) each).name());
+        }
+
+        assertEquals(theRulesWithNoLine(), said);
+    }
+
+    /** The same of the reasons that name a position and no rule. */
+    @Test
+    void everyStopAtAPositionSaysWhatItIsCalled() {
+        Map<String, String> said = new LinkedHashMap<>();
+        for (BlockReason.AboutThePosition each : everyStopAtAPosition()) {
+            said.put(each.getClass().getSimpleName(), ReportedReason.of(each).name());
+        }
+
+        assertEquals(theStopsAtAPosition(), said);
+    }
+
+    /**
+     * Which half a reason is in decides both answers, and the table says the same thing.
+     *
+     * <p>The rule under the thirteen rows: a reading that stopped leaves whatever the rule states
+     * unknown, so both measures are short of it; a rule read from end to end has had whatever it
+     * places placed, so neither is. Said as a rule beside the rows, a reason added to the table with
+     * the wrong pair of words fails here as well — the rows are what someone changing an answer has
+     * to write, and this is what says whether the answer they wrote is one the halves allow.
+     */
+    @Test
+    void aReadingThatStoppedLeavesBothShortAndOneThatFinishedLeavesNeither() {
+        for (BlockReason.RuleWithoutLineReason each : everyRuleWithoutALine()) {
+            boolean stopped = each instanceof BlockReason.RuleReadingStopped;
+            assertEquals(stopped, each.leavesShort(CoverageObligation.Measure.PARTITION),
+                    each.getClass().getSimpleName());
+            assertEquals(stopped, each.leavesShort(CoverageObligation.Measure.BOUNDARY),
+                    each.getClass().getSimpleName());
+        }
+    }
+
+    /**
+     * Every member of the seal, one of each.
+     *
+     * <p>Listed rather than found by reflection, because what this test is about is the answers and
+     * a list that built itself from the same source would move with them. A member added is refused
+     * by the switch in {@code leavesShort} before it reaches here, and one added and left out of the
+     * table is what the assertions above catch.
+     */
+    private static List<BlockReason.RuleWithoutLineReason> everyRuleWithoutALine() {
+        return List.of(
+                new BlockReason.UnreadComparisonForm(),
+                new BlockReason.UnreadComparisonDomain(),
+                new BlockReason.RuleAboutADerivedValue(),
+                new BlockReason.UnreadValueRule(),
+                new BlockReason.ValueRuleRelatingTwoPositions(),
+                new BlockReason.CompetingCoordinates(),
+                new BlockReason.ComparisonCuttingNothing(),
+                new BlockReason.ComparisonCuttingOutsideDomain(),
+                new BlockReason.ComparisonBetweenPositions());
+    }
+
+    private static List<BlockReason.AboutThePosition> everyStopAtAPosition() {
+        return List.of(
+                new BlockReason.TypeUnresolved(),
+                new BlockReason.DepthLimit(),
+                new BlockReason.UnsupportedTraversal(BlockReason.Traversal.MAPPING_CONTENT),
+                new BlockReason.ValueRulesNotReached());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
@@ -42,7 +42,7 @@ class AClosedReadingIsOneThatDrewEveryLineItFoundTest {
     void aReadingThatDrewItsLineMayBeClosed() {
         LinesRead read = new LinesRead();
         read.found(aLine(), bound("cap"));
-        read.drew(aBorder("cap"));
+        read.returning(List.of(read.drew(aBorder("cap"))));
 
         MeasureClosure.Both closed =
                 MeasureClosure.of(List.of(anAxis()), List.of(), List.of(), read);
@@ -105,6 +105,47 @@ class AClosedReadingIsOneThatDrewEveryLineItFoundTest {
                 () -> MeasureClosure.of(List.of(anAxis()), List.of(), List.of(), read));
 
         assertTrue(refused.getMessage().startsWith("a border this reading cannot account for"),
+                refused.getMessage());
+    }
+
+    /**
+     * And a border the reading hands back that it never wrote down.
+     *
+     * <p>The other end of the account, and the one that does not depend on a producer having
+     * remembered. Every producer there is writes into this today; a third one added later would be
+     * off the books from the day it is written, and what it made would still reach a caller — so
+     * what the reading returns is held against what it says it made.
+     */
+    @Test
+    void aBorderReturnedThatWasNeverWrittenDownIsRefused() {
+        LinesRead read = new LinesRead();
+        read.found(aLine(), bound("cap"));
+        read.drew(aBorder("cap"));
+        read.returning(List.of(aBorder("cap"), aBorder("floor")));
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> MeasureClosure.of(List.of(anAxis()), List.of(), List.of(), read));
+
+        assertTrue(refused.getMessage().startsWith(
+                        "a border returned by a reading that did not write it down"),
+                refused.getMessage());
+    }
+
+    /**
+     * And one it wrote down and did not hand back, which is a loss between the two.
+     */
+    @Test
+    void aBorderDrawnAndNotReturnedIsRefused() {
+        LinesRead read = new LinesRead();
+        read.found(aLine(), bound("cap"));
+        read.drew(aBorder("cap"));
+        read.returning(List.of());
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> MeasureClosure.of(List.of(anAxis()), List.of(), List.of(), read));
+
+        assertTrue(refused.getMessage().startsWith(
+                        "a border this reading drew and did not return"),
                 refused.getMessage());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/report/TwoSurfacesAgreeWhichBehaviorsHaveASectionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/TwoSurfacesAgreeWhichBehaviorsHaveASectionTest.java
@@ -1,0 +1,169 @@
+package souther.compiler.report;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A page and a document are written from one reading, and disagree about how much to say and never
+ * about what there was to say.
+ *
+ * <p>Which behaviors have anything said about their positions was worked out twice. The page left
+ * the two lines out where the lists beside the measures were all empty; the document left the object
+ * out where the boundary the positions come off was not derived. Neither read the measures. So one
+ * compilation answered a reader two ways: a {@code >->} composition wrote {@code no_subject} into
+ * the document and nothing onto the page, and a behavior bounded only on a {@code Decimal} wrote
+ * that its rules draw no line into one and nothing into the other (issue #1079).
+ *
+ * <p>Measured over a module holding every shape that decides it, because the two rules agreed on
+ * most of them: a model with one shape passes against either rule and says nothing about the pair.
+ */
+class TwoSurfacesAgreeWhichBehaviorsHaveASectionTest {
+
+    /**
+     * One module holding each way the answer can go.
+     *
+     * <p>A composition with no positions of its own; a behavior whose rules divide nothing and draw
+     * no line; one bounded only on a carrier with no step, whose lines were the ones being lost; and
+     * one the rules divide and bound in the ordinary way.
+     */
+    private static final String MODEL = """
+            module example.surfaces
+
+            data Wrap = { v: String }
+            data Mid = { v: String }
+            data Out = { v: String }
+
+            behavior widen : (w: Wrap) -> Mid constructs Mid
+            let widen (w) = Mid { v = w.v }
+            behavior narrow : (m: Mid) -> Out constructs Out
+            let narrow (m) = Out { v = m.v }
+
+            behavior both = widen >-> narrow
+
+            example both
+                | (Wrap { v = "x" }) -> Out { v = "x" }
+
+            data Rate = Decimal
+                invariant open = value > 0.00m && value < 1.00m
+
+            data Priced = { rate: Rate }
+            data Ok
+
+            behavior take : (p: Priced) -> Ok
+            let take (p) = Ok
+
+            data Amount = Int
+                invariant capped = value >= 0 && value <= 1000
+
+            data Req = { cost: Amount }
+            data Yes
+            data No
+            data Verdict = Yes | No
+
+            behavior judge : (r: Req) -> Verdict
+            let judge (r) = if r.cost.value < 500 then Yes else No
+            """;
+
+    /**
+     * The same behaviors, on both surfaces.
+     *
+     * <p>Written as one equality rather than as two lists to be read side by side: what is being
+     * held is that the two answers are one answer, and a pair of expectations would be two places to
+     * keep in step with whichever rule moved.
+     */
+    @Test
+    void bothSurfacesSayWhichBehaviorsHaveASectionAboutTheirPositions() {
+        assertEquals(inTheJson(), inTheText(),
+                "a page and a document written from one reading");
+    }
+
+    /**
+     * And it is not the empty answer on both.
+     *
+     * <p>An equality holds against two surfaces that both say nothing, which is what the page did
+     * over the model this issue was about. Every behavior here has a section, the composition
+     * included: it is measured at its stages, which is what its two measures say, and a measure that
+     * says why it has no number is one a reader is owed rather than one to leave out.
+     */
+    @Test
+    void andTheAnswerIsNotThatNobodyHasOne() {
+        assertEquals(Set.of("widen", "narrow", "both", "take", "judge"), inTheText());
+        assertFalse(inTheText().isEmpty());
+    }
+
+    /**
+     * The one that was lost is in it, and says what it measured.
+     *
+     * <p>{@code take}'s every rule is a bound on a {@code Decimal}. Its lines went unbuilt and its
+     * section unwritten, so the page said nothing about the behavior at all while the module was
+     * called adequate. Named here because an agreement between two surfaces is also what two
+     * surfaces that both lost it have.
+     */
+    @Test
+    void theBehaviorThisIssueWasAboutHasOneAndSaysWhatItFound() {
+        String take = block(report().human(SourceNameResolver.identity()), "take");
+
+        assertTrue(take.contains("border      borders 2"), take);
+        assertTrue(take.contains("this order names no value there"), take);
+    }
+
+    /** The lines a report writes under one behavior's name. */
+    private static String block(String report, String behavior) {
+        StringBuilder out = new StringBuilder();
+        boolean under = false;
+        for (String line : report.split("\n")) {
+            if (line.startsWith("  ") && !line.startsWith("    ") && !line.isBlank()) {
+                under = line.trim().split("\\s+")[0].equals(behavior);
+            }
+            if (under) {
+                out.append(line).append('\n');
+            }
+        }
+        return out.toString();
+    }
+
+    private static Set<String> inTheText() {
+        Set<String> out = new LinkedHashSet<>();
+        String name = null;
+        for (String line : report().human(SourceNameResolver.identity()).split("\n")) {
+            if (line.startsWith("  ") && !line.startsWith("    ") && !line.isBlank()) {
+                name = line.trim().split("\\s+")[0];
+            } else if (name != null && line.startsWith("    partition ")) {
+                out.add(name);
+            }
+        }
+        return out;
+    }
+
+    private static Set<String> inTheJson() {
+        JsonNode root = JsonMapper.builder().build()
+                .readTree(report().json(SourceNameResolver.identity()));
+        Set<String> out = new LinkedHashSet<>();
+        root.get("modules").forEach(module -> module.get("behaviors").forEach(behavior -> {
+            if (behavior.has("partition")) {
+                out.add(behavior.get("name").asString());
+            }
+        }));
+        return out;
+    }
+
+    private static AdequacyReport report() {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/report/TwoSurfacesAgreeWhichBehaviorsHaveASectionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/TwoSurfacesAgreeWhichBehaviorsHaveASectionTest.java
@@ -13,7 +13,6 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -101,7 +100,6 @@ class TwoSurfacesAgreeWhichBehaviorsHaveASectionTest {
     @Test
     void andTheAnswerIsNotThatNobodyHasOne() {
         assertEquals(Set.of("widen", "narrow", "both", "take", "judge"), inTheText());
-        assertFalse(inTheText().isEmpty());
     }
 
     /**


### PR DESCRIPTION
The second and last of #1079. #1090 closed the semantics; this one is about how
the measures are shown and about the tests that keep them.

## Two surfaces, two answers, one reading

Which behaviors a report says anything about was worked out twice, and neither
place read the measures:

```java
// text  AdequacyReport.java
if (partition == null || (partition.axes().isEmpty() && partition.boundaries().isEmpty()
        && partition.notDerivable().isEmpty() && behavior.claimed().all().isEmpty())) return;

// json  AdequacyReport.java
if (partition == null) return;
if (partition.boundaryNotDerived()) return;
```

So one compilation answered a reader two ways. A `>->` composition wrote a
`partition` object saying `no_subject` into the document and no line at all onto
the page. And a behavior whose every rule is a bound on a `Decimal` — the model
this issue was about — wrote `no_rule_draws_a_line` into one and nothing into
the other, so the surface a person reads was the one that lost it.

`PartitionSection` is that decision, made once. The principle it holds:

> A surface may say less than the measurement, and may not work out for itself
> whether there was one.

A page for a person and a document for a program are owed different amounts of
one reading. Whether the reading exists is a fact about the model, and two
surfaces deciding it separately disagree about the model rather than about how
much to say.

## What changed on the page

A composition says why its two measures do not apply to it:

```
  both                     implemented   rows 1    pending 0
    signature   not applicable (this behavior's output is not a sum)
+   partition   not applicable (this behavior is measured at its stages)
+   border      not applicable (this behavior is measured at its stages)
    branch      not applicable (this behavior has no body)
```

Those sentences were already written — `whyNoPartition` and `whyNoBoundary` each
had a `NoSubject` arm — and the guard had made them unreachable. Leaving them out
was also what a behavior whose measures had something to say got, and telling
those two apart is the whole of what the section is for.

The document is unchanged, and so is the conformance corpus.

## Tests that were holding nothing

`AnEndIsWhereItsRuleStopsTest` said what the report must not contain:

```java
assertFalse(report.contains("point value = 1"));
assertFalse(report.contains("not derivable: h.a"));
```

Both hold over a report that names no line at all, which is exactly what this
model got. They say where the lines are now — `h.p = 0`, `h.a = 5`, two borders —
and that the point against each is one the order cannot name. Verified by
reintroducing the pre-#1079 drop: both fail.

## And a table for the reasons

The seal already refuses a reason nobody answered for: `leavesShort` switches
over its members with no `default`. Nothing refused a reason *moved* from one arm
to another — both switches keep compiling when a reason changes which measure it
leaves short or which word the document writes for it, and every sentence built
on the old answer goes on being written.

`WhatEachWayOfDrawingNoLineLeavesIsWrittenDownOnceTest` writes the thirteen
answers out, plus the rule under them: a reading that stopped leaves both
measures short, one that finished leaves neither. It also records that
`ValueRuleRelatingTwoPositions` and `ComparisonBetweenPositions` share a word on
purpose — two readings of `a < b`, and a document promises which kind of thing
stopped a derivation rather than which reader stopped.

## Not in here

#1092, which carries the side a bound keeps instead of reconstructing it from
its reach. That is a change of semantic data ownership and would blur this PR's
boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)