### PR TITLE
Carry the side a bound keeps, and keep a debt out of the reading that reached it

### DIFF
--- a/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
+++ b/souther-cli/src/test/java/souther/cli/AReportOfOneBorder.java
@@ -62,7 +62,8 @@ final class AReportOfOneBorder {
     static Border aBoundedBorder() {
         OriginRef origin = new OriginRef.InvariantOrigin(new RuleRef.Invariant(new Clause.Ref(
                 new Clause.Id(TypeSymbols.declared(new TypeKey("example.rate", "Amount")), 0),
-                java.util.Optional.of(new ClauseName("cap")))), 0, true);
+                java.util.Optional.of(new ClauseName("cap")))), 0,
+                souther.compiler.numeric.Towards.ABOVE, true);
         return Border.at(
                 BoundaryTarget.at(
                         new BorderQuantity.OfACoordinate(new AxisId("weigh", "w.a"),
@@ -79,7 +80,8 @@ final class AReportOfOneBorder {
     static Border aBorderAtTheEdgeOfItsDomain() {
         OriginRef origin = new OriginRef.InvariantOrigin(new RuleRef.Invariant(new Clause.Ref(
                 new Clause.Id(TypeSymbols.declared(new TypeKey("example.rate", "Amount")), 0),
-                java.util.Optional.of(new ClauseName("cap")))), 0, true);
+                java.util.Optional.of(new ClauseName("cap")))), 0,
+                souther.compiler.numeric.Towards.ABOVE, true);
         return Border.at(
                 BoundaryTarget.at(
                         new BorderQuantity.OfACoordinate(new AxisId("weigh", "w.a"),

--- a/souther-compiler/src/main/java/souther/compiler/check/DeclaredBorders.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DeclaredBorders.java
@@ -27,8 +27,8 @@ import java.util.Map;
  * switch over the arms a citation has.
  *
  * <p>Nothing here is an identity. What tells one authored line from another is the clause and which
- * of its conjuncts drew the end ({@link souther.compiler.partition.BorderObligationId}), and that is
- * what this is keyed by; what it hands back is what to call the line. Held as part of the identity,
+ * of its conjuncts drew the end ({@link souther.compiler.partition.AuthoredLine}), and that is what
+ * this is keyed by; what it hands back is what to call the line. Held as part of the identity,
  * the frames above would make one line two.
  */
 public record DeclaredBorders(souther.compiler.diag.Citation at,

--- a/souther-compiler/src/main/java/souther/compiler/partition/AuthoredLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AuthoredLine.java
@@ -1,0 +1,107 @@
+package souther.compiler.partition;
+
+import souther.compiler.check.DeclaredBorders;
+import souther.compiler.check.RuleRef;
+import souther.compiler.types.TypeSymbol;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * One line of the model: which rule, and which of that rule's lines.
+ *
+ * <p>What the author wrote, with nothing about the reading that reached it. A rule is read once per
+ * position of every behavior carrying it and once per call of every helper holding it, and none of
+ * that is here — no position, no behavior, no occurrence, no place a body arrived at it by. Those
+ * are {@link OriginRef}'s, which is which reading of the rule this is, and this is what several
+ * readings of one line share.
+ *
+ * <p><b>Not the rule alone.</b> One clause places as many lines as it has conjuncts with an end in
+ * them: {@code invariant within = value >= 1 && value <= 10} is one {@link RuleRef.Invariant} and
+ * two lines, and a row at the bottom of the range is no evidence about the top. So which conjunct
+ * drew it is part of this, and it is the clause's own text rather than the number it was written
+ * about ({@link souther.compiler.check.DeclaredBounds.Drawn}).
+ *
+ * <p><b>And what the line is.</b> Two lines of one rule at one value are told apart by what each
+ * says about its own value ({@link LineFacts}) — {@code value >= 5 && value <= 5} places a minimum
+ * and a maximum at 5, and they are two lines however few values are left between them. Whether some
+ * row could show the two apart is not asked: what row is left over is a fact about every other rule
+ * of the model, so an identity read off it would be worked back out of what the rules happened to
+ * leave rather than read from what this rule says.
+ *
+ * @param rule           which rule of the model drew it
+ * @param conjunct       which of that rule's lines this is, counted over the conjuncts the author
+ *                       wrote. Zero for a rule that draws one line, which is what a comparison and
+ *                       an {@code ensures} clause each do
+ * @param facts          what the rule says about its own line
+ * @param narrowedWithin the declarations that took a bound's end in, kept so that a narrowed line
+ *                       stays apart from the bare one it narrows: {@code MinuteOfDay}'s maximum is
+ *                       the same rule whether or not {@code WorkInterval} moved where it lands, and
+ *                       the line the two settled together is not the line the bound would have
+ *                       drawn alone
+ */
+public record AuthoredLine(RuleRef rule, int conjunct, LineFacts facts,
+                           List<TypeSymbol> narrowedWithin) {
+
+    public AuthoredLine {
+        if (rule == null || facts == null) {
+            throw new IllegalArgumentException("a line of the model is some rule's, and says what it"
+                    + " is: " + rule + " " + facts);
+        }
+        if (conjunct < 0) {
+            throw new IllegalArgumentException(
+                    "a conjunct of a rule is counted from zero: " + conjunct);
+        }
+        narrowedWithin = List.copyOf(narrowedWithin);
+    }
+
+    /**
+     * What a report calls this line.
+     *
+     * <p>The rule's own name, and the declarations that took it in beside it. A narrowing is not
+     * part of the rule, so the rule does not say it and this does.
+     *
+     * <p>A name and not a place, because a debt is not at one: a line an {@code invariant} drew is
+     * met wherever the type is carried, so any place to print would be the position of whichever
+     * behavior a walk reached first. Where a reading of it is being named rather than the line, the
+     * place is said by {@link OriginRef#describe}.
+     */
+    public String named() {
+        return rule.named() + (narrowedWithin.isEmpty() ? ""
+                : " within " + narrowedWithin.stream().map(TypeSymbol::name)
+                        .collect(java.util.stream.Collectors.joining(" or ")));
+    }
+
+    /**
+     * The declaration this line is owed to, where it is a declaration's line rather than a body's.
+     *
+     * <p>Whose debt a row at the line is. A clause of a {@code data} says something about the type
+     * wherever the type is carried, so a row standing at the line is evidence about the type and the
+     * behaviors carrying it have nothing to add — one line, owed once, at the declaration that wrote
+     * it. A comparison and an {@code ensures} clause are written in a body and say something about
+     * that body at that position, so they are owed per behavior.
+     *
+     * <p>A narrowed end is the bound's declaration. The declarations that took it in are what
+     * {@link #named} says beside the rule, and each of them is one where taking any away leaves the
+     * end where it is — so there is no one of them to send a reader to, and the rule that placed the
+     * end is where the line came from.
+     */
+    public Optional<TypeSymbol> owedToTheDeclaration() {
+        return rule instanceof RuleRef.Invariant i
+                ? Optional.of(i.clause().id().declaredOn())
+                : Optional.empty();
+    }
+
+    /**
+     * Which authored line of a declaration this is, where it is a declaration's line.
+     *
+     * <p>The clause and the conjunct that drew the end, which together name one line the author
+     * wrote — what a report reads the declaration's own words for the line by
+     * ({@link DeclaredBorders}).
+     */
+    public Optional<DeclaredBorders.Key> declaredLine() {
+        return rule instanceof RuleRef.Invariant i
+                ? Optional.of(new DeclaredBorders.Key(i, conjunct))
+                : Optional.empty();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/AuthoredLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AuthoredLine.java
@@ -67,7 +67,18 @@ public record AuthoredLine(RuleRef rule, int conjunct, LineFacts facts,
      * place is said by {@link OriginRef#describe}.
      */
     public String named() {
-        return rule.named() + (narrowedWithin.isEmpty() ? ""
+        return said(rule.named());
+    }
+
+    /**
+     * The same about a rule a reader is calling something else.
+     *
+     * <p>A comparison has no name, so a reading of one is said by where it is written
+     * ({@link OriginRef#describe}) — and what the narrowing adds is the same words either way. Said
+     * in both places, the two spellings of one narrowing read as two.
+     */
+    public String said(String rule) {
+        return rule + (narrowedWithin.isEmpty() ? ""
                 : " within " + narrowedWithin.stream().map(TypeSymbol::name)
                         .collect(java.util.stream.Collectors.joining(" or ")));
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/AuthoredLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/AuthoredLine.java
@@ -11,10 +11,17 @@ import java.util.Optional;
  * One line of the model: which rule, and which of that rule's lines.
  *
  * <p>What the author wrote, with nothing about the reading that reached it. A rule is read once per
- * position of every behavior carrying it and once per call of every helper holding it, and none of
- * that is here — no position, no behavior, no occurrence, no place a body arrived at it by. Those
- * are {@link OriginRef}'s, which is which reading of the rule this is, and this is what several
+ * position of every behavior carrying it and once per call of every helper holding it; which
+ * position, and which call of which helper, are {@link OriginRef}'s, and this is what several
  * readings of one line share.
+ *
+ * <p><b>How far that reaches is the rule's own answer and is not restated here.</b> {@link RuleRef}
+ * is what a rule is, and it does not tell every kind of rule apart the same way: a clause of a
+ * {@code data} is the type's rule wherever the type is carried, and a comparison and an
+ * {@code ensures} clause are written in a body and are that behavior's — so a helper's comparison
+ * called from two behaviors is two rules and two lines, while a type's clause read in two behaviors
+ * is one. Said again here as "no behavior", this would be a second answer to a question the rule
+ * already answers, and the two would differ for whichever kind of rule was added next.
  *
  * <p><b>Not the rule alone.</b> One clause places as many lines as it has conjuncts with an end in
  * them: {@code invariant within = value >= 1 && value <= 10} is one {@link RuleRef.Invariant} and

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -34,10 +34,10 @@ import java.util.Optional;
  * value instead of a side — all arrived as a shorter list. A role that goes missing now stops the
  * build where the border is made.
  *
- * <p>Which rule drew it is {@link #origin}'s, which reading of that rule this is is the origin's too,
- * and which of those readings are one line is {@link BoundaryLine}'s. This is not a fourth identity:
- * a border is a line together with what it owes, and two readings of one line owe the same four
- * things.
+ * <p>Which rule drew it and which line of that rule is {@link #origin}'s, which reading of that line
+ * this is is the origin's too, and which of those readings are one line is {@link BoundaryLine}'s.
+ * This is not another identity: a border is a line together with what it owes, and two readings of
+ * one line owe the same four things.
  *
  * @param cut     where the line is: what is cut, and where on it
  * @param origin  the rule that drew it, as this reading met it

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -74,7 +74,7 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
      * asked for once per position of every behavior carrying the type (issue #1062).
      */
     public BorderObligationId obligation() {
-        return new BorderObligationId(origin, cut.at());
+        return new BorderObligationId(origin.authoredLine(), cut.at());
     }
 
     /** Where the line is, as a report names it. Not what any one of its points asks for: that is
@@ -617,10 +617,14 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
      */
     private static boolean ordersAroundTheCut(OriginRef origin) {
         return switch (origin) {
-            case OriginRef.ComparisonOrigin g -> !g.singles();
-            case OriginRef.EnsuresOrigin e -> !e.singles();
-            case OriginRef.NarrowedOrigin n -> ordersAroundTheCut(n.bound());
+            // Nothing outside a bound can be constructed, so a bound has no far side to order
+            // against however its own values run. Which is not what `singles` says of it, and
+            // reading the two as one question is why this is asked here and not answered by the
+            // rule.
             case OriginRef.InvariantOrigin _ -> false;
+            case OriginRef.NarrowedOrigin n -> ordersAroundTheCut(n.bound());
+            case OriginRef.ComparisonOrigin _, OriginRef.EnsuresOrigin _ ->
+                    !origin.lineFacts().singles();
         };
     }
 
@@ -640,21 +644,11 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
 
     /** Whether the threshold's own value satisfies the rule that drew the line. */
     private static boolean holdsAtTheValue(OriginRef origin) {
-        return switch (origin) {
-            case OriginRef.ComparisonOrigin g -> g.holdsAtTheValue();
-            case OriginRef.EnsuresOrigin e -> e.holdsAtTheValue();
-            case OriginRef.InvariantOrigin i -> i.holdsAtTheValue();
-            case OriginRef.NarrowedOrigin n -> holdsAtTheValue(n.bound());
-        };
+        return origin.lineFacts().holdsAtTheValue();
     }
 
     /** Which side of the line the threshold's own value belongs to. */
     private static boolean valueBelongsBelow(OriginRef origin) {
-        return switch (origin) {
-            case OriginRef.ComparisonOrigin g -> g.valueBelongsBelow();
-            case OriginRef.EnsuresOrigin e -> e.valueBelongsBelow();
-            case OriginRef.InvariantOrigin _ -> false;
-            case OriginRef.NarrowedOrigin n -> valueBelongsBelow(n.bound());
-        };
+        return origin.lineFacts().valueBelongsBelow();
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -67,11 +67,14 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
     /**
      * What a row here is owed for, which several readings of this line share.
      *
-     * <p>The line the author wrote, without the position it was read at. Everything that folds
-     * readings together keys on this; everything that says where a row would go reads {@link #cut}.
-     * Both are here rather than one being worked out from the other by whoever needs it, because a
-     * caller deriving a key from the parts it happened to know is how one clause's row came to be
-     * asked for once per position of every behavior carrying the type (issue #1062).
+     * <p>The line the author wrote, without the position it was read at. What folds readings
+     * together keys on {@link BoundaryLine}, which is this line and where it was read; this is what
+     * such a fold may not cross, and {@code Coverages} holds itself to that where it merges.
+     * Everything that says where a row would go reads {@link #cut}.
+     *
+     * <p>Both are here rather than one being worked out from the other by whoever needs it: a caller
+     * deriving a key from the parts it happened to know asks for one clause's row once per position
+     * of every behavior carrying the type.
      */
     public BorderObligationId obligation() {
         return new BorderObligationId(origin.authoredLine(), cut.at());

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -424,17 +424,12 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
         Criterion rest = new Criterion.AnythingBut(cut);
         switch (noSideOf(origin)) {
             case THE_RULES_REFUSE_IT -> {
-                // Which way the bound keeps its values, taken from the end of what the rules leave
-                // that this line is: a bound orders nothing around itself, so there is no side to
-                // read off the rule, and its line is where what it leaves stops.
-                Towards kept = keptBy(within, cut);
-                if (kept == null) {
-                    // The reader of where a bound stops and the reader of what the position is left
-                    // with disagreeing about one rule. A bound's line is an end of what it leaves,
-                    // and a line inside that is not one this rule drew.
-                    throw new IllegalStateException(
-                            "a bound whose line is not an end of what it leaves: " + origin.named());
-                }
+                // Which way the bound keeps its values, from what the reading that placed the end
+                // recorded: a bound orders nothing around itself, so there is no side to read off
+                // the line, and which of the two ends it is is what says which way it runs. Held
+                // against the range below, which the same reading settled.
+                Towards kept = satisfyingSide(origin);
+                requireItIsTheEndItKeeps(within, cut, kept, origin);
                 Demand on = againstABound(space, cut, kept, holdsHere, within, origin);
                 demands.put(PointRole.ON, on);
                 demands.put(PointRole.OFF, new Demand.NotOwed(NotOwedReason.THE_RULES_REFUSE_IT));
@@ -513,25 +508,25 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
     }
 
     /**
-     * Which way a bound keeps its values, from the end of what the rules leave that its line is.
+     * That a bound's line stands where what the rules leave stops on the side the bound keeps.
      *
-     * <p>Asked of what the rules leave rather than of the rule. A bound records where it stops and
-     * not which side of that it keeps ({@link OriginRef.InvariantOrigin}), and it does not have to:
-     * a bound's line is an end of what it leaves, so which end it is says which way the values run.
+     * <p>Two readings of one rule held against each other. Which way the bound runs comes from the
+     * reading that placed the end and the range comes from the reading of everything the position
+     * is left with, and a bound's line is by construction the end of that range on the side it
+     * keeps. Where the two disagree, one of them is about a rule the other did not read — which is
+     * not a state a model can put them in, and a line inside the range is not one this rule drew.
      *
-     * <p>Null where the line is neither end, which is nothing a model can write. Where both ends are
-     * the line — a rule leaving one value — either answer names the same point, and the low end is
-     * taken.
+     * <p>The side and not either end. A rule leaving one value puts both ends at the line, and each
+     * of its two bounds answers for the end it placed rather than for whichever end matches.
      */
-    private static Towards keptBy(NumericDomain.Bounds within, Level cut) {
-        if (within == null) {
-            return null;
+    private static void requireItIsTheEndItKeeps(NumericDomain.Bounds within, Level cut,
+                                                 Towards kept, OriginRef origin) {
+        Endpoint end = within == null ? null
+                : kept == Towards.ABOVE ? within.min() : within.max();
+        if (end == null || !end.at().sameAs(placeOf(cut))) {
+            throw new IllegalStateException(
+                    "a bound whose line is not where what it leaves stops: " + origin.named());
         }
-        Place at = placeOf(cut);
-        if (within.min() != null && within.min().at().sameAs(at)) {
-            return Towards.ABOVE;
-        }
-        return within.max() != null && within.max().at().sameAs(at) ? Towards.BELOW : null;
     }
 
     /** A side of the border, or the reason the rules leave nothing there for a row to be at. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderObligationId.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderObligationId.java
@@ -3,49 +3,59 @@ package souther.compiler.partition;
 /**
  * What a row is owed for: one line the author wrote, wherever it is read.
  *
- * <p>The key evidence is interchangeable under. Two readings are one debt when a row standing at
- * either establishes what a row standing at the other would, and that is a property of the line and
- * not of the reading — so {@code UserId}'s clause saying a user id is a string of one character or
- * more is one row to write, whether the position it was read at is {@code draft.owner} or
- * {@code activities[*]@CallTask.owner}, and whether the behavior carrying it is {@code scheduleMeeting}
- * or {@code touchCount}. Neither behavior says anything about the length of a user id, so neither
- * can disagree with the other about a row at length 1 (issue #1062).
+ * <p>Two readings are one debt when they are readings of that same line — whatever position of
+ * whatever behavior each was met at, and whatever occurrence of it a body reached. A row standing at
+ * one then establishes what a row standing at the other would, which is what follows from their
+ * being one debt and not the test for it: {@code value >= 5 && value <= 5} places two lines at one
+ * value, one row stands at both, and they are two.
+ *
+ * <p>So {@code UserId}'s clause saying a user id is a string of one character or more is one row to
+ * write, whether the position it was read at is {@code draft.owner} or
+ * {@code activities[*]@CallTask.owner}, and whether the behavior carrying it is
+ * {@code scheduleMeeting} or {@code touchCount}. Neither behavior says anything about the length of
+ * a user id, so neither can disagree with the other about a row at length 1.
  *
  * <p><b>Not the rule.</b> One clause places two ends: {@code invariant within = value >= 1 && value
  * <= 10} is one {@link souther.compiler.check.RuleRef.Invariant} and two lines, and a row at the
  * bottom of the range is no evidence about the top. Keyed on the rule, the author writes one row and
- * the other end goes quiet.
+ * the other end goes quiet. Which line of the rule this is is {@link AuthoredLine}'s.
  *
  * <p><b>Not the level either.</b> Two rules can cut at one value on one carrier — a record stopping
  * a {@code Minute} at 1000 and another record stopping it at the same 1000 — and each is a rule the
- * author could change without touching the other. That is the accounting {@link OriginRef} already
- * keeps for cuts, and it is kept here for the same reason.
+ * author could change without touching the other. That is the accounting {@link OriginRef} keeps for
+ * cuts, and it is kept here for the same reason.
  *
  * <p><b>And not where it was read.</b> The quantity a line was met on — which position of which
  * behavior — is the occurrence, one per position of every behavior carrying the type. It is what
- * {@link Border#cut()} holds, and holding it here is what asked for one clause's row 126 times over
- * {@code crm}'s {@code UserId}.
+ * {@link Border#cut()} holds, and holding it here asks for one clause's row once per position.
  *
- * <p>Three identities and not one, the way {@link souther.compiler.coverage.CoverageSites.Obligation}
- * and {@link souther.compiler.coverage.ControlPointId} are on the arm side. {@link OriginRef#rule()}
- * answers which rule of the model this came from and is provenance; this answers which debt it is;
- * {@link Border} answers where it was read. A narrowing moves the second without moving the first:
+ * <p><b>Nor which reading of the rule reached it.</b> A comparison inside a non-recursive helper is
+ * read once per call of that helper: the calls carry different comparison sites, each is measured on
+ * its own, and the author wrote one guard and owes one row for it. Keyed on the reading, the two are
+ * two debts that only the merge collecting what each reading saw brings back to one — and which call
+ * site the surviving debt names then comes down to the order a walk took. What an occurrence is for
+ * is measurement: a row meets a guard's line by getting that comparison to answer, and which one it
+ * lit is read where the reading is, before anything is folded.
+ *
+ * <p>Four identities and not one, the way {@link souther.compiler.coverage.CoverageSites.Obligation}
+ * and {@link souther.compiler.coverage.ControlPointId} are on the arm side.
+ * {@link OriginRef#rule()} answers which rule of the model this came from and is provenance; this
+ * answers which debt it is; {@link BoundaryLine} answers which readings are one line; {@link Border}
+ * answers where one of them was read. A narrowing moves the debt without moving the rule:
  * {@code MinuteOfDay}'s maximum is the same rule whether or not {@code WorkInterval} moved where it
  * lands, and the line the two settled together is not the line the bound would have drawn alone — so
  * it comes back the same from {@code rule()} and different from here.
  *
- * @param origin the rule that drew the line, as the reading met it — narrowings and all, because a
- *               narrowed end is a distinction the narrowing declarations authored and not one the
- *               bound authored on its own
- * @param at     where on the quantity it cut. A level and not a place: what a line is drawn on is
- *               not always a position, and two of the three shapes count something no position holds
+ * @param line which line of the model a row here is owed for
+ * @param at   where on the quantity it cut. A level and not a place: what a line is drawn on is not
+ *             always a position, and two of the three shapes count something no position holds
  */
-public record BorderObligationId(OriginRef origin, Level at) {
+public record BorderObligationId(AuthoredLine line, Level at) {
 
     public BorderObligationId {
-        if (origin == null || at == null) {
+        if (line == null || at == null) {
             throw new IllegalArgumentException(
-                    "a debt is some rule's line somewhere: " + origin + " " + at);
+                    "a debt is some rule's line somewhere: " + line + " " + at);
         }
     }
 
@@ -53,9 +63,26 @@ public record BorderObligationId(OriginRef origin, Level at) {
      * Which rule of the model this came from, through however many narrowings.
      *
      * <p>Provenance, and never a key. Offered here so that a reader wanting to say what drew the
-     * line does not reach past this into the origin and come back holding something that groups.
+     * line does not reach past this into the line and come back holding something that groups.
      */
     public souther.compiler.check.RuleRef provenance() {
-        return origin.rule();
+        return line.rule();
+    }
+
+    /** What a report calls this line, which is the rule's own name and never a place a body reached
+     *  it at. */
+    public String named() {
+        return line.named();
+    }
+
+    /** The declaration this line is owed to, where a declaration's clause drew it. */
+    public java.util.Optional<souther.compiler.types.TypeSymbol> owedToTheDeclaration() {
+        return line.owedToTheDeclaration();
+    }
+
+    /** Which authored line of that declaration it is, for a reader that wants the words the
+     *  declaration wrote it in. */
+    public java.util.Optional<souther.compiler.check.DeclaredBorders.Key> declaredLine() {
+        return line.declaredLine();
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderObligationId.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderObligationId.java
@@ -3,17 +3,20 @@ package souther.compiler.partition;
 /**
  * What a row is owed for: one line the author wrote, wherever it is read.
  *
- * <p>Two readings are one debt when they are readings of that same line — whatever position of
- * whatever behavior each was met at, and whatever occurrence of it a body reached. A row standing at
- * one then establishes what a row standing at the other would, which is what follows from their
- * being one debt and not the test for it: {@code value >= 5 && value <= 5} places two lines at one
- * value, one row stands at both, and they are two.
+ * <p>Two readings are one debt when they are readings of that same line — whatever position each was
+ * met at and whatever occurrence of it a body reached, as far as the rule itself is one rule
+ * ({@link AuthoredLine}). A row standing at one then establishes what a row standing at the other
+ * would, which is what follows from their being one debt and not the test for it:
+ * {@code value >= 5 && value <= 5} places two lines at one value, one row stands at both, and they
+ * are two.
  *
  * <p>So {@code UserId}'s clause saying a user id is a string of one character or more is one row to
  * write, whether the position it was read at is {@code draft.owner} or
  * {@code activities[*]@CallTask.owner}, and whether the behavior carrying it is
  * {@code scheduleMeeting} or {@code touchCount}. Neither behavior says anything about the length of
- * a user id, so neither can disagree with the other about a row at length 1.
+ * a user id, so neither can disagree with the other about a row at length 1. A comparison written in
+ * a body is the other way about — it says something about that body — so a helper's comparison
+ * called from two behaviors is two rules, and two rows to write.
  *
  * <p><b>Not the rule.</b> One clause places two ends: {@code invariant within = value >= 1 && value
  * <= 10} is one {@link souther.compiler.check.RuleRef.Invariant} and two lines, and a row at the

--- a/souther-compiler/src/main/java/souther/compiler/partition/BoundaryLine.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BoundaryLine.java
@@ -1,84 +1,52 @@
 package souther.compiler.partition;
 
 import souther.compiler.check.RuleRef;
-import souther.compiler.types.TypeSymbol;
-
-import java.util.List;
 
 /**
  * One line a row can be written at, told from another.
  *
- * <p>The third of the three equivalences, and not a correction of either of the others. Which rule
- * it is is {@link RuleRef}'s and is the same value however many times the rule is read; which
- * reading of it drew a boundary is {@link OriginRef}'s; and this says which of those boundaries are
- * one line. They are three questions, and a reader that had one of them for another folded two
- * lines together or asked for a row twice.
+ * <p>One of four equivalences and not a correction of any of them. Which rule it is is
+ * {@link RuleRef}'s and is the same value however many times the rule is read; which line of the
+ * model that rule drew is {@link AuthoredLine}'s; which reading of it drew a boundary is
+ * {@link OriginRef}'s; and this says which of those boundaries a partition folds into one. A reader
+ * that had one of them for another folded two lines together or asked for a row twice.
  *
  * <p>Where the line is is part of it, and it has to be. One comparison written in a helper draws a
  * line wherever the helper is applied — {@code cap(a)} and {@code cap(b)} are one rule, drawn the
  * same way — and the lines are at different positions, so a row at one is not a row at the other.
- * Told apart by the rule and the drawing alone they fold into one, and a row is owed once for two.
+ * Told apart by the rule and what it drew alone they fold into one, and a row is owed once for two.
  *
  * <p>Which reading drew it is not part of it, and that is the other half. A guard inside a
  * non-recursive helper is read once per call of that helper, so one line the author drew at one
  * position arrives as several origins — they carry different arms and a different comparison site,
  * each is a real occurrence measured on its own, and they are one line.
  *
- * <p>Here rather than on {@link OriginRef}, because a line is what a partition makes of an origin
- * and not something an origin knows about itself. Asked of it there, the folding read as the
- * origin's own identity, and the next thing to key on an origin keyed on the reading.
+ * <p><b>Which authored line it is, and not the folding, is asked of the origin.</b> A reading knows
+ * which line of the model it is a reading of, and says so ({@link OriginRef#authoredLine}); what
+ * this adds is where that line was read, which is the position and behavior a row would be written
+ * for. The folding stays a partition's answer rather than an origin's, so that what an origin
+ * answers about itself is never the key something else groups it by.
+ *
+ * <p><b>So a debt is what is left when the position goes.</b> Two borders under one of these are
+ * one {@link BorderObligationId} by construction: this holds the authored line and where it was
+ * read, and a debt holds the authored line and the value it is at. Folding readings into a line
+ * therefore never folds two debts together, which is what {@code Coverages} holds itself to when it
+ * merges what each reading saw. The converse does not hold and must not: one authored line is read
+ * at as many positions and behaviors as carry the rule, and every one of them is the same row to
+ * write.
  *
  * <p>The line and not one of its points. Which of the four coverage items a row is at is
- * {@link PointRole}'s, and it used to be part of this — so the {@code ON} point and the
- * {@code OFF} point of one border were two lines, and nothing could ask what one border owed. Two
- * readings of one line owe the same four things, which is what makes this the key they are merged
- * under.
+ * {@link PointRole}'s, and holding it here makes the {@code ON} point and the {@code OFF} point of
+ * one border two lines, leaving nothing to ask what one border owes. Two readings of one line owe
+ * the same four things, which is what makes this the key they are merged under.
  *
- * @param target  where the line is
- * @param drawing whose rule drew it, and what the line it drew is
+ * @param target where the line is
+ * @param line   which line of the model was drawn there
  */
-public record BoundaryLine(BoundaryTarget target, Drawing drawing) {
-
-    /**
-     * Whose rule drew a line, and what the line it drew is.
-     *
-     * <p>Beside the rule rather than in it. Two boundaries of one rule at one value are two lines
-     * where they answer these differently, since a row on the line is what shows them apart — and
-     * none of them tells one rule from another, which is why the rule does not carry them.
-     *
-     * @param narrowedWithin the declarations a bound was taken in by, kept so that a narrowed line
-     *                       stays apart from the bare one it narrows
-     */
-    public record Drawing(RuleRef rule, boolean valueBelongsBelow, boolean holdsAtTheValue,
-                          boolean singles, List<TypeSymbol> narrowedWithin) {
-
-        public Drawing {
-            narrowedWithin = List.copyOf(narrowedWithin);
-        }
-    }
+public record BoundaryLine(BoundaryTarget target, AuthoredLine line) {
 
     /** The line {@code border} is the coverage items of. */
     public static BoundaryLine of(Border border) {
-        return new BoundaryLine(border.cut(), drawnBy(border.origin()));
-    }
-
-    private static Drawing drawnBy(OriginRef origin) {
-        return switch (origin) {
-            case OriginRef.ComparisonOrigin g -> new Drawing(g.rule(), g.valueBelongsBelow(),
-                    g.holdsAtTheValue(), g.singles(), List.of());
-            case OriginRef.EnsuresOrigin e -> new Drawing(e.rule(), e.valueBelongsBelow(),
-                    e.holdsAtTheValue(), e.singles(), List.of());
-            // A bound leaves nothing outside itself, so no value below or above it is a line of its
-            // own and `valueBelongsBelow` has nothing to say. Whether the cut is one of the range's
-            // own does have something to say, and telling two ends at one value apart by it is what
-            // keeps a bound that admits the value from folding into one that stops short of it.
-            case OriginRef.InvariantOrigin i ->
-                    new Drawing(i.rule(), false, i.holdsAtTheValue(), false, List.of());
-            case OriginRef.NarrowedOrigin n -> {
-                Drawing inner = drawnBy(n.bound());
-                yield new Drawing(inner.rule(), inner.valueBelongsBelow(),
-                        inner.holdsAtTheValue(), inner.singles(), n.within());
-            }
-        };
+        return new BoundaryLine(border.cut(), border.origin().authoredLine());
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/EnsuresThresholds.java
@@ -120,13 +120,18 @@ public final class EnsuresThresholds {
                 new ArrayList<>(), new ArrayList<>());
         for (StatedContract.StatedRule rule : stated.rules()) {
             String clause = labelOf(rule);
+            // Which line of the clause each one is, counted over every comparison the clause states
+            // in the order they are written. A clause states as many lines as it has comparisons,
+            // and a row at one of them says nothing about the next.
+            int line = 0;
             for (StatedContract.Conjunct conjunct : rule.conjuncts()) {
                 // A conjunct this compiler could not type is one it has not read. Nothing is
                 // concluded from it either way: it draws no line here, and that it drew none is not
-                // a statement that the model has none there.
-                if (conjunct.stated().orNull() != null) {
-                    stated(conjunct.stated().orNull(), rule, clause, reads, symbols, quantities, drawn);
-                }
+                // a statement that the model has none there. It is still counted, so that which
+                // line of the clause the next one is does not move with what this reading managed.
+                line = conjunct.stated().orNull() == null ? line + 1
+                        : stated(conjunct.stated().orNull(), rule, clause, line, reads, symbols,
+                                quantities, drawn);
             }
         }
         return new Clauses(drawn.thresholds(), drawn.singled(), drawn.between(), drawn.rulesWithoutALine());
@@ -145,13 +150,18 @@ public final class EnsuresThresholds {
      * <p>Nothing below anything else. A disjunct holds where the other one does not, a call's
      * argument is not what the call comes to, and neither states the comparison inside it — so a
      * line drawn from one would be a line the model does not draw.
+     *
+     * @param line which line of the clause this one is
+     * @return which line of the clause the next one is. Every statement the walk reaches takes one,
+     *         whether or not a line came out of it, so that a reading which could make nothing of
+     *         one numbers the rest the same as a reading that could
      */
-    private static void stated(Core e, StatedContract.StatedRule rule, String clause,
-                               InputReads reads, Symbols symbols, souther.compiler.inputs.Quantities quantities, Drawn out) {
+    private static int stated(Core e, StatedContract.StatedRule rule, String clause, int line,
+                              InputReads reads, Symbols symbols, souther.compiler.inputs.Quantities quantities, Drawn out) {
         if (e instanceof Core.Binary both && both.op() == BinOp.AND) {
-            stated(both.left(), rule, clause, reads, symbols, quantities, out);
-            stated(both.right(), rule, clause, reads, symbols, quantities, out);
-            return;
+            return stated(both.right(), rule, clause,
+                    stated(both.left(), rule, clause, line, reads, symbols, quantities, out),
+                    reads, symbols, quantities, out);
         }
         // Through what a `let` binds, which is not a choice: what the expression comes to is its
         // body, so the body states whatever the rule states. This is the shape a helper called from
@@ -159,15 +169,14 @@ public final class EnsuresThresholds {
         // parameter — and a walk that stopped here found the rule stating nothing while the model
         // plainly says something about the position.
         if (e instanceof Core.LetIn let) {
-            stated(let.body(), rule, clause, reads.and(let.binder(), let.value()), symbols,
-                    quantities, out);
-            return;
+            return stated(let.body(), rule, clause, line, reads.and(let.binder(), let.value()),
+                    symbols, quantities, out);
         }
         // A disjunction was read, and what it states is not what either side of it states. Said as
         // nothing rather than as a rule this could not read: reporting it would send an author after
         // a limit of this compiler that is not there.
         if (e instanceof Core.Binary or && or.op() == BinOp.OR) {
-            return;
+            return line + 1;
         }
         // Anything else is a form this walk does not read. Which positions it is about is still
         // said, because a position left out of every answer is reported as one the model draws no
@@ -181,7 +190,7 @@ public final class EnsuresThresholds {
                     GuardThresholds.mentionedIn(e, reads, symbols).stream()
                             .map(FilingCoordinate::at).toList(),
                     out.rulesWithoutALine());
-            return;
+            return line + 1;
         }
         // What the comparison comes to is read the same way wherever a comparison is written, which
         // is what {@link ComparisonAssessment} is for: a clause and a guard over one arithmetic form
@@ -201,7 +210,7 @@ public final class EnsuresThresholds {
             // reading of the comparison; taken off the level the rule was written with, a rule that
             // wrote a multiple of the position named a class at a number the position never holds.
             case ComparisonAssessment.AtAPosition at -> {
-                OriginRef.EnsuresOrigin origin = originOf(rule, clause, at.cutting());
+                OriginRef.EnsuresOrigin origin = originOf(rule, clause, line, at.cutting());
                 if (at.cutting().singles()) {
                     // The value the rule names, for the reason a body's rule gets: where its line
                     // falls and not the value beside it.
@@ -234,7 +243,7 @@ public final class EnsuresThresholds {
                 // border to owe a row away from.
                 if (over.drawsABorder()) {
                     out.between().add(new LineDrawn(over.cutting(),
-                            originOf(rule, clause, over.cutting())));
+                            originOf(rule, clause, line, over.cutting())));
                 }
             }
             // Nothing this reader draws at any of them. What each leaves the positions is said
@@ -243,13 +252,14 @@ public final class EnsuresThresholds {
                  ComparisonAssessment.OutsideTheDomain _,
                  ComparisonAssessment.AnswerDependent _, ComparisonAssessment.NoInput _ -> { }
         }
+        return line + 1;
     }
 
     /** How a row meets a line this clause drew, which is the clause's own answer and no other
      *  rule's. */
     private static OriginRef.EnsuresOrigin originOf(StatedContract.StatedRule rule, String clause,
-                                                    Cutting cutting) {
-        return new OriginRef.EnsuresOrigin(new RuleRef.Ensures(rule.id(), clause),
+                                                    int line, Cutting cutting) {
+        return new OriginRef.EnsuresOrigin(new RuleRef.Ensures(rule.id(), clause), line,
                 cutting.valueBelongsBelow(), cutting.holdsAtTheValue(), cutting.singles());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/LineFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LineFacts.java
@@ -1,0 +1,34 @@
+package souther.compiler.partition;
+
+/**
+ * What a reading of a rule recorded about the line it drew.
+ *
+ * <p>One projection and not three questions. Each of these is a fact some producer wrote down and
+ * every consumer of a line wants. Asked one at a time, each answer is a switch over the arms an
+ * {@link OriginRef} has, written wherever the answer is wanted, and two such switches are free to
+ * fill one slot differently — a slot a rule leaves empty is then filled by whoever is reading rather
+ * than by whoever knows. Kept as one value, a rule answers all three where it is written and no
+ * consumer has a slot to fill in for it.
+ *
+ * <p>Recorded rather than worked out. What a border <em>makes</em> of these — which way the rule is
+ * satisfied from its line, whether it orders the values around it at all, which of the four points a
+ * row stands at — is {@link Border}'s, derived there from these and derived nowhere else. A reading
+ * says what it read, and a measure says what that means for the rows it asks for.
+ *
+ * @param valueBelongsBelow which side of the line the cut value itself is on. For a rule that orders
+ *                          the values around its line it decides which neighbour is the other
+ *                          class's edge: {@code <= 3000} leaves 3001 over there, {@code < 3000}
+ *                          leaves 2999. For a bound, which orders nothing across its line because
+ *                          nothing outside it can be constructed, it is still an answer — the value
+ *                          a bound stops at is one it keeps or one it leaves, and which of the two
+ *                          says which way the bound runs
+ * @param holdsAtTheValue   whether the rule is true at the line's own value, which is what says
+ *                          whether a row there is the border's {@code ON} point or its {@code OFF}
+ *                          point. Not derivable from {@code valueBelongsBelow}: {@code x <= c} and
+ *                          {@code x > c} agree about the class the value is in and disagree here
+ * @param singles           whether the rule singles the value out rather than ordering the values
+ *                          either side of it. False of a bound, and not because a bound has nothing
+ *                          to say: a bound keeps a run of the order and the run is what it is about,
+ *                          which is a different thing from the far side holding no value
+ */
+public record LineFacts(boolean valueBelongsBelow, boolean holdsAtTheValue, boolean singles) {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/LineFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LineFacts.java
@@ -10,10 +10,15 @@ package souther.compiler.partition;
  * than by whoever knows. Kept as one value, a rule answers all three where it is written and no
  * consumer has a slot to fill in for it.
  *
- * <p>Recorded rather than worked out. What a border <em>makes</em> of these — which way the rule is
- * satisfied from its line, whether it orders the values around it at all, which of the four points a
- * row stands at — is {@link Border}'s, derived there from these and derived nowhere else. A reading
- * says what it read, and a measure says what that means for the rows it asks for.
+ * <p>Worked out once from what the producer knows, and never worked back out of what came later. A
+ * bound records which way it keeps its values and whether it admits the value it stops at, and which
+ * side of the line that value is on follows from the two — so it is settled here, beside the rule
+ * that knows both, rather than by a consumer holding the range every rule together left.
+ *
+ * <p>And what a border <em>makes</em> of these — which way the rule is satisfied from its line,
+ * whether it orders the values around it at all, which of the four points a row stands at — is
+ * {@link Border}'s, derived there from these and derived nowhere else. A reading says what it read,
+ * and a measure says what that means for the rows it asks for.
  *
  * @param valueBelongsBelow which side of the line the cut value itself is on. For a rule that orders
  *                          the values around its line it decides which neighbour is the other

--- a/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
@@ -110,14 +110,24 @@ final class LocalInspection {
             return List.of();
         }
         Map<String, Cut> byValue = new LinkedHashMap<>();
-        cut(byValue, bounds.min(), own == null ? null : own.min(), bounds.carrier(), under);
-        cut(byValue, bounds.max(), own == null ? null : own.max(), bounds.carrier(), over);
+        cut(byValue, bounds.min(), own == null ? null : own.min(), bounds.carrier(),
+                souther.compiler.numeric.Towards.ABOVE, under);
+        cut(byValue, bounds.max(), own == null ? null : own.max(), bounds.carrier(),
+                souther.compiler.numeric.Towards.BELOW, over);
         return List.copyOf(byValue.values());
     }
 
-    /** One end as a cut, owed once to each rule that put it there. */
+    /**
+     * One end as a cut, owed once to each rule that put it there.
+     *
+     * @param keeps which way the bound runs from this end, which is which of the two ends it is.
+     *              Known here because the ends are read one at a time, and nowhere below: a bound
+     *              records where it stops, and everything past this holds the range the rules leave
+     *              rather than the end that made it
+     */
     private static void cut(Map<String, Cut> into, DeclaredBounds.End end, DeclaredBounds.End own,
-                            Carrier carrier, List<TypeSymbol> within) {
+                            Carrier carrier, souther.compiler.numeric.Towards keeps,
+                            List<TypeSymbol> within) {
         if (end == null) {
             return;
         }
@@ -131,7 +141,7 @@ final class LocalInspection {
         // these declarations — which is nothing the rule says about itself.
         for (DeclaredBounds.Drawn from : end.from()) {
             put(into, carrier, end.value(),
-                    new OriginRef.InvariantOrigin(from.rule(), from.conjunct(),
+                    new OriginRef.InvariantOrigin(from.rule(), from.conjunct(), keeps,
                             end.at().inclusive()),
                     moved ? within : List.<TypeSymbol>of());
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
@@ -168,6 +168,14 @@ public sealed interface OriginRef {
      * which shape the line has.
      *
      * @param rule              which clause of which behavior — the rule and the whole of it
+     * @param conjunct          which of the clause's comparisons drew this line, counted over every
+     *                          one the clause states in the order they are written. A clause states
+     *                          as many lines as it has comparisons in it, and they are not each
+     *                          other's: {@code r.a >= 5 && r.b >= 5} is one clause naming two
+     *                          positions, and a row whose {@code a} is 5 says nothing about
+     *                          {@code b}. Counted over all of them and not over the ones a line came
+     *                          out of, so that a reading which could make nothing of one still
+     *                          numbers the next the same as a reading that could
      * @param valueBelongsBelow which side of the line the cut value itself is on, which decides
      *                          which neighbour is the other class's edge
      * @param holdsAtTheValue   whether the comparison is true at the line's own value. Not derivable
@@ -180,8 +188,16 @@ public sealed interface OriginRef {
      * @param singles           whether the comparison singles the value out rather than ordering
      *                          the values either side of it
      */
-    record EnsuresOrigin(RuleRef.Ensures rule, boolean valueBelongsBelow,
-                         boolean holdsAtTheValue, boolean singles) implements OriginRef {}
+    record EnsuresOrigin(RuleRef.Ensures rule, int conjunct, boolean valueBelongsBelow,
+                         boolean holdsAtTheValue, boolean singles) implements OriginRef {
+
+        public EnsuresOrigin {
+            if (conjunct < 0) {
+                throw new IllegalArgumentException(
+                        "a conjunct of a clause is counted from zero: " + conjunct);
+            }
+        }
+    }
 
     /**
      * A bound one rule put there and another took in.
@@ -254,9 +270,9 @@ public sealed interface OriginRef {
             // and a line it drew are found the same way, and two spellings of one place read as two
             // places.
             case ComparisonOrigin g -> g.read().written().said(names, sectionSource);
-            case NarrowedOrigin n -> n.bound().describe(names, sectionSource) + " within "
-                    + n.within().stream().map(TypeSymbol::name)
-                            .collect(java.util.stream.Collectors.joining(" or "));
+            // The declarations that took the end in, said the way the line itself says them.
+            case NarrowedOrigin n ->
+                    n.authoredLine().said(n.bound().describe(names, sectionSource));
         };
     }
 
@@ -302,11 +318,12 @@ public sealed interface OriginRef {
         return switch (this) {
             case InvariantOrigin i ->
                     new AuthoredLine(i.rule(), i.conjunct(), lineFacts(), List.of());
-            // One line each, so the zeroth of the one. A comparison and an `ensures` clause are read
-            // as a rule apiece — a condition holding three comparisons is three rules — so there is
-            // no second line of either to tell this one from.
+            // One line, so the zeroth of the one. A comparison is a rule apiece — a condition
+            // holding three comparisons is three rules — so there is no second line of it to tell
+            // this one from.
             case ComparisonOrigin g -> new AuthoredLine(g.rule(), 0, lineFacts(), List.of());
-            case EnsuresOrigin e -> new AuthoredLine(e.rule(), 0, lineFacts(), List.of());
+            case EnsuresOrigin e ->
+                    new AuthoredLine(e.rule(), e.conjunct(), lineFacts(), List.of());
             // The bound's line, said to have been taken in. What the narrowing adds is about the
             // end and not about the rule, so the rule comes back the same and this is kept beside
             // it.

--- a/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
@@ -18,10 +18,11 @@ import java.util.List;
  * line the cut value falls on, which declarations took an end in. None of those tell one rule from
  * another, and a question keyed on them is a question the reading raised rather than the model.
  *
- * <p>Three identities and not one, because they are three equivalences. {@link RuleRef} answers
- * whose rule it is; this answers which reading of that rule a boundary was drawn off; and
- * {@link BoundaryLine} answers which of them a partition folds into one line. A guard inside a
- * helper is read once per call: those are several of these, one {@code RuleRef}, and one line.
+ * <p>Four identities and not one, because they are four equivalences. {@link RuleRef} answers whose
+ * rule it is; {@link AuthoredLine} answers which of that rule's lines was drawn; this answers which
+ * reading of that line a boundary was drawn off; and {@link BoundaryLine} answers which of them a
+ * partition folds into one. A guard inside a helper is read once per call: those are several of
+ * these, one {@code RuleRef}, one authored line, and one line.
  *
  * <p>Kept per cut rather than per axis. Several rules can put a cut at the same value — a type's
  * invariant and a {@code guard} that repeats it, or two guards written in different behaviors — and
@@ -247,6 +248,59 @@ public sealed interface OriginRef {
     }
 
     /**
+     * What this reading recorded about the line it drew.
+     *
+     * <p>Asked of the reading and never assembled by whoever wants it. Written as a switch at each
+     * consumer, each of the three is a slot a consumer can fill in for a rule that leaves it empty,
+     * and two consumers filling one slot are free to fill it differently. One projection, one place
+     * a rule answers.
+     */
+    default LineFacts lineFacts() {
+        return switch (this) {
+            case ComparisonOrigin g ->
+                    new LineFacts(g.valueBelongsBelow(), g.holdsAtTheValue(), g.singles());
+            case EnsuresOrigin e ->
+                    new LineFacts(e.valueBelongsBelow(), e.holdsAtTheValue(), e.singles());
+            // Which way a bound keeps its values is not recorded on the bound, so this is the one
+            // slot here that is filled in rather than read: a border works the side out from what
+            // the rules leave.
+            case InvariantOrigin i -> new LineFacts(false, i.holdsAtTheValue(), false);
+            case NarrowedOrigin n -> n.bound().lineFacts();
+        };
+    }
+
+    /**
+     * Which line of the model this reading drew.
+     *
+     * <p>This reading with everything only this reading knows taken out: no position, no behavior,
+     * no occurrence of a comparison a body reached. What is left is what several readings of one
+     * line share, and it is what a debt is ({@link BorderObligationId}) and what a partition folds
+     * readings under ({@link BoundaryLine}).
+     *
+     * <p>Not a fold made here. Which readings are one line is still a question about a partition,
+     * and it is asked where a line is: this only says which line of the model each reading is a
+     * reading of, which is the reading's own answer and nobody else's.
+     */
+    default AuthoredLine authoredLine() {
+        return switch (this) {
+            case InvariantOrigin i ->
+                    new AuthoredLine(i.rule(), i.conjunct(), lineFacts(), List.of());
+            // One line each, so the zeroth of the one. A comparison and an `ensures` clause are read
+            // as a rule apiece — a condition holding three comparisons is three rules — so there is
+            // no second line of either to tell this one from.
+            case ComparisonOrigin g -> new AuthoredLine(g.rule(), 0, lineFacts(), List.of());
+            case EnsuresOrigin e -> new AuthoredLine(e.rule(), 0, lineFacts(), List.of());
+            // The bound's line, said to have been taken in. What the narrowing adds is about the
+            // end and not about the rule, so the rule comes back the same and this is kept beside
+            // it.
+            case NarrowedOrigin n -> {
+                AuthoredLine bound = n.bound().authoredLine();
+                yield new AuthoredLine(bound.rule(), bound.conjunct(), bound.facts(), n.within());
+            }
+        };
+    }
+
+    /**
      * The same rule, named without a place.
      *
      * <p>What a diagnostic's own sentence says. A diagnostic is built where no reader is — nothing
@@ -255,19 +309,7 @@ public sealed interface OriginRef {
      * is a guard, the place is pointed at instead, by {@link #citation}.
      */
     default String named() {
-        return switch (this) {
-            case InvariantOrigin i -> i.rule().named();
-            case EnsuresOrigin e -> e.rule().named();
-            // What the rule is, since it has no name: a comparison is written rather than called
-            // something. Never rendered to a reader either way — a rule with no name gets a
-            // sentence of its own, and the catalog holds those words in every language rather than
-            // this building one.
-            case ComparisonOrigin _ -> "the " + souther.compiler.check.RuleCitation.WHAT_IT_IS;
-            // A narrowing is not part of the rule, so it is said here and not by the rule.
-            case NarrowedOrigin n -> n.bound().named() + " within "
-                    + n.within().stream().map(TypeSymbol::name)
-                            .collect(java.util.stream.Collectors.joining(" or "));
-        };
+        return authoredLine().named();
     }
 
     /**
@@ -319,12 +361,7 @@ public sealed interface OriginRef {
      * the end is where the line came from.
      */
     default java.util.Optional<TypeSymbol> owedToTheDeclaration() {
-        return switch (this) {
-            case InvariantOrigin i ->
-                    java.util.Optional.of(i.rule().clause().id().declaredOn());
-            case ComparisonOrigin _, EnsuresOrigin _ -> java.util.Optional.empty();
-            case NarrowedOrigin n -> n.bound().owedToTheDeclaration();
-        };
+        return authoredLine().owedToTheDeclaration();
     }
 
     /**
@@ -340,13 +377,7 @@ public sealed interface OriginRef {
      * the rule's, so both are asked of it.
      */
     default java.util.Optional<souther.compiler.check.DeclaredBorders.Key> declaredLine() {
-        return switch (this) {
-            case InvariantOrigin i ->
-                    java.util.Optional.of(
-                            new souther.compiler.check.DeclaredBorders.Key(i.rule(), i.conjunct()));
-            case ComparisonOrigin _, EnsuresOrigin _ -> java.util.Optional.empty();
-            case NarrowedOrigin n -> n.bound().declaredLine();
-        };
+        return authoredLine().declaredLine();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
@@ -34,10 +34,10 @@ public sealed interface OriginRef {
     /**
      * A clause of a {@code data}'s invariant, as the clause it is.
      *
-     * <p>The clause and not the end it placed. This used to be the declaration together with the
-     * word {@code min} or {@code max}, which says what the clause did: two clauses of one
-     * declaration bounding a position at one value came out as one origin, and the cut kept one
-     * rule where ADR-0090 says it keeps every rule that drew it.
+     * <p>The clause that placed the end, and not the declaration it is written on together with the
+     * word {@code min} or {@code max}. Two clauses of one declaration bounding a position at one
+     * value are two rules, and a cut keeps every rule that drew it; named by the declaration and the
+     * word, they are one.
      *
      * @param conjunct        which conjunct of the clause drew this end. What tells one line of a
      *                        clause from another where the clause drew several: {@code
@@ -46,6 +46,14 @@ public sealed interface OriginRef {
      *                        other. The clause's own text and not the number it was written about,
      *                        which is spelled differently by every reading that reaches it
      *                        ({@link souther.compiler.check.DeclaredBounds.Drawn})
+     * @param keeps           which way along the order the bound keeps its values, which is the end
+     *                        it placed: a minimum keeps what is above it and a maximum what is
+     *                        below. Read where the end is read, and carried for the same reason the
+     *                        inclusivity beside it is — a bound orders nothing across its line, so
+     *                        there is no side to read off the rule further down, and what is left to
+     *                        work it back out of is the range the rules leave. That derivation has a
+     *                        case with no answer, and it answers a rule leaving one value the same
+     *                        way for both of its ends
      * @param holdsAtTheValue whether the cut value is one the bound admits, which is the end's own
      *                        inclusivity and is what says whether a row at the cut is the border's
      *                        {@code ON} point or its {@code OFF} point. Carried for the same reason
@@ -59,12 +67,17 @@ public sealed interface OriginRef {
      *                        derivation gets and not one about the end, and reading the end is what
      *                        keeps the two from being confused if it ever does get further
      */
-    record InvariantOrigin(RuleRef.Invariant rule, int conjunct, boolean holdsAtTheValue)
+    record InvariantOrigin(RuleRef.Invariant rule, int conjunct,
+                           souther.compiler.numeric.Towards keeps, boolean holdsAtTheValue)
             implements OriginRef {
 
         public InvariantOrigin {
             if (rule == null) {
                 throw new IllegalArgumentException("a bound drawn by no clause");
+            }
+            if (keeps == null) {
+                throw new IllegalArgumentException(
+                        "a bound keeps its values one way or the other: " + rule.named());
             }
             if (conjunct < 0) {
                 throw new IllegalArgumentException(
@@ -261,10 +274,14 @@ public sealed interface OriginRef {
                     new LineFacts(g.valueBelongsBelow(), g.holdsAtTheValue(), g.singles());
             case EnsuresOrigin e ->
                     new LineFacts(e.valueBelongsBelow(), e.holdsAtTheValue(), e.singles());
-            // Which way a bound keeps its values is not recorded on the bound, so this is the one
-            // slot here that is filled in rather than read: a border works the side out from what
-            // the rules leave.
-            case InvariantOrigin i -> new LineFacts(false, i.holdsAtTheValue(), false);
+            // Which side the value a bound stops at is on, from the end it placed and whether it
+            // admits that value: a minimum keeps what is above, so its value is below the line
+            // exactly when the bound does not admit it. A bound singles nothing out — it keeps a run
+            // of the order — and that the far side holds no value at all is a different answer,
+            // given where a border reads what a line has sides.
+            case InvariantOrigin i -> new LineFacts(
+                    (i.keeps() == souther.compiler.numeric.Towards.BELOW) == i.holdsAtTheValue(),
+                    i.holdsAtTheValue(), false);
             case NarrowedOrigin n -> n.bound().lineFacts();
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1653,10 +1653,8 @@ public final class Adequacy {
 
         @Override
         public Answer<List<BorderAssessment>> compute(Db db) {
-            Answer<List<BorderAssessment>> readings = db.ask(new Readings(name, behavior));
-            return readings.present() && readings.value() != null
-                    ? Answer.of(Coverages.merged(readings.value()))
-                    : Answer.absent();
+            List<BorderAssessment> readings = db.ask(new Readings(name, behavior)).value();
+            return readings == null ? Answer.absent() : Answer.of(Coverages.merged(readings));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -3654,7 +3654,7 @@ public final class Adequacy {
             List<DeclaredDebt> out = new ArrayList<>();
             for (BorderObligationAssessment debt : BorderObligationAssessment.across(readings,
                     id -> axisOf(id, declarations, symbols, policy))) {
-                TypeSymbol declaredOn = debt.origin().owedToTheDeclaration().orElseThrow();
+                TypeSymbol declaredOn = debt.id().owedToTheDeclaration().orElseThrow();
                 out.add(new DeclaredDebt(debt, declaredOn,
                         read(declarations, declaredOn, symbols, policy).at()));
             }
@@ -3671,16 +3671,16 @@ public final class Adequacy {
         private static String axisOf(souther.compiler.partition.BorderObligationId id,
                                      Map<TypeSymbol, souther.compiler.check.DeclaredBorders> read,
                                      Symbols symbols, souther.compiler.check.ReadingPolicy policy) {
-            TypeSymbol declaredOn = id.origin().owedToTheDeclaration().orElseThrow();
+            TypeSymbol declaredOn = id.owedToTheDeclaration().orElseThrow();
             souther.compiler.check.FieldDomains.Coordinate at =
                     read(read, declaredOn, symbols, policy)
                             // Which line of the declaration this is, asked of the rule. Taken apart
                             // here, a reader would be deciding which rules have a clause and a
                             // conjunct, which is the rule's own answer.
-                            .at(id.origin().declaredLine().orElseThrow());
+                            .at(id.declaredLine().orElseThrow());
             // A clause whose end this could not read from the declaration has no form to print, and
             // the rule's own name is the whole of what there is to call the line.
-            return at == null ? id.origin().named() : written(at);
+            return at == null ? id.named() : written(at);
         }
 
         /** The declaration's own reading of its own rules, kept: it draws as many lines as its
@@ -4110,11 +4110,11 @@ public final class Adequacy {
                                 role.againstTheLine()
                                         ? new ExampleMessage.NoRowIsAtThePointOfTheBorderARuleDrew(
                                                 role.name(), debt.axis(), debt.against(role),
-                                                debt.origin().named())
+                                                debt.id().named())
                                         : new ExampleMessage
                                                 .NoRowIsAtThePointAwayFromTheBorderARuleDrew(
                                                 role.name(), debt.axis(), debt.against(role),
-                                                debt.origin().named());
+                                                debt.id().named());
                         case About.APointOfABorder(var point) ->
                                 point.role().againstTheLine()
                                         ? point.border().origin().isWrittenRatherThanNamed()

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1280,11 +1280,18 @@ public final class Adequacy {
      * an editor that wants the rows at one behavior's edges may not have to wait for every
      * behavior's.
      *
-     * <p><b>Not a second assessment.</b> It asks {@link Boundaries} and adds to what came back:
-     * every border, every demand, every coverage and every projection is carried through untouched,
-     * and the only thing put in is the attempt at the points the measurement itself says are worth
-     * one. So the two answers are ordered rather than rival — this one holds strictly more evidence
-     * about the same lines, and a verdict read off evidence can gain a witness and never lose one.
+     * <p><b>Not a second assessment.</b> Every border, every demand, every coverage and every
+     * projection is carried through untouched, and the only thing put in is the attempt at the
+     * points the measurement itself says are worth one. So the two answers are ordered rather than
+     * rival — this one holds strictly more evidence about the same lines, and a verdict read off
+     * evidence can gain a witness and never lose one.
+     *
+     * <p><b>Asked of the readings, and folded after.</b> {@link Boundaries} is the same readings
+     * folded, and a row is composed against the conditions the reading it is for is reached under —
+     * so this takes {@link Readings} and folds what came back, which is the same fold and not a
+     * second one. Taken from {@code Boundaries} instead, the conditions would be those of whichever
+     * reading that fold kept. What keeps the two in this order is {@link LineReadings}: what a fold
+     * gives back is not what a search takes.
      *
      * <p>Which is what lets it be asked later than the measurement, or not at all. Nobody having
      * asked is said by this key not having been asked, and not by an answer inside the measurement
@@ -1300,7 +1307,7 @@ public final class Adequacy {
 
         @Override
         public Answer<List<BorderAssessment>> compute(Db db) {
-            List<BorderAssessment> measured = db.ask(new Readings(name, behavior)).value();
+            LineReadings measured = db.ask(new Readings(name, behavior)).value();
             if (measured == null) {
                 return Answer.absent();
             }
@@ -1653,7 +1660,7 @@ public final class Adequacy {
 
         @Override
         public Answer<List<BorderAssessment>> compute(Db db) {
-            List<BorderAssessment> readings = db.ask(new Readings(name, behavior)).value();
+            LineReadings readings = db.ask(new Readings(name, behavior)).value();
             return readings == null ? Answer.absent() : Answer.of(Coverages.merged(readings));
         }
     }
@@ -1666,9 +1673,12 @@ public final class Adequacy {
      * each of those is reached under its caller's own conditions — so what a row for it may be
      * composed out of is a reading's own answer, and a search made after the readings are one has
      * to pick one of them to compose against.
+     *
+     * <p>Answered as {@link LineReadings} rather than as the same list a line comes back in, so that
+     * which of the two a caller is holding is a thing the compiler knows.
      */
     public record Readings(String name, String behavior)
-            implements Key<List<BorderAssessment>> {
+            implements Key<LineReadings> {
 
         @Override
         public String module() {
@@ -1676,7 +1686,7 @@ public final class Adequacy {
         }
 
         @Override
-        public Answer<List<BorderAssessment>> compute(Db db) {
+        public Answer<LineReadings> compute(Db db) {
             Answer<souther.compiler.check.Prepared> prepared = db.ask(new Shapes.Prepared(name));
             Answer<Symbols> scope = Names.derivedSymbols(db, name);
             Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(name));
@@ -1701,7 +1711,7 @@ public final class Adequacy {
         }
 
         /** Every line of one behavior, with what the rows and the decoder say about each. */
-        private static List<BorderAssessment> assess(
+        private static LineReadings assess(
                 Hir.SpecBehavior spec, Sig sig, Symbols symbols,
                 souther.compiler.check.ReadingPolicy policy,
                 souther.compiler.partition.Partitions.Partitioning divided, RowReading observed,
@@ -1727,7 +1737,7 @@ public final class Adequacy {
                                 partitioning.edgeIsKnownWritable(axis.term()))));
             }
             out.addAll(Coverages.assessBetween(partitioning, inputs, observed, level));
-            return List.copyOf(out);
+            return new LineReadings(out);
         }
 
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1300,7 +1300,7 @@ public final class Adequacy {
 
         @Override
         public Answer<List<BorderAssessment>> compute(Db db) {
-            List<BorderAssessment> measured = db.ask(new Boundaries(name, behavior)).value();
+            List<BorderAssessment> measured = db.ask(new Readings(name, behavior)).value();
             if (measured == null) {
                 return Answer.absent();
             }
@@ -1324,11 +1324,11 @@ public final class Adequacy {
             souther.compiler.partition.BehaviorInputs inputs =
                     new souther.compiler.partition.BehaviorInputs(parameters, sig.inputTypes(),
                             symbols, policy);
-            return Answer.of(Coverages.searched(measured, inputs,
+            return Answer.of(Coverages.merged(Coverages.searched(measured, inputs,
                     probing(spec.name(), divided, sig, symbols, policy, parameters,
                             constructing(db, name),
                             domain),
-                    domain.quantities(symbols), divided.reaching()));
+                    domain.quantities(symbols), divided.reaching())));
         }
 
         /**
@@ -1644,6 +1644,32 @@ public final class Adequacy {
      * readings of this one answer and not three measurements.
      */
     public record Boundaries(String name, String behavior)
+            implements Key<List<BorderAssessment>> {
+
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<List<BorderAssessment>> compute(Db db) {
+            Answer<List<BorderAssessment>> readings = db.ask(new Readings(name, behavior));
+            return readings.present() && readings.value() != null
+                    ? Answer.of(Coverages.merged(readings.value()))
+                    : Answer.absent();
+        }
+    }
+
+    /**
+     * The same lines, one entry per reading of one.
+     *
+     * <p>Below {@link Boundaries} and asked by whatever has something to do while the readings are
+     * still apart. A guard inside a non-recursive helper is read once per call of that helper, and
+     * each of those is reached under its caller's own conditions — so what a row for it may be
+     * composed out of is a reading's own answer, and a search made after the readings are one has
+     * to pick one of them to compose against.
+     */
+    public record Readings(String name, String behavior)
             implements Key<List<BorderAssessment>> {
 
         @Override

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderObligationAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderObligationAssessment.java
@@ -285,11 +285,6 @@ public record BorderObligationAssessment(BorderObligationId id, String axis,
         return met.keySet().stream().map(Reading::behavior).distinct().toList();
     }
 
-    /** The rule that drew the line, as the readings met it. */
-    public souther.compiler.partition.OriginRef origin() {
-        return id.origin();
-    }
-
     /**
      * What one point of the line asks of a row, as a report writes it.
      *

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -1007,6 +1007,10 @@ final class Coverages {
      * that was found is the whole of what a point asks for; where neither reading found one, the
      * reading that composed a row to offer has something to say that a reading which composed
      * nothing does not, and the point is owed the same row either way.
+     *
+     * <p>Here because the search is made per reading. One search against one region has one outcome
+     * and nothing to choose between; two readings carry two, and keeping the first would drop a row
+     * an author could have been offered.
      */
     private static boolean keeps(ItemAssessment a, ItemAssessment b) {
         if (rank(a) != rank(b)) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -570,9 +570,9 @@ final class Coverages {
      * a debt holds the authored line and the value it is at — so two readings under one line are one
      * debt by construction, and a pair that is not says the two identities have come apart.
      */
-    static List<BorderAssessment> merged(List<BorderAssessment> readings) {
+    static List<BorderAssessment> merged(LineReadings readings) {
         java.util.SequencedMap<BoundaryLine, BorderAssessment> out = new java.util.LinkedHashMap<>();
-        for (BorderAssessment each : readings) {
+        for (BorderAssessment each : readings.each()) {
             out.merge(BoundaryLine.of(each.border()), each, Coverages::whicheverSawMore);
         }
         return List.copyOf(out.values());
@@ -590,12 +590,12 @@ final class Coverages {
      * evidence, and nothing a search finds is evidence against a point — so this can add a ground and
      * can never take one away, whenever it is run and however many points it is run over.
      */
-    static List<BorderAssessment> searched(List<BorderAssessment> measured, BehaviorInputs where,
-                                           Probe probe, souther.compiler.inputs.Quantities rules,
-                                           ReachingCuts reaching) {
+    static LineReadings searched(LineReadings measured, BehaviorInputs where,
+                                 Probe probe, souther.compiler.inputs.Quantities rules,
+                                 ReachingCuts reaching) {
         LevelRealizer realizer = new LevelRealizer();
         List<BorderAssessment> out = new ArrayList<>();
-        for (BorderAssessment border : measured) {
+        for (BorderAssessment border : measured.each()) {
             OneSearchOfABorder search = searching(border.border(), where, probe, realizer,
                     regionFor(border.border(), rules, reaching));
             java.util.EnumMap<PointRole, ItemAssessment> items =
@@ -609,7 +609,7 @@ final class Coverages {
             }
             out.add(new BorderAssessment(border.border(), items));
         }
-        return List.copyOf(out);
+        return new LineReadings(out);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -543,14 +543,37 @@ final class Coverages {
             souther.compiler.query.Adequacy.RowReading observed,
             souther.compiler.query.Adequacy.Level level,
             ItemAssessment.WritabilityProjection projection) {
-        // Keyed by the line rather than by the reading of it. A guard inside a non-recursive helper
-        // is read once per call of that helper, and the rows do not owe the same border twice for
-        // having been offered it twice; what each reading saw is merged below.
-        java.util.SequencedMap<BoundaryLine, BorderAssessment> out = new java.util.LinkedHashMap<>();
+        // One entry per reading and not per line. A guard inside a non-recursive helper is read once
+        // per call of that helper, and the rows do not owe the same border twice for having been
+        // offered it twice — but each reading is reached under its caller's own conditions, so what
+        // a row for it may be composed out of is the reading's and is settled while the readings are
+        // still apart. They are brought together by {@link #merged}, after that.
+        List<BorderAssessment> out = new ArrayList<>();
         for (Border each : lines) {
-            out.merge(BoundaryLine.of(each), assessed(each, reading(each, where, projection),
-                            observed, level),
-                    Coverages::whicheverSawMore);
+            out.add(assessed(each, reading(each, where, projection), observed, level));
+        }
+        return List.copyOf(out);
+    }
+
+    /**
+     * The readings of one behavior's lines, one entry per line.
+     *
+     * <p>What each reading saw, kept whole: a point one reading found a row at is found, and no
+     * other reading of the line takes that back.
+     *
+     * <p><b>After everything that is a reading's own.</b> Which conditions a row has to satisfy to
+     * reach the comparison is one of those, so a search is made per reading and merged here rather
+     * than made once against whichever reading this kept. Merged first, the region a row is composed
+     * in is one reading's, chosen by the order a walk took.
+     *
+     * <p><b>And never across two debts.</b> A line holds the authored line and where it was read;
+     * a debt holds the authored line and the value it is at — so two readings under one line are one
+     * debt by construction, and a pair that is not says the two identities have come apart.
+     */
+    static List<BorderAssessment> merged(List<BorderAssessment> readings) {
+        java.util.SequencedMap<BoundaryLine, BorderAssessment> out = new java.util.LinkedHashMap<>();
+        for (BorderAssessment each : readings) {
+            out.merge(BoundaryLine.of(each.border()), each, Coverages::whicheverSawMore);
         }
         return List.copyOf(out.values());
     }
@@ -966,11 +989,36 @@ final class Coverages {
      * on the whole would throw away a point the other one had.
      */
     private static BorderAssessment whicheverSawMore(BorderAssessment a, BorderAssessment b) {
+        if (!a.border().obligation().equals(b.border().obligation())) {
+            throw new IllegalStateException("two readings of one line owing different rows: "
+                    + a.border().obligation() + " and " + b.border().obligation());
+        }
         java.util.EnumMap<PointRole, ItemAssessment> kept = new java.util.EnumMap<>(PointRole.class);
         for (PointRole role : PointRole.values()) {
-            kept.put(role, rank(b.at(role)) > rank(a.at(role)) ? b.at(role) : a.at(role));
+            kept.put(role, keeps(a.at(role), b.at(role)) ? a.at(role) : b.at(role));
         }
         return new BorderAssessment(a.border(), kept);
+    }
+
+    /**
+     * Whether what the first reading saw at a point stands, rather than what the second saw.
+     *
+     * <p>What was measured first, and what was composed only where the two measured alike. A row
+     * that was found is the whole of what a point asks for; where neither reading found one, the
+     * reading that composed a row to offer has something to say that a reading which composed
+     * nothing does not, and the point is owed the same row either way.
+     */
+    private static boolean keeps(ItemAssessment a, ItemAssessment b) {
+        if (rank(a) != rank(b)) {
+            return rank(a) > rank(b);
+        }
+        return composed(a) >= composed(b);
+    }
+
+    /** Whether the search of this reading's own region built a row to offer. */
+    private static int composed(ItemAssessment item) {
+        return item instanceof ItemAssessment.Owed owed
+                && owed.attempt() instanceof ItemAssessment.Attempt.Built ? 1 : 0;
     }
 
     private static int rank(ItemAssessment item) {
@@ -1048,19 +1096,16 @@ final class Coverages {
             Partitions.Partitioning partitioning, BehaviorInputs where,
             souther.compiler.query.Adequacy.RowReading observed,
             souther.compiler.query.Adequacy.Level level) {
-        // Keyed by the line the author drew, the way a line at a place is. A guard inside a
-        // non-recursive helper is read once per call of that helper, and the rows do not owe the same
-        // line twice for having been offered it twice — nor may one reading of it take back what
-        // another established.
-        java.util.SequencedMap<BoundaryLine, BorderAssessment> out = new LinkedHashMap<>();
+        // One entry per reading, the way a line at a place is read: what several readings of one
+        // line come to is one answer, and it is put together where the last thing that is a
+        // reading's own has been asked ({@link #merged}).
+        List<BorderAssessment> out = new ArrayList<>();
         for (Border each : partitioning.between()) {
-            out.merge(BoundaryLine.of(each),
-                    assessed(each, reading(each, where,
-                                    ItemAssessment.WritabilityProjection.NOT_COMPUTED),
-                            observed, level),
-                    Coverages::whicheverSawMore);
+            out.add(assessed(each, reading(each, where,
+                            ItemAssessment.WritabilityProjection.NOT_COMPUTED),
+                    observed, level));
         }
-        return List.copyOf(out.values());
+        return List.copyOf(out);
     }
 
     /** What a reading of the rows comes to, once what could not be read is accounted for. */

--- a/souther-compiler/src/main/java/souther/compiler/query/LineReadings.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/LineReadings.java
@@ -1,0 +1,26 @@
+package souther.compiler.query;
+
+import java.util.List;
+
+/**
+ * One behavior's lines, one entry per reading of one.
+ *
+ * <p>A type of its own so that a reading and a line are not the same thing to hold. Both are lists
+ * of the same assessment, and what tells them apart is only whether the readings of one line have
+ * been brought together yet — written as one type, a caller could hand either to anything and the
+ * order the two are asked in would be kept by nothing but a comment.
+ *
+ * <p>What the order is about: a reading is reached under its caller's own conditions, and that is
+ * what a row for its line is composed against ({@link Coverages#searched}). Once the readings are
+ * one, the conditions belong to whichever of them the fold kept. So a search takes these and gives
+ * these back, {@link Coverages#merged} takes these and gives back the lines, and nothing goes the
+ * other way round: asking for a fold and then searching what came out of it does not compile.
+ *
+ * @param each the readings, in the order they were made
+ */
+public record LineReadings(List<BorderAssessment> each) {
+
+    public LineReadings {
+        each = List.copyOf(each);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -394,7 +394,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 if (f.about() instanceof About.APointOfADeclaredBorder(var debt, var role)) {
                     out.append(String.format("      %s no row is at the %s point %s = %s (%s)%n",
                             mark(f), role, debt.axis(), debt.against(role),
-                            debt.origin().describe(names, module.declaredIn())));
+                            debt.id().named()));
                 }
             }
         });

--- a/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryFindingHasAGenerationDispositionTest.java
@@ -234,7 +234,7 @@ class EveryFindingHasAGenerationDispositionTest {
      */
     private static List<DeclarationResolution> drawnBy(DeclaredRows rows, String declaredOn) {
         return rows.resolved().entrySet().stream()
-                .filter(each -> each.getKey().line().origin().owedToTheDeclaration()
+                .filter(each -> each.getKey().line().owedToTheDeclaration()
                         .map(on -> on.name().equals(declaredOn)).orElse(false))
                 .map(each -> each.getValue().resolution()).toList();
     }
@@ -411,7 +411,7 @@ class EveryFindingHasAGenerationDispositionTest {
         resolved(compiled(EITHER_END), "example.ends", new GenerationScope.Module()).resolved()
                 .forEach((at, answer) -> {
                     if (answer.resolution() instanceof DeclarationResolution.Generated(var by, var _)
-                            && at.line().origin().owedToTheDeclaration()
+                            && at.line().owedToTheDeclaration()
                                     .map(on -> on.name().equals("Code")).orElse(false)) {
                         composers.put(at.line().at(), by);
                     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
@@ -180,7 +180,8 @@ class ABorderDebtIsTheLineTheAuthorWroteTest {
     void aComparisonAndABoundAtOneValueAreTwoDebts() {
         Border guard = Border.at(aLineAt(100), readAt(1), ANYWHERE);
         Border bound = Border.at(aLineAt(100),
-                new OriginRef.InvariantOrigin(aClause(), 0, true),
+                new OriginRef.InvariantOrigin(aClause(), 0,
+                        souther.compiler.numeric.Towards.ABOVE, true),
                 new souther.compiler.numeric.NumericDomain.Bounds(
                         souther.compiler.numeric.Endpoint.inclusive(
                                 souther.compiler.numeric.Count.of(100)), null));

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
@@ -141,6 +141,101 @@ class ABorderDebtIsTheLineTheAuthorWroteTest {
                 "and the number the clause was written about does");
     }
 
+    /**
+     * Two readings of one comparison are one debt.
+     *
+     * <p>A non-recursive helper is spliced into every body that calls it, so one guard the author
+     * wrote is read once per call: the readings carry different comparison sites, each is measured
+     * on its own, and the author owes one row for the line. Keyed on the reading they are two debts
+     * that only the merge collecting what each reading saw brings back to one, and which of the two
+     * call sites the surviving debt names then comes down to the order a walk took.
+     *
+     * <p>Built here rather than compiled, because what is being told apart is two readings of one
+     * line at one position: through a model they are merged into one assessment before anything can
+     * be asked of the pair, and the question is what the pair answers.
+     */
+    @Test
+    void twoReadingsOfOneComparisonAreOneDebt() {
+        BoundaryTarget line = aLineAt(100);
+        Border first = Border.at(line, readAt(1), ANYWHERE);
+        Border second = Border.at(line, readAt(5), ANYWHERE);
+
+        assertNotEquals(first.origin(), second.origin(),
+                "two occurrences of the guard, each a reading measured on its own");
+        assertEquals(first.obligation(), second.obligation(),
+                "and one line the author wrote, which is one row to write");
+        assertEquals(BoundaryLine.of(first), BoundaryLine.of(second),
+                "so the two readings fold into one line, and the fold is inside the one debt");
+    }
+
+    /**
+     * A comparison and a bound at one value are two debts.
+     *
+     * <p>The pair that keeps the case above from being satisfied by a debt keyed on the value and
+     * the behavior. Both lines stand at 100 on one carrier and are read at one position; an
+     * {@code invariant} drew one and a comparison in a body drew the other, and either could be
+     * changed without the other.
+     */
+    @Test
+    void aComparisonAndABoundAtOneValueAreTwoDebts() {
+        Border guard = Border.at(aLineAt(100), readAt(1), ANYWHERE);
+        Border bound = Border.at(aLineAt(100),
+                new OriginRef.InvariantOrigin(aClause(), 0, true),
+                new souther.compiler.numeric.NumericDomain.Bounds(
+                        souther.compiler.numeric.Endpoint.inclusive(
+                                souther.compiler.numeric.Count.of(100)), null));
+
+        assertEquals(guard.cut(), bound.cut(), "one value of one quantity, read at one position");
+        assertNotEquals(guard.obligation(), bound.obligation(),
+                "and two rules the author wrote, each owed a row of its own");
+    }
+
+    /** What the rules leave the quantity, where they leave it everything. */
+    private static final souther.compiler.numeric.NumericDomain.Bounds ANYWHERE =
+            new souther.compiler.numeric.NumericDomain.Bounds(null, null);
+
+    /** One position's line at {@code at}, on the carrier a count of whole numbers runs on. */
+    private static BoundaryTarget aLineAt(int at) {
+        souther.compiler.check.Carrier carrier = new souther.compiler.check.Carrier.Whole();
+        AxisId axis = new AxisId("twice", "a.value");
+        return BoundaryTarget.at(
+                new BorderQuantity.OfACoordinate(axis,
+                        new souther.compiler.inputs.NumericTerm.ValueOf(
+                                souther.compiler.inputs.TermPath.of(axis.term())),
+                        souther.compiler.inputs.TermOrders.itself(carrier)),
+                new Level.OnACarrier(carrier, souther.compiler.numeric.Count.of(at)));
+    }
+
+    /**
+     * One reading of one comparison: the same rule and the same place it is written, at the
+     * occurrence the call it was spliced into was numbered.
+     */
+    private static OriginRef readAt(int occurrence) {
+        souther.compiler.check.RuleRef.Comparison rule =
+                new souther.compiler.check.RuleRef.Comparison("twice",
+                        new souther.compiler.types.CoverageOrigin("example.banding", 2, 0,
+                                souther.compiler.types.CoverageConstruct.BINARY));
+        return new OriginRef.ComparisonOrigin(rule,
+                new OriginRef.ComparisonOrigin.Read(
+                        new souther.compiler.coverage.ComparisonOccurrence(occurrence),
+                        new souther.compiler.check.RuleCitation.WrittenAt(
+                                souther.compiler.diag.Citation.of(
+                                        new souther.compiler.diag.SourcePos(15, 16)))),
+                true, true);
+    }
+
+    /** The clause the bound in these tests names, which is only an identity here. */
+    private static souther.compiler.check.RuleRef.Invariant aClause() {
+        return new souther.compiler.check.RuleRef.Invariant(
+                new souther.compiler.check.Clause.Ref(
+                        new souther.compiler.check.Clause.Id(
+                                souther.compiler.types.TypeSymbols.declared(
+                                        new souther.compiler.types.TypeKey("example.banding",
+                                                "Amount")), 0),
+                        java.util.Optional.of(
+                                new souther.compiler.check.ClauseName("cap"))));
+    }
+
     /** One clause bounding two numbers of the declaration it is written on. */
     private static final String TWO_NUMBERS = """
             module example.numbers

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
@@ -237,6 +237,45 @@ class ABorderDebtIsTheLineTheAuthorWroteTest {
                                 new souther.compiler.check.ClauseName("cap"))));
     }
 
+    /**
+     * One {@code ensures} clause naming two positions is two debts.
+     *
+     * <p>The same pair as the clause above, on the other rule that states something about values.
+     * {@code Found -> r.a >= 5 && r.b >= 5} is one clause and two lines, and a row whose {@code a}
+     * is 5 says nothing about {@code b}. Which of the clause's comparisons drew the line is what
+     * tells them apart: everything else about the two is the same, down to the value and the
+     * carrier.
+     */
+    @Test
+    void oneEnsuresClauseNamingTwoPositionsIsTwoDebts() {
+        Map<String, BorderAssessment> lines = bordersOf(TWO_STATED, "example.stated");
+        BorderAssessment first = at(lines, "r.a = 5");
+        BorderAssessment second = at(lines, "r.b = 5");
+
+        assertEquals(first.border().obligation().provenance(),
+                second.border().obligation().provenance(), "one clause states both");
+        assertEquals(first.border().cut().at(), second.border().cut().at(),
+                "at one value of one carrier, so neither the rule nor the level tells them apart");
+        assertNotEquals(first.border().obligation(), second.border().obligation(),
+                "and which comparison of the clause drew the line does");
+    }
+
+    /** One {@code ensures} clause stating something about two of a record's numbers. */
+    private static final String TWO_STATED = """
+            module example.stated
+
+            data R = { a: Int, b: Int }
+            data Found
+            data Missing
+
+            behavior f : (r: R) -> Found | Missing
+                ensures Found -> r.a >= 5 && r.b >= 5
+            let f (r) = if r.a >= 30 * 2 then Found else Missing
+
+            example f
+                | "one" : (R { a = 1, b = 1 }) -> Missing
+            """;
+
     /** One clause bounding two numbers of the declaration it is written on. */
     private static final String TWO_NUMBERS = """
             module example.numbers

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderDebtIsTheLineTheAuthorWroteTest.java
@@ -18,15 +18,17 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * What a row is owed for is the line the author wrote, and neither the rule it came from nor the
  * position it was read at.
  *
- * <p>Three identities where there used to be one. Which rule drew the line is provenance and the
- * same value however many lines the rule drew; which line is owed a row is the debt; where that line
- * was read is an occurrence, one per position of every behavior carrying the type. A measure keyed
- * on the occurrence asks for one rule's row once per position — 126 times over {@code crm}'s
+ * <p>Four questions and not one. Which rule drew the line is provenance and the same value however
+ * many lines the rule drew; which line of that rule it is, and which value it is at, are the debt;
+ * where that line was read is an occurrence, one per position of every behavior carrying the type,
+ * and which of those readings are one line is what a partition folds under. A measure keyed on the
+ * occurrence asks for one rule's row once per position — 126 times over {@code crm}'s
  * {@code UserId} — and a measure keyed on the rule asks for one row where the author drew two lines.
  *
- * <p>Written before the debt exists, because the whole of what this change is worth is the answer to
- * "why are these the same debt". Left to be read off whatever the implementation keyed on, that
- * answer lives outside the types and the next reading takes it back.
+ * <p>How far a debt reaches is the rule's own answer: a clause of a {@code data} is the type's
+ * wherever the type is carried, and a comparison is written in a body and is that body's. Both
+ * directions are measured here, because a debt that dropped the behavior would pass the first and
+ * fail the second.
  */
 class ABorderDebtIsTheLineTheAuthorWroteTest {
 
@@ -236,6 +238,56 @@ class ABorderDebtIsTheLineTheAuthorWroteTest {
                         java.util.Optional.of(
                                 new souther.compiler.check.ClauseName("cap"))));
     }
+
+    /**
+     * One helper's comparison called from two behaviors is two debts.
+     *
+     * <p>The other side of the equivalence above, and the reason a debt does not simply drop the
+     * behavior it was read in. A clause of a {@code data} states something about the type wherever
+     * the type is carried; a comparison is written in a body and states something about that body,
+     * so {@code one} and {@code two} each owe a row at the line {@code band}'s comparison draws in
+     * them. What the rule is is where that is decided
+     * ({@link souther.compiler.check.RuleRef.Comparison}), and a debt says no more about it.
+     */
+    @Test
+    void oneHelpersComparisonCalledFromTwoBehaviorsIsTwoDebts() {
+        Map<String, List<BorderAssessment>> lines = boundariesOf(TWO_CALLERS, "example.callers");
+        BorderAssessment first = at(lines.get("one"), "a = 100");
+        BorderAssessment second = at(lines.get("two"), "a = 100");
+
+        assertNotEquals(first.border().obligation(), second.border().obligation(),
+                "a comparison is written in a body, so each body that holds it owes its own row");
+        assertEquals(at(lines.get("one"), "a = 0").border().obligation(),
+                at(lines.get("two"), "a = 0").border().obligation(),
+                "and the clause of the type they both carry is the one row it always was");
+    }
+
+    /** One helper holding a comparison, called from two behaviors. */
+    private static final String TWO_CALLERS = """
+            module example.callers
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Small
+            data Large
+            data Size = Small | Large
+
+            let band (a: Amount): Size =
+                if a.value <= 100 then Small else Large
+
+            behavior one : (a: Amount) -> Size
+            let one (a) = band(a)
+
+            behavior two : (a: Amount) -> Size
+            let two (a) = band(a)
+
+            example one
+                | "x" : (Amount(1)) -> Small
+
+            example two
+                | "y" : (Amount(1)) -> Small
+            """;
 
     /**
      * One {@code ensures} clause naming two positions is two debts.
@@ -467,6 +519,15 @@ class ABorderDebtIsTheLineTheAuthorWroteTest {
         BorderAssessment line = lines.get(label);
         assertNotNull(line, () -> label + " is not a line of this model: " + lines.keySet());
         return line;
+    }
+
+    /** The line one behavior draws at {@code label}, for a caller reading the behaviors apart. */
+    private static BorderAssessment at(List<BorderAssessment> lines, String label) {
+        return lines.stream().filter(each -> each.border().label().equals(label)).findFirst()
+                .orElseGet(() -> {
+                    throw new AssertionError(label + " is not a line of this behavior: "
+                            + lines.stream().map(each -> each.border().label()).toList());
+                });
     }
 
     /** Every border of {@code module}, as the measure holds them: per behavior, and one entry per

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
@@ -208,12 +208,14 @@ class ABorderSaysWhichOfItsTwoPointsALineIsTest {
     @Test
     void aBoundThatStopsShortOfItsLineWhereTheOrderStepsIsRefused() {
         Border kept = borderOf(
-                new OriginRef.InvariantOrigin(invariant(), THE_ONLY_CONJUNCT, true));
+                new OriginRef.InvariantOrigin(invariant(), THE_ONLY_CONJUNCT,
+                        souther.compiler.numeric.Towards.ABOVE, true));
         assertEquals("= 5", kept.demand(PointRole.ON).criterion().asked(kept.cut().of()),
                 "a bound that admits its own end is at that end's ON point");
 
         IllegalStateException refused = assertThrows(IllegalStateException.class,
-                () -> borderOf(new OriginRef.InvariantOrigin(invariant(), THE_ONLY_CONJUNCT, false)),
+                () -> borderOf(new OriginRef.InvariantOrigin(invariant(), THE_ONLY_CONJUNCT,
+                        souther.compiler.numeric.Towards.ABOVE, false)),
                 "an `Int` bounded strictly at 5 is an inclusive 6 long before it reaches a border");
         assertTrue(refused.getMessage().startsWith(
                         "a bound that stops short of its own line where the order names 6 beside it"),
@@ -260,7 +262,8 @@ class ABorderSaysWhichOfItsTwoPointsALineIsTest {
                 border.demand(PointRole.OUT).criterion().asked(border.cut().of()));
 
         // A bound owes nothing outside itself, and says which of the three answers settled it.
-        Border bound = borderOf(new OriginRef.InvariantOrigin(invariant(), THE_ONLY_CONJUNCT, true));
+        Border bound = borderOf(new OriginRef.InvariantOrigin(invariant(), THE_ONLY_CONJUNCT,
+                        souther.compiler.numeric.Towards.ABOVE, true));
         assertEquals(new Demand.NotOwed(NotOwedReason.THE_RULES_REFUSE_IT),
                 bound.demand(PointRole.OFF));
         assertEquals(new Demand.NotOwed(NotOwedReason.THE_RULES_REFUSE_IT),

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABorderSaysWhichOfItsTwoPointsALineIsTest.java
@@ -249,7 +249,7 @@ class ABorderSaysWhichOfItsTwoPointsALineIsTest {
         Carrier carrier = new Carrier.Whole();
         OriginRef closed = new OriginRef.EnsuresOrigin(
                 new RuleRef.Ensures(new BehaviorContract.RuleId(null, 0, 0, null), "cap"),
-                true, true, false);
+                THE_ONLY_CONJUNCT, true, true, false);
         Border border = Border.at(lineAt(new AxisId("cap", "n"), carrier, Count.of(100)), closed,
                 new NumericDomain.Bounds(null, null));
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABoundSaysWhichSideItKeepsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABoundSaysWhichSideItKeepsTest.java
@@ -1,0 +1,201 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Carrier;
+import souther.compiler.check.Clause;
+import souther.compiler.check.ClauseName;
+import souther.compiler.check.RuleRef;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.numeric.Towards;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.Compilation;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A bound carries which way it keeps its values, and nothing works it back out.
+ *
+ * <p>Which end a clause placed is settled where the end is read: the ends are read one at a time,
+ * so a minimum is known to be a minimum there and nowhere else. What is left to recover it from
+ * further down is the range the rules leave the position — and that is every rule's answer and not
+ * this one's, so a bound at a value both ends stand at comes back the same for both of them, and a
+ * bound at a value neither end stands at comes back as nothing at all.
+ *
+ * <p>What the range is still worth is a check. Which way the bound runs and where the position stops
+ * are two readings of the same rules, and a bound's line is the end of what it leaves on the side it
+ * keeps — so the two are held against each other and a model that puts them at odds stops the build.
+ */
+class ABoundSaysWhichSideItKeepsTest {
+
+    /**
+     * A clause leaving one value draws both of its lines there.
+     *
+     * <p>{@code value >= 5 && value <= 5} places a minimum and a maximum at 5. They are two lines
+     * the author wrote, a row at 5 stands at both, and what tells them apart is which side each
+     * keeps. Told apart by the range instead, both come back as the minimum: the line is the low end
+     * of what the rules leave and it is the high end as well, and one of the two answers is taken.
+     */
+    @Test
+    void aClauseLeavingOneValueDrawsBothOfItsLinesThere() {
+        Map<String, List<BorderAssessment>> lines = boundariesOf(ONE_VALUE, "example.one");
+        List<BorderAssessment> at = lines.values().stream().flatMap(List::stream).toList();
+
+        assertEquals(2, at.size(),
+                () -> "one minimum and one maximum, both at 5: "
+                        + at.stream().map(each -> each.border().label()).toList());
+        assertEquals(2, at.stream().map(each -> each.border().obligation()).distinct().count(),
+                "and two rows to write, one owed to each conjunct of the clause");
+        assertEquals(List.of("n = 5", "n = 5"),
+                at.stream().map(each -> each.border().label()).toList(),
+                "at one value, so nothing about where they are tells them apart");
+    }
+
+    /**
+     * A maximum keeps what is below it and a minimum what is above.
+     *
+     * <p>Read through the point inside the partition each bounds, which is the one thing the side
+     * decides for a bound: the run is the values the bound leaves, and it lies one way of the line.
+     */
+    @Test
+    void eachEndKeepsItsOwnSideOfTheLine() {
+        Map<String, BorderAssessment> lines = bordersOf(RANGE, "example.range");
+
+        assertEquals("1 < n <= 10", inside(lines, "n = 1"),
+                "a minimum keeps what is above it");
+        assertEquals("1 <= n < 10", inside(lines, "n = 10"),
+                "and a maximum what is below");
+    }
+
+    /**
+     * A bound whose line is not where what it leaves stops is refused.
+     *
+     * <p>The reading that placed the end and the reading of what the position is left with are two
+     * readings of the same rules, and this is where they meet. A bound at 100 over a run from 1 is a
+     * border no model draws — nothing is below a bound — and taken at its word it would offer an
+     * {@code ON} point at the line and a point inside covering the values it refuses.
+     */
+    @Test
+    void aBoundThatDoesNotStopWhereItsRangeStopsIsRefused() {
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> Border.at(aLineAt(100),
+                        new OriginRef.InvariantOrigin(aClause(), 0, Towards.ABOVE, true),
+                        new NumericDomain.Bounds(Endpoint.inclusive(Count.of(1)),
+                                Endpoint.inclusive(Count.of(1000)))));
+        assertTrue(refused.getMessage()
+                        .startsWith("a bound whose line is not where what it leaves stops"),
+                refused.getMessage());
+    }
+
+    /**
+     * And so is a maximum held against the end a minimum stands at.
+     *
+     * <p>The half a check that took either end would pass. Both ends of a range leaving one value
+     * are at the line, and a bound is answered for by the end it placed rather than by whichever end
+     * happens to match — so a maximum over a range that has no upper end is refused however far its
+     * lower end reaches.
+     */
+    @Test
+    void aMaximumIsHeldAgainstTheUpperEndAndNotTheLowerOne() {
+        assertThrows(IllegalStateException.class,
+                () -> Border.at(aLineAt(5),
+                        new OriginRef.InvariantOrigin(aClause(), 0, Towards.BELOW, true),
+                        new NumericDomain.Bounds(Endpoint.inclusive(Count.of(5)), null)),
+                "the line is the low end of what the rules leave, and this bound placed the high"
+                        + " one");
+        assertEquals("= 5", Border.at(aLineAt(5),
+                        new OriginRef.InvariantOrigin(aClause(), 0, Towards.ABOVE, true),
+                        new NumericDomain.Bounds(Endpoint.inclusive(Count.of(5)), null))
+                .demand(PointRole.ON).criterion().asked(aLineAt(5).of()),
+                "and the minimum that did place it is the border this range draws");
+    }
+
+    /** The point inside the partition a border bounds, as the report writes it. */
+    private static String inside(Map<String, BorderAssessment> lines, String label) {
+        BorderAssessment line = lines.get(label);
+        assertNotNull(line, () -> label + " is not a line of this model: " + lines.keySet());
+        Border border = line.border();
+        return border.label(border.demand(PointRole.IN).criterion());
+    }
+
+    /** One position's line at {@code at}, on the carrier whole numbers run on. */
+    private static BoundaryTarget aLineAt(int at) {
+        Carrier carrier = new Carrier.Whole();
+        AxisId axis = new AxisId("f", "n");
+        return BoundaryTarget.at(
+                new BorderQuantity.OfACoordinate(axis,
+                        new souther.compiler.inputs.NumericTerm.ValueOf(
+                                souther.compiler.inputs.TermPath.of(axis.term())),
+                        souther.compiler.inputs.TermOrders.itself(carrier)),
+                new Level.OnACarrier(carrier, Count.of(at)));
+    }
+
+    /** The clause the bounds here name, which is only an identity. */
+    private static RuleRef.Invariant aClause() {
+        return new RuleRef.Invariant(new Clause.Ref(
+                new Clause.Id(TypeSymbols.declared(new TypeKey("example.one", "N")), 0),
+                Optional.of(new ClauseName("within"))));
+    }
+
+    /** A clause whose two conjuncts leave the position one value. */
+    private static final String ONE_VALUE = """
+            module example.one
+
+            data N = Int
+                invariant within = value >= 5 && value <= 5
+
+            data Ok
+
+            behavior f : (n: N) -> Ok
+            let f (n) = Ok
+
+            example f
+                | "x" : (N(5)) -> Ok
+            """;
+
+    /** The same clause with room between its ends. */
+    private static final String RANGE = """
+            module example.range
+
+            data N = Int
+                invariant within = value >= 1 && value <= 10
+
+            data Ok
+
+            behavior f : (n: N) -> Ok
+            let f (n) = Ok
+
+            example f
+                | "x" : (N(3)) -> Ok
+            """;
+
+    private static Map<String, List<BorderAssessment>> boundariesOf(String model, String module) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, List<BorderAssessment>> boundaries =
+                Adequacy.boundariesOf(compilation.db(), module);
+        assertNotNull(boundaries, "the model under test compiles");
+        return boundaries;
+    }
+
+    private static Map<String, BorderAssessment> bordersOf(String model, String module) {
+        Map<String, BorderAssessment> out = new LinkedHashMap<>();
+        boundariesOf(model, module).values()
+                .forEach(each -> each.forEach(b -> out.put(b.border().label(), b)));
+        return out;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABoundSaysWhichSideItKeepsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABoundSaysWhichSideItKeepsTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -62,6 +63,27 @@ class ABoundSaysWhichSideItKeepsTest {
         assertEquals(List.of("n = 5", "n = 5"),
                 at.stream().map(each -> each.border().label()).toList(),
                 "at one value, so nothing about where they are tells them apart");
+    }
+
+    /**
+     * The side is what the two ends of one conjunct are told apart by.
+     *
+     * <p>Under the test above, which reads a model: {@code value >= 5 && value <= 5} draws its two
+     * lines from two conjuncts, so a reading that carried no side at all would still tell them
+     * apart by the conjunct and the model test would pass. What the side is worth is here — one
+     * rule, one conjunct, one inclusivity, and two lines.
+     */
+    @Test
+    void theTwoEndsOfOneConjunctAreToldApartByTheSideTheyKeep() {
+        OriginRef least = new OriginRef.InvariantOrigin(aClause(), 0, Towards.ABOVE, true);
+        OriginRef most = new OriginRef.InvariantOrigin(aClause(), 0, Towards.BELOW, true);
+
+        assertNotEquals(least.lineFacts(), most.lineFacts(),
+                "which side of the line the value it stops at is on is what the two disagree about");
+        assertNotEquals(least.authoredLine(), most.authoredLine(),
+                "so they are two lines of the model, and two rows to write");
+        assertEquals(least.authoredLine().rule(), most.authoredLine().rule(),
+                "one clause placed both, which is what provenance answers");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AClosedReadingIsOneThatDrewEveryLineItFoundTest.java
@@ -171,6 +171,7 @@ class AClosedReadingIsOneThatDrewEveryLineItFoundTest {
     private static OriginRef bound(String clause) {
         return new OriginRef.InvariantOrigin(new RuleRef.Invariant(new Clause.Ref(
                 new Clause.Id(TypeSymbols.declared(new TypeKey("example.rate", "Amount")), 0),
-                java.util.Optional.of(new ClauseName(clause)))), 0, true);
+                java.util.Optional.of(new ClauseName(clause)))), 0,
+                souther.compiler.numeric.Towards.ABOVE, true);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/ARowIsLookedForWhereEachReadingOfTheLineIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ARowIsLookedForWhereEachReadingOfTheLineIsTest.java
@@ -59,15 +59,15 @@ class ARowIsLookedForWhereEachReadingOfTheLineIsTest {
     }
 
     /**
-     * Each reading is searched under the conditions it is reached by.
+     * A row is still offered at a line that was read twice.
      *
-     * <p>Read through the row that comes back: it stands at the line and it carries a {@code side},
-     * because getting to either call takes one. A search made after the readings are one has a
-     * region to compose against either way — what it does not have is a reason for the region it
-     * got.
+     * <p>What searching the readings apart may not cost. Two searches come back where one used to
+     * and the fold keeps one item per point, so a fold that kept the wrong one would leave the point
+     * with nothing to offer while a row for it had been composed. The row carries a {@code side},
+     * because getting to either call takes one.
      */
     @Test
-    void theRowOfferedIsComposedUnderTheConditionsOfAReading() {
+    void aRowIsStillOfferedAtALineReadTwice() {
         Compilation compilation = compiled();
         List<BorderAssessment> searched = compilation.db()
                 .ask(new Adequacy.BoundarySearch("example.banding", "twice")).value();

--- a/souther-compiler/src/test/java/souther/compiler/query/ARowIsLookedForWhereEachReadingOfTheLineIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ARowIsLookedForWhereEachReadingOfTheLineIsTest.java
@@ -1,0 +1,132 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.partition.BorderObligationId;
+import souther.compiler.partition.PointRole;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A row for a line is looked for where each reading of that line is.
+ *
+ * <p>A non-recursive helper is spliced into every body that calls it, so one comparison is read once
+ * per call — and each of those readings is reached under its caller's own conditions. Which
+ * conditions a row has to satisfy to get there is therefore the reading's own answer, and it is the
+ * region a search composes a row in.
+ *
+ * <p>So the readings are searched apart and brought together after. Brought together first, the
+ * region a row is composed in belongs to whichever reading the fold kept, which is the one a walk
+ * met first — so the row an author is offered is written for a call site nobody chose.
+ *
+ * <p>What the fold is still right about is the report: the readings owe one row between them, and a
+ * point one of them found a row at is found.
+ */
+class ARowIsLookedForWhereEachReadingOfTheLineIsTest {
+
+    /**
+     * One guard called twice is two readings, one line and one row to write.
+     *
+     * <p>The two are what a search runs over and the one is what a report says. Both readings owe
+     * the same row, which is what makes bringing them together right; what they do not share is
+     * where a row for it may be composed.
+     */
+    @Test
+    void aGuardCalledTwiceIsReadTwiceAndReportedOnce() {
+        Compilation compilation = compiled();
+        List<BorderAssessment> readings = compilation.db()
+                .ask(new Adequacy.Readings("example.banding", "twice")).value();
+        List<BorderAssessment> lines = compilation.db()
+                .ask(new Adequacy.Boundaries("example.banding", "twice")).value();
+        assertNotNull(readings, "the model under test compiles");
+        assertNotNull(lines, "the model under test compiles");
+
+        assertEquals(2, at(readings, "a = 100").size(),
+                () -> "the helper is called from both arms, so its line is read twice: "
+                        + labels(readings));
+        assertEquals(1, at(lines, "a = 100").size(),
+                () -> "and a report says it once: " + labels(lines));
+
+        List<BorderObligationId> owed = at(readings, "a = 100").stream()
+                .map(each -> each.border().obligation()).distinct().toList();
+        assertEquals(1, owed.size(),
+                () -> "both readings owe the one row the author wrote: " + owed);
+    }
+
+    /**
+     * Each reading is searched under the conditions it is reached by.
+     *
+     * <p>Read through the row that comes back: it stands at the line and it carries a {@code side},
+     * because getting to either call takes one. A search made after the readings are one has a
+     * region to compose against either way — what it does not have is a reason for the region it
+     * got.
+     */
+    @Test
+    void theRowOfferedIsComposedUnderTheConditionsOfAReading() {
+        Compilation compilation = compiled();
+        List<BorderAssessment> searched = compilation.db()
+                .ask(new Adequacy.BoundarySearch("example.banding", "twice")).value();
+        assertNotNull(searched, "the model under test compiles");
+
+        ItemAssessment.Owed on = assertInstanceOf(ItemAssessment.Owed.class,
+                at(searched, "a = 100").get(0).at(PointRole.ON));
+        ItemAssessment.Attempt.Built built = assertInstanceOf(
+                ItemAssessment.Attempt.Built.class, on.attempt(),
+                () -> "a row stands at the line under one of the two calls: " + on.attempt());
+        List<String> row = built.row().inputs().stream()
+                .map(each -> each.text()).toList();
+
+        assertTrue(row.contains("Amount(100)"), () -> "the row is written at the line: " + row);
+        assertTrue(row.contains("Left") || row.contains("Right"),
+                () -> "and under the arm one of the two calls is reached by: " + row);
+    }
+
+    private static List<BorderAssessment> at(List<BorderAssessment> lines, String label) {
+        return lines.stream().filter(each -> each.border().label().equals(label)).toList();
+    }
+
+    private static List<String> labels(List<BorderAssessment> lines) {
+        return lines.stream().map(each -> each.border().label()).toList();
+    }
+
+    private static Compilation compiled() {
+        Compilation compilation = Compilation.ofSource(TWICE, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    /** A helper called from both arms of a fork, so its comparison is read once per call. */
+    private static final String TWICE = """
+            module example.banding
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Small
+            data Large
+            data Size = Small | Large
+
+            data Left
+            data Right
+            data Side = Left | Right
+
+            let band (a: Amount): Size =
+                if a.value <= 100 then Small else Large
+
+            behavior twice : (side: Side, a: Amount) -> Size
+            let twice (side, a) =
+                match side with
+                    | Left -> band(a)
+                    | Right -> band(a)
+
+            example twice
+                | "left small" : (Left, Amount(1)) -> Small
+                | "left large" : (Left, Amount(500)) -> Large
+            """;
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ARowIsLookedForWhereEachReadingOfTheLineIsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ARowIsLookedForWhereEachReadingOfTheLineIsTest.java
@@ -39,13 +39,14 @@ class ARowIsLookedForWhereEachReadingOfTheLineIsTest {
     @Test
     void aGuardCalledTwiceIsReadTwiceAndReportedOnce() {
         Compilation compilation = compiled();
-        List<BorderAssessment> readings = compilation.db()
+        LineReadings read = compilation.db()
                 .ask(new Adequacy.Readings("example.banding", "twice")).value();
         List<BorderAssessment> lines = compilation.db()
                 .ask(new Adequacy.Boundaries("example.banding", "twice")).value();
-        assertNotNull(readings, "the model under test compiles");
+        assertNotNull(read, "the model under test compiles");
         assertNotNull(lines, "the model under test compiles");
 
+        List<BorderAssessment> readings = read.each();
         assertEquals(2, at(readings, "a = 100").size(),
                 () -> "the helper is called from both arms, so its line is read twice: "
                         + labels(readings));


### PR DESCRIPTION
Closes #1092.

`Border` asked which way a bound keeps its values by looking at what the rules left the position and finding the end its line is. That fact is settled two readings earlier — the ends are read one at a time, so a minimum is known to be a minimum where it is placed — and the derivation over what every rule left has a case with nothing to answer with and calls both ends of a clause leaving one value the minimum.

Chasing it turned up the same seam in the other direction, so the change is three commits.

### Owe a row for the line the author wrote, not for the reading that reached it

`BorderObligationId` was keyed on the whole reading. A comparison inside a non-recursive helper is read once per call, so one guard came out as one debt per call site, and what brought them back to one was the merge that collects what each reading saw — which keeps the first border it met, so the call site the surviving debt named followed the order a walk took.

What several readings of one line share is now a value: `AuthoredLine`. A debt is that and the level it cuts at; a `BoundaryLine` is that and where it was read. So folding readings into a line never folds two debts, and one debt is still read at as many positions and behaviors as carry the rule.

`LineFacts` is the one place the three facts a reading records are answered. `Border` and `BoundaryLine` each switched over the arms of `OriginRef` for them, and each filled the slot a bound leaves empty for itself.

### Carry the side a bound keeps instead of reconstructing it from its reach

`InvariantOrigin` records the side; what it says about its own line follows from it; `Border` reads it the way it reads every other rule's. The range is kept as a check rather than as the source: a bound's line is the end of what it leaves on the side it keeps, so a producer and a range that disagree stop the build. `value >= 5 && value <= 5` now reports the two lines the author wrote instead of one.

### Fold readings into a line only after what is a reading's own is asked

Each reading of a guard is reached under its caller's own conditions, and that region is what a search composes a row in. Searched after the fold, the region belongs to whichever reading the fold kept. `Boundaries` now folds what `Readings` holds apart, and the search runs over the readings.

Where the fold does happen it is held to a debt: two readings under one line owing two rows stops the build.

### What I could not show

I could not build a model where the arbitrary region changes a verdict rather than which call site's row is offered. Where a call site cannot reach the line, that reading draws no border at all and never reaches the fold, so the two readings that do meet there have regions that both compose. The change removes the dependence; the difference I can demonstrate is which arm the offered row names.

`mvn -o verify` is green.