### PR TITLE
Read what a sum's cases share where the sum itself stands

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
@@ -141,15 +141,16 @@ final class Clauses {
      */
     StatedClauses statedAt(TypeSymbol.AtModule named, Hir.Data data, Map<BindingId, Core> given) {
         List<Stated> stated = new ArrayList<>();
-        int declared = 0;
+        List<RuleRef.Invariant> lost = new ArrayList<>();
         for (TypeOps.Declared inv : declared(named, data)) {
-            declared++;
             Core one = statedAt(inv.clause().expr(), named, data, given);
             if (one != null) {
                 stated.add(new Stated(Clause.of(inv), one));
+            } else {
+                lost.add(new RuleRef.Invariant(Clause.of(inv).ref()));
             }
         }
-        return new StatedClauses(List.copyOf(stated), stated.size() == declared);
+        return new StatedClauses(List.copyOf(stated), List.copyOf(lost));
     }
 
     /**
@@ -161,15 +162,26 @@ final class Clauses {
      * two are the same list with different things missing from it. Said here, where the dropping
      * happens, rather than counted again by whoever needs to know.
      *
-     * @param everyClauseStated whether every clause the declaration writes is in {@code clauses}.
-     *                          A caller that asked for none of them was not asked to lose any and
-     *                          is told so
+     * @param lost which clauses the declaration writes are not in {@code clauses}, named rather
+     *             than counted. A caller told only that something was lost has to find out what it
+     *             was about by reading the declaration again, and a reader that answers for the
+     *             rules it was handed would otherwise answer for a rule it never saw
      */
-    record StatedClauses(List<Stated> clauses, boolean everyClauseStated) {
+    record StatedClauses(List<Stated> clauses, List<RuleRef.Invariant> lost) {
+
+        public StatedClauses {
+            clauses = List.copyOf(clauses);
+            lost = List.copyOf(lost);
+        }
 
         /** What a reading told to leave a declaration's clauses out gets: none of them, and nothing
          * lost. */
-        static final StatedClauses NONE_ASKED_FOR = new StatedClauses(List.of(), true);
+        static final StatedClauses NONE_ASKED_FOR = new StatedClauses(List.of(), List.of());
+
+        /** Whether every clause the declaration writes is in {@link #clauses}. */
+        boolean everyClauseStated() {
+            return lost.isEmpty();
+        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -879,13 +879,13 @@ public final class DataChecker {
      * can see in every case. */
     private static Map<String, Type> spreadOfSum(String name, Hir.SumData sum, Type bound,
                                                  SourcePos pos, CheckContext ctx) {
-        Map<String, Type> shared = TypeOps.commonSpreadFields(sum, ctx.symbols());
-        if (shared.isEmpty()) {
+        if (!(TypeView.of(Type.ref(sum.declares()), ctx.symbols()).shape() instanceof Shape.Sum shape)
+                || !(shape.common() instanceof Shape.CommonProduct.Shared shared)) {
             throw CompileException.of(Diagnostic.at(pos)
                     .say(new DataMessage.SpreadOfASumWhoseCasesShareNothing(name, Type.show(bound)))
                     .build());
         }
-        return shared;
+        return shared.fields();
     }
 
     private static void checkEncoder(Hir.EncoderDef enc, CheckContext ctx) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -485,11 +485,16 @@ public final class Elaborator {
             // sealed interface declares the accessor its cases already carry (issue #160). Only a
             // named sum, whose interface this compile emits — an anonymous union's cases are not
             // written together, so nothing declares their shared part.
-            if (target instanceof Type.Ref ref && ctx.symbols().declarations().declaration(ref.name()) instanceof Hir.SumData) {
-                Type shared = TypeOps.commonSpreadFields(cases, ctx.symbols()).get(fa.field());
-                if (shared != null) {
-                    return new Core.FieldAccess(targetCore, fa.field(), shared, fa.pos());
-                }
+            // Asked of the type as written and not through the names it wears: how far a read looks
+            // through a newtype is this elaboration's policy, and a `data X = S` over a sum is a
+            // value of X, whose fields are X's. `TypeView` keeps both directions available for that
+            // reason, and this reader takes the one it has always taken.
+            TypeView view = TypeView.of(target, ctx.symbols());
+            if (!view.isWrapped() && view.shape() instanceof Shape.Sum shape
+                    && shape.common() instanceof Shape.CommonProduct.Shared shared
+                    && shared.fields().get(fa.field()) != null) {
+                return new Core.FieldAccess(targetCore, fa.field(),
+                        shared.fields().get(fa.field()), fa.pos());
             }
             // A sum carries no fields of its own — its cases do, and which case it is is not known
             // until it is opened. Saying that is the difference between "this value has no such

--- a/souther-compiler/src/main/java/souther/compiler/check/GuaranteeWalk.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/GuaranteeWalk.java
@@ -4,6 +4,7 @@ import souther.compiler.core.Core;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -48,22 +49,26 @@ final class GuaranteeWalk {
     /**
      * How far a reader is asking this walk to go.
      *
+     * <p>The last two are asked of different things, and are different types for that reason. A
+     * name supposed to hold values is a position; a rule left out is a rule, and one a spread
+     * carries in was written where it was written whatever value it is read at.
+     *
      * @param extent          how far down to read
      * @param stopAt          names this reader is supposing hold values whatever is written under
      *                        them, so nothing under one of them is read
-     * @param withoutClauses  names whose own clauses this reader asked to leave out, what is under
-     *                        them still being read
+     * @param withoutClauses  rules this reader asked to leave out, what is under the declarations
+     *                        that wrote them still being read
      */
-    record Scope(Extent extent, Predicate<TypeSymbol> stopAt, Predicate<TypeSymbol> withoutClauses) {
+    record Scope(Extent extent, Predicate<TypeSymbol> stopAt, RulesLeftOut withoutClauses) {
 
         /** Every rule down to {@code positions} positions, wherever it is written. */
         static Scope asFarAs(int positions) {
-            return new Scope(new Extent.AsFarAs(positions), _ -> false, _ -> false);
+            return new Scope(new Extent.AsFarAs(positions), _ -> false, RulesLeftOut.NONE);
         }
 
         /** Every rule the model writes under this value. */
         static Scope everyPosition() {
-            return new Scope(new Extent.EveryPosition(), _ -> false, _ -> false);
+            return new Scope(new Extent.EveryPosition(), _ -> false, RulesLeftOut.NONE);
         }
     }
 
@@ -196,14 +201,24 @@ final class GuaranteeWalk {
                 return;
             }
         }
-        // What the declaration states is read whatever this walk was asked for; whether this reader
-        // hears it is the scope's answer. A reader told to leave a declaration's clauses out was not
-        // asked to lose any, so nothing is reported lost for them either.
-        if (name == null || !scope.withoutClauses().test(name)) {
-            if (here.coverage() instanceof TypeGuarantees.At.Coverage.Incomplete incomplete) {
-                reader.lostAClause(path, incomplete.lost());
+        // What the declarations state is read whatever this walk was asked for; which of them this
+        // reader hears is the scope's answer, asked of each rule. A rule the reader asked to leave
+        // out is not one it was asked to lose, so nothing is reported lost for it either — and the
+        // rules read here need not have been written on the declaration standing here, which is why
+        // this is not one question about the position.
+        List<RuleRef.Invariant> lost = new ArrayList<>();
+        if (here.coverage() instanceof TypeGuarantees.At.Coverage.Incomplete incomplete) {
+            for (RuleRef.Invariant each : incomplete.lost()) {
+                if (!scope.withoutClauses().excludes(each)) {
+                    lost.add(each);
+                }
             }
-            for (TypeGuarantee guarantee : here.here()) {
+        }
+        if (!lost.isEmpty()) {
+            reader.lostAClause(path, lost);
+        }
+        for (TypeGuarantee guarantee : here.here()) {
+            if (!scope.withoutClauses().excludes(guarantee.rule())) {
                 reader.guaranteed(path, guarantee);
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/GuaranteeWalk.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/GuaranteeWalk.java
@@ -5,6 +5,7 @@ import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -112,7 +113,7 @@ final class GuaranteeWalk {
         }
     }
 
-    /** Told what was read, and where the reading stopped. */
+    /** Told what was read, what another reading answers for, and where this walk stopped. */
     interface Reader {
 
         /** What the declaration at {@code path} guarantees of the value there. */
@@ -121,32 +122,41 @@ final class GuaranteeWalk {
         /** Where the walk went no further, and what stood there. */
         default void stopped(String path, Type type, Stop why) {}
 
-        /** That a declaration at {@code path} writes clauses this reading could not state, so what
-         * they were about is not among what was handed over. */
-        default void lostAClause(String path) {}
+        /**
+         * That rules stand under {@code path} which no reading here takes in, and which a reading
+         * opened elsewhere answers for — the cases of a sum, what a container holds.
+         *
+         * <p>Not a stop. The position was read and what it states was heard; this says only that
+         * something below it belongs to somebody else. Reported as a stop, a sum whose cases share a
+         * spread would have to be either read or handed on, and it is both.
+         */
+        default void handedOn(String path, Type type) {}
+
+        /** That a declaration at {@code path} writes these clauses and this reading could not state
+         * them, so what they were about is not among what was handed over. */
+        default void lostAClause(String path, List<RuleRef.Invariant> lost) {}
     }
 
-    /** Why a walk went no further. */
+    /**
+     * Why a walk went no further.
+     *
+     * <p>Every one of them is this walk's own doing. A position it did not enter because nothing
+     * there belongs to it is not a stop at all — that is {@link Reader#handedOn}, and it is answered
+     * by the reading rather than by the walk. Held here as a stop, a position that both states rules
+     * and leaves something below to another reading could only be one of the two.
+     */
     enum Stop {
 
         /** As far down as the reader asked to be taken. Not a limit on the model: a rule four
          * records down refuses the outermost construction exactly as one on its own fields does. */
         PAST_THE_DEPTH,
 
-        /** Nothing is declared here that could hold a rule about every value standing at it: a
-         * container or an optional, a type nothing is written under, or a choice between
-         * declarations, whose rules are about values of one case and not about every value here. */
-        NOTHING_DECLARED,
-
         /** A name the reader is supposing holds values, so what is under it says nothing here. */
         ASKED_TO_STOP,
 
         /** Met already on the way down, and read where it was met. A record holding one of its own
          * kind stops here and nothing is short of anything for it. */
-        ALREADY_ENTERED,
-
-        /** A declaration names a position the walk could find no value for. */
-        NO_VALUE_THERE
+        ALREADY_ENTERED
     }
 
     /**
@@ -168,57 +178,56 @@ final class GuaranteeWalk {
             reader.stopped(path, root.type(), Stop.PAST_THE_DEPTH);
             return;
         }
-        if (!(root.type() instanceof Type.Ref ref)) {
-            // Nothing here is named, so there is nothing this walk could have been told to stop at
-            // and nothing to record as entered.
-            reader.stopped(path, root.type(), Stop.NOTHING_DECLARED);
-            return;
+        // The reading first, because what stands here is what this walk's own limits are about: the
+        // name it was told to stop at and the name it has already entered are the declaration's, and
+        // asking the type for one beside the reading is a second answer to that.
+        TypeGuarantees.At here = guarantees.at(root, at);
+        TypeSymbol name = here.name();
+        if (name != null) {
+            if (scope.stopAt().test(name)) {
+                reader.stopped(path, root.type(), Stop.ASKED_TO_STOP);
+                return;
+            }
+            // A name already entered was read where it was met, so reading it again would be the
+            // same reading done twice — which costs, and which a reader that remembers what it was
+            // asked would see twice.
+            if (entered.contains(name)) {
+                reader.stopped(path, root.type(), Stop.ALREADY_ENTERED);
+                return;
+            }
         }
-        // Asked of the name and before the reading, because being told to stop at a name is this
-        // walk's business and says nothing about what the declaration states.
-        if (scope.stopAt().test(ref.name())) {
-            reader.stopped(path, root.type(), Stop.ASKED_TO_STOP);
-            return;
+        // What the declaration states is read whatever this walk was asked for; whether this reader
+        // hears it is the scope's answer. A reader told to leave a declaration's clauses out was not
+        // asked to lose any, so nothing is reported lost for them either.
+        if (name == null || !scope.withoutClauses().test(name)) {
+            if (here.coverage() instanceof TypeGuarantees.At.Coverage.Incomplete incomplete) {
+                reader.lostAClause(path, incomplete.lost());
+            }
+            for (TypeGuarantee guarantee : here.here()) {
+                reader.guaranteed(path, guarantee);
+            }
         }
-        // Asked before the declaration is read, and of the type's own name, which is the name a
-        // reading here would answer with. A name already entered was read where it was met, so
-        // reading it again would be the same reading done twice — which costs, and which a reader
-        // that remembers what it was asked would see twice.
-        if (entered.contains(ref.name())) {
-            reader.stopped(path, root.type(), Stop.ALREADY_ENTERED);
-            return;
-        }
-        if (!(guarantees.at(root, at) instanceof TypeGuarantees.At.Declared here)) {
-            reader.stopped(path, root.type(), Stop.NOTHING_DECLARED);
-            return;
+        // Said whether or not anything was read here, and never instead of it. Both are true of a
+        // sum whose cases share a spread.
+        if (here.handedOn() instanceof TypeGuarantees.At.HandedOn.ToAnotherReading) {
+            reader.handedOn(path, root.type());
         }
         // Entered before anything under it is walked, so that the one name and the other stay
         // paired: a stop taken after entering would leave the name on the path with nothing to take
         // it off, and the next field of the same type would be passed over as one already read.
-        entered.add(here.name());
-        // What the declaration states is read whatever this walk was asked for; whether this reader
-        // hears it is the scope's answer. A reader told to leave a declaration's clauses out was not
-        // asked to lose any, so nothing is reported lost for them either.
-        if (!scope.withoutClauses().test(here.name())) {
-            if (!here.everyClauseStated()) {
-                reader.lostAClause(path);
-            }
-            for (TypeGuarantee guarantee : here.guarantees()) {
-                reader.guaranteed(path, guarantee);
-            }
+        if (name != null) {
+            entered.add(name);
         }
         for (TypeGuarantees.At.Beneath under : here.beneath()) {
             // A position wearing a name is at a path of its own; a newtype's value is the same
             // position and keeps this one's, which is the rule a path walks by: wearing a name is
             // not being somewhere else.
             String there = under.field().isEmpty() ? path : under(path, under.field());
-            if (under.value() == null) {
-                reader.stopped(there, under.type(), Stop.NO_VALUE_THERE);
-            } else {
-                walk(under.value(), there, at, depth + 1, scope, entered, reader);
-            }
+            walk(under.value(), there, at, depth + 1, scope, entered, reader);
         }
-        entered.remove(here.name());
+        if (name != null) {
+            entered.remove(name);
+        }
     }
 
     /** A field of the value at {@code path}. The root of a newtype's own reading is the value it

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -830,11 +830,13 @@ public final class InvariantChecker {
             inner = new Core.FieldAccess(inner, "value", under, NOWHERE);
             worn = under;
         }
-        if (depth > GuaranteeWalk.FIELDS_SEEDED || !(worn instanceof Type.Ref ref)
-                || !(symbols.declarations().declaration(ref.name()) instanceof Hir.Data data) || data.newtype()) {
+        if (depth > GuaranteeWalk.FIELDS_SEEDED) {
             return;
         }
-        for (Map.Entry<String, Type> field : clauses.fieldsOf(data).entrySet()) {
+        // Which positions a value has is the reading's answer and not a second classification here:
+        // a record's fields, and the part a sum's cases share, which is readable on a value of the
+        // sum exactly as a field of a record is.
+        for (Map.Entry<String, Type> field : PositionReading.of(worn, symbols).positionsUnder().entrySet()) {
             name(new Core.FieldAccess(inner, field.getKey(), field.getValue(), NOWHERE),
                     GuaranteeWalk.under(path, field.getKey()), field.getValue(), at, symbols, depth + 1,
                     atoms, typeAt, held, keys);

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -476,25 +476,32 @@ public final class InvariantChecker {
      * was still descended into, so a value supposed to exist came back impossible by the rules of
      * what it wraps — the supposing undone one step in, by the same walk that honoured it.
      *
-     * @param withoutClauses which declarations' own clauses are left out, what is under them still
-     *                       being read
+     * <p><b>One of them is asked of a rule and the other of a position, and they are different
+     * types for that reason.</b> Which rules are left out is a property of each rule — the
+     * declaration that wrote it — and a rule a spread carries in was written where it was written,
+     * whatever value it is being read at. Which names are not read at all is a property of the
+     * position. The two are the same name only where a declaration writes its own clauses and
+     * spreads nothing, and asked alike a spread rule was left in whatever a reader asked for, so
+     * every end it held was held by nobody a report could name.
+     *
+     * @param withoutClauses which rules are left out, what is under the declarations that wrote
+     *                       them still being read
      * @param stopAt         which declarations are not read at all
      */
-    record Reach(java.util.function.Predicate<TypeSymbol> withoutClauses,
-                 java.util.function.Predicate<TypeSymbol> stopAt) {
+    record Reach(RulesLeftOut withoutClauses, java.util.function.Predicate<TypeSymbol> stopAt) {
 
         /** Every rule, wherever it is written. */
-        static final Reach EVERYTHING = new Reach(_ -> false, _ -> false);
+        static final Reach EVERYTHING = new Reach(RulesLeftOut.NONE, _ -> false);
 
         /** Every rule but the ones {@code these} names wrote. */
         static Reach withoutClausesOf(java.util.function.Predicate<TypeSymbol> these) {
-            return new Reach(these, _ -> false);
+            return new Reach(RulesLeftOut.writtenOn(these), _ -> false);
         }
 
         /** Every rule that is not reached through one of {@code these}, they being supposed to hold
          * values whatever is written under them. */
         static Reach stoppingAt(java.util.function.Predicate<TypeSymbol> these) {
-            return new Reach(_ -> false, these);
+            return new Reach(RulesLeftOut.NONE, these);
         }
     }
 
@@ -588,26 +595,34 @@ public final class InvariantChecker {
             }
         };
         try {
-            boolean own = !reach.withoutClauses().test(named) && !reach.stopAt().test(named);
-            if (!own && !c.clauses.of(named, data).isEmpty()) {
-                // Left out because this reading was asked to leave them out, which is still a rule
-                // of the value that no reading here took in. At the value itself, since a clause of
-                // this declaration can name any position of it.
+            // Not read at all, which is a question about this position and is asked once.
+            boolean opened = !reach.stopAt().test(named);
+            // And whether any rule of it was left out, which is asked of each rule. The two are
+            // recorded at different grains on purpose: what is left out is a rule, and what is
+            // missing from this reading is the position, since a clause of this declaration can
+            // name any position of it.
+            boolean skipped = false;
+            if (!opened && !c.clauses.of(named, data).isEmpty()) {
                 gathering.missed(FieldDomains.THE_VALUE, Borne.BY_EVERY_VALUE);
             }
             for (TypeOps.Declared declared :
-                    own ? c.clauses.declared(named, data) : List.<TypeOps.Declared>of()) {
+                    opened ? c.clauses.declared(named, data) : List.<TypeOps.Declared>of()) {
+                // Where this clause becomes a rule of the model something can be attributed to.
+                // Everything below carries the origin as it is: what is written down here is read
+                // back by a report, and a reader handed the clause reference instead would have to
+                // decide for itself which of the rules that draw a line it was looking at. It is
+                // also what says whether this reader asked for the rule at all.
+                RuleRef.Invariant origin = new RuleRef.Invariant(Clause.Ref.of(declared));
+                if (reach.withoutClauses().excludes(origin)) {
+                    skipped = true;
+                    continue;
+                }
                 Core stated = c.clauses.typed(declared.clause().expr(), named, data).orNull();
                 if (stated == null) {
                     read = false;
                     gathering.missed(FieldDomains.THE_VALUE, Borne.BY_EVERY_VALUE);
                     continue;
                 }
-                // Where this clause becomes a rule of the model something can be attributed to.
-                // Everything below carries the origin as it is: what is written down here is read
-                // back by a report, and a reader handed the clause reference instead would have to
-                // decide for itself which of the rules that draw a line it was looking at.
-                RuleRef.Invariant origin = new RuleRef.Invariant(Clause.Ref.of(declared));
                 written.add(new Written(origin, stated));
                 Predicates.Owed owed = c.predicates.assumed(stated, at, false,
                         (part, said) -> gathering.constrained(origin, part, partRead(said)));
@@ -618,6 +633,12 @@ public final class InvariantChecker {
                 Predicates.subjectsIn(owed).forEach(spoken -> took.record(origin, spoken));
                 read &= !owed.unreadable();
                 k = c.predicates.assume(owed, k, Known.Held.OF_THE_VALUE);
+            }
+            if (skipped) {
+                // A rule of this value that no reading here took in, said once however many were
+                // left out: what is recorded is which position is short, and the position is this
+                // value either way.
+                gathering.missed(FieldDomains.THE_VALUE, Borne.BY_EVERY_VALUE);
             }
             // And what each field's own type says of it, at the field's own location. A depth of one
             // is already spent on the record, so this reaches the field's newtype and stops where the
@@ -915,11 +936,11 @@ public final class InvariantChecker {
      * said there. Read off the path instead, a reader would be deciding from a spelling what the
      * walk knew.
      *
-     * <p><b>Asked only of the stops that leave rules unread.</b> Which those are is
-     * {@link PathEngine#leftBy}'s answer and is not restated here: a stop that hands the rules to a
-     * reading one position down leaves nothing for anybody to bear ({@link Gathering#handedOn}).
-     * Nothing here decides what is handed on, so the day these two questions stop agreeing is a day
-     * nothing was resting on their agreeing (#1072).
+     * <p><b>Asked only of a stop, and never of a handing on.</b> Every way a walk stops short
+     * leaves its rules unread and this says how much of the position they were about; whether some
+     * rule below belongs to a reading opened elsewhere is a separate answer the reading gives beside
+     * what it read ({@link Gathering#handedOn}). Nothing here decides that, and a position may
+     * truthfully be both.
      */
     enum Borne {
 
@@ -1988,10 +2009,10 @@ public final class InvariantChecker {
                 Known out = walk(m.scrutinee(), k, at, copies);
                 List<Entered> ways = new ArrayList<>();
                 for (Core.Case c : m.cases()) {
-                    // A sum has no fields of its own, so the scrutinee is not a location any clause
-                    // could have named — the case's value names only itself. What the arm binds is a
-                    // value of the case's type, reached only here, so it is a location this arm
-                    // introduces and it carries what that type guarantees.
+                    // What the arm binds is a value of the case's type, reached only here, so it is
+                    // a location this arm introduces and it carries what that type guarantees. What
+                    // the scrutinee itself guarantees was read where the scrutinee stands, the part
+                    // its cases share included, and is not read again under the case.
                     // The scrutinee travels with the arm: what a caller may assume of an answer is
                     // decided by which behavior answered and which case this arm opened, and the
                     // first of those is a question about what is being matched.

--- a/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PathEngine.java
@@ -631,7 +631,16 @@ final class PathEngine {
         }
 
         @Override
-        public void lostAClause(String path) {
+        public void handedOn(String path, Type type) {
+            // Whether a rule stands under what is being left is the reading's answer and was asked
+            // there. Nothing is re-derived here from the type.
+            if (gathering != null) {
+                gathering.handedOn(path);
+            }
+        }
+
+        @Override
+        public void lostAClause(String path, List<RuleRef.Invariant> lost) {
             // Said whatever stands under the position, because the clause was read and lost rather
             // than never reached: a reader answering for the clauses it was handed would otherwise
             // answer for a rule it never saw.
@@ -667,76 +676,42 @@ final class PathEngine {
     }
 
     /**
-     * Tells the reading where it stopped, and which of the two kinds of stop it was.
+     * Tells the reading where it stopped, and how much of what stands there the rules it left are
+     * about.
      *
-     * <p>Every way the walk stops short comes here. Whether a stop is worth saying anything about is
-     * a question about the model — is any rule written under what is being left — and asking it of
-     * the walk's own reach would answer that whatever was not read had nothing in it. That question
-     * decides whether anything is owed here; it does not decide what is owed, which is the
-     * distinction below.
+     * <p>Every way the walk stops short comes here, and every one of them leaves the rules unread.
+     * Whether a stop is worth saying anything about is a question about the model — is any rule
+     * written under what is being left — and asking it of the walk's own reach would answer that
+     * whatever was not read had nothing in it.
+     *
+     * <p><b>Nothing here hands anything on.</b> A position whose rules belong to a reading opened
+     * elsewhere is not a position this walk stopped at: the walk reads it, says what it states, and
+     * says separately that something below it is somebody else's ({@link Seeding#handedOn}).
      */
     private void stopping(Type type, String path, InvariantChecker.Gathering gathering,
                           GuaranteeWalk.Stop why) {
         if (gathering == null || type == null || !guarantees.anyRuleUnder(type)) {
             return;
         }
-        switch (leftBy(why)) {
-            case Leaves.ToAnotherReading _ -> gathering.handedOn(path);
-            case Leaves.Unread(InvariantChecker.Borne borne) -> gathering.missed(path, borne);
-        }
-    }
-
-    /** What a stop leaves behind. */
-    sealed interface Leaves {
-
-        /**
-         * Rules for a reading one position down, and nothing wrong here.
-         *
-         * <p>There is no declaration standing at the position for this reading to take in — a
-         * container, an optional, a choice between declarations — so what is written under it is
-         * written about a value below, where a reading of that declaration is opened and a row meets
-         * it. The rules are not lost; the responsibility for them is somebody else's, and whoever
-         * walks the positions has to show that somebody took it (#1072).
-         */
-        record ToAnotherReading() implements Leaves {}
-
-        /** Rules no reading here took in, and how much of what stands at the position they were
-         *  about. */
-        record Unread(InvariantChecker.Borne borne) implements Leaves {}
+        gathering.missed(path, leftBy(why));
     }
 
     /**
-     * What each way of stopping leaves behind.
-     *
-     * <p><b>The one statement of it.</b> Which stops hand the rules on and which leave them unread
-     * is one partition of one enum, and it used to be spelled again in the prose of every word
-     * downstream of it — {@link InvariantChecker.Borne}, {@link souther.compiler.values.UnreadReason},
-     * the account a seeding gives of itself. A partition restated is a partition that goes on being
-     * true only until somebody moves an arm, and then the code is right and the sentences are not.
-     * So it is written here once and referred to.
+     * How much of what stands at a position the rules a stop left unread are about.
      *
      * <p>Exhaustive with no {@code default}, so a way of stopping added later is a compile error
-     * here rather than a stop quietly counted as a loss — or, worse, quietly counted as handed on to
-     * a reading that was never opened.
-     *
-     * <p>Asked of the stop and never of {@link InvariantChecker.Borne}. What a stop leaves unread
-     * and whether the rules pass to another reading are different questions that agree today by
-     * coincidence: every stop that hands on is borne by some values, and one that is borne by some
-     * values need not hand anything on. Read off the second, the coincidence becomes the rule.
+     * here rather than a stop quietly counted as borne by every value.
      */
-    static Leaves leftBy(GuaranteeWalk.Stop why) {
+    static InvariantChecker.Borne leftBy(GuaranteeWalk.Stop why) {
         return switch (why) {
-            case NOTHING_DECLARED -> new Leaves.ToAnotherReading();
-            // A depth this reader could not afford, a name it was told to suppose holds values, and
-            // a field it could find no value for. Each stops where a construction still has to make
-            // the value, so a rule under it can refuse the construction.
-            case PAST_THE_DEPTH, ASKED_TO_STOP, NO_VALUE_THERE ->
-                    new Leaves.Unread(InvariantChecker.Borne.BY_EVERY_VALUE);
+            // A depth this reader could not afford, and a name it was told to suppose holds values.
+            // Each stops where a construction still has to make the value, so a rule under it can
+            // refuse the construction.
+            case PAST_THE_DEPTH, ASKED_TO_STOP -> InvariantChecker.Borne.BY_EVERY_VALUE;
             // Read where the name was met, and nothing is opened here — so nobody takes the rules
             // over. Counted as a handing on, a type holding its own kind would be discharged by the
             // reading made of it further up.
-            case ALREADY_ENTERED ->
-                    new Leaves.Unread(InvariantChecker.Borne.BY_SOME_VALUES);
+            case ALREADY_ENTERED -> InvariantChecker.Borne.BY_SOME_VALUES;
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/PositionReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PositionReading.java
@@ -1,0 +1,158 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Hir;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * What the model writes at a position, before any value stands there.
+ *
+ * <p>The one step every reading of a declaration takes. Which declarations state something of every
+ * value here, what is readable on such a value, and what stands below that no reading here takes in
+ * are three facts about a type, and every reader of a position wants some of them. Each working them
+ * out from the declaration is how a sum comes to be a position that states nothing to one reader, a
+ * position with a readable field to a second, and a class with an accessor to a third.
+ *
+ * <p><b>What kind of position this is, is {@link Shape}'s answer, and the shared part of a sum is
+ * part of that answer.</b> Nothing here resolves a name to a declaration to find out what kind of
+ * thing it is; {@link TypeView} has done that, and this says what the model writes at each kind.
+ *
+ * <p>Nothing here reads a clause, a value, or a path. What a clause states of a value in hand is
+ * {@link TypeGuarantees}, which asks this where it starts; how far to walk is
+ * {@link GuaranteeWalk}'s. Held together, the depth a reader could afford would be part of what a
+ * declaration means.
+ *
+ * @param owners    the declarations whose clauses hold of every value standing here. One for a
+ *                  record or a newtype; for a sum, the declarations its cases share — a rule written
+ *                  on one case refuses values of that case and not every value here
+ * @param fields    what is readable on a value here, in the order it is declared
+ * @param atOwnPath whether those fields are at paths of their own. A newtype's {@code value} is not:
+ *                  wearing a name is not being somewhere else
+ * @param handedOn  what stands under this position that no reading here takes in — the cases of a
+ *                  sum, what a container holds
+ */
+record PositionReading(List<Owner> owners, Map<String, Type> fields, boolean atOwnPath,
+                       List<Type> handedOn) {
+
+    /** A declaration whose clauses hold of every value standing at a position, and the name it was
+     *  reached by — which is what a clause of it resolves its fields against. */
+    record Owner(TypeSymbol.AtModule named, Hir.Data data) {}
+
+    PositionReading {
+        owners = List.copyOf(owners);
+        handedOn = List.copyOf(handedOn);
+    }
+
+    private static final PositionReading NOTHING =
+            new PositionReading(List.of(), Map.of(), true, List.of());
+
+    /** What the model writes at a position of {@code type}. */
+    static PositionReading of(Type type, Symbols symbols) {
+        TypeView view = TypeView.of(type, symbols);
+        if (view.isWrapped()) {
+            // One name at a time. What the layer states is stated of this very atom, and what the
+            // value under it states is read where a walk reaches it.
+            TypeOps.Layer worn = view.wrappers().getFirst();
+            return new PositionReading(owning(worn.named(), symbols),
+                    TypeOps.fieldTypes(worn.data(), symbols), false, List.of());
+        }
+        return switch (view.shape()) {
+            // Through the one step down a type, which the reading of a behavior's inputs and the
+            // plan for building a value already share.
+            case Shape.Product product -> {
+                StructuralDescent.Children under = StructuralDescent.of(product);
+                yield new PositionReading(owning(under.of(), symbols), under.under(), true,
+                        List.of());
+            }
+            // A sum is a common product times a choice of case. What the cases share is stated of
+            // every value standing here; what one case declares is under that case, and a reading of
+            // it is opened where a match opens the case.
+            case Shape.Sum sum -> switch (sum.common()) {
+                case Shape.CommonProduct.Shared shared -> new PositionReading(
+                        owning(shared.origins(), symbols), shared.fields(), true,
+                        cases(sum.name(), symbols));
+                case Shape.CommonProduct.None _ -> new PositionReading(List.of(), Map.of(), true,
+                        cases(sum.name(), symbols));
+            };
+            // A unit data holds nothing and may write no rule about it (spec §unit-data), and a
+            // primitive is written under no declaration of its own.
+            case Shape.Unit _, Shape.Scalar _ -> NOTHING;
+            // What a container holds, what an option holds when it holds anything, an unnamed
+            // union's members, a tuple's elements. Each is a value a reading of its own is opened
+            // at, and none of them is a value standing here.
+            case Shape.Cases _, Shape.Sequence _, Shape.Mapping _, Shape.Optional _, Shape.Tuple _,
+                 Shape.Function _ -> new PositionReading(List.of(), Map.of(), true, held(type));
+            // Nothing was interpreted, so nothing is written here and nothing is under it.
+            case Shape.Unresolved _, Shape.Uninhabited _, Shape.Bottom _, Shape.Erroneous _,
+                 Shape.Undecided _ -> NOTHING;
+        };
+    }
+
+    /**
+     * The declaration standing here, which a walk files what it has entered under, or null where no
+     * declaration does.
+     *
+     * <p>A sum whose cases share nothing declares nothing of every value here and is still a
+     * declaration a walk has entered, so this is asked of the shape and not of {@link #owners}.
+     */
+    static TypeSymbol entering(Type type, Symbols symbols) {
+        TypeView view = TypeView.of(type, symbols);
+        if (view.isWrapped()) {
+            return view.wrappers().getFirst().named();
+        }
+        return switch (view.shape()) {
+            case Shape.Product product -> product.name();
+            case Shape.Sum sum -> sum.name();
+            case Shape.Unit unit -> unit.name();
+            case Shape.Scalar _, Shape.Cases _, Shape.Sequence _, Shape.Mapping _,
+                 Shape.Optional _, Shape.Tuple _, Shape.Function _, Shape.Unresolved _,
+                 Shape.Uninhabited _, Shape.Bottom _, Shape.Erroneous _, Shape.Undecided _ -> null;
+        };
+    }
+
+    /**
+     * The positions a value here has of its own, each at the name it is reached by.
+     *
+     * <p>Empty for a position whose contents are at no path of its own — a newtype is the value it
+     * wraps, and a caller stepping into one would file every position under it one step too deep.
+     */
+    Map<String, Type> positionsUnder() {
+        return atOwnPath ? fields : Map.of();
+    }
+
+    private static List<Owner> owning(TypeSymbol name, Symbols symbols) {
+        return owning(List.of(name), symbols);
+    }
+
+    /** The declarations these names denote, leaving out any that denotes none. */
+    private static List<Owner> owning(List<TypeSymbol> names, Symbols symbols) {
+        List<Owner> out = new ArrayList<>();
+        for (TypeSymbol name : names) {
+            Owner owner = TypeOps.writingFields(name, symbols);
+            if (owner != null) {
+                out.add(owner);
+            }
+        }
+        return out;
+    }
+
+    /** A sum's cases, as the one closure over them answers. */
+    private static List<Type> cases(TypeSymbol sum, Symbols symbols) {
+        List<Type> out = new ArrayList<>();
+        for (TypeSymbol leaf : AtomSpace.subjectAtoms(Type.ref(sum), symbols)) {
+            out.add(Type.ref(leaf));
+        }
+        return out;
+    }
+
+    /** The types a compound holds. */
+    private static List<Type> held(Type type) {
+        List<Type> out = new ArrayList<>();
+        Type.forEachChild(type, out::add);
+        return out;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/PositionReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PositionReading.java
@@ -26,6 +26,10 @@ import java.util.Map;
  * {@link GuaranteeWalk}'s. Held together, the depth a reader could afford would be part of what a
  * declaration means.
  *
+ * @param entering  the declaration standing here, which a walk files what it has entered under and
+ *                  a reader supposing values names, or null where no declaration stands here. Not
+ *                  {@link #owners}: a sum whose cases share nothing declares nothing of every value
+ *                  here and is a declaration a walk has entered all the same
  * @param owners    the declarations whose clauses hold of every value standing here. One for a
  *                  record or a newtype; for a sum, the declarations its cases share — a rule written
  *                  on one case refuses values of that case and not every value here
@@ -35,8 +39,8 @@ import java.util.Map;
  * @param handedOn  what stands under this position that no reading here takes in — the cases of a
  *                  sum, what a container holds
  */
-record PositionReading(List<Owner> owners, Map<String, Type> fields, boolean atOwnPath,
-                       List<Type> handedOn) {
+record PositionReading(TypeSymbol entering, List<Owner> owners, Map<String, Type> fields,
+                       boolean atOwnPath, List<Type> handedOn) {
 
     /** A declaration whose clauses hold of every value standing at a position, and the name it was
      *  reached by — which is what a clause of it resolves its fields against. */
@@ -47,8 +51,9 @@ record PositionReading(List<Owner> owners, Map<String, Type> fields, boolean atO
         handedOn = List.copyOf(handedOn);
     }
 
-    private static final PositionReading NOTHING =
-            new PositionReading(List.of(), Map.of(), true, List.of());
+    private static PositionReading nothing(TypeSymbol entering) {
+        return new PositionReading(entering, List.of(), Map.of(), true, List.of());
+    }
 
     /** What the model writes at a position of {@code type}. */
     static PositionReading of(Type type, Symbols symbols) {
@@ -57,7 +62,7 @@ record PositionReading(List<Owner> owners, Map<String, Type> fields, boolean atO
             // One name at a time. What the layer states is stated of this very atom, and what the
             // value under it states is read where a walk reaches it.
             TypeOps.Layer worn = view.wrappers().getFirst();
-            return new PositionReading(owning(worn.named(), symbols),
+            return new PositionReading(worn.named(), owning(worn.named(), symbols),
                     TypeOps.fieldTypes(worn.data(), symbols), false, List.of());
         }
         return switch (view.shape()) {
@@ -65,52 +70,32 @@ record PositionReading(List<Owner> owners, Map<String, Type> fields, boolean atO
             // plan for building a value already share.
             case Shape.Product product -> {
                 StructuralDescent.Children under = StructuralDescent.of(product);
-                yield new PositionReading(owning(under.of(), symbols), under.under(), true,
-                        List.of());
+                yield new PositionReading(under.of(), owning(under.of(), symbols), under.under(),
+                        true, List.of());
             }
             // A sum is a common product times a choice of case. What the cases share is stated of
             // every value standing here; what one case declares is under that case, and a reading of
             // it is opened where a match opens the case.
             case Shape.Sum sum -> switch (sum.common()) {
-                case Shape.CommonProduct.Shared shared -> new PositionReading(
+                case Shape.CommonProduct.Shared shared -> new PositionReading(sum.name(),
                         owning(shared.origins(), symbols), shared.fields(), true,
                         cases(sum.name(), symbols));
-                case Shape.CommonProduct.None _ -> new PositionReading(List.of(), Map.of(), true,
-                        cases(sum.name(), symbols));
+                case Shape.CommonProduct.None _ -> new PositionReading(sum.name(), List.of(),
+                        Map.of(), true, cases(sum.name(), symbols));
             };
             // A unit data holds nothing and may write no rule about it (spec §unit-data), and a
             // primitive is written under no declaration of its own.
-            case Shape.Unit _, Shape.Scalar _ -> NOTHING;
+            case Shape.Unit unit -> nothing(unit.name());
+            case Shape.Scalar _ -> nothing(null);
             // What a container holds, what an option holds when it holds anything, an unnamed
             // union's members, a tuple's elements. Each is a value a reading of its own is opened
             // at, and none of them is a value standing here.
             case Shape.Cases _, Shape.Sequence _, Shape.Mapping _, Shape.Optional _, Shape.Tuple _,
-                 Shape.Function _ -> new PositionReading(List.of(), Map.of(), true, held(type));
+                 Shape.Function _ -> new PositionReading(null, List.of(), Map.of(), true,
+                         held(type));
             // Nothing was interpreted, so nothing is written here and nothing is under it.
             case Shape.Unresolved _, Shape.Uninhabited _, Shape.Bottom _, Shape.Erroneous _,
-                 Shape.Undecided _ -> NOTHING;
-        };
-    }
-
-    /**
-     * The declaration standing here, which a walk files what it has entered under, or null where no
-     * declaration does.
-     *
-     * <p>A sum whose cases share nothing declares nothing of every value here and is still a
-     * declaration a walk has entered, so this is asked of the shape and not of {@link #owners}.
-     */
-    static TypeSymbol entering(Type type, Symbols symbols) {
-        TypeView view = TypeView.of(type, symbols);
-        if (view.isWrapped()) {
-            return view.wrappers().getFirst().named();
-        }
-        return switch (view.shape()) {
-            case Shape.Product product -> product.name();
-            case Shape.Sum sum -> sum.name();
-            case Shape.Unit unit -> unit.name();
-            case Shape.Scalar _, Shape.Cases _, Shape.Sequence _, Shape.Mapping _,
-                 Shape.Optional _, Shape.Tuple _, Shape.Function _, Shape.Unresolved _,
-                 Shape.Uninhabited _, Shape.Bottom _, Shape.Erroneous _, Shape.Undecided _ -> null;
+                 Shape.Undecided _ -> nothing(null);
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/RulesLeftOut.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/RulesLeftOut.java
@@ -1,0 +1,39 @@
+package souther.compiler.check;
+
+import souther.compiler.types.TypeSymbol;
+
+import java.util.function.Predicate;
+
+/**
+ * Which rules a reading was asked to leave out.
+ *
+ * <p>A reading is asked to leave a declaration's rules out so that the end which moves says which
+ * declaration was holding it. What is left out is a property of each rule — the declaration that
+ * wrote it — and not of the value the reading happens to be opened at. The two are the same name
+ * only where a declaration writes its own clauses and spreads nothing: a rule a spread carries in
+ * was written where it was written, and a sum states what its cases share while writing none of it.
+ *
+ * <p><b>A type and not a predicate.</b> Held as a {@code Predicate}, a caller could hand one over
+ * a position's name and it would compile — a method reference to {@code equals} takes an
+ * {@code Object} and satisfies a predicate of any argument — and the reading would leave nothing
+ * out while looking as though it had. Nothing here can be built except by naming declarations, and
+ * nothing outside asks the question in any other terms.
+ *
+ * @param declarations which declarations' rules are left out, named as a caller thinks of them
+ */
+record RulesLeftOut(Predicate<TypeSymbol> declarations) {
+
+    /** Every rule is read. */
+    static final RulesLeftOut NONE = new RulesLeftOut(_ -> false);
+
+    /** The rules {@code these} names wrote, wherever they are read. */
+    static RulesLeftOut writtenOn(Predicate<TypeSymbol> these) {
+        return new RulesLeftOut(these);
+    }
+
+    /** Whether this reading was asked to leave {@code rule} out. Asked of the rule, which carries
+     *  the declaration it was written on however far it has travelled. */
+    boolean excludes(RuleRef.Invariant rule) {
+        return declarations.test(rule.clause().id().declaredOn());
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Shape.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Shape.java
@@ -115,6 +115,8 @@ public sealed interface Shape permits Shape.ReadablePositionShape, Shape.Cases, 
         record Shared(List<TypeSymbol> origins, Map<String, Type> fields) implements CommonProduct {
 
             public Shared {
+                // A data with no fields is a unit data and is written without a body (E1008), so a
+                // shared declaration has fields and a clause of it is about them.
                 if (origins.isEmpty() || fields.isEmpty()) {
                     throw new IllegalArgumentException("a shared part sharing nothing is None");
                 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Shape.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Shape.java
@@ -81,11 +81,53 @@ public sealed interface Shape permits Shape.ReadablePositionShape, Shape.Cases, 
         }
     }
 
-    /** A declared sum, {@code data S = A | B}. */
-    record Sum(TypeSymbol name) implements ReadablePositionShape {}
+    /**
+     * A declared sum, {@code data S = A | B}, and the part its cases hold in common.
+     *
+     * <p>The two are independent and the record says so by holding both. A sum is a common product
+     * times a choice of case, never a choice between the common part and the cases: sharing a spread
+     * adds no case and changes no case's identity, so a reader asking what the position divides into
+     * reads {@link #name} and is right to ignore {@link #common}.
+     */
+    record Sum(TypeSymbol name, CommonProduct common) implements ReadablePositionShape {}
+
+    /**
+     * What every case of a sum spreads, or that they spread nothing.
+     *
+     * <p>Sharing is nominal: the cases hold this in common because the author wrote the same
+     * {@code ...Common} in each, not because two of them happen to declare a field of one name. So
+     * what is shared is declarations, and the fields are read off them — which is why {@link Shared}
+     * keeps both. Held as fields alone, a reader wanting the rules written over them has only the
+     * field names to find the declaration back from, and works it out again.
+     */
+    sealed interface CommonProduct {
+
+        /** The cases share no spread, so the sum has no part of its own. */
+        record None() implements CommonProduct {}
+
+        /**
+         * The declarations every case spreads, and the fields they contribute.
+         *
+         * @param origins the shared declarations, outermost spread first — what a rule written over
+         *                the shared fields is written on
+         * @param fields  what those declarations declare, in the order they are written
+         */
+        record Shared(List<TypeSymbol> origins, Map<String, Type> fields) implements CommonProduct {
+
+            public Shared {
+                if (origins.isEmpty() || fields.isEmpty()) {
+                    throw new IllegalArgumentException("a shared part sharing nothing is None");
+                }
+                origins = List.copyOf(origins);
+                fields = java.util.Collections.unmodifiableMap(new java.util.LinkedHashMap<>(fields));
+            }
+        }
+    }
 
     /** A union nobody named — what a branch widened to, or a behavior's written answer. Told apart
-     *  from {@link Sum} because it has no declaration to be read off. */
+     *  from {@link Sum} because it has no declaration to be read off, which is also why it has no
+     *  {@link CommonProduct}: a spread is shared by being written, and nothing writes these
+     *  together. */
     record Cases(Set<TypeSymbol> members) implements Shape {
         public Cases {
             members = Set.copyOf(members);

--- a/souther-compiler/src/main/java/souther/compiler/check/StructuralDescent.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/StructuralDescent.java
@@ -1,6 +1,5 @@
-package souther.compiler.inputs;
+package souther.compiler.check;
 
-import souther.compiler.check.Shape;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 
@@ -14,7 +13,8 @@ import java.util.Map;
  * where a value has to be built are different questions about the same fields, and each had a
  * recursion of its own, kept in step by hand and already out of step about how deep to go, about
  * whether a shape outside the readable set is refused, and about whether a path is a
- * {@link TermPath} or a string. A third reader of that question would have written a third.
+ * {@link souther.compiler.inputs.TermPath} or a string. A third reader of that question
+ * would have written a third.
  *
  * <p><b>One step and no walk.</b> What is under a type is a fact about the type. How far down to
  * follow it, where to stop because the caller has already settled something, and what type stands at
@@ -25,7 +25,8 @@ import java.util.Map;
  * hold one level up.
  *
  * <p>So there is no depth here, no stop, no recipe, and nothing of what either reader does with the
- * answer. {@link InputDomain} reads what the declaration says an input has; the generator refines a
+ * answer. {@link souther.compiler.inputs.InputDomain} reads what the declaration says an
+ * input has; the generator refines a
  * declared position into one a value is built at and asks again. Both take their steps from here and
  * neither takes the other's meaning with it.
  */

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -2628,12 +2628,11 @@ final class Terms {
     }
 
 
-    /** The type of {@code field} read from {@code owner}, or null where that is not a field of a
-     * declaration this module can see. Asked of the one field, since resolving the whole
-     * declaration's fields is a question about a declaration this reader may not own. */
+    /** The type of {@code field} read from {@code owner}, or null where nothing of that name is
+     * readable there. What a value has of its own is the one reading's answer, so a field every case
+     * of a sum spreads is read off the sum here exactly as it is where a body reads one. */
     Type fieldType(Type owner, String field) {
-        return owner instanceof Type.Ref r && symbols.declarations().declaration(r.name()) instanceof Hir.Data data
-                ? TypeOps.fieldType(data, field, symbols) : null;
+        return PositionReading.of(owner, symbols).fields().get(field);
     }
 
     /** What a container hands its closure: a list's or set's element, a map's value (the key is the

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
@@ -101,8 +101,7 @@ final class TypeGuarantees {
                 }
             }
         }
-        return new At(PositionReading.entering(root.type(), symbols), here, beneath,
-                handedOn(written, already),
+        return new At(written.entering(), here, beneath, handedOn(written, already),
                 lost.isEmpty() ? new At.Coverage.Complete() : new At.Coverage.Incomplete(lost));
     }
 
@@ -192,11 +191,10 @@ final class TypeGuarantees {
     /** {@code seen} stops a type that holds its own kind. A name met on the way here was read where
      * it was met, so what it holds is accounted for and reaching it again adds nothing. */
     private boolean anyRuleUnder(Type type, Set<TypeSymbol> seen) {
-        TypeSymbol entered = PositionReading.entering(type, symbols);
-        if (entered != null && !seen.add(entered)) {
+        PositionReading written = PositionReading.of(type, symbols);
+        if (written.entering() != null && !seen.add(written.entering())) {
             return false;
         }
-        PositionReading written = PositionReading.of(type, symbols);
         for (PositionReading.Owner owner : written.owners()) {
             if (!clauses.declared(owner.named(), owner.data()).isEmpty()) {
                 return true;

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeGuarantees.java
@@ -1,6 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.ast.Hir;
 import souther.compiler.core.Core;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
@@ -9,6 +8,7 @@ import souther.compiler.types.TypeSymbol;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -24,10 +24,15 @@ import java.util.Set;
  *
  * <p><b>A question about a position, not a walk over positions.</b> Everything a walk would carry —
  * how deep to go, which names to leave out, what a stop costs, what is being measured — is missing
- * on purpose. A caller that wants the positions beneath one asks {@link At.Declared#beneath} and
- * decides for itself whether to go there. Held the other way, the depth a walk could afford would be
- * part of what a declaration means, and two callers that could afford different depths would be two
- * readings of the model.
+ * on purpose. A caller that wants the positions beneath one asks {@link At#beneath} and decides for
+ * itself whether to go there. Held the other way, the depth a walk could afford would be part of
+ * what a declaration means, and two callers that could afford different depths would be two readings
+ * of the model.
+ *
+ * <p><b>What stands at a position is {@link PositionReading}'s answer.</b> Nothing here resolves a
+ * name to a declaration, so this cannot come to a conclusion of its own about what kind of position
+ * it is reading — which declarations state something of every value here, and what is readable on
+ * one, are settled before this starts.
  *
  * <p>Nothing here mentions {@link Known}, a path, or a {@link InvariantChecker.Gathering}. Reading a
  * clause as an assumption cannot consult what was already known ({@link Predicates.Discharge}), so
@@ -48,38 +53,99 @@ final class TypeGuarantees {
     }
 
     /**
-     * What the type of the value at {@code root} guarantees of it, and what positions are beneath it.
+     * What the type of the value at {@code root} guarantees of it, what positions are beneath it,
+     * and what a reading opened elsewhere answers for.
      *
      * <p>The clauses are the declaration's, rebased onto this very value: a rule written about a
      * field is a rule about that field of this value, and where it is established and where it is
      * owed differ only in direction.
      */
     At at(Core root, Denotations denotations) {
-        if (!(root.type() instanceof Type.Ref(TypeSymbol.AtModule named))
-                || !(symbols.declarations().declaration(named) instanceof Hir.Data data)) {
-            // Either not a declaration of its own — a container or an optional, whose element is a
-            // value that need not be there, or a type nothing is written under at all — or a choice
-            // between declarations, which is the only kind that reaches here holding a rule at all.
-            // A construction picks one of the cases, so a rule written on one of them refuses values
-            // of that case and not every value of this.
-            return new At.Undeclared();
+        PositionReading written = PositionReading.of(root.type(), symbols);
+        Map<String, Core> values = new LinkedHashMap<>();
+        List<At.Beneath> beneath = new ArrayList<>();
+        for (Map.Entry<String, Type> field : written.fields().entrySet()) {
+            Core value = new Core.FieldAccess(root, field.getKey(), field.getValue(), root.pos());
+            values.put(field.getKey(), value);
+            // A newtype's `value` is the same location as the newtype, so what its base guarantees
+            // is guaranteed of this very atom: `data Outer = Inner` carries Inner's invariant. It is
+            // at no path of its own — wearing a name is not being somewhere else — which is what an
+            // empty field says.
+            beneath.add(new At.Beneath(written.atOwnPath() ? field.getKey() : "", value,
+                    field.getValue()));
         }
-        Map<String, Type> fields = clauses.fieldsOf(data);
-        Map<String, BindingId> bindings = clauses.bindingsOf(named, data);
-        Map<BindingId, Core> given = new HashMap<>();
-        fields.forEach((name, type) -> {
-            BindingId field = bindings.get(name);
-            if (field != null) {
-                given.put(field, new Core.FieldAccess(root, name, type, root.pos()));
+        List<TypeGuarantee> here = new ArrayList<>();
+        List<RuleRef.Invariant> lost = new ArrayList<>();
+        // One rule stated once. A declaration's clauses are what it writes and what it spreads, so
+        // a shared part reached through two of its own ancestors states the ancestor's rule twice —
+        // and a reader counting what it was handed would count one rule of the model as two.
+        Set<Object> already = new HashSet<>();
+        for (PositionReading.Owner owner : written.owners()) {
+            Map<BindingId, Core> given = new HashMap<>();
+            clauses.bindingsOf(owner.named(), owner.data()).forEach((name, binding) -> {
+                Core value = values.get(name);
+                if (value != null) {
+                    given.put(binding, value);
+                }
+            });
+            Clauses.StatedClauses stated =
+                    clauses.statedAt(owner.named(), owner.data(), given);
+            for (Clauses.Stated one : stated.clauses()) {
+                if (already.add(one.clause().ref())) {
+                    here.add(read(one, denotations));
+                }
             }
-        });
-        Clauses.StatedClauses stated = clauses.statedAt(named, data, given);
-        List<TypeGuarantee> guarantees = new ArrayList<>();
-        for (Clauses.Stated one : stated.clauses()) {
-            guarantees.add(read(one, denotations));
+            for (RuleRef.Invariant each : stated.lost()) {
+                if (already.add(each.clause())) {
+                    lost.add(each);
+                }
+            }
         }
-        return new At.Declared(named, List.copyOf(guarantees), stated.everyClauseStated(),
-                beneath(data, fields, bindings, given));
+        return new At(PositionReading.entering(root.type(), symbols), here, beneath,
+                handedOn(written, already),
+                lost.isEmpty() ? new At.Coverage.Complete() : new At.Coverage.Incomplete(lost));
+    }
+
+    /**
+     * What another reading answers for at a position.
+     *
+     * <p>Asked of what this reading did not take in, which is why {@code stated} is here: a case of
+     * a sum carries the clauses its cases share as well as its own, and those were read at this very
+     * position. Handed on all the same, one rule of the model would be owed twice — once here and
+     * once by whoever opens the case — and nothing below could settle the first.
+     */
+    private At.HandedOn handedOn(PositionReading written, Set<Object> stated) {
+        List<Type> under = new ArrayList<>();
+        for (Type each : written.handedOn()) {
+            if (beyond(each, written, stated)) {
+                under.add(each);
+            }
+        }
+        return under.isEmpty() ? new At.HandedOn.Nothing() : new At.HandedOn.ToAnotherReading(under);
+    }
+
+    /** Whether {@code type} holds a rule that is not one this position already stated, nor one under
+     * a position this reading already reaches. */
+    private boolean beyond(Type type, PositionReading here, Set<Object> stated) {
+        PositionReading there = PositionReading.of(type, symbols);
+        for (PositionReading.Owner owner : there.owners()) {
+            for (TypeOps.Declared each : clauses.declared(owner.named(), owner.data())) {
+                if (!stated.contains(Clause.of(each).ref())) {
+                    return true;
+                }
+            }
+        }
+        for (Map.Entry<String, Type> field : there.fields().entrySet()) {
+            if (!here.fields().containsKey(field.getKey()) && anyRuleUnder(field.getValue())) {
+                return true;
+            }
+        }
+        for (Type deeper : there.handedOn()) {
+            if (anyRuleUnder(deeper)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -102,46 +168,22 @@ final class TypeGuarantees {
     }
 
     /**
-     * The positions under a declaration.
-     *
-     * <p>A newtype's {@code .value} is the same location as the newtype, so what its base guarantees
-     * is guaranteed of this very atom: {@code data Outer = Inner} carries Inner's invariant. It is at
-     * no path of its own — wearing a name is not being somewhere else — which is what an empty
-     * {@link At.Beneath#field} says.
-     */
-    private List<At.Beneath> beneath(Hir.Data data, Map<String, Type> fields,
-                                     Map<String, BindingId> bindings, Map<BindingId, Core> given) {
-        List<At.Beneath> out = new ArrayList<>();
-        if (data.newtype()) {
-            BindingId held = bindings.get("value");
-            Core value = held == null ? null : given.get(held);
-            out.add(value == null ? new At.Beneath("", null, fields.get("value"))
-                    : new At.Beneath("", value, value.type()));
-            return out;
-        }
-        for (Map.Entry<String, BindingId> field : bindings.entrySet()) {
-            Core value = given.get(field.getValue());
-            if (value != null) {
-                out.add(new At.Beneath(field.getKey(), value, value.type()));
-            }
-        }
-        return out;
-    }
-
-    /**
      * Whether any rule is written anywhere under {@code type}.
      *
      * <p>A question about the model and not about any walk, which is what makes it the right one to
      * ask where a reader stops: the reader's own reach is what is being decided, so reading that
      * would answer that whatever was not read had nothing in it.
      *
-     * <p><b>Whether anything is owed here, and never what became of it.</b> A reader that stopped
-     * asks this to find out if there is anything to hand on: a field of a plain {@code Int} leaves
-     * nothing under it and owes nobody a reading. What became of what was handed on is a fact about
-     * the walk over positions and is settled there
-     * ({@link souther.compiler.inputs.RuleHandoffs}). Answered as that, a position was reported
-     * short of a rule the walk had already gone to one position down, and no row could ever
-     * discharge it (#1072).
+     * <p><b>The closure over {@link PositionReading}, and not a second reading of what a position
+     * is.</b> One step is what a declaration says; this is the transitive question built from that
+     * step, the way {@link AtomSpace} is the one closure over a sum's cases. Written as a switch of
+     * its own it can answer that a sum has rules under it while {@link #at} answers that the sum has
+     * nothing at all, and the two are readings of one model.
+     *
+     * <p><b>Whether anything is owed here, and never what became of it.</b> What became of what was
+     * handed on is a fact about the walk over positions and is settled there
+     * ({@link souther.compiler.inputs.RuleHandoffs}). Answered as that, a position is reported short
+     * of a rule the walk has already gone to one position down, and no row can discharge it.
      */
     boolean anyRuleUnder(Type type) {
         return anyRuleUnder(type, new HashSet<>());
@@ -150,72 +192,105 @@ final class TypeGuarantees {
     /** {@code seen} stops a type that holds its own kind. A name met on the way here was read where
      * it was met, so what it holds is accounted for and reaching it again adds nothing. */
     private boolean anyRuleUnder(Type type, Set<TypeSymbol> seen) {
-        if (type instanceof Type.Ref ref) {
-            if (!seen.add(ref.name())) {
-                return false;
-            }
-            // What the language declares has no rule written under it here, which is what the
-            // lookup below answered for one before it was asked with the identity.
-            if (!(ref.name() instanceof TypeSymbol.AtModule named)) {
-                return false;
-            }
-            return switch (symbols.declarations().declaration(named)) {
-                // A unit data holds nothing and may write no rule about it (spec §unit-data), so a
-                // sum of them is a type nothing is written under — which is what makes an
-                // enumeration a position this still speaks for.
-                case Hir.UnitData _ -> false;
-                case Hir.SumData sum -> AtomSpace.subjectAtoms(Type.ref(sum.declares()), symbols).stream()
-                        .anyMatch(each -> anyRuleUnder(Type.ref(each), seen));
-                case Hir.Data data -> !clauses.declared(named, data).isEmpty()
-                        || TypeOps.fieldTypes(data, symbols).values().stream()
-                                .anyMatch(each -> anyRuleUnder(each, seen));
-                case null, default -> false;
-            };
+        TypeSymbol entered = PositionReading.entering(type, symbols);
+        if (entered != null && !seen.add(entered)) {
+            return false;
         }
-        boolean[] found = {false};
-        Type.forEachChild(type, child -> found[0] |= anyRuleUnder(child, seen));
-        return found[0];
+        PositionReading written = PositionReading.of(type, symbols);
+        for (PositionReading.Owner owner : written.owners()) {
+            if (!clauses.declared(owner.named(), owner.data()).isEmpty()) {
+                return true;
+            }
+        }
+        for (Type under : written.fields().values()) {
+            if (anyRuleUnder(under, seen)) {
+                return true;
+            }
+        }
+        for (Type under : written.handedOn()) {
+            if (anyRuleUnder(under, seen)) {
+                return true;
+            }
+        }
+        return false;
     }
 
-    /** What stands at one position. */
-    sealed interface At {
+    /**
+     * What stands at one position: what is guaranteed here, what is beneath, what another reading
+     * answers for, and whether every rule written here could be read.
+     *
+     * <p><b>A product and not a classification.</b> The three are independent — a sum whose cases
+     * share a spread states rules here <em>and</em> leaves its cases to a reading opened elsewhere —
+     * so one answer standing for all three leaves a reader that recognises the first unable to
+     * account for the second. An arm for the pair is the same shape one case later.
+     *
+     * @param name      the declaration entered here, or null where none stands here
+     * @param here      what the rules written here guarantee of this value
+     * @param beneath   the positions under this one
+     * @param handedOn  what a reading opened elsewhere answers for
+     * @param coverage  whether every rule written here was read
+     */
+    record At(TypeSymbol name, List<TypeGuarantee> here, List<Beneath> beneath,
+              HandedOn handedOn, Coverage coverage) {
 
-        /**
-         * A position whose type declares rules of its own, with what they guarantee here.
-         *
-         * @param name             the declaration, which is what a caller keeping track of the ones
-         *                         it has entered files under
-         * @param guarantees       what each of its clauses states of this value
-         * @param everyClauseStated whether every clause of the declaration could be read at all. A
-         *                          clause stating nothing a reader can use is gone before any
-         *                          reading sees it, and which position it was about goes with it, so
-         *                          a caller answering for the rules it was handed would answer for a
-         *                          rule it never saw
-         * @param beneath          the positions under this one
-         */
-        record Declared(TypeSymbol name, List<TypeGuarantee> guarantees, boolean everyClauseStated,
-                        List<Beneath> beneath) implements At {
+        public At {
+            here = List.copyOf(here);
+            beneath = List.copyOf(beneath);
+        }
 
-            public Declared {
-                guarantees = List.copyOf(guarantees);
-                beneath = List.copyOf(beneath);
+        /** What a reading opened elsewhere answers for at this position. */
+        sealed interface HandedOn {
+
+            /** Nothing under this position is left for another reading — either nothing stands under
+             * it, or no rule is written under what does. */
+            record Nothing() implements HandedOn {}
+
+            /**
+             * Rules stand under this position that no reading here takes in, and these are the types
+             * they are written under. A case of a sum is opened by a match; what a container holds
+             * is reached by whoever walks into it.
+             */
+            record ToAnotherReading(List<Type> under) implements HandedOn {
+
+                public ToAnotherReading {
+                    under = List.copyOf(under);
+                }
             }
         }
 
-        /** A position with no declaration of its own to read, so nothing is stated here of every
-         * value that stands at it. What is written under its type may still be worth asking about
-         * ({@link TypeGuarantees#anyRuleUnder}). */
-        record Undeclared() implements At {}
+        /** Whether every rule written at this position was read as one. */
+        sealed interface Coverage {
+
+            /** Every clause written here states something this reading could use. */
+            record Complete() implements Coverage {}
+
+            /**
+             * These clauses state nothing this reading can use, so what they were about is not among
+             * what was handed over.
+             *
+             * <p>Named and not counted. A clause lost here is not a clause handed on: nobody else
+             * takes it, and it stands at run time. Told apart from {@link HandedOn} for that reason —
+             * read as one axis, a reader would have to work out from the count which of the two it
+             * was.
+             */
+            record Incomplete(List<RuleRef.Invariant> lost) implements Coverage {
+
+                public Incomplete {
+                    if (lost.isEmpty()) {
+                        throw new IllegalArgumentException("nothing lost is Complete");
+                    }
+                    lost = List.copyOf(lost);
+                }
+            }
+        }
 
         /**
          * A position under another.
          *
          * @param field the name it is reached by, or empty where it is this same position wearing a
          *              name
-         * @param value what stands there, or null where the declaration names a field this could not
-         *              read a value for
-         * @param type  what stands there is of this type, which is answerable even where the value
-         *              is not
+         * @param value what stands there
+         * @param type  what stands there is of this type
          */
         record Beneath(String field, Core value, Type type) {}
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -1162,9 +1162,8 @@ public final class TypeOps {
                 fields.putAll(fieldTypes(d, symbols));
             }
         }
-        // A shared declaration contributing no field is shared all the same, and a rule may be
-        // written on it — but there is nothing at this position for such a rule to be about, since
-        // what a sum exposes of the shared part is its fields. Nothing shared to read means None.
+        // A data declaring no field is a unit data and is written without a body (E1008), so this
+        // is empty only where the cases share nothing at all.
         return fields.isEmpty() ? new Shape.CommonProduct.None()
                 : new Shape.CommonProduct.Shared(origins, fields);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -1119,20 +1119,27 @@ public final class TypeOps {
     }
 
     /**
-     * The fields a sum exposes: those contributed by a data that every one of its cases spreads,
-     * transitively. What holds of every case is a property of the sum, and a spread is nominal
-     * (ADR-0012), so what makes the fields shared is that the author wrote `...Common` in each case —
-     * not that two cases happen to agree on a field name, which would be the structural reading
-     * ADR-0012 declines. Empty when the cases share no spread, so the read stays the error it is.
+     * The part a sum's cases hold in common: the declarations every one of them spreads,
+     * transitively, and the fields those declare.
+     *
+     * <p>What holds of every case is a property of the sum, and a spread is nominal, so what makes
+     * the part shared is that the author wrote `...Common` in each case — not that two cases happen
+     * to agree on a field name, which is the structural reading the language declines.
+     * {@link Shape.CommonProduct.None} when they share no spread, so a read of a field stays the
+     * error it is.
+     *
+     * <p>Package-private, and the answer travels as {@link Shape.Sum#common}. Every reader of a
+     * sum's shared part is a reader of what a position is, which is {@link Shape}'s to say; asked
+     * here directly, a reader would have a second way to find out what kind of sum it is holding.
      */
-    public static Map<String, Type> commonSpreadFields(Hir.SumData sum, Symbols symbols) {
-        return commonSpreadFields(AtomSpace.subjectAtoms(Type.ref(sum.declares()), symbols), symbols);
+    static Shape.CommonProduct commonSpreadOf(Hir.SumData sum, Symbols symbols) {
+        return commonSpreadOf(AtomSpace.subjectAtoms(Type.ref(sum.declares()), symbols), symbols);
     }
 
-    /** As {@link #commonSpreadFields(Hir.SumData, Symbols)}, for cases already flattened to leaves. */
-    public static Map<String, Type> commonSpreadFields(List<TypeSymbol> cases, Symbols symbols) {
+    /** As {@link #commonSpreadOf(Hir.SumData, Symbols)}, for cases already flattened to leaves. */
+    static Shape.CommonProduct commonSpreadOf(List<TypeSymbol> cases, Symbols symbols) {
         if (cases == null || cases.isEmpty()) {
-            return Map.of();
+            return new Shape.CommonProduct.None();
         }
         Set<TypeSymbol> common = null;
         for (TypeSymbol c : cases) {
@@ -1144,16 +1151,37 @@ public final class TypeOps {
                 common.retainAll(spreads);
             }
             if (common.isEmpty()) {
-                return Map.of();
+                return new Shape.CommonProduct.None();
             }
         }
         Map<String, Type> fields = new LinkedHashMap<>();
+        List<TypeSymbol> origins = new ArrayList<>();
         for (TypeSymbol ancestor : common) {
             if (symbols.declarations().declaration(ancestor) instanceof Hir.Data d) {
+                origins.add(ancestor);
                 fields.putAll(fieldTypes(d, symbols));
             }
         }
-        return fields;
+        // A shared declaration contributing no field is shared all the same, and a rule may be
+        // written on it — but there is nothing at this position for such a rule to be about, since
+        // what a sum exposes of the shared part is its fields. Nothing shared to read means None.
+        return fields.isEmpty() ? new Shape.CommonProduct.None()
+                : new Shape.CommonProduct.Shared(origins, fields);
+    }
+
+    /**
+     * The declaration {@code name} denotes where it writes fields, with the name it was reached by,
+     * and null where it denotes none.
+     *
+     * <p>The one resolution. What kind of position a name makes is {@link Shape}'s answer and is
+     * settled before anything asks this; what is left is finding the declaration that answer is
+     * about, and a reader doing that for itself has a second way to decide what stands at a
+     * position.
+     */
+    static PositionReading.Owner writingFields(TypeSymbol name, Symbols symbols) {
+        return name instanceof TypeSymbol.AtModule at
+                && symbols.declarations().declaration(at) instanceof Hir.Data data
+                ? new PositionReading.Owner(at, data) : null;
     }
 
     /** Every data reachable from {@code data} through spreads, transitively — the set two cases are

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeView.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeView.java
@@ -100,7 +100,7 @@ public record TypeView(Type declared, List<TypeOps.Layer> wrappers, Shape shape)
      */
     private static Shape denoted(TypeSymbol name, Symbols symbols) {
         return switch (symbols.declarations().declaration(name)) {
-            case Hir.SumData _ -> new Shape.Sum(name);
+            case Hir.SumData sum -> new Shape.Sum(name, TypeOps.commonSpreadOf(sum, symbols));
             case Hir.UnitData _ -> new Shape.Unit(name);
             case Hir.Data data when data.newtype() -> new Shape.Unresolved(name);
             case Hir.Data data -> new Shape.Product(name, TypeOps.fieldTypes(data, symbols));

--- a/souther-compiler/src/main/java/souther/compiler/check/UniversalElementFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/UniversalElementFacts.java
@@ -117,21 +117,29 @@ record UniversalElementFacts(Map<String, Bounds> byPath) {
      * the container's elements.
      */
     static Map<String, Bounds> guaranteed(Type type, Symbols symbols, ReadingPolicy policy) {
-        if (!(type instanceof Type.Ref(TypeSymbol.AtModule named))
-                || !(symbols.declarations().declaration(named) instanceof Hir.Data data)) {
-            return Map.of();
-        }
-        InvariantChecker.Seeded seeded = seededOf(named, data, symbols, policy);
-        if (seeded == null) {
-            return Map.of();
-        }
+        // Whose clauses hold of a value of this type is the one reading's answer. Asked here from
+        // the declaration instead, an element that is a sum is an element nothing is known about,
+        // while the same value read as a field of a record carries the shared part's bounds.
+        List<PositionReading.Owner> owners = PositionReading.of(type, symbols).owners();
         Map<String, Bounds> guaranteed = new LinkedHashMap<>();
-        seeded.atoms().forEach((path, atom) -> {
-            Bounds bounds = seeded.numbers().boundsOf(atom);
-            if (bounds != null && !bounds.saysNothing()) {
-                guaranteed.put(path, bounds);
+        for (PositionReading.Owner owner : owners) {
+            InvariantChecker.Seeded seeded =
+                    seededOf(owner.named(), owner.data(), symbols, policy);
+            if (seeded == null) {
+                // All of them or none, which is what leaves an element unbounded rather than bounded
+                // by half of what the declarations say.
+                return Map.of();
             }
-        });
+            seeded.atoms().forEach((path, atom) -> {
+                Bounds bounds = seeded.numbers().boundsOf(atom);
+                if (bounds != null && !bounds.saysNothing()) {
+                    // A shared part reached through two of its own ancestors is read twice and reads
+                    // alike both times, since a declaration's clauses are what it writes and what it
+                    // spreads.
+                    guaranteed.putIfAbsent(path, bounds);
+                }
+            });
+        }
         return guaranteed;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
@@ -6,7 +6,9 @@ import souther.compiler.ast.Hir;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;
 import souther.compiler.check.Ordering;
+import souther.compiler.check.Shape;
 import souther.compiler.check.TypeOps;
+import souther.compiler.check.TypeView;
 import souther.compiler.core.ValueShape;
 
 import souther.compiler.jvm.DecoderKind;
@@ -236,9 +238,12 @@ final class ValueClassGen {
             cb.with(PermittedSubclassesAttribute.ofSymbols(caseCds));
             // A field every case spreads is readable on the sum (issue #160): declared here, and
             // implemented by each case record's accessor of the same name and descriptor.
-            for (Map.Entry<String, Type> e : TypeOps.commonSpreadFields(sum, symbols).entrySet()) {
-                cb.withMethod(e.getKey(), MethodTypeDesc.of(jvmType(e.getValue())),
-                        ClassFile.ACC_PUBLIC | ClassFile.ACC_ABSTRACT, mb -> { });
+            if (TypeView.of(Type.ref(sum.declares()), symbols).shape() instanceof Shape.Sum shape
+                    && shape.common() instanceof Shape.CommonProduct.Shared shared) {
+                for (Map.Entry<String, Type> e : shared.fields().entrySet()) {
+                    cb.withMethod(e.getKey(), MethodTypeDesc.of(jvmType(e.getValue())),
+                            ClassFile.ACC_PUBLIC | ClassFile.ACC_ABSTRACT, mb -> { });
+                }
             }
             // An enumeration travels as its case's name (issue #161): one place says which name that
             // is, and the codecs on both sides read it from here.

--- a/souther-compiler/src/main/java/souther/compiler/inputs/StructuralInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/inputs/StructuralInspection.java
@@ -1,6 +1,7 @@
 package souther.compiler.inputs;
 
 import souther.compiler.check.Shape;
+import souther.compiler.check.StructuralDescent;
 import souther.compiler.types.Type;
 
 import java.util.ArrayList;

--- a/souther-compiler/src/main/java/souther/compiler/partition/BehaviorInputs.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BehaviorInputs.java
@@ -5,7 +5,7 @@ import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
 import souther.compiler.check.TypeView;
 import souther.compiler.inputs.Refinement;
-import souther.compiler.inputs.StructuralDescent;
+import souther.compiler.check.StructuralDescent;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.types.Type;

--- a/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ConstructionPlan.java
@@ -5,7 +5,7 @@ import souther.compiler.check.TypeOps;
 import souther.compiler.check.TypeView;
 import souther.compiler.inputs.Refinement;
 import souther.compiler.inputs.Requirements;
-import souther.compiler.inputs.StructuralDescent;
+import souther.compiler.check.StructuralDescent;
 import souther.compiler.inputs.TermPath;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeSymbol;

--- a/souther-compiler/src/test/java/souther/compiler/WhatEveryCaseOfASumSpreadsEstablishesAConstructionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatEveryCaseOfASumSpreadsEstablishesAConstructionTest.java
@@ -1,0 +1,142 @@
+package souther.compiler;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Messages;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * What every case of a sum spreads holds of a value of the sum, so a construction reached through
+ * one is established by it.
+ *
+ * <p>The same value, reached the same way, has to be established in both shapes. A model holding its
+ * amounts in a record and a model holding them in a sum of categories differ by the sum between the
+ * line and its amount, and that is not a difference the rules know about: every amount summed is an
+ * amount, so every one of them satisfies what an amount states, and so does their total.
+ *
+ * <p>Which is a claim about the sharing being nominal and not about sums in general. The last test
+ * is the other side of it: cases that merely declare a field of the same name share nothing, and a
+ * construction reached through one of those is established by nothing.
+ */
+class WhatEveryCaseOfASumSpreadsEstablishesAConstructionTest {
+
+    private static List<String> warningsOf(String source) {
+        return Compiler.compileWithWarnings(source).warnings().stream()
+                .map(Diagnostic::code)
+                .toList();
+    }
+
+    private static String said(String source) {
+        return Compiler.compileWithWarnings(source).warnings().stream()
+                .map(d -> Messages.render(d.said(), Locale.ENGLISH))
+                .findFirst()
+                .orElse("");
+    }
+
+    /** A field every case spreads is read off the sum, and what its type states comes with it. */
+    @Test
+    void anAmountBehindASumIsStillAnAmount() {
+        assertEquals(List.of(), warningsOf("""
+                module demo
+
+                data Amount = Int
+                    invariant value >= 0
+
+                data Costed = { amount: Amount }
+                data Travel = { ...Costed }
+                data Lodging = { ...Costed }
+                data Expense = Travel | Lodging
+
+                data Line = { expense: Expense }
+
+                let total (lines: List<Line>): Int =
+                    List.sum(List.map(one -> one.expense.amount.value, lines))
+
+                behavior totalled : (lines: List<Line>) -> Amount
+                    constructs Amount
+                let totalled (lines) = Amount(total(lines))
+                """));
+    }
+
+    /** And so is one held directly by the elements of a container. */
+    @Test
+    void anAmountBehindASumHeldByAContainerIsStillAnAmount() {
+        assertEquals(List.of(), warningsOf("""
+                module demo
+
+                data Amount = Int
+                    invariant value >= 0
+
+                data Costed = { amount: Amount }
+                data Travel = { ...Costed }
+                data Lodging = { ...Costed }
+                data Expense = Travel | Lodging
+
+                let total (expenses: List<Expense>): Int =
+                    List.sum(List.map(one -> one.amount.value, expenses))
+
+                behavior totalled : (expenses: List<Expense>) -> Amount
+                    constructs Amount
+                let totalled (expenses) = Amount(total(expenses))
+                """));
+    }
+
+    /** A relation the shared declaration states holds of every case, so a spread of the sum carries
+     *  it to what is built out of it. */
+    @Test
+    void aRelationEveryCaseSpreadsCarriesThroughASpreadOfTheSum() {
+        assertEquals(List.of(), warningsOf("""
+                module demo
+
+                data Period =
+                    { from: Date
+                    , to: Date
+                    }
+                    invariant Date.daysBetween(from, to) >= 0
+
+                data Draft = { ...Period }
+                data Sealed = { ...Period, at: Date }
+                data Filed = Draft | Sealed
+
+                data Reopened = { ...Period }
+
+                behavior reopen : (filed: Filed) -> Reopened
+                    constructs Reopened
+
+                let reopen (filed) = Reopened { ...filed }
+                """));
+    }
+
+    /**
+     * Cases that share no spread state nothing of a value of the sum.
+     *
+     * <p>Sharing is nominal: two cases holding a field of one name have not shared it, so nothing
+     * here is established and the construction is still one an author has to answer for.
+     */
+    @Test
+    void casesThatShareNoSpreadEstablishNothing() {
+        String source = """
+                module demo
+
+                data Amount = Int
+                    invariant value >= 0
+
+                data Travel = { fare: Amount }
+                data Lodging = { rate: Amount }
+                data Expense = Travel | Lodging
+
+                behavior totalled : (expense: Expense, n: Int) -> Amount
+                    constructs Amount
+                let totalled (expense, n) = Amount(n)
+                """;
+
+        assertEquals(List.of("E2011"), warningsOf(source));
+        assertFalse(said(source).isEmpty(), "and it says which construction it is about");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ASumStatesWhatItsCasesShareAndLeavesTheCasesToAMatchTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ASumStatesWhatItsCasesShareAndLeavesTheCasesToAMatchTest.java
@@ -1,0 +1,191 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.ast.Hir;
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A sum is a common product times a choice of case, and the reading of one says both.
+ *
+ * <p>What every case spreads is stated of every value standing at the sum: a value of the sum was
+ * built through one case's checked constructor, and every case carries the shared declaration, so
+ * what that declaration writes holds here. What one case writes does not — it refuses values of that
+ * case and not every value here — so it stays for the reading a {@code match} opens.
+ *
+ * <p><b>The two are independent, and this is the test that says so.</b> Each row below fixes one
+ * combination of the two, and the pair in {@code aSumCanBothStateARuleAndLeaveOneToItsCases} is the
+ * one an answer with a single arm cannot hold: dropping what is read here and dropping what is left
+ * to the cases each turn a different assertion red.
+ */
+class ASumStatesWhatItsCasesShareAndLeavesTheCasesToAMatchTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    private static final String SOURCE = """
+            module demo exposing ( Shared, Marked, Both, Quiet, Apart, Alone, keep )
+
+            data NonNegInt = Int
+                invariant value >= 0
+
+            data Common = { amount: NonNegInt }
+                invariant capped = amount.value <= 100
+
+            data Plain = { ...Common }
+
+            data Stamped = { ...Common, mark: NonNegInt }
+                invariant stamped = mark.value >= 1
+
+            data Shared = Plain | Plain
+
+            data Both = Plain | Stamped
+
+            data Quiet = { ...Common }
+
+            data Marked = Quiet | Plain
+
+            data OneWay = { a: NonNegInt }
+
+            data OtherWay = { b: NonNegInt }
+
+            data Apart = OneWay | OtherWay
+
+            data Alone = { ...Common }
+
+            behavior keep : (n: NonNegInt) -> NonNegInt
+
+            let keep (n) = n
+            """;
+
+    private final Symbols symbols = symbols();
+
+    private final PathEngine engine = new PathEngine(symbols, Map.of(),
+            Terms.Of.THE_DISCHARGE_TREE, souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+
+    private final GuaranteeWalk walk = new GuaranteeWalk(engine.guarantees());
+
+    private static Symbols symbols() {
+        Compilation compilation = Compilation.ofSource(SOURCE, "Main");
+        compilation.answerEverything();
+        return Scopes.derived(compilation.db(), compilation.modules().get(0)).value();
+    }
+
+    private Core.Read place(String name) {
+        BindingId binding = CoreBinders
+                .of(new Hir.Binders(new BindingOwner.OfValue("demo", "keep")).binder("v", POS))
+                .binding();
+        return new Core.Read("v", binding,
+                Type.ref(TypeSymbols.declared(new TypeKey("demo", name))), POS);
+    }
+
+    /** What the walk was told, by the position it was told it at. */
+    private record Told(Map<String, List<String>> guaranteed, List<String> handedOn) {}
+
+    private Told reading(String name) {
+        Core.Read root = place(name);
+        Denotations at = Denotations.none().location(root.binding(),
+                engine.terms().placeSubject(root.binding()),
+                engine.terms().placeTerm(root.binding()));
+        Map<String, List<String>> guaranteed = new LinkedHashMap<>();
+        List<String> handedOn = new ArrayList<>();
+        walk.from(root, FieldDomains.THE_VALUE, at, GuaranteeWalk.Scope.everyPosition(),
+                new GuaranteeWalk.Reader() {
+                    @Override
+                    public void guaranteed(String path, TypeGuarantee guarantee) {
+                        guaranteed.computeIfAbsent(path, _ -> new ArrayList<>())
+                                .add(guarantee.rule().clause().toString());
+                    }
+
+                    @Override
+                    public void handedOn(String path, Type type) {
+                        // The value itself is at the empty path, which reads as nothing in a
+                        // failure message. Named here so a diff says which position it was.
+                        handedOn.add(path.isEmpty() ? "the value" : path);
+                    }
+                });
+        return new Told(guaranteed, handedOn);
+    }
+
+    /** A record states its own rules here and leaves nothing to anybody. */
+    @Test
+    void aRecordStatesItsRulesHereAndLeavesNothing() {
+        Told told = reading("Alone");
+
+        assertTrue(states(told, "capped"), "the spread's rule is a rule about this value");
+        assertEquals(List.of(), told.handedOn(),
+                "nothing under a record waits for a reading somebody else opens");
+    }
+
+    /** A sum whose cases share nothing states nothing here, and every rule under it is a case's. */
+    @Test
+    void aSumSharingNothingStatesNothingAndLeavesEverything() {
+        Told told = reading("Apart");
+
+        assertEquals(Map.of(), told.guaranteed(),
+                "a rule written on one case refuses values of that case, not every value here");
+        assertEquals(List.of("the value"), told.handedOn(),
+                "so the rules under it are for the reading a match opens");
+    }
+
+    /** A sum whose cases share a spread and write nothing of their own states the shared rules, and
+     *  leaves nothing over: what a case carries is what was read here. */
+    @Test
+    void aSumWhoseCasesWriteNothingOfTheirOwnLeavesNothingOver() {
+        Told told = reading("Marked");
+
+        assertTrue(states(told, "capped"), "every case spreads Common, so Common holds here");
+        assertEquals(List.of(), told.handedOn(),
+                "the cases carry the shared rule and nothing besides, and it was read here");
+    }
+
+    /**
+     * And the row a single answer cannot hold: rules read here, and rules left to the cases.
+     *
+     * <p>Both assertions are about one reading of one position. Stop reading what the cases share
+     * and the first fails; stop saying that a case writes something of its own and the second does.
+     * Neither failure implies the other, which is what makes the two independent rather than two
+     * spellings of one.
+     */
+    @Test
+    void aSumCanBothStateARuleAndLeaveOneToItsCases() {
+        Told told = reading("Both");
+
+        assertTrue(states(told, "capped"),
+                "Plain and Stamped both spread Common, so what Common writes holds of either");
+        assertFalse(states(told, "stamped"),
+                "and what Stamped writes holds of a Stamped, not of every value here");
+        assertEquals(List.of("the value"), told.handedOn(),
+                "so Stamped's own rule is left for the reading a match opens");
+    }
+
+    /** The shared part is a position of its own, so what its type writes is read there. */
+    @Test
+    void theSharedFieldIsAPositionOfTheSum() {
+        Told told = reading("Both");
+
+        assertTrue(told.guaranteed().containsKey("amount"),
+                "a field every case spreads is readable on the sum, and so are its rules: "
+                        + told.guaranteed());
+    }
+
+    private static boolean states(Told told, String clause) {
+        return told.guaranteed().values().stream().flatMap(List::stream)
+                .anyMatch(each -> each.contains(clause));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ASumStatesWhatItsCasesShareAndLeavesTheCasesToAMatchTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ASumStatesWhatItsCasesShareAndLeavesTheCasesToAMatchTest.java
@@ -98,13 +98,17 @@ class ASumStatesWhatItsCasesShareAndLeavesTheCasesToAMatchTest {
     private record Told(Map<String, List<String>> guaranteed, List<String> handedOn) {}
 
     private Told reading(String name) {
+        return reading(name, GuaranteeWalk.Scope.everyPosition());
+    }
+
+    private Told reading(String name, GuaranteeWalk.Scope scope) {
         Core.Read root = place(name);
         Denotations at = Denotations.none().location(root.binding(),
                 engine.terms().placeSubject(root.binding()),
                 engine.terms().placeTerm(root.binding()));
         Map<String, List<String>> guaranteed = new LinkedHashMap<>();
         List<String> handedOn = new ArrayList<>();
-        walk.from(root, FieldDomains.THE_VALUE, at, GuaranteeWalk.Scope.everyPosition(),
+        walk.from(root, FieldDomains.THE_VALUE, at, scope,
                 new GuaranteeWalk.Reader() {
                     @Override
                     public void guaranteed(String path, TypeGuarantee guarantee) {
@@ -182,6 +186,76 @@ class ASumStatesWhatItsCasesShareAndLeavesTheCasesToAMatchTest {
         assertTrue(told.guaranteed().containsKey("amount"),
                 "a field every case spreads is readable on the sum, and so are its rules: "
                         + told.guaranteed());
+    }
+
+    /** The reading of the value itself, without walking anywhere. */
+    private TypeGuarantees.At at(String name) {
+        Core.Read root = place(name);
+        return engine.guarantees().at(root, Denotations.none().location(root.binding(),
+                engine.terms().placeSubject(root.binding()),
+                engine.terms().placeTerm(root.binding())));
+    }
+
+    /** Reading everything but the rules {@code declaration} wrote. */
+    private static GuaranteeWalk.Scope without(String declaration) {
+        return new GuaranteeWalk.Scope(new GuaranteeWalk.Extent.EveryPosition(), _ -> false,
+                RulesLeftOut.writtenOn(each -> each.name().equals(declaration)));
+    }
+
+    /**
+     * A rule is left out by the declaration that wrote it, and a sum writes none of what it states.
+     *
+     * <p>The two identities this reading tells apart, asked of one position. What stands at the sum
+     * is the sum; what wrote the rule read there is the declaration its cases spread. A reader
+     * naming the first leaves the rule in, because the sum wrote nothing, and a reader naming the
+     * second takes it out although the sum is what it was read at.
+     */
+    @Test
+    void aRuleIsLeftOutByWhoWroteItAndNotByWhereItIsRead() {
+        assertTrue(states(reading("Marked"), "capped"),
+                "read in full, what the cases share is stated at the sum");
+        assertFalse(states(reading("Marked", without("Common")), "capped"),
+                "Common wrote it, so leaving Common's rules out leaves it out");
+        assertTrue(states(reading("Marked", without("Marked")), "capped"),
+                "the sum wrote no rule, so leaving its rules out leaves this one standing");
+    }
+
+    /**
+     * The same of a record that spreads, which is where the two identities first came apart.
+     *
+     * <p>A record's own name and the name that wrote a rule it carries are two names, exactly as a
+     * sum's are. That they are the same name for a declaration writing its own clauses is what let
+     * one predicate stand for both.
+     */
+    @Test
+    void aRuleASpreadCarriesIntoARecordIsLeftOutByWhoWroteIt() {
+        assertTrue(states(reading("Alone"), "capped"));
+        assertFalse(states(reading("Alone", without("Common")), "capped"),
+                "Common wrote it, wherever it is read");
+        assertTrue(states(reading("Alone", without("Alone")), "capped"),
+                "Alone wrote no rule of its own");
+    }
+
+    /**
+     * What is left to the cases is what was not read here, and no more.
+     *
+     * <p>Said of the residual itself rather than of the fact that there is one. Handing the cases on
+     * whole would name a case whose every rule was read at the sum, and nothing below could settle
+     * a rule that was already settled above.
+     */
+    @Test
+    void whatIsLeftToTheCasesIsWhatWasNotReadHere() {
+        assertEquals(List.of("Stamped"), residualOf("Both"),
+                "Plain carries only what the sum states; Stamped writes a rule of its own");
+        assertEquals(List.of(), residualOf("Marked"),
+                "neither case writes anything the sum did not state");
+    }
+
+    /** What the reading at {@code name} says another reading answers for. */
+    private List<String> residualOf(String name) {
+        return at(name).handedOn() instanceof TypeGuarantees.At.HandedOn.ToAnotherReading passed
+                ? passed.under().stream().map(each -> Type.show(each)).toList()
+                : List.of();
     }
 
     private static boolean states(Told told, String clause) {

--- a/souther-compiler/src/test/java/souther/compiler/check/OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest.java
@@ -66,7 +66,8 @@ class OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest {
     /** The reading issue #631 is about. What the position is, is what the name wraps. */
     @Test
     void aNewtypeOverASumIsThatSum() {
-        assertEquals(new Shape.Sum(TypeSymbols.declared(new TypeKey(symbols.module(), "Stage"))), view("StageN").shape());
+        assertEquals(new Shape.Sum(TypeSymbols.declared(new TypeKey(symbols.module(), "Stage")),
+                new Shape.CommonProduct.None()), view("StageN").shape());
     }
 
     @Test
@@ -131,7 +132,8 @@ class OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest {
     void eachTypeConstructorReadsAsItsOwnShape() {
         assertEquals(new Shape.Scalar(Type.Prim.STRING), view(Type.STRING).shape());
         assertEquals(new Shape.Unit(TypeSymbols.declared(new TypeKey(symbols.module(), "Won"))), view("Won").shape());
-        assertEquals(new Shape.Sum(TypeSymbols.declared(new TypeKey(symbols.module(), "Stage"))), view("Stage").shape());
+        assertEquals(new Shape.Sum(TypeSymbols.declared(new TypeKey(symbols.module(), "Stage")),
+                new Shape.CommonProduct.None()), view("Stage").shape());
         assertEquals(new Shape.Sequence(Shape.Sequence.Kind.LIST, Type.INT),
                 view(Type.list(Type.INT)).shape());
         assertEquals(new Shape.Sequence(Shape.Sequence.Kind.SET, Type.INT),

--- a/souther-compiler/src/test/java/souther/compiler/check/TheInvariantReadingAsksWhatAPositionIsRatherThanDecidingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TheInvariantReadingAsksWhatAPositionIsRatherThanDecidingTest.java
@@ -1,0 +1,154 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.test.RepositoryLayout;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The readings that discharge an invariant ask what a position is; they do not work it out.
+ *
+ * <p>What kind of thing stands at a position is {@link Shape}'s answer and what the model writes
+ * there is {@link PositionReading}'s. A reader that resolves a name to a declaration and switches on
+ * what it finds has a second way to answer both, and two answers about one position is how a field
+ * every case of a sum spreads came to be readable off the sum by the elaborator and invisible to the
+ * check that reads what the sum guarantees.
+ *
+ * <p><b>Narrow on purpose.</b> Not every {@code instanceof Hir.Data} in the compiler is this
+ * mistake — enumerating the declarations that write an invariant is a different question, and so is
+ * resolving what a construction builds — and a check that refused all of them would need an
+ * exception list longer than the rule. What is held here is the set of files that read a position on
+ * the way to discharging an invariant, and they resolve no declaration at all.
+ *
+ * <p>A tripwire and not a proof. A helper in between defeats it; what it does see is the line that
+ * has to be written first.
+ */
+class TheInvariantReadingAsksWhatAPositionIsRatherThanDecidingTest {
+
+    /** Read once: what this asks of it does not change between its checks. */
+    private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
+
+    /** The files that read a position on the way to discharging an invariant. */
+    private static final List<String> THE_READING = List.of(
+            "TypeGuarantees.java",
+            "GuaranteeWalk.java",
+            "PathEngine.java",
+            "UniversalElementFacts.java",
+            "StepInputFacts.java");
+
+    /**
+     * None of them resolves a name to a declaration.
+     *
+     * <p>Of the code and not of the prose, so that explaining the rule in a javadoc and breaking it
+     * are not the same thing to this check.
+     */
+    @Test
+    void theReadingResolvesNoDeclarationOfItsOwn() throws IOException {
+        List<String> resolving = new ArrayList<>();
+        for (Path source : theReading()) {
+            String code = code(source);
+            if (code.contains("declarations().declaration(")
+                    || code.contains("instanceof Hir.SumData")
+                    || code.contains("instanceof Hir.UnitData")) {
+                resolving.add(source.getFileName().toString());
+            }
+        }
+
+        assertEquals(List.of(), resolving,
+                "these decide what a position is instead of asking; what stands at one is"
+                        + " PositionReading's answer");
+    }
+
+    /**
+     * And what a sum's cases share is worked out in one place.
+     *
+     * <p>Of who makes one and not of who reads one. Reading {@code Shape.Sum.common} is what a
+     * consumer of the shape is supposed to do — the elaborator and the construction checker both
+     * do, and so does the backend — and the answer being one answer rests on nobody else deriving
+     * it from the declarations.
+     */
+    @Test
+    void whatASumsCasesShareIsDerivedInOnePlace() throws IOException {
+        List<String> deriving = new ArrayList<>();
+        for (Path source : REPOSITORY.mainJavaSources()) {
+            if (code(source).contains("new Shape.CommonProduct.Shared(")) {
+                deriving.add(source.getFileName().toString());
+            }
+        }
+
+        assertEquals(List.of("TypeOps.java"), deriving,
+                "the shared part of a sum is derived where the spreads are intersected, and read"
+                        + " off the shape everywhere else");
+    }
+
+    private static List<Path> theReading() throws IOException {
+        List<Path> found = new ArrayList<>();
+        for (Path source : REPOSITORY.mainJavaSources()) {
+            if (THE_READING.contains(source.getFileName().toString())) {
+                found.add(source);
+            }
+        }
+        assertEquals(THE_READING.size(), found.size(),
+                "a file this holds was renamed or moved, and the check stopped seeing it: " + found);
+        return found;
+    }
+
+    private static String code(Path source) throws IOException {
+        return withoutComments(Files.readString(source, StandardCharsets.UTF_8));
+    }
+
+    /**
+     * The source with its comments taken out.
+     *
+     * <p>Lexical and small, and deliberately not a parser. It follows string and character literals
+     * so that a {@code //} inside one does not read as a comment, and it keeps what is inside them —
+     * so the worst it can do is leave a comment standing, never take code away.
+     */
+    private static String withoutComments(String source) {
+        StringBuilder out = new StringBuilder(source.length());
+        int at = 0;
+        while (at < source.length()) {
+            char here = source.charAt(at);
+            char next = at + 1 < source.length() ? source.charAt(at + 1) : '\0';
+            if (here == '/' && next == '/') {
+                while (at < source.length() && source.charAt(at) != '\n') {
+                    at++;
+                }
+            } else if (here == '/' && next == '*') {
+                at += 2;
+                while (at + 1 < source.length()
+                        && !(source.charAt(at) == '*' && source.charAt(at + 1) == '/')) {
+                    at++;
+                }
+                at = Math.min(source.length(), at + 2);
+            } else if (here == '"' || here == '\'') {
+                out.append(here);
+                at++;
+                while (at < source.length() && source.charAt(at) != here) {
+                    if (source.charAt(at) == '\\' && at + 1 < source.length()) {
+                        out.append(source.charAt(at));
+                        at++;
+                    }
+                    out.append(source.charAt(at));
+                    at++;
+                }
+                if (at < source.length()) {
+                    out.append(source.charAt(at));
+                    at++;
+                }
+            } else {
+                out.append(here);
+                at++;
+            }
+        }
+        return out.toString();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest.java
@@ -123,6 +123,23 @@ class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
         return out;
     }
 
+    /** Every position whose rules the walk said belong to a reading opened elsewhere. */
+    private List<String> handedOnIn(String name, GuaranteeWalk.Scope scope) {
+        List<String> out = new ArrayList<>();
+        Read read = place(name);
+        walk.from(read.root(), FieldDomains.THE_VALUE, read.at(), scope,
+                new GuaranteeWalk.Reader() {
+                    @Override
+                    public void guaranteed(String path, TypeGuarantee guarantee) {}
+
+                    @Override
+                    public void handedOn(String path, Type type) {
+                        out.add(path);
+                    }
+                });
+        return out;
+    }
+
     /**
      * A clause written on a field's type is a rule about that field of this value, at that field's
      * position.
@@ -153,8 +170,13 @@ class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
     }
 
     /**
-     * A record holding another of its own kind stops rather than descending for ever, and stopping
-     * there is not being short of anything: the name was read where it was met.
+     * A record holding another of its own kind does not descend for ever, and what it leaves is not
+     * lost: the list under it is read by whoever opens an element.
+     *
+     * <p>{@code Chain} reaches itself through a {@code List}, and a list is a position no value of
+     * this reading stands at — so the rules under it are handed to a reading opened at an element
+     * rather than left short here. A position this walk stopped at and a position whose rules are
+     * somebody else's are two answers, and this is the second.
      */
     @Test
     void aRecordHoldingItsOwnKindIsReadWhereItWasMet() {
@@ -163,8 +185,8 @@ class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
 
         assertEquals(List.of("here"), List.copyOf(guaranteed.keySet()),
                 "the chain's own field is read once, and the list under it reaches no further");
-        assertFalse(stoppedIn("Chain", GuaranteeWalk.Scope.asFarAs(6)).isEmpty(),
-                "and the walk says where it stopped rather than going round again");
+        assertEquals(List.of("next"), handedOnIn("Chain", GuaranteeWalk.Scope.asFarAs(6)),
+                "and the walk says whose the rules under it are rather than going round again");
     }
 
     /**
@@ -253,7 +275,9 @@ class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
                 List.of("Known", "Gathering", "PathEngine", "GuaranteeWalk", "Reach", "Borne");
         List<String> found = new ArrayList<>();
         for (Class<?> each : List.of(TypeGuarantees.class, TypeGuarantees.At.class,
-                TypeGuarantees.At.Declared.class, TypeGuarantees.At.Beneath.class,
+                TypeGuarantees.At.Beneath.class,
+                TypeGuarantees.At.HandedOn.ToAnotherReading.class,
+                TypeGuarantees.At.Coverage.Incomplete.class,
                 TypeGuarantee.class, TypeGuarantee.Part.class)) {
             for (java.lang.reflect.Field field : each.getDeclaredFields()) {
                 mentioning(theirs, each.getSimpleName() + "." + field.getName(),

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest.java
@@ -208,7 +208,8 @@ class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
     @Test
     void aNameTheReaderStopsAtIsNotDescendedInto() {
         GuaranteeWalk.Scope stopping =
-                new GuaranteeWalk.Scope(new GuaranteeWalk.Extent.AsFarAs(4), named("NonNegInt")::equals, _ -> false);
+                new GuaranteeWalk.Scope(new GuaranteeWalk.Extent.AsFarAs(4),
+                        named("NonNegInt")::equals, RulesLeftOut.NONE);
 
         assertTrue(guaranteedUnder("Money", stopping).isEmpty(),
                 "the only clause under Money is NonNegInt's, and this reader stops there");
@@ -229,7 +230,8 @@ class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
                 "both rules stand: Bounded's own, and NonNegInt's about the field");
 
         GuaranteeWalk.Scope without =
-                new GuaranteeWalk.Scope(new GuaranteeWalk.Extent.AsFarAs(2), _ -> false, named("Bounded")::equals);
+                new GuaranteeWalk.Scope(new GuaranteeWalk.Extent.AsFarAs(2), _ -> false,
+                        RulesLeftOut.writtenOn(named("Bounded")::equals));
 
         assertEquals(List.of("cap"),
                 List.copyOf(guaranteedUnder("Bounded", without).keySet()),
@@ -252,7 +254,7 @@ class WhatATypeGuaranteesIsOneAnswerWhoeverAsksTest {
                 "the rule three positions down is read, and read at the position it governs");
         assertTrue(guaranteedUnder("Deeper",
                         new GuaranteeWalk.Scope(new GuaranteeWalk.Extent.AsFarAs(2), _ -> false,
-                                _ -> false)).isEmpty(),
+                                RulesLeftOut.NONE)).isEmpty(),
                 "a reader that can afford two positions does not reach it — which is what makes"
                         + " borrowing its number a change to what the model says");
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatEachWayOfStoppingLeavesIsWrittenDownOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatEachWayOfStoppingLeavesIsWrittenDownOnceTest.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Which ways of stopping hand the rules to another reading, and which leave them unread.
+ * How much of what stands at a position the rules a stop leaves unread are about.
  *
  * <p>One partition of one enum, written down here so that moving an arm is an edit somebody has to
  * make on purpose. {@link PathEngine#leftBy} is exhaustive, so a way of stopping <em>added</em> is
@@ -20,54 +20,34 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * <p>So the table below is a finding and not a fixture. A diff here is a claim that a stop leaves
  * something different behind, and whoever writes it owes the reason — the words that read
  * {@code leftBy} are what change meaning with it.
+ *
+ * <p><b>No way of stopping hands the rules to another reading, and that is javac's to say.</b>
+ * Whether a position's rules belong to a reading opened elsewhere is
+ * {@link TypeGuarantees.At.HandedOn}, answered by the reading and said beside what was read, and
+ * {@code leftBy} answers a {@link InvariantChecker.Borne}. A position that both states rules and
+ * leaves something below to another reading — a sum whose cases share a spread is one — has no
+ * single arm to be, so the two are not one enum.
  */
 class WhatEachWayOfStoppingLeavesIsWrittenDownOnceTest {
 
     @Test
     void everyWayOfStoppingLeavesWhatIsWrittenHere() {
-        Map<GuaranteeWalk.Stop, PathEngine.Leaves> expected = new LinkedHashMap<>();
-        // Nothing is declared here to read, so what is written below is written about a value one
-        // position down — where a reading of that declaration is opened and a row meets it. The one
-        // arm on this side, and the whole of what #1072 turned on.
-        expected.put(GuaranteeWalk.Stop.NOTHING_DECLARED, new PathEngine.Leaves.ToAnotherReading());
-        // A depth this reader could not afford, a name it was told to suppose holds values, and a
-        // field it could find no value for. Each stops where a construction still has to make the
-        // value, so a rule under it can refuse the construction.
-        expected.put(GuaranteeWalk.Stop.PAST_THE_DEPTH,
-                new PathEngine.Leaves.Unread(InvariantChecker.Borne.BY_EVERY_VALUE));
-        expected.put(GuaranteeWalk.Stop.ASKED_TO_STOP,
-                new PathEngine.Leaves.Unread(InvariantChecker.Borne.BY_EVERY_VALUE));
-        expected.put(GuaranteeWalk.Stop.NO_VALUE_THERE,
-                new PathEngine.Leaves.Unread(InvariantChecker.Borne.BY_EVERY_VALUE));
+        Map<GuaranteeWalk.Stop, InvariantChecker.Borne> expected = new LinkedHashMap<>();
+        // A depth this reader could not afford, and a name it was told to suppose holds values.
+        // Each stops where a construction still has to make the value, so a rule under it can refuse
+        // the construction.
+        expected.put(GuaranteeWalk.Stop.PAST_THE_DEPTH, InvariantChecker.Borne.BY_EVERY_VALUE);
+        expected.put(GuaranteeWalk.Stop.ASKED_TO_STOP, InvariantChecker.Borne.BY_EVERY_VALUE);
         // Read where the name was met, and nothing is opened here — so nobody takes the rules over,
         // and this is not a handing on however much it looks like one.
-        expected.put(GuaranteeWalk.Stop.ALREADY_ENTERED,
-                new PathEngine.Leaves.Unread(InvariantChecker.Borne.BY_SOME_VALUES));
+        expected.put(GuaranteeWalk.Stop.ALREADY_ENTERED, InvariantChecker.Borne.BY_SOME_VALUES);
 
-        Map<GuaranteeWalk.Stop, PathEngine.Leaves> answered = new LinkedHashMap<>();
+        Map<GuaranteeWalk.Stop, InvariantChecker.Borne> answered = new LinkedHashMap<>();
         for (GuaranteeWalk.Stop stop : GuaranteeWalk.Stop.values()) {
             answered.put(stop, PathEngine.leftBy(stop));
         }
 
         assertEquals(expected, answered,
                 "what each way of stopping leaves is what the words downstream of it mean");
-    }
-
-    /**
-     * And exactly one of them hands the rules on.
-     *
-     * <p>Said apart from the table, because it is the fact the words are about rather than a second
-     * spelling of them. A second arm on that side is a second way for a position to be discharged
-     * by a reading somebody has to have opened, and whoever adds one has to say who opens it.
-     */
-    @Test
-    void oneWayOfStoppingHandsTheRulesToAnotherReading() {
-        long handing = java.util.Arrays.stream(GuaranteeWalk.Stop.values())
-                .map(PathEngine::leftBy)
-                .filter(each -> each instanceof PathEngine.Leaves.ToAnotherReading)
-                .count();
-
-        assertEquals(1, handing,
-                "each of these is a position somebody has to be shown to have read");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhichRuleHoldsAnEndIsAskedOfTheRuleAndNotOfWhereItIsReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhichRuleHoldsAnEndIsAskedOfTheRuleAndNotOfWhereItIsReadTest.java
@@ -1,0 +1,88 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.ast.Hir;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Scopes;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbol;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Which declaration holds an end is answered by taking that declaration's rules away, and a rule a
+ * spread brought in is that declaration's.
+ *
+ * <p>A reading is asked to leave a declaration's clauses out so that the end which moves says which
+ * declaration was holding it. What is left out is a property of each rule — the declaration that
+ * wrote it — and not of the value the reading happens to be opened at. The two are the same name
+ * only where a declaration writes its own clauses and spreads nothing, which is most of a model and
+ * was every fixture that asked this question.
+ *
+ * <p>So a rule a spread carries in is left in whatever the reading was told, every end it holds is
+ * held by nobody the reading can name, and the answer falls back to naming every declaration that
+ * wrote a relation about the coordinate.
+ */
+class WhichRuleHoldsAnEndIsAskedOfTheRuleAndNotOfWhereItIsReadTest {
+
+    private static final String SOURCE = """
+            module demo exposing ( Held, keep )
+
+            data Common =
+                { lo: Int
+                , hi: Int
+                }
+                invariant based = lo >= 100
+                invariant far = hi >= lo + 10
+
+            data Held = { ...Common }
+                invariant near = hi >= lo + 5
+
+            behavior keep : (h: Held) -> Held
+
+            let keep (h) = h
+            """;
+
+    private final Symbols symbols = symbols();
+
+    private static Symbols symbols() {
+        Compilation compilation = Compilation.ofSource(SOURCE, "Main");
+        compilation.answerEverything();
+        return Scopes.derived(compilation.db(), compilation.modules().get(0)).value();
+    }
+
+    private static TypeSymbol.AtModule named(String name) {
+        return TypeSymbols.declared(new TypeKey("demo", name));
+    }
+
+    private FieldDomains reading() {
+        Hir.Data data = (Hir.Data) symbols.declarations().declaration(named("Held"));
+        return FieldDomains.of(named("Held"), data, symbols,
+                souther.compiler.query.ReadAs.THE_COMPILATION_DOES);
+    }
+
+    /**
+     * Two declarations write a lower end on one coordinate and only one of them holds it.
+     *
+     * <p>{@code Common} puts {@code hi} ten above {@code lo} and {@code Held} puts it five above,
+     * so ten above is where {@code hi} stops and {@code Common} is what put it there. Taking
+     * {@code Held}'s own clause away moves nothing; taking {@code Common}'s does.
+     *
+     * <p>Which is only answerable if leaving a declaration's clauses out leaves out the ones it
+     * wrote rather than the ones read where it was. Read the second way, taking {@code Common} away
+     * takes nothing away — its rule arrives through {@code Held} — so neither candidate moves the
+     * end on its own and both are named.
+     */
+    @Test
+    void aSpreadRuleIsHeldByTheDeclarationThatWroteIt() {
+        List<String> holding = reading().narrowedBy("hi", true).stream()
+                .map(TypeSymbol::name)
+                .toList();
+
+        assertEquals(List.of("Common"), holding,
+                "ten above is the end, and Common is what says ten above");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/inputs/TheReadingAndThePlanTakeOneStepDownATypeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/inputs/TheReadingAndThePlanTakeOneStepDownATypeTest.java
@@ -31,6 +31,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * nothing here has shown to be the same walk. What is guarded is the duplicated descent that decided
  * where a row's positions are, and the one step the two readers of that question now share.
  *
+ * <p>The invariant reading is a third reader of the same step, which is why the one place is beside
+ * {@code Shape} rather than in this package: what is under a type is a fact about a shape, and every
+ * reader of one already looks there.
+ *
  * <p>A tripwire and not a proof. The same fact is reachable by other spellings, so a helper in
  * between defeats it; what it does see is the line that has to be added first.
  */
@@ -40,7 +44,7 @@ class TheReadingAndThePlanTakeOneStepDownATypeTest {
     private static final RepositoryLayout REPOSITORY = RepositoryLayout.ofWorkingDirectory();
 
     /** Where the fields are taken off a product shape. */
-    private static final String THE_ONE_PLACE = "inputs/StructuralDescent.java";
+    private static final String THE_ONE_PLACE = "check/StructuralDescent.java";
 
     /**
      * The fields of a {@code Shape.Product} are read in one place.


### PR DESCRIPTION
Closes #1096.

## What was wrong

Four readers worked out what a value's type guarantees, each from the
declaration, and they disagreed about a sum.

- `Elaborator.elaborateFieldAccess` let a field every case spreads be read off
  the sum, through `TypeOps.commonSpreadFields`.
- `ValueClassGen` declared an accessor for it on the generated interface.
- `TypeGuarantees.at` answered that a choice between declarations states nothing
  and has nothing under it, so the invariant reading could neither state what the
  cases share nor walk into it.
- `TypeGuarantees.anyRuleUnder` descended into the cases and answered that a sum
  *does* have rules under it — a third answer, inside the class that gave the
  second.

Two more readers had the same gap for the same reason: the naming of subjects
under a parameter (`InvariantChecker.name`) and what holds of every element of a
container (`UniversalElementFacts.guaranteed`) both stopped at anything that was
not a `Hir.Data`.

Measured with the axis moved one element at a time: depth, a helper, and
`List.sum` all made no difference; the sum did.

| shape | before |
|---|---|
| `x: A` (record), `Amount(x.v.value)` | silent |
| `x: Expense` (sum), `Amount(x.v.value)` | E2011 |
| three record hops | silent |
| through `List.sum(List.map(...))`, record | silent |
| `C { ...x }`, `x: A` | silent |
| `C { ...x }`, `x: Choice` | E2011 |

## What this does

**`Shape.Sum` carries what its cases share.** `CommonProduct` is `None` or
`Shared(origins, fields)`. The origins are kept because the sharing is nominal
and the clauses are written on those declarations: held as fields alone, a reader
wanting the rules over them has only the names to find the declaration back from.
`Shape.Cases` — an unnamed union — has no common part, since a spread is shared
by being written and nothing writes those together.

**`PositionReading` is the one step off that shape.** It answers which
declarations state something of every value at a position, what is readable on
such a value, whether those are at paths of their own, and what stands below that
no reading there takes in. `TypeGuarantees`, `InvariantChecker.name`,
`UniversalElementFacts.guaranteed` and `Terms.fieldType` ask it. None of them
resolves a name to a declaration any more.

**`TypeGuarantees.At` is a product, not a choice.** A sum whose cases share a
spread states rules at the position *and* leaves its cases to the reading a match
opens. `Declared | Undeclared` could hold one of those, and an arm for the pair
would be the same shape one case later. So the answer is four independent
components:

| | |
|---|---|
| `here` | what the rules written here guarantee of this value |
| `beneath` | the positions under this one |
| `handedOn` | what a reading opened elsewhere answers for |
| `coverage` | `Complete`, or `Incomplete` naming the rules that could not be read |

`coverage` replaces the `everyClauseStated` boolean and names the rules rather
than counting them, so a reader is not left working out from a count which of
"handed on" and "lost" had happened. The two are different in kind: a rule handed
on is somebody's, and a clause lost here is nobody's and stands at run time.

**Handing on is no longer a way of stopping.** `GuaranteeWalk.Stop` is now only
what the walk itself did, and `PathEngine.leftBy` answers an
`InvariantChecker.Borne` rather than choosing between a handoff and a loss.
`NOTHING_DECLARED` and `NO_VALUE_THERE` are gone.

**Only the difference is handed on.** A case carries the shared clauses as well
as its own. Passed whole, one rule of the model would be owed twice — once at the
sum where it was read, once by whoever opens the case — and nothing below could
settle the first.

**`StructuralDescent` moves to `check`,** beside `Shape`. What is under a type is
a fact about a shape, and the invariant reading is its third reader.
`TheReadingAndThePlanTakeOneStepDownATypeTest` is what found that, by going red
on the new `product.fields()`.

## What is fixed

All four of the `businesstrip` reports the issue names, plus the container case
the measurement turned up (`List<Expense>` where the element type is the sum).
A sum whose cases share no spread still warns, which is right: the sharing is
nominal, and cases that merely declare a field of one name have not shared it.

## Tests

`ASumStatesWhatItsCasesShareAndLeavesTheCasesToAMatchTest` fixes each combination
of the two axes, and the row that matters is a sum whose cases share a spread and
one of which writes a rule of its own. Two mutations were run against it:

- stop reading what the cases share → 3 assertions red, including
  `states("capped")` inside that row
- never answer `ToAnotherReading` → 3 different assertions red, including
  `handedOn` inside that same row

Neither failure implies the other, which is the property the product exists for.

`WhatEveryCaseOfASumSpreadsEstablishesAConstructionTest` fixes the reported
symptom end to end, including the case that still warns.

`WhatEachWayOfStoppingLeavesIsWrittenDownOnceTest` no longer asserts that exactly
one way of stopping hands the rules on. That count is javac's now: nothing a stop
can answer says anybody else took them.

**Not covered:** the `coverage` axis has no mutation test. At a read position
every field is given, so `statedAt` answers null only when typing the clause
fails, and there is no source that makes that happen — so what is missing is a
witness, not a test.

## Leaving a rule out asks who wrote it

A reading is asked to leave a declaration's rules out so that the end which moves
says which declaration was holding it. What is left out is a property of each
rule, and both readers were asking it of the value the reading happened to be
opened at. The two are the same name only where a declaration writes its own
clauses and spreads nothing, so a rule a spread carried in was outside what either
reader could leave out — and that predates this branch:

```souther
data Common =
    { lo: Int
    , hi: Int
    }
    invariant based = lo >= 100
    invariant far = hi >= lo + 10

data Held = { ...Common }
    invariant near = hi >= lo + 5
```

`hi` stops at 110 and `far` puts it there, but `narrowedBy("hi", true)` answered
`[Held]` — the wrong declaration, because taking `Held` away took `Common`'s rule
with it. `WhichRuleHoldsAnEndIsAskedOfTheRuleAndNotOfWhereItIsReadTest` was red
on that before the fix.

`RulesLeftOut` is the question. A caller names declarations; a consumer can only
ask `excludes(RuleRef.Invariant)`. Held as a `Predicate`, a caller could hand one
over a position's name and it would compile — a method reference to `equals` takes
an `Object` and satisfies a predicate of any argument — and one of the tests here
was doing exactly that. So the two identities are separated by type:

| | |
|---|---|
| `stopAt`, `entered` | position identity, `TypeSymbol` |
| `withoutClauses` | rule provenance, `RulesLeftOut` |

Both readings ask it per rule now, `seedFields` included: whether the position is
read at all is asked once of the name, whether a rule is left out is asked of each
rule, and a reading short of one records a single `missed` against the position.
`Coverage.Incomplete.lost` is filtered by the same value.

## Scope of the tripwire

`TheInvariantReadingAsksWhatAPositionIsRatherThanDecidingTest` holds five files —
`TypeGuarantees`, `GuaranteeWalk`, `PathEngine`, `UniversalElementFacts`,
`StepInputFacts` — and the one place a shared part is derived. It does not cover
`InvariantChecker.name` or `Terms.fieldType`, which were two of the sites this
change moved onto the one reading: those files access declarations for other
reasons, and a check over the file would have to allow what it is meant to refuse.
Those two are held by the tests of what they answer, not by the tripwire.

`mvn -o test` from the reactor root: 10,376 tests, all green.

## Left out

The same exclusivity is in `StructuralInspection` (`Decomposed | Retained`) on
the input-coverage side, and it is deliberately not changed here. A spike that
gave a shared-spread sum children turned
`APositionUnderACaseIsAPositionTest` red, and its expectations say why: the
coverage reading already reaches those fields, once under each case
(`query@GlobalQuery.limit`, `query@FeedQuery.limit`). Decomposing the sum
position as well would give one field a second name and owe a row both.

The two readings differ for a reason. The invariant reading has no step that
opens a case — nothing opens one at a construction site — so the shared part is
out of reach unless the sum states it. The coverage reading walks into every
case, so it is already there.

Filed separately as #1099.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

