### PR TITLE
Ask the program what an identity declares, not the module that owns it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedData.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedData.java
@@ -24,11 +24,15 @@ import java.util.NoSuchElementException;
  * a product with no fields is a declaration a reader cannot tell from one that happens to have
  * none — while {@link souther.compiler.core.Core.UnitValue} names exactly the first.
  *
- * <p>Only what a module declares. What the language gives — a primitive standing as a case,
- * {@code Option}'s cases — is declared by no module, which is why every arm is named by a
- * {@link TypeSymbol.AtModule} rather than by a {@link TypeSymbol}. A name that is not one, among
- * them what {@code Core.UnitValue} can carry, names something no module declared; it is not a
- * declaration this snapshot is missing.
+ * <p>What was declared, by a module of this compilation or by the language in the reserved
+ * namespace. The two are one kind of thing here, and which of them declared a given one is
+ * {@link DeclaredBy}, answered where a reader asks what an identity is a declaration of.
+ *
+ * <p>What is outside is what nothing declares. A primitive standing as a case and {@code Option}'s
+ * cases are given by the language directly, with no declaration behind them, which is why every arm
+ * is named by a {@link TypeSymbol.AtModule} rather than by a {@link TypeSymbol}. A name that is not
+ * one, among them what {@code Core.UnitValue} can carry, is answered for by the sealed identity
+ * itself; it is not a declaration this snapshot is missing.
  *
  * <p>{@link Product} is a class and answers no {@code equals}. What a value of a product is made
  * of is {@link ValueShape}, which the check answers and this hands over whole — the fields, the

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedModule.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedModule.java
@@ -1,6 +1,5 @@
 package souther.compiler.program;
 
-import souther.compiler.types.TypeSymbol;
 import souther.compiler.types.ValueName;
 
 import java.util.LinkedHashMap;
@@ -22,7 +21,6 @@ public final class CheckedModule {
     private final List<CheckedHelper> helpers;
     private final Map<ValueName.Helper, CheckedHelper> helperByName;
     private final List<CheckedData> data;
-    private final Map<TypeSymbol.AtModule, CheckedData> dataByName;
 
     CheckedModule(String name, List<CheckedBehavior> behaviors, List<CheckedHelper> helpers,
                   List<CheckedData> data) {
@@ -40,11 +38,6 @@ public final class CheckedModule {
             byHelper.put(helper.name(), helper);
         }
         this.helperByName = Map.copyOf(byHelper);
-        Map<TypeSymbol.AtModule, CheckedData> byData = new LinkedHashMap<>();
-        for (CheckedData declared : this.data) {
-            byData.put(declared.name(), declared);
-        }
-        this.dataByName = Map.copyOf(byData);
     }
 
     /** What the module is called: what its own declarations are under, and what an import names. */
@@ -73,27 +66,19 @@ public final class CheckedModule {
     }
 
     /**
-     * What it declares.
+     * What it declares: what an output emitting this module has to emit.
      *
-     * <p>No order is answered for. A declaration is reached by its name —
-     * {@link #data(TypeSymbol.AtModule)} — and where one stands among the others is a fact about
-     * how the module was read rather than one the language decided. The orders that are decided
-     * are inside a declaration: the fields a value lays out, and the cases it can be.
+     * <p>The enumeration and not a way of reaching one. What a given identity is a declaration of is
+     * {@link CheckedProgram#declaration}, which answers for the language's own declarations as well
+     * — and a module answering it about its own would be that same answer reachable a second way,
+     * by the route that has nothing to say about the rest.
+     *
+     * <p>No order is answered for. Where a declaration stands among the others is a fact about how
+     * the module was read rather than one the language decided. The orders that are decided are
+     * inside a declaration: the fields a value lays out, and the cases it can be.
      */
     public List<CheckedData> data() {
         return data;
-    }
-
-    /**
-     * The declaration {@code name} reaches, or null where it is not one of this module's.
-     *
-     * <p>Reached through the module that declares it, as a behavior and a helper are. A name
-     * carries the module it was declared by, so a reader holding one asks that module — and where
-     * this compile did not check it, {@link CheckedProgram#module} has already answered null and the
-     * two absences stay apart.
-     */
-    public CheckedData data(TypeSymbol.AtModule name) {
-        return dataByName.get(name);
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgram.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgram.java
@@ -1,10 +1,13 @@
 package souther.compiler.program;
 
 import souther.compiler.meta.ModulePath;
+import souther.compiler.types.TypeSymbol;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A Souther program the compiler checked, for an output that lives outside this compiler.
@@ -38,25 +41,75 @@ import java.util.Map;
  * read off the path declares — a behavior it calls, a data whose field it reads — and that module
  * is not among {@link #modules()}. What the body carries is the identity resolution gave it; what
  * the declaring module says about that identity is not part of this snapshot. A call carries no
- * signature and no body, and a name carries no fields and no cases.
+ * signature and no body.
  *
- * <p>Which module a name belongs to is therefore asked before what it is. {@link #module} answers
- * null for a module this compile did not check, and a module answers null for a name it does not
- * declare, so the two absences are separate answers and neither reads as the other. Nothing here
- * shortens that into one question: shortened, a single null would carry both.
+ * <p>A name does carry its fields and its cases, and it is asked with the identity rather than
+ * through whoever declared it. {@link #declaration} is the whole of that: it answers what a value
+ * of a data is made of, and whether the declaration is one this compile checked, one the language
+ * gives, or one a module off the path declares. A reader that chose the owner first would be
+ * deciding, of every identity it holds, which world to ask — and the reserved namespace is a world
+ * with no module of the compilation in it, so the reader that chose had nothing to choose.
+ *
+ * <p>{@link #modules()} enumerates and {@link #declaration} resolves, and those are two questions.
+ * What a module declares is what an output emitting that module has to emit; what an identity is a
+ * declaration of is what an output laying out a value has to know. A module answering the second
+ * about its own would be the same answer reachable two ways, and the way through the module is the
+ * one that has no answer for what the language declares.
  */
 public final class CheckedProgram {
 
     private final List<CheckedModule> modules;
     private final Map<String, CheckedModule> byName;
+    /** Every declaration this snapshot holds, by the identity that names it — the one index both
+     *  {@link #declaration} and {@link #languageDeclarations} are read out of. Two indexes, one per
+     *  world, would be two places for a declaration to be filed and one of them to be looked in. */
+    private final Map<TypeSymbol.AtModule, Declared.Available> declarations;
+    private final List<CheckedData> languageDeclarations;
+    private final Set<TypeSymbol.AtModule> onThePath;
 
-    CheckedProgram(List<CheckedModule> modules) {
+    CheckedProgram(List<CheckedModule> modules, List<CheckedData> languageDeclarations,
+                   Set<TypeSymbol.AtModule> onThePath) {
         this.modules = List.copyOf(modules);
         Map<String, CheckedModule> named = new LinkedHashMap<>();
         for (CheckedModule module : this.modules) {
             named.put(module.name(), module);
         }
         this.byName = Map.copyOf(named);
+        // Built here out of what the modules hold, rather than handed in beside them: an index
+        // assembled somewhere else is a second statement of what this program declares, and the two
+        // would agree until one of them was filled from a different reading.
+        Map<TypeSymbol.AtModule, Declared.Available> index = new LinkedHashMap<>();
+        for (CheckedModule module : this.modules) {
+            for (CheckedData declared : module.data()) {
+                index.put(declared.name(), new Declared.Available(declared, DeclaredBy.A_MODULE));
+            }
+        }
+        List<CheckedData> ofTheLanguage = new ArrayList<>();
+        for (CheckedData declared : languageDeclarations) {
+            Declared.Available already = index.put(declared.name(),
+                    new Declared.Available(declared, DeclaredBy.THE_LANGUAGE));
+            if (already != null) {
+                // A module of this compilation and the language both declaring one address is the
+                // reserved namespace having been taken, which is refused where a module is read.
+                // Reaching here means it was not, and the second answer would silently be the one
+                // every reader got.
+                throw new IllegalStateException(
+                        "`" + declared.name() + "` is declared by the language and by a module");
+            }
+            ofTheLanguage.add(declared);
+        }
+        this.declarations = Map.copyOf(index);
+        this.languageDeclarations = List.copyOf(ofTheLanguage);
+        this.onThePath = Set.copyOf(onThePath);
+        for (TypeSymbol.AtModule elsewhere : this.onThePath) {
+            if (this.declarations.containsKey(elsewhere)) {
+                // The two are answers to one question and an identity that is both would be
+                // answered by whichever was consulted first — which would make the order the
+                // lookup happens to try into a rule about what a declaration is.
+                throw new IllegalStateException("`" + elsewhere
+                        + "` is declared here and read off the path");
+            }
+        }
     }
 
     /**
@@ -90,5 +143,57 @@ public final class CheckedProgram {
     /** The module called {@code name}, or null where this compile did not check one. */
     public CheckedModule module(String name) {
         return byName.get(name);
+    }
+
+    /**
+     * What the declaration {@code name} identifies is made of, or that it is in a module off the
+     * path.
+     *
+     * <p>Asked with the identity a body carries, which is what a reader laying out a value holds.
+     * Whoever declared it — a module of this compile, or the language, in the reserved namespace
+     * where no compilation declares anything — is answered here rather than chosen by the reader,
+     * so a value of a data the language gives is read exactly as a value of a module's own is.
+     *
+     * <p>Never a null and never an absence to interpret. Every identity this compile resolved is
+     * one of the two arms, and the arms are told apart by what was decided rather than by what was
+     * left over: {@link Declared.OnThePath} is answered because this compile read that module off
+     * the path and found the name among what it declares, not because nothing else answered.
+     *
+     * <p>What this is total over is the identities this compile resolved, and not every value the
+     * Java type admits. An identity is minted where a declaration world says one is at an address,
+     * so an address nothing declares is a mistake at the reader — refused here, for the reason
+     * {@link CheckedData.Product#positionOf} refuses a name that is no field.
+     *
+     * @throws IllegalArgumentException where nothing this compile read declares {@code name}
+     */
+    public Declared declaration(TypeSymbol.AtModule name) {
+        if (name == null) {
+            throw new IllegalArgumentException("a declaration is asked for by its identity");
+        }
+        Declared.Available available = declarations.get(name);
+        if (available != null) {
+            return available;
+        }
+        if (onThePath.contains(name)) {
+            return new Declared.OnThePath();
+        }
+        throw new IllegalArgumentException(
+                "nothing this compile read declares `" + name + "`");
+    }
+
+    /**
+     * What the language itself declares, which no module of any compilation does.
+     *
+     * <p>Here so that an output that has to materialise them has the list rather than a walk of its
+     * own. Which declarations the language gives is a fact about the language this program was
+     * checked with; an output that collected them by walking the bodies it was given would be right
+     * about the ones its walk reached, and a declaration nothing in this program happens to name
+     * would be one it never emitted.
+     *
+     * <p>The same declarations {@link #declaration} answers with under {@link DeclaredBy#THE_LANGUAGE},
+     * read out of the one index rather than gathered again.
+     */
+    public List<CheckedData> languageDeclarations() {
+        return languageDeclarations;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgram.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgram.java
@@ -43,10 +43,11 @@ import java.util.Set;
  * the declaring module says about that identity is not part of this snapshot. A call carries no
  * signature and no body.
  *
- * <p>A name does carry its fields and its cases, and it is asked with the identity rather than
- * through whoever declared it. {@link #declaration} is the whole of that: it answers what a value
- * of a data is made of, and whether the declaration is one this compile checked, one the language
- * gives, or one a module off the path declares. A reader that chose the owner first would be
+ * <p>What a name is a declaration of is asked with the identity, rather than through whoever
+ * declared it. {@link #declaration} is the whole of that: it answers what a value of a data is made
+ * of where this snapshot holds the declaration, and says the declaration is a module off the path's
+ * where it does not — so a name whose fields and cases are not here is one that says so, and not
+ * one that reads as no declaration at all. A reader that chose the owner first would be
  * deciding, of every identity it holds, which world to ask — and the reserved namespace is a world
  * with no module of the compilation in it, so the reader that chose had nothing to choose.
  *

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgram.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgram.java
@@ -4,10 +4,10 @@ import souther.compiler.meta.ModulePath;
 import souther.compiler.types.TypeSymbol;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A Souther program the compiler checked, for an output that lives outside this compiler.
@@ -37,39 +37,40 @@ import java.util.Set;
  * carries it is how an accepted one is obtained, and that moves when what acceptance runs a program
  * with stops being named by the thing that asks.
  *
- * <p>Only the modules this compile checked are here. A checked body may name something a module
- * read off the path declares — a behavior it calls, a data whose field it reads — and that module
- * is not among {@link #modules()}. What the body carries is the identity resolution gave it; what
- * the declaring module says about that identity is not part of this snapshot. A call carries no
- * signature and no body.
+ * <p>Only the modules this compile checked are here. A checked body may name a behavior a module
+ * read off the path declares, and that module is not among {@link #modules()}: what the body
+ * carries is the identity resolution gave it, and a call carries no signature and no body.
  *
- * <p>What a name is a declaration of is asked with the identity, rather than through whoever
- * declared it. {@link #declaration} is the whole of that: it answers what a value of a data is made
- * of where this snapshot holds the declaration, and says the declaration is a module off the path's
- * where it does not — so a name whose fields and cases are not here is one that says so, and not
- * one that reads as no declaration at all. A reader that chose the owner first would be
- * deciding, of every identity it holds, which world to ask — and the reserved namespace is a world
- * with no module of the compilation in it, so the reader that chose had nothing to choose.
+ * <p>What a name is a declaration of is another question, and it is asked with the identity rather
+ * than through whoever declared it. {@link #declaration} answers what a value of that data is made
+ * of, for every identity this compile resolved — its own modules', the language's, and a
+ * dependency's alike, because this compile read the dependency's declarations to check the module
+ * that names them, and an output laying such a value out needs exactly what the checker read. Who
+ * declared it comes with the answer and decides who emits it.
  *
  * <p>{@link #modules()} enumerates and {@link #declaration} resolves, and those are two questions.
  * What a module declares is what an output emitting that module has to emit; what an identity is a
- * declaration of is what an output laying out a value has to know. A module answering the second
- * about its own would be the same answer reachable two ways, and the way through the module is the
- * one that has no answer for what the language declares.
+ * declaration of is what an output laying out a value has to know. A reader made to pick the owner
+ * before it could ask the second would be restating what its identity already carries — and where
+ * the declaration is the language's there is no module of the compilation to pick at all.
  */
 public final class CheckedProgram {
 
     private final List<CheckedModule> modules;
     private final Map<String, CheckedModule> byName;
-    /** Every declaration this snapshot holds, by the identity that names it — the one index both
-     *  {@link #declaration} and {@link #languageDeclarations} are read out of. Two indexes, one per
-     *  world, would be two places for a declaration to be filed and one of them to be looked in. */
-    private final Map<TypeSymbol.AtModule, Declared.Available> declarations;
-    private final List<CheckedData> languageDeclarations;
-    private final Set<TypeSymbol.AtModule> onThePath;
+    /**
+     * Every declaration this compile resolved, by the identity that names it, in the order the
+     * three worlds were read: this compilation's modules, the language's own, then what was read
+     * off the path.
+     *
+     * <p>The one index everything here is read out of. A second collection holding some of these
+     * again — the language's, say, for a reader that wants them listed — is a second membership to
+     * keep true, and the day something is filed in one of them it is missing from the other.
+     */
+    private final Map<TypeSymbol.AtModule, Declared> declarations;
 
     CheckedProgram(List<CheckedModule> modules, List<CheckedData> languageDeclarations,
-                   Set<TypeSymbol.AtModule> onThePath) {
+                   List<CheckedData> declaredOnThePath) {
         this.modules = List.copyOf(modules);
         Map<String, CheckedModule> named = new LinkedHashMap<>();
         for (CheckedModule module : this.modules) {
@@ -79,37 +80,38 @@ public final class CheckedProgram {
         // Built here out of what the modules hold, rather than handed in beside them: an index
         // assembled somewhere else is a second statement of what this program declares, and the two
         // would agree until one of them was filled from a different reading.
-        Map<TypeSymbol.AtModule, Declared.Available> index = new LinkedHashMap<>();
+        Map<TypeSymbol.AtModule, Declared> index = new LinkedHashMap<>();
         for (CheckedModule module : this.modules) {
             for (CheckedData declared : module.data()) {
-                index.put(declared.name(), new Declared.Available(declared, DeclaredBy.A_MODULE));
+                file(index, declared, DeclaredBy.A_MODULE);
             }
         }
-        List<CheckedData> ofTheLanguage = new ArrayList<>();
         for (CheckedData declared : languageDeclarations) {
-            Declared.Available already = index.put(declared.name(),
-                    new Declared.Available(declared, DeclaredBy.THE_LANGUAGE));
-            if (already != null) {
-                // A module of this compilation and the language both declaring one address is the
-                // reserved namespace having been taken, which is refused where a module is read.
-                // Reaching here means it was not, and the second answer would silently be the one
-                // every reader got.
-                throw new IllegalStateException(
-                        "`" + declared.name() + "` is declared by the language and by a module");
-            }
-            ofTheLanguage.add(declared);
+            file(index, declared, DeclaredBy.THE_LANGUAGE);
         }
-        this.declarations = Map.copyOf(index);
-        this.languageDeclarations = List.copyOf(ofTheLanguage);
-        this.onThePath = Set.copyOf(onThePath);
-        for (TypeSymbol.AtModule elsewhere : this.onThePath) {
-            if (this.declarations.containsKey(elsewhere)) {
-                // The two are answers to one question and an identity that is both would be
-                // answered by whichever was consulted first — which would make the order the
-                // lookup happens to try into a rule about what a declaration is.
-                throw new IllegalStateException("`" + elsewhere
-                        + "` is declared here and read off the path");
-            }
+        for (CheckedData declared : declaredOnThePath) {
+            file(index, declared, DeclaredBy.A_MODULE_ON_THE_PATH);
+        }
+        // Ordered, because what is read out of it is read in an order: the language declares its
+        // data in an order and a reader listing them is shown one. A map that kept none would show
+        // an order nothing decided, which can differ between two runs of one compiler.
+        this.declarations = Collections.unmodifiableMap(index);
+    }
+
+    /**
+     * Files one declaration, and refuses a second at the same address.
+     *
+     * <p>An address belongs to one world. A module of a compilation may not be in the reserved
+     * namespace, and a module of the compilation takes the name over one of the same name on the
+     * path — so the three never meet, and one that did would be answered for by whichever was filed
+     * last with nothing saying the other had been there.
+     */
+    private static void file(Map<TypeSymbol.AtModule, Declared> index, CheckedData declared,
+                             DeclaredBy by) {
+        Declared already = index.put(declared.name(), new Declared(declared, by));
+        if (already != null) {
+            throw new IllegalStateException("`" + declared.name() + "` is declared by "
+                    + already.declaredBy() + " and by " + by);
         }
     }
 
@@ -155,10 +157,11 @@ public final class CheckedProgram {
      * where no compilation declares anything — is answered here rather than chosen by the reader,
      * so a value of a data the language gives is read exactly as a value of a module's own is.
      *
-     * <p>Never a null and never an absence to interpret. Every identity this compile resolved is
-     * one of the two arms, and the arms are told apart by what was decided rather than by what was
-     * left over: {@link Declared.OnThePath} is answered because this compile read that module off
-     * the path and found the name among what it declares, not because nothing else answered.
+     * <p>Never a null and never an absence to interpret. Every identity this compile resolved has
+     * what a value of it is made of here, a dependency's included: this compile read that
+     * dependency's declarations to check the module that names one, and an output laying such a
+     * value out needs exactly what the checker read. Who declared it says who emits it and never
+     * whether it can be laid out.
      *
      * <p>What this is total over is the identities this compile resolved, and not every value the
      * Java type admits. An identity is minted where a declaration world says one is at an address,
@@ -171,15 +174,12 @@ public final class CheckedProgram {
         if (name == null) {
             throw new IllegalArgumentException("a declaration is asked for by its identity");
         }
-        Declared.Available available = declarations.get(name);
-        if (available != null) {
-            return available;
+        Declared declared = declarations.get(name);
+        if (declared == null) {
+            throw new IllegalArgumentException(
+                    "nothing this compile read declares `" + name + "`");
         }
-        if (onThePath.contains(name)) {
-            return new Declared.OnThePath();
-        }
-        throw new IllegalArgumentException(
-                "nothing this compile read declares `" + name + "`");
+        return declared;
     }
 
     /**
@@ -191,10 +191,20 @@ public final class CheckedProgram {
      * about the ones its walk reached, and a declaration nothing in this program happens to name
      * would be one it never emitted.
      *
-     * <p>The same declarations {@link #declaration} answers with under {@link DeclaredBy#THE_LANGUAGE},
-     * read out of the one index rather than gathered again.
+     * <p>Read out of the index {@link #declaration} answers from, and not held beside it. Kept
+     * beside it, the two would be a membership each and the day a declaration reached one of them
+     * it would be missing from the other; taken from it, a language declaration is listed exactly
+     * when it is answered for.
+     *
+     * <p>In the order the library declares them, which is the order they are filed in.
      */
     public List<CheckedData> languageDeclarations() {
-        return languageDeclarations;
+        List<CheckedData> language = new ArrayList<>();
+        for (Declared declared : declarations.values()) {
+            if (declared.declaredBy() == DeclaredBy.THE_LANGUAGE) {
+                language.add(declared.data());
+            }
+        }
+        return List.copyOf(language);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
@@ -1,10 +1,10 @@
 package souther.compiler.program;
 
-import souther.compiler.ast.Ast;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.AtomSpace;
 import souther.compiler.check.BehaviorImplementation;
 import souther.compiler.check.CoreBinders;
+import souther.compiler.check.Derived;
 import souther.compiler.check.Lower;
 import souther.compiler.check.Sig;
 import souther.compiler.check.SpecImplementation;
@@ -26,15 +26,12 @@ import souther.compiler.query.Shapes;
 import souther.compiler.stdlib.Stdlib;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
-import souther.compiler.types.TypeSymbols;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Takes the snapshot: reads what the compiler decided and writes it down as a {@link
@@ -104,31 +101,43 @@ final class CheckedProgramAssembler {
     }
 
     /**
-     * Every declaration this compile read off the path: the identities it resolved against a module
-     * it did not check.
+     * What every module this compile read off the path declares, as a value of one is laid out.
      *
-     * <p>Taken from what the front end read rather than from what is left over. A reader asking
-     * about one of these is asking about a declaration that was made when that module was compiled,
-     * so what is recorded here is that the compile found the name among what that module declares —
-     * and an identity nothing declares reaches none of this and is refused instead.
+     * <p>Read here and not left to the compile that built the dependency. This one read those
+     * declarations already — it had to, to check a module that constructs one of them or reads a
+     * field off one — so what is handed over is the reading the checker itself used, and an output
+     * laying such a value out places its fields exactly where the check placed them.
      *
-     * <p>The identities and not the declarations. What one is made of belongs to the compile that
-     * made it, and reading it here would be this compiler deciding a second time what another one
-     * already settled.
+     * <p>Which modules those are is {@link Front.FromPath}'s answer: the ones this compilation may
+     * read declarations from, which is not every module on the path and never one it refused. What
+     * each of them declares comes from the derivation this compile ran over it, in the same three
+     * forms a module of its own is read in.
      *
-     * <p>Each identity comes off the declaration that says which one it is. Paired together out of
-     * the module a declaration was read under and the name it is indexed by, it would be this
-     * answering for a declaration whatever the two strings came from.
+     * <p>The whole of what each declares, and not the part something here happens to name. Which
+     * declarations a body reaches is a walk, and a snapshot carrying only what one walk found would
+     * be right about the names that walk thought to visit.
      */
-    private static Set<TypeSymbol.AtModule> declaredOnThePath(Db db) {
+    private static List<CheckedData> declaredOnThePath(Db db) {
         Front.FromPath.Of read = db.ask(new Front.FromPath()).value();
-        Set<TypeSymbol.AtModule> declared = new LinkedHashSet<>();
+        List<CheckedData> declared = new ArrayList<>();
         if (read == null) {
             return declared;
         }
-        for (Front.FromPath.OnThePath onThePath : read.modules().values()) {
-            for (Ast.Def def : onThePath.declarations().values()) {
-                declared.add(TypeSymbols.declared(def.declaredKey()));
+        for (String module : read.modules().keySet()) {
+            Map<String, Derived.Def> defs = db.ask(new Shapes.DerivedDeclarations(module)).value();
+            Map<TypeSymbol.AtModule, ValueShape> shapes =
+                    db.ask(new Shapes.ValueShapes(module)).value();
+            Symbols symbols = Names.derivedSymbols(db, module).value();
+            if (defs == null || shapes == null || symbols == null) {
+                // This compile read the module and checked a module against it, so what it declares
+                // is something this compile already worked out. Letting it through would hand an
+                // output a program whose identities it cannot all lay out, which is the thing this
+                // is here to end.
+                throw new IllegalStateException("`" + module + "` was read off the path and this"
+                        + " compile has nothing to say about what it declares");
+            }
+            for (Derived.Def def : defs.values()) {
+                declared.add(declaredAs(def.read(), symbols, shapes));
             }
         }
         return declared;

--- a/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/CheckedProgramAssembler.java
@@ -1,5 +1,6 @@
 package souther.compiler.program;
 
+import souther.compiler.ast.Ast;
 import souther.compiler.ast.Hir;
 import souther.compiler.check.AtomSpace;
 import souther.compiler.check.BehaviorImplementation;
@@ -19,16 +20,21 @@ import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Compositions;
 import souther.compiler.query.Db;
+import souther.compiler.query.Front;
 import souther.compiler.query.Names;
 import souther.compiler.query.Shapes;
+import souther.compiler.stdlib.Stdlib;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Takes the snapshot: reads what the compiler decided and writes it down as a {@link
@@ -59,7 +65,73 @@ final class CheckedProgramAssembler {
         for (String module : compilation.modules()) {
             modules.add(moduleOf(db, module));
         }
-        return new CheckedProgram(modules);
+        return new CheckedProgram(modules, languageDataOf(db), declaredOnThePath(db));
+    }
+
+    /**
+     * What the language itself declares, as a value of one is laid out.
+     *
+     * <p>Read off the library this compilation was checked against, and not off a library fetched
+     * here: what a name in a checked body denotes was settled against that one, and a second copy
+     * could be a different version of the language.
+     *
+     * <p>Read against a world with no module in it. Which cases a sum descends to is answered by
+     * {@link AtomSpace}, which asks the declarations it is given — and the language's own resolve
+     * against the library alone, so reading them beside any one module's declarations would be
+     * reading them somewhere they could have come out differently.
+     */
+    private static List<CheckedData> languageDataOf(Db db) {
+        Stdlib stdlib = db.ask(new Front.Library()).value();
+        if (stdlib == null) {
+            throw new IllegalStateException("this compilation was checked against no library");
+        }
+        Symbols language = Symbols.none(stdlib);
+        List<CheckedData> declared = new ArrayList<>();
+        for (Hir.Def def : stdlib.languageDeclarations().values()) {
+            if (def instanceof Hir.Data product) {
+                // The language declares sums and the units under them, and a product of its own
+                // would be one nothing here has the fields and clauses of: what a value of a
+                // declaration is made of is derived over a compilation's modules, and derivation
+                // does not run over the library. Said as what it is, rather than reached as an
+                // absent shape — which is also what an assembler that forgot to read the shapes
+                // would look like.
+                throw new IllegalStateException("the language declares `" + product.declares()
+                        + "` as a product, and what a value of one is made of is not derived here");
+            }
+            declared.add(declaredAs(def, language, Map.of()));
+        }
+        return declared;
+    }
+
+    /**
+     * Every declaration this compile read off the path: the identities it resolved against a module
+     * it did not check.
+     *
+     * <p>Taken from what the front end read rather than from what is left over. A reader asking
+     * about one of these is asking about a declaration that was made when that module was compiled,
+     * so what is recorded here is that the compile found the name among what that module declares —
+     * and an identity nothing declares reaches none of this and is refused instead.
+     *
+     * <p>The identities and not the declarations. What one is made of belongs to the compile that
+     * made it, and reading it here would be this compiler deciding a second time what another one
+     * already settled.
+     *
+     * <p>Each identity comes off the declaration that says which one it is. Paired together out of
+     * the module a declaration was read under and the name it is indexed by, it would be this
+     * answering for a declaration whatever the two strings came from.
+     */
+    private static Set<TypeSymbol.AtModule> declaredOnThePath(Db db) {
+        Front.FromPath.Of read = db.ask(new Front.FromPath()).value();
+        Set<TypeSymbol.AtModule> declared = new LinkedHashSet<>();
+        if (read == null) {
+            return declared;
+        }
+        for (Front.FromPath.OnThePath onThePath : read.modules().values()) {
+            for (Ast.Def def : onThePath.declarations().values()) {
+                declared.add(TypeSymbols.declared(def.declaredKey()));
+            }
+        }
+        return declared;
     }
 
     private static CheckedModule moduleOf(Db db, String module) {
@@ -136,14 +208,26 @@ final class CheckedProgramAssembler {
                                            Map<TypeSymbol.AtModule, ValueShape> shapes) {
         List<CheckedData> declared = new ArrayList<>();
         for (Hir.Def def : declarations.defs()) {
-            declared.add(switch (def) {
-                case Hir.Data product -> productOf(product, shapes);
-                case Hir.SumData sum -> new CheckedData.Sum(sum.declares(),
-                        AtomSpace.subjectAtoms(Type.ref(sum.declares()), symbols));
-                case Hir.UnitData unit -> new CheckedData.Unit(unit.declares());
-            });
+            declared.add(declaredAs(def, symbols, shapes));
         }
         return declared;
+    }
+
+    /**
+     * One declaration, in whichever of the three forms it was written.
+     *
+     * <p>One reading for both worlds. A module's declaration and the language's are the same kind
+     * of thing — they resolve and type alike and a value of either lays out alike — and this is
+     * where that stops being something two readings agree about.
+     */
+    private static CheckedData declaredAs(Hir.Def def, Symbols symbols,
+                                          Map<TypeSymbol.AtModule, ValueShape> shapes) {
+        return switch (def) {
+            case Hir.Data product -> productOf(product, shapes);
+            case Hir.SumData sum -> new CheckedData.Sum(sum.declares(),
+                    AtomSpace.subjectAtoms(Type.ref(sum.declares()), symbols));
+            case Hir.UnitData unit -> new CheckedData.Unit(unit.declares());
+        };
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/program/Declared.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/Declared.java
@@ -1,0 +1,50 @@
+package souther.compiler.program;
+
+/**
+ * What {@link CheckedProgram#declaration} answers: where the declaration an identity names is, and
+ * — where this snapshot holds it — what a value of it is made of.
+ *
+ * <p>Two arms and two questions, kept apart. Whether the snapshot holds the declaration is this
+ * sum; who declared it is {@link DeclaredBy}, under the arm that holds one. Answered as one they
+ * were the same question for as long as every declaration a body could name was one this compile
+ * checked, and the day the language's own had to be reached the reader was left choosing which
+ * owner to ask.
+ *
+ * <p>No arm for a name nothing declares. An identity comes from a declaration world having said one
+ * is at an address, so a reader that assembled one from two strings is asking about something that
+ * is not a declaration — and {@link CheckedProgram#declaration} refuses rather than answering, for
+ * the reason {@link CheckedData.Product#positionOf} does. An arm for it would be an output handling
+ * a mistake of its own as one of the states a checked program is in.
+ */
+public sealed interface Declared {
+
+    /**
+     * The declaration is here, and this is what a value of it is made of.
+     *
+     * <p>One arm for both worlds, which is what makes a language-declared sum and a module-declared
+     * sum read the same way rather than by two readers agreeing to. A reader that only lays values
+     * out takes {@link #data} and never looks at {@link #declaredBy}.
+     */
+    record Available(CheckedData data, DeclaredBy declaredBy) implements Declared {
+
+        public Available {
+            if (data == null || declaredBy == null) {
+                throw new IllegalArgumentException(
+                        "an available declaration is what it is made of and who declared it");
+            }
+        }
+    }
+
+    /**
+     * The declaration is in a module this compile read off the path, and this snapshot does not
+     * hold it.
+     *
+     * <p>Said because the compile resolved the identity against a module it read off the path, and
+     * not because nothing else answered: a fourth way for a declaration to arrive would fall
+     * through to being refused rather than being taken for this one. What such a declaration is
+     * made of was decided when that module was compiled, and is in that compile's own snapshot.
+     *
+     * <p>It carries nothing. Which module it is, is on the identity the reader asked with.
+     */
+    record OnThePath() implements Declared {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/program/Declared.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/Declared.java
@@ -1,50 +1,29 @@
 package souther.compiler.program;
 
 /**
- * What {@link CheckedProgram#declaration} answers: where the declaration an identity names is, and
- * — where this snapshot holds it — what a value of it is made of.
+ * What {@link CheckedProgram#declaration} answers: what a value of the data an identity names is
+ * made of, and who declared it.
  *
- * <p>Two arms and two questions, kept apart. Whether the snapshot holds the declaration is this
- * sum; who declared it is {@link DeclaredBy}, under the arm that holds one. Answered as one they
- * were the same question for as long as every declaration a body could name was one this compile
- * checked, and the day the language's own had to be reached the reader was left choosing which
- * owner to ask.
+ * <p>One answer and not two questions. Every declaration this compile resolved is here — its own
+ * modules', the language's, and those of the modules it read off the path — so which world a
+ * declaration came from decides who emits it and never whether it can be laid out. A reader that
+ * had to ask where a declaration was before it could ask what it is would be choosing, of every
+ * identity it holds, which world to look in; and one told that a dependency's data is somewhere
+ * else has been told to go and find a snapshot that was never made — what a dependency ships is an
+ * artifact, and the layout in it is this compile's own reading of that artifact.
  *
- * <p>No arm for a name nothing declares. An identity comes from a declaration world having said one
- * is at an address, so a reader that assembled one from two strings is asking about something that
- * is not a declaration — and {@link CheckedProgram#declaration} refuses rather than answering, for
- * the reason {@link CheckedData.Product#positionOf} does. An arm for it would be an output handling
+ * <p>Nothing for a name nothing declares. An identity comes from a declaration world having said
+ * one is at an address, so a reader that assembled one from two strings is asking about something
+ * that is not a declaration — {@link CheckedProgram#declaration} refuses rather than answering, for
+ * the reason {@link CheckedData.Product#positionOf} does. A case for it would be an output handling
  * a mistake of its own as one of the states a checked program is in.
  */
-public sealed interface Declared {
+public record Declared(CheckedData data, DeclaredBy declaredBy) {
 
-    /**
-     * The declaration is here, and this is what a value of it is made of.
-     *
-     * <p>One arm for both worlds, which is what makes a language-declared sum and a module-declared
-     * sum read the same way rather than by two readers agreeing to. A reader that only lays values
-     * out takes {@link #data} and never looks at {@link #declaredBy}.
-     */
-    record Available(CheckedData data, DeclaredBy declaredBy) implements Declared {
-
-        public Available {
-            if (data == null || declaredBy == null) {
-                throw new IllegalArgumentException(
-                        "an available declaration is what it is made of and who declared it");
-            }
+    public Declared {
+        if (data == null || declaredBy == null) {
+            throw new IllegalArgumentException(
+                    "a declaration is what it is made of and who declared it");
         }
     }
-
-    /**
-     * The declaration is in a module this compile read off the path, and this snapshot does not
-     * hold it.
-     *
-     * <p>Said because the compile resolved the identity against a module it read off the path, and
-     * not because nothing else answered: a fourth way for a declaration to arrive would fall
-     * through to being refused rather than being taken for this one. What such a declaration is
-     * made of was decided when that module was compiled, and is in that compile's own snapshot.
-     *
-     * <p>It carries nothing. Which module it is, is on the identity the reader asked with.
-     */
-    record OnThePath() implements Declared {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/program/DeclaredBy.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/DeclaredBy.java
@@ -1,29 +1,37 @@
 package souther.compiler.program;
 
 /**
- * Which of the two worlds declared a data: a module of this compilation, or the language itself.
+ * Who declared a data: a module this compile checked, the language itself, or a module this compile
+ * read off the path.
  *
- * <p>Provenance and nothing else. Whether the snapshot holds what a value of it is made of is
- * {@link Declared}'s question and is answered by which arm carries this, so nothing here says
- * anything about where the declaration was found.
+ * <p>Provenance and nothing else. What a value of it is made of is answered the same way for all
+ * three — that is what {@link Declared} being one thing says — and this is the question an output
+ * asks when it is deciding what to emit rather than how to lay a value out.
  *
- * <p>Two values with nothing under them, which is why this is an enum rather than a sum: a module's
- * declaration and the language's differ in who wrote them and in nothing a reader is handed. Which
+ * <p>Three values with nothing under them, which is why this is an enum rather than a sum. Which
  * module wrote it is on the identity the reader asked with, and a copy of it here would be a second
  * one that nothing holds to the first.
  */
 public enum DeclaredBy {
 
-    /** A module this compile checked. What such a declaration is called on a machine, and what
-     *  emits it, is the emitting output's own. */
+    /** A module this compile checked. An output emitting this program emits this declaration. */
     A_MODULE,
 
     /**
      * The language, in the reserved namespace, and no module of any compilation.
      *
-     * <p>It resolves and types like a module's own and a value of it lays out like one, which is why
-     * it is read the same way. What differs is that nothing generates it: an output either ships an
-     * implementation of it by hand or generates one, and which of the two is that output's answer.
+     * <p>Nothing generates it: an output either ships an implementation of it by hand or generates
+     * one, and which of the two is that output's own answer.
      */
-    THE_LANGUAGE
+    THE_LANGUAGE,
+
+    /**
+     * A module this compile read off the path — a dependency, already built.
+     *
+     * <p>What a value of one is made of is here, because this compile read it to check the module
+     * that names it, and an output laying out such a value needs exactly what the checker did. What
+     * an output does not do is emit it: the build that made that module emitted it already, and a
+     * second one under the same name would be two definitions of one declaration.
+     */
+    A_MODULE_ON_THE_PATH
 }

--- a/souther-compiler/src/main/java/souther/compiler/program/DeclaredBy.java
+++ b/souther-compiler/src/main/java/souther/compiler/program/DeclaredBy.java
@@ -1,0 +1,29 @@
+package souther.compiler.program;
+
+/**
+ * Which of the two worlds declared a data: a module of this compilation, or the language itself.
+ *
+ * <p>Provenance and nothing else. Whether the snapshot holds what a value of it is made of is
+ * {@link Declared}'s question and is answered by which arm carries this, so nothing here says
+ * anything about where the declaration was found.
+ *
+ * <p>Two values with nothing under them, which is why this is an enum rather than a sum: a module's
+ * declaration and the language's differ in who wrote them and in nothing a reader is handed. Which
+ * module wrote it is on the identity the reader asked with, and a copy of it here would be a second
+ * one that nothing holds to the first.
+ */
+public enum DeclaredBy {
+
+    /** A module this compile checked. What such a declaration is called on a machine, and what
+     *  emits it, is the emitting output's own. */
+    A_MODULE,
+
+    /**
+     * The language, in the reserved namespace, and no module of any compilation.
+     *
+     * <p>It resolves and types like a module's own and a value of it lays out like one, which is why
+     * it is read the same way. What differs is that nothing generates it: an output either ships an
+     * implementation of it by hand or generates one, and which of the two is that output's answer.
+     */
+    THE_LANGUAGE
+}

--- a/souther-compiler/src/main/java/souther/compiler/stdlib/Stdlib.java
+++ b/souther-compiler/src/main/java/souther/compiler/stdlib/Stdlib.java
@@ -267,6 +267,19 @@ public final class Stdlib {
         return names;
     }
 
+    /**
+     * Every declaration the language itself gives, by the address it is declared under, in the
+     * order the library declares them.
+     *
+     * <p>Which those are is the library's own answer. A reader that walked the reserved namespace's
+     * modules asking each what it declares would be building this again, and would be right about
+     * the modules it thought to walk — a declaration written in a module that reader did not name
+     * would be one the language gives and nothing knows about.
+     */
+    public Map<TypeKey, Hir.Def> languageDeclarations() {
+        return language;
+    }
+
     /** What the language declares in {@code moduleName}, keyed by the name written there. Empty
      *  where no module of the library is called that. */
     public Map<String, Hir.Def> languageDeclarationsIn(String moduleName) {

--- a/souther-compiler/src/test/java/souther/compiler/NoPublicWayToTurnASpellingIntoATypeIdentityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/NoPublicWayToTurnASpellingIntoATypeIdentityTest.java
@@ -213,6 +213,11 @@ class NoPublicWayToTurnASpellingIntoATypeIdentityTest {
                         // identity — what a source may write it as is a separate answer, and
                         // `LibraryNames` is where that one is.
                         "StdlibLoader.java: def.declaredKey()",
+                        // What a module read off the path declares, as the snapshot records which
+                        // identities were resolved against one. Each declaration says which one it
+                        // is; the module it was read under and the name it is indexed by are the
+                        // two strings that would answer for whatever they came from.
+                        "CheckedProgramAssembler.java: def.declaredKey()",
                         // The address a declaration world has just been asked about and answered for.
                         "Registry.java: address",
                         "Declarations.java: address",

--- a/souther-compiler/src/test/java/souther/compiler/NoPublicWayToTurnASpellingIntoATypeIdentityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/NoPublicWayToTurnASpellingIntoATypeIdentityTest.java
@@ -213,11 +213,6 @@ class NoPublicWayToTurnASpellingIntoATypeIdentityTest {
                         // identity — what a source may write it as is a separate answer, and
                         // `LibraryNames` is where that one is.
                         "StdlibLoader.java: def.declaredKey()",
-                        // What a module read off the path declares, as the snapshot records which
-                        // identities were resolved against one. Each declaration says which one it
-                        // is; the module it was read under and the name it is indexed by are the
-                        // two strings that would answer for whatever they came from.
-                        "CheckedProgramAssembler.java: def.declaredKey()",
                         // The address a declaration world has just been asked about and answered for.
                         "Registry.java: address",
                         "Declarations.java: address",

--- a/souther-compiler/src/test/java/souther/compiler/program/WhatTheLanguageDeclaresCrossesAsADeclarationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/program/WhatTheLanguageDeclaresCrossesAsADeclarationTest.java
@@ -1,0 +1,114 @@
+package souther.compiler.program;
+
+import souther.compiler.DefaultStdlib;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The declarations the language gives cross whole, and an address is one world's or the other's.
+ *
+ * <p>In this compiler's own tests because it is the two sides that are held together here: what the
+ * library declares, which is {@code stdlib}'s answer, and what the snapshot carries. An output
+ * outside cannot see the first, so a test written there could only say the snapshot agreed with
+ * itself.
+ */
+class WhatTheLanguageDeclaresCrossesAsADeclarationTest {
+
+    private static final String MODULE = """
+            module demo
+
+            behavior rounded : (d: Decimal) -> Decimal
+
+            let rounded (d) = Decimal.round(2, HALF_UP, d)
+            """;
+
+    /**
+     * Every declaration the library gives is in the snapshot, and the snapshot invents none.
+     *
+     * <p>The two are one set said twice, and what is being watched for is the day they stop being.
+     * A declaration written into a library module and not carried over is a value an output can
+     * hold and cannot lay out, which is what this exists about; one carried over that the library
+     * does not declare is a name nothing writes.
+     */
+    @Test
+    void everyDeclarationTheLibraryGivesIsInTheSnapshotAndNoOther() {
+        List<TypeSymbol.AtModule> carried =
+                CheckedProgram.of(List.of(MODULE)).languageDeclarations().stream()
+                        .map(CheckedData::name).sorted().toList();
+
+        assertEquals(DefaultStdlib.get().languageDeclarations().keySet().stream()
+                        .map(TypeSymbols::declared).sorted().toList(),
+                carried);
+    }
+
+    /**
+     * And a form the snapshot has no reading for is refused where it would be read, rather than
+     * arriving as a shape nothing answered for.
+     *
+     * <p>The language declares sums and the units under them. A product of its own would need what
+     * a value of it is made of and what must hold of one, and both are derived over a compilation's
+     * modules — which the library's are not. Watched here so that the day one is written, it is the
+     * declaration that is refused and not an assembler that looks like it forgot to read a shape.
+     */
+    @Test
+    void andTheLanguageDeclaresNothingThisHasNoReadingFor() {
+        List<CheckedData> language = CheckedProgram.of(List.of(MODULE)).languageDeclarations();
+
+        assertEquals(List.of(),
+                language.stream().filter(each -> each instanceof CheckedData.Product).toList(),
+                "a product the language declares has no fields to hand over");
+    }
+
+    /**
+     * One address is declared by the language or by a module, and never by both.
+     *
+     * <p>Nothing of a compilation is in the reserved namespace, so the two never meet — and were
+     * they to, whichever was filed second would silently be the answer every reader got. Refused
+     * where the index is built, which is the one place both are in hand.
+     */
+    @Test
+    void oneAddressIsNotDeclaredByBothWorlds() {
+        CheckedData twice = new CheckedData.Unit(named("demo", "Mode"));
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> new CheckedProgram(List.of(module("demo", twice)), List.of(twice), Set.of()));
+
+        assertEquals("`demo.Mode` is declared by the language and by a module", refused.getMessage());
+    }
+
+    /**
+     * And an identity is declared here or read off the path, and never both.
+     *
+     * <p>A module of this compile takes the name over a module of the same name on the path, so what
+     * is read off the path is what nothing here declares. Held because the lookup tries one and then
+     * the other: with an identity in both, which arm a reader was answered with would be the order
+     * the tries happen to be written in.
+     */
+    @Test
+    void anIdentityIsNotBothDeclaredHereAndReadOffThePath() {
+        CheckedData here = new CheckedData.Unit(named("demo", "Mode"));
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> new CheckedProgram(List.of(module("demo", here)), List.of(),
+                        Set.of(named("demo", "Mode"))));
+
+        assertEquals("`demo.Mode` is declared here and read off the path", refused.getMessage());
+    }
+
+    private static TypeSymbol.AtModule named(String module, String name) {
+        return TypeSymbols.declared(new TypeKey(module, name));
+    }
+
+    private static CheckedModule module(String name, CheckedData declares) {
+        return new CheckedModule(name, List.of(), List.of(), List.of(declares));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/program/WhatTheLanguageDeclaresCrossesAsADeclarationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/program/WhatTheLanguageDeclaresCrossesAsADeclarationTest.java
@@ -34,10 +34,10 @@ class WhatTheLanguageDeclaresCrossesAsADeclarationTest {
     /**
      * Every declaration the library gives is in the snapshot, and the snapshot invents none.
      *
-     * <p>The two are one set said twice, and what is being watched for is the day they stop being.
-     * A declaration written into a library module and not carried over is a value an output can
-     * hold and cannot lay out, which is what this exists about; one carried over that the library
-     * does not declare is a name nothing writes.
+     * <p>What this holds is that nothing selects on the way over. The snapshot is one reading of the
+     * library's own declarations, and a reading that took some of them would leave an output holding
+     * values of the rest with nothing to lay them out by — which is the shape of what this change
+     * was about, one selection later.
      */
     @Test
     void everyDeclarationTheLibraryGivesIsInTheSnapshotAndNoOther() {
@@ -48,24 +48,6 @@ class WhatTheLanguageDeclaresCrossesAsADeclarationTest {
         assertEquals(DefaultStdlib.get().languageDeclarations().keySet().stream()
                         .map(TypeSymbols::declared).sorted().toList(),
                 carried);
-    }
-
-    /**
-     * And a form the snapshot has no reading for is refused where it would be read, rather than
-     * arriving as a shape nothing answered for.
-     *
-     * <p>The language declares sums and the units under them. A product of its own would need what
-     * a value of it is made of and what must hold of one, and both are derived over a compilation's
-     * modules — which the library's are not. Watched here so that the day one is written, it is the
-     * declaration that is refused and not an assembler that looks like it forgot to read a shape.
-     */
-    @Test
-    void andTheLanguageDeclaresNothingThisHasNoReadingFor() {
-        List<CheckedData> language = CheckedProgram.of(List.of(MODULE)).languageDeclarations();
-
-        assertEquals(List.of(),
-                language.stream().filter(each -> each instanceof CheckedData.Product).toList(),
-                "a product the language declares has no fields to hand over");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/program/WhatTheLanguageDeclaresCrossesAsADeclarationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/program/WhatTheLanguageDeclaresCrossesAsADeclarationTest.java
@@ -8,7 +8,6 @@ import souther.compiler.types.TypeSymbols;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -51,39 +50,26 @@ class WhatTheLanguageDeclaresCrossesAsADeclarationTest {
     }
 
     /**
-     * One address is declared by the language or by a module, and never by both.
+     * One address belongs to one world.
      *
-     * <p>Nothing of a compilation is in the reserved namespace, so the two never meet — and were
-     * they to, whichever was filed second would silently be the answer every reader got. Refused
-     * where the index is built, which is the one place both are in hand.
+     * <p>Nothing of a compilation is in the reserved namespace, and a module of this compile takes
+     * its name over one of the same name on the path, so the three never meet. Were two of them to,
+     * whichever was filed last would silently be the answer every reader got, and nothing would say
+     * the other had been there. Refused where the index is built, which is the one place all three
+     * are in hand.
      */
     @Test
-    void oneAddressIsNotDeclaredByBothWorlds() {
+    void oneAddressBelongsToOneWorld() {
         CheckedData twice = new CheckedData.Unit(named("demo", "Mode"));
 
-        IllegalStateException refused = assertThrows(IllegalStateException.class,
-                () -> new CheckedProgram(List.of(module("demo", twice)), List.of(twice), Set.of()));
-
-        assertEquals("`demo.Mode` is declared by the language and by a module", refused.getMessage());
-    }
-
-    /**
-     * And an identity is declared here or read off the path, and never both.
-     *
-     * <p>A module of this compile takes the name over a module of the same name on the path, so what
-     * is read off the path is what nothing here declares. Held because the lookup tries one and then
-     * the other: with an identity in both, which arm a reader was answered with would be the order
-     * the tries happen to be written in.
-     */
-    @Test
-    void anIdentityIsNotBothDeclaredHereAndReadOffThePath() {
-        CheckedData here = new CheckedData.Unit(named("demo", "Mode"));
-
-        IllegalStateException refused = assertThrows(IllegalStateException.class,
-                () -> new CheckedProgram(List.of(module("demo", here)), List.of(),
-                        Set.of(named("demo", "Mode"))));
-
-        assertEquals("`demo.Mode` is declared here and read off the path", refused.getMessage());
+        assertEquals("`demo.Mode` is declared by A_MODULE and by THE_LANGUAGE",
+                assertThrows(IllegalStateException.class, () -> new CheckedProgram(
+                        List.of(module("demo", twice)), List.of(twice), List.of()))
+                        .getMessage());
+        assertEquals("`demo.Mode` is declared by A_MODULE and by A_MODULE_ON_THE_PATH",
+                assertThrows(IllegalStateException.class, () -> new CheckedProgram(
+                        List.of(module("demo", twice)), List.of(), List.of(twice)))
+                        .getMessage());
     }
 
     private static TypeSymbol.AtModule named(String module, String name) {

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatAModulesDataAreMadeOfTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatAModulesDataAreMadeOfTest.java
@@ -111,10 +111,9 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
      * module that declares it is on the name, and the reader neither picks it nor is told to.
      */
     private static CheckedData layout(CheckedProgram program, TypeSymbol.AtModule name) {
-        Declared.Available available = assertInstanceOf(Declared.Available.class,
-                program.declaration(name), name::toString);
-        assertEquals(DeclaredBy.A_MODULE, available.declaredBy(), name::toString);
-        return available.data();
+        Declared declared = program.declaration(name);
+        assertEquals(DeclaredBy.A_MODULE, declared.declaredBy(), name::toString);
+        return declared.data();
     }
 
     private static CheckedData declared(CheckedModule module, String name) {

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatAModulesDataAreMadeOfTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatAModulesDataAreMadeOfTest.java
@@ -8,6 +8,8 @@ import souther.compiler.program.CheckedHelper;
 import souther.compiler.program.CheckedImplementation;
 import souther.compiler.program.CheckedModule;
 import souther.compiler.program.CheckedProgram;
+import souther.compiler.program.Declared;
+import souther.compiler.program.DeclaredBy;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 
@@ -92,11 +94,27 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
             let widen (n) = Wide { extra = n, id = n, tag = "t" }
             """;
 
+    private static CheckedProgram demoProgram() {
+        return CheckedProgram.of(List.of(MODULE));
+    }
+
     private static CheckedModule demo() {
-        CheckedProgram program = CheckedProgram.of(List.of(MODULE));
-        CheckedModule module = program.module("demo");
+        CheckedModule module = demoProgram().module("demo");
         assertNotNull(module, "the compile checked this module");
         return module;
+    }
+
+    /**
+     * What a value of {@code name} is made of, as an output laying one out asks for it.
+     *
+     * <p>Of the program and with the identity, which is the whole of what a reader has to do: the
+     * module that declares it is on the name, and the reader neither picks it nor is told to.
+     */
+    private static CheckedData layout(CheckedProgram program, TypeSymbol.AtModule name) {
+        Declared.Available available = assertInstanceOf(Declared.Available.class,
+                program.declaration(name), name::toString);
+        assertEquals(DeclaredBy.A_MODULE, available.declaredBy(), name::toString);
+        return available.data();
     }
 
     private static CheckedData declared(CheckedModule module, String name) {
@@ -262,7 +280,9 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
      */
     @Test
     void everyConstructionFillsTheDeclaredFieldsInTheOrderTheyAreLaidOut() {
-        CheckedModule module = demo();
+        CheckedProgram program = demoProgram();
+        CheckedModule module = program.module("demo");
+        assertNotNull(module, "the compile checked this module");
         List<Core.Construct> constructions = new ArrayList<>();
         for (Core body : bodiesOf(module)) {
             collect(body, Core.Construct.class, constructions);
@@ -272,7 +292,7 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
                 + constructions.stream().map(each -> each.typeName().name()).toList());
         for (Core.Construct construction : constructions) {
             CheckedData.Product built = assertInstanceOf(CheckedData.Product.class,
-                    module.data(construction.typeName()), construction.typeName()::toString);
+                    layout(program, construction.typeName()), construction.typeName()::toString);
             assertEquals(fieldNames(built),
                     construction.values().stream().map(Core.FieldValue::field).toList(),
                     () -> "what `" + construction.typeName() + "` is built with");
@@ -289,7 +309,9 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
      */
     @Test
     void everyFieldReadNamesAFieldOfWhatItReadsFrom() {
-        CheckedModule module = demo();
+        CheckedProgram program = demoProgram();
+        CheckedModule module = program.module("demo");
+        assertNotNull(module, "the compile checked this module");
         List<Core.FieldAccess> reads = new ArrayList<>();
         for (Core body : bodiesOf(module)) {
             collect(body, Core.FieldAccess.class, reads);
@@ -305,7 +327,7 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
                 unaccounted.add(read);
                 continue;
             }
-            switch (module.data(named)) {
+            switch (layout(program, named)) {
                 // Answering at all is the assertion: a name that is no field of it is refused.
                 case CheckedData.Product product -> {
                     offProducts++;
@@ -318,14 +340,13 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
                             () -> "the cases " + named + " is read across");
                     for (TypeSymbol leaf : sum.cases()) {
                         CheckedData.Product carrying = assertInstanceOf(CheckedData.Product.class,
-                                module.data(assertInstanceOf(TypeSymbol.AtModule.class, leaf)),
+                                layout(program, assertInstanceOf(TypeSymbol.AtModule.class, leaf)),
                                 leaf::toString);
                         carrying.positionOf(read.field());
                     }
                 }
                 case CheckedData.Unit _ ->
                         throw new AssertionError("a unit has no field to read: " + named);
-                case null -> throw new AssertionError(named + " is declared by no module here");
             }
         }
         assertEquals(1, offSums, "the read off a sum is the one this module writes");
@@ -347,27 +368,23 @@ class AnOutputReadsWhatAModulesDataAreMadeOfTest {
             """;
 
     /**
-     * A module this compile did not check and a name a module does not declare are two answers.
+     * A declaration is reached by its identity, and not through whichever module the reader holds.
      *
-     * <p>Which module a name belongs to is asked before what the name is, and both questions can
-     * answer nothing. Asked as one they would answer nothing once, and a reader could not tell a
-     * program it was given too little of from a name that is not a declaration. Held with a name
-     * another module really declares, because a name no module declares cannot be made at all —
-     * which is the same reason the two questions can be kept apart.
+     * <p>Which module declares a name is on the name, so a reader asked to pick the owner first is
+     * being asked to restate what it is already holding — and where the declaration is the
+     * language's own there is no module of the compilation to pick. Enumerating is still a module's
+     * question, and a module this compile did not check is still nothing.
      */
     @Test
-    void aModuleThisCompileDidNotCheckAndANameItDoesNotDeclareAreTwoAnswers() {
+    void aDeclarationIsReachedByItsIdentityAndNotThroughAModule() {
         CheckedProgram program = CheckedProgram.of(List.of(MODULE, OTHER));
-        CheckedModule demo = program.module("demo");
         CheckedModule other = program.module("other");
-        assertNotNull(demo);
         assertNotNull(other);
         TypeSymbol.AtModule elsewhere = declared(other, "Elsewhere").name();
 
         assertNull(program.module("nowhere"), "this compile checked no module of that name");
-        assertNull(demo.data(elsewhere), "`demo` declares no `Elsewhere`");
-        assertSame(declared(other, "Elsewhere"), other.data(elsewhere),
-                "the module that declares it answers for it");
+        assertSame(declared(other, "Elsewhere"), layout(program, elsewhere),
+                "the program answers for it, whichever module the reader happened to be holding");
     }
 
     /** Every body this module holds: a behavior written here, and a helper it emits. */

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatTheLanguageDeclaresTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatTheLanguageDeclaresTest.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -41,10 +40,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * value it could not lay out. What is held here is that the question is asked of the program with
  * the identity, and that a declaration the language gives is read exactly as a module's own is.
  *
- * <p>And that the two absences that are not one another stay apart. A module read off the path
- * declares data of its own, and what a value of one is made of was settled by the compile that
- * built it — so this program says where it is rather than that it has none. A name nothing declares
- * is neither, and is refused.
+ * <p>And that a dependency's data is read the same way again. Such a declaration is one this
+ * compile read to check the module that names it, so what a value of one is made of is here as
+ * well; who declared it says who emits it. A name nothing declares is not a third state of that and
+ * is refused.
  */
 class AnOutputReadsWhatTheLanguageDeclaresTest {
 
@@ -74,11 +73,10 @@ class AnOutputReadsWhatTheLanguageDeclaresTest {
     void aSumTheLanguageDeclaresIsReadAsAnyOtherSumIs() {
         CheckedProgram program = CheckedProgram.of(List.of(ROUNDS));
 
-        Declared.Available available = assertInstanceOf(Declared.Available.class,
-                program.declaration(ROUNDING_MODE));
-        assertEquals(DeclaredBy.THE_LANGUAGE, available.declaredBy(),
+        Declared declared = program.declaration(ROUNDING_MODE);
+        assertEquals(DeclaredBy.THE_LANGUAGE, declared.declaredBy(),
                 "no module of a compilation declares it");
-        CheckedData.Sum sum = assertInstanceOf(CheckedData.Sum.class, available.data());
+        CheckedData.Sum sum = assertInstanceOf(CheckedData.Sum.class, declared.data());
         assertEquals(
                 List.of("HALF_UP", "HALF_EVEN", "HALF_DOWN", "UP", "DOWN", "CEILING", "FLOOR"),
                 sum.cases().stream().map(TypeSymbol::name).toList(),
@@ -90,10 +88,9 @@ class AnOutputReadsWhatTheLanguageDeclaresTest {
     void aCaseOfItIsTheUnitDataItIs() {
         CheckedProgram program = CheckedProgram.of(List.of(ROUNDS));
 
-        Declared.Available available = assertInstanceOf(Declared.Available.class,
-                program.declaration(HALF_UP));
-        assertEquals(DeclaredBy.THE_LANGUAGE, available.declaredBy());
-        assertEquals(HALF_UP, assertInstanceOf(CheckedData.Unit.class, available.data()).name());
+        Declared declared = program.declaration(HALF_UP);
+        assertEquals(DeclaredBy.THE_LANGUAGE, declared.declaredBy());
+        assertEquals(HALF_UP, assertInstanceOf(CheckedData.Unit.class, declared.data()).name());
     }
 
     /**
@@ -120,17 +117,17 @@ class AnOutputReadsWhatTheLanguageDeclaresTest {
     /**
      * Every identity a checked program reaches is one this program answers for.
      *
-     * <p>The wider of the two holdings: an identity in a body was resolved by this compile, so
-     * something knows what declares it, and a program that refused one would be handing an output a
-     * name with nothing behind it. Whether the declaration is here or in the compile that built a
-     * dependency is the next question and not this one.
+     * <p>An identity in a body was resolved by this compile, so something here knows what declares
+     * it, and a program that refused one would be handing an output a name with nothing behind it.
+     * Whichever world declared it, what a value of it is made of is the answer — so this holds at
+     * every position a reader can arrive at and not only where a value is laid out.
      */
     @Test
     void everyIdentityAProgramReachesIsOneItAnswersFor() {
         Map<String, byte[]> classes = Compiler.compile(PUBLISHED);
-        // Both programs, because the two arms are what this is about: one reaches a declaration the
-        // language gives and the other one a dependency made, and a walk over either alone would
-        // hold while the other went unanswered.
+        // Both programs, because the two worlds a declaration can come from besides this
+        // compilation's own are one each, and a walk over either alone would hold while the other
+        // went unanswered.
         CheckedProgram language = CheckedProgram.of(List.of(ROUNDS));
         CheckedProgram dependency =
                 CheckedProgram.of(List.of(IMPORTS), (ModulePath) classes::get);
@@ -149,31 +146,15 @@ class AnOutputReadsWhatTheLanguageDeclaresTest {
         }
     }
 
-    /**
-     * And where a value of one is being laid out, the declaration is here.
-     *
-     * <p>The narrower holding, and the one an output emits by. These are the places a backend has to
-     * know what a value is made of — what a construction fills, what a unit value stands for, what a
-     * field is read off, and which cases an arm selects — and a declaration that was somewhere else
-     * would leave it with nothing to emit.
-     */
-    @Test
-    void andWhereAValueIsLaidOutTheDeclarationIsHere() {
-        CheckedProgram program = CheckedProgram.of(List.of(ROUNDS));
-        Set<TypeSymbol.AtModule> laidOut = everyIdentityLaidOutIn(program);
-
-        assertFalse(laidOut.isEmpty(), "this module lays values out");
-        for (TypeSymbol.AtModule named : laidOut) {
-            assertInstanceOf(Declared.Available.class, program.declaration(named),
-                    named::toString);
-        }
-    }
-
     /** Published by another project, and on the path rather than among the sources. */
     private static final String PUBLISHED = """
-            module lib.money exposing ( Amount )
+            module lib.money exposing ( Amount, Kind )
 
-            data Amount = Int
+            data Amount =
+                { cents: Int }
+                invariant cents > 0
+
+            data Kind = Untouched | AlsoUntouched
             """;
 
     private static final String IMPORTS = """
@@ -185,28 +166,90 @@ class AnOutputReadsWhatTheLanguageDeclaresTest {
             behavior bill : (a: Amount) -> Receipt constructs Receipt
 
             let bill (a) = Receipt { total = a }
+
+            behavior cents : (a: Amount) -> Int
+
+            let cents (a) = a.cents
             """;
 
     /**
-     * A declaration a module off the path makes is said to be there, and not said to be missing.
+     * A field read off a dependency's data is one this program says how to place.
      *
-     * <p>What a value of it is made of was decided when that module was compiled and is in that
-     * compile's own snapshot. Answered because this compile read the module and found the name among
-     * what it declares — so a declaration arriving some fourth way would fall through to being
-     * refused rather than be taken for one of these.
+     * <p>A field of an exposed data is readable across modules, so this body is one the language
+     * admits, and the read is a load an output has to emit. What it loads is at the position the
+     * check placed it — which this compile worked out when it checked this module, and which an
+     * output told to go and ask the build that made the dependency would have to work out again.
      */
     @Test
-    void aDeclarationOffThePathIsSaidToBeThere() {
-        Map<String, byte[]> classes = Compiler.compile(PUBLISHED);
-        ModulePath path = classes::get;
-        CheckedProgram program = CheckedProgram.of(List.of(IMPORTS), path);
+    void aFieldReadOffADependencysDataIsOneThisProgramPlaces() {
+        CheckedProgram program = CheckedProgram.of(List.of(IMPORTS), dependency());
+        CheckedModule module = program.module("app.bills");
+        assertNotNull(module);
+        TypeSymbol.AtModule amount = theTypeRead(module, "cents");
+
+        Declared declared = program.declaration(amount);
+
+        assertEquals(DeclaredBy.A_MODULE_ON_THE_PATH, declared.declaredBy(),
+                "a dependency's, and not this compile's to emit");
+        CheckedData.Product product =
+                assertInstanceOf(CheckedData.Product.class, declared.data());
+        assertEquals(0, product.positionOf("cents"), "where the load goes");
+        assertEquals(1, product.invariants().size(),
+                "what must hold of one, as the dependency's author wrote it");
+    }
+
+    /** And the same data reached as a field's type, which is the reading a construction needs. */
+    @Test
+    void andTheSameDataReachedAsAFieldsType() {
+        CheckedProgram program = CheckedProgram.of(List.of(IMPORTS), dependency());
         CheckedModule module = program.module("app.bills");
         assertNotNull(module);
 
         TypeSymbol.AtModule amount = assertInstanceOf(TypeSymbol.AtModule.class,
                 assertInstanceOf(Type.Ref.class, fieldOf(module, "Receipt", "total").type()).name());
+
         assertEquals("lib.money", amount.module(), "the field's type is the dependency's data");
-        assertInstanceOf(Declared.OnThePath.class, program.declaration(amount));
+        assertEquals(DeclaredBy.A_MODULE_ON_THE_PATH,
+                program.declaration(amount).declaredBy());
+    }
+
+    /**
+     * And what a dependency declares is here whether or not this program names it.
+     *
+     * <p>A snapshot holding what one walk of this program reached would be right about the names
+     * that walk thought to visit. A value of any of them can arrive from anywhere the dependency's
+     * own artifact reaches.
+     */
+    @Test
+    void andWhatADependencyDeclaresIsHereWhetherOrNotThisProgramNamesIt() {
+        CheckedProgram program = CheckedProgram.of(List.of(IMPORTS), dependency());
+
+        Declared unnamed = program.declaration(
+                TypeSymbols.declared(new TypeKey("lib.money", "Untouched")));
+
+        assertEquals(DeclaredBy.A_MODULE_ON_THE_PATH, unnamed.declaredBy());
+        assertInstanceOf(CheckedData.Unit.class, unnamed.data());
+    }
+
+    private static ModulePath dependency() {
+        Map<String, byte[]> classes = Compiler.compile(PUBLISHED);
+        return classes::get;
+    }
+
+    /** The declaration whose field the behavior called {@code named} reads. */
+    private static TypeSymbol.AtModule theTypeRead(CheckedModule module, String named) {
+        for (CheckedBehavior behavior : module.behaviors()) {
+            if (!behavior.name().name().equals(named)) {
+                continue;
+            }
+            List<Core.FieldAccess> reads = new ArrayList<>();
+            collect(((CheckedImplementation.Body) behavior.implementation()).body(),
+                    Core.FieldAccess.class, reads);
+            assertEquals(1, reads.size(), () -> named + " reads one field");
+            return assertInstanceOf(TypeSymbol.AtModule.class,
+                    assertInstanceOf(Type.Ref.class, reads.get(0).target().type()).name());
+        }
+        throw new AssertionError(named + " is no behavior of " + module.name());
     }
 
     /**
@@ -248,7 +291,7 @@ class AnOutputReadsWhatTheLanguageDeclaresTest {
                         "CEILING", "FLOOR"),
                 language.stream().map(each -> each.name().name()).toList());
         for (CheckedData declared : language) {
-            assertEquals(new Declared.Available(declared, DeclaredBy.THE_LANGUAGE),
+            assertEquals(new Declared(declared, DeclaredBy.THE_LANGUAGE),
                     program.declaration(declared.name()),
                     "the list and the lookup are one index read two ways");
         }

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatTheLanguageDeclaresTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatTheLanguageDeclaresTest.java
@@ -131,11 +131,19 @@ class AnOutputReadsWhatTheLanguageDeclaresTest {
         // Both programs, because the two arms are what this is about: one reaches a declaration the
         // language gives and the other one a dependency made, and a walk over either alone would
         // hold while the other went unanswered.
-        for (CheckedProgram program : List.of(CheckedProgram.of(List.of(ROUNDS)),
-                CheckedProgram.of(List.of(IMPORTS), (ModulePath) classes::get))) {
-            Set<TypeSymbol.AtModule> reached = everyIdentityIn(program);
-            assertFalse(reached.isEmpty(), () -> "nothing reached from " + program.modules());
-            for (TypeSymbol.AtModule named : reached) {
+        CheckedProgram language = CheckedProgram.of(List.of(ROUNDS));
+        CheckedProgram dependency =
+                CheckedProgram.of(List.of(IMPORTS), (ModulePath) classes::get);
+
+        // What each of them reaches, said out loud. A walk that quietly reached nothing would hold
+        // here exactly as one that reached everything, and the second of these is a name this
+        // compile did not check.
+        assertEquals(List.of(HALF_UP), List.copyOf(everyIdentityIn(language)));
+        assertEquals(List.of("app.bills.Receipt", "lib.money.Amount"),
+                everyIdentityIn(dependency).stream().map(TypeSymbol.AtModule::toString).toList());
+
+        for (CheckedProgram program : List.of(language, dependency)) {
+            for (TypeSymbol.AtModule named : everyIdentityIn(program)) {
                 program.declaration(named);   // answering at all is the assertion
             }
         }
@@ -262,23 +270,49 @@ class AnOutputReadsWhatTheLanguageDeclaresTest {
     }
 
     /**
-     * Every identity this program reaches: what its declarations are made of, and what its bodies
-     * name.
+     * Every identity this program reaches: what its declarations are made of, what its behaviors
+     * take and answer, and the type of every node of every body.
+     *
+     * <p>Every node and not the nodes a value is laid out at. What is being held is that nothing a
+     * reader can arrive at is a name the program will not answer for, so a walk that visited the
+     * places the answer is already known to be needed would be holding for the reader it was
+     * written from.
      */
     private static Set<TypeSymbol.AtModule> everyIdentityIn(CheckedProgram program) {
         Set<TypeSymbol.AtModule> named = new LinkedHashSet<>(everyIdentityLaidOutIn(program));
         for (CheckedModule module : program.modules()) {
             for (CheckedData declared : module.data()) {
                 named.add(declared.name());
-                if (declared instanceof CheckedData.Product product) {
-                    for (ValueShape.Field field : product.fields()) {
-                        namesIn(field.type(), named);
+                switch (declared) {
+                    case CheckedData.Product product -> {
+                        for (ValueShape.Field field : product.fields()) {
+                            namesIn(field.type(), named);
+                        }
                     }
+                    case CheckedData.Sum sum -> {
+                        for (TypeSymbol each : sum.cases()) {
+                            namesIn(each, named);
+                        }
+                    }
+                    case CheckedData.Unit _ -> { }
                 }
-                if (declared instanceof CheckedData.Sum sum) {
-                    for (TypeSymbol each : sum.cases()) {
-                        namesIn(each, named);
-                    }
+            }
+            for (CheckedBehavior behavior : module.behaviors()) {
+                for (Type takes : behavior.signature().takes()) {
+                    namesIn(takes, named);
+                }
+                namesIn(behavior.signature().answers(), named);
+            }
+            for (CheckedHelper helper : module.helpers()) {
+                for (CheckedHelper.Parameter parameter : helper.parameters()) {
+                    namesIn(parameter.type(), named);
+                }
+            }
+            for (Core body : bodiesOf(module)) {
+                List<Core> nodes = new ArrayList<>();
+                collect(body, Core.class, nodes);
+                for (Core node : nodes) {
+                    namesIn(node.type(), named);
                 }
             }
         }
@@ -319,11 +353,27 @@ class AnOutputReadsWhatTheLanguageDeclaresTest {
         return named;
     }
 
-    /** The declaration {@code type} names, where it names one. */
+    /**
+     * Every declaration {@code type} names, the ones inside a compound included.
+     *
+     * <p>Exhaustive over the sealed type rather than over the arms this test's fixtures happen to
+     * produce: a walk written to the shapes at hand holds for those shapes, and a
+     * {@code List<RoundingMode>} is as much a reader holding an identity as a bare one is.
+     */
     private static void namesIn(Type type, Set<TypeSymbol.AtModule> named) {
-        if (type instanceof Type.Ref ref) {
-            namesIn(ref.name(), named);
+        switch (type) {
+            case Type.Ref ref -> namesIn(ref.name(), named);
+            case Type.Union union -> {
+                for (TypeSymbol member : union.members()) {
+                    namesIn(member, named);
+                }
+            }
+            // A compound names no declaration itself. What it holds is reached below, by the walk
+            // that says once which positions each kind of compound has.
+            case Type.Compound _ -> { }
+            case Type.Prim _, Type.Nothing _, Type.Never _, Type.Erroneous _, Type.Open _ -> { }
         }
+        Type.forEachChild(type, child -> namesIn(child, named));
     }
 
     /** The same, of a name: what the language gives directly is no declaration and is not one of

--- a/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatTheLanguageDeclaresTest.java
+++ b/souther-program-api-test/src/test/java/souther/program/api/AnOutputReadsWhatTheLanguageDeclaresTest.java
@@ -1,0 +1,356 @@
+package souther.program.api;
+
+import souther.compiler.Compiler;
+import souther.compiler.core.Core;
+import souther.compiler.core.ValueShape;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.program.CheckedBehavior;
+import souther.compiler.program.CheckedData;
+import souther.compiler.program.CheckedHelper;
+import souther.compiler.program.CheckedImplementation;
+import souther.compiler.program.CheckedModule;
+import souther.compiler.program.CheckedProgram;
+import souther.compiler.program.Declared;
+import souther.compiler.program.DeclaredBy;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * What a data an output holds a value of is made of, asked with the identity and answered whoever
+ * declared it.
+ *
+ * <p>A body that writes {@code HALF_UP} carries a value typed against a declaration no module of
+ * the compilation made. Reached through the module that declares it, there was nothing to reach: the
+ * standard library's modules are not modules of a compilation, and an output was left holding a
+ * value it could not lay out. What is held here is that the question is asked of the program with
+ * the identity, and that a declaration the language gives is read exactly as a module's own is.
+ *
+ * <p>And that the two absences that are not one another stay apart. A module read off the path
+ * declares data of its own, and what a value of one is made of was settled by the compile that
+ * built it — so this program says where it is rather than that it has none. A name nothing declares
+ * is neither, and is refused.
+ */
+class AnOutputReadsWhatTheLanguageDeclaresTest {
+
+    /** Writes a value of a data the language declares, and nothing else out of the ordinary. */
+    private static final String ROUNDS = """
+            module money
+
+            behavior rounded : (d: Decimal) -> Decimal
+
+            let rounded (d) = Decimal.round(2, HALF_UP, d)
+            """;
+
+    private static final TypeSymbol.AtModule ROUNDING_MODE =
+            TypeSymbols.declared(new TypeKey("souther.decimal", "RoundingMode"));
+
+    private static final TypeSymbol.AtModule HALF_UP =
+            TypeSymbols.declared(new TypeKey("souther.decimal", "HALF_UP"));
+
+    /**
+     * The sum the language declares is read as any other sum is: its cases, in the order it states
+     * them.
+     *
+     * <p>Which is the whole of what a match over one needs, and none of it was reachable while the
+     * only way to a declaration was through a module of the compilation.
+     */
+    @Test
+    void aSumTheLanguageDeclaresIsReadAsAnyOtherSumIs() {
+        CheckedProgram program = CheckedProgram.of(List.of(ROUNDS));
+
+        Declared.Available available = assertInstanceOf(Declared.Available.class,
+                program.declaration(ROUNDING_MODE));
+        assertEquals(DeclaredBy.THE_LANGUAGE, available.declaredBy(),
+                "no module of a compilation declares it");
+        CheckedData.Sum sum = assertInstanceOf(CheckedData.Sum.class, available.data());
+        assertEquals(
+                List.of("HALF_UP", "HALF_EVEN", "HALF_DOWN", "UP", "DOWN", "CEILING", "FLOOR"),
+                sum.cases().stream().map(TypeSymbol::name).toList(),
+                "the cases a value of it can be");
+    }
+
+    /** And a case of it is the unit data it is, which is what the value a body writes stands for. */
+    @Test
+    void aCaseOfItIsTheUnitDataItIs() {
+        CheckedProgram program = CheckedProgram.of(List.of(ROUNDS));
+
+        Declared.Available available = assertInstanceOf(Declared.Available.class,
+                program.declaration(HALF_UP));
+        assertEquals(DeclaredBy.THE_LANGUAGE, available.declaredBy());
+        assertEquals(HALF_UP, assertInstanceOf(CheckedData.Unit.class, available.data()).name());
+    }
+
+    /**
+     * And the body really does write one, so the reading above is of something a reader meets.
+     *
+     * <p>A test that only asked the program about an identity it spelled out itself would hold for a
+     * declaration no program could name.
+     */
+    @Test
+    void andABodyWritesAValueOfIt() {
+        CheckedProgram program = CheckedProgram.of(List.of(ROUNDS));
+        CheckedModule module = program.module("money");
+        assertNotNull(module);
+
+        List<Core.UnitValue> written = new ArrayList<>();
+        for (Core body : bodiesOf(module)) {
+            collect(body, Core.UnitValue.class, written);
+        }
+
+        assertEquals(List.of(HALF_UP), written.stream().map(Core.UnitValue::data).toList(),
+                "the unit values this module writes");
+    }
+
+    /**
+     * Every identity a checked program reaches is one this program answers for.
+     *
+     * <p>The wider of the two holdings: an identity in a body was resolved by this compile, so
+     * something knows what declares it, and a program that refused one would be handing an output a
+     * name with nothing behind it. Whether the declaration is here or in the compile that built a
+     * dependency is the next question and not this one.
+     */
+    @Test
+    void everyIdentityAProgramReachesIsOneItAnswersFor() {
+        Map<String, byte[]> classes = Compiler.compile(PUBLISHED);
+        // Both programs, because the two arms are what this is about: one reaches a declaration the
+        // language gives and the other one a dependency made, and a walk over either alone would
+        // hold while the other went unanswered.
+        for (CheckedProgram program : List.of(CheckedProgram.of(List.of(ROUNDS)),
+                CheckedProgram.of(List.of(IMPORTS), (ModulePath) classes::get))) {
+            Set<TypeSymbol.AtModule> reached = everyIdentityIn(program);
+            assertFalse(reached.isEmpty(), () -> "nothing reached from " + program.modules());
+            for (TypeSymbol.AtModule named : reached) {
+                program.declaration(named);   // answering at all is the assertion
+            }
+        }
+    }
+
+    /**
+     * And where a value of one is being laid out, the declaration is here.
+     *
+     * <p>The narrower holding, and the one an output emits by. These are the places a backend has to
+     * know what a value is made of — what a construction fills, what a unit value stands for, what a
+     * field is read off, and which cases an arm selects — and a declaration that was somewhere else
+     * would leave it with nothing to emit.
+     */
+    @Test
+    void andWhereAValueIsLaidOutTheDeclarationIsHere() {
+        CheckedProgram program = CheckedProgram.of(List.of(ROUNDS));
+        Set<TypeSymbol.AtModule> laidOut = everyIdentityLaidOutIn(program);
+
+        assertFalse(laidOut.isEmpty(), "this module lays values out");
+        for (TypeSymbol.AtModule named : laidOut) {
+            assertInstanceOf(Declared.Available.class, program.declaration(named),
+                    named::toString);
+        }
+    }
+
+    /** Published by another project, and on the path rather than among the sources. */
+    private static final String PUBLISHED = """
+            module lib.money exposing ( Amount )
+
+            data Amount = Int
+            """;
+
+    private static final String IMPORTS = """
+            module app.bills
+            import lib.money ( Amount )
+
+            data Receipt = { total: Amount }
+
+            behavior bill : (a: Amount) -> Receipt constructs Receipt
+
+            let bill (a) = Receipt { total = a }
+            """;
+
+    /**
+     * A declaration a module off the path makes is said to be there, and not said to be missing.
+     *
+     * <p>What a value of it is made of was decided when that module was compiled and is in that
+     * compile's own snapshot. Answered because this compile read the module and found the name among
+     * what it declares — so a declaration arriving some fourth way would fall through to being
+     * refused rather than be taken for one of these.
+     */
+    @Test
+    void aDeclarationOffThePathIsSaidToBeThere() {
+        Map<String, byte[]> classes = Compiler.compile(PUBLISHED);
+        ModulePath path = classes::get;
+        CheckedProgram program = CheckedProgram.of(List.of(IMPORTS), path);
+        CheckedModule module = program.module("app.bills");
+        assertNotNull(module);
+
+        TypeSymbol.AtModule amount = assertInstanceOf(TypeSymbol.AtModule.class,
+                assertInstanceOf(Type.Ref.class, fieldOf(module, "Receipt", "total").type()).name());
+        assertEquals("lib.money", amount.module(), "the field's type is the dependency's data");
+        assertInstanceOf(Declared.OnThePath.class, program.declaration(amount));
+    }
+
+    /**
+     * And a name nothing declares is refused rather than taken for one of those.
+     *
+     * <p>An identity exists because a declaration world said one is at an address, so a reader that
+     * assembled one out of two strings is asking about something that is not a declaration. Answered
+     * with the arm for a module off the path, the reader would be told to go and find a snapshot
+     * that does not exist — which is the mistake it made, handed back as a state of the program.
+     */
+    @Test
+    void andANameNothingDeclaresIsRefused() {
+        CheckedProgram program = CheckedProgram.of(List.of(ROUNDS));
+
+        assertThrows(IllegalArgumentException.class, () -> program.declaration(
+                TypeSymbols.declared(new TypeKey("no.such.module", "Missing"))),
+                "no module of this compile, no module off its path, and not the language's");
+        assertThrows(IllegalArgumentException.class, () -> program.declaration(
+                TypeSymbols.declared(new TypeKey("souther.decimal", "Missing"))),
+                "the reserved namespace is not a place a reader may name a declaration into");
+    }
+
+    /**
+     * What the language declares is enumerable, so an output that has to materialise them is not
+     * left walking the bodies it happened to be given.
+     *
+     * <p>A walk answers about the declarations something in the program names. A language
+     * declaration nothing in this program writes is one such an output would never emit, and the
+     * program would run into it the first time a value of it arrived from somewhere else.
+     */
+    @Test
+    void whatTheLanguageDeclaresIsEnumerable() {
+        CheckedProgram program = CheckedProgram.of(List.of(ROUNDS));
+
+        List<CheckedData> language = program.languageDeclarations();
+
+        assertEquals(
+                List.of("RoundingMode", "HALF_UP", "HALF_EVEN", "HALF_DOWN", "UP", "DOWN",
+                        "CEILING", "FLOOR"),
+                language.stream().map(each -> each.name().name()).toList());
+        for (CheckedData declared : language) {
+            assertEquals(new Declared.Available(declared, DeclaredBy.THE_LANGUAGE),
+                    program.declaration(declared.name()),
+                    "the list and the lookup are one index read two ways");
+        }
+    }
+
+    /** The field called {@code field} of the module's data called {@code data}. */
+    private static ValueShape.Field fieldOf(CheckedModule module, String data, String field) {
+        for (CheckedData declared : module.data()) {
+            if (declared.name().name().equals(data)) {
+                for (ValueShape.Field each : assertInstanceOf(CheckedData.Product.class, declared)
+                        .fields()) {
+                    if (each.name().equals(field)) {
+                        return each;
+                    }
+                }
+            }
+        }
+        throw new AssertionError(data + "." + field + " is not declared by " + module.name());
+    }
+
+    /**
+     * Every identity this program reaches: what its declarations are made of, and what its bodies
+     * name.
+     */
+    private static Set<TypeSymbol.AtModule> everyIdentityIn(CheckedProgram program) {
+        Set<TypeSymbol.AtModule> named = new LinkedHashSet<>(everyIdentityLaidOutIn(program));
+        for (CheckedModule module : program.modules()) {
+            for (CheckedData declared : module.data()) {
+                named.add(declared.name());
+                if (declared instanceof CheckedData.Product product) {
+                    for (ValueShape.Field field : product.fields()) {
+                        namesIn(field.type(), named);
+                    }
+                }
+                if (declared instanceof CheckedData.Sum sum) {
+                    for (TypeSymbol each : sum.cases()) {
+                        namesIn(each, named);
+                    }
+                }
+            }
+        }
+        return named;
+    }
+
+    /** The identities a value is laid out at: the four places a body says what one is made of. */
+    private static Set<TypeSymbol.AtModule> everyIdentityLaidOutIn(CheckedProgram program) {
+        Set<TypeSymbol.AtModule> named = new LinkedHashSet<>();
+        for (CheckedModule module : program.modules()) {
+            for (Core body : bodiesOf(module)) {
+                List<Core.Construct> constructions = new ArrayList<>();
+                collect(body, Core.Construct.class, constructions);
+                for (Core.Construct construction : constructions) {
+                    named.add(construction.typeName());
+                }
+                List<Core.UnitValue> units = new ArrayList<>();
+                collect(body, Core.UnitValue.class, units);
+                for (Core.UnitValue unit : units) {
+                    namesIn(unit.data(), named);
+                }
+                List<Core.FieldAccess> reads = new ArrayList<>();
+                collect(body, Core.FieldAccess.class, reads);
+                for (Core.FieldAccess read : reads) {
+                    namesIn(read.target().type(), named);
+                }
+                List<Core.Match> matches = new ArrayList<>();
+                collect(body, Core.Match.class, matches);
+                for (Core.Match match : matches) {
+                    for (Core.Case arm : match.cases()) {
+                        for (TypeSymbol selected : arm.caseTypes()) {
+                            namesIn(selected, named);
+                        }
+                    }
+                }
+            }
+        }
+        return named;
+    }
+
+    /** The declaration {@code type} names, where it names one. */
+    private static void namesIn(Type type, Set<TypeSymbol.AtModule> named) {
+        if (type instanceof Type.Ref ref) {
+            namesIn(ref.name(), named);
+        }
+    }
+
+    /** The same, of a name: what the language gives directly is no declaration and is not one of
+     *  these. */
+    private static void namesIn(TypeSymbol name, Set<TypeSymbol.AtModule> named) {
+        if (name instanceof TypeSymbol.AtModule at) {
+            named.add(at);
+        }
+    }
+
+    private static List<Core> bodiesOf(CheckedModule module) {
+        List<Core> bodies = new ArrayList<>();
+        for (CheckedBehavior behavior : module.behaviors()) {
+            if (behavior.implementation() instanceof CheckedImplementation.Body written) {
+                bodies.add(written.body());
+            }
+        }
+        for (CheckedHelper helper : module.helpers()) {
+            bodies.add(helper.body());
+        }
+        return bodies;
+    }
+
+    private static <T extends Core> void collect(Core from, Class<T> of, List<T> out) {
+        if (of.isInstance(from)) {
+            out.add(of.cast(from));
+        }
+        Core.forEachChild(from, child -> collect(child, of, out));
+    }
+}


### PR DESCRIPTION
Closes #1094.

## What was wrong

A body that writes `d |> Decimal.round(2, HALF_UP)` puts a value of `RoundingMode` into `Core`. The only way to what a declaration is made of ran through the module that declares it, and `souther.decimal` is not a module of a compilation, so `CheckedProgram.module("souther.decimal")` was null and an output outside this compiler held a typed value it could not lay out.

The route was the defect. A snapshot whose declarations are indexed by who compiled them hands over `Core` indexed by identity, and the two come apart wherever an identity was resolved somewhere the compilation did not check. The reserved namespace is the case where the reader that picks an owner first has no owner to pick — and a dependency's module is the case where picking one gets it nothing.

## What crosses now

`CheckedProgram.declaration(TypeSymbol.AtModule)` is the one place an identity becomes a declaration, and it answers for every identity this compile resolved.

```java
record Declared(CheckedData data, DeclaredBy declaredBy)

enum DeclaredBy { A_MODULE, THE_LANGUAGE, A_MODULE_ON_THE_PATH }
```

What a value is made of is answered the same way for all three worlds. Who declared it decides **who emits it**: a module of this compile is this output's to emit, the language's own is shipped or generated by the output, and a dependency's was emitted by the build that made it. None of those is a reason a value of it cannot be laid out — a dependency's declaration is one this compile read in order to check the module that names it, so what is handed over is the reading the checker itself used.

A name nothing declares is refused, for the reason `CheckedData.Product.positionOf` refuses a name that is no field. What `declaration` is total over is the identities this compile resolved, not every value the Java type admits.

`CheckedProgram.languageDeclarations()` enumerates what the language itself declares, read out of that same index. Without it, an output that has to materialise them would walk the bodies it was given and be right only about the names its walk reached — and `RoundingMode` is not reachable that way at all, since a language-declared type may not stand at a behavior's boundary.

`CheckedModule.data(TypeSymbol.AtModule)` is gone. A module still enumerates what it declares, which is what an output emitting that module has to emit; it no longer answers what a given identity is.

## Mechanisms rather than reminders

- One index, built in one place from what the modules hold plus the two other worlds. Filing refuses a second declaration at any address, so no world can silently take over another's name.
- The assembler mints no identity: a declaration off the path says which one it is.
- The language declares sums and the units under them. A product of its own is refused where the declaration is read, rather than reaching an absent shape — which is what an assembler that forgot to read the shapes would look like too.

## What is held

Outside the compiler (`AnOutputReadsWhatTheLanguageDeclaresTest`): every identity a checked program reaches is answered for, over a program that reaches the language's own and one that reaches a dependency's; `RoundingMode`'s seven cases and `HALF_UP`'s unit come back under `THE_LANGUAGE`; a field read off a dependency's product comes back with the position the check placed it at and the invariant its author wrote; what a dependency declares is here whether or not this program names it; a name nothing declares is refused; the list and the lookup are one index.

Inside (`WhatTheLanguageDeclaresCrossesAsADeclarationTest`): nothing selects on the way over from the library, and one address belongs to one world.

Both refusals were checked by breaking them: falling through to an arm instead of refusing, and dropping the path's products, each turn the tests that name them red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
