### PR TITLE
Make a run of a quantity say what stops it at each end

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/numeric/Count.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/Count.java
@@ -157,6 +157,12 @@ public record Count(BigDecimal at) implements Place {
         return at.stripTrailingZeros().toPlainString();
     }
 
+    /** The same count with the trailing zeros gone, which is the number {@link #key()} names. */
+    @Override
+    public Count canonical() {
+        return new Count(at.stripTrailingZeros());
+    }
+
     @Override
     public String toString() {
         return key();

--- a/souther-compiler/src/main/java/souther/compiler/numeric/Place.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/Place.java
@@ -37,6 +37,19 @@ public sealed interface Place extends Comparable<Place> permits Count, Text {
         return other != null && compareTo(other) == 0;
     }
 
+    /**
+     * This place spelled the one way {@link #key()} names it.
+     *
+     * <p>For a caller that has to compare places it cannot ask {@link #sameAs} — a value used as a
+     * map key, or held inside a larger value that is. Two places of one line come back equal here,
+     * so the derived equality of whatever holds them answers the question the order would.
+     *
+     * <p>Beside the two above rather than replacing them: what a rule wrote is what a report writes
+     * back, and {@code 0.00m} is written as the author wrote it. This is the same place said the one
+     * way, and it is only ever what an identity is built from.
+     */
+    Place canonical();
+
     /** What a comparison across two carriers is, where one happens. Never reachable from a model:
      * the places the algebra compares are the places of one position. */
     static IllegalArgumentException notOneOrder(Place left, Place right) {

--- a/souther-compiler/src/main/java/souther/compiler/numeric/Text.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/Text.java
@@ -53,6 +53,12 @@ public record Text(String at) implements Place {
         return at;
     }
 
+    /** Itself, there being no second spelling of a string to fold. */
+    @Override
+    public Text canonical() {
+        return this;
+    }
+
     @Override
     public String toString() {
         return at;

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -69,7 +69,7 @@ import java.util.List;
  *                 from the other end
  */
 public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> classes,
-                   List<Cut> cuts, List<Seam> parted, ReadingResidue residue,
+                   List<Cut> cuts, List<Parting> parted, ReadingResidue residue,
                    StructuralInspection.Continuation pending, LeftAtThePosition leftWith) {
 
     public Axis {
@@ -116,7 +116,7 @@ public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> 
     }
 
     /** The same position, with what a body's rules divided it into and the lines they drew. */
-    public Axis carrying(List<PartitionClass> classes, List<Cut> cuts, List<Seam> parted) {
+    public Axis carrying(List<PartitionClass> classes, List<Cut> cuts, List<Parting> parted) {
         return new Axis(id, term, type, classes, cuts, parted, residue, pending, leftWith);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Band.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Band.java
@@ -36,12 +36,13 @@ public record Band(BandEnd lower, BandEnd upper) {
      *
      * @param inward which way the run lies from this end
      */
-    public static BandEnd endAt(Seam parted, Bound leaves, Towards inward) {
+    public static BandEnd endAt(Parting parted, Bound leaves, Towards inward) {
         if (parted == null) {
             return leaves == null ? new BandEnd.AtOrderEnd(inward.opposite())
                     : new BandEnd.AtDomain(leaves);
         }
-        return new BandEnd.AtParting(parted, tighter(atTheLine(parted, inward), leaves, inward));
+        return new BandEnd.AtParting(parted,
+                tighter(atTheLine(parted.geometry(), inward), leaves, inward));
     }
 
     /**
@@ -83,8 +84,8 @@ public record Band(BandEnd lower, BandEnd upper) {
 
     private static BandEnd canonical(BandEnd end) {
         return switch (end) {
-            case BandEnd.AtParting(Seam seam, Bound reaches) ->
-                    new BandEnd.AtParting(seam.canonical(), reaches.canonical());
+            case BandEnd.AtParting(Parting parted, Bound reaches) ->
+                    new BandEnd.AtParting(parted.canonical(), reaches.canonical());
             case BandEnd.AtDomain(Bound reaches) -> new BandEnd.AtDomain(reaches.canonical());
             case BandEnd.AtOrderEnd order -> order;
         };
@@ -100,13 +101,13 @@ public record Band(BandEnd lower, BandEnd upper) {
      * is named after the line an author wrote and not after the value beside it.
      */
     public souther.compiler.numeric.Endpoint lineBelow(souther.compiler.numeric.Endpoint leaves) {
-        Seam parted = lower.parting();
+        Seam parted = lower.seam();
         return parted == null ? leaves : asAnEnd(parted, Towards.ABOVE);
     }
 
     /** The line above it, on the same reading. */
     public souther.compiler.numeric.Endpoint lineAbove(souther.compiler.numeric.Endpoint leaves) {
-        Seam parted = upper.parting();
+        Seam parted = upper.seam();
         return parted == null ? leaves : asAnEnd(parted, Towards.BELOW);
     }
 
@@ -147,13 +148,13 @@ public record Band(BandEnd lower, BandEnd upper) {
 
     /** The first value in this run, or null where the order names none there. */
     public Level first() {
-        Seam parted = lower.parting();
+        Seam parted = lower.seam();
         return parted == null ? valueAt(left(lower)) : parted.above();
     }
 
     /** The last, on the same reading. */
     public Level last() {
-        Seam parted = upper.parting();
+        Seam parted = upper.seam();
         return parted == null ? valueAt(left(upper)) : parted.below();
     }
 
@@ -197,8 +198,8 @@ public record Band(BandEnd lower, BandEnd upper) {
      * hundred is the one value that will not do.
      */
     public String written(BorderQuantity of, Level except) {
-        Seam under = lower.parting();
-        Seam over = upper.parting();
+        Seam under = lower.seam();
+        Seam over = upper.seam();
         String low = except != null && same(except, first())
                 ? of.writtenAt(except) + " < "
                 : under != null ? said(of, under, Towards.ABOVE)
@@ -307,8 +308,8 @@ public record Band(BandEnd lower, BandEnd upper) {
      * on the position and a line on a multiple of it relates a row to both.
      */
     public java.math.BigDecimal sharedMultiple() {
-        Seam under = lower.parting();
-        Seam over = upper.parting();
+        Seam under = lower.seam();
+        Seam over = upper.seam();
         if (under == null || over == null
                 || under.attainedLine() != null || over.attainedLine() != null
                 || under.below() != null || under.above() != null
@@ -357,17 +358,18 @@ public record Band(BandEnd lower, BandEnd upper) {
     private static BandEnd mappedBy(BandEnd end, Towards inward,
                                     java.util.function.UnaryOperator<Level> onto) {
         return switch (end) {
-            case BandEnd.AtParting(Seam seam, Bound reaches) -> {
-                Seam moved = seam.mappedBy(onto);
+            case BandEnd.AtParting(Parting parted, Bound reaches) -> {
+                Seam moved = parted.geometry().mappedBy(onto);
                 if (moved == null) {
                     yield null;
                 }
                 // Where the run reaches is worked out again from what moved, because the two things
                 // it is the tighter of move by different rules: a line goes through the seam, and an
                 // end the rules leave is at a value of the quantity and goes through that.
-                yield new BandEnd.AtParting(moved, reaches.equals(atTheLine(seam, inward))
-                        ? atTheLine(moved, inward)
-                        : tighter(atTheLine(moved, inward), mapped(reaches, onto), inward));
+                yield new BandEnd.AtParting(new Parting(moved, parted.alternatives()),
+                        reaches.equals(atTheLine(parted.geometry(), inward))
+                                ? atTheLine(moved, inward)
+                                : tighter(atTheLine(moved, inward), mapped(reaches, onto), inward));
             }
             case BandEnd.AtDomain(Bound reaches) -> new BandEnd.AtDomain(mapped(reaches, onto));
             case BandEnd.AtOrderEnd order -> order;

--- a/souther-compiler/src/main/java/souther/compiler/partition/Band.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Band.java
@@ -35,6 +35,21 @@ public record Band(Seam under, Seam over, Bound from, Bound to) {
     }
 
     /**
+     * The same run with every level written the one way, for an identity to be built from.
+     *
+     * <p>Not {@link #key()}, which reads the run off the values at its ends and so says nothing
+     * about where a run with no first value starts: {@code 0 < x} and {@code 5 < x} over the
+     * decimals have the same first value, which is none. What holds a run and is compared as a value
+     * holds this.
+     */
+    public Band canonical() {
+        return new Band(under == null ? null : under.canonical(),
+                over == null ? null : over.canonical(),
+                from == null ? null : from.canonical(),
+                to == null ? null : to.canonical());
+    }
+
+    /**
      * The line below this run, as an end of the position's counts, or the end the rules leave where
      * nothing parts it there.
      *

--- a/souther-compiler/src/main/java/souther/compiler/partition/Band.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Band.java
@@ -101,14 +101,30 @@ public record Band(BandEnd lower, BandEnd upper) {
      * is named after the line an author wrote and not after the value beside it.
      */
     public souther.compiler.numeric.Endpoint lineBelow(souther.compiler.numeric.Endpoint leaves) {
-        Seam parted = lower.seam();
-        return parted == null ? leaves : asAnEnd(parted, Towards.ABOVE);
+        return lineAt(lower, Towards.ABOVE, leaves);
     }
 
     /** The line above it, on the same reading. */
     public souther.compiler.numeric.Endpoint lineAbove(souther.compiler.numeric.Endpoint leaves) {
-        Seam parted = upper.seam();
-        return parted == null ? leaves : asAnEnd(parted, Towards.BELOW);
+        return lineAt(upper, Towards.BELOW, leaves);
+    }
+
+    /**
+     * One end of the run as an end of the position's counts.
+     *
+     * <p>{@code leaves} is what the rules leave the quantity, for a run built without being told —
+     * an arrangement made of the lines alone has no end to give, and its outermost runs are open
+     * ({@link Intervals} builds one and holds it to the range afterwards). A run that was told keeps
+     * its own answer, so the two cannot say different things about one end.
+     */
+    private static souther.compiler.numeric.Endpoint lineAt(
+            BandEnd end, Towards inward, souther.compiler.numeric.Endpoint leaves) {
+        return switch (end) {
+            case BandEnd.AtParting parted -> asAnEnd(parted.parting().geometry(), inward);
+            case BandEnd.AtDomain domain -> new souther.compiler.numeric.Endpoint(
+                    placeOf(valueOrRefuse(domain.reaches())), domain.reaches().inclusive());
+            case BandEnd.AtOrderEnd _ -> leaves;
+        };
     }
 
     /**
@@ -366,6 +382,11 @@ public record Band(BandEnd lower, BandEnd upper) {
                 // Where the run reaches is worked out again from what moved, because the two things
                 // it is the tighter of move by different rules: a line goes through the seam, and an
                 // end the rules leave is at a value of the quantity and goes through that.
+                //
+                // Asked with the records' own equality, which is the question here: whether this
+                // reach is the one built from the line, and not whether the two are one place. A
+                // reach that came off the rules' end is at the same place under another spelling as
+                // often as not, and either answer takes the same branch.
                 yield new BandEnd.AtParting(new Parting(moved, parted.alternatives()),
                         reaches.equals(atTheLine(parted.geometry(), inward))
                                 ? atTheLine(moved, inward)

--- a/souther-compiler/src/main/java/souther/compiler/partition/Band.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Band.java
@@ -9,19 +9,56 @@ import souther.compiler.numeric.Towards;
  * The two used to be derived apart, and only the first of them knew about the lines further along —
  * so a row well past the next line answered for a point that was supposed to be inside this run.
  *
- * @param under the seam this run starts above, or null where nothing parts it there
- * @param over  the seam it stops below, or null on the same reading
- * @param from  what the rules leave the quantity at the low end, which is where a run with no seam
- *              under it starts. Null where they leave it everything that way.
- *              <p>Where it stops and whether it keeps the place it stops at, and not the first value
- *              in it. The two are one thing on a carrier that steps, because a strict end is moved
- *              onto the value it leaves before it is ever read — and on one with no step there is no
- *              such value: {@code value > 0.00m} leaves every decimal above zero and no least one.
- *              Held as the value, such a run either ran to the end of the order or held the very
- *              value its bound refuses, and the class it is came out spelled {@code 0 <= rate}
- * @param to    the same at the high end
+ * <p>Both ends are always there, and each says what stops the run ({@link BandEnd}). They used to be
+ * a line that might be null beside an end the rules leave that might be null, and what a run stops
+ * at was read back out of which of the four combinations had turned up.
+ *
+ * @param lower what stops the run at the low end
+ * @param upper the same at the high end
  */
-public record Band(Seam under, Seam over, Bound from, Bound to) {
+public record Band(BandEnd lower, BandEnd upper) {
+
+    public Band {
+        if (lower == null || upper == null) {
+            throw new IllegalArgumentException(
+                    "a run stops somewhere at both ends, or runs to the end of the order: "
+                            + lower + " " + upper);
+        }
+    }
+
+    /**
+     * One end of a run, from the line that parts the values there and the end the rules leave.
+     *
+     * <p>Both are consulted, because a run is on this side of the line and inside what the rules
+     * leave at once: a run parted by a line the rules stop short of reaches the rules' end. Which of
+     * the two named the run is a different question and is the shape's ({@link BandEnd.AtParting}
+     * names the line whether or not the run reaches it).
+     *
+     * @param inward which way the run lies from this end
+     */
+    public static BandEnd endAt(Seam parted, Bound leaves, Towards inward) {
+        if (parted == null) {
+            return leaves == null ? new BandEnd.AtOrderEnd(inward.opposite())
+                    : new BandEnd.AtDomain(leaves);
+        }
+        return new BandEnd.AtParting(parted, tighter(atTheLine(parted, inward), leaves, inward));
+    }
+
+    /**
+     * Where a line lets the run beside it start.
+     *
+     * <p>The value beside the line where the quantity has one, and the line itself where it has
+     * none. Written as the line, the run above a seam that keeps its own value would hold that
+     * value; written as the value, a run over an order whose values fill would have no end at all.
+     */
+    private static Bound atTheLine(Seam parted, Towards inward) {
+        Level edge = inward == Towards.ABOVE ? parted.above() : parted.below();
+        return edge != null ? Bound.at(edge, true) : new Bound(parted.at(), false);
+    }
+
+    private static Bound tighter(Bound line, Bound leaves, Towards inward) {
+        return inward == Towards.ABOVE ? Bound.lower(line, leaves) : Bound.upper(line, leaves);
+    }
 
     /**
      * How this run reads: the first value in it and the last.
@@ -34,43 +71,43 @@ public record Band(Seam under, Seam over, Bound from, Bound to) {
         return where(first()) + "|" + where(last());
     }
 
-    /**
-     * The same run with every level written the one way, for an identity to be built from.
+    /** The same run with every level written the one way, for an identity to be built from.
      *
      * <p>Not {@link #key()}, which reads the run off the values at its ends and so says nothing
      * about where a run with no first value starts: {@code 0 < x} and {@code 5 < x} over the
      * decimals have the same first value, which is none. What holds a run and is compared as a value
-     * holds this.
-     */
+     * holds this. */
     public Band canonical() {
-        return new Band(under == null ? null : under.canonical(),
-                over == null ? null : over.canonical(),
-                from == null ? null : from.canonical(),
-                to == null ? null : to.canonical());
+        return new Band(canonical(lower), canonical(upper));
+    }
+
+    private static BandEnd canonical(BandEnd end) {
+        return switch (end) {
+            case BandEnd.AtParting(Seam seam, Bound reaches) ->
+                    new BandEnd.AtParting(seam.canonical(), reaches.canonical());
+            case BandEnd.AtDomain(Bound reaches) -> new BandEnd.AtDomain(reaches.canonical());
+            case BandEnd.AtOrderEnd order -> order;
+        };
     }
 
     /**
      * The line below this run, as an end of the position's counts, or the end the rules leave where
      * nothing parts it there.
      *
-     * <p>Apart from {@link #low}, and both are this run's own answer about where it starts. One
-     * names the first value in it and the other names the line it starts from — on a carrier that
+     * <p>Apart from the first value in it, and both are this run's own answer about where it starts.
+     * One names the first value and the other names the line it starts from — on a carrier that
      * steps the two describe one boundary and only the first exists on every carrier, while a class
      * is named after the line an author wrote and not after the value beside it.
      */
     public souther.compiler.numeric.Endpoint lineBelow(souther.compiler.numeric.Endpoint leaves) {
-        if (under == null) {
-            return leaves;
-        }
-        return asAnEnd(under, Towards.ABOVE);
+        Seam parted = lower.parting();
+        return parted == null ? leaves : asAnEnd(parted, Towards.ABOVE);
     }
 
     /** The line above it, on the same reading. */
     public souther.compiler.numeric.Endpoint lineAbove(souther.compiler.numeric.Endpoint leaves) {
-        if (over == null) {
-            return leaves;
-        }
-        return asAnEnd(over, Towards.BELOW);
+        Seam parted = upper.parting();
+        return parted == null ? leaves : asAnEnd(parted, Towards.BELOW);
     }
 
     /**
@@ -110,12 +147,20 @@ public record Band(Seam under, Seam over, Bound from, Bound to) {
 
     /** The first value in this run, or null where the order names none there. */
     public Level first() {
-        return under == null ? valueAt(from) : under.above();
+        Seam parted = lower.parting();
+        return parted == null ? valueAt(left(lower)) : parted.above();
     }
 
     /** The last, on the same reading. */
     public Level last() {
-        return over == null ? valueAt(to) : over.below();
+        Seam parted = upper.parting();
+        return parted == null ? valueAt(left(upper)) : parted.below();
+    }
+
+    /** What the rules leave the quantity at this end, where that is what stops the run and there is
+     *  an end at all. */
+    private static Bound left(BandEnd end) {
+        return end instanceof BandEnd.AtDomain domain ? domain.reaches() : null;
     }
 
     /**
@@ -152,12 +197,16 @@ public record Band(Seam under, Seam over, Bound from, Bound to) {
      * hundred is the one value that will not do.
      */
     public String written(BorderQuantity of, Level except) {
+        Seam under = lower.parting();
+        Seam over = upper.parting();
         String low = except != null && same(except, first())
                 ? of.writtenAt(except) + " < "
-                : under != null ? said(of, under, Towards.ABOVE) : leaves(of, from, Towards.ABOVE);
+                : under != null ? said(of, under, Towards.ABOVE)
+                        : leaves(of, left(lower), Towards.ABOVE);
         String high = except != null && same(except, last())
                 ? " < " + of.writtenAt(except)
-                : over != null ? said(of, over, Towards.BELOW) : leaves(of, to, Towards.BELOW);
+                : over != null ? said(of, over, Towards.BELOW)
+                        : leaves(of, left(upper), Towards.BELOW);
         // An end only the rule that drew it can name relates a row to the quantity rather than to
         // the position, so it is a condition of its own beside the rest. Dropped, the run read as
         // reaching past the very line that ends it.
@@ -258,6 +307,8 @@ public record Band(Seam under, Seam over, Bound from, Bound to) {
      * on the position and a line on a multiple of it relates a row to both.
      */
     public java.math.BigDecimal sharedMultiple() {
+        Seam under = lower.parting();
+        Seam over = upper.parting();
         if (under == null || over == null
                 || under.attainedLine() != null || over.attainedLine() != null
                 || under.below() != null || under.above() != null
@@ -292,15 +343,35 @@ public record Band(Seam under, Seam over, Bound from, Bound to) {
      * run of distances until the other end of it is known.
      */
     Band mappedBy(java.util.function.UnaryOperator<Level> onto) {
-        Seam below = under == null ? null : under.mappedBy(onto);
-        Seam above = over == null ? null : over.mappedBy(onto);
+        BandEnd low = mappedBy(lower, Towards.ABOVE, onto);
+        BandEnd high = mappedBy(upper, Towards.BELOW, onto);
         // A line with no place on the other order leaves the run nothing to be read as: which side
         // of it this run lies is the whole of what the run says. An end the carrier does not reach
         // is a different answer and is kept as no end.
-        if (under != null && below == null || over != null && above == null) {
+        if (low == null || high == null) {
             return null;
         }
-        return new Band(below, above, mapped(from, onto), mapped(to, onto));
+        return new Band(low, high);
+    }
+
+    private static BandEnd mappedBy(BandEnd end, Towards inward,
+                                    java.util.function.UnaryOperator<Level> onto) {
+        return switch (end) {
+            case BandEnd.AtParting(Seam seam, Bound reaches) -> {
+                Seam moved = seam.mappedBy(onto);
+                if (moved == null) {
+                    yield null;
+                }
+                // Where the run reaches is worked out again from what moved, because the two things
+                // it is the tighter of move by different rules: a line goes through the seam, and an
+                // end the rules leave is at a value of the quantity and goes through that.
+                yield new BandEnd.AtParting(moved, reaches.equals(atTheLine(seam, inward))
+                        ? atTheLine(moved, inward)
+                        : tighter(atTheLine(moved, inward), mapped(reaches, onto), inward));
+            }
+            case BandEnd.AtDomain(Bound reaches) -> new BandEnd.AtDomain(mapped(reaches, onto));
+            case BandEnd.AtOrderEnd order -> order;
+        };
     }
 
     /** An end the rules leave, read on another order. Whether the run keeps the place it stops at
@@ -340,33 +411,9 @@ public record Band(Seam under, Seam over, Bound from, Bound to) {
      * last value below is in the run below. Where a seam names no value on the side facing this run
      * — a carrier whose values fill has no first value above a line it keeps — the run is open at
      * the line itself, which is where the seam's own position says the values part.
-     *
-     * <p>And the ends the rules leave narrow it further wherever they are the tighter, since a run
-     * is what every one of them leaves.
      */
     public LevelRegion region() {
-        return LevelRegion.of(new LevelInterval(
-                endOf(under, from, Towards.ABOVE), endOf(over, to, Towards.BELOW)));
-    }
-
-    /**
-     * One end of this run, from the line that parts it there and the end the rules leave.
-     *
-     * <p>Whichever of the two is the tighter, because a run is on this side of the line and inside
-     * what the rules leave at once. Read as one or the other, a run bounded by a rule and parted by
-     * a line reached past whichever of them was not consulted.
-     */
-    private static Bound endOf(Seam parted, Bound left, Towards side) {
-        if (parted == null) {
-            return left;
-        }
-        Level edge = side == Towards.ABOVE ? parted.above() : parted.below();
-        // The value beside the line where the quantity has one, and the line itself where it has
-        // none. Written as the line, the run above a seam that keeps its own value would hold that
-        // value; written as the value, a run over an order whose values fill would have no end at
-        // all.
-        Bound atTheLine = edge != null ? Bound.at(edge, true) : new Bound(parted.at(), false);
-        return side == Towards.ABOVE ? Bound.lower(atTheLine, left) : Bound.upper(atTheLine, left);
+        return LevelRegion.of(new LevelInterval(lower.reaches(), upper.reaches()));
     }
 
     /** Whether a value of the quantity lies in this run. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/Band.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Band.java
@@ -36,13 +36,12 @@ public record Band(BandEnd lower, BandEnd upper) {
      *
      * @param inward which way the run lies from this end
      */
-    public static BandEnd endAt(Parting parted, Bound leaves, Towards inward) {
+    public static BandEnd endAt(Seam parted, Bound leaves, Towards inward) {
         if (parted == null) {
             return leaves == null ? new BandEnd.AtOrderEnd(inward.opposite())
                     : new BandEnd.AtDomain(leaves);
         }
-        return new BandEnd.AtParting(parted,
-                tighter(atTheLine(parted.geometry(), inward), leaves, inward));
+        return new BandEnd.AtParting(parted, tighter(atTheLine(parted, inward), leaves, inward));
     }
 
     /**
@@ -84,7 +83,7 @@ public record Band(BandEnd lower, BandEnd upper) {
 
     private static BandEnd canonical(BandEnd end) {
         return switch (end) {
-            case BandEnd.AtParting(Parting parted, Bound reaches) ->
+            case BandEnd.AtParting(Seam parted, Bound reaches) ->
                     new BandEnd.AtParting(parted.canonical(), reaches.canonical());
             case BandEnd.AtDomain(Bound reaches) -> new BandEnd.AtDomain(reaches.canonical());
             case BandEnd.AtOrderEnd order -> order;
@@ -120,7 +119,7 @@ public record Band(BandEnd lower, BandEnd upper) {
     private static souther.compiler.numeric.Endpoint lineAt(
             BandEnd end, Towards inward, souther.compiler.numeric.Endpoint leaves) {
         return switch (end) {
-            case BandEnd.AtParting parted -> asAnEnd(parted.parting().geometry(), inward);
+            case BandEnd.AtParting parted -> asAnEnd(parted.seam(), inward);
             case BandEnd.AtDomain domain -> new souther.compiler.numeric.Endpoint(
                     placeOf(valueOrRefuse(domain.reaches())), domain.reaches().inclusive());
             case BandEnd.AtOrderEnd _ -> leaves;
@@ -374,8 +373,8 @@ public record Band(BandEnd lower, BandEnd upper) {
     private static BandEnd mappedBy(BandEnd end, Towards inward,
                                     java.util.function.UnaryOperator<Level> onto) {
         return switch (end) {
-            case BandEnd.AtParting(Parting parted, Bound reaches) -> {
-                Seam moved = parted.geometry().mappedBy(onto);
+            case BandEnd.AtParting(Seam parted, Bound reaches) -> {
+                Seam moved = parted.mappedBy(onto);
                 if (moved == null) {
                     yield null;
                 }
@@ -387,10 +386,9 @@ public record Band(BandEnd lower, BandEnd upper) {
                 // reach is the one built from the line, and not whether the two are one place. A
                 // reach that came off the rules' end is at the same place under another spelling as
                 // often as not, and either answer takes the same branch.
-                yield new BandEnd.AtParting(new Parting(moved, parted.alternatives()),
-                        reaches.equals(atTheLine(parted.geometry(), inward))
-                                ? atTheLine(moved, inward)
-                                : tighter(atTheLine(moved, inward), mapped(reaches, onto), inward));
+                yield new BandEnd.AtParting(moved, reaches.equals(atTheLine(parted, inward))
+                        ? atTheLine(moved, inward)
+                        : tighter(atTheLine(moved, inward), mapped(reaches, onto), inward));
             }
             case BandEnd.AtDomain(Bound reaches) -> new BandEnd.AtDomain(mapped(reaches, onto));
             case BandEnd.AtOrderEnd order -> order;

--- a/souther-compiler/src/main/java/souther/compiler/partition/BandEnd.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BandEnd.java
@@ -27,16 +27,24 @@ public sealed interface BandEnd {
     /**
      * A rule parts the values here.
      *
-     * @param parting where they part and which lines the model wrote there, which is what the run
-     *                is named after and what a row inside it is owed to
+     * <p><b>Where they part, and not which rules put a line there.</b> A run is what a border's
+     * point away from the line asks a row for, and what a row has to do is the same whether one rule
+     * wrote the line beside it or three did. Which rules did is the arrangement's
+     * ({@link Parting#alternatives}), where a reader asking who owes a row inside the run finds it —
+     * held here as well, it would be inside every value that says what is asked of a row, and two
+     * readings asking one thing would come out asking two.
+     *
+     * @param seam    where the values part, which is what the run is named after
      * @param reaches how far the run gets on this side, which is the line or what the rules leave,
      *                whichever is the tighter
      */
-    record AtParting(Parting parting, Bound reaches) implements BandEnd {
+    record AtParting(Seam seam, Bound reaches) implements BandEnd {
 
         public AtParting {
-            if (parting == null) {
-                throw new IllegalArgumentException("a run parted here is parted by something");
+            if (seam == null || reaches == null) {
+                throw new IllegalArgumentException(
+                        "a run parted here is parted somewhere and reaches somewhere: "
+                                + seam + " " + reaches);
             }
         }
     }
@@ -83,9 +91,8 @@ public sealed interface BandEnd {
     }
 
     /** Where the values part here, or null where nothing parts them and the run stops for another
-     *  reason. The quantity's own answer: which lines the model wrote there is the shape's
-     *  ({@link AtParting#parting}), and nothing asks it until a run is owed to one of them. */
+     *  reason. */
     default Seam seam() {
-        return this instanceof AtParting parted ? parted.parting().geometry() : null;
+        return this instanceof AtParting parted ? parted.seam() : null;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/BandEnd.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BandEnd.java
@@ -82,13 +82,9 @@ public sealed interface BandEnd {
         };
     }
 
-    /** Where the values part here and what wrote the lines, or null where nothing parts them and
-     *  the run stops for another reason. */
-    default Parting parting() {
-        return this instanceof AtParting parted ? parted.parting() : null;
-    }
-
-    /** The same place as the quantity's own answer about it, or null on the same reading. */
+    /** Where the values part here, or null where nothing parts them and the run stops for another
+     *  reason. The quantity's own answer: which lines the model wrote there is the shape's
+     *  ({@link AtParting#parting}), and nothing asks it until a run is owed to one of them. */
     default Seam seam() {
         return this instanceof AtParting parted ? parted.parting().geometry() : null;
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/BandEnd.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BandEnd.java
@@ -1,0 +1,89 @@
+package souther.compiler.partition;
+
+import souther.compiler.numeric.Towards;
+
+/**
+ * What stops a run of a quantity's values on one side.
+ *
+ * <p>Three things can, and they are not the same thing. A rule can part the values there, and then
+ * the run is named after that line and whoever wrote it. The rules can leave the quantity nothing
+ * past a place, and then the run stops where every rule together leaves off — which is not one rule's
+ * line and has no one author. Or nothing stops it, and the run goes as far as the order does.
+ *
+ * <p>Held as three shapes because a reader acts on which of them it is. It used to be a seam that
+ * might be null beside an end that might be null, and the three states were the four combinations
+ * with one left over: a caller that wanted the line asked whether the seam was there, and a caller
+ * that wanted where the run reaches asked both and worked out the tighter. Which of the three a run
+ * has is now what it says.
+ *
+ * <p><b>Where the run reaches is the end's own answer.</b> A line parts the values and the rules
+ * leave the quantity an end, and a run is on this side of the line and inside what the rules leave
+ * at once — so a run parted by a line the rules stop short of reaches the rules' end and not the
+ * line. The two are brought together where the run is built, which is the one place that holds
+ * both.
+ */
+public sealed interface BandEnd {
+
+    /**
+     * A rule parts the values here.
+     *
+     * @param seam    where they part, which is what the run is named after
+     * @param reaches how far the run gets on this side, which is the line or what the rules leave,
+     *                whichever is the tighter
+     */
+    record AtParting(Seam seam, Bound reaches) implements BandEnd {
+
+        public AtParting {
+            if (seam == null) {
+                throw new IllegalArgumentException("a run parted here is parted by something");
+            }
+        }
+    }
+
+    /**
+     * The rules leave the quantity nothing past here, and no line parts the values.
+     *
+     * <p>What every rule about the position leaves together, and the order's own extent among them:
+     * a length is never negative and no clause says so. So this is where the run stops and not who
+     * stopped it, which is a question about the reading that produced the end rather than about the
+     * run.
+     */
+    record AtDomain(Bound reaches) implements BandEnd {
+
+        public AtDomain {
+            if (reaches == null) {
+                throw new IllegalArgumentException("an end the rules leave is somewhere");
+            }
+        }
+    }
+
+    /** Nothing stops the run this way: it runs as far as the order does. */
+    record AtOrderEnd(Towards towards) implements BandEnd {
+
+        public AtOrderEnd {
+            if (towards == null) {
+                throw new IllegalArgumentException("an end of the order is one of its two");
+            }
+        }
+    }
+
+    /**
+     * How far the run gets on this side, or null where nothing stops it.
+     *
+     * <p>The one answer about where the run reaches, so that whether a value is in it and where to
+     * look for one cannot come apart.
+     */
+    default Bound reaches() {
+        return switch (this) {
+            case AtParting parted -> parted.reaches();
+            case AtDomain domain -> domain.reaches();
+            case AtOrderEnd _ -> null;
+        };
+    }
+
+    /** The line that parts the values here, or null where nothing parts them and the run stops for
+     *  another reason. */
+    default Seam parting() {
+        return this instanceof AtParting parted ? parted.seam() : null;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/BandEnd.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BandEnd.java
@@ -27,14 +27,15 @@ public sealed interface BandEnd {
     /**
      * A rule parts the values here.
      *
-     * @param seam    where they part, which is what the run is named after
+     * @param parting where they part and which lines the model wrote there, which is what the run
+     *                is named after and what a row inside it is owed to
      * @param reaches how far the run gets on this side, which is the line or what the rules leave,
      *                whichever is the tighter
      */
-    record AtParting(Seam seam, Bound reaches) implements BandEnd {
+    record AtParting(Parting parting, Bound reaches) implements BandEnd {
 
         public AtParting {
-            if (seam == null) {
+            if (parting == null) {
                 throw new IllegalArgumentException("a run parted here is parted by something");
             }
         }
@@ -81,9 +82,14 @@ public sealed interface BandEnd {
         };
     }
 
-    /** The line that parts the values here, or null where nothing parts them and the run stops for
-     *  another reason. */
-    default Seam parting() {
-        return this instanceof AtParting parted ? parted.seam() : null;
+    /** Where the values part here and what wrote the lines, or null where nothing parts them and
+     *  the run stops for another reason. */
+    default Parting parting() {
+        return this instanceof AtParting parted ? parted.parting() : null;
+    }
+
+    /** The same place as the quantity's own answer about it, or null on the same reading. */
+    default Seam seam() {
+        return this instanceof AtParting parted ? parted.parting().geometry() : null;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -319,11 +319,7 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
         return parts == null ? null : Parting.by(parts, origin.authoredLine());
     }
 
-    /**
-     * The same as the quantity's own answer about it, for a caller that is asking where the values
-     * part and not who parted them.
-     */
-    public static Seam parts(BoundaryTarget target, OriginRef origin) {
+    private static Seam parts(BoundaryTarget target, OriginRef origin) {
         // Null for a rule that orders nothing around its line. A bound is where the quantity stops
         // and not a place its values part — nothing outside one can be constructed, so there is no
         // run on the far side (ADR-0090) — and a rule that singles a value out puts every other

--- a/souther-compiler/src/main/java/souther/compiler/partition/Border.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Border.java
@@ -150,7 +150,7 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
      *               or not
      */
     public static Border at(BoundaryTarget target, OriginRef origin, NumericDomain.Bounds within,
-                            java.util.List<Seam> parted) {
+                            java.util.List<Parting> parted) {
         NumericDomain.Bounds reach = within == null ? new NumericDomain.Bounds(null, null) : within;
         LevelSpace space = target.levels();
         Level cut = target.at();
@@ -161,9 +161,13 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
                     "a border built on a line the quantity does not reach: " + target.left()
                             + " at " + target.right());
         }
-        Seam mine = parts(target, origin);
-        java.util.List<Seam> all = new java.util.ArrayList<>(parted);
-        if (mine != null && all.stream().noneMatch(each -> each.key().equals(mine.key()))) {
+        Parting mine = partedBy(target, origin);
+        java.util.List<Parting> all = new java.util.ArrayList<>(parted);
+        if (mine != null) {
+            // Handed over as a candidate rather than told apart here. Whether this line is one the
+            // others already hold is a question about where the values part, and the arrangement is
+            // what answers it — asked here as well, this reading kept whichever of two lines at one
+            // place it met first and the other went unsaid.
             all.add(mine);
         }
         QuantityArrangement arrangement = QuantityArrangement.of(space, all,
@@ -253,25 +257,24 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
      */
     public static java.util.List<Border> allOf(java.util.List<LineDrawn> drawn,
                                                java.util.Map<String,
-                                                       java.util.List<Seam>> alsoParted,
+                                                       java.util.List<Parting>> alsoParted,
                                                LinesRead read) {
         // Collected in the quantity's own units, because that is the only order the lines of one
         // quantity are all on. Two rules can write one quantity at two scales — `3a + 6b > 48` and
         // `a + 2b > 20` run the same way — and the numbers they carry are not comparable until both
         // are read as what they are a multiple of.
-        java.util.Map<String, java.util.List<Seam>> byQuantity = new java.util.LinkedHashMap<>();
+        java.util.Map<String, java.util.List<Parting>> byQuantity = new java.util.LinkedHashMap<>();
         alsoParted.forEach((key, parted) ->
                 byQuantity.computeIfAbsent(key, _ -> new java.util.ArrayList<>()).addAll(parted));
         for (LineDrawn each : drawn) {
             if (!ordersAroundTheCut(each.by())) {
                 continue;
             }
-            Seam parts = each.cuts().seam();
-            java.util.List<Seam> already = byQuantity.computeIfAbsent(
-                    each.cuts().quantity().key(), _ -> new java.util.ArrayList<>());
-            if (already.stream().noneMatch(had -> had.key().equals(parts.key()))) {
-                already.add(parts);
-            }
+            // Every line as it was read. Two of them at one place are one place with two lines
+            // against it, which the arrangement says and this does not: told apart here, whichever
+            // was read first stood for the other and the second line was not written down anywhere.
+            byQuantity.computeIfAbsent(each.cuts().quantity().key(), _ -> new java.util.ArrayList<>())
+                    .add(Parting.by(each.cuts().seam(), each.by().authoredLine()));
         }
         java.util.List<Border> out = new java.util.ArrayList<>();
         for (LineDrawn each : drawn) {
@@ -279,9 +282,9 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
             // a row in. A border reads rows through the form it was written as, so a run handed to
             // it in another scale would be held against numbers of a different size.
             java.math.BigDecimal per = each.cuts().per();
-            java.util.List<Seam> beside =
+            java.util.List<Parting> beside =
                     byQuantity.getOrDefault(each.cuts().quantity().key(), java.util.List.of())
-                            .stream().map(seam -> seam.scaledBy(per)).toList();
+                            .stream().map(parting -> parting.scaledBy(per)).toList();
             // One line drawn, one border. Which lines there are was settled by whoever read the
             // rules — a comparison whose line the quantity does not reach is no line, and says so
             // there ({@code ComparisonAssessment.OutsideTheDomain}) — so nothing here decides it
@@ -301,11 +304,24 @@ public record Border(BoundaryTarget cut, OriginRef origin, Map<PointRole, Demand
     }
 
     /**
-     * Where the rule this reading met parts the quantity's values.
+     * Where the rule this reading met parts the quantity's values, and the line it wrote there.
      *
      * <p>For a caller collecting every place one quantity is parted before any border is built. A
      * border's two points away from the line are runs of the arrangement those places make, so a
      * border built without them knows only its own line and reads each side to the end of the order.
+     *
+     * <p>The line travels with the place because what a run beside it is owed to is the line and not
+     * the place: two rules can part the values at one number, and each of them is one an author
+     * could move without touching the other.
+     */
+    public static Parting partedBy(BoundaryTarget target, OriginRef origin) {
+        Seam parts = parts(target, origin);
+        return parts == null ? null : Parting.by(parts, origin.authoredLine());
+    }
+
+    /**
+     * The same as the quantity's own answer about it, for a caller that is asking where the values
+     * part and not who parted them.
      */
     public static Seam parts(BoundaryTarget target, OriginRef origin) {
         // Null for a rule that orders nothing around its line. A bound is where the quantity stops

--- a/souther-compiler/src/main/java/souther/compiler/partition/BorderObligationId.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BorderObligationId.java
@@ -60,6 +60,10 @@ public record BorderObligationId(AuthoredLine line, Level at) {
             throw new IllegalArgumentException(
                     "a debt is some rule's line somewhere: " + line + " " + at);
         }
+        // Written the one way, because this is compared as a value and is what a map of debts is
+        // keyed on. A level keeps the spelling its rule was written in, so one line read at two
+        // positions can arrive here as 0 and as 0.00 — one line, and two keys.
+        at = at.canonical();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Bound.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Bound.java
@@ -35,6 +35,12 @@ public record Bound(CutPosition at, boolean inclusive) {
         return new Bound(CutPosition.at(level), inclusive);
     }
 
+    /** The same end with its place written the one way, for an identity to be built from
+     *  ({@link CutPosition#canonical()}). */
+    public Bound canonical() {
+        return new Bound(at.canonical(), inclusive);
+    }
+
     /** Whether {@code value} is on the upper side of this, read as the lower end of a region. */
     public boolean admitsFromBelow(Level value) {
         int order = at.compare(value);

--- a/souther-compiler/src/main/java/souther/compiler/partition/Criterion.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Criterion.java
@@ -236,7 +236,8 @@ public sealed interface Criterion {
         // And the line itself where the run has no value at that end. A search starts there and
         // walks away from it — which is why this is not what the run holds: two decimals a rule
         // holds apart have every distance past the line and no first one.
-        Seam edge = in.away() == Towards.ABOVE ? in.band().under() : in.band().over();
+        Seam edge = in.away() == Towards.ABOVE
+                ? in.band().lower().parting() : in.band().upper().parting();
         return edge == null ? null : edge.at().asALevelOfTheQuantity();
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Criterion.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Criterion.java
@@ -237,7 +237,7 @@ public sealed interface Criterion {
         // walks away from it — which is why this is not what the run holds: two decimals a rule
         // holds apart have every distance past the line and no first one.
         Seam edge = in.away() == Towards.ABOVE
-                ? in.band().lower().parting() : in.band().upper().parting();
+                ? in.band().lower().seam() : in.band().upper().seam();
         return edge == null ? null : edge.at().asALevelOfTheQuantity();
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Criterion.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Criterion.java
@@ -160,6 +160,35 @@ public sealed interface Criterion {
         return region().contains(value);
     }
 
+    /**
+     * The same demand on a row, with every level written the one way.
+     *
+     * <p>What an identity built out of a criterion is built from, and what two of them are compared
+     * through. A level keeps the spelling the rule was written in, because that is what a report
+     * writes back ({@link Level#canonical()}), so two readings of one line can arrive here holding
+     * {@code 0} and {@code 0.00} — which is one demand and was two values.
+     */
+    default Criterion canonical() {
+        return switch (this) {
+            case AtTheLevel(Level at) -> new AtTheLevel(at.canonical());
+            case Within(Band band, Level except, Towards away) -> new Within(band.canonical(),
+                    except == null ? null : except.canonical(), away);
+            case AnythingBut(Level excluded) -> new AnythingBut(excluded.canonical());
+        };
+    }
+
+    /**
+     * Whether two criteria ask a row for the same thing.
+     *
+     * <p>The same shape asking for the same values, and not the same region: a rule that names a
+     * value and a run over everything else are two ways of writing one set of rows, and which of
+     * them a border owes is what says where a search starts and what a report prints. So this asks
+     * whether the two are one demand, which is narrower than whether one row answers both.
+     */
+    default boolean sameAs(Criterion other) {
+        return other != null && canonical().equals(other.canonical());
+    }
+
     /** How this relates a row's quantity to what it is against. */
     String operator();
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/CutPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/CutPosition.java
@@ -64,6 +64,33 @@ public record CutPosition(Level written, BigDecimal per) {
     }
 
     /**
+     * This line written the one way {@link #key()} names it: the fraction reduced, and the place
+     * spelled as the order spells it.
+     *
+     * <p>So that a value holding a position and compared as a value answers what {@link #key()}
+     * would. A third and two sixths come back the same, and so do a line at {@code 0} and one at
+     * {@code 0.00}.
+     *
+     * <p>An order with no numbers has no fraction to reduce, and its place is its own value.
+     */
+    public CutPosition canonical() {
+        BigDecimal at = numberOf(written);
+        if (at == null) {
+            return new CutPosition(written.canonical(), per);
+        }
+        BigDecimal[] rule = asARule();
+        return new CutPosition(reduced(written, rule[1]), rule[0]);
+    }
+
+    /** The reduced numerator, put back on whatever order the line was written on. */
+    private static Level reduced(Level written, BigDecimal to) {
+        return switch (written) {
+            case Level.ACount _ -> new Level.ACount(new Count(to));
+            case Level.OnACarrier on -> new Level.OnACarrier(on.of(), new Count(to));
+        };
+    }
+
+    /**
      * This line as a value of the quantity, or null where it is not one.
      *
      * <p>The one way to get a level out of a position, and it answers null exactly where the rule

--- a/souther-compiler/src/main/java/souther/compiler/partition/Demand.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Demand.java
@@ -29,6 +29,22 @@ public sealed interface Demand {
     }
 
     /**
+     * Whether two readings ask a row for the same thing here.
+     *
+     * <p>Asked rather than left to {@link #equals}, because a criterion holds levels and a level
+     * keeps the spelling the rule was written in ({@link Criterion#sameAs}). Two readings of one
+     * line that differ only in how a number was written have not disagreed, and a check that read
+     * them as disagreeing would name the identity as wrong over a spelling.
+     */
+    default boolean sameAs(Demand other) {
+        return switch (this) {
+            case NotOwed not -> other instanceof NotOwed also && not.reason() == also.reason();
+            case Owed owed -> other instanceof Owed also
+                    && owed.criterion().sameAs(also.criterion());
+        };
+    }
+
+    /**
      * Whether the model itself discharged this point, as against this language having no way to name
      * it or the side holding nothing.
      *

--- a/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
@@ -71,9 +71,11 @@ final class Intervals {
          * out is a class that reads as holding the values past the next line along.
          */
         String label(Carrier carrier) {
-            String low = lo == null ? ruleEnd(of == null ? null : of.under(), Towards.ABOVE)
+            String low = lo == null
+                    ? ruleEnd(of == null ? null : of.lower().parting(), Towards.ABOVE)
                     : carrier.written(lo) + (loInclusive ? " <= x" : " < x");
-            String high = hi == null ? ruleEnd(of == null ? null : of.over(), Towards.BELOW)
+            String high = hi == null
+                    ? ruleEnd(of == null ? null : of.upper().parting(), Towards.BELOW)
                     : (hiInclusive ? "x <= " : "x < ") + carrier.written(hi);
             if (low == null && high == null) {
                 return "any";

--- a/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
@@ -72,10 +72,10 @@ final class Intervals {
          */
         String label(Carrier carrier) {
             String low = lo == null
-                    ? ruleEnd(of == null ? null : of.lower().parting(), Towards.ABOVE)
+                    ? ruleEnd(of == null ? null : of.lower().seam(), Towards.ABOVE)
                     : carrier.written(lo) + (loInclusive ? " <= x" : " < x");
             String high = hi == null
-                    ? ruleEnd(of == null ? null : of.upper().parting(), Towards.BELOW)
+                    ? ruleEnd(of == null ? null : of.upper().seam(), Towards.BELOW)
                     : (hiInclusive ? "x <= " : "x < ") + carrier.written(hi);
             if (low == null && high == null) {
                 return "any";
@@ -140,12 +140,12 @@ final class Intervals {
         // Which subsumes the reason this was keyed by the number rather than by the count's own
         // equality: `0.00` and `0` are one number and part the values in one place.
         LevelSpace space = LevelSpace.onACarrier(carrier);
-        List<Seam> parted = new ArrayList<>();
+        List<Parting> parted = new ArrayList<>();
         for (Threshold each : thresholds) {
             // The division the rule made, taken as it was read rather than rebuilt from a number.
             // A rule that wrote a multiple of the position parts its values where the position may
             // hold none, and rebuilding the seam from a value of the position lost exactly those.
-            parted.add(each.parts());
+            parted.add(Parting.by(each.parts(), each.origin().authoredLine()));
         }
         // The one arrangement, which the points of every border on this position are read off as
         // well. Where the values part, in what order and with what left between them are questions

--- a/souther-compiler/src/main/java/souther/compiler/partition/Level.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Level.java
@@ -19,7 +19,8 @@ import souther.compiler.numeric.Place;
  *
  * <p>Equality is the records' own, and is not the order. {@code 0} and {@code 0.00} are two values
  * here and one level, which is what {@link Place#key()} is for and what every comparison in the
- * algebra goes through instead.
+ * algebra goes through instead. A reader that has to compare two of them asks {@link #sameAs}, and
+ * one that has to put a level inside something compared as a value holds {@link #canonical()}.
  */
 public sealed interface Level {
 
@@ -92,5 +93,31 @@ public sealed interface Level {
             case OnACarrier on -> on.at().key();
             case ACount count -> count.at().key();
         };
+    }
+
+    /**
+     * This level with its place spelled the one way, for an identity to be built from.
+     *
+     * <p>{@link #key()} answers the same question and answers it about the place alone: a level of a
+     * carrier and a number the quantity counts to have the same key where the number is the same,
+     * and they are not one level. So a value that holds a level and is compared as a value holds
+     * this rather than that.
+     */
+    default Level canonical() {
+        return switch (this) {
+            case OnACarrier(Carrier of, Place at) -> new OnACarrier(of, at.canonical());
+            case ACount(Count at) -> new ACount(at.canonical());
+        };
+    }
+
+    /**
+     * Whether these are one level: the same shape, on the same order, at the same place.
+     *
+     * <p>Total, where {@link Place#sameAs} is not: two carriers' places are never compared and say
+     * so, and two levels of different orders are simply not one level. What a reader asking this has
+     * is two levels from somewhere and a question about whether they are the same one.
+     */
+    default boolean sameAs(Level other) {
+        return other != null && canonical().equals(other.canonical());
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Level.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Level.java
@@ -19,8 +19,8 @@ import souther.compiler.numeric.Place;
  *
  * <p>Equality is the records' own, and is not the order. {@code 0} and {@code 0.00} are two values
  * here and one level, which is what {@link Place#key()} is for and what every comparison in the
- * algebra goes through instead. A reader that has to compare two of them asks {@link #sameAs}, and
- * one that has to put a level inside something compared as a value holds {@link #canonical()}.
+ * algebra goes through instead. A reader that has to put a level inside something compared as a
+ * value holds {@link #canonical()}.
  */
 public sealed interface Level {
 
@@ -108,16 +108,5 @@ public sealed interface Level {
             case OnACarrier(Carrier of, Place at) -> new OnACarrier(of, at.canonical());
             case ACount(Count at) -> new ACount(at.canonical());
         };
-    }
-
-    /**
-     * Whether these are one level: the same shape, on the same order, at the same place.
-     *
-     * <p>Total, where {@link Place#sameAs} is not: two carriers' places are never compared and say
-     * so, and two levels of different orders are simply not one level. What a reader asking this has
-     * is two levels from somewhere and a question about whether they are the same one.
-     */
-    default boolean sameAs(Level other) {
-        return other != null && canonical().equals(other.canonical());
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Parting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Parting.java
@@ -1,0 +1,77 @@
+package souther.compiler.partition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * One place a quantity's values part, and the lines the model wrote there.
+ *
+ * <p>Two questions, and they are not one. Where the values part is the quantity's
+ * ({@link Seam}), which is why two rules cutting at one number divide it once. Which rules put a
+ * line there is the model's, and a rule is something an author can move without touching the one
+ * beside it — so a place divides once and can have been written more than once.
+ *
+ * <p><b>Alternatives and not one cause.</b> Each of these is enough on its own to part the values
+ * here: a declaration stopping a minute at 1000 and a body comparing against the same 1000 each do
+ * it, and taking one of the two away leaves the place where it is. Held as one set of contributors,
+ * adding a second line that changes nothing about the quantity would change what the first one is —
+ * so they are kept apart, and whoever asks what a run is owed to asks about each of them.
+ *
+ * <p>Where the values part is settled once, by the arrangement of the quantity
+ * ({@link QuantityArrangement}). Each producer of lines hands its candidates over as they are read;
+ * two candidates at one place come back as one place with both lines against it.
+ *
+ * @param geometry     where the values part
+ * @param alternatives the lines the model wrote there, in the order they were read, each of them
+ *                     enough on its own. Never empty
+ */
+public record Parting(Seam geometry, List<AuthoredLine> alternatives) {
+
+    public Parting {
+        if (geometry == null) {
+            throw new IllegalArgumentException("a parting is somewhere");
+        }
+        alternatives = List.copyOf(alternatives);
+        if (alternatives.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "the values part here because something parts them: " + geometry.key());
+        }
+    }
+
+    /** One line, where a producer is reading them one at a time. */
+    public static Parting by(Seam geometry, AuthoredLine line) {
+        return new Parting(geometry, List.of(line));
+    }
+
+    /**
+     * The same place, with the lines of {@code also} against it as well.
+     *
+     * <p>One entry per line: a rule read twice is one rule, and what counts these is what says how
+     * many runs a row inside one of them answers for.
+     */
+    public Parting and(Parting also) {
+        List<AuthoredLine> both = new ArrayList<>(alternatives);
+        for (AuthoredLine line : also.alternatives) {
+            if (!both.contains(line)) {
+                both.add(line);
+            }
+        }
+        return new Parting(geometry, both);
+    }
+
+    /** The same place said in units {@code per} times smaller, which is what a rule that wrote a
+     *  multiple of the quantity divides in the quantity's own terms. */
+    public Parting scaledBy(java.math.BigDecimal per) {
+        return new Parting(geometry.scaledBy(per), alternatives);
+    }
+
+    /** What makes two of these one place, which is the quantity's answer and not the model's. */
+    public String key() {
+        return geometry.key();
+    }
+
+    /** The same place with every level written the one way, for an identity to be built from. */
+    public Parting canonical() {
+        return new Parting(geometry.canonical(), alternatives);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Parting.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Parting.java
@@ -69,9 +69,4 @@ public record Parting(Seam geometry, List<AuthoredLine> alternatives) {
     public String key() {
         return geometry.key();
     }
-
-    /** The same place with every level written the one way, for an identity to be built from. */
-    public Parting canonical() {
-        return new Parting(geometry.canonical(), alternatives);
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -541,7 +541,9 @@ public final class Partitions {
                             within == null ? null : within.min(),
                             within == null ? null : within.max()),
                     merged(axis.cuts(), reachable, carrier),
-                    reachable.stream().map(Threshold::parts).toList()),
+                    reachable.stream()
+                            .map(each -> Parting.by(each.parts(), each.origin().authoredLine()))
+                            .toList()),
                     reachable.isEmpty() ? null : new BodyCutInspection.Evidence(), rules);
         }
         // Both producers into the one account. A line that divides a position leaves its border on
@@ -623,7 +625,7 @@ public final class Partitions {
      *                  working them out would be a reading whose answer is thrown away
      */
     private static Axis refine(Axis axis, java.util.function.Supplier<List<PartitionClass>> otherwise,
-                               List<Cut> cuts, List<Seam> parted) {
+                               List<Cut> cuts, List<Parting> parted) {
         return axis.carrying(axis.derivable() ? axis.classes() : otherwise.get(), cuts, parted);
     }
 
@@ -743,8 +745,8 @@ public final class Partitions {
      * position has a value at it. A line over a form of several positions divides none of them and
      * is on a quantity of its own, which no axis names — those arrive with the lines themselves.
      */
-    private static Map<String, List<Seam>> partedByQuantity(List<Axis> axes) {
-        Map<String, List<Seam>> out = new LinkedHashMap<>();
+    private static Map<String, List<Parting>> partedByQuantity(List<Axis> axes) {
+        Map<String, List<Parting>> out = new LinkedHashMap<>();
         for (Axis axis : axes) {
             if (axis.parted().isEmpty()) {
                 continue;
@@ -807,7 +809,7 @@ public final class Partitions {
         // Every place the rules part this position's values: the ones its cuts stand at, and the
         // ones no cut stands at because the position holds no value there. A border built from the
         // cuts alone read its two sides past exactly the lines that were left out.
-        List<Seam> parted = new ArrayList<>(axis.parted());
+        List<Parting> parted = new ArrayList<>(axis.parted());
         for (Cut cut : axis.cuts()) {
             BoundaryTarget where = BoundaryTarget.at(
                     new BorderQuantity.OfACoordinate(axis.id(), axis.term(),
@@ -815,9 +817,11 @@ public final class Partitions {
                                     axis.term().observedOn(axis.type(), symbols), cut.carrier())),
                     new Level.OnACarrier(cut.carrier(), cut.at()));
             for (OriginRef origin : cut.origins()) {
-                Seam parts = Border.parts(where, origin);
-                if (parts != null && parted.stream()
-                        .noneMatch(had -> had.key().equals(parts.key()))) {
+                // Every rule that drew a line here, as it was read. Which of them fall in one place
+                // is the arrangement's answer, and telling them apart here kept the first and lost
+                // the rest — so a run bounded by two rules knew about one of them.
+                Parting parts = Border.partedBy(where, origin);
+                if (parts != null) {
                     parted.add(parts);
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/partition/QuantityArrangement.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/QuantityArrangement.java
@@ -77,11 +77,18 @@ public record QuantityArrangement(List<Seam> seams, List<Band> bands) {
         List<Band> bands = new ArrayList<>();
         Seam under = null;
         for (Seam seam : ordered) {
-            keep(space, bands, new Band(under, seam, from, to));
+            keep(space, bands, runBetween(under, seam, from, to));
             under = seam;
         }
-        keep(space, bands, new Band(under, null, from, to));
+        keep(space, bands, runBetween(under, null, from, to));
         return new QuantityArrangement(ordered, bands);
+    }
+
+    /** The run between two of the places the values part, held to what the rules leave either
+     *  side. */
+    private static Band runBetween(Seam under, Seam over, Bound from, Bound to) {
+        return new Band(Band.endAt(under, from, Towards.ABOVE),
+                Band.endAt(over, to, Towards.BELOW));
     }
 
     /**
@@ -110,12 +117,14 @@ public record QuantityArrangement(List<Seam> seams, List<Band> bands) {
      * to.
      */
     public Band above(Seam seam) {
-        return bands.stream().filter(each -> is(each.under(), seam)).findFirst().orElse(null);
+        return bands.stream().filter(each -> is(each.lower().parting(), seam)).findFirst()
+                .orElse(null);
     }
 
     /** The run just below it, on the same reading. */
     public Band below(Seam seam) {
-        return bands.stream().filter(each -> is(each.over(), seam)).findFirst().orElse(null);
+        return bands.stream().filter(each -> is(each.upper().parting(), seam)).findFirst()
+                .orElse(null);
     }
 
     /** The run one value of the quantity is in, or null where the rules leave it in none. */
@@ -134,7 +143,8 @@ public record QuantityArrangement(List<Seam> seams, List<Band> bands) {
      */
     public Band endmost(Towards inward) {
         return bands.stream()
-                .filter(each -> inward == Towards.ABOVE ? each.under() == null : each.over() == null)
+                .filter(each -> (inward == Towards.ABOVE ? each.lower() : each.upper())
+                        .parting() == null)
                 .findFirst().orElse(null);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/QuantityArrangement.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/QuantityArrangement.java
@@ -26,10 +26,10 @@ import java.util.Map;
  * @param seams where the values part, in the order the values are in
  * @param bands the runs between them, one more than there are seams
  */
-public record QuantityArrangement(List<Seam> seams, List<Band> bands) {
+public record QuantityArrangement(List<Parting> partings, List<Band> bands) {
 
     public QuantityArrangement {
-        seams = List.copyOf(seams);
+        partings = List.copyOf(partings);
         bands = List.copyOf(bands);
     }
 
@@ -40,7 +40,7 @@ public record QuantityArrangement(List<Seam> seams, List<Band> bands) {
      * than by which rule parted them: the rules that drew a place are a property of the place and
      * are kept beside it, while what the quantity is divided into is a property of the quantity.
      */
-    public static QuantityArrangement of(LevelSpace space, List<Seam> parted) {
+    public static QuantityArrangement of(LevelSpace space, List<Parting> parted) {
         return of(space, parted, null, null);
     }
 
@@ -59,26 +59,29 @@ public record QuantityArrangement(List<Seam> seams, List<Band> bands) {
      *             refuses
      * @param to   the same at the high end
      */
-    public static QuantityArrangement of(LevelSpace space, List<Seam> parted, Bound from,
+    public static QuantityArrangement of(LevelSpace space, List<Parting> parted, Bound from,
                                          Bound to) {
-        Map<String, Seam> distinct = new LinkedHashMap<>();
-        for (Seam each : parted) {
+        Map<String, Parting> distinct = new LinkedHashMap<>();
+        for (Parting each : parted) {
             // A place the rules leave nothing at divides nothing. The values it would tell apart are
             // values no row can be written at, so it is dropped rather than kept as a run holding
             // none — which is a class an author would be told to write a row for and could not.
-            if (outside(each, from, to)) {
+            if (outside(each.geometry(), from, to)) {
                 continue;
             }
-            distinct.putIfAbsent(each.key(), each);
+            // One place, and every line the model wrote there against it. Which is the whole of what
+            // this being the one canonicaliser buys: a producer that told two candidates apart for
+            // itself kept whichever it read first, and the other line went unsaid.
+            distinct.merge(each.key(), each, Parting::and);
         }
-        List<Seam> ordered = new ArrayList<>(distinct.values());
+        List<Parting> ordered = new ArrayList<>(distinct.values());
         ordered.sort(QuantityArrangement::inOrderOfTheValues);
 
         List<Band> bands = new ArrayList<>();
-        Seam under = null;
-        for (Seam seam : ordered) {
-            keep(space, bands, runBetween(under, seam, from, to));
-            under = seam;
+        Parting under = null;
+        for (Parting parting : ordered) {
+            keep(space, bands, runBetween(under, parting, from, to));
+            under = parting;
         }
         keep(space, bands, runBetween(under, null, from, to));
         return new QuantityArrangement(ordered, bands);
@@ -86,7 +89,7 @@ public record QuantityArrangement(List<Seam> seams, List<Band> bands) {
 
     /** The run between two of the places the values part, held to what the rules leave either
      *  side. */
-    private static Band runBetween(Seam under, Seam over, Bound from, Bound to) {
+    private static Band runBetween(Parting under, Parting over, Bound from, Bound to) {
         return new Band(Band.endAt(under, from, Towards.ABOVE),
                 Band.endAt(over, to, Towards.BELOW));
     }
@@ -103,10 +106,10 @@ public record QuantityArrangement(List<Seam> seams, List<Band> bands) {
      * <p>Asked of the line and not of the values beside it, because a line the quantity names no
      * value beside has none to be asked about.
      */
-    private static int inOrderOfTheValues(Seam one, Seam other) {
-        int where = one.at().compareTo(other.at());
-        return where != 0 ? where
-                : Boolean.compare(one.keepsItsOwnValueBelow(), other.keepsItsOwnValueBelow());
+    private static int inOrderOfTheValues(Parting one, Parting other) {
+        int where = one.geometry().at().compareTo(other.geometry().at());
+        return where != 0 ? where : Boolean.compare(one.geometry().keepsItsOwnValueBelow(),
+                other.geometry().keepsItsOwnValueBelow());
     }
 
     /**
@@ -116,14 +119,14 @@ public record QuantityArrangement(List<Seam> seams, List<Band> bands) {
      * leave nothing in, which is a point nobody is owed a row at rather than one nothing has got
      * to.
      */
-    public Band above(Seam seam) {
-        return bands.stream().filter(each -> is(each.lower().parting(), seam)).findFirst()
+    public Band above(Parting parting) {
+        return bands.stream().filter(each -> is(each.lower().seam(), parting)).findFirst()
                 .orElse(null);
     }
 
     /** The run just below it, on the same reading. */
-    public Band below(Seam seam) {
-        return bands.stream().filter(each -> is(each.upper().parting(), seam)).findFirst()
+    public Band below(Parting parting) {
+        return bands.stream().filter(each -> is(each.upper().seam(), parting)).findFirst()
                 .orElse(null);
     }
 
@@ -144,11 +147,11 @@ public record QuantityArrangement(List<Seam> seams, List<Band> bands) {
     public Band endmost(Towards inward) {
         return bands.stream()
                 .filter(each -> (inward == Towards.ABOVE ? each.lower() : each.upper())
-                        .parting() == null)
+                        .seam() == null)
                 .findFirst().orElse(null);
     }
 
-    private static boolean is(Seam one, Seam other) {
+    private static boolean is(Seam one, Parting other) {
         return one != null && other != null && one.key().equals(other.key());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/QuantityArrangement.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/QuantityArrangement.java
@@ -90,8 +90,12 @@ public record QuantityArrangement(List<Parting> partings, List<Band> bands) {
     /** The run between two of the places the values part, held to what the rules leave either
      *  side. */
     private static Band runBetween(Parting under, Parting over, Bound from, Bound to) {
-        return new Band(Band.endAt(under, from, Towards.ABOVE),
-                Band.endAt(over, to, Towards.BELOW));
+        // The places and not the lines against them. What a run asks a row for is the same however
+        // many rules wrote a line where it stops, and which of them did is this arrangement's answer
+        // to a different question ({@link Parting#alternatives}) — carried into the run, it would be
+        // inside every value that says what is asked of a row.
+        return new Band(Band.endAt(under == null ? null : under.geometry(), from, Towards.ABOVE),
+                Band.endAt(over == null ? null : over.geometry(), to, Towards.BELOW));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Seam.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Seam.java
@@ -115,6 +115,14 @@ public record Seam(CutPosition at, Level below, Level above) {
         return (below == null ? "" : below.key()) + "|" + (above == null ? "" : above.key());
     }
 
+    /** The same division with every level written the one way, for an identity to be built from.
+     *  What {@link #key()} answers, kept as the seam rather than as a word. */
+    public Seam canonical() {
+        return new Seam(at.canonical(),
+                below == null ? null : below.canonical(),
+                above == null ? null : above.canonical());
+    }
+
     /**
      * How a level written in one form's terms reads as a level of the quantity it is a multiple of.
      *

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderAssessment.java
@@ -63,7 +63,7 @@ public record BorderAssessment(Border border, Map<PointRole, ItemAssessment> ite
             }
             case ItemAssessment.Owed owed -> {
                 if (!(demand instanceof Demand.Owed asked)
-                        || !asked.criterion().equals(owed.criterion())) {
+                        || !asked.criterion().sameAs(owed.criterion())) {
                     throw new IllegalArgumentException("the " + role + " point of " + border.label()
                             + " is assessed against " + owed.criterion()
                             + ", and its border asks " + demand);

--- a/souther-compiler/src/main/java/souther/compiler/query/BorderObligationAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BorderObligationAssessment.java
@@ -187,7 +187,7 @@ public record BorderObligationAssessment(BorderObligationId id, String axis,
         Demand asked = readings.get(0).border().demand(role);
         for (BorderAssessment reading : readings) {
             Demand also = reading.border().demand(role);
-            if (!asked.equals(also)) {
+            if (!asked.sameAs(also)) {
                 throw new IllegalStateException("two readings of one line disagree about what its "
                         + role + " point asks for, so they are not one line: " + id
                         + " asks " + asked + " at " + readings.get(0).border().cut().named()

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnEndTheOrderSuppliesIsNotOneARuleWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnEndTheOrderSuppliesIsNotOneARuleWroteTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -61,8 +62,11 @@ class AnEndTheOrderSuppliesIsNotOneARuleWroteTest {
 
         assertEquals("take/String.length(n) in 0 <= String.length(n) < 9",
                 said(line, PointRole.IN), "the run has both ends and the model wrote one of them");
-        assertNotNull(inside.band().from(), "the low end is there");
-        assertNotNull(inside.band().to(), "and so is the high one");
+        assertInstanceOf(BandEnd.AtDomain.class, inside.band().lower(),
+                "the low end is one the rules leave");
+        assertInstanceOf(BandEnd.AtDomain.class, inside.band().upper(),
+                "and so is the high one, which is the same shape though one was written and one"
+                        + " was not");
     }
 
     /**
@@ -79,10 +83,10 @@ class AnEndTheOrderSuppliesIsNotOneARuleWroteTest {
         NumericDomain.Bounds order = termOf(line).intrinsicBounds();
 
         assertNotNull(order.min(), "a length is never less than nothing, and nothing wrote that");
-        assertEquals(0, inside.band().from().at().compare(order.min().at()),
+        assertEquals(0, inside.band().lower().reaches().at().compare(order.min().at()),
                 "which is where the run stops below");
         assertNull(order.max(), "the order says nothing about how long a string gets");
-        assertNotNull(inside.band().to(),
+        assertNotNull(inside.band().upper().reaches(),
                 "and the run stops above all the same, where the clause put it");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnEndTheOrderSuppliesIsNotOneARuleWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnEndTheOrderSuppliesIsNotOneARuleWroteTest.java
@@ -1,0 +1,123 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.inputs.NumericTerm;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * A run can stop where the order itself stops, and what reaches a border does not say which end is
+ * which.
+ *
+ * <p>A length is never negative, and no clause of the model says so: it is what the operation taking
+ * the length answers ({@link NumericTerm#intrinsicBounds}). What a position runs between is that
+ * met with what the rules leave it, and the two arrive at a border as one pair of ends — so the end
+ * a clause wrote and the end the order supplies are the same shape and are told apart by nothing.
+ *
+ * <p>Which matters to whoever is asked for a row inside the run. An end a declaration wrote is
+ * something an author can move; an end the order supplies is not, and there is nobody to name for
+ * it. Read off the value instead — this end is where the carrier stops, so nobody wrote it — a model
+ * that does write {@code String.length(value) >= 0} would be read as having written nothing.
+ */
+class AnEndTheOrderSuppliesIsNotOneARuleWroteTest {
+
+    /** One clause, stopping a length at nine and saying nothing about the other end. */
+    private static final String LENGTH = """
+            module example.extent
+
+            data Name = String
+                invariant String.length(value) <= 9
+
+            data Ok
+
+            behavior take : (n: Name) -> Ok
+            let take (n) = Ok
+
+            example take
+                | "x" : (Name("abc")) -> Ok
+            """;
+
+    /**
+     * The run below the line stops at both ends, and only one of them was written.
+     *
+     * <p>Nine is the clause's. Zero is the length's own floor, and the run carries it as an end just
+     * as it carries the other.
+     */
+    @Test
+    void aRunStopsAtAnEndNoClauseWrote() {
+        BorderAssessment line = borderAt("String.length(n) = 9");
+        Criterion criterion = line.border().demand(PointRole.IN).criterion();
+        Criterion.Within inside = (Criterion.Within) criterion;
+
+        assertEquals("take/String.length(n) in 0 <= String.length(n) < 9",
+                said(line, PointRole.IN), "the run has both ends and the model wrote one of them");
+        assertNotNull(inside.band().from(), "the low end is there");
+        assertNotNull(inside.band().to(), "and so is the high one");
+    }
+
+    /**
+     * And the low end is the one the operation answers, not the one the clause wrote.
+     *
+     * <p>Held against {@link NumericTerm#intrinsicBounds} rather than against the number, so that
+     * what this says is where the end came from and not what it happens to be.
+     */
+    @Test
+    void theLowEndIsTheOnesTheOperationAnswers() {
+        BorderAssessment line = borderAt("String.length(n) = 9");
+        Criterion.Within inside =
+                (Criterion.Within) line.border().demand(PointRole.IN).criterion();
+        NumericDomain.Bounds order = termOf(line).intrinsicBounds();
+
+        assertNotNull(order.min(), "a length is never less than nothing, and nothing wrote that");
+        assertEquals(0, inside.band().from().at().compare(order.min().at()),
+                "which is where the run stops below");
+        assertNull(order.max(), "the order says nothing about how long a string gets");
+        assertNotNull(inside.band().to(),
+                "and the run stops above all the same, where the clause put it");
+    }
+
+    /** A position's own value has no such end, so nothing about the position says one is coming. */
+    @Test
+    void aPositionsOwnValueHasNoEndOfItsOwn() {
+        assertEquals(NumericDomain.Bounds.OPEN,
+                new NumericTerm.ValueOf(souther.compiler.inputs.TermPath.of("x"))
+                        .intrinsicBounds(),
+                "the order under a position runs as far as the carrier does");
+    }
+
+    private static NumericTerm termOf(BorderAssessment line) {
+        if (!(line.border().cut().of() instanceof BorderQuantity.OfACoordinate one)) {
+            throw new AssertionError("this line is not on a coordinate: " + line.border().cut());
+        }
+        return one.term();
+    }
+
+    private static String said(BorderAssessment line, PointRole role) {
+        return line.points().stream().filter(point -> point.role() == role).findFirst()
+                .orElseThrow(() -> new AssertionError("no " + role + " point")).said();
+    }
+
+    private static BorderAssessment borderAt(String label) {
+        Compilation compilation = Compilation.ofSource(LENGTH, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, List<BorderAssessment>> boundaries =
+                Adequacy.boundariesOf(compilation.db(), "example.extent");
+        assertNotNull(boundaries, "the model under test compiles");
+        return boundaries.values().stream().flatMap(List::stream)
+                .filter(each -> each.label().equals(label)).findFirst()
+                .orElseThrow(() -> new AssertionError(label + " is not a line of this model: "
+                        + boundaries.values().stream().flatMap(List::stream)
+                                .map(BorderAssessment::label).toList()));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/TwoSpellingsOfOneLevelAreOneDemandTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/TwoSpellingsOfOneLevelAreOneDemandTest.java
@@ -1,0 +1,147 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Carrier;
+import souther.compiler.check.Clause;
+import souther.compiler.check.ClauseName;
+import souther.compiler.check.RuleRef;
+import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Towards;
+import souther.compiler.types.TypeKey;
+import souther.compiler.types.TypeSymbols;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Two spellings of one number are one level, so they are one demand and one debt.
+ *
+ * <p>A level keeps the spelling the rule was written in, because that is what a report writes back:
+ * {@code 0} and {@code 0.00} are two values and one place on the order. Everything that compares
+ * levels goes through the order, and a value that <em>holds</em> a level and is compared as a value
+ * cannot — a map keyed on a debt asks {@link Object#equals}, and a check that two readings ask the
+ * same thing asks it of two criteria. Those readers hold the level written the one way.
+ *
+ * <p>What this is for is the check itself. Two readings of one line that disagree about what a point
+ * asks for say the identity that put them together is wrong, and that is only worth acting on where
+ * a disagreement is one: over a spelling it names a defect that is not there.
+ */
+class TwoSpellingsOfOneLevelAreOneDemandTest {
+
+    private static final Carrier DECIMALS = new Carrier.Dense();
+
+    /** A level of {@code DECIMALS} at the number {@code at} is written with. */
+    private static Level at(String at) {
+        return new Level.OnACarrier(DECIMALS, new Count(new BigDecimal(at)));
+    }
+
+    /**
+     * The two spellings are two values here, which is what the projection exists for.
+     *
+     * <p>Asserted rather than assumed: were the records themselves to fold the two, everything below
+     * would pass without anything having been asked.
+     */
+    @Test
+    void aLevelKeepsTheSpellingItsRuleWasWrittenIn() {
+        assertNotEquals(at("0"), at("0.00"),
+                "a level is written back as the author wrote it, so the two are two values");
+        assertTrue(at("0").sameAs(at("0.00")), "and they are one place on the order");
+    }
+
+    /** Two orders' levels are not one level, whatever the number is written as. */
+    @Test
+    void aLevelOfAnotherCarrierIsAnotherLevel() {
+        Level onWhole = new Level.OnACarrier(new Carrier.Whole(), new Count(BigDecimal.ZERO));
+        assertFalse(at("0").sameAs(onWhole), "one number on two orders is two levels");
+        assertFalse(at("0").sameAs(new Level.ACount(new Count(BigDecimal.ZERO))),
+                "and a number the quantity counts to is on no carrier at all");
+        assertEquals(at("0").key(), onWhole.key(),
+                "which the key does not tell apart, being about the place alone");
+    }
+
+    /** One demand asked at two readings, each spelling its level its own way. */
+    @Test
+    void twoSpellingsOfOnePointAreOneDemand() {
+        Demand asked = new Demand.Owed(new Criterion.AtTheLevel(at("0")));
+        Demand also = new Demand.Owed(new Criterion.AtTheLevel(at("0.00")));
+
+        assertNotEquals(asked, also, "two values, so the derived equality has them apart");
+        assertTrue(asked.sameAs(also), "and one row answers both, so they are one demand");
+    }
+
+    /** And two demands that differ in what they ask are still two. */
+    @Test
+    void twoPointsAtTwoLevelsAreTwoDemands() {
+        Demand asked = new Demand.Owed(new Criterion.AtTheLevel(at("0")));
+        Demand other = new Demand.Owed(new Criterion.AtTheLevel(at("1")));
+
+        assertFalse(asked.sameAs(other), "a row at zero is no row at one");
+        assertFalse(asked.sameAs(new Demand.NotOwed(NotOwedReason.THE_RULES_REFUSE_IT)),
+                "and a point nobody is owed a row at is not a point asking for one");
+    }
+
+    /** A run written two ways is one run, and two runs that start apart are two. */
+    @Test
+    void aRunIsToldByWhereItStartsAndNotByWhatItsFirstValueIs() {
+        Criterion from0 = run("0", "10");
+        Criterion from0Again = run("0.00", "10.0");
+        Criterion from5 = run("5", "10");
+
+        assertTrue(from0.sameAs(from0Again), "one run, spelled two ways");
+        assertFalse(from0.sameAs(from5), "and a run starting at five is another run");
+        assertEquals(band("0", "10").key(), band("5", "10").key(),
+                "which the run's own key does not tell apart: over the decimals neither has a"
+                        + " first value, and the key is read off the values at the ends");
+    }
+
+    /** A debt keyed on a level is keyed on the level and not on how it was written. */
+    @Test
+    void twoSpellingsOfOneLineAreOneDebt() {
+        BorderObligationId one = new BorderObligationId(aLine(), at("0"));
+        BorderObligationId same = new BorderObligationId(aLine(), at("0.00"));
+
+        assertEquals(one, same, "one line at one place is one debt");
+        assertEquals(one.hashCode(), same.hashCode(), "and a map of debts finds it there");
+        assertNotEquals(one, new BorderObligationId(aLine(), at("1")),
+                "while the same rule cutting at another place is another debt");
+    }
+
+    /** A line at a third and one at two sixths fall in one place, so they are one debt. */
+    @Test
+    void oneLineWrittenInTwoUnitsIsOneDebt() {
+        CutPosition third = new CutPosition(new Level.ACount(new Count(BigDecimal.ONE)),
+                new BigDecimal("3"));
+        CutPosition twoSixths = new CutPosition(new Level.ACount(new Count(new BigDecimal("2"))),
+                new BigDecimal("6"));
+
+        assertEquals(third.key(), twoSixths.key(), "which is what the key already said");
+        assertEquals(third.canonical(), twoSixths.canonical(), "and now what the value says");
+    }
+
+    /** The run between two levels of {@code DECIMALS}, without the value it is named for. */
+    private static Criterion run(String from, String to) {
+        return new Criterion.Within(band(from, to), null, Towards.ABOVE);
+    }
+
+    private static Band band(String from, String to) {
+        return new Band(null, null, new Bound(CutPosition.at(at(from)), false),
+                new Bound(CutPosition.at(at(to)), false));
+    }
+
+    /** One clause of one declaration, which is only an identity here. */
+    private static AuthoredLine aLine() {
+        return new AuthoredLine(
+                new RuleRef.Invariant(new Clause.Ref(
+                        new Clause.Id(TypeSymbols.declared(new TypeKey("example.probe", "Amount")),
+                                0),
+                        Optional.of(new ClauseName("floor")))),
+                0, new LineFacts(false, true, false), List.of());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/TwoSpellingsOfOneLevelAreOneDemandTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/TwoSpellingsOfOneLevelAreOneDemandTest.java
@@ -131,8 +131,8 @@ class TwoSpellingsOfOneLevelAreOneDemandTest {
     }
 
     private static Band band(String from, String to) {
-        return new Band(null, null, new Bound(CutPosition.at(at(from)), false),
-                new Bound(CutPosition.at(at(to)), false));
+        return new Band(new BandEnd.AtDomain(new Bound(CutPosition.at(at(from)), false)),
+                new BandEnd.AtDomain(new Bound(CutPosition.at(at(to)), false)));
     }
 
     /** One clause of one declaration, which is only an identity here. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/TwoSpellingsOfOneLevelAreOneDemandTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/TwoSpellingsOfOneLevelAreOneDemandTest.java
@@ -52,15 +52,18 @@ class TwoSpellingsOfOneLevelAreOneDemandTest {
     void aLevelKeepsTheSpellingItsRuleWasWrittenIn() {
         assertNotEquals(at("0"), at("0.00"),
                 "a level is written back as the author wrote it, so the two are two values");
-        assertTrue(at("0").sameAs(at("0.00")), "and they are one place on the order");
+        assertEquals(at("0").canonical(), at("0.00").canonical(),
+                "and they are one place on the order");
     }
 
     /** Two orders' levels are not one level, whatever the number is written as. */
     @Test
     void aLevelOfAnotherCarrierIsAnotherLevel() {
         Level onWhole = new Level.OnACarrier(new Carrier.Whole(), new Count(BigDecimal.ZERO));
-        assertFalse(at("0").sameAs(onWhole), "one number on two orders is two levels");
-        assertFalse(at("0").sameAs(new Level.ACount(new Count(BigDecimal.ZERO))),
+        assertNotEquals(at("0").canonical(), onWhole.canonical(),
+                "one number on two orders is two levels");
+        assertNotEquals(at("0").canonical(),
+                new Level.ACount(new Count(BigDecimal.ZERO)).canonical(),
                 "and a number the quantity counts to is on no carrier at all");
         assertEquals(at("0").key(), onWhole.key(),
                 "which the key does not tell apart, being about the place alone");

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatTheRulesTogetherLeaveAQuantityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatTheRulesTogetherLeaveAQuantityTest.java
@@ -48,10 +48,32 @@ class WhatTheRulesTogetherLeaveAQuantityTest {
 
     /** The same, where the rules leave the quantity only what lies between two values. */
     private static List<String> within(String low, String high, Seam... parted) {
-        return QuantityArrangement.of(NUMBERS, List.of(parted),
+        return QuantityArrangement.of(NUMBERS, byItsOwnRule(parted),
                         low == null ? null : Bound.at(at(low), true),
                         high == null ? null : Bound.at(at(high), true))
                 .bands().stream().map(Band::key).toList();
+    }
+
+    /** Each place with a line of its own against it, these being tests about where the values part
+     *  and not about who parted them. */
+    private static List<Parting> byItsOwnRule(Seam... parted) {
+        List<Parting> out = new java.util.ArrayList<>();
+        for (Seam each : parted) {
+            out.add(Parting.by(each, aLine(out.size())));
+        }
+        return out;
+    }
+
+    /** One clause of one declaration, told from the next by which clause of it this is. */
+    static AuthoredLine aLine(int clause) {
+        return new AuthoredLine(new souther.compiler.check.RuleRef.Invariant(
+                new souther.compiler.check.Clause.Ref(
+                        new souther.compiler.check.Clause.Id(
+                                souther.compiler.types.TypeSymbols.declared(
+                                        new souther.compiler.types.TypeKey("example.runs", "N")),
+                                clause),
+                        java.util.Optional.empty())),
+                0, new LineFacts(false, true, false), List.of());
     }
 
     /**
@@ -64,7 +86,8 @@ class WhatTheRulesTogetherLeaveAQuantityTest {
      */
     @Test
     void aRunHoldsTheValuesFromItsFirstToItsLast() {
-        Band mid = QuantityArrangement.of(NUMBERS, List.of(upTo("10"), upTo("20"))).bands().get(1);
+        Band mid = QuantityArrangement.of(NUMBERS, byItsOwnRule(upTo("10"), upTo("20")))
+                .bands().get(1);
 
         assertEquals(false, mid.holds(at("10")), "ten is the last value below it");
         assertEquals(true, mid.holds(at("11")), "eleven is its first");
@@ -75,7 +98,7 @@ class WhatTheRulesTogetherLeaveAQuantityTest {
     /** And a run with no seam under it runs from wherever the rules start the quantity. */
     @Test
     void aRunWithNothingPartingItBelowRunsFromTheStart() {
-        Band first = QuantityArrangement.of(NUMBERS, List.of(upTo("10")),
+        Band first = QuantityArrangement.of(NUMBERS, byItsOwnRule(upTo("10")),
                         Bound.at(at("0"), true), null)
                 .bands().get(0);
 
@@ -102,7 +125,7 @@ class WhatTheRulesTogetherLeaveAQuantityTest {
                 LevelSpace.overFiniteDecimals(LevelSpace.generatorOverFiniteDecimals(three)),
                 new Level.ACount(new Count(java.math.BigDecimal.ONE)), Towards.BELOW,
                 new Seam.Scale(three, dense));
-        Band below = QuantityArrangement.of(decimals, List.of(third)).bands().get(0);
+        Band below = QuantityArrangement.of(decimals, byItsOwnRule(third)).bands().get(0);
 
         assertEquals(true, below.holds(decimal(dense, "0.2")), "a fifth is under a third");
         assertEquals(false, below.holds(decimal(dense, "0.5")),
@@ -133,10 +156,44 @@ class WhatTheRulesTogetherLeaveAQuantityTest {
 
         for (List<Seam> order : List.of(List.of(keeps, givesAway), List.of(givesAway, keeps))) {
             assertEquals(List.of("|", "0.5|0.5", "|"),
-                    QuantityArrangement.of(decimals, order).bands().stream()
+                    QuantityArrangement.of(decimals,
+                                    byItsOwnRule(order.toArray(new Seam[0]))).bands().stream()
                             .map(Band::key).toList(),
                     "read in either order, the number itself is a run of its own: " + order);
         }
+    }
+
+    /**
+     * Two rules at one place divide the quantity once, and both of them are against that place.
+     *
+     * <p>Where the values part is the quantity's answer, so a second rule at one number leaves the
+     * runs as they were. Which rules put a line there is the model's, and both did — each of them
+     * enough on its own, since taking either away leaves the place where it is.
+     *
+     * <p>Told apart by whoever read them instead, one of the two stood for the other and the second
+     * line was not written down anywhere. Which is why the arrangement is the only place that says
+     * two candidates are one place.
+     */
+    @Test
+    void twoRulesAtOnePlaceAreOnePlaceWithBothLinesAgainstIt() {
+        QuantityArrangement arranged = QuantityArrangement.of(NUMBERS,
+                List.of(Parting.by(upTo("10"), aLine(0)), Parting.by(upTo("10"), aLine(1))));
+
+        assertEquals(1, arranged.partings().size(), "the values part once");
+        assertEquals(List.of(aLine(0), aLine(1)), arranged.partings().get(0).alternatives(),
+                "and each of the two lines is against that place");
+        assertEquals(List.of("|10", "11|"), arranged.bands().stream().map(Band::key).toList(),
+                "so there are two runs and not three");
+    }
+
+    /** And a rule read twice is one rule, which is what says how many runs a row answers for. */
+    @Test
+    void oneRuleReadTwiceIsOneLineAgainstThePlace() {
+        QuantityArrangement arranged = QuantityArrangement.of(NUMBERS,
+                List.of(Parting.by(upTo("10"), aLine(0)), Parting.by(upTo("10"), aLine(0))));
+
+        assertEquals(List.of(aLine(0)), arranged.partings().get(0).alternatives(),
+                "one line, however many readings of it arrived");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatTheRulesTogetherLeaveAQuantityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatTheRulesTogetherLeaveAQuantityTest.java
@@ -9,6 +9,9 @@ import souther.compiler.numeric.Towards;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * The runs of values several rules leave one quantity.
@@ -52,6 +55,21 @@ class WhatTheRulesTogetherLeaveAQuantityTest {
                         low == null ? null : Bound.at(at(low), true),
                         high == null ? null : Bound.at(at(high), true))
                 .bands().stream().map(Band::key).toList();
+    }
+
+    /**
+     * A run parted at one end reaches somewhere on that side, and is refused without it.
+     *
+     * <p>A line gives the run beside it an end whether or not the quantity has a value there, so
+     * there is no run parted here that reaches nowhere. Left open, such an end would answer where
+     * the run reaches with the same nothing an end of the order does, and everything that reads a
+     * run as a set of values would take it for one that runs on.
+     */
+    @Test
+    void aRunPartedAtOneEndReachesSomewhereOnThatSide() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new BandEnd.AtParting(upTo("10"), null),
+                "a parted end without a reach is not a state a run can be in");
     }
 
     /** Each place with a line of its own against it, these being tests about where the values part
@@ -184,6 +202,35 @@ class WhatTheRulesTogetherLeaveAQuantityTest {
                 "and each of the two lines is against that place");
         assertEquals(List.of("|10", "11|"), arranged.bands().stream().map(Band::key).toList(),
                 "so there are two runs and not three");
+    }
+
+    /**
+     * A second line at one place leaves what a row is asked for exactly as it was.
+     *
+     * <p>Which is the whole of why the lines against a place are the arrangement's answer and not
+     * the run's. A body comparing against a number a declaration already stops the quantity at adds
+     * a line and moves nothing: the values part where they parted, and the run beside it reaches
+     * where it reached. Carried into the run, that redundant rule would be inside every value
+     * saying what is asked of a row — and two readings asking one thing would come out asking two,
+     * which is exactly what the check for two readings of one line disagreeing is about.
+     */
+    @Test
+    void aSecondLineAtOnePlaceDoesNotChangeWhatARowIsAskedFor() {
+        QuantityArrangement one = QuantityArrangement.of(NUMBERS,
+                List.of(Parting.by(upTo("10"), aLine(0))));
+        QuantityArrangement also = QuantityArrangement.of(NUMBERS,
+                List.of(Parting.by(upTo("10"), aLine(0)), Parting.by(upTo("10"), aLine(1))));
+
+        assertNotEquals(one.partings(), also.partings(),
+                "the two arrangements do differ, and this is what they differ in");
+        assertEquals(one.bands(), also.bands(), "and the runs they leave are the same runs");
+        assertTrue(run(one).sameAs(run(also)),
+                "so one row answers both, and the second line has not made a second demand");
+    }
+
+    /** The run above the line, as a border's point away from it asks for it. */
+    private static Criterion run(QuantityArrangement arranged) {
+        return new Criterion.Within(arranged.bands().get(1), null, Towards.ABOVE);
     }
 
     /** And a rule read twice is one rule, which is what says how many runs a row answers for. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhereAPositionRunsIsNotSomethingABodyMovesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhereAPositionRunsIsNotSomethingABodyMovesTest.java
@@ -1,0 +1,132 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BorderAssessment;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * A rule written in a body draws a line and does not move where the position runs.
+ *
+ * <p>Two things bound the run a border's {@code IN} point asks for: the places the rules part the
+ * position's values, and the ends the rules leave it between. The first is every rule that cuts the
+ * quantity, a body's own among them; the second is what the declarations say a position holds, and a
+ * body says nothing about that — it cannot refuse a value it is given, only branch on it.
+ *
+ * <p>Which is what says who owes a row inside such a run. A run bounded by a body's line is that
+ * body's; a run bounded by an end the declarations leave is owed wherever the type is carried. So
+ * the two are told apart by what bounds them, and this is where the compiler's answer to that is
+ * pinned: a body's rule reaches a run as a place the values part and never as an end.
+ */
+class WhereAPositionRunsIsNotSomethingABodyMovesTest {
+
+    /** A body's comparison, with nothing declared about the position at all. */
+    private static final String GUARDED = """
+            module example.projection
+
+            data Amount = Int
+
+            data Small
+            data Large
+            data Size = Small | Large
+
+            behavior guarded : (a: Amount) -> Size
+            let guarded (a) = if a.value <= 10 then Small else Large
+
+            example guarded
+                | "y" : (Amount(1)) -> Small
+            """;
+
+    /** An {@code ensures} clause, which is written on a behavior and draws a line the same way. */
+    private static final String STATED = """
+            module example.stated
+
+            data R = { a: Int, b: Int }
+            data Found
+            data Missing
+
+            behavior f : (r: R) -> Found | Missing
+                ensures Found -> r.a >= 5 && r.b >= 5
+            let f (r) = if r.a >= 30 * 2 then Found else Missing
+
+            example f
+                | "one" : (R { a = 1, b = 1 }) -> Missing
+            """;
+
+    /**
+     * A comparison in a body parts the values and leaves the position running as far as it did.
+     *
+     * <p>Nothing is declared about {@code Amount}, so the position runs the whole of its carrier.
+     * The comparison at ten divides it, and the two runs either side of that line are bounded by the
+     * line and by nothing else — an {@code Int} has no end for them to stop at.
+     */
+    @Test
+    void aComparisonInABodyPartsThePositionAndLeavesItsEndsAlone() {
+        Criterion.Within inside = runAt(GUARDED, "example.projection", "a = 10", PointRole.IN);
+
+        assertNotNull(inside.band().over(), "the line it is named for parts the values there");
+        assertNull(inside.band().from(),
+                "and the rules leave the position no end below, the comparison included");
+        assertNull(inside.band().to(), "nor above");
+        assertEquals("guarded/a in a < 10", saidAt(GUARDED, "example.projection", "a = 10",
+                PointRole.IN), "so the run is written from its line and runs on");
+    }
+
+    /**
+     * And an {@code ensures} clause is a body's rule too.
+     *
+     * <p>{@code r.a} is bounded below by the clause's own line at five and above by the comparison
+     * at sixty, and both of those are places the values part. Neither is an end: the position runs
+     * as far as an {@code Int} does either way.
+     */
+    @Test
+    void anEnsuresClauseDrawsALineTheSameWay() {
+        Criterion.Within inside = runAt(STATED, "example.stated", "r.a = 5", PointRole.IN);
+
+        assertNotNull(inside.band().under(), "its own line below");
+        assertNotNull(inside.band().over(), "the comparison's line above");
+        assertNull(inside.band().from(), "and no end the rules leave, below");
+        assertNull(inside.band().to(), "or above");
+    }
+
+    /** The run one point of one border asks a row to land in. */
+    private static Criterion.Within runAt(String model, String module, String label,
+                                          PointRole role) {
+        Criterion criterion = borderAt(model, module, label).border().demand(role).criterion();
+        if (!(criterion instanceof Criterion.Within inside)) {
+            throw new AssertionError("the " + role + " point of " + label
+                    + " is not a run of the position: " + criterion);
+        }
+        return inside;
+    }
+
+    /** What a report writes over a row at that point. */
+    private static String saidAt(String model, String module, String label, PointRole role) {
+        return borderAt(model, module, label).points().stream()
+                .filter(point -> point.role() == role).findFirst()
+                .orElseThrow(() -> new AssertionError("no " + role + " point of " + label))
+                .said();
+    }
+
+    private static BorderAssessment borderAt(String model, String module, String label) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.fullReport());
+        compilation.answerEverything();
+        Map<String, List<BorderAssessment>> boundaries =
+                Adequacy.boundariesOf(compilation.db(), module);
+        assertNotNull(boundaries, "the model under test compiles");
+        return boundaries.values().stream().flatMap(List::stream)
+                .filter(each -> each.label().equals(label)).findFirst()
+                .orElseThrow(() -> new AssertionError(label + " is not a line of this model: "
+                        + boundaries.values().stream().flatMap(List::stream)
+                                .map(BorderAssessment::label).toList()));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhereAPositionRunsIsNotSomethingABodyMovesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhereAPositionRunsIsNotSomethingABodyMovesTest.java
@@ -10,8 +10,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * A rule written in a body draws a line and does not move where the position runs.
@@ -72,10 +72,10 @@ class WhereAPositionRunsIsNotSomethingABodyMovesTest {
     void aComparisonInABodyPartsThePositionAndLeavesItsEndsAlone() {
         Criterion.Within inside = runAt(GUARDED, "example.projection", "a = 10", PointRole.IN);
 
-        assertNotNull(inside.band().over(), "the line it is named for parts the values there");
-        assertNull(inside.band().from(),
-                "and the rules leave the position no end below, the comparison included");
-        assertNull(inside.band().to(), "nor above");
+        assertInstanceOf(BandEnd.AtParting.class, inside.band().upper(),
+                "the line it is named for parts the values there");
+        assertInstanceOf(BandEnd.AtOrderEnd.class, inside.band().lower(),
+                "and nothing stops the run below, the comparison included");
         assertEquals("guarded/a in a < 10", saidAt(GUARDED, "example.projection", "a = 10",
                 PointRole.IN), "so the run is written from its line and runs on");
     }
@@ -91,10 +91,9 @@ class WhereAPositionRunsIsNotSomethingABodyMovesTest {
     void anEnsuresClauseDrawsALineTheSameWay() {
         Criterion.Within inside = runAt(STATED, "example.stated", "r.a = 5", PointRole.IN);
 
-        assertNotNull(inside.band().under(), "its own line below");
-        assertNotNull(inside.band().over(), "the comparison's line above");
-        assertNull(inside.band().from(), "and no end the rules leave, below");
-        assertNull(inside.band().to(), "or above");
+        assertInstanceOf(BandEnd.AtParting.class, inside.band().lower(), "its own line below");
+        assertInstanceOf(BandEnd.AtParting.class, inside.band().upper(),
+                "and the comparison's line above, so neither end is one the rules leave");
     }
 
     /** The run one point of one border asks a row to land in. */


### PR DESCRIPTION
Groundwork for #1082. No answer moves: the conformance corpus keeps every axis, class, coverage item, finding and generated row it had, and the expected files are untouched.

A border's `IN` and `OUT` points ask a row to land somewhere inside a run of the quantity's values. What a run is owed to turns on what stops it — a line a rule wrote, or the end every rule leaves together — and the run carried neither answer: a seam that might be null beside a bound that might be null, with the lines that drew the seam thrown away as soon as two of them fell in one place. So the only thing left that told two runs apart was the reading they turned up in. This makes the run say it.

## Compare a level by the place it is

A level keeps the spelling its rule was written in, because that is what a report writes back — so `0` and `0.00` are two values here and one place on the order. Everything that compares levels goes through the order, and two readers cannot: a map keyed on a debt asks `equals`, and the check that two readings of one line ask a row for the same thing compares two criteria. Over a spelling, that check names the identity that put the readings together as wrong, and there is nothing wrong with it.

`Place.canonical()` says the place the one way, and every value that holds a level and is compared as a value is built from it — a position, a division, an end, a run, a criterion, and the debt a border owes. `Criterion.sameAs` and `Demand.sameAs` are the same question asked of two.

## Pin what bounds a run

A body's rule reaches a run as a place the values part and never as an end: a comparison in a body and an `ensures` clause both draw their line and leave the position running as far as it did. An end can be the order's own — a length is never negative and no clause says so — and it is met with what the rules leave before either reaches a border, so the end a clause wrote and the end the order supplies arrive as one pair and are told apart by nothing they carry.

Both are measured rather than assumed, and the second is why an end is not attributed to anybody here: a model that does write `String.length(value) >= 0` would be read as having written nothing.

## Say what stops a run

`BandEnd` is one of three: a rule parts the values there, the rules leave the quantity nothing past a place, or nothing stops it and the run goes as far as the order does. Both ends of a run are always there.

Where the run reaches is the end's own answer. A run is on this side of the line and inside what the rules leave at once, so a run parted by a line the rules stop short of reaches the rules' end and not the line — which every reader wanting the reach was working out for itself from the two fields.

## Let the arrangement say which candidates are one place

Where the values part was settled in four places: the reading that turns a position's cuts into lines, the one that collects the lines of a body, the one that adds a border's own line to what it was told about, and the arrangement itself. Each kept whichever of two candidates at one place it read first, so a place two rules wrote a line at came out as one line — and which of the two survived came down to the order a walk took.

A producer now hands over what it read and nothing else. The arrangement is the one thing that says two candidates are one place, and it keeps both lines against it: each is enough on its own to have parted the values there, since taking either away leaves the place where it is. A rule read twice is still one line.

## What is not here

Nothing about which points a border owes, what a debt is, or where a row is owed. `#1082` changes that on top of this, and its diff should read as a change of identity and nothing else.

An end the rules leave carries no attribution yet. What could answer it is a candidate set — the declarations that could have moved where the position stops — and that is a question for placement rather than for the run, so it arrives with the reader that needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
